### PR TITLE
Fix monitor/video power path routing

### DIFF
--- a/script.js
+++ b/script.js
@@ -3061,11 +3061,22 @@ function renderSetupDiagram() {
     let lx = 0, ly = 0, ang = angleBetween;
 
     if (fromSide || toSide) {
-      const viaY = ROUTE_Y + offset;
-      path = `M ${sx} ${sy} L ${sx} ${viaY} L ${tx} ${viaY} L ${tx} ${ty}`;
-      lx = (sx + tx) / 2;
-      ly = viaY - 8 - labelSpacing;
-      ang = 0;
+      if (toSide === 'left') {
+        const midX = (sx + tx) / 2;
+        const destAbove = ty < sy;
+        const offsetDir = destAbove ? -1 : 1;
+        const viaY = sy + offsetDir * (NODE_H + 20) + offset;
+        path = `M ${sx} ${sy} L ${sx} ${viaY} L ${midX} ${viaY} L ${midX} ${ty} L ${tx} ${ty}`;
+        lx = midX;
+        ly = viaY - 8 - labelSpacing;
+        ang = 0;
+      } else {
+        const viaY = ROUTE_Y + offset;
+        path = `M ${sx} ${sy} L ${sx} ${viaY} L ${tx} ${viaY} L ${tx} ${ty}`;
+        lx = (sx + tx) / 2;
+        ly = viaY - 8 - labelSpacing;
+        ang = 0;
+      }
     } else if (Math.abs(sy - ty) < 1) {
       const minX = Math.min(sx, tx);
       const maxX = Math.max(sx, tx);


### PR DESCRIPTION
## Summary
- adjust routing logic so power cables to monitor and wireless video rise vertically first
- ensure resulting diagram connection path goes up-right-down-right

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687fde2e2d108320a287f9bdd28ab726