### PR TITLE
Add dynamic editors for power distribution and timecode

### DIFF
--- a/index.html
+++ b/index.html
@@ -201,8 +201,8 @@
       <div class="camera-subsection">
         <h4 id="powerDistributionHeading">Power Distribution</h4>
         <div class="form-row">
-          <label for="cameraPowerDist" id="cameraPowerDistLabel">Outputs (JSON):</label>
-          <textarea id="cameraPowerDist" rows="3"></textarea>
+          <label id="cameraPowerDistLabel">Outputs:</label>
+          <div id="powerDistContainer" style="flex:1;"></div>
         </div>
       </div>
       <div class="camera-subsection">
@@ -243,8 +243,8 @@
       <div class="camera-subsection">
         <h4 id="timecodeHeading">Timecode</h4>
         <div class="form-row">
-          <label for="cameraTimecode" id="cameraTimecodeLabel">Timecode (JSON):</label>
-          <textarea id="cameraTimecode" rows="3"></textarea>
+          <label id="cameraTimecodeLabel">Timecode:</label>
+          <div id="timecodeContainer" style="flex:1;"></div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- replace JSON textareas with dynamic rows for power distribution and timecode
- implement JS helpers to manage new interfaces
- refresh option lists when devices change
- update labels and translations
- ensure lens mount list is always shown

## Testing
- `npm test`
- `npx eslint .`


------
https://chatgpt.com/codex/tasks/task_e_687dfe58277483208c435fe767e95739