### PR TITLE
Fix device list name filter

### DIFF
--- a/script.js
+++ b/script.js
@@ -2096,7 +2096,9 @@ function filterSelect(selectElem, filterValue) {
 function filterDeviceList(listElem, filterValue) {
   const text = filterValue.toLowerCase();
   Array.from(listElem.querySelectorAll('li')).forEach(li => {
-    if (text === '' || li.textContent.toLowerCase().includes(text)) {
+    const nameSpan = li.querySelector('.device-summary span');
+    const nameText = nameSpan ? nameSpan.textContent.toLowerCase() : li.textContent.toLowerCase();
+    if (text === '' || nameText.includes(text)) {
       li.style.display = '';
     } else {
       li.style.display = 'none';
@@ -4006,5 +4008,6 @@ if (typeof module !== "undefined" && module.exports) {
     generatePrintableOverview,
     updateBatteryPlateVisibility,
     updateBatteryOptions,
+    filterDeviceList,
   };
 }

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -292,4 +292,27 @@ describe('script.js functions', () => {
     generatePrintableOverview();
     expect(window.open).toHaveBeenCalled();
   });
+
+  test('filterDeviceList only matches device names', () => {
+    global.devices.cameras.CamB = { powerDrawWatts: 5 };
+    script.setLanguage('en');
+
+    const list = document.getElementById('cameraList');
+    expect(list.children.length).toBe(2);
+
+    script.filterDeviceList(list, 'CamA');
+    const items = list.children;
+    expect(items[0].style.display).toBe('');
+    expect(items[1].style.display).toBe('none');
+
+    script.filterDeviceList(list, 'power');
+    Array.from(list.children).forEach(li => {
+      expect(li.style.display).toBe('none');
+    });
+
+    script.filterDeviceList(list, '');
+    Array.from(list.children).forEach(li => {
+      expect(li.style.display).toBe('');
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- filter existing device list entries by device name only
- expose `filterDeviceList` for tests
- test the new filtering behaviour

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687ed75421c8832083451991711a93ea