### PR TITLE
Normalize viewfinder dropdown options

### DIFF
--- a/data.js
+++ b/data.js
@@ -567,7 +567,7 @@ let devices={
       ],
       "viewfinder": [
         {
-          "type": "LEMO 26 pin",
+          "type": "LEMO 26-pin port",
           "notes": "For Sony DVF-EL200 Viewfinder"
         }
       ],
@@ -717,7 +717,7 @@ let devices={
       ],
       "viewfinder": [
         {
-          "type": "LEMO 26 pin",
+          "type": "LEMO 26-pin port",
           "notes": "For Sony DVF-EL200 Viewfinder"
         }
       ],
@@ -824,7 +824,7 @@ let devices={
           "notes": "For Sony EVF"
         },
         {
-          "type": "LCD Monitor (Native)",
+          "type": "Integrated LCD monitor",
           "size": "3.5-inch",
           "resolution": "1280x720"
         }
@@ -908,7 +908,7 @@ let devices={
       ],
       "viewfinder": [
         {
-          "type": "LCD Monitor (Native)",
+          "type": "Integrated LCD monitor",
           "size": "3.0-inch",
           "resolution": "1.44M dots",
           "notes": "Vari-angle touchscreen"
@@ -1026,7 +1026,7 @@ let devices={
       ],
       "viewfinder": [
         {
-          "type": "Native LCD Viewfinder",
+          "type": "Integrated LCD monitor",
           "size": "3.5-inch",
           "notes": "Touch operation, flexible attachment"
         }
@@ -1130,7 +1130,7 @@ let devices={
           "notes": "For Sony EVF"
         },
         {
-          "type": "LCD Monitor (Native)",
+          "type": "Integrated LCD monitor",
           "size": "3.5-inch",
           "resolution": "1280x720"
         }
@@ -1200,7 +1200,7 @@ let devices={
       ],
       "viewfinder": [
         {
-          "type": "LCD Touch Panel",
+          "type": "LCD touchscreen",
           "size": "3.5 inch",
           "resolution": "1280 x 720"
         }
@@ -1403,11 +1403,11 @@ let devices={
       ],
       "viewfinder": [
         {
-          "type": "LCD Monitor LM-V2 (Supplied)",
+          "type": "LCD Monitor LM-V2",
           "notes": "4.3” rotating touchscreen LCD unit"
         },
         {
-          "type": "Optional EVF-V70 viewfinder"
+          "type": "EVF-V70 (Optional)"
         }
       ],
       "lensMount": [
@@ -1508,7 +1508,7 @@ let devices={
       ],
       "viewfinder": [
         {
-          "type": "LCD Touchscreen",
+          "type": "LCD touchscreen",
           "size": "3.5 inch",
           "resolution": "1280 x 720"
         }
@@ -1613,14 +1613,14 @@ let devices={
       ],
       "viewfinder": [
         {
-          "type": "LCD Monitor LM-V2 (Supplied)",
+          "type": "LCD Monitor LM-V2",
           "notes": "Canon's proprietary specification (special 13-pin jack)"
         },
         {
-          "type": "Optional EVF-V70 viewfinder"
+          "type": "EVF-V70 (Optional)"
         },
         {
-          "type": "Optional EVF-V50"
+          "type": "EVF-V50 (Optional)"
         }
       ],
       "lensMount": [
@@ -1702,7 +1702,7 @@ let devices={
       ],
       "viewfinder": [
         {
-          "type": "LCD capacitive touchscreen",
+          "type": "LCD touchscreen",
           "size": "5 inch",
           "resolution": "1920 x 1080"
         }
@@ -1774,13 +1774,13 @@ let devices={
       ],
       "viewfinder": [
         {
-          "type": "LCD capacitive touchscreen",
+          "type": "LCD touchscreen",
           "size": "5 inch",
           "resolution": "1920 x 1080",
           "notes": "Adjustable HDR touchscreen"
         },
         {
-          "type": "Optional OLED viewfinder"
+          "type": "OLED EVF (Optional)"
         }
       ],
       "lensMount": [
@@ -1858,7 +1858,7 @@ let devices={
       ],
       "viewfinder": [
         {
-          "type": "LCD capacitive touchscreen",
+          "type": "LCD touchscreen",
           "size": "5 inch",
           "resolution": "1920 x 1080"
         }
@@ -1940,12 +1940,12 @@ let devices={
       ],
       "viewfinder": [
         {
-          "type": "Native LCD Capacitive Touchscreen",
+          "type": "LCD touchscreen",
           "size": "5-inch",
           "resolution": "1920x1080"
         },
         {
-          "type": "Blackmagic Pocket Cinema Camera Pro EVF (Optional)",
+          "type": "Blackmagic Pro EVF (Optional)",
           "resolution": "1280x960",
           "notes": "Micro OLED display"
         }
@@ -2039,12 +2039,12 @@ let devices={
       ],
       "viewfinder": [
         {
-          "type": "LCD capacitive touchscreen",
+          "type": "LCD touchscreen",
           "size": "4 inch",
           "notes": "Fold out touchscreen"
         },
         {
-          "type": "External backlit LCD status display"
+          "type": "LCD status display"
         }
       ],
       "lensMount": [
@@ -2162,7 +2162,7 @@ let devices={
       ],
       "viewfinder": [
         {
-          "type": "Built-in Fold-out LCD",
+          "type": "Fold-out LCD",
           "size": "5-inch",
           "resolution": "1920x1080"
         },
@@ -2248,7 +2248,7 @@ let devices={
       ],
       "viewfinder": [
         {
-          "type": "LCD capacitive touchscreen",
+          "type": "LCD touchscreen",
           "size": "4 inch",
           "resolution": "1280x720"
         }
@@ -2319,7 +2319,7 @@ let devices={
       ],
       "viewfinder": [
         {
-          "type": "LCD capacitive touchscreen",
+          "type": "LCD touchscreen",
           "size": "4 inch",
           "resolution": "1280x720"
         }
@@ -2405,12 +2405,12 @@ let devices={
       ],
       "viewfinder": [
         {
-          "type": "Integrated Touchscreen LCD",
+          "type": "LCD touchscreen",
           "size": "2.9-inch",
           "resolution": "1440x1440"
         },
         {
-          "type": "DSMC3 RED Touch 7\" LCD (Optional)"
+          "type": "RED Touch 7\" LCD (Optional)"
         }
       ],
       "lensMount": [
@@ -2485,11 +2485,11 @@ let devices={
       ],
       "viewfinder": [
         {
-          "type": "Integrated Touchscreen LCD",
+          "type": "LCD touchscreen",
           "size": "2.9-inch"
         },
         {
-          "type": "DSMC3 RED Touch 7\" LCD (Optional)"
+          "type": "RED Touch 7\" LCD (Optional)"
         }
       ],
       "lensMount": [
@@ -2588,7 +2588,7 @@ let devices={
       ],
       "viewfinder": [
         {
-          "type": "DSMC3 RED Touch 7\" LCD (Optional)"
+          "type": "RED Touch 7\" LCD (Optional)"
         }
       ],
       "lensMount": [
@@ -2691,7 +2691,7 @@ let devices={
       ],
       "viewfinder": [
         {
-          "type": "DSMC3 RED Touch 7\" LCD (Optional)"
+          "type": "RED Touch 7\" LCD (Optional)"
         }
       ],
       "lensMount": [
@@ -2794,7 +2794,7 @@ let devices={
       ],
       "viewfinder": [
         {
-          "type": "DSMC3 RED Touch 7\" LCD (Optional)"
+          "type": "RED Touch 7\" LCD (Optional)"
         }
       ],
       "lensMount": [
@@ -2897,7 +2897,7 @@ let devices={
       ],
       "viewfinder": [
         {
-          "type": "DSMC3 RED Touch 7\" LCD (Optional)"
+          "type": "RED Touch 7\" LCD (Optional)"
         }
       ],
       "lensMount": [
@@ -2968,7 +2968,7 @@ let devices={
       ],
       "viewfinder": [
         {
-          "type": "DSMC3 RED Touch 7\" LCD (Optional)"
+          "type": "RED Touch 7\" LCD (Optional)"
         }
       ],
       "lensMount": [
@@ -3039,7 +3039,7 @@ let devices={
       ],
       "viewfinder": [
         {
-          "type": "DSMC3 RED Touch 7\" LCD (Optional)"
+          "type": "RED Touch 7\" LCD (Optional)"
         }
       ],
       "lensMount": [
@@ -3110,7 +3110,7 @@ let devices={
       ],
       "viewfinder": [
         {
-          "type": "DSMC3 RED Touch 7\" LCD (Optional)"
+          "type": "RED Touch 7\" LCD (Optional)"
         }
       ],
       "lensMount": [
@@ -3181,7 +3181,7 @@ let devices={
       ],
       "viewfinder": [
         {
-          "type": "DSMC3 RED Touch 7\" LCD (Optional)"
+          "type": "RED Touch 7\" LCD (Optional)"
         }
       ],
       "lensMount": [
@@ -3248,7 +3248,7 @@ let devices={
       ],
       "viewfinder": [
         {
-          "type": "RED Touch 7.0\" LCD (Optional)"
+          "type": "RED Touch 7\" LCD (Optional)"
         }
       ],
       "lensMount": [
@@ -3315,7 +3315,7 @@ let devices={
       ],
       "viewfinder": [
         {
-          "type": "RED Touch 7.0\" LCD (Optional)"
+          "type": "RED Touch 7\" LCD (Optional)"
         }
       ],
       "lensMount": [
@@ -3382,7 +3382,7 @@ let devices={
       ],
       "viewfinder": [
         {
-          "type": "RED Touch 7.0\" LCD (Optional)"
+          "type": "RED Touch 7\" LCD (Optional)"
         }
       ],
       "lensMount": [
@@ -3449,7 +3449,7 @@ let devices={
       ],
       "viewfinder": [
         {
-          "type": "RED Touch 7.0\" LCD (Optional)"
+          "type": "RED Touch 7\" LCD (Optional)"
         }
       ],
       "lensMount": [
@@ -3516,7 +3516,7 @@ let devices={
       ],
       "viewfinder": [
         {
-          "type": "RED Touch 7.0\" LCD (Optional)"
+          "type": "RED Touch 7\" LCD (Optional)"
         }
       ],
       "lensMount": [
@@ -3583,7 +3583,7 @@ let devices={
       ],
       "viewfinder": [
         {
-          "type": "RED Touch 7.0\" LCD (Optional)"
+          "type": "RED Touch 7\" LCD (Optional)"
         }
       ],
       "lensMount": [
@@ -3650,7 +3650,7 @@ let devices={
       ],
       "viewfinder": [
         {
-          "type": "RED Touch 7.0\" LCD (Optional)"
+          "type": "RED Touch 7\" LCD (Optional)"
         }
       ],
       "lensMount": [
@@ -3722,11 +3722,11 @@ let devices={
       ],
       "viewfinder": [
         {
-          "type": "OLED LVF (Live View Finder)",
+          "type": "OLED EVF",
           "resolution": "3,680k-dot"
         },
         {
-          "type": "Free-angle LCD",
+          "type": "Vari-angle LCD",
           "size": "3.0-inch",
           "resolution": "1,840k-dot"
         }
@@ -3797,11 +3797,11 @@ let devices={
       ],
       "viewfinder": [
         {
-          "type": "OLED LVF (Live View Finder)",
+          "type": "OLED EVF",
           "resolution": "3,680k-dot"
         },
         {
-          "type": "Free-angle LCD",
+          "type": "Vari-angle LCD",
           "size": "3.0-inch",
           "resolution": "1,840k-dot"
         }
@@ -4063,7 +4063,7 @@ let devices={
       ],
       "viewfinder": [
         {
-          "type": "Integrated Main Monitor",
+          "type": "Integrated LCD monitor",
           "size": "5.5-inch",
           "resolution": "1920x1080"
         },
@@ -4150,7 +4150,7 @@ let devices={
       ],
       "viewfinder": [
         {
-          "type": "LCD Monitor (Native)",
+          "type": "Integrated LCD monitor",
           "size": "3.0-type (7.5 cm)",
           "resolution": "Approx. 2.36M dots",
           "notes": "Vari-angle touch panel [S1.1]"
@@ -4283,7 +4283,7 @@ let devices={
       ],
       "viewfinder": [
         {
-          "type": "LCD Monitor (Native)",
+          "type": "Integrated LCD monitor",
           "size": "3.0-type (7.5 cm)",
           "resolution": "Approx. 1.03M dots",
           "notes": "Vari-angle touch panel [S3.1]"
@@ -4350,7 +4350,7 @@ let devices={
           "notes": "No built-in viewfinder, relies on LCD [4.1]"
         },
         {
-          "type": "LCD Monitor (Native)",
+          "type": "Integrated LCD monitor",
           "size": "3.0-inch",
           "resolution": "1.04 million dots",
           "notes": "Vari-angle touchscreen [4.1]"
@@ -4424,7 +4424,7 @@ let devices={
           "resolution": "Approx. 5.76 million dots"
         },
         {
-          "type": "LCD Monitor (Native)",
+          "type": "Integrated LCD monitor",
           "size": "3.2-inch",
           "resolution": "Approx. 2.1 million dots",
           "notes": "Vari-angle touchscreen"
@@ -4500,7 +4500,7 @@ let devices={
           "resolution": "High-resolution"
         },
         {
-          "type": "LCD Monitor (Native)",
+          "type": "Integrated LCD monitor",
           "size": "Vari-angle touchscreen"
         }
       ],
@@ -4575,7 +4575,7 @@ let devices={
           "resolution": "High-resolution"
         },
         {
-          "type": "LCD Monitor (Native)",
+          "type": "Integrated LCD monitor",
           "size": "Vari-angle touchscreen"
         }
       ],

--- a/script.js
+++ b/script.js
@@ -59,6 +59,33 @@ function normalizeFizConnectorType(type) {
   return map[type] || type;
 }
 
+function normalizeViewfinderType(type) {
+  if (!type) return '';
+  const map = {
+    'DSMC3 RED Touch 7" LCD (Optional)': 'RED Touch 7" LCD (Optional)',
+    'RED Touch 7.0" LCD (Optional)': 'RED Touch 7" LCD (Optional)',
+    'LCD Touch Panel': 'LCD touchscreen',
+    'LCD Touchscreen': 'LCD touchscreen',
+    'Native LCD Capacitive Touchscreen': 'LCD touchscreen',
+    'Integrated Touchscreen LCD': 'LCD touchscreen',
+    'Free-angle LCD': 'Vari-angle LCD',
+    'LCD Monitor (Native)': 'Integrated LCD monitor',
+    'Native LCD Viewfinder': 'Integrated LCD monitor',
+    'LCD Monitor LM-V2 (Supplied)': 'LCD Monitor LM-V2',
+    'Integrated Main Monitor': 'Integrated LCD monitor',
+    'Optional EVF-V70 viewfinder': 'EVF-V70 (Optional)',
+    'Optional EVF-V50': 'EVF-V50 (Optional)',
+    'Optional OLED viewfinder': 'OLED EVF (Optional)',
+    'Blackmagic Pocket Cinema Camera Pro EVF (Optional)': 'Blackmagic Pro EVF (Optional)',
+    'External backlit LCD status display': 'LCD status display',
+    'Built-in Fold-out LCD': 'Fold-out LCD',
+    'OLED LVF (Live View Finder)': 'OLED EVF',
+    'LCD capacitive touchscreen': 'LCD touchscreen',
+    'LEMO 26 pin': 'LEMO 26-pin port'
+  };
+  return map[type] || type;
+}
+
 // Load any saved device data from localStorage
 const storedDevices = loadDeviceData();
 if (storedDevices) {
@@ -118,7 +145,12 @@ function unifyDevices(data) {
       type: normalizeFizConnectorType(fc.type),
       notes: fc.notes
     }));
-    cam.viewfinder = ensureList(cam.viewfinder, { type: '', resolution: '', connector: '', notes: '' });
+    cam.viewfinder = ensureList(cam.viewfinder, { type: '', resolution: '', connector: '', notes: '' }).map(vf => ({
+      type: normalizeViewfinderType(vf.type),
+      resolution: vf.resolution,
+      connector: vf.connector,
+      notes: vf.notes
+    }));
     cam.timecode = ensureList(cam.timecode, { type: '', notes: '' });
   });
 }

--- a/unifyViewfinderTypes.js
+++ b/unifyViewfinderTypes.js
@@ -1,0 +1,43 @@
+const fs = require('fs');
+const devices = require('./data.js');
+
+const map = {
+  'DSMC3 RED Touch 7" LCD (Optional)': 'RED Touch 7" LCD (Optional)',
+  'RED Touch 7.0" LCD (Optional)': 'RED Touch 7" LCD (Optional)',
+  'LCD Touch Panel': 'LCD touchscreen',
+  'LCD Touchscreen': 'LCD touchscreen',
+  'Native LCD Capacitive Touchscreen': 'LCD touchscreen',
+  'Integrated Touchscreen LCD': 'LCD touchscreen',
+  'Free-angle LCD': 'Vari-angle LCD',
+  'LCD Monitor (Native)': 'Integrated LCD monitor',
+  'Native LCD Viewfinder': 'Integrated LCD monitor',
+  'LCD Monitor LM-V2 (Supplied)': 'LCD Monitor LM-V2',
+  'Integrated Main Monitor': 'Integrated LCD monitor',
+  'Optional EVF-V70 viewfinder': 'EVF-V70 (Optional)',
+  'Optional EVF-V50': 'EVF-V50 (Optional)',
+  'Optional OLED viewfinder': 'OLED EVF (Optional)',
+  'Blackmagic Pocket Cinema Camera Pro EVF (Optional)': 'Blackmagic Pro EVF (Optional)',
+  'External backlit LCD status display': 'LCD status display',
+  'Built-in Fold-out LCD': 'Fold-out LCD',
+  'OLED LVF (Live View Finder)': 'OLED EVF',
+  'LCD capacitive touchscreen': 'LCD touchscreen',
+  'LEMO 26 pin': 'LEMO 26-pin port'
+};
+
+for (const cam of Object.values(devices.cameras)) {
+  const list = cam.viewfinder;
+  if (Array.isArray(list)) {
+    list.forEach(vf => {
+      if (vf && vf.type && map[vf.type]) {
+        vf.type = map[vf.type];
+      }
+    });
+  }
+}
+
+const content =
+  'let devices=' +
+  JSON.stringify(devices, null, 2) +
+  ';\n' +
+  'if (typeof module !== "undefined" && module.exports) { module.exports = devices; }\n';
+fs.writeFileSync('data.js', content);


### PR DESCRIPTION
## Summary
- add many more mappings for common viewfinder names
- rewrite `data.js` using the updated mapping
- normalize viewfinder names when loading camera data

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687e2e9b63f883208c9ebc1e27b6a4b1