### PR TITLE
Remove gradient from select elements

### DIFF
--- a/style.css
+++ b/style.css
@@ -56,6 +56,12 @@ p {
 
 /* Ensure dropdowns use a solid background across browsers */
 select {
+  padding: 4px;
+  font-size: 1em;
+  background-color: #e8e8e8; /* Grey background */
+  color: #333; /* Darker text color */
+  border: 0px solid #ccc; /* Light grey border */
+  border-radius: 5px;
   background-image: none;
   -webkit-appearance: none;
   appearance: none;

--- a/style.css
+++ b/style.css
@@ -54,6 +54,13 @@ p {
   margin: 5px 5px 0 0;
 }
 
+/* Ensure dropdowns use a solid background across browsers */
+select {
+  background-image: none;
+  -webkit-appearance: none;
+  appearance: none;
+}
+
 /* Specific style for the setupSelect dropdown */
 #setupSelect {
   flex: 1; /* Allow it to grow */


### PR DESCRIPTION
## Summary
- remove default gradients from dropdown menus so they use solid colors

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687d6671204c8320999a0bc901cb343c