### PR TITLE
Add toggleable device details

### DIFF
--- a/script.js
+++ b/script.js
@@ -2556,17 +2556,23 @@ function formatValue(value) {
   return String(value);
 }
 
-function formatDeviceData(deviceData) {
+function createDeviceDetailsList(deviceData) {
+  const list = document.createElement('ul');
+  list.className = 'device-detail-list';
   if (typeof deviceData !== 'object') {
-    return `Power (W): ${deviceData}`;
+    const li = document.createElement('li');
+    li.innerHTML = `<strong>${humanizeKey('powerDrawWatts')}:</strong> ${formatValue(deviceData)}`;
+    list.appendChild(li);
+    return list;
   }
-  const parts = [];
   for (const key in deviceData) {
     const val = deviceData[key];
     if (val === '' || val === null || val === undefined) continue;
-    parts.push(`${humanizeKey(key)}: ${formatValue(val)}`);
+    const li = document.createElement('li');
+    li.innerHTML = `<strong>${humanizeKey(key)}:</strong> ${formatValue(val)}`;
+    list.appendChild(li);
   }
-  return parts.join(', ');
+  return list;
 }
 
 // Helper to render existing devices in the manager section
@@ -2583,26 +2589,40 @@ function renderDeviceList(categoryKey, ulElement) {
   for (let name in categoryDevices) {
     if (name === "None") continue;
     const deviceData = categoryDevices[name];
-    const displayData = formatDeviceData(deviceData);
-
     const li = document.createElement("li");
-    const span = document.createElement("span");
-    span.textContent = `${name} (${displayData})`;
-    li.appendChild(span);
+    const header = document.createElement("div");
+    header.className = "device-summary";
+
+    const toggleBtn = document.createElement("button");
+    toggleBtn.className = "detail-toggle";
+    toggleBtn.textContent = texts[currentLang].showDetails;
+    header.appendChild(toggleBtn);
+
+    const nameSpan = document.createElement("span");
+    nameSpan.textContent = name;
+    header.appendChild(nameSpan);
 
     const editBtn = document.createElement("button");
     editBtn.className = "edit-btn";
     editBtn.dataset.name = name;
     editBtn.dataset.category = categoryKey;
     editBtn.textContent = texts[currentLang].editBtn;
-    li.appendChild(editBtn);
+    header.appendChild(editBtn);
 
     const deleteBtn = document.createElement("button");
     deleteBtn.className = "delete-btn";
     deleteBtn.dataset.name = name;
     deleteBtn.dataset.category = categoryKey;
     deleteBtn.textContent = texts[currentLang].deleteDeviceBtn;
-    li.appendChild(deleteBtn);
+    header.appendChild(deleteBtn);
+
+    li.appendChild(header);
+
+    const detailsDiv = document.createElement("div");
+    detailsDiv.className = "device-details";
+    detailsDiv.style.display = "none";
+    detailsDiv.appendChild(createDeviceDetailsList(deviceData));
+    li.appendChild(detailsDiv);
 
     ulElement.appendChild(li);
   }
@@ -2769,7 +2789,19 @@ if (toggleDeviceManagerButton) { // Check if element exists before adding listen
 
 // Handle "Edit" and "Delete" buttons in device lists (event delegation)
 deviceManagerSection.addEventListener("click", (event) => {
-  if (event.target.classList.contains("edit-btn")) {
+  if (event.target.classList.contains("detail-toggle")) {
+    const details = event.target.closest('li').querySelector('.device-details');
+    const expanded = event.target.dataset.expanded === 'true';
+    if (expanded) {
+      details.style.display = 'none';
+      event.target.textContent = texts[currentLang].showDetails;
+      event.target.dataset.expanded = 'false';
+    } else {
+      details.style.display = 'block';
+      event.target.textContent = texts[currentLang].hideDetails;
+      event.target.dataset.expanded = 'true';
+    }
+  } else if (event.target.classList.contains("edit-btn")) {
     const name = event.target.dataset.name;
     const categoryKey = event.target.dataset.category;
 

--- a/style.css
+++ b/style.css
@@ -227,19 +227,41 @@ button:disabled {
 }
 
 .device-ul li {
+  border-bottom: 1px dashed #eee;
+  padding: 5px 0;
+  font-size: 0.9em;
+}
+
+.device-summary {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 5px 0;
-  border-bottom: 1px dashed #eee;
-  font-size: 0.9em;
+}
+
+.detail-toggle {
+  margin-right: 5px;
+}
+
+.device-details {
+  margin-left: 20px;
+  font-size: 0.85em;
+}
+
+.device-detail-list {
+  list-style: none;
+  padding-left: 0;
+  margin: 3px 0;
+}
+
+.device-detail-list li {
+  margin: 2px 0;
 }
 
 .device-ul li:last-child {
   border-bottom: none;
 }
 
-.device-ul li span {
+.device-summary span {
   flex-grow: 1;
   margin-right: 10px;
 }
@@ -439,6 +461,9 @@ body.dark-mode .device-category h4 {
 
 body.dark-mode .device-ul li {
   border-bottom: 1px dashed #ffffff;
+}
+body.dark-mode .device-details {
+  color: #ddd;
 }
 body.dark-mode .field-with-label::before {
   color: #ccc;

--- a/translations.js
+++ b/translations.js
@@ -132,6 +132,8 @@ const texts = {
 
     toggleDeviceManager: "Edit Device Data…",
     hideDeviceManager: "Hide Device Data",
+    showDetails: "Show Details",
+    hideDetails: "Hide Details",
 
     batteryTableLabel: "Battery",
     runtimeLabel: "Estimated Runtime (h)",
@@ -297,6 +299,8 @@ const texts = {
 
     toggleDeviceManager: "Editar Datos de Dispositivos…",
     hideDeviceManager: "Ocultar Datos de Dispositivos",
+    showDetails: "Mostrar Detalles",
+    hideDetails: "Ocultar Detalles",
 
     batteryTableLabel: "Batería",
     runtimeLabel: "Autonomía Estimada (h)",
@@ -460,6 +464,8 @@ const texts = {
 
     toggleDeviceManager: "Éditer les Données…",
     hideDeviceManager: "Masquer les Données",
+    showDetails: "Afficher les Détails",
+    hideDetails: "Masquer les Détails",
 
     batteryTableLabel: "Batterie",
     runtimeLabel: "Autonomie Estimée (h)",
@@ -623,6 +629,8 @@ const texts = {
 
     toggleDeviceManager: "Gerätedaten bearbeiten…",
     hideDeviceManager: "Gerätedaten ausblenden",
+    showDetails: "Details anzeigen",
+    hideDetails: "Details verbergen",
 
     batteryTableLabel: "Akku",
     runtimeLabel: "Geschätzte Laufzeit (h)",


### PR DESCRIPTION
## Summary
- add show/hide detail strings to translations
- add styles for toggling and detailed view
- render existing devices with collapsible details

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687ed3b29b048320aa97ed2813be658a