### PR TITLE
Fix translation comment

### DIFF
--- a/translations.js
+++ b/translations.js
@@ -1,5 +1,5 @@
 // translations.js - Translated UI strings and labels
-// Translation text for English and German
+// Translation text for English, Spanish, French and German
 const texts = {
   en: {
     appTitle: "Camera Power Planner",


### PR DESCRIPTION
## Summary
- correct comment in translations.js to list all languages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6880005fb00c83208c3b0103d416efa1