### PR TITLE
Save battery plate selection in setups

### DIFF
--- a/script.js
+++ b/script.js
@@ -2687,6 +2687,7 @@ saveSetupBtn.addEventListener("click", () => {
     motors: motorSelects.map(sel => sel.value),
     controllers: controllerSelects.map(sel => sel.value),
     distance: distanceSelect.value,
+    batteryPlate: batteryPlateSelect.value,
     battery: batterySelect.value
   };
   let setups = loadSetups();
@@ -2739,18 +2740,23 @@ setupSelect.addEventListener("change", (event) => {
     });
     motorSelects.forEach(sel => { if (sel.options.length) sel.value = "None"; });
     controllerSelects.forEach(sel => { if (sel.options.length) sel.value = "None"; });
+    updateBatteryPlateVisibility();
+    updateBatteryOptions();
   } else {
     let setups = loadSetups();
     const setup = setups[setupName];
     if (setup) {
       setupNameInput.value = setupName;
       cameraSelect.value = setup.camera;
+      updateBatteryPlateVisibility();
+      batteryPlateSelect.value = setup.batteryPlate || batteryPlateSelect.value;
       monitorSelect.value = setup.monitor;
       videoSelect.value = setup.video;
       setup.motors.forEach((val, i) => { if (motorSelects[i]) motorSelects[i].value = val; });
       setup.controllers.forEach((val, i) => { if (controllerSelects[i]) controllerSelects[i].value = val; });
       distanceSelect.value = setup.distance;
       batterySelect.value = setup.battery;
+      updateBatteryOptions();
     }
   }
   updateCalculations();

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -292,4 +292,45 @@ describe('script.js functions', () => {
     generatePrintableOverview();
     expect(window.open).toHaveBeenCalled();
   });
+
+  test('battery plate selection is saved and loaded with setups', () => {
+    // Add camera supporting both plates and matching batteries
+    global.devices.cameras.BothCam = {
+      powerDrawWatts: 10,
+      power: { batteryPlateSupport: [ { type: 'V-Mount', mount: 'native' }, { type: 'B-Mount', mount: 'native' } ] }
+    };
+    global.devices.batteries.VBatt = { capacity: 100, pinA: 10, dtapA: 5, mount_type: 'V-Mount' };
+    global.devices.batteries.BBatt = { capacity: 100, pinA: 10, dtapA: 5, mount_type: 'B-Mount' };
+
+    const addOpt = (id, value) => {
+      const sel = document.getElementById(id);
+      sel.innerHTML = `<option value="${value}">${value}</option>`;
+      sel.value = value;
+    };
+    addOpt('cameraSelect', 'BothCam');
+    addOpt('monitorSelect', 'MonA');
+    addOpt('videoSelect', 'VidA');
+    addOpt('motor1Select', 'MotorA');
+    addOpt('controller1Select', 'ControllerA');
+    addOpt('distanceSelect', 'DistA');
+    const plateSel = document.getElementById('batteryPlateSelect');
+    plateSel.innerHTML = '<option value="V-Mount">V-Mount</option><option value="B-Mount">B-Mount</option>';
+    plateSel.value = 'B-Mount';
+    addOpt('batterySelect', 'BBatt');
+
+    document.getElementById('setupName').value = 'TestSetup';
+    document.getElementById('saveSetupBtn').click();
+
+    const saved = global.saveSetups.mock.calls[0][0];
+    expect(saved.TestSetup.batteryPlate).toBe('B-Mount');
+
+    // Simulate loading
+    global.loadSetups.mockReturnValue(saved);
+    const sel = document.getElementById('setupSelect');
+    sel.innerHTML = '<option value="">-- New Setup --</option><option value="TestSetup">TestSetup</option>';
+    sel.value = 'TestSetup';
+    sel.dispatchEvent(new Event('change'));
+
+    expect(document.getElementById('batteryPlateSelect').value).toBe('B-Mount');
+  });
 });


### PR DESCRIPTION
## Summary
- save selected battery plate when storing setups
- restore battery plate choice when loading setups
- test that battery plate value persists in setups

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687ed5cb5db083209e356d6835fc26dc