### PR TITLE
Unify recording media representation

### DIFF
--- a/data.js
+++ b/data.js
@@ -67,7 +67,10 @@ let devices={
         }
       ],
       "recordingMedia": [
-        "Codex Compact Drive (1TB, 2TB)"
+        {
+          "type": "Codex Compact Drive",
+          "notes": "1TB, 2TB"
+        }
       ],
       "viewfinder": [
         {
@@ -201,7 +204,10 @@ let devices={
         }
       ],
       "recordingMedia": [
-        "CFast 2.0"
+        {
+          "type": "CFast 2.0",
+          "notes": ""
+        }
       ],
       "viewfinder": [
         {
@@ -321,7 +327,10 @@ let devices={
         }
       ],
       "recordingMedia": [
-        "Codex Compact Drive (1TB, 2TB)"
+        {
+          "type": "Codex Compact Drive",
+          "notes": "1TB, 2TB"
+        }
       ],
       "viewfinder": [
         {
@@ -435,7 +444,10 @@ let devices={
         }
       ],
       "recordingMedia": [
-        "CFast 2.0"
+        {
+          "type": "CFast 2.0",
+          "notes": ""
+        }
       ],
       "viewfinder": [
         {
@@ -579,8 +591,14 @@ let devices={
         }
       ],
       "recordingMedia": [
-        "AXS Memory A-Series slot",
-        "SD Card"
+        {
+          "type": "AXS Memory A-Series slot",
+          "notes": ""
+        },
+        {
+          "type": "SD Card",
+          "notes": ""
+        }
       ],
       "viewfinder": [
         {
@@ -733,8 +751,14 @@ let devices={
         }
       ],
       "recordingMedia": [
-        "AXS Memory A-Series slot",
-        "SD Card"
+        {
+          "type": "AXS Memory A-Series slot",
+          "notes": ""
+        },
+        {
+          "type": "SD Card",
+          "notes": ""
+        }
       ],
       "viewfinder": [
         {
@@ -842,7 +866,10 @@ let devices={
         }
       ],
       "recordingMedia": [
-        "CFexpress Type B"
+        {
+          "type": "CFexpress Type B",
+          "notes": ""
+        }
       ],
       "viewfinder": [
         {
@@ -934,8 +961,14 @@ let devices={
         }
       ],
       "recordingMedia": [
-        "CFexpress Type A",
-        "SD (UHS-II/UHS-I)"
+        {
+          "type": "CFexpress Type A",
+          "notes": ""
+        },
+        {
+          "type": "SD",
+          "notes": "UHS-II/UHS-I"
+        }
       ],
       "viewfinder": [
         {
@@ -1044,8 +1077,14 @@ let devices={
         }
       ],
       "recordingMedia": [
-        "CFexpress Type A",
-        "SD (UHS-II/UHS-I)"
+        {
+          "type": "CFexpress Type A",
+          "notes": ""
+        },
+        {
+          "type": "SD",
+          "notes": "UHS-II/UHS-I"
+        }
       ],
       "viewfinder": [
         {
@@ -1146,8 +1185,14 @@ let devices={
         }
       ],
       "recordingMedia": [
-        "XQD Card",
-        "SD Card (for proxy/backup)"
+        {
+          "type": "XQD Card",
+          "notes": ""
+        },
+        {
+          "type": "SD Card",
+          "notes": "for proxy/backup"
+        }
       ],
       "viewfinder": [
         {
@@ -1223,7 +1268,10 @@ let devices={
         }
       ],
       "recordingMedia": [
-        "SD Card (Dual Slots)"
+        {
+          "type": "SD Card",
+          "notes": "Dual Slots"
+        }
       ],
       "viewfinder": [
         {
@@ -1338,8 +1386,14 @@ let devices={
         }
       ],
       "recordingMedia": [
-        "SD Card",
-        "SD Card (Dual Slots)"
+        {
+          "type": "SD Card",
+          "notes": ""
+        },
+        {
+          "type": "SD Card",
+          "notes": "Dual Slots"
+        }
       ],
       "viewfinder": [
         {
@@ -1431,8 +1485,14 @@ let devices={
         }
       ],
       "recordingMedia": [
-        "CFexpress Type B (Dual Slots)",
-        "SD Card (for proxy/backup)"
+        {
+          "type": "CFexpress Type B",
+          "notes": "Dual Slots"
+        },
+        {
+          "type": "SD Card",
+          "notes": "for proxy/backup"
+        }
       ],
       "viewfinder": [
         {
@@ -1535,8 +1595,14 @@ let devices={
         }
       ],
       "recordingMedia": [
-        "CFexpress Type B",
-        "SD UHS-II"
+        {
+          "type": "CFexpress Type B",
+          "notes": ""
+        },
+        {
+          "type": "SD Card",
+          "notes": "UHS-II"
+        }
       ],
       "viewfinder": [
         {
@@ -1648,7 +1714,10 @@ let devices={
         }
       ],
       "recordingMedia": [
-        "CFexpress Type B (Dual Slots)"
+        {
+          "type": "CFexpress Type B",
+          "notes": "Dual Slots"
+        }
       ],
       "viewfinder": [
         {
@@ -1734,9 +1803,18 @@ let devices={
         }
       ],
       "recordingMedia": [
-        "CFast 2.0",
-        "SD UHS-II",
-        "USB-C 3.1 Gen 1 expansion port for external media"
+        {
+          "type": "CFast 2.0",
+          "notes": ""
+        },
+        {
+          "type": "SD Card",
+          "notes": "UHS-II"
+        },
+        {
+          "type": "USB-C 3.1 Gen 1 expansion port for external media",
+          "notes": ""
+        }
       ],
       "viewfinder": [
         {
@@ -1799,9 +1877,18 @@ let devices={
         }
       ],
       "recordingMedia": [
-        "CFast 2.0",
-        "SD UHS-II",
-        "USB-C 3.1 Gen 1 expansion port for external media"
+        {
+          "type": "CFast 2.0",
+          "notes": ""
+        },
+        {
+          "type": "SD Card",
+          "notes": "UHS-II"
+        },
+        {
+          "type": "USB-C 3.1 Gen 1 expansion port for external media",
+          "notes": ""
+        }
       ],
       "viewfinder": [
         {
@@ -1877,9 +1964,18 @@ let devices={
         }
       ],
       "recordingMedia": [
-        "CFast 2.0",
-        "SD UHS-II",
-        "USB-C 3.1 Gen 1 expansion port for external media"
+        {
+          "type": "CFast 2.0",
+          "notes": ""
+        },
+        {
+          "type": "SD Card",
+          "notes": "UHS-II"
+        },
+        {
+          "type": "USB-C 3.1 Gen 1 expansion port for external media",
+          "notes": ""
+        }
       ],
       "viewfinder": [
         {
@@ -1953,9 +2049,18 @@ let devices={
         }
       ],
       "recordingMedia": [
-        "CFast 2.0",
-        "SD UHS-II",
-        "USB-C to external SSD/HDD"
+        {
+          "type": "CFast 2.0",
+          "notes": ""
+        },
+        {
+          "type": "SD Card",
+          "notes": "UHS-II"
+        },
+        {
+          "type": "USB-C to external SSD/HDD",
+          "notes": ""
+        }
       ],
       "viewfinder": [
         {
@@ -2053,9 +2158,18 @@ let devices={
         }
       ],
       "recordingMedia": [
-        "CFast 2.0",
-        "SD UHS-II (Dual Slots)",
-        "USB-C 3.1 Gen 2 expansion port for external media"
+        {
+          "type": "CFast 2.0",
+          "notes": ""
+        },
+        {
+          "type": "SD Card",
+          "notes": "Dual Slots; UHS-II"
+        },
+        {
+          "type": "USB-C 3.1 Gen 2 expansion port for external media",
+          "notes": ""
+        }
       ],
       "viewfinder": [
         {
@@ -2176,8 +2290,14 @@ let devices={
         }
       ],
       "recordingMedia": [
-        "Blackmagic Media Module (8TB)",
-        "CFexpress Type B (via adapter)"
+        {
+          "type": "Blackmagic Media Module",
+          "notes": "8TB"
+        },
+        {
+          "type": "CFexpress Type B",
+          "notes": "via adapter"
+        }
       ],
       "viewfinder": [
         {
@@ -2262,8 +2382,14 @@ let devices={
         }
       ],
       "recordingMedia": [
-        "CFexpress Type B",
-        "USB-C to external SSD/HDD"
+        {
+          "type": "CFexpress Type B",
+          "notes": ""
+        },
+        {
+          "type": "USB-C to external SSD/HDD",
+          "notes": ""
+        }
       ],
       "viewfinder": [
         {
@@ -2330,8 +2456,14 @@ let devices={
         }
       ],
       "recordingMedia": [
-        "CFexpress Type B",
-        "USB-C to external SSD/HDD"
+        {
+          "type": "CFexpress Type B",
+          "notes": ""
+        },
+        {
+          "type": "USB-C to external SSD/HDD",
+          "notes": ""
+        }
       ],
       "viewfinder": [
         {
@@ -2418,7 +2550,10 @@ let devices={
         }
       ],
       "recordingMedia": [
-        "CFast 2.0"
+        {
+          "type": "CFast 2.0",
+          "notes": ""
+        }
       ],
       "viewfinder": [
         {
@@ -2501,7 +2636,10 @@ let devices={
         }
       ],
       "recordingMedia": [
-        "CFexpress Type B"
+        {
+          "type": "CFexpress Type B",
+          "notes": ""
+        }
       ],
       "viewfinder": [
         {
@@ -2605,7 +2743,10 @@ let devices={
         }
       ],
       "recordingMedia": [
-        "CFexpress Type B"
+        {
+          "type": "CFexpress Type B",
+          "notes": ""
+        }
       ],
       "viewfinder": [
         {
@@ -2710,7 +2851,10 @@ let devices={
         }
       ],
       "recordingMedia": [
-        "CFexpress Type B"
+        {
+          "type": "CFexpress Type B",
+          "notes": ""
+        }
       ],
       "viewfinder": [
         {
@@ -2815,7 +2959,10 @@ let devices={
         }
       ],
       "recordingMedia": [
-        "CFexpress Type B"
+        {
+          "type": "CFexpress Type B",
+          "notes": ""
+        }
       ],
       "viewfinder": [
         {
@@ -2920,7 +3067,10 @@ let devices={
         }
       ],
       "recordingMedia": [
-        "CFexpress Type B"
+        {
+          "type": "CFexpress Type B",
+          "notes": ""
+        }
       ],
       "viewfinder": [
         {
@@ -2993,7 +3143,10 @@ let devices={
         }
       ],
       "recordingMedia": [
-        "CFexpress Type B"
+        {
+          "type": "CFexpress Type B",
+          "notes": ""
+        }
       ],
       "viewfinder": [
         {
@@ -3066,7 +3219,10 @@ let devices={
         }
       ],
       "recordingMedia": [
-        "CFexpress Type B"
+        {
+          "type": "CFexpress Type B",
+          "notes": ""
+        }
       ],
       "viewfinder": [
         {
@@ -3139,7 +3295,10 @@ let devices={
         }
       ],
       "recordingMedia": [
-        "CFexpress Type B"
+        {
+          "type": "CFexpress Type B",
+          "notes": ""
+        }
       ],
       "viewfinder": [
         {
@@ -3212,7 +3371,10 @@ let devices={
         }
       ],
       "recordingMedia": [
-        "CFexpress Type B"
+        {
+          "type": "CFexpress Type B",
+          "notes": ""
+        }
       ],
       "viewfinder": [
         {
@@ -3281,7 +3443,10 @@ let devices={
         }
       ],
       "recordingMedia": [
-        "RED MINI-MAG"
+        {
+          "type": "RED MINI-MAG",
+          "notes": ""
+        }
       ],
       "viewfinder": [
         {
@@ -3350,7 +3515,10 @@ let devices={
         }
       ],
       "recordingMedia": [
-        "RED MINI-MAG"
+        {
+          "type": "RED MINI-MAG",
+          "notes": ""
+        }
       ],
       "viewfinder": [
         {
@@ -3419,7 +3587,10 @@ let devices={
         }
       ],
       "recordingMedia": [
-        "RED MINI-MAG"
+        {
+          "type": "RED MINI-MAG",
+          "notes": ""
+        }
       ],
       "viewfinder": [
         {
@@ -3488,7 +3659,10 @@ let devices={
         }
       ],
       "recordingMedia": [
-        "REDMAG 1.8\" SSD"
+        {
+          "type": "REDMAG 1.8\" SSD",
+          "notes": ""
+        }
       ],
       "viewfinder": [
         {
@@ -3557,7 +3731,10 @@ let devices={
         }
       ],
       "recordingMedia": [
-        "REDMAG 1.8\" SSD"
+        {
+          "type": "REDMAG 1.8\" SSD",
+          "notes": ""
+        }
       ],
       "viewfinder": [
         {
@@ -3626,7 +3803,10 @@ let devices={
         }
       ],
       "recordingMedia": [
-        "REDMAG 1.8\" SSD"
+        {
+          "type": "REDMAG 1.8\" SSD",
+          "notes": ""
+        }
       ],
       "viewfinder": [
         {
@@ -3695,7 +3875,10 @@ let devices={
         }
       ],
       "recordingMedia": [
-        "REDMAG 1.8\" SSD"
+        {
+          "type": "REDMAG 1.8\" SSD",
+          "notes": ""
+        }
       ],
       "viewfinder": [
         {
@@ -3772,7 +3955,10 @@ let devices={
         }
       ],
       "recordingMedia": [
-        "SD UHS-II"
+        {
+          "type": "SD Card",
+          "notes": "UHS-II"
+        }
       ],
       "viewfinder": [
         {
@@ -3845,8 +4031,14 @@ let devices={
         }
       ],
       "recordingMedia": [
-        "CFexpress Type B",
-        "SD UHS-II"
+        {
+          "type": "CFexpress Type B",
+          "notes": ""
+        },
+        {
+          "type": "SD Card",
+          "notes": "UHS-II"
+        }
       ],
       "viewfinder": [
         {
@@ -3919,8 +4111,14 @@ let devices={
         }
       ],
       "recordingMedia": [
-        "CFexpress Type A",
-        "SD (UHS-II/UHS-I)"
+        {
+          "type": "CFexpress Type A",
+          "notes": ""
+        },
+        {
+          "type": "SD",
+          "notes": "UHS-II/UHS-I"
+        }
       ],
       "viewfinder": [
         {
@@ -3993,8 +4191,14 @@ let devices={
         }
       ],
       "recordingMedia": [
-        "CFexpress Type B",
-        "SD UHS-II"
+        {
+          "type": "CFexpress Type B",
+          "notes": ""
+        },
+        {
+          "type": "SD Card",
+          "notes": "UHS-II"
+        }
       ],
       "viewfinder": [
         {
@@ -4108,8 +4312,14 @@ let devices={
         }
       ],
       "recordingMedia": [
-        "DJI PROSSD",
-        "CFexpress Type B (via adapter)"
+        {
+          "type": "DJI PROSSD",
+          "notes": ""
+        },
+        {
+          "type": "CFexpress Type B",
+          "notes": "via adapter"
+        }
       ],
       "viewfinder": [
         {
@@ -4196,8 +4406,14 @@ let devices={
         }
       ],
       "recordingMedia": [
-        "CFexpress Type A",
-        "SD (UHS-II/UHS-I)"
+        {
+          "type": "CFexpress Type A",
+          "notes": ""
+        },
+        {
+          "type": "SD",
+          "notes": "UHS-II/UHS-I"
+        }
       ],
       "viewfinder": [
         {
@@ -4271,8 +4487,14 @@ let devices={
         }
       ],
       "recordingMedia": [
-        "SD UHS-II",
-        "SD UHS-II (Dual Slots)"
+        {
+          "type": "SD Card",
+          "notes": "UHS-II"
+        },
+        {
+          "type": "SD Card",
+          "notes": "Dual Slots; UHS-II"
+        }
       ],
       "viewfinder": [
         {
@@ -4338,7 +4560,10 @@ let devices={
         }
       ],
       "recordingMedia": [
-        "SD (UHS-II/UHS-I)"
+        {
+          "type": "SD",
+          "notes": "UHS-II/UHS-I"
+        }
       ],
       "viewfinder": [
         {
@@ -4405,7 +4630,10 @@ let devices={
         }
       ],
       "recordingMedia": [
-        "SDXC (UHS-I)"
+        {
+          "type": "SDXC",
+          "notes": "UHS-I"
+        }
       ],
       "viewfinder": [
         {
@@ -4477,8 +4705,14 @@ let devices={
         }
       ],
       "recordingMedia": [
-        "CFexpress Type B",
-        "SD UHS-II"
+        {
+          "type": "CFexpress Type B",
+          "notes": ""
+        },
+        {
+          "type": "SD Card",
+          "notes": "UHS-II"
+        }
       ],
       "viewfinder": [
         {
@@ -4554,7 +4788,10 @@ let devices={
         }
       ],
       "recordingMedia": [
-        "CFexpress Type B (Dual Slots)"
+        {
+          "type": "CFexpress Type B",
+          "notes": "Dual Slots"
+        }
       ],
       "viewfinder": [
         {
@@ -4628,8 +4865,14 @@ let devices={
         }
       ],
       "recordingMedia": [
-        "SD UHS-II",
-        "CFexpress Type B"
+        {
+          "type": "SD Card",
+          "notes": "UHS-II"
+        },
+        {
+          "type": "CFexpress Type B",
+          "notes": ""
+        }
       ],
       "viewfinder": [
         {

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -152,6 +152,42 @@ describe('script.js functions', () => {
     ]);
   });
 
+  test('unifyDevices normalizes recordingMedia', () => {
+    jest.resetModules();
+
+    const html = fs.readFileSync(path.join(__dirname, '../index.html'), 'utf8');
+    const body = html.split('<body>')[1].split('</body>')[0];
+    document.body.innerHTML = body;
+
+    global.devices = {
+      cameras: {
+        CamD: {
+          powerDrawWatts: 5,
+          recordingMedia: ['SD UHS-II', 'CFexpress Type B (Dual Slots)']
+        }
+      },
+      monitors: {},
+      video: {},
+      fiz: { motors: {}, controllers: {}, distance: {} },
+      batteries: {}
+    };
+
+    global.loadDeviceData = jest.fn(() => null);
+    global.saveDeviceData = jest.fn();
+    global.loadSetups = jest.fn(() => ({}));
+    global.saveSetups = jest.fn();
+    global.saveSetup = jest.fn();
+    global.loadSetup = jest.fn();
+    global.deleteSetup = jest.fn();
+
+    script = require('../script.js');
+
+    expect(global.devices.cameras.CamD.recordingMedia).toEqual([
+      { type: 'SD Card', notes: 'UHS-II' },
+      { type: 'CFexpress Type B', notes: 'Dual Slots' }
+    ]);
+  });
+
   test('setBatteryPlates and getBatteryPlates roundtrip', () => {
     const { setBatteryPlates, getBatteryPlates } = script;
     setBatteryPlates([
@@ -164,6 +200,21 @@ describe('script.js functions', () => {
     expect(list).toEqual([
       { type: 'V-Mount', mount: 'native', notes: 'Main' },
       { type: 'Gold', mount: 'adapted', notes: '' }
+    ]);
+  });
+
+  test('setRecordingMedia and getRecordingMedia roundtrip', () => {
+    const { setRecordingMedia, getRecordingMedia } = script;
+    setRecordingMedia([
+      { type: 'SD Card', notes: 'UHS-II' },
+      { type: 'CFexpress Type B', notes: 'Dual Slots' }
+    ]);
+    const rows = document.querySelectorAll('#cameraMediaContainer .form-row');
+    expect(rows.length).toBe(2);
+    const list = getRecordingMedia();
+    expect(list).toEqual([
+      { type: 'SD Card', notes: 'UHS-II' },
+      { type: 'CFexpress Type B', notes: 'Dual Slots' }
     ]);
   });
 

--- a/unifyRecordingMedia.js
+++ b/unifyRecordingMedia.js
@@ -2,33 +2,60 @@ const fs = require('fs');
 const devices = require('./data.js');
 
 const map = {
-  'CFast': 'CFast 2.0',
-  'CFast card slot': 'CFast 2.0',
-  'CFast 2.0 card slot': 'CFast 2.0',
-  'CFast 2.0 card slots': 'CFast 2.0',
-  'CFast 2.0 memory cards': 'CFast 2.0',
-  'Dual CFexpress slots': 'CFexpress Type B (Dual Slots)',
-  'SD CARD X2': 'SD Card (Dual Slots)',
-  'Dual SD card slots for simultaneous recording': 'SD Card (Dual Slots)',
-  'Dual slot recording function available [P2.1]': 'SD UHS-II (Dual Slots)',
-  'SD card slot': 'SD Card',
-  'SD card slot (for proxy/backup)': 'SD Card (for proxy/backup)',
-  'SD Card (SD / SDHC / SDXC)': 'SD Card',
-  'SD memory card / SDHC memory card / SDXC memory card (UHS-II V90 recommended)': 'SD UHS-II',
-  'UHS-II SD': 'SD UHS-II',
-  'SD UHS-II card slot': 'SD UHS-II',
-  'SD UHS-II card slots': 'SD UHS-II (Dual Slots)'
+  'CFast': { type: 'CFast 2.0', notes: '' },
+  'CFast card slot': { type: 'CFast 2.0', notes: '' },
+  'CFast 2.0 card slot': { type: 'CFast 2.0', notes: '' },
+  'CFast 2.0 card slots': { type: 'CFast 2.0', notes: 'Dual Slots' },
+  'CFast 2.0 memory cards': { type: 'CFast 2.0', notes: '' },
+  'Dual CFexpress slots': { type: 'CFexpress Type B', notes: 'Dual Slots' },
+  'SD CARD X2': { type: 'SD Card', notes: 'Dual Slots' },
+  'Dual SD card slots for simultaneous recording': { type: 'SD Card', notes: 'Dual Slots' },
+  'Dual slot recording function available [P2.1]': { type: 'SD Card', notes: 'UHS-II (Dual Slots)' },
+  'SD card slot': { type: 'SD Card', notes: '' },
+  'SD card slot (for proxy/backup)': { type: 'SD Card', notes: 'for proxy/backup' },
+  'SD Card (SD / SDHC / SDXC)': { type: 'SD Card', notes: '' },
+  'SD memory card / SDHC memory card / SDXC memory card (UHS-II V90 recommended)': { type: 'SD Card', notes: 'UHS-II V90 recommended' },
+  'UHS-II SD': { type: 'SD Card', notes: 'UHS-II' },
+  'SD UHS-II card slot': { type: 'SD Card', notes: 'UHS-II' },
+  'SD UHS-II card slots': { type: 'SD Card', notes: 'UHS-II (Dual Slots)' },
+  'CFexpress Type B (Dual Slots)': { type: 'CFexpress Type B', notes: 'Dual Slots' },
+  'CFexpress Type B (via adapter)': { type: 'CFexpress Type B', notes: 'via adapter' }
 };
+
+function normalize(item) {
+  if (!item) return null;
+  if (typeof item === 'object' && item.type) {
+    return { type: item.type, notes: item.notes || '' };
+  }
+  if (map[item]) return map[item];
+  const m = String(item).match(/^(.*?)(?:\((.*)\))?$/);
+  let type = m ? m[1].trim() : String(item);
+  let notes = m && m[2] ? m[2].trim() : '';
+  if (/^SD UHS-II$/i.test(type)) {
+    type = 'SD Card';
+    notes = notes ? `${notes}; UHS-II` : 'UHS-II';
+  } else if (/^SD \(UHS-II\/UHS-I\)$/i.test(type)) {
+    type = 'SD Card';
+    notes = 'UHS-II/UHS-I';
+  }
+  return { type, notes };
+}
 
 for (const cam of Object.values(devices.cameras)) {
   const list = cam.recordingMedia;
   if (Array.isArray(list)) {
-    for (let i = 0; i < list.length; i++) {
-      const val = list[i];
-      if (map[val]) {
-        list[i] = map[val];
+    const result = [];
+    const seen = new Set();
+    for (const val of list) {
+      const item = normalize(val);
+      if (!item) continue;
+      const key = `${item.type}|${item.notes}`;
+      if (!seen.has(key)) {
+        seen.add(key);
+        result.push(item);
       }
     }
+    cam.recordingMedia = result;
   }
 }
 


### PR DESCRIPTION
## Summary
- store recording media as objects with notes
- normalise media entries via new `unifyRecordingMedia.js`
- support new format in `script.js` and update placeholders
- test set/get helpers for recording media

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687e3aad10648320bf8028f78b57d554