### PR TITLE
Add Pinky mode toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,6 +19,7 @@
       <option value="fr">Français</option>
     </select>
     <button id="darkModeToggle" title="Toggle dark mode" aria-label="Toggle dark mode">☾</button>
+    <button id="pinkyToggle" title="Toggle pink mode" aria-label="Toggle pink mode">💙</button>
     <button id="helpButton" aria-haspopup="dialog" aria-controls="helpDialog" title="Help">?</button>
   </div>
 

--- a/script.js
+++ b/script.js
@@ -857,6 +857,10 @@ function setLanguage(lang) {
     darkModeToggle.setAttribute("title", texts[lang].darkModeLabel);
     darkModeToggle.setAttribute("aria-label", texts[lang].darkModeLabel);
   }
+  if (pinkyToggle) {
+    pinkyToggle.setAttribute("title", texts[lang].pinkyModeLabel);
+    pinkyToggle.setAttribute("aria-label", texts[lang].pinkyModeLabel);
+  }
   if (helpButton) {
     helpButton.setAttribute("title", texts[lang].helpButtonLabel);
     helpButton.setAttribute("aria-label", texts[lang].helpButtonLabel);
@@ -990,6 +994,7 @@ const importFileInput = document.getElementById("importFileInput");
 const importDataBtn   = document.getElementById("importDataBtn");
 const languageSelect  = document.getElementById("languageSelect");
 const darkModeToggle  = document.getElementById("darkModeToggle");
+const pinkyToggle  = document.getElementById("pinkyToggle");
 const helpButton      = document.getElementById("helpButton");
 const helpDialog      = document.getElementById("helpDialog");
 const closeHelpBtn    = document.getElementById("closeHelp");
@@ -5290,6 +5295,36 @@ if (darkModeToggle) {
   });
 }
 
