### PR TITLE
Reload defaults on export and revert

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Es berechnet **Stromverbrauch**, **Stromstärke** (bei 14,4 V und 12 V) sowi
     - Add new devices or edit/delete existing ones
     - Export full list as JSON
     - **Import Database**: Use the "Import Database" button and select a previously exported JSON file to load device data into the application. This will overwrite existing device data.
-    - **Export & Revert**: "Export and Revert to default Database" saves the current data and resets the database to its default state.
+    - **Export & Revert**: "Export and Revert to default Database" downloads the current data, clears the saved database and reloads the page so the defaults from `data.js` are used.
 
 ---
 

--- a/script.js
+++ b/script.js
@@ -2037,29 +2037,10 @@ if (exportAndRevertBtn) {
 
       // Give a small delay to ensure download prompt appears before next step
       setTimeout(() => {
-        // Step 2: Revert to the default database
-        devices = JSON.parse(JSON.stringify(window.defaultDevices)); // Use window.defaultDevices here
-        saveDeviceData(devices); // Save the default data back to localStorage
-
-        viewfinderTypeOptions = getAllViewfinderTypes();
-        viewfinderConnectorOptions = getAllViewfinderConnectors();
-        updatePlateTypeOptions();
-        updatePlateTypeOptions();
-
-        // Update the UI to reflect the reverted database
-        populateSelect(cameraSelect, devices.cameras, true);
-        populateSelect(monitorSelect, devices.monitors, true);
-        populateSelect(videoSelect, devices.video, true);
-        motorSelects.forEach(sel => populateSelect(sel, devices.fiz.motors, true));
-        controllerSelects.forEach(sel => populateSelect(sel, devices.fiz.controllers, true));
-        populateSelect(distanceSelect, devices.fiz.distance, true);
-        populateSelect(batterySelect, devices.batteries, true);
-        updateFizConnectorOptions();
-        applyFilters();
-        refreshDeviceLists(); // Refresh device manager lists
-        updateCalculations();
-
-        alert(texts[currentLang].alertExportAndRevertSuccess); // Success message for both actions
+        // Step 2: Remove saved database and reload page so data.js is re-read
+        localStorage.removeItem('cameraPowerPlanner_devices');
+        alert(texts[currentLang].alertExportAndRevertSuccess);
+        location.reload();
       }, 500); // 500ms delay
     }
   });


### PR DESCRIPTION
## Summary
- reload the page when exporting and reverting device data
- document new behavior in README

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687df8d50f6c8320b049d1374abc367d