### PR TITLE
Fix empty setup diagram

### DIFF
--- a/script.js
+++ b/script.js
@@ -2574,6 +2574,11 @@ function renderSetupDiagram() {
     edges.push({ from: 'controllers', to: 'motors', label: 'ctrl' });
   }
 
+  if (nodes.length === 0) {
+    setupDiagramContainer.innerHTML = `<p class="diagram-placeholder">${texts[currentLang].setupDiagramPlaceholder}</p>`;
+    return;
+  }
+
   let svg = '<svg viewBox="0 0 360 300" xmlns="http://www.w3.org/2000/svg">';
   svg += '<defs><marker id="arrow" markerWidth="10" markerHeight="7" refX="10" refY="3.5" orient="auto"><polygon points="0 0, 10 3.5, 0 7" /></marker></defs>';
 

--- a/style.css
+++ b/style.css
@@ -341,6 +341,12 @@ button:disabled {
   stroke-width: 2px;
 }
 
+#setupDiagram .diagram-placeholder {
+  font-style: italic;
+  color: #666;
+  margin: 0;
+}
+
 body.dark-mode #setupDiagram .node-box {
   fill: #333;
   stroke: #ddd;
@@ -348,6 +354,10 @@ body.dark-mode #setupDiagram .node-box {
 
 body.dark-mode #setupDiagram line {
   stroke: #ddd;
+}
+
+body.dark-mode #setupDiagram .diagram-placeholder {
+  color: #bbb;
 }
 
 /* Battery comparison section */

--- a/translations.js
+++ b/translations.js
@@ -12,6 +12,7 @@ const texts = {
     deviceManagerHeading: "Manage Device Database",
     batteryComparisonHeading: "Battery Comparison",
     setupDiagramHeading: "Setup Diagram",
+    setupDiagramPlaceholder: "Select devices to visualize the setup.",
 
     savedSetupsLabel: "Saved Setups:",
     newSetupOption: "-- New Setup --",
@@ -192,6 +193,7 @@ const texts = {
     deviceManagerHeading: "Gestionar Base de Datos",
     batteryComparisonHeading: "Comparación de Baterías",
     setupDiagramHeading: "Diagrama de Configuración",
+    setupDiagramPlaceholder: "Elige dispositivos para visualizar el diagrama.",
 
     savedSetupsLabel: "Configuraciones Guardadas:",
     newSetupOption: "-- Nueva Configuración --",
@@ -370,6 +372,7 @@ const texts = {
     deviceManagerHeading: "Gérer la Base de Données",
     batteryComparisonHeading: "Comparaison des Batteries",
     setupDiagramHeading: "Diagramme de Configuration",
+    setupDiagramPlaceholder: "Sélectionnez des appareils pour afficher le schéma.",
 
     savedSetupsLabel: "Configurations Enregistrées:",
     newSetupOption: "-- Nouvelle Configuration --",
@@ -548,6 +551,7 @@ const texts = {
     deviceManagerHeading: "Geräte-Datenbank verwalten",
     batteryComparisonHeading: "Akkuvergleich",
     setupDiagramHeading: "Setup-Diagramm",
+    setupDiagramPlaceholder: "Geräte auswählen, um das Diagramm zu sehen.",
 
     savedSetupsLabel: "Gespeicherte Setups:",
     newSetupOption: "-- Neues Setup --",


### PR DESCRIPTION
## Summary
- render a placeholder message when the setup diagram has no devices
- translate placeholder message in all languages
- style the placeholder for light and dark mode

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687f4f2939788320be8b07d58cc8b616