+// Pinky mode handling
+function applyPinkyMode(enabled) {
+  if (enabled) {
+    document.body.classList.add("pinky-mode");
+    if (pinkyToggle) pinkyToggle.textContent = "💗";
+  } else {
+    document.body.classList.remove("pinky-mode");
+    if (pinkyToggle) pinkyToggle.textContent = "🔵";
+  }
+}
+
+let pinkyModeEnabled = false;
+try {
+  pinkyModeEnabled = localStorage.getItem("pinkyMode") === "true";
+} catch (e) {
+  console.warn("Could not load pinky mode preference", e);
+}
+applyPinkyMode(pinkyModeEnabled);
+
+if (pinkyToggle) {
+  pinkyToggle.addEventListener("click", () => {
+    pinkyModeEnabled = !document.body.classList.contains("pinky-mode");
+    applyPinkyMode(pinkyModeEnabled);
+    try {
+      localStorage.setItem("pinkyMode", pinkyModeEnabled);
+    } catch (e) {
+      console.warn("Could not save pinky mode preference", e);
+    }
+  });
+}
 if (downloadDiagramBtn) {
   downloadDiagramBtn.addEventListener('click', (e) => {
     const svgEl = setupDiagramContainer.querySelector('svg');
@@ -5380,6 +5415,7 @@ if (typeof module !== "undefined" && module.exports) {
     setRecordingMedia,
     getRecordingMedia,
     applyDarkMode,
+    applyPinkyMode,
     generatePrintableOverview,
     updateBatteryPlateVisibility,
     updateBatteryOptions,

--- a/style.css
+++ b/style.css
@@ -1,3 +1,4 @@
+:root { --accent-color: #001589; }
 
 /* General styles */
 /* Ensure predictable sizing */
@@ -18,7 +19,7 @@ body {
   position: absolute;
   left: -999px;
   top: -999px;
-  background: #001589;
+  background: var(--accent-color);
   color: #fff;
   padding: 8px 12px;
   z-index: 100;
@@ -38,7 +39,7 @@ body {
 h1, h2, h3 {
   font-family: 'Open Sans', sans-serif;
   font-weight: 500;
-  color: #001589;
+  color: var(--accent-color);
 }
 h1 {
   font-size: 1.8em;
@@ -47,7 +48,7 @@ h1 {
 h2 {
   font-size: 1.4em;
   margin-top: 1.3em;
-  border-bottom: 2px solid #001589;
+  border-bottom: 2px solid var(--accent-color);
 }
 h3 {
   font-size: 1.1em;
@@ -114,7 +115,7 @@ p {
   left: 50%;
   transform: translate(-50%, -50%);
   background: #fff;
-  border: 2px solid #001589;
+  border: 2px solid var(--accent-color);
   padding: 20px;
   z-index: 200;
 }
@@ -200,14 +201,14 @@ select {
 
 /* FIZ group fieldset */
 fieldset {
-  border: 1px solid #001589;
+  border: 1px solid var(--accent-color);
   border-radius: 5px;
   padding: 10px;
   margin-top: 1em;
 }
 legend {
   font-weight: 500;
-  color: #001589;
+  color: var(--accent-color);
   padding: 0 5px;
 }
 
@@ -262,7 +263,7 @@ button:disabled {
 }
 
 .device-category h4 {
-  color: #001589;
+  color: var(--accent-color);
   margin-top: 0;
   margin-bottom: 10px;
   border-bottom: 1px solid #eee;
@@ -611,6 +612,9 @@ body.dark-mode #setupDiagram .diagram-placeholder {
 }
 
 /* Dark mode */
+body.pinky-mode {
+  --accent-color: #e91e63;
+}
 body.dark-mode {
   background-color: #121212;
   color: #f0f0f0;

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -313,6 +313,17 @@ describe('script.js functions', () => {
     expect(document.body.classList.contains('dark-mode')).toBe(false);
     expect(toggle.textContent).toBe('☾');
   });
+  test("applyPinkyMode toggles class", () => {
+    const { applyPinkyMode } = script;
+    const toggle = document.getElementById("pinkyToggle");
+    applyPinkyMode(true);
+    expect(document.body.classList.contains("pinky-mode")).toBe(true);
+    expect(toggle.textContent).toBe("💗");
+    applyPinkyMode(false);
+    expect(document.body.classList.contains("pinky-mode")).toBe(false);
+    expect(toggle.textContent).toBe("🔵");
+  });
+
 
   test('generatePrintableOverview opens window with content', () => {
     const { generatePrintableOverview } = script;

--- a/translations.js
+++ b/translations.js
@@ -19,6 +19,7 @@ const texts = {
     downloadDiagramBtn: "Download Diagram",
     existingDevicesHeading: "Existing Devices",
     darkModeLabel: "Toggle dark mode",
+    pinkyModeLabel: "Toggle pink mode",
 
     savedSetupsLabel: "Saved Setups:",
     newSetupOption: "-- New Setup --",
@@ -223,6 +224,7 @@ const texts = {
     downloadDiagramBtn: "Descargar Diagrama",
     existingDevicesHeading: "Dispositivos Existentes",
     darkModeLabel: "Alternar modo oscuro",
+    pinkyModeLabel: "Toggle pink mode",
 
     savedSetupsLabel: "Configuraciones Guardadas:",
     newSetupOption: "-- Nueva Configuración --",
@@ -425,6 +427,7 @@ const texts = {
     downloadDiagramBtn: "Télécharger le Diagramme",
     existingDevicesHeading: "Appareils Existants",
     darkModeLabel: "Basculer mode sombre",
+    pinkyModeLabel: "Toggle pink mode",
 
     savedSetupsLabel: "Configurations Enregistrées:",
     newSetupOption: "-- Nouvelle Configuration --",
@@ -627,6 +630,7 @@ const texts = {
     downloadDiagramBtn: "Diagramm herunterladen",
     existingDevicesHeading: "Vorhandene Geräte",
     darkModeLabel: "Dunkelmodus umschalten",
+    pinkyModeLabel: "Toggle pink mode",
 
     savedSetupsLabel: "Gespeicherte Setups:",
     newSetupOption: "-- Neues Setup --",


### PR DESCRIPTION
## Summary
- add Pinky toggle button in the header
- implement pinky mode switching via class and localStorage
- export `applyPinkyMode`
- support translation for Pinky toggle label
- test `applyPinkyMode`
- theme colors now use `--accent-color` CSS variable

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68814a92f2fc8320a3cf969c2b8f4f62