### PR TITLE
Improve popup formatting

### DIFF
--- a/script.js
+++ b/script.js
@@ -3625,11 +3625,13 @@ function attachDiagramPopups(map) {
     const connectors = data ? generateConnectorSummary(data) : '';
     const details = data ? formatDeviceDataHtml(data) : '';
     const portHtml =
-      `Power In: ${format(ports.powerIn)}<br>` +
-      `Power Out: ${format(ports.powerOut)}<br>` +
-      `FIZ: ${format(ports.fiz)}<br>` +
-      `Video In: ${format(ports.videoIn)}<br>` +
-      `Video Out: ${format(ports.videoOut)}`;
+      '<table class="port-table">' +
+      `<tr><th>Power In</th><td>${format(ports.powerIn)}</td></tr>` +
+      `<tr><th>Power Out</th><td>${format(ports.powerOut)}</td></tr>` +
+      `<tr><th>FIZ</th><td>${format(ports.fiz)}</td></tr>` +
+      `<tr><th>Video In</th><td>${format(ports.videoIn)}</td></tr>` +
+      `<tr><th>Video Out</th><td>${format(ports.videoOut)}</td></tr>` +
+      '</table>';
     const html = `<strong>${escapeHtml(info.name)}</strong><br>` +
       portHtml + connectors + details;
 

--- a/style.css
+++ b/style.css
@@ -488,6 +488,21 @@ body.dark-mode .diagram-popup {
   font-size: 0.75em;
 }
 
+.port-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 4px;
+  font-size: 0.8em;
+}
+.port-table th {
+  text-align: left;
+  padding: 2px 6px 2px 0;
+  white-space: nowrap;
+}
+.port-table td {
+  padding: 2px 0;
+}
+
 .power-conn { border-color: #f44336; }
 .fiz-conn { border-color: #4caf50; }
 .video-conn { border-color: #2196f3; }


### PR DESCRIPTION
## Summary
- reorganize port information into a table for diagram popups
- style the new table for readability

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6883e20ef9dc83208159301875163a59