### PR TITLE
Restore full-width selector layout

### DIFF
--- a/style.css
+++ b/style.css
@@ -77,6 +77,7 @@ p {
 .select-wrapper {
   display: flex;
   flex-direction: column;
+  flex: 1;
 }
 
 .select-wrapper .filter-input {


### PR DESCRIPTION
## Summary
- make select-wrapper flex to fill the row

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687d7b086c2c8320818789329fe13ea9