### PR TITLE
Update distance device logic for ARRI cameras

### DIFF
--- a/script.js
+++ b/script.js
@@ -593,6 +593,12 @@ function checkArriCompatibility() {
   controllers.sort((a, b) => controllerPriority(a) - controllerPriority(b));
   const distance = distanceSelect.value;
 
+  const camName = cameraSelect.value;
+  const cam = devices.cameras[camName];
+  const cameraHasLBUS = Array.isArray(cam?.fizConnectors) &&
+    cam.fizConnectors.some(fc => /LBUS/i.test(fc.type));
+  const builtInController = cameraHasLBUS && /arri/i.test(camName);
+
   const usesUMC4 = controllers.some(n => /UMC-4/i.test(n));
   const usesRIA1 = controllers.some(n => /RIA-1/i.test(n));
   const usesRF = controllers.some(n => /cforce.*rf/i.test(n)) || motors.some(m => /cforce.*rf/i.test(m));
@@ -602,7 +608,11 @@ function checkArriCompatibility() {
     msg = texts[currentLang].arriUMC4Warning;
   } else if ((usesRIA1 || usesRF) && motors.some(m => /CLM-4|CLM-5/i.test(m))) {
     msg = texts[currentLang].arriRIA1Warning;
-  } else if (distance && distance !== 'None' && !(usesUMC4 || usesRIA1 || usesRF)) {
+  } else if (
+    distance &&
+    distance !== 'None' &&
+    !(usesUMC4 || usesRIA1 || usesRF || builtInController)
+  ) {
     msg = texts[currentLang].distanceControllerWarning;
   }
 

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -455,6 +455,48 @@ describe('script.js functions', () => {
     expect(port).toBe('EXT LEMO 7-pin');
   });
 
+  test('ARRI camera with LBUS avoids distance warning', () => {
+    jest.resetModules();
+
+    const html = fs.readFileSync(path.join(__dirname, '../index.html'), 'utf8');
+    const body = html.split('<body>')[1].split('</body>')[0];
+    document.body.innerHTML = body;
+
+    global.devices = {
+      cameras: { 'ArriCam': { powerDrawWatts: 10, fizConnectors: [{ type: 'LBUS (LEMO 4-pin)' }] } },
+      monitors: {},
+      video: {},
+      fiz: {
+        motors: {},
+        controllers: {},
+        distance: { DistA: { powerDrawWatts: 1 } }
+      },
+      batteries: { BattA: { capacity: 100, pinA: 10, dtapA: 5 } }
+    };
+
+    global.loadDeviceData = jest.fn(() => null);
+    global.saveDeviceData = jest.fn();
+    global.loadSetups = jest.fn(() => ({}));
+    global.saveSetups = jest.fn();
+    global.saveSetup = jest.fn();
+    global.loadSetup = jest.fn();
+    global.deleteSetup = jest.fn();
+
+    require('../translations.js');
+    const localScript = require('../script.js');
+
+    const addOpt = (id, value) => {
+      const sel = document.getElementById(id);
+      sel.innerHTML = `<option value="${value}">${value}</option>`;
+      sel.value = value;
+    };
+    addOpt('cameraSelect', 'ArriCam');
+    addOpt('distanceSelect', 'DistA');
+    addOpt('batterySelect', 'BattA');
+    localScript.updateCalculations();
+    expect(document.getElementById('compatWarning').textContent).toBe('');
+  });
+
   test('renderSetupDiagram runs without errors', () => {
     const { renderSetupDiagram } = script;
     expect(() => renderSetupDiagram()).not.toThrow();


### PR DESCRIPTION
## Summary
- avoid the distance controller warning when the selected camera has a built‑in LBUS port
- test that ARRI cameras with LBUS connectors can use distance devices without an external controller

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687febad00988320a9e01440628d1e1d