### PR TITLE
Improve diagram connection offsets

### DIFF
--- a/script.js
+++ b/script.js
@@ -2923,9 +2923,14 @@ function renderSetupDiagram() {
 
   let chain = [];
   const edges = [];
+  const pairCounts = {};
+  // Assign offsets based on how many edges already exist between two nodes.
+  // This keeps parallel connections from overlapping each other.
   const pushEdge = (edge, type) => {
+    const key = [edge.from, edge.to].sort().join('|');
+    const idx = pairCounts[key] || 0;
+    pairCounts[key] = idx + 1;
     if (!('offset' in edge)) {
-      const idx = edges.length;
       if (idx === 0) edge.offset = 0;
       else {
         const dir = idx % 2 === 1 ? 1 : -1;


### PR DESCRIPTION
## Summary
- make connection offsets depend on pairs of nodes so parallel lines don't overlap

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687fed4639b883209b6b785c8cfbb050