### PR TITLE
Add dropdown for power input port types

### DIFF
--- a/data.js
+++ b/data.js
@@ -5,7 +5,7 @@ let devices={
       "power": {
         "input": {
           "voltageRange": "11V-34V DC",
-          "portType": "LEMO 8-pin (DC In / BAT)",
+          "portType": "Bat LEMO 8-pin",
           "powerDrawWatts": 89
         },
         "batteryPlateSupport": [
@@ -130,7 +130,7 @@ let devices={
       "power": {
         "input": {
           "voltageRange": "11V-34V DC",
-          "portType": "LEMO 8-pin (BAT)",
+          "portType": "Bat LEMO 8-pin",
           "powerDrawWatts": 84
         },
         "batteryPlateSupport": [
@@ -243,7 +243,7 @@ let devices={
       "power": {
         "input": {
           "voltageRange": "19.5V-34V DC",
-          "portType": "BAT (LEMO 8-pin)",
+          "portType": "Bat LEMO 8-pin",
           "powerDrawWatts": 110
         },
         "batteryPlateSupport": [
@@ -354,7 +354,7 @@ let devices={
       "power": {
         "input": {
           "voltageRange": "10.5V - 34V DC",
-          "portType": "XLR 4-pin (main input)",
+          "portType": "XLR 4-pin",
           "powerDrawWatts": 50
         },
         "batteryPlateSupport": [
@@ -455,7 +455,10 @@ let devices={
       "power": {
         "input": {
           "voltageRange": "DC 12 V (11.0 to 17.0 V) / DC 24 V (22.0 to 32.0 V)",
-          "portType": "XLR-type 4 pin (male) / Square-shaped 5 pin connector (Battery)",
+          "portType": [
+            "XLR 4-pin",
+            "Square 5-pin"
+          ],
           "powerDrawWatts": 76
         },
         "batteryPlateSupport": [
@@ -601,7 +604,10 @@ let devices={
       "power": {
         "input": {
           "voltageRange": "DC 12 V (11.0 to 17.0 V) / DC 24 V (22.0 to 32.0 V)",
-          "portType": "XLR-type 4 pin (male) / Square-shaped 5 pin connector (Battery)",
+          "portType": [
+            "XLR 4-pin",
+            "Square 5-pin"
+          ],
           "powerDrawWatts": 60
         },
         "batteryPlateSupport": [
@@ -843,7 +849,10 @@ let devices={
       "power": {
         "input": {
           "voltageRange": "7.2V DC (via NP-FZ100) / 5V DC (via USB-C)",
-          "portType": "USB-C (Power Delivery) / Battery Slot",
+          "portType": [
+            "Battery Slot",
+            "USB-C PD"
+          ],
           "powerDrawWatts": 7.3
         },
         "batteryPlateSupport": [
@@ -1141,7 +1150,7 @@ let devices={
       "power": {
         "input": {
           "voltageRange": "24V DC",
-          "portType": "DC Input",
+          "portType": "DC IN",
           "powerDrawWatts": 14.6
         },
         "batteryPlateSupport": [
@@ -1332,7 +1341,7 @@ let devices={
       "power": {
         "input": {
           "voltageRange": "11.5V - 20V DC",
-          "portType": "XLR 4-pin jack",
+          "portType": "XLR 4-pin",
           "powerDrawWatts": 31
         },
         "batteryPlateSupport": [
@@ -1424,7 +1433,7 @@ let devices={
       "power": {
         "input": {
           "voltageRange": "11.5V-20V DC",
-          "portType": "4-pin XLR / DC IN 12V",
+          "portType": "XLR 4-pin",
           "powerDrawWatts": 32.5
         },
         "batteryPlateSupport": [
@@ -1539,7 +1548,7 @@ let devices={
       "power": {
         "input": {
           "voltageRange": "11.5V - 20V DC",
-          "portType": "XLR 4-pin jack",
+          "portType": "XLR 4-pin",
           "powerDrawWatts": 63
         },
         "batteryPlateSupport": [
@@ -1633,7 +1642,7 @@ let devices={
       "power": {
         "input": {
           "voltageRange": "12V-20V",
-          "portType": "2-pin locking connector",
+          "portType": "LEMO 2-pin",
           "powerDrawWatts": 22
         },
         "batteryPlateSupport": [
@@ -1705,7 +1714,7 @@ let devices={
       "power": {
         "input": {
           "voltageRange": "12V - 20V DC",
-          "portType": "2-pin locking connector",
+          "portType": "LEMO 2-pin",
           "powerDrawWatts": 26
         },
         "batteryPlateSupport": [
@@ -1781,7 +1790,7 @@ let devices={
       "power": {
         "input": {
           "voltageRange": "12V-20V",
-          "portType": "2-pin locking connector",
+          "portType": "LEMO 2-pin",
           "powerDrawWatts": 26
         },
         "batteryPlateSupport": [
@@ -1857,7 +1866,7 @@ let devices={
       "power": {
         "input": {
           "voltageRange": "12V-20V",
-          "portType": "2-pin locking connector / 2-pin LEMO",
+          "portType": "LEMO 2-pin",
           "powerDrawWatts": 26
         },
         "batteryPlateSupport": [
@@ -1940,7 +1949,10 @@ let devices={
       "power": {
         "input": {
           "voltageRange": "12V DC",
-          "portType": "12-pin Molex connector (at battery plate rear) / 4-pin XLR (external power)",
+          "portType": [
+            "Molex 12-pin",
+            "XLR 4-pin"
+          ],
           "powerDrawWatts": 55
         },
         "batteryPlateSupport": [
@@ -2041,7 +2053,7 @@ let devices={
       "power": {
         "input": {
           "voltageRange": "20V-30V DC",
-          "portType": "2-pin XLR",
+          "portType": "XLR 2-pin",
           "powerDrawWatts": 100
         },
         "batteryPlateSupport": [
@@ -2164,7 +2176,7 @@ let devices={
       "power": {
         "input": {
           "voltageRange": "12V-20V DC",
-          "portType": "2-pin locking connector",
+          "portType": "LEMO 2-pin",
           "powerDrawWatts": 60
         },
         "batteryPlateSupport": [
@@ -2231,7 +2243,7 @@ let devices={
       "power": {
         "input": {
           "voltageRange": "12V-20V DC",
-          "portType": "2-pin locking connector",
+          "portType": "LEMO 2-pin",
           "powerDrawWatts": 90
         },
         "batteryPlateSupport": [
@@ -2298,7 +2310,7 @@ let devices={
       "power": {
         "input": {
           "voltageRange": "+7 to +17 V DC",
-          "portType": "2-pin DC-Input",
+          "portType": "2-pin DC-IN",
           "powerDrawWatts": 37
         },
         "batteryPlateSupport": [
@@ -2395,7 +2407,7 @@ let devices={
       "power": {
         "input": {
           "voltageRange": "+7 to +17 V DC",
-          "portType": "2-pin DC-Input",
+          "portType": "2-pin DC-IN",
           "powerDrawWatts": 45
         },
         "batteryPlateSupport": [
@@ -2466,7 +2478,7 @@ let devices={
       "power": {
         "input": {
           "voltageRange": "24V DC",
-          "portType": "4-pin XLR / V-Lock",
+          "portType": "XLR 4-pin",
           "powerDrawWatts": 75
         },
         "batteryPlateSupport": [
@@ -2569,7 +2581,7 @@ let devices={
       "power": {
         "input": {
           "voltageRange": "24V DC",
-          "portType": "4-pin XLR / V-Lock",
+          "portType": "XLR 4-pin",
           "powerDrawWatts": 75
         },
         "batteryPlateSupport": [
@@ -2672,7 +2684,7 @@ let devices={
       "power": {
         "input": {
           "voltageRange": "24V DC",
-          "portType": "4-pin XLR / V-Lock",
+          "portType": "XLR 4-pin",
           "powerDrawWatts": 75
         },
         "batteryPlateSupport": [
@@ -2775,7 +2787,7 @@ let devices={
       "power": {
         "input": {
           "voltageRange": "24V DC",
-          "portType": "4-pin XLR / V-Lock",
+          "portType": "XLR 4-pin",
           "powerDrawWatts": 75
         },
         "batteryPlateSupport": [
@@ -3631,7 +3643,10 @@ let devices={
       "power": {
         "input": {
           "voltageRange": "8.4V DC (battery) / 9V DC (USB-C PD)",
-          "portType": "Battery Slot / USB-C PD",
+          "portType": [
+            "Battery Slot",
+            "USB-C PD"
+          ],
           "powerDrawWatts": 27
         },
         "batteryPlateSupport": [
@@ -3700,7 +3715,10 @@ let devices={
       "power": {
         "input": {
           "voltageRange": "9.0V DC (battery) / 9V DC (USB-C PD)",
-          "portType": "Battery Slot / USB-C PD",
+          "portType": [
+            "Battery Slot",
+            "USB-C PD"
+          ],
           "powerDrawWatts": 27
         },
         "batteryPlateSupport": [
@@ -3770,7 +3788,10 @@ let devices={
       "power": {
         "input": {
           "voltageRange": "7.2V DC (battery) / 9V DC (USB-C PD)",
-          "portType": "Battery Slot / USB-C PD",
+          "portType": [
+            "Battery Slot",
+            "USB-C PD"
+          ],
           "powerDrawWatts": 27
         },
         "batteryPlateSupport": [
@@ -3845,7 +3866,10 @@ let devices={
       "power": {
         "input": {
           "voltageRange": "7.2V (battery) / 5V DC (USB-C PD)",
-          "portType": "Battery Slot / USB-C PD",
+          "portType": [
+            "Battery Slot",
+            "USB-C PD"
+          ],
           "powerDrawWatts": 15
         },
         "batteryPlateSupport": [
@@ -3915,7 +3939,10 @@ let devices={
       "power": {
         "input": {
           "voltageRange": "DC 12-30V",
-          "portType": "6-pin 1B DC-IN / TB50 Battery Mount",
+          "portType": [
+            "6-pin 1B DC-IN",
+            "TB50"
+          ],
           "powerDrawWatts": 40
         },
         "batteryPlateSupport": [
@@ -4033,7 +4060,10 @@ let devices={
       "power": {
         "input": {
           "voltageRange": "7.2V DC (battery) / 9V DC (USB-C PD)",
-          "portType": "Battery Slot / USB Type-C®",
+          "portType": [
+            "Battery Slot",
+            "USB-C"
+          ],
           "powerDrawWatts": 5.6
         },
         "batteryPlateSupport": [
@@ -4110,7 +4140,10 @@ let devices={
       "power": {
         "input": {
           "voltageRange": "12V DC (11.4V to 12.6V)",
-          "portType": "Weipu SF610/S2 (12VDC) Input",
+          "portType": [
+            "Weipu SF610",
+            "S2"
+          ],
           "powerDrawWatts": 8.1
         },
         "batteryPlateSupport": [
@@ -4179,7 +4212,10 @@ let devices={
       "power": {
         "input": {
           "voltageRange": "7.2V DC (battery) / 5V DC (USB-C PD)",
-          "portType": "Battery Slot / USB Type-C®",
+          "portType": [
+            "Battery Slot",
+            "USB-C"
+          ],
           "powerDrawWatts": 7
         },
         "batteryPlateSupport": [
@@ -4238,7 +4274,10 @@ let devices={
       "power": {
         "input": {
           "voltageRange": "7.2V (battery) / USB-C",
-          "portType": "Battery Slot / USB-C",
+          "portType": [
+            "Battery Slot",
+            "USB-C"
+          ],
           "powerDrawWatts": 5.5
         },
         "batteryPlateSupport": [
@@ -4305,7 +4344,10 @@ let devices={
       "power": {
         "input": {
           "voltageRange": "7.2V (LP-E6P) / USB-C PD (45W+ recommended)",
-          "portType": "Battery Slot / USB-C PD",
+          "portType": [
+            "Battery Slot",
+            "USB-C PD"
+          ],
           "powerDrawWatts": 15
         },
         "batteryPlateSupport": [
@@ -4378,7 +4420,10 @@ let devices={
       "power": {
         "input": {
           "voltageRange": "7.2V (LP-E19) / USB-C PD",
-          "portType": "Battery Slot / USB-C PD",
+          "portType": [
+            "Battery Slot",
+            "USB-C PD"
+          ],
           "powerDrawWatts": 18
         },
         "batteryPlateSupport": [
@@ -4447,7 +4492,10 @@ let devices={
       "power": {
         "input": {
           "voltageRange": "7.2V (battery) / USB-C",
-          "portType": "Battery Slot / USB-C",
+          "portType": [
+            "Battery Slot",
+            "USB-C"
+          ],
           "powerDrawWatts": 10
         },
         "batteryPlateSupport": [

--- a/index.html
+++ b/index.html
@@ -185,7 +185,7 @@
         </div>
         <div class="form-row">
           <label for="cameraPortType" id="cameraPortTypeLabel">Port Type:</label>
-          <input type="text" id="cameraPortType" />
+          <select id="cameraPortType"></select>
         </div>
         <div class="form-row">
           <label id="cameraPlatesLabel">Battery Plates:</label>

--- a/unifyPowerInputPortTypes.js
+++ b/unifyPowerInputPortTypes.js
@@ -1,0 +1,41 @@
+const fs = require('fs');
+const devices = require('./data.js');
+
+const map = {
+  'LEMO 8-pin (DC In / BAT)': 'Bat LEMO 8-pin',
+  'LEMO 8-pin (BAT)': 'Bat LEMO 8-pin',
+  'BAT (LEMO 8-pin)': 'Bat LEMO 8-pin',
+  'LEMO 8-pin': 'Bat LEMO 8-pin',
+  '2-pin DC-Input': '2-pin DC-IN',
+  '2-pin XLR': 'XLR 2-pin',
+  '2-pin locking connector': 'LEMO 2-pin',
+  '2-pin locking connector / 2-pin LEMO': 'LEMO 2-pin',
+  '4-pin XLR / DC IN 12V': 'XLR 4-pin',
+  '4-pin XLR / V-Lock': 'XLR 4-pin',
+  'XLR 4-pin jack': 'XLR 4-pin',
+  'XLR 4-pin (main input)': 'XLR 4-pin',
+  'XLR-type 4 pin (male) / Square-shaped 5 pin connector (Battery)': 'XLR 4-pin / Square 5-pin',
+  '12-pin Molex connector (at battery plate rear) / 4-pin XLR (external power)': 'Molex 12-pin / XLR 4-pin',
+  'USB-C (Power Delivery) / Battery Slot': 'Battery Slot / USB-C PD',
+  'Battery Slot / USB Type-C®': 'Battery Slot / USB-C',
+  'Battery Slot / USB-C': 'Battery Slot / USB-C',
+  'Battery Slot / USB-C PD': 'Battery Slot / USB-C PD',
+  'DC Input': 'DC IN',
+  'Weipu SF610/S2 (12VDC) Input': 'Weipu SF610/S2',
+  '6-pin 1B DC-IN / TB50 Battery Mount': '6-pin 1B DC-IN / TB50'
+};
+
+for (const cam of Object.values(devices.cameras)) {
+  const input = cam.power?.input;
+  if (!input || !input.portType) continue;
+  const original = input.portType;
+  const arr = ([]).concat(original).flatMap(val => {
+    const mapped = map[val] || val;
+    return mapped.split('/').map(p => map[p.trim()] || p.trim());
+  });
+  input.portType = arr.length > 1 ? arr : arr[0];
+}
+
+const content = 'let devices=' + JSON.stringify(devices, null, 2) + ';\n' +
+  'if (typeof module !== "undefined" && module.exports) { module.exports = devices; }\n';
+fs.writeFileSync('data.js', content);


### PR DESCRIPTION
## Summary
- unify power port type names and map 'LEMO 8-pin' to 'Bat LEMO 8-pin'
- split combined port type strings into arrays
- refresh dropdown options from new power input types
- support cameras with multiple power input port types

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687e327922ec83208d60059871588a90