### PR TITLE
Fix FIZ connectors

### DIFF
--- a/data.js
+++ b/data.js
@@ -1214,10 +1214,6 @@ let devices={
       ],
       "fizConnectors": [
         {
-          "type": "Canon RF mount",
-          "notes": "For electronic lens control (iris, focus, zoom) on compatible lenses"
-        },
-        {
           "type": "REMOTE A connector",
           "notes": "2.5 mm stereo mini-mini jack (input only)"
         }


### PR DESCRIPTION
## Summary
- remove Canon RF mount from Canon C70 FIZ connectors

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687e3a1151c08320b097617409f6a6d5