### PR TITLE
Improve help dialog accessibility

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -66,6 +66,8 @@ You can switch the language in the top right corner. The choice is remembered fo
 ### 🌓 Dark Mode
 - Toggleable via the moon button next to the language selector
 - Preference is stored in your browser
+- The help dialog can be opened via the ? button or by pressing `?`/`H`
+  and closed with Escape or by clicking outside the popup
 
 ---
 

--- a/script.js
+++ b/script.js
@@ -5348,10 +5348,29 @@ if (helpButton && helpDialog) {
     helpDialog.setAttribute("hidden", "");
     helpButton.focus();
   };
-  helpButton.addEventListener("click", openHelp);
+  const toggleHelp = () => {
+    if (helpDialog.hasAttribute("hidden")) {
+      openHelp();
+    } else {
+      closeHelp();
+    }
+  };
+
+  helpButton.addEventListener("click", toggleHelp);
   if (closeHelpBtn) closeHelpBtn.addEventListener("click", closeHelp);
-  helpDialog.addEventListener("keydown", e => {
-    if (e.key === "Escape") closeHelp();
+
+  document.addEventListener("keydown", e => {
+    if (e.key === "Escape" && !helpDialog.hasAttribute("hidden")) {
+      closeHelp();
+    } else if ((e.key === "?" || e.key.toLowerCase() === "h") &&
+               document.activeElement.tagName !== "INPUT" &&
+               document.activeElement.tagName !== "TEXTAREA") {
+      toggleHelp();
+    }
+  });
+
+  helpDialog.addEventListener("click", e => {
+    if (e.target === helpDialog) closeHelp();
   });
 }
 

--- a/style.css
+++ b/style.css
@@ -110,12 +110,11 @@ p {
 /* Help dialog */
 #helpDialog {
   position: fixed;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  background: #fff;
-  border: 2px solid #001589;
-  padding: 20px;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
   z-index: 200;
 }
 
@@ -123,7 +122,13 @@ p {
   display: none;
 }
 
-body.dark-mode #helpDialog {
+.help-content {
+  background: #fff;
+  border: 2px solid #001589;
+  padding: 20px;
+}
+
+body.dark-mode .help-content {
   background: #1e1e1e;
   color: #f0f0f0;
   border-color: #555;

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -662,4 +662,16 @@ describe('script.js functions', () => {
     const labels = Array.from(document.querySelectorAll('.edge-label')).map(el => el.textContent);
     expect(labels.some(l => l.includes('D-Tap'))).toBe(false);
   });
+
+  test('help dialog toggles with keyboard and overlay click', () => {
+    const helpDialog = document.getElementById('helpDialog');
+
+    // open via question mark key
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: '?' }));
+    expect(helpDialog.hasAttribute('hidden')).toBe(false);
+
+    // close by clicking outside
+    helpDialog.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(helpDialog.hasAttribute('hidden')).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary
- enhance the help dialog with overlay styling
- allow toggling help via `?`/`H` key and clicking outside the popup
- document new help shortcuts
- test help dialog interactions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68814a5b578c8320851f61dc17c03a83