### PR TITLE
Clarify Tilta motor diagram connections

### DIFF
--- a/data.js
+++ b/data.js
@@ -6307,7 +6307,7 @@ let devices={
           "0.6 mod",
           "0.8 mod 29mm wide"
         ],
-        "notes": "Rated 2.5 N·m at 14.8V. Can be daisy-chained for power and control. Supports a 29mm thick 0.8 mod gear for lenses with telescoping focus gears. Compatible with standard 0.8 mod lens gears of various diameters.",
+        "notes": "Rated 2.5 N·m at 14.8V. Can be daisy-chained for power and control. Uses a proprietary 7-pin LEMO cable to the camera\u2019s FIZ port rather than ARRI LBUS. Supports a 29mm thick 0.8 mod gear for lenses with telescoping focus gears. Compatible with standard 0.8 mod lens gears of various diameters.",
       },
       "Tilta Nucleus M II": {
         "powerDrawWatts": 50,
@@ -6320,7 +6320,7 @@ let devices={
           "0.5 mod",
           "0.6 mod"
         ],
-        "notes": "Higher torque than Nucleus M, designed for improved performance. The 50W rating is likely a max stall power. Compatible with standard 0.8 mod lens gears of various diameters.",
+        "notes": "Higher torque than Nucleus M, designed for improved performance. Uses the same 7-pin LEMO connection to the camera FIZ port (not LBUS). The 50W rating is likely a max stall power. Compatible with standard 0.8 mod lens gears of various diameters.",
       },
       "Tilta Nucleus Nano (Original)": {
         "powerDrawWatts": 5,

--- a/script.js
+++ b/script.js
@@ -364,9 +364,13 @@ function controllerCamPort(name) {
     if (/UMC-4/i.test(name)) return '3-Pin R/S';
     const connStr = (c.fizConnectors || []).map(fc => fc.type).join(', ');
     if (/CAM/i.test(connStr)) return 'Cam';
+    if (/7-pin/i.test(connStr)) return 'LEMO 7-pin';
   }
   const m = devices.fiz?.motors?.[name];
-  if (m && /CAM/i.test(m.fizConnector || '')) return 'Cam';
+  if (m) {
+    if (/CAM/i.test(m.fizConnector || '')) return 'Cam';
+    if (/7-pin/i.test(m.fizConnector || '')) return 'LEMO 7-pin';
+  }
   return 'LBUS';
 }
 


### PR DESCRIPTION
## Summary
- improve FIZ connection labels so 7-pin motors show a direct LEMO 7-pin link instead of LBUS

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68815bd4d16483209139caa74cbd7914