### PR TITLE
Make UMC‑4 warning orange

### DIFF
--- a/script.js
+++ b/script.js
@@ -699,7 +699,11 @@ function checkArriCompatibility() {
 
   if (msg) {
     compatElem.textContent = msg;
-    compatElem.style.color = 'red';
+    if (msg === texts[currentLang].arriUMC4Warning) {
+      compatElem.style.color = 'orange';
+    } else {
+      compatElem.style.color = 'red';
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- change colour for ARRI UMC‑4 compatibility warning

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6882ac2144788320a11c87e6626442e1