### PR TITLE
Fix distance unit labels

### DIFF
--- a/script.js
+++ b/script.js
@@ -376,6 +376,7 @@ function controllerCamPort(name) {
 
 function controllerDistancePort(name) {
   const c = devices.fiz?.controllers?.[name];
+  if (/RIA-1/i.test(name) || /UMC-4/i.test(name)) return 'Serial';
   if (c && (c.fizConnectors || []).some(fc => /SERIAL/i.test(fc.type))) return 'Serial';
   return 'LBUS';
 }
@@ -453,7 +454,7 @@ function motorFizPort(name) {
 
 function distanceFizPort(name) {
   const d = devices.fiz?.distance?.[name];
-  if (!d) return 'Proprietary';
+  if (!d) return 'LBUS';
   let portStr = '';
   if (Array.isArray(d.fizConnectors) && d.fizConnectors.length) {
     const lbus = d.fizConnectors.find(fc => /LBUS/i.test(fc.type));
@@ -474,7 +475,7 @@ function fizPort(name) {
   if (devices.fiz?.controllers?.[name]) return controllerFizPort(name);
   if (devices.fiz?.motors?.[name]) return motorFizPort(name);
   if (devices.fiz?.distance?.[name]) return distanceFizPort(name);
-  return 'Proprietary';
+  return 'LBUS';
 }
 
 function fizPowerPort(name) {

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -49,4 +49,42 @@ describe('utility function tests', () => {
     expect(connectionLabel('SDI', 'SDI')).toBe('SDI');
     expect(connectionLabel('', '')).toBe('');
   });
+
+  test('distanceFizPort defaults to LBUS', () => {
+    const { renderSetupDiagram } = utils;
+    const addOpt = (id, value) => {
+      const sel = document.getElementById(id);
+      sel.innerHTML = `<option value="${value}">${value}</option>`;
+      sel.value = value;
+    };
+    global.devices.fiz.distance = {};
+    global.devices.fiz.controllers.TestCtrl = { fizConnectors: [{ type: 'LBUS (LEMO 4-pin)' }] };
+    global.devices.cameras.CamX = { powerDrawWatts: 10, fizConnectors: [{ type: 'LBUS (LEMO 4-pin)' }] };
+    addOpt('distanceSelect', 'Unknown');
+    addOpt('controller1Select', 'TestCtrl');
+    addOpt('cameraSelect', 'CamX');
+    renderSetupDiagram();
+    const labels = Array.from(document.querySelectorAll('.edge-label')).map(el => el.textContent);
+    expect(labels.some(l => l.includes('LBUS'))).toBe(true);
+  });
+
+  test('distance connection uses Serial for RIA-1 controller', () => {
+    const { renderSetupDiagram } = utils;
+    const addOpt = (id, value) => {
+      const sel = document.getElementById(id);
+      sel.innerHTML = `<option value="${value}">${value}</option>`;
+      sel.value = value;
+    };
+    global.devices.cameras.CamX = { powerDrawWatts: 10, fizConnectors: [{ type: 'LBUS (LEMO 4-pin)' }] };
+    global.devices.fiz.controllers['Arri RIA-1'] = {
+      fizConnectors: [{ type: 'LBUS (LEMO 4-pin)' }, { type: 'SERIAL (LEMO 4-pin)' }]
+    };
+    global.devices.fiz.distance.Dist = {};
+    addOpt('cameraSelect', 'CamX');
+    addOpt('controller1Select', 'Arri RIA-1');
+    addOpt('distanceSelect', 'Dist');
+    renderSetupDiagram();
+    const labels = Array.from(document.querySelectorAll('.edge-label')).map(el => el.textContent);
+    expect(labels.some(l => /Serial/.test(l))).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary
- default distance unit port labels to LBUS
- mark RIA‑1 and UMC‑4 distance ports as Serial
- update unit tests for new behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6882ab9db2bc8320b95ec203d0c11abb