### PR TITLE
Enforce accessory controller priority

### DIFF
--- a/data.js
+++ b/data.js
@@ -6597,7 +6597,7 @@ let devices={
         "power_source": "External (via LBUS)",
         "battery_type": "N/A",
         "connectivity": "Wired (LBUS) or Wireless (via ZMU-4/RIA-1/Master Grips)",
-        "notes": "Single-axis FIZ control (override for WCU-4/Hi-5), compact, lightweight, three assignable user buttons, controls EF lenses without motors on ALEXA Mini/AMIRA, controls SRH-3 roll axis.",
+        "notes": "Single-axis FIZ control (override for WCU-4/Hi-5), compact, lightweight, three assignable user buttons, controls EF lenses without motors on ALEXA Mini/AMIRA, controls SRH-3 roll axis. Should be connected after the main motor controller for correct priority.",
       },
       "Arri ZMU-4 (body only, wired)": {
         "powerDrawWatts": 1,
@@ -6615,7 +6615,7 @@ let devices={
         "power_source": "External DC (10.5-34V via LBUS/CAM) or Internal Battery",
         "battery_type": "Sony NP-F550/750 compatible, ARRI LBP-3500",
         "connectivity": "Wired (LBUS, CAM) or Wireless (with optional RF module - 2400 MHz DSSS)",
-        "notes": "Force-sensitive zoom knob, transflective TFT display, user buttons, can act as a radio module host for other LBUS devices (OCU-1, Master Grips), robust, weather-resistant, firmware update via USB-C, configurable camera control.",
+        "notes": "Force-sensitive zoom knob, transflective TFT display, user buttons, can act as a radio module host for other LBUS devices (OCU-1, Master Grips), robust, weather-resistant, firmware update via USB-C, configurable camera control. Connect after the main motor controller for correct priority.",
       },
       "Arri UMC-4": {
         "powerDrawWatts": 4,
@@ -6666,7 +6666,7 @@ let devices={
         "power_source": "External (12-34VDC via LBUS)",
         "battery_type": "N/A (no internal battery)",
         "connectivity": "Wired (LBUS) or Wireless (when connected to ZMU-4 or RIA-1 with radio module)",
-        "notes": "Ergonomic cine-style handgrip with integrated lens and camera controls. Available in rocker (zoom) or thumbwheel (focus/iris) versions. Can control EF/ENG and cine lenses. Advanced camera control via LCUBE CUB-1 (for third-party cameras). Override function for WCU-4 and Hi-5. Assignable user buttons, multilingual display, focus tracking, adjustable speed control.",
+        "notes": "Ergonomic cine-style handgrip with integrated lens and camera controls. Available in rocker (zoom) or thumbwheel (focus/iris) versions. Can control EF/ENG and cine lenses. Advanced camera control via LCUBE CUB-1 (for third-party cameras). Override function for WCU-4 and Hi-5. Assignable user buttons, multilingual display, focus tracking, adjustable speed control. Connect after the main motor controller for correct priority.",
       },
       "Tilta Nucleus-M Hand Grip (single)": {
         "powerDrawWatts": 0.5,

--- a/script.js
+++ b/script.js
@@ -378,7 +378,7 @@ function controllerDistancePort(name) {
 
 function controllerPriority(name) {
   if (/cforce.*rf/i.test(name) || /RIA-1/i.test(name) || /UMC-4/i.test(name)) return 0;
-  if (/Master Grip/i.test(name)) return 1;
+  if (/Master Grip/i.test(name) || /ZMU-4/i.test(name) || /OCU-1/i.test(name)) return 1;
   return 2;
 }
 

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -727,6 +727,60 @@ describe('script.js functions', () => {
     expect(firstNode.getAttribute('data-node')).toBe('controller0');
   });
 
+  test('UMC-4 controller is first FIZ device over ZMU-4', () => {
+    global.devices.fiz.controllers['Arri UMC-4'] = {
+      powerDrawWatts: 1,
+      fizConnectors: [{ type: 'LBUS (LEMO 4-pin)' }]
+    };
+    global.devices.fiz.controllers['Arri ZMU-4 (body only, wired)'] = {
+      powerDrawWatts: 1,
+      fizConnectors: [{ type: 'LBUS (LEMO 4-pin)' }]
+    };
+
+    const addOpt = (id, value) => {
+      const sel = document.getElementById(id);
+      sel.innerHTML = `<option value="${value}">${value}</option>`;
+      sel.value = value;
+    };
+    addOpt('cameraSelect', 'CamA');
+    addOpt('controller1Select', 'Arri UMC-4');
+    addOpt('controller2Select', 'Arri ZMU-4 (body only, wired)');
+    addOpt('motor1Select', 'MotorA');
+    addOpt('batterySelect', 'BattA');
+
+    script.renderSetupDiagram();
+
+    const firstNode = document.querySelector('#setupDiagram .diagram-node.first-fiz');
+    expect(firstNode.getAttribute('data-node')).toBe('controller0');
+  });
+
+  test('UMC-4 controller is first FIZ device over OCU-1', () => {
+    global.devices.fiz.controllers['Arri UMC-4'] = {
+      powerDrawWatts: 1,
+      fizConnectors: [{ type: 'LBUS (LEMO 4-pin)' }]
+    };
+    global.devices.fiz.controllers['Arri OCU-1'] = {
+      powerDrawWatts: 1,
+      fizConnectors: [{ type: 'LBUS (LEMO 4-pin)' }]
+    };
+
+    const addOpt = (id, value) => {
+      const sel = document.getElementById(id);
+      sel.innerHTML = `<option value="${value}">${value}</option>`;
+      sel.value = value;
+    };
+    addOpt('cameraSelect', 'CamA');
+    addOpt('controller1Select', 'Arri UMC-4');
+    addOpt('controller2Select', 'Arri OCU-1');
+    addOpt('motor1Select', 'MotorA');
+    addOpt('batterySelect', 'BattA');
+
+    script.renderSetupDiagram();
+
+    const firstNode = document.querySelector('#setupDiagram .diagram-node.first-fiz');
+    expect(firstNode.getAttribute('data-node')).toBe('controller0');
+  });
+
   test('ARRI FIZ requires battery on non-ARRI camera', () => {
     global.devices.fiz.controllers['Arri RIA-1'] = {
       powerDrawWatts: 1,


### PR DESCRIPTION
## Summary
- adjust `controllerPriority()` to sort OCU‑1 and ZMU‑4 after main motor controllers
- note proper daisy‑chain order in device data
- test that ZMU‑4 and OCU‑1 follow a UMC‑4 controller

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6881556c60788320beb0e2ae28c4209e