### PR TITLE
Limit device list filter to device name

### DIFF
--- a/script.js
+++ b/script.js
@@ -2096,7 +2096,9 @@ function filterSelect(selectElem, filterValue) {
 function filterDeviceList(listElem, filterValue) {
   const text = filterValue.toLowerCase();
   Array.from(listElem.querySelectorAll('li')).forEach(li => {
-    if (text === '' || li.textContent.toLowerCase().includes(text)) {
+    const nameSpan = li.querySelector('.device-summary span');
+    const name = nameSpan ? nameSpan.textContent.toLowerCase() : '';
+    if (text === '' || name.includes(text)) {
       li.style.display = '';
     } else {
       li.style.display = 'none';


### PR DESCRIPTION
## Summary
- only use the name text when filtering existing device lists

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687f4239e4088320b28b3b63ff054627