### PR TITLE
Update distance connection label

### DIFF
--- a/translations.js
+++ b/translations.js
@@ -128,7 +128,7 @@ const texts = {
     controllerPowerLabel: "Power Source:",
     controllerBatteryLabel: "Battery Type:",
     controllerConnectivityLabel: "Connectivity:",
-    distanceConnectionLabel: "Connection:",
+    distanceConnectionLabel: "The connections to the distance unit are still to proprietary not LBUS or Serial:",
     distanceMethodLabel: "Method:",
     distanceRangeLabel: "Range:",
     distanceAccuracyLabel: "Accuracy:",


### PR DESCRIPTION
## Summary
- change English distance connection label to emphasize proprietary connectors

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68815b77920083208444bcc3e34c500d