### PR TITLE
Add floating connector summary boxes

### DIFF
--- a/script.js
+++ b/script.js
@@ -4727,10 +4727,24 @@ function formatDeviceDataHtml(data) {
     if (!data || typeof data !== 'object') {
         return escapeHtml(String(data));
     }
-    const buildList = (obj) => {
+    const shouldSkip = (path, key) => {
+        const p = path.concat(key).join('.');
+        return p === 'power.powerDistributionOutputs' ||
+               p === 'power.input.portType' ||
+               p === 'fizConnectors' ||
+               p === 'videoOutputs' ||
+               p === 'timecode' ||
+               p === 'video.inputs' ||
+               p === 'video.outputs' ||
+               p === 'audioOutput' ||
+               p === 'audioInput' ||
+               p === 'audioIo';
+    };
+    const buildList = (obj, path = []) => {
         let html = '<ul class="device-data">';
         for (const [key, value] of Object.entries(obj)) {
             if (value === undefined || value === null || value === '') continue;
+            if (shouldSkip(path, key)) continue;
             html += '<li><strong>' + escapeHtml(key) + '</strong>: ';
             if (typeof value === 'object') {
                 if (Array.isArray(value)) {
@@ -4739,12 +4753,12 @@ function formatDeviceDataHtml(data) {
                     } else {
                         html += '<ul class="device-data">';
                         for (const val of value) {
-                            html += '<li>' + (typeof val === 'object' ? buildList(val) : escapeHtml(String(val))) + '</li>';
+                            html += '<li>' + (typeof val === 'object' ? buildList(val, path.concat(key)) : escapeHtml(String(val))) + '</li>';
                         }
                         html += '</ul>';
                     }
                 } else {
-                    html += buildList(value);
+                    html += buildList(value, path.concat(key));
                 }
             } else {
                 html += escapeHtml(String(value));
@@ -4767,7 +4781,7 @@ function summarizeByType(list) {
     return counts;
 }
 
-function connectorBlocks(items, icon, cls) {
+function connectorBlocks(items, icon, cls = 'neutral-conn') {
     const counts = summarizeByType(items);
     return Object.entries(counts).map(([type, count]) =>
         `<span class="connector-block ${cls}">${icon} ${escapeHtml(type)}${count > 1 ? ` ×${count}` : ''}</span>`
@@ -4796,6 +4810,24 @@ function generateConnectorSummary(data) {
     }
     if (Array.isArray(data.videoOutputs)) {
         html += connectorBlocks(data.videoOutputs, '📺', 'video-conn');
+    }
+    if (Array.isArray(data.timecode)) {
+        html += connectorBlocks(data.timecode, '⏱️');
+    }
+    if (data.video && Array.isArray(data.video.inputs)) {
+        html += connectorBlocks(data.video.inputs, '🎥');
+    }
+    if (data.video && Array.isArray(data.video.outputs)) {
+        html += connectorBlocks(data.video.outputs, '🎥');
+    }
+    if (data.audioOutput && data.audioOutput.portType) {
+        html += connectorBlocks([{ type: data.audioOutput.portType }], '🔊');
+    }
+    if (data.audioInput && data.audioInput.portType) {
+        html += connectorBlocks([{ type: data.audioInput.portType }], '🎤');
+    }
+    if (data.audioIo && data.audioIo.portType) {
+        html += connectorBlocks([{ type: data.audioIo.portType }], '🎚️');
     }
     return html ? `<div class="connector-summary">${html}</div>` : '';
 }
@@ -5069,6 +5101,8 @@ function generatePrintableOverview() {
                 }
                 .connector-summary {
                   margin-top: 5px;
+                  display: flex;
+                  flex-wrap: wrap;
                 }
                 .connector-block {
                   display: inline-block;
@@ -5081,6 +5115,7 @@ function generatePrintableOverview() {
                 .power-conn { border-color: #f44336; }
                 .fiz-conn { border-color: #4caf50; }
                 .video-conn { border-color: #2196f3; }
+                .neutral-conn { border-color: #9e9e9e; }
                 /* Setup diagram styles */
                 #setupDiagram svg { width: 100%; max-width: 900px; height: 420px; }
                 ${diagramCss}
@@ -5159,6 +5194,8 @@ function generatePrintableOverview() {
                     }
                     .connector-summary {
                       margin-top: 5px;
+                      display: flex;
+                      flex-wrap: wrap;
                     }
                     .connector-block {
                       display: inline-block;
@@ -5171,6 +5208,7 @@ function generatePrintableOverview() {
                     .power-conn { border-color: #f44336 !important; }
                     .fiz-conn { border-color: #4caf50 !important; }
                     .video-conn { border-color: #2196f3 !important; }
+                    .neutral-conn { border-color: #9e9e9e !important; }
                     /* Styles for Battery Comparison Bars in Overview for Print */
                     .barContainer {
                       width: 100%;


### PR DESCRIPTION
## Summary
- show connector summaries in flex floating boxes in printable overview
- skip connector fields in device details so boxes don't repeat text
- add neutral style for connectors that don't fit a color category

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6882a897001483209a8fa02da68f1d7f