### PR TITLE
Fix SDI label overlap

### DIFF
--- a/script.js
+++ b/script.js
@@ -2991,7 +2991,7 @@ function renderSetupDiagram() {
   const pos = {};
   const nodeMap = {};
   const step = 300; // extra spacing for edge labels
-  const VIDEO_LABEL_SPACING = 6;
+  const VIDEO_LABEL_SPACING = 10;
   const baseY = 220;
   let x = 80;
 


### PR DESCRIPTION
## Summary
- tweak video label spacing so SDI labels no longer touch connection lines

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688098b8266c8320bf30fbda2d857fb3