### PR TITLE
Fix missing German translations

### DIFF
--- a/index.html
+++ b/index.html
@@ -107,7 +107,7 @@
     <p><strong><span id="totalPowerLabel">Total Consumption:</span></strong> <span id="totalPower">0.0</span> W</p>
     <p><strong><span id="totalCurrent144Label">Total Current (at 14.4V):</span></strong> <span id="totalCurrent144">0.00</span> A</p>
     <p><strong><span id="totalCurrent12Label">Total Current (at 12V):</span></strong> <span id="totalCurrent12">0.00</span> A</p>
-    <p><strong><span id="batteryLifeLabel">Runtime (estimated):</span></strong> <span id="batteryLife">0.00</span> hrs</p>
+    <p><strong><span id="batteryLifeLabel">Runtime (estimated):</span></strong> <span id="batteryLife">0.00</span> <span id="batteryLifeUnit">hrs</span></p>
     <p id="pinWarning" style="color: red; font-weight: bold;"></p>
     <p id="dtapWarning" style="color: red; font-weight: bold;"></p>
   </section>

--- a/script.js
+++ b/script.js
@@ -91,6 +91,7 @@ const texts = {
 
     batteryLabel: "Battery",
     runtimeLabel: "Estimated Runtime (h)",
+    batteryLifeUnit: "hrs",
 
     noBatterySupports: "No battery can supply this load.",
 
@@ -117,6 +118,7 @@ const texts = {
     alertImportSetupsError: "Error: Could not import setups. The file may be invalid or corrupted.",
     alertSelectSetupForOverview: "Please select a saved setup to generate an overview.",
     overviewTitle: "Setup Overview",
+    exportAndRevertBtn: "Export and Revert to default Database",
     // NEW TEXTS FOR SETUP MANAGEMENT END HERE
   },
   de: {
@@ -193,6 +195,7 @@ const texts = {
 
     batteryLabel: "Akku",
     runtimeLabel: "Geschätzte Laufzeit (h)",
+    batteryLifeUnit: "Std.",
 
     noBatterySupports: "Kein Akku kann diese Last liefern.",
 
@@ -209,15 +212,16 @@ const texts = {
     alertDeviceName: "Der Gerätename darf nicht leer sein.",
 
     // NEW TEXTS FOR SETUP MANAGEMENT START HERE
-    setupActionsHeading: "Setup Actions",
-    exportSetupsBtn: "Export All Setups",
-    importSetupsBtn: "Import Setups",
-    generateOverviewBtn: "Generate Overview",
-    alertNoSetupsToExport: "There are no saved setups to export.",
+    setupActionsHeading: "Setup-Aktionen",
+    exportSetupsBtn: "Alle Setups exportieren",
+    importSetupsBtn: "Setups importieren",
+    generateOverviewBtn: "Übersicht erstellen",
+    alertNoSetupsToExport: "Es gibt keine gespeicherten Setups zum Exportieren.",
     alertImportSetupsSuccess: "{num_setups} Setups erfolgreich importiert.",
-    alertImportSetupsError: "Error: Could not import setups. The file may be invalid or corrupted.",
-    alertSelectSetupForOverview: "Please select a saved setup to generate an overview.",
-    overviewTitle: "Setup Overview",
+    alertImportSetupsError: "Fehler: Setups konnten nicht importiert werden. Die Datei ist möglicherweise ungültig oder beschädigt.",
+    alertSelectSetupForOverview: "Bitte wählen Sie ein gespeichertes Setup, um eine Übersicht zu erstellen.",
+    overviewTitle: "Setup-Übersicht",
+    exportAndRevertBtn: "Exportieren und auf Standarddatenbank zurücksetzen",
     // NEW TEXTS FOR SETUP MANAGEMENT END HERE
   }
 };
@@ -290,6 +294,8 @@ function setLanguage(lang) {
   document.getElementById("totalCurrent144Label").textContent = texts[lang].totalCurrent144Label;
   document.getElementById("totalCurrent12Label").textContent = texts[lang].totalCurrent12Label;
   document.getElementById("batteryLifeLabel").textContent = texts[lang].batteryLifeLabel;
+  const unitElem = document.getElementById("batteryLifeUnit");
+  if (unitElem) unitElem.textContent = texts[lang].batteryLifeUnit;
   // Device manager category headings
   document.getElementById("category_cameras").textContent = texts[lang].category_cameras;
   document.getElementById("category_monitors").textContent = texts[lang].category_monitors;
@@ -352,6 +358,8 @@ function setLanguage(lang) {
   document.getElementById("exportSetupsBtn").textContent = texts[lang].exportSetupsBtn;
   document.getElementById("importSetupsBtn").textContent = texts[lang].importSetupsBtn;
   document.getElementById("generateOverviewBtn").textContent = texts[lang].generateOverviewBtn;
+  const exportRevert = document.getElementById("exportAndRevertBtn");
+  if (exportRevert) exportRevert.textContent = texts[lang].exportAndRevertBtn;
 }
 
 // Reference elements (DOM Elements)


### PR DESCRIPTION
## Summary
- add missing translations for setup actions and export/revert button
- add language-specific unit for runtime display
- display runtime unit in its own span for translation

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687d52de1bcc8320abea8248b5dcc8c7