### PR TITLE
Enhance help dialog

### DIFF
--- a/index.html
+++ b/index.html
@@ -481,9 +481,34 @@
 
   <div id="helpDialog" role="dialog" aria-modal="true" aria-labelledby="helpTitle" tabindex="-1" hidden>
     <div class="help-content">
-      <h2 id="helpTitle">How to use</h2>
-      <p>Choose devices, save your setup and review power warnings. Use the dark mode button for a darker theme.</p>
       <button id="closeHelp">Close</button>
+      <h2 id="helpTitle">How to use</h2>
+      <input type="text" id="helpSearch" placeholder="Search..." aria-label="Search help" />
+      <div id="helpSections">
+        <section data-help-section id="gettingStarted">
+          <h3>Getting Started</h3>
+          <p>Pick your camera, monitor and other devices from the dropdown menus. The app will automatically calculate total power draw.</p>
+        </section>
+        <section data-help-section id="managingSetups">
+          <h3>Managing Setups</h3>
+          <p>Use the save button to store the current configuration. Saved setups can be imported, exported or deleted in the Setup Actions section.</p>
+        </section>
+        <section data-help-section id="powerCalculator">
+          <h3>Power Calculator</h3>
+          <p>Select a battery to see estimated run time. Warnings appear if your configuration exceeds the battery output limits.</p>
+        </section>
+        <section data-help-section id="faq">
+          <h3>FAQ</h3>
+          <details class="faq-item">
+            <summary>How do I save a setup?</summary>
+            <p>Enter a name in the Setup Name field and click Save. It will then appear in the Saved Setups list.</p>
+          </details>
+          <details class="faq-item">
+            <summary>Can I export my setups?</summary>
+            <p>Yes. Use the Export All Setups button to download a JSON file containing every saved setup.</p>
+          </details>
+        </section>
+      </div>
     </div>
   </div>
 

--- a/script.js
+++ b/script.js
@@ -994,6 +994,7 @@ const darkModeToggle  = document.getElementById("darkModeToggle");
 const helpButton      = document.getElementById("helpButton");
 const helpDialog      = document.getElementById("helpDialog");
 const closeHelpBtn    = document.getElementById("closeHelp");
+const helpSearch      = document.getElementById("helpSearch");
 const existingDevicesHeading = document.getElementById("existingDevicesHeading");
 const batteryComparisonSection = document.getElementById("batteryComparison");
 const batteryTableElem = document.getElementById("batteryTable");
@@ -5359,6 +5360,23 @@ if (helpButton && helpDialog) {
 
   helpButton.addEventListener("click", toggleHelp);
   if (closeHelpBtn) closeHelpBtn.addEventListener("click", closeHelp);
+
+  const filterHelp = () => {
+    if (!helpSearch) return;
+    const query = helpSearch.value.toLowerCase();
+    const sections = helpDialog.querySelectorAll('[data-help-section]');
+    const items = helpDialog.querySelectorAll('.faq-item');
+    [...sections, ...items].forEach(el => {
+      const text = el.textContent.toLowerCase();
+      if (!query || text.includes(query)) {
+        el.removeAttribute('hidden');
+      } else {
+        el.setAttribute('hidden', '');
+      }
+    });
+  };
+
+  if (helpSearch) helpSearch.addEventListener('input', filterHelp);
 
   document.addEventListener("keydown", e => {
     if (e.key === "Escape" && !helpDialog.hasAttribute("hidden")) {

--- a/style.css
+++ b/style.css
@@ -126,12 +126,26 @@ p {
   background: #fff;
   border: 2px solid #001589;
   padding: 20px;
+  max-height: 80vh;
+  overflow-y: auto;
 }
 
 body.dark-mode .help-content {
   background: #1e1e1e;
   color: #f0f0f0;
   border-color: #555;
+}
+
+#helpSearch {
+  width: 100%;
+  margin: 10px 0;
+  padding: 5px;
+  box-sizing: border-box;
+}
+
+#helpSections section[hidden],
+#helpSections details[hidden] {
+  display: none;
 }
 
 /* Ensure selects and inputs inside wrappers match normal form fields */


### PR DESCRIPTION
## Summary
- expand help dialog with categories, FAQ and search
- add searchable help sections in JS
- style the updated dialog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68814e4182688320a78d443505d54d6b