### PR TITLE
Align connection labels with diagram lines

### DIFF
--- a/script.js
+++ b/script.js
@@ -3218,8 +3218,10 @@ function renderSetupDiagram() {
     const ly = (from.y + to.y) / 2 - 8 - labelSpacing;
     const dx = to.x - from.x;
     const dy = to.y - from.y;
+    // Rotate labels so they run parallel to the connection line
+    // without forcing them to stay upright. This keeps the text
+    // aligned with the line direction regardless of orientation.
     let angle = Math.atan2(dy, dx) * 180 / Math.PI;
-    if (angle > 90 || angle < -90) angle += 180; // keep text upright
     return { path, labelX: lx, labelY: ly, angle };
   }
 


### PR DESCRIPTION
## Summary
- rotate connection labels according to the direction of their line

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688021285a288320ac2e98a81d1595c5