### PR TITLE
Remove blue device borders

### DIFF
--- a/script.js
+++ b/script.js
@@ -1012,8 +1012,8 @@ let lastDiagramPositions = {};
 
 // CSS used when exporting the setup diagram
 const diagramCssLight = `
-.node-box{fill:#e8f0fe;stroke:#3367d6;}
-.node-box.first-fiz{stroke:#3367d6;}
+.node-box{fill:#e8f0fe;stroke:none;}
+.node-box.first-fiz{stroke:none;}
 .first-fiz-highlight{stroke:url(#firstFizGrad);stroke-width:1px;fill:none;}
 .node-icon{font-size:20px;}
 .conn{stroke:#333;stroke-width:1px;}
@@ -1029,8 +1029,8 @@ path.fiz{stroke:#090;}
 .diagram-placeholder{font-style:italic;color:#666;margin:0;}
 `;
 const diagramCssDark = `
-.node-box{fill:#333;stroke:#ddd;}
-.node-box.first-fiz{stroke:#ddd;}
+.node-box{fill:#333;stroke:none;}
+.node-box.first-fiz{stroke:none;}
 .first-fiz-highlight{stroke:url(#firstFizGrad);}
 text{fill:#fff;}
 line{stroke:#fff;}

--- a/style.css
+++ b/style.css
@@ -442,10 +442,10 @@ body.dark-mode .diagram-popup {
 
 #setupDiagram .node-box {
   fill: #e8f0fe;
-  stroke: #3367d6;
+  stroke: none;
 }
 #setupDiagram .node-box.first-fiz {
-  stroke: #3367d6;
+  stroke: none;
 }
 
 #setupDiagram .first-fiz-highlight {
@@ -497,10 +497,10 @@ body.dark-mode .diagram-popup {
 
 body.dark-mode #setupDiagram .node-box {
   fill: #333;
-  stroke: #ddd;
+  stroke: none;
 }
 body.dark-mode #setupDiagram .node-box.first-fiz {
-  stroke: #ddd;
+  stroke: none;
 }
 body.dark-mode #setupDiagram .first-fiz-highlight {
   stroke: url(#firstFizGrad);


### PR DESCRIPTION
## Summary
- remove blue stroke from diagram node boxes
- keep corner gradient on first FIZ nodes when exporting the diagram

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6880ac3d70c48320ba3f794158fb26fe