### PR TITLE
Add dropdown options for FIZ devices

### DIFF
--- a/index.html
+++ b/index.html
@@ -325,7 +325,7 @@
     <div id="motorFields" style="display:none;">
       <div class="form-row">
         <label for="motorConnector" id="motorConnectorLabel">Connector:</label>
-        <input type="text" id="motorConnector" />
+        <select id="motorConnector"></select>
       </div>
       <div class="form-row">
         <label for="motorInternal" id="motorInternalLabel">Internal Controller:</label>
@@ -347,19 +347,19 @@
     <div id="controllerFields" style="display:none;">
       <div class="form-row">
         <label for="controllerConnector" id="controllerConnectorLabel">Connector:</label>
-        <input type="text" id="controllerConnector" />
+        <select id="controllerConnector"></select>
       </div>
       <div class="form-row">
         <label for="controllerPower" id="controllerPowerLabel">Power Source:</label>
-        <input type="text" id="controllerPower" />
+        <select id="controllerPower"></select>
       </div>
       <div class="form-row">
         <label for="controllerBattery" id="controllerBatteryLabel">Battery Type:</label>
-        <input type="text" id="controllerBattery" />
+        <select id="controllerBattery"></select>
       </div>
       <div class="form-row">
         <label for="controllerConnectivity" id="controllerConnectivityLabel">Connectivity:</label>
-        <input type="text" id="controllerConnectivity" />
+        <select id="controllerConnectivity"></select>
       </div>
       <div class="form-row">
         <label for="controllerNotes" id="notesLabel">Notes:</label>
@@ -369,11 +369,11 @@
     <div id="distanceFields" style="display:none;">
       <div class="form-row">
         <label for="distanceConnection" id="distanceConnectionLabel">Connection:</label>
-        <input type="text" id="distanceConnection" />
+        <select id="distanceConnection"></select>
       </div>
       <div class="form-row">
         <label for="distanceMethod" id="distanceMethodLabel">Method:</label>
-        <input type="text" id="distanceMethod" />
+        <select id="distanceMethod"></select>
       </div>
       <div class="form-row">
         <label for="distanceRange" id="distanceRangeLabel">Range:</label>
@@ -385,7 +385,7 @@
       </div>
       <div class="form-row">
         <label for="distanceOutput" id="distanceOutputLabel">Display:</label>
-        <input type="text" id="distanceOutput" />
+        <select id="distanceOutput"></select>
       </div>
       <div class="form-row">
         <label for="distanceNotes" id="notesLabel">Notes:</label>

--- a/script.js
+++ b/script.js
@@ -633,6 +633,209 @@ function updateFizConnectorOptions() {
   });
 }
 
+function getAllMotorConnectorTypes() {
+  const types = new Set();
+  Object.values(devices.fiz?.motors || {}).forEach(m => {
+    if (m && m.connector) types.add(m.connector);
+  });
+  return Array.from(types).filter(Boolean).sort();
+}
+
+let motorConnectorOptions = getAllMotorConnectorTypes();
+
+function updateMotorConnectorOptions() {
+  motorConnectorOptions = getAllMotorConnectorTypes();
+  if (motorConnectorInput) {
+    const cur = motorConnectorInput.value;
+    motorConnectorInput.innerHTML = '';
+    addEmptyOption(motorConnectorInput);
+    motorConnectorOptions.forEach(optVal => {
+      const opt = document.createElement('option');
+      opt.value = optVal;
+      opt.textContent = optVal;
+      motorConnectorInput.appendChild(opt);
+    });
+    if (motorConnectorOptions.includes(cur)) motorConnectorInput.value = cur;
+  }
+}
+
+function getAllControllerConnectors() {
+  const types = new Set();
+  Object.values(devices.fiz?.controllers || {}).forEach(c => {
+    if (c && c.FIZ_connector) types.add(c.FIZ_connector);
+  });
+  return Array.from(types).filter(Boolean).sort();
+}
+
+function getAllControllerPowerSources() {
+  const types = new Set();
+  Object.values(devices.fiz?.controllers || {}).forEach(c => {
+    if (c && c.power_source) types.add(c.power_source);
+  });
+  return Array.from(types).filter(Boolean).sort();
+}
+
+function getAllControllerBatteryTypes() {
+  const types = new Set();
+  Object.values(devices.fiz?.controllers || {}).forEach(c => {
+    if (c && c.battery_type) types.add(c.battery_type);
+  });
+  return Array.from(types).filter(Boolean).sort();
+}
+
+function getAllControllerConnectivity() {
+  const types = new Set();
+  Object.values(devices.fiz?.controllers || {}).forEach(c => {
+    if (c && c.connectivity) types.add(c.connectivity);
+  });
+  return Array.from(types).filter(Boolean).sort();
+}
+
+let controllerConnectorOptions = getAllControllerConnectors();
+let controllerPowerOptions = getAllControllerPowerSources();
+let controllerBatteryOptions = getAllControllerBatteryTypes();
+let controllerConnectivityOptions = getAllControllerConnectivity();
+
+function updateControllerConnectorOptions() {
+  controllerConnectorOptions = getAllControllerConnectors();
+  if (controllerConnectorInput) {
+    const cur = controllerConnectorInput.value;
+    controllerConnectorInput.innerHTML = '';
+    addEmptyOption(controllerConnectorInput);
+    controllerConnectorOptions.forEach(optVal => {
+      const opt = document.createElement('option');
+      opt.value = optVal;
+      opt.textContent = optVal;
+      controllerConnectorInput.appendChild(opt);
+    });
+    if (controllerConnectorOptions.includes(cur)) controllerConnectorInput.value = cur;
+  }
+}
+
+function updateControllerPowerOptions() {
+  controllerPowerOptions = getAllControllerPowerSources();
+  if (controllerPowerInput) {
+    const cur = controllerPowerInput.value;
+    controllerPowerInput.innerHTML = '';
+    addEmptyOption(controllerPowerInput);
+    controllerPowerOptions.forEach(optVal => {
+      const opt = document.createElement('option');
+      opt.value = optVal;
+      opt.textContent = optVal;
+      controllerPowerInput.appendChild(opt);
+    });
+    if (controllerPowerOptions.includes(cur)) controllerPowerInput.value = cur;
+  }
+}
+
+function updateControllerBatteryOptions() {
+  controllerBatteryOptions = getAllControllerBatteryTypes();
+  if (controllerBatteryInput) {
+    const cur = controllerBatteryInput.value;
+    controllerBatteryInput.innerHTML = '';
+    addEmptyOption(controllerBatteryInput);
+    controllerBatteryOptions.forEach(optVal => {
+      const opt = document.createElement('option');
+      opt.value = optVal;
+      opt.textContent = optVal;
+      controllerBatteryInput.appendChild(opt);
+    });
+    if (controllerBatteryOptions.includes(cur)) controllerBatteryInput.value = cur;
+  }
+}
+
+function updateControllerConnectivityOptions() {
+  controllerConnectivityOptions = getAllControllerConnectivity();
+  if (controllerConnectivityInput) {
+    const cur = controllerConnectivityInput.value;
+    controllerConnectivityInput.innerHTML = '';
+    addEmptyOption(controllerConnectivityInput);
+    controllerConnectivityOptions.forEach(optVal => {
+      const opt = document.createElement('option');
+      opt.value = optVal;
+      opt.textContent = optVal;
+      controllerConnectivityInput.appendChild(opt);
+    });
+    if (controllerConnectivityOptions.includes(cur)) controllerConnectivityInput.value = cur;
+  }
+}
+
+function getAllDistanceConnections() {
+  const types = new Set();
+  Object.values(devices.fiz?.distance || {}).forEach(d => {
+    if (d && d.connection_compatibility) types.add(d.connection_compatibility);
+  });
+  return Array.from(types).filter(Boolean).sort();
+}
+
+function getAllDistanceMethods() {
+  const types = new Set();
+  Object.values(devices.fiz?.distance || {}).forEach(d => {
+    if (d && d.measurement_method) types.add(d.measurement_method);
+  });
+  return Array.from(types).filter(Boolean).sort();
+}
+
+function getAllDistanceDisplays() {
+  const types = new Set();
+  Object.values(devices.fiz?.distance || {}).forEach(d => {
+    if (d && d.output_display) types.add(d.output_display);
+  });
+  return Array.from(types).filter(Boolean).sort();
+}
+
+let distanceConnectionOptions = getAllDistanceConnections();
+let distanceMethodOptions = getAllDistanceMethods();
+let distanceDisplayOptions = getAllDistanceDisplays();
+
+function updateDistanceConnectionOptions() {
+  distanceConnectionOptions = getAllDistanceConnections();
+  if (distanceConnectionInput) {
+    const cur = distanceConnectionInput.value;
+    distanceConnectionInput.innerHTML = '';
+    addEmptyOption(distanceConnectionInput);
+    distanceConnectionOptions.forEach(optVal => {
+      const opt = document.createElement('option');
+      opt.value = optVal;
+      opt.textContent = optVal;
+      distanceConnectionInput.appendChild(opt);
+    });
+    if (distanceConnectionOptions.includes(cur)) distanceConnectionInput.value = cur;
+  }
+}
+
+function updateDistanceMethodOptions() {
+  distanceMethodOptions = getAllDistanceMethods();
+  if (distanceMethodInput) {
+    const cur = distanceMethodInput.value;
+    distanceMethodInput.innerHTML = '';
+    addEmptyOption(distanceMethodInput);
+    distanceMethodOptions.forEach(optVal => {
+      const opt = document.createElement('option');
+      opt.value = optVal;
+      opt.textContent = optVal;
+      distanceMethodInput.appendChild(opt);
+    });
+    if (distanceMethodOptions.includes(cur)) distanceMethodInput.value = cur;
+  }
+}
+
+function updateDistanceDisplayOptions() {
+  distanceDisplayOptions = getAllDistanceDisplays();
+  if (distanceOutputInput) {
+    const cur = distanceOutputInput.value;
+    distanceOutputInput.innerHTML = '';
+    addEmptyOption(distanceOutputInput);
+    distanceDisplayOptions.forEach(optVal => {
+      const opt = document.createElement('option');
+      opt.value = optVal;
+      opt.textContent = optVal;
+      distanceOutputInput.appendChild(opt);
+    });
+    if (distanceDisplayOptions.includes(cur)) distanceOutputInput.value = cur;
+  }
+}
+
 // Wrap a form field with a div containing a data-label attribute for styling.
 function createFieldWithLabel(el, label) {
   const wrapper = document.createElement('div');
@@ -1870,6 +2073,14 @@ setMonitorVideoInputs([]);
 setMonitorVideoOutputs([]);
 setFizConnectors([]);
 updateFizConnectorOptions();
+updateMotorConnectorOptions();
+updateControllerConnectorOptions();
+updateControllerPowerOptions();
+updateControllerBatteryOptions();
+updateControllerConnectivityOptions();
+updateDistanceConnectionOptions();
+updateDistanceMethodOptions();
+updateDistanceDisplayOptions();
 setViewfinders([]);
 setBatteryPlates([]);
 setRecordingMedia([]);
@@ -1884,6 +2095,9 @@ updatePowerDistVoltageOptions();
 updatePowerDistCurrentOptions();
 setTimecodes([]);
 updateTimecodeTypeOptions();
+updateDistanceConnectionOptions();
+updateDistanceMethodOptions();
+updateDistanceDisplayOptions();
 
 // Set default selections for dropdowns
 
@@ -2564,11 +2778,19 @@ deviceManagerSection.addEventListener("click", (event) => {
       controllerSelects.forEach(sel => populateSelect(sel, devices.fiz.controllers, true));
       populateSelect(distanceSelect, devices.fiz.distance, true);
       populateSelect(batterySelect, devices.batteries, true);
-      updateFizConnectorOptions();
-      updatePowerDistTypeOptions();
-      updatePowerDistVoltageOptions();
-      updatePowerDistCurrentOptions();
-      updateTimecodeTypeOptions();
+        updateFizConnectorOptions();
+        updateMotorConnectorOptions();
+        updateControllerConnectorOptions();
+        updateControllerPowerOptions();
+        updateControllerBatteryOptions();
+        updateControllerConnectivityOptions();
+        updatePowerDistTypeOptions();
+        updatePowerDistVoltageOptions();
+        updatePowerDistCurrentOptions();
+        updateTimecodeTypeOptions();
+        updateDistanceConnectionOptions();
+        updateDistanceMethodOptions();
+        updateDistanceDisplayOptions();
       applyFilters();
       updateCalculations();
     }
@@ -3026,6 +3248,14 @@ importFileInput.addEventListener("change", (event) => {
         populateSelect(distanceSelect, devices.fiz.distance, true);
         populateSelect(batterySelect, devices.batteries, true);
         updateFizConnectorOptions();
+        updateMotorConnectorOptions();
+        updateControllerConnectorOptions();
+        updateControllerPowerOptions();
+        updateControllerBatteryOptions();
+        updateControllerConnectivityOptions();
+        updateDistanceConnectionOptions();
+        updateDistanceMethodOptions();
+        updateDistanceDisplayOptions();
         applyFilters();
         updateCalculations();
 


### PR DESCRIPTION
## Summary
- add select elements for editing FIZ motor, controller and distance devices
- provide functions to extract connector, power, battery and other options from `data.js`
- populate dropdowns on page load and after modifications

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687ecfb5b74c8320b73ea7af6949fc3d