### PR TITLE
Add editable viewfinder rows

### DIFF
--- a/index.html
+++ b/index.html
@@ -226,8 +226,8 @@
       <div class="camera-subsection">
         <h4 id="viewfinderHeading">Viewfinder</h4>
         <div class="form-row">
-          <label for="cameraViewfinder" id="cameraViewfinderLabel">Viewfinders (JSON):</label>
-          <textarea id="cameraViewfinder" rows="3"></textarea>
+          <label id="cameraViewfinderLabel">Viewfinders:</label>
+          <div id="viewfinderContainer" style="flex:1;"></div>
         </div>
       </div>
       <div class="camera-subsection">


### PR DESCRIPTION
## Summary
- enable multi-row editing of viewfinders in camera editor
- keep a set of viewfinder type and connector options
- normalize viewfinder data to include connector field
- update import/export, edit and revert flows to refresh viewfinder options

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687dedda4dc083209792a5147bf58ae9