### PR TITLE
Normalize recording media names

### DIFF
--- a/data.js
+++ b/data.js
@@ -417,7 +417,7 @@ let devices={
         }
       ],
       "recordingMedia": [
-        "CFast 2.0 memory cards"
+        "CFast 2.0"
       ],
       "viewfinder": [
         {
@@ -555,7 +555,7 @@ let devices={
       ],
       "recordingMedia": [
         "AXS Memory A-Series slot",
-        "SD card slot"
+        "SD Card"
       ],
       "viewfinder": [
         {
@@ -701,7 +701,7 @@ let devices={
       ],
       "recordingMedia": [
         "AXS Memory A-Series slot",
-        "SD card slot"
+        "SD Card"
       ],
       "viewfinder": [
         {
@@ -1180,7 +1180,7 @@ let devices={
         }
       ],
       "recordingMedia": [
-        "SD CARD X2"
+        "SD Card (Dual Slots)"
       ],
       "viewfinder": [
         {
@@ -1293,8 +1293,8 @@ let devices={
         }
       ],
       "recordingMedia": [
-        "SD Card (SD / SDHC / SDXC)",
-        "Dual SD card slots for simultaneous recording"
+        "SD Card",
+        "SD Card (Dual Slots)"
       ],
       "viewfinder": [
         {
@@ -1382,8 +1382,8 @@ let devices={
         }
       ],
       "recordingMedia": [
-        "Dual CFexpress slots",
-        "SD card slot (for proxy/backup)"
+        "CFexpress Type B (Dual Slots)",
+        "SD Card (for proxy/backup)"
       ],
       "viewfinder": [
         {
@@ -1589,7 +1589,7 @@ let devices={
         }
       ],
       "recordingMedia": [
-        "Dual CFexpress slots"
+        "CFexpress Type B (Dual Slots)"
       ],
       "viewfinder": [
         {
@@ -1672,8 +1672,8 @@ let devices={
         }
       ],
       "recordingMedia": [
-        "CFast card slot",
-        "SD UHS-II card slot",
+        "CFast 2.0",
+        "SD UHS-II",
         "USB-C 3.1 Gen 1 expansion port for external media"
       ],
       "viewfinder": [
@@ -1740,8 +1740,8 @@ let devices={
         }
       ],
       "recordingMedia": [
-        "CFast 2.0 card slot",
-        "SD UHS-II card slot",
+        "CFast 2.0",
+        "SD UHS-II",
         "USB-C 3.1 Gen 1 expansion port for external media"
       ],
       "viewfinder": [
@@ -1820,8 +1820,8 @@ let devices={
         }
       ],
       "recordingMedia": [
-        "CFast card slot",
-        "SD UHS-II card slot",
+        "CFast 2.0",
+        "SD UHS-II",
         "USB-C 3.1 Gen 1 expansion port for external media"
       ],
       "viewfinder": [
@@ -1898,7 +1898,7 @@ let devices={
         }
       ],
       "recordingMedia": [
-        "CFast",
+        "CFast 2.0",
         "SD UHS-II",
         "USB-C to external SSD/HDD"
       ],
@@ -1997,8 +1997,8 @@ let devices={
         }
       ],
       "recordingMedia": [
-        "CFast 2.0 card slots",
-        "SD UHS-II card slots",
+        "CFast 2.0",
+        "SD UHS-II (Dual Slots)",
         "USB-C 3.1 Gen 2 expansion port for external media"
       ],
       "viewfinder": [
@@ -4152,8 +4152,8 @@ let devices={
         }
       ],
       "recordingMedia": [
-        "SD memory card / SDHC memory card / SDXC memory card (UHS-II V90 recommended)",
-        "Dual slot recording function available [P2.1]"
+        "SD UHS-II",
+        "SD UHS-II (Dual Slots)"
       ],
       "viewfinder": [
         {
@@ -4487,7 +4487,7 @@ let devices={
         }
       ],
       "recordingMedia": [
-        "UHS-II SD",
+        "SD UHS-II",
         "CFexpress Type B"
       ],
       "viewfinder": [

--- a/unifyRecordingMedia.js
+++ b/unifyRecordingMedia.js
@@ -1,0 +1,40 @@
+const fs = require('fs');
+const devices = require('./data.js');
+
+const map = {
+  'CFast': 'CFast 2.0',
+  'CFast card slot': 'CFast 2.0',
+  'CFast 2.0 card slot': 'CFast 2.0',
+  'CFast 2.0 card slots': 'CFast 2.0',
+  'CFast 2.0 memory cards': 'CFast 2.0',
+  'Dual CFexpress slots': 'CFexpress Type B (Dual Slots)',
+  'SD CARD X2': 'SD Card (Dual Slots)',
+  'Dual SD card slots for simultaneous recording': 'SD Card (Dual Slots)',
+  'Dual slot recording function available [P2.1]': 'SD UHS-II (Dual Slots)',
+  'SD card slot': 'SD Card',
+  'SD card slot (for proxy/backup)': 'SD Card (for proxy/backup)',
+  'SD Card (SD / SDHC / SDXC)': 'SD Card',
+  'SD memory card / SDHC memory card / SDXC memory card (UHS-II V90 recommended)': 'SD UHS-II',
+  'UHS-II SD': 'SD UHS-II',
+  'SD UHS-II card slot': 'SD UHS-II',
+  'SD UHS-II card slots': 'SD UHS-II (Dual Slots)'
+};
+
+for (const cam of Object.values(devices.cameras)) {
+  const list = cam.recordingMedia;
+  if (Array.isArray(list)) {
+    for (let i = 0; i < list.length; i++) {
+      const val = list[i];
+      if (map[val]) {
+        list[i] = map[val];
+      }
+    }
+  }
+}
+
+const content =
+  'let devices=' +
+  JSON.stringify(devices, null, 2) +
+  ';\n' +
+  'if (typeof module !== "undefined" && module.exports) { module.exports = devices; }\n';
+fs.writeFileSync('data.js', content);


### PR DESCRIPTION
## Summary
- add `unifyRecordingMedia.js` utility to map various recording media labels
- run the script to update `data.js`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687e30b2fd74832088424003bfdcb609