### PR TITLE
Fix Safari select gradient in dark mode

### DIFF
--- a/style.css
+++ b/style.css
@@ -313,6 +313,8 @@ body.dark-mode textarea {
 /* Remove Safari's gradient on selects in dark mode */
 body.dark-mode select {
   background-image: none;
+  -webkit-appearance: none;
+  appearance: none;
 }
 
 body.dark-mode #setupSelect,


### PR DESCRIPTION
## Summary
- remove Safari's default select gradient in dark mode by disabling appearance

## Testing
- `grep -n "Safari's gradient" -n style.css`

------
https://chatgpt.com/codex/tasks/task_e_687d5fb8aa9c8320b8873162cad42388