### PR TITLE
Fix UMC‑4 connection labels

### DIFF
--- a/script.js
+++ b/script.js
@@ -431,7 +431,10 @@ function cameraFizPort(camName, controllerPort, deviceName = '') {
 function controllerFizPort(name) {
   const c = devices.fiz?.controllers?.[name];
   let portStr = '';
-  if (Array.isArray(c?.fizConnectors) && c.fizConnectors.length) {
+  if (/UMC-4/i.test(name)) {
+    const lcs = c?.fizConnectors?.find(fc => /LCS/i.test(fc.type));
+    portStr = lcs ? lcs.type : 'LCS (LEMO 7-pin)';
+  } else if (Array.isArray(c?.fizConnectors) && c.fizConnectors.length) {
     portStr = c.fizConnectors[0].type;
   } else if (c?.fizConnector) {
     portStr = c.fizConnector;

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -781,6 +781,35 @@ describe('script.js functions', () => {
     expect(firstNode.getAttribute('data-node')).toBe('controller0');
   });
 
+  test('UMC-4 connects to LBUS devices via LCS port', () => {
+    global.devices.fiz.controllers['Arri UMC-4'] = {
+      powerDrawWatts: 1,
+      fizConnectors: [
+        { type: 'Serial (LEMO 7-pin)' },
+        { type: 'LCS (LEMO 7-pin)' }
+      ]
+    };
+    global.devices.fiz.motors.LBUSMotor = {
+      powerDrawWatts: 2,
+      fizConnector: 'LBUS (LEMO 4-pin)'
+    };
+
+    const addOpt = (id, value) => {
+      const sel = document.getElementById(id);
+      sel.innerHTML = `<option value="${value}">${value}</option>`;
+      sel.value = value;
+    };
+    addOpt('cameraSelect', 'CamA');
+    addOpt('controller1Select', 'Arri UMC-4');
+    addOpt('motor1Select', 'LBUSMotor');
+    addOpt('batterySelect', 'BattA');
+
+    script.renderSetupDiagram();
+
+    const labels = Array.from(document.querySelectorAll('.edge-label')).map(el => el.textContent);
+    expect(labels.some(l => l.includes('LCS to LBUS'))).toBe(true);
+  });
+
   test('ARRI FIZ requires battery on non-ARRI camera', () => {
     global.devices.fiz.controllers['Arri RIA-1'] = {
       powerDrawWatts: 1,


### PR DESCRIPTION
## Summary
- ensure `controllerFizPort` returns the LCS connector for UMC‑4
- test that diagram labels show `LCS to LBUS` when connecting UMC‑4 to an LBUS device

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6882a70db8d08320b19584b449f40305