### PR TITLE
Fix Safari dark mode select gradient

### DIFF
--- a/style.css
+++ b/style.css
@@ -310,6 +310,11 @@ body.dark-mode textarea {
   border-color: #555;
 }
 
+/* Remove Safari's gradient on selects in dark mode */
+body.dark-mode select {
+  background-image: none;
+}
+
 body.dark-mode #setupSelect,
 body.dark-mode #setupName {
   background-color: #333;


### PR DESCRIPTION
## Summary
- make dark mode select elements solid background

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687d5e45af8c8320aa1bef84fade43a5