### PR TITLE
Fix distance port mapping for RIA-1

### DIFF
--- a/script.js
+++ b/script.js
@@ -345,6 +345,12 @@ function controllerCamPort(name) {
   return 'LBUS';
 }
 
+function controllerDistancePort(name) {
+  const c = devices.fiz?.controllers?.[name];
+  if (c && /SERIAL/i.test(c.FIZ_connector || '')) return 'Serial';
+  return 'LBUS';
+}
+
 function controllerPriority(name) {
   if (/RIA-1/i.test(name) || /UMC-4/i.test(name)) return 0;
   return 1;
@@ -3036,7 +3042,8 @@ function renderSetupDiagram() {
 
   if (dedicatedDistance && controllerIds.length && distanceSelected) {
     const ctrlName = inlineControllers[0] || controllers[0];
-    const portLabel = formatConnLabel(fizPort(ctrlName), 'LBUS');
+    const distPort = controllerDistancePort(ctrlName);
+    const portLabel = formatConnLabel(fizPort(ctrlName), distPort);
     pushEdge({ from: controllerIds[0], to: 'distance', label: portLabel, noArrow: true }, 'fiz');
   }
 


### PR DESCRIPTION
## Summary
- update diagram logic for connecting distance units
- add helper to pick Serial vs LBUS distance port based on controller

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687fe724e7d88320b1b695b8d9e19678