### PR TITLE
Fix edit page responsiveness

### DIFF
--- a/style.css
+++ b/style.css
@@ -37,6 +37,7 @@ p {
   display: flex;
   align-items: center;
   margin: 5px 0;
+  flex-wrap: wrap; /* allow inputs to wrap on smaller screens */
 }
 .form-row label {
   width: 150px;
@@ -70,6 +71,7 @@ p {
   flex-direction: column;
   flex: 1;
   margin-right: 5px;
+  min-width: 150px; /* prevent fields from becoming too narrow */
 }
 .field-with-label::before {
   content: attr(data-label);


### PR DESCRIPTION
## Summary
- allow form rows in edit page to wrap
- prevent edit field columns from becoming too narrow

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687e3d4d7f348320b72c5f9102b9b790