### PR TITLE
Add setup diagram visualization

### DIFF
--- a/index.html
+++ b/index.html
@@ -145,6 +145,11 @@
     <p id="dtapWarning" style="color: red; font-weight: bold;"></p>
   </section>
 
+  <section id="setupDiagram">
+    <h2 id="setupDiagramHeading">Setup Diagram</h2>
+    <div id="diagramContainer"></div>
+  </section>
+
   <section id="batteryComparison" style="display:none;">
     <h2 id="batteryComparisonHeading">Battery Comparison</h2>
     <div id="batteryTableContainer">

--- a/style.css
+++ b/style.css
@@ -350,6 +350,21 @@ button:disabled {
   background-color: #ffffff;
 }
 
+/* Setup Diagram */
+#setupDiagram {
+  overflow-x: auto;
+}
+
+#setupDiagram .diagram-svg {
+  width: 100%;
+  height: 160px;
+}
+
+.device-box {
+  fill: #f0f0f0;
+  stroke: #333;
+}
+
 /* Battery comparison bars */
 .barContainer {
   width: 100%;

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -333,4 +333,19 @@ describe('script.js functions', () => {
 
     expect(document.getElementById('batteryPlateSelect').value).toBe('B-Mount');
   });
+
+  test('renderSetupDiagram runs without errors', () => {
+    const { renderSetupDiagram } = script;
+    const addOpt = (id, value) => {
+      const sel = document.getElementById(id);
+      sel.innerHTML = `<option value="${value}">${value}</option>`;
+      sel.value = value;
+    };
+    addOpt('cameraSelect', 'CamA');
+    addOpt('monitorSelect', 'MonA');
+    addOpt('batterySelect', 'BattA');
+    expect(() => renderSetupDiagram()).not.toThrow();
+    const diag = document.getElementById('diagramContainer');
+    expect(diag.innerHTML).toContain('svg');
+  });
 });

--- a/translations.js
+++ b/translations.js
@@ -9,6 +9,7 @@ const texts = {
     setupManageHeading: "Manage Setup",
     deviceSelectionHeading: "Device Selection",
     resultsHeading: "Results",
+    setupDiagramHeading: "Setup Diagram",
     deviceManagerHeading: "Manage Device Database",
     batteryComparisonHeading: "Battery Comparison",
 
@@ -176,6 +177,7 @@ const texts = {
     setupManageHeading: "Gestionar Configuración",
     deviceSelectionHeading: "Selección de Dispositivos",
     resultsHeading: "Resultados",
+    setupDiagramHeading: "Diagrama de Conexión",
     deviceManagerHeading: "Gestionar Base de Datos",
     batteryComparisonHeading: "Comparación de Baterías",
 
@@ -341,6 +343,7 @@ const texts = {
     setupManageHeading: "Gérer la Configuration",
     deviceSelectionHeading: "Sélection des Appareils",
     resultsHeading: "Résultats",
+    setupDiagramHeading: "Diagramme de Connexion",
     deviceManagerHeading: "Gérer la Base de Données",
     batteryComparisonHeading: "Comparaison des Batteries",
 
@@ -506,6 +509,7 @@ const texts = {
     setupManageHeading: "Setup verwalten",
     deviceSelectionHeading: "Geräte-Auswahl",
     resultsHeading: "Ergebnisse",
+    setupDiagramHeading: "Verbindungsdiagramm",
     deviceManagerHeading: "Geräte-Datenbank verwalten",
     batteryComparisonHeading: "Akkuvergleich",
 


### PR DESCRIPTION
## Summary
- insert Setup Diagram section in the results page
- style diagram container
- implement `renderSetupDiagram()` and call it when calculations update
- include diagram in printable overview
- add translations for Setup Diagram heading
- test that `renderSetupDiagram()` executes without errors

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687f456468f883209f57ca08b26a922f