### PR TITLE
Fix bottom-right connector for distance unit

### DIFF
--- a/script.js
+++ b/script.js
@@ -3466,6 +3466,7 @@ function renderSetupDiagram() {
       if (c.side === 'top') { cx = p.x; cy = p.y - NODE_H / 2; }
       else if (c.side === 'bottom') { cx = p.x; cy = p.y + NODE_H / 2; }
       else if (c.side === 'bottom-left') { cx = p.x - NODE_W / 2 + NODE_W / 3; cy = p.y + NODE_H / 2; }
+      else if (c.side === 'bottom-right') { cx = p.x + NODE_W / 2 - NODE_W / 3; cy = p.y + NODE_H / 2; }
       else if (c.side === 'left') { cx = p.x - NODE_W / 2; cy = p.y; }
       else if (c.side === 'right') { cx = p.x + NODE_W / 2; cy = p.y; }
       svg += `<circle class="conn ${c.color}" cx="${cx}" cy="${cy}" r="4" />`;


### PR DESCRIPTION
## Summary
- adjust connector rendering logic so the distance node's second connection appears correctly at the bottom-right

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6881568ffc908320bb937537a05f9ae8