### PR TITLE
Fix notes labels and dropdown filtering

### DIFF
--- a/index.html
+++ b/index.html
@@ -350,7 +350,7 @@
         <input type="text" id="motorGearTypes" />
       </div>
       <div class="form-row">
-        <label for="motorNotes" id="notesLabel">Notes:</label>
+        <label for="motorNotes" id="motorNotesLabel">Notes:</label>
         <input type="text" id="motorNotes" />
       </div>
     </div>
@@ -372,7 +372,7 @@
         <select id="controllerConnectivity"></select>
       </div>
       <div class="form-row">
-        <label for="controllerNotes" id="notesLabel">Notes:</label>
+        <label for="controllerNotes" id="controllerNotesLabel">Notes:</label>
         <input type="text" id="controllerNotes" />
       </div>
     </div>
@@ -398,7 +398,7 @@
         <select id="distanceOutput"></select>
       </div>
       <div class="form-row">
-        <label for="distanceNotes" id="notesLabel">Notes:</label>
+        <label for="distanceNotes" id="distanceNotesLabel">Notes:</label>
         <input type="text" id="distanceNotes" />
       </div>
     </div>

--- a/script.js
+++ b/script.js
@@ -709,6 +709,9 @@ function setLanguage(lang) {
   updateBatteryLabel();
   // FIZ legend
   document.getElementById("fizLegend").textContent = texts[lang].fizLegend;
+  document.querySelectorAll('#motorNotesLabel,#controllerNotesLabel,#distanceNotesLabel').forEach(el => {
+    el.textContent = texts[lang].notesLabel;
+  });
   // Results labels
   document.getElementById("totalPowerLabel").textContent = texts[lang].totalPowerLabel;
   document.getElementById("totalCurrent144Label").textContent = texts[lang].totalCurrent144Label;
@@ -2408,8 +2411,10 @@ function filterSelect(selectElem, filterValue) {
   Array.from(selectElem.options).forEach(opt => {
     if (opt.value === "None" || text === "" || opt.textContent.toLowerCase().includes(text)) {
       opt.hidden = false;
+      opt.disabled = false;
     } else {
       opt.hidden = true;
+      opt.disabled = true;
     }
   });
 }


### PR DESCRIPTION
## Summary
- give each notes label a unique `id`
- translate all notes labels in `setLanguage`
- disable dropdown options hidden by the filter

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687ff1fd6c6c832087b2022690f6a01f