### PR TITLE
Remove plate node from diagram

### DIFF
--- a/script.js
+++ b/script.js
@@ -1097,7 +1097,6 @@ const diagramIcons = {
   motors: "\u2699\uFE0F", // ⚙️ lens motor
   controllers: "\uD83C\uDFAE", // 🎮 game controller
   handle: "\uD83C\uDFAE", // 🎮 handle/grip (same icon as controller)
-  plate: "\uD83D\uDD0C", // 🔌 battery plate
   // Using a triangular ruler to represent a distance measuring device.
   distance: "\uD83D\uDCD0" // 📐 distance sensor
 };
@@ -3055,18 +3054,14 @@ function renderSetupDiagram() {
   let x = 80;
 
   if (batteryName && batteryName !== 'None') {
-    pos.battery = { x, y: baseY, label: batteryName };
+    let batteryLabel = batteryName;
+    const battMount = devices.batteries[batteryName]?.mount_type;
+    if (cam && battMount && cam.power?.batteryPlateSupport?.some(bp => bp.type === battMount && bp.mount === 'native')) {
+      batteryLabel += ` on native ${battMount} plate via Pins`;
+    }
+    pos.battery = { x, y: baseY, label: batteryLabel };
     nodes.push('battery');
     nodeMap.battery = { category: 'batteries', name: batteryName };
-    x += step;
-  }
-
-  const plateType = getSelectedPlate();
-  const nativePlate = plateType && isSelectedPlateNative(camName);
-  if (plateType && batteryName && batteryName !== 'None' && !nativePlate) {
-    pos.plate = { x, y: baseY, label: plateType + ' Plate' };
-    nodes.push('plate');
-    nodeMap.plate = { category: 'plates', name: plateType };
     x += step;
   }
 
@@ -3380,13 +3375,6 @@ function renderSetupDiagram() {
           { side: 'right', color: 'red' },
           { side: 'bottom', color: 'red' },
           { side: 'bottom-left', color: 'red' }
-        ];
-      case 'plate':
-        return [
-          { side: 'top', color: 'red' },
-          { side: 'right', color: 'red' },
-          { side: 'bottom', color: 'red' },
-          { side: 'left', color: 'red' }
         ];
       case 'monitor':
         return [

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -599,7 +599,7 @@ describe('script.js functions', () => {
     expect(() => renderSetupDiagram()).not.toThrow();
   });
 
-  test('native plate connection uses empty label', () => {
+  test('native plate adds label to battery', () => {
     global.devices.cameras.NativeCam = {
       powerDrawWatts: 10,
       power: { batteryPlateSupport: [{ type: 'V-Mount', mount: 'native' }] }
@@ -617,8 +617,9 @@ describe('script.js functions', () => {
     script.updateBatteryPlateVisibility();
     script.renderSetupDiagram();
 
-    const labels = Array.from(document.querySelectorAll('.edge-label')).map(el => el.textContent);
-    expect(labels.some(l => l.includes('V-Mount'))).toBe(false);
+    const batteryNode = document.querySelector('#diagramArea [data-node="battery"]');
+    const text = batteryNode.textContent.replace(/\s+/g, '');
+    expect(text).toContain('onnativeV-MountplateviaPins');
   });
 
   test('battery connects to FIZ motor when controller is internal power', () => {


### PR DESCRIPTION
## Summary
- annotate battery label when native plate matches battery
- drop rendering of intermediate plate node
- update diagram connectors accordingly
- adjust tests for new battery label

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6882a313c8008320a1d3f09a8c6e22a4