### PR TITLE
Fix dark mode device headings

### DIFF
--- a/style.css
+++ b/style.css
@@ -354,6 +354,7 @@ body.dark-mode .selectedBatteryRow {
 }
 
 body.dark-mode .device-category h4 {
+  color: #ffffff;
   border-bottom: 1px solid #ffffff;
 }
 


### PR DESCRIPTION
## Summary
- set `.device-category h4` color to white in dark mode

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687d64bbd2188320b5a474ed75706d52