### PR TITLE
Fix FIZ connector names

### DIFF
--- a/data.js
+++ b/data.js
@@ -6337,7 +6337,7 @@ let devices={
       },
       "Tilta Nucleus M": {
         "powerDrawWatts": 20,
-        "connector": "7-pin Lemo",
+        "connector": "LEMO 7-pin",
         "internalController": true,
         "torqueNm": 2.5,
         "gearTypes": [
@@ -6351,7 +6351,7 @@ let devices={
       },
       "Tilta Nucleus M II": {
         "powerDrawWatts": 50,
-        "connector": "7-pin Lemo",
+        "connector": "LEMO 7-pin",
         "internalController": true,
         "torqueNm": null,
         "gearTypes": [
@@ -6386,7 +6386,7 @@ let devices={
       },
       "Arri Cforce Mini": {
         "powerDrawWatts": 20,
-        "connector": "Lemo 4-pin (LBUS)",
+        "connector": "LBUS (LEMO 4-pin)",
         "internalController": false,
         "torqueNm": 0.5,
         "gearTypes": [
@@ -6401,7 +6401,7 @@ let devices={
       },
       "Arri Cforce Plus": {
         "powerDrawWatts": 32,
-        "connector": "Lemo 4-pin (LBUS)",
+        "connector": "LBUS (LEMO 4-pin)",
         "internalController": false,
         "torqueNm": 1,
         "gearTypes": [
@@ -6416,7 +6416,7 @@ let devices={
       },
       "Arri CLM-4 (K2.72114.0)": {
         "powerDrawWatts": 12,
-        "connector": "7-pin Lemo (LCS)",
+        "connector": "LEMO 7-pin (LCS)",
         "internalController": false,
         "torqueNm": 0.5,
         "gearTypes": [
@@ -6428,7 +6428,7 @@ let devices={
       },
       "Arri CLM-5 (K2.0006361)": {
         "powerDrawWatts": 24,
-        "connector": "7-pin Lemo (LCS)",
+        "connector": "LEMO 7-pin (LCS)",
         "internalController": false,
         "torqueNm": 1.2,
         "gearTypes": [
@@ -6440,7 +6440,7 @@ let devices={
       },
       "Arri cforce mini RF (KK.0040345)": {
         "powerDrawWatts": 20,
-        "connector": "Lemo 4-pin (LBUS), 7-pin Lemo (CAM)",
+        "connector": "LBUS (LEMO 4-pin), CAM (LEMO 7-pin)",
         "internalController": true,
         "torqueNm": 0.5,
         "gearTypes": [
@@ -6455,7 +6455,7 @@ let devices={
       },
       "Teradek RT Motion FIZ (MOTR.S)": {
         "powerDrawWatts": 24,
-        "connector": "4-pin 0B Lemo",
+        "connector": "LEMO 4-pin 0B",
         "internalController": false,
         "torqueNm": 0.95,
         "gearTypes": [
@@ -6469,7 +6469,7 @@ let devices={
       },
       "Preston DM1X": {
         "powerDrawWatts": 32.4,
-        "connector": "4-pin Lemo",
+        "connector": "LEMO 4-pin",
         "internalController": false,
         "torqueNm": null,
         "gearTypes": [
@@ -6481,7 +6481,7 @@ let devices={
       },
       "Preston DM2": {
         "powerDrawWatts": 22.2,
-        "connector": "4-pin Lemo",
+        "connector": "LEMO 4-pin",
         "internalController": false,
         "torqueNm": null,
         "gearTypes": [
@@ -6493,7 +6493,7 @@ let devices={
       },
       "Preston DM2X": {
         "powerDrawWatts": 22.2,
-        "connector": "4-pin Lemo",
+        "connector": "LEMO 4-pin",
         "internalController": false,
         "torqueNm": null,
         "gearTypes": [
@@ -6505,7 +6505,7 @@ let devices={
       },
       "Preston DM-A": {
         "powerDrawWatts": 18,
-        "connector": "4-pin Lemo",
+        "connector": "LEMO 4-pin",
         "internalController": false,
         "torqueNm": null,
         "gearTypes": [
@@ -6515,7 +6515,7 @@ let devices={
       },
       "Preston DM-C": {
         "powerDrawWatts": 18,
-        "connector": "4-pin Lemo",
+        "connector": "LEMO 4-pin",
         "internalController": false,
         "torqueNm": null,
         "gearTypes": [
@@ -6525,7 +6525,7 @@ let devices={
       },
       "Chrosziel CDM-100 Digital": {
         "powerDrawWatts": 12,
-        "connector": "Lemo 7-pin 1B",
+        "connector": "LEMO 7-pin 1B",
         "internalController": false,
         "torqueNm": 0.5,
         "gearTypes": [
@@ -6539,7 +6539,7 @@ let devices={
       },
       "Chrosziel CDM-M (Universal Zoom Servo Drive)": {
         "powerDrawWatts": 4.2,
-        "connector": "Lemo 5-pin 0B",
+        "connector": "LEMO 5-pin 0B",
         "internalController": false,
         "torqueNm": 0.5,
         "gearTypes": [
@@ -6586,7 +6586,7 @@ let devices={
       },
       "Cmotion cPRO": {
         "powerDrawWatts": 24,
-        "connector": "Lemo 4-pin",
+        "connector": "LEMO 4-pin",
         "internalController": true,
         "torqueNm": 1.2,
         "gearTypes": [
@@ -6629,7 +6629,7 @@ let devices={
       },
       "Arri OCU-1": {
         "powerDrawWatts": 1.32,
-        "FIZ_connector": "LBUS (4-pin Lemo)",
+        "FIZ_connector": "LBUS (LEMO 4-pin)",
         "power_source": "External (via LBUS)",
         "battery_type": "N/A",
         "connectivity": "Wired (LBUS) or Wireless (via ZMU-4/RIA-1/Master Grips)",
@@ -6637,7 +6637,7 @@ let devices={
       },
       "Arri ZMU-4 (body only, wired)": {
         "powerDrawWatts": 1,
-        "FIZ_connector": "LBUS (4-pin Lemo for motors), CAM (7-pin Lemo for camera control)",
+        "FIZ_connector": "LBUS (LEMO 4-pin for motors), CAM (LEMO 7-pin for camera control)",
         "power_source": "External DC (10.5-34V via LBUS/CAM) or Internal Battery",
         "battery_type": "Sony NP-F550/750 compatible, ARRI LBP-3500",
         "connectivity": "Wired (LBUS, CAM) or Wireless (with optional RF module - 2400 MHz DSSS)",
@@ -6645,7 +6645,7 @@ let devices={
       },
       "Arri UMC-4": {
         "powerDrawWatts": 1.68,
-        "FIZ_connector": "2x LBUS (4-pin Lemo for motors), 2x SERIAL (4-pin Lemo), CAM (7-pin Lemo), EXT (6-pin/16-pin depending on camera)",
+        "FIZ_connector": "2x LBUS (LEMO 4-pin for motors), 2x SERIAL (LEMO 4-pin), CAM (LEMO 7-pin), EXT (6-pin/16-pin depending on camera)",
         "power_source": "External DC (via CAM or LBUS chain)",
         "battery_type": "N/A (no internal battery)",
         "connectivity": "Wireless (proprietary ARRI radio system, works with WCU-4, SXU-1, Master Grips, cmotion pan-bar zoom), Wired (LBUS, CAM, SERIAL)",
@@ -6653,7 +6653,7 @@ let devices={
       },
       "Arri RIA-1": {
         "powerDrawWatts": 2.5,
-        "FIZ_connector": "2x LBUS (4-pin Lemo), 1x CAM (7-pin Lemo), 1x SERIAL (4-pin Lemo)",
+        "FIZ_connector": "2x LBUS (LEMO 4-pin), 1x CAM (LEMO 7-pin), 1x SERIAL (LEMO 4-pin)",
         "power_source": "External DC (10.5-34V, can be powered via camera CAM port)",
         "battery_type": "N/A (no internal battery, draws power from camera or external source)",
         "connectivity": "Wireless (swappable ARRI radio modules: RF-EMIP, RF-2400, RF-900) or Wired (LBUS, CAM, SERIAL)",
@@ -6661,7 +6661,7 @@ let devices={
       },
       "Arri Master Grip (single unit)": {
         "powerDrawWatts": 0.72,
-        "FIZ_connector": "2x LBUS (4-pin Lemo)",
+        "FIZ_connector": "2x LBUS (LEMO 4-pin)",
         "power_source": "External (12-34VDC via LBUS)",
         "battery_type": "N/A (no internal battery)",
         "connectivity": "Wired (LBUS) or Wireless (when connected to ZMU-4 or RIA-1 with radio module)",
@@ -6693,7 +6693,7 @@ let devices={
       },
       "Preston MDR4": {
         "powerDrawWatts": 48,
-        "FIZ_connector": "2x Motor Ports (proprietary 7-pin Lemo), Serial (for Light Ranger 2), Analog (for Micro Force), USB (firmware)",
+        "FIZ_connector": "2x Motor Ports (proprietary LEMO 7-pin), Serial (for Light Ranger 2), Analog (for Micro Force), USB (firmware)",
         "power_source": "External DC (4-pin XLR or D-Tap)",
         "battery_type": "N/A (no internal battery)",
         "connectivity": "Wireless (Preston G4 radio link to hand units), Wired (via specific cables for camera run/stop, Light Ranger 2)",
@@ -6701,7 +6701,7 @@ let devices={
       },
       "ARRI ECM-1": {
         "powerDrawWatts": 84,
-        "FIZ_connector": "6x Motor ports (proprietary Lemo), 1x Camera (7-pin Lemo), 1x Accessory (4-pin Lemo), 1x Ethernet, 1x USB",
+        "FIZ_connector": "6x Motor ports (proprietary Lemo), 1x Camera (LEMO 7-pin), 1x Accessory (LEMO 4-pin), 1x Ethernet, 1x USB",
         "power_source": "External DC (LEMO 2-pin or 4-pin XLR)",
         "battery_type": "N/A (no internal battery)",
         "connectivity": "Wired (Ethernet, Camera cable to ALEXA 65/LF/Mini LF/35, USB) or Wireless (integrated Wi-Fi and ARRI White Radio)",
@@ -6717,7 +6717,7 @@ let devices={
       },
       "ARRI LBUS Distributor (LBS-1)": {
         "powerDrawWatts": 0.24,
-        "FIZ_connector": "Multiple LBUS ports (4-pin Lemo)",
+        "FIZ_connector": "Multiple LBUS ports (LEMO 4-pin)",
         "power_source": "External (via any LBUS connection)",
         "battery_type": "N/A (passive device)",
         "connectivity": "Wired (LBUS)",
@@ -6725,7 +6725,7 @@ let devices={
       },
       "Cmotion compact LCS receiver": {
         "powerDrawWatts": 20,
-        "FIZ_connector": "3x Motor ports (4-pin Lemo), 1x Camera (7-pin Lemo), 1x EXT (4-pin Lemo)",
+        "FIZ_connector": "3x Motor ports (LEMO 4-pin), 1x Camera (LEMO 7-pin), 1x EXT (LEMO 4-pin)",
         "power_source": "External DC (10-34V via Camera port or EXT port)",
         "battery_type": "N/A (no internal battery)",
         "connectivity": "Wireless (proprietary cmotion RF, 2.4 GHz FHSS, up to 150m/500ft range) or Wired (CAM, EXT)",
@@ -6733,7 +6733,7 @@ let devices={
       },
       "Teradek RT Motion CTRL.3 Controller": {
         "powerDrawWatts": 15,
-        "FIZ_connector": "USB-C, LEMO 2-pin (power out), 4-pin Lemo (data to MDR)",
+        "FIZ_connector": "USB-C, LEMO 2-pin (power out), LEMO 4-pin (data to MDR)",
         "power_source": "Internal Battery (rechargeable) or External (USB-C)",
         "battery_type": "Internal Li-ion (proprietary, typically 1-2 hours runtime), charges via USB-C",
         "connectivity": "Wireless (Teradek RT FHSS, up to 5000ft/1500m range) or Wired (via MDR to camera/motors)",
@@ -7235,4 +7235,4 @@ let devices={
     }
   }
 };
-if (typeof module!=="undefined" && module.exports){module.exports=devices;}
+if (typeof module !== "undefined" && module.exports) { module.exports = devices; }

--- a/normalizeData.js
+++ b/normalizeData.js
@@ -8,6 +8,22 @@ function unifyFizConnectorTypes() {
   const map = {
     'LEMO 4-pin (LBUS)': 'LBUS (LEMO 4-pin)',
     'Lemo 4-pin (LBUS)': 'LBUS (LEMO 4-pin)',
+    'LBUS (4-pin Lemo)': 'LBUS (LEMO 4-pin)',
+    'LBUS (4-pin Lemo for motors), CAM (7-pin Lemo for camera control)':
+      'LBUS (LEMO 4-pin for motors), CAM (LEMO 7-pin for camera control)',
+    '2x LBUS (4-pin Lemo for motors), 2x SERIAL (4-pin Lemo), CAM (7-pin Lemo), EXT (6-pin/16-pin depending on camera)':
+      '2x LBUS (LEMO 4-pin for motors), 2x SERIAL (LEMO 4-pin), CAM (LEMO 7-pin), EXT (6-pin/16-pin depending on camera)',
+    '2x LBUS (4-pin Lemo), 1x CAM (7-pin Lemo), 1x SERIAL (4-pin Lemo)':
+      '2x LBUS (LEMO 4-pin), 1x CAM (LEMO 7-pin), 1x SERIAL (LEMO 4-pin)',
+    '2x LBUS (4-pin Lemo)': '2x LBUS (LEMO 4-pin)',
+    '3x Motor ports (4-pin Lemo), 1x Camera (7-pin Lemo), 1x EXT (4-pin Lemo)':
+      '3x Motor ports (LEMO 4-pin), 1x Camera (LEMO 7-pin), 1x EXT (LEMO 4-pin)',
+    'Multiple LBUS ports (4-pin Lemo)': 'Multiple LBUS ports (LEMO 4-pin)',
+    '6x Motor ports (proprietary Lemo), 1x Camera (7-pin Lemo), 1x Accessory (4-pin Lemo), 1x Ethernet, 1x USB':
+      '6x Motor ports (proprietary Lemo), 1x Camera (LEMO 7-pin), 1x Accessory (LEMO 4-pin), 1x Ethernet, 1x USB',
+    'USB-C, LEMO 2-pin (power out), 4-pin Lemo (data to MDR)':
+      'USB-C, LEMO 2-pin (power out), LEMO 4-pin (data to MDR)',
+    'Lemo 4-pin (LBUS), 7-pin Lemo (CAM)': 'LBUS (LEMO 4-pin), CAM (LEMO 7-pin)',
     'EXT (LEMO 7-pin)': 'EXT LEMO 7-pin',
     'Hirose 12pin': 'Hirose 12-pin',
     '12-pin Hirose': 'Hirose 12-pin',
@@ -25,7 +41,16 @@ function unifyFizConnectorTypes() {
     '2.5 mm Sub-Mini (LANC)': 'LANC',
     'REMOTE A (2.5mm)': 'REMOTE A connector',
     'Remote Control Terminal': 'REMOTE A connector',
-    'Remote 8 pin': 'REMOTE B connector'
+    'Remote 8 pin': 'REMOTE B connector',
+    'Lemo 4-pin': 'LEMO 4-pin',
+    '4-pin Lemo': 'LEMO 4-pin',
+    '4-pin 0B Lemo': 'LEMO 4-pin 0B',
+    'Lemo 5-pin 0B': 'LEMO 5-pin 0B',
+    '7-pin Lemo': 'LEMO 7-pin',
+    '7-pin Lemo (LCS)': 'LEMO 7-pin (LCS)',
+    'Lemo 7-pin 1B': 'LEMO 7-pin 1B',
+    '2x Motor Ports (proprietary 7-pin Lemo), Serial (for Light Ranger 2), Analog (for Micro Force), USB (firmware)':
+      '2x Motor Ports (proprietary LEMO 7-pin), Serial (for Light Ranger 2), Analog (for Micro Force), USB (firmware)'
   };
   for (const cam of Object.values(devices.cameras)) {
     const list = cam.fizConnectors;
@@ -35,6 +60,18 @@ function unifyFizConnectorTypes() {
           conn.type = map[conn.type];
         }
       });
+    }
+  }
+
+  for (const motor of Object.values(devices.fiz?.motors || {})) {
+    if (motor.connector && map[motor.connector]) {
+      motor.connector = map[motor.connector];
+    }
+  }
+
+  for (const controller of Object.values(devices.fiz?.controllers || {})) {
+    if (controller.FIZ_connector && map[controller.FIZ_connector]) {
+      controller.FIZ_connector = map[controller.FIZ_connector];
     }
   }
 }


### PR DESCRIPTION
## Summary
- normalize FIZ connector naming so all devices use the same string
- expand the normalizer to fix motors and controllers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687fde662a2483208e4b2d8fc8787507