### PR TITLE
Fix Safari select gradient

### DIFF
--- a/style.css
+++ b/style.css
@@ -317,6 +317,15 @@ body.dark-mode select {
   appearance: none;
 }
 
+/* Remove Safari's gradient on selects in light mode */
+@supports (-webkit-touch-callout: none) {
+  body:not(.dark-mode) select {
+    background-image: none;
+    -webkit-appearance: none;
+    appearance: none;
+  }
+}
+
 body.dark-mode #setupSelect,
 body.dark-mode #setupName {
   background-color: #333;


### PR DESCRIPTION
## Summary
- remove Safari select gradient in light mode

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687d6250633483209efbec81b71a8090