### PR TITLE
Add pink interface toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,6 +19,7 @@
       <option value="fr">Français</option>
     </select>
     <button id="darkModeToggle" title="Toggle dark mode" aria-label="Toggle dark mode">☾</button>
+    <button id="pinkModeToggle" title="Toggle pink mode" aria-label="Toggle pink mode">🐴</button>
     <button id="helpButton" aria-haspopup="dialog" aria-controls="helpDialog" title="Help">?</button>
   </div>
 

--- a/script.js
+++ b/script.js
@@ -858,6 +858,10 @@ function setLanguage(lang) {
     darkModeToggle.setAttribute("title", texts[lang].darkModeLabel);
     darkModeToggle.setAttribute("aria-label", texts[lang].darkModeLabel);
   }
+  if (pinkModeToggle) {
+    pinkModeToggle.setAttribute("title", texts[lang].pinkModeLabel);
+    pinkModeToggle.setAttribute("aria-label", texts[lang].pinkModeLabel);
+  }
   if (helpButton) {
     helpButton.setAttribute("title", texts[lang].helpButtonLabel);
     helpButton.setAttribute("aria-label", texts[lang].helpButtonLabel);
@@ -991,6 +995,7 @@ const importFileInput = document.getElementById("importFileInput");
 const importDataBtn   = document.getElementById("importDataBtn");
 const languageSelect  = document.getElementById("languageSelect");
 const darkModeToggle  = document.getElementById("darkModeToggle");
+const pinkModeToggle  = document.getElementById("pinkModeToggle");
 const helpButton      = document.getElementById("helpButton");
 const helpDialog      = document.getElementById("helpDialog");
 const closeHelpBtn    = document.getElementById("closeHelp");
@@ -5252,6 +5257,37 @@ if (darkModeToggle) {
   });
 }
 
+// Pink mode handling
+function applyPinkMode(enabled) {
+  if (enabled) {
+    document.body.classList.add("pink-mode");
+    if (pinkModeToggle) pinkModeToggle.textContent = "🦄";
+  } else {
+    document.body.classList.remove("pink-mode");
+    if (pinkModeToggle) pinkModeToggle.textContent = "🐴";
+  }
+}
+
+let pinkModeEnabled = false;
+try {
+  pinkModeEnabled = localStorage.getItem("pinkMode") === "true";
+} catch (e) {
+  console.warn("Could not load pink mode preference", e);
+}
+applyPinkMode(pinkModeEnabled);
+
+if (pinkModeToggle) {
+  pinkModeToggle.addEventListener("click", () => {
+    pinkModeEnabled = !document.body.classList.contains("pink-mode");
+    applyPinkMode(pinkModeEnabled);
+    try {
+      localStorage.setItem("pinkMode", pinkModeEnabled);
+    } catch (e) {
+      console.warn("Could not save pink mode preference", e);
+    }
+  });
+}
+
 if (downloadDiagramBtn) {
   downloadDiagramBtn.addEventListener('click', (e) => {
     const svgEl = setupDiagramContainer.querySelector('svg');
@@ -5361,6 +5397,7 @@ if (typeof module !== "undefined" && module.exports) {
     setRecordingMedia,
     getRecordingMedia,
     applyDarkMode,
+    applyPinkMode,
     generatePrintableOverview,
     updateBatteryPlateVisibility,
     updateBatteryOptions,

--- a/style.css
+++ b/style.css
@@ -1,5 +1,11 @@
 
 /* General styles */
+:root {
+  --accent-color: #001589;
+}
+body.pink-mode {
+  --accent-color: #ff69b4;
+}
 /* Ensure predictable sizing */
 *, *::before, *::after {
   box-sizing: border-box;
@@ -18,7 +24,7 @@ body {
   position: absolute;
   left: -999px;
   top: -999px;
-  background: #001589;
+  background: var(--accent-color);
   color: #fff;
   padding: 8px 12px;
   z-index: 100;
@@ -38,7 +44,7 @@ body {
 h1, h2, h3 {
   font-family: 'Open Sans', sans-serif;
   font-weight: 500;
-  color: #001589;
+  color: var(--accent-color);
 }
 h1 {
   font-size: 1.8em;
@@ -47,7 +53,7 @@ h1 {
 h2 {
   font-size: 1.4em;
   margin-top: 1.3em;
-  border-bottom: 2px solid #001589;
+  border-bottom: 2px solid var(--accent-color);
 }
 h3 {
   font-size: 1.1em;
@@ -124,7 +130,7 @@ p {
 
 .help-content {
   background: #fff;
-  border: 2px solid #001589;
+  border: 2px solid var(--accent-color);
   padding: 20px;
 }
 
@@ -205,14 +211,14 @@ select {
 
 /* FIZ group fieldset */
 fieldset {
-  border: 1px solid #001589;
+  border: 1px solid var(--accent-color);
   border-radius: 5px;
   padding: 10px;
   margin-top: 1em;
 }
 legend {
   font-weight: 500;
-  color: #001589;
+  color: var(--accent-color);
   padding: 0 5px;
 }
 
@@ -267,7 +273,7 @@ button:disabled {
 }
 
 .device-category h4 {
-  color: #001589;
+  color: var(--accent-color);
   margin-top: 0;
   margin-bottom: 10px;
   border-bottom: 1px solid #eee;

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -314,6 +314,17 @@ describe('script.js functions', () => {
     expect(toggle.textContent).toBe('☾');
   });
 
+  test('applyPinkMode toggles class', () => {
+    const { applyPinkMode } = script;
+    const toggle = document.getElementById('pinkModeToggle');
+    applyPinkMode(true);
+    expect(document.body.classList.contains('pink-mode')).toBe(true);
+    expect(toggle.textContent).toBe('🦄');
+    applyPinkMode(false);
+    expect(document.body.classList.contains('pink-mode')).toBe(false);
+    expect(toggle.textContent).toBe('🐴');
+  });
+
   test('generatePrintableOverview opens window with content', () => {
     const { generatePrintableOverview } = script;
     window.open = jest.fn(() => ({ document: { write: jest.fn(), close: jest.fn() } }));

--- a/translations.js
+++ b/translations.js
@@ -19,6 +19,7 @@ const texts = {
     downloadDiagramBtn: "Download Diagram",
     existingDevicesHeading: "Existing Devices",
     darkModeLabel: "Toggle dark mode",
+    pinkModeLabel: "Toggle pink mode",
 
     savedSetupsLabel: "Saved Setups:",
     newSetupOption: "-- New Setup --",
@@ -223,6 +224,7 @@ const texts = {
     downloadDiagramBtn: "Descargar Diagrama",
     existingDevicesHeading: "Dispositivos Existentes",
     darkModeLabel: "Alternar modo oscuro",
+    pinkModeLabel: "Alternar modo rosa",
 
     savedSetupsLabel: "Configuraciones Guardadas:",
     newSetupOption: "-- Nueva Configuración --",
@@ -425,6 +427,7 @@ const texts = {
     downloadDiagramBtn: "Télécharger le Diagramme",
     existingDevicesHeading: "Appareils Existants",
     darkModeLabel: "Basculer mode sombre",
+    pinkModeLabel: "Basculer mode rose",
 
     savedSetupsLabel: "Configurations Enregistrées:",
     newSetupOption: "-- Nouvelle Configuration --",
@@ -627,6 +630,7 @@ const texts = {
     downloadDiagramBtn: "Diagramm herunterladen",
     existingDevicesHeading: "Vorhandene Geräte",
     darkModeLabel: "Dunkelmodus umschalten",
+    pinkModeLabel: "Pinkmodus umschalten",
 
     savedSetupsLabel: "Gespeicherte Setups:",
     newSetupOption: "-- Neues Setup --",


### PR DESCRIPTION
## Summary
- add toggle button for a new pink mode
- change blue accent styles to use CSS custom property
- implement pink mode toggle logic and persistence
- translate new "pink mode" label
- test pink mode functionality

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68814f0087088320a36cacd0add04881