### PR TITLE
Improve details layout for device list

### DIFF
--- a/style.css
+++ b/style.css
@@ -249,10 +249,10 @@ button:disabled {
 
 /* Arrange top-level device details in two columns */
 .device-details > .device-detail-list {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
+  column-count: 2;
   column-gap: 20px;
 }
+
 
 .device-detail-list {
   list-style: none;
@@ -268,6 +268,7 @@ button:disabled {
 
 .device-detail-list li {
   margin: 2px 0;
+  break-inside: avoid;
 }
 
 .device-detail-list strong {


### PR DESCRIPTION
## Summary
- restyle device details section so content flows in two columns using CSS columns
- prevent nested detail blocks from splitting across columns

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687f471a8b2483209ed7ccf06a035ea5