### PR TITLE
Colorize battery comparison labels

### DIFF
--- a/script.js
+++ b/script.js
@@ -1334,8 +1334,10 @@ if (!battery || battery === "None" || !devices.batteries[battery]) {
       };
       // Helper to display method label
       const getMethodLabel = (method) => {
-          return method === "pins" ? "pins only!" : method;
-      };
+            if (method === "pins") return "<span style=\"color:#FF9800;\">pins only!</span>";
+            if (method === "both pins and D-Tap") return "<span style=\"color:#4CAF50;\">both pins and D-Tap</span>";
+            return method;
+        };
 
       // Add selected battery first, if it's a valid candidate
       if (selectedCandidate) {
@@ -2200,7 +2202,9 @@ function generatePrintableOverview() {
         };
 
         const getMethodLabel = (method) => {
-            return method === "pins" ? "pins only!" : method;
+            if (method === "pins") return "<span style=\"color:#FF9800;\">pins only!</span>";
+            if (method === "both pins and D-Tap") return "<span style=\"color:#4CAF50;\">both pins and D-Tap</span>";
+            return method;
         };
 
         const getRuntimeDisplay = (hours) => {


### PR DESCRIPTION
## Summary
- update label generation for battery method to include color spans

## Testing
- `npm test` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_687df5bc541c83208336b97af2312904