### PR TITLE
Fix connector naming for Tilta handles

### DIFF
--- a/data.js
+++ b/data.js
@@ -6672,7 +6672,7 @@ let devices={
         "powerDrawWatts": 0.5,
         "fizConnectors": [
           {
-            "type": "Proprietary 7-pin (to motor)"
+            "type": "LEMO 7-pin"
           },
           {
             "type": "ARRI rosette or gimbal bar adapter"
@@ -6688,7 +6688,7 @@ let devices={
         "powerDrawWatts": 0.5,
         "fizConnectors": [
           {
-            "type": "Proprietary 7-pin (to motor)"
+            "type": "LEMO 7-pin"
           },
           {
             "type": "ARRI rosette or gimbal bar adapter"


### PR DESCRIPTION
## Summary
- unify Tilta Nucleus hand grip connector naming to match other Nucleus motors

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6882a465d7e48320a2690bfb08c70f3e