### PR TITLE
Add dark mode toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,6 +13,7 @@
       <option value="en">English</option>
       <option value="de">Deutsch</option>
     </select>
+    <button id="darkModeToggle" title="Toggle dark mode">🌙</button>
   </div>
 
   <h1 id="mainTitle">Camera Power Consumption App</h1>

--- a/script.js
+++ b/script.js
@@ -407,6 +407,7 @@ const exportOutput    = document.getElementById("exportOutput");
 const importFileInput = document.getElementById("importFileInput");
 const importDataBtn   = document.getElementById("importDataBtn");
 const languageSelect  = document.getElementById("languageSelect");
+const darkModeToggle  = document.getElementById("darkModeToggle");
 const batteryComparisonSection = document.getElementById("batteryComparison");
 const batteryTableElem = document.getElementById("batteryTable");
 const breakdownListElem = document.getElementById("breakdownList");
@@ -1563,6 +1564,37 @@ function generatePrintableOverview() {
 
 motorSelects.forEach(sel => sel?.addEventListener("change", updateCalculations));
 controllerSelects.forEach(sel => sel?.addEventListener("change", updateCalculations));
+
+// Dark mode handling
+function applyDarkMode(enabled) {
+  if (enabled) {
+    document.body.classList.add("dark-mode");
+    if (darkModeToggle) darkModeToggle.textContent = "☀";
+  } else {
+    document.body.classList.remove("dark-mode");
+    if (darkModeToggle) darkModeToggle.textContent = "🌙";
+  }
+}
+
+let darkModeEnabled = false;
+try {
+  darkModeEnabled = localStorage.getItem("darkMode") === "true";
+} catch (e) {
+  console.warn("Could not load dark mode preference", e);
+}
+applyDarkMode(darkModeEnabled);
+
+if (darkModeToggle) {
+  darkModeToggle.addEventListener("click", () => {
+    darkModeEnabled = !document.body.classList.contains("dark-mode");
+    applyDarkMode(darkModeEnabled);
+    try {
+      localStorage.setItem("darkMode", darkModeEnabled);
+    } catch (e) {
+      console.warn("Could not save dark mode preference", e);
+    }
+  });
+}
 
 // Initial calculation and language set
 setLanguage(currentLang);

--- a/style.css
+++ b/style.css
@@ -178,7 +178,10 @@ button:disabled {
   top: 10px;
   right: 10px;
   padding: 5px;
-  
+  display: flex;
+  gap: 5px;
+  align-items: center;
+
 }
 #langSelector select {
   font-size: 1em;
@@ -187,6 +190,9 @@ button:disabled {
   color: #333; /* Darker text color */
   border: 0px solid #ccc; /* Light grey border */
   border-radius: 5px;
+}
+#darkModeToggle {
+  min-width: 32px;
 }
 
 /* Breakdown list */
@@ -261,4 +267,61 @@ button:disabled {
 .selectedBatteryRow {
     background-color: #e6f7ff; /* Light blue background for selected row */
     font-weight: bold;
+}
+
+/* Dark mode */
+body.dark-mode {
+  background-color: #121212;
+  color: #e0e0e0;
+}
+
+body.dark-mode h1,
+body.dark-mode h2,
+body.dark-mode h3 {
+  color: #80b3ff;
+}
+
+body.dark-mode section,
+body.dark-mode .device-category,
+body.dark-mode #batteryComparison {
+  background-color: #1e1e1e;
+  border-color: #333;
+}
+
+body.dark-mode fieldset {
+  border-color: #80b3ff;
+}
+
+body.dark-mode legend {
+  color: #80b3ff;
+}
+
+body.dark-mode button,
+body.dark-mode #langSelector select,
+body.dark-mode input,
+body.dark-mode select,
+body.dark-mode textarea {
+  background-color: #333;
+  color: #e0e0e0;
+  border-color: #555;
+}
+
+body.dark-mode button:hover {
+  background-color: #444;
+}
+
+body.dark-mode button:active {
+  background-color: #555;
+}
+
+body.dark-mode #batteryComparison th {
+  background-color: #333;
+}
+
+body.dark-mode .barContainer {
+  background-color: #333;
+}
+
+body.dark-mode .selectedBatteryRow {
+  background-color: #003366;
 }


### PR DESCRIPTION
## Summary
- add a dark mode toggle button next to the language selector
- style the selector area to allow the extra button
- implement dark-mode styles for body, sections and controls
- preserve dark mode preference with localStorage

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687d511d74608320b1cf16ba54e50572