### PR TITLE
Improve diagram popup and overview boxes

### DIFF
--- a/script.js
+++ b/script.js
@@ -3652,11 +3652,11 @@ function attachDiagramPopups(map) {
     const details = data ? formatDeviceDataHtml(data) : '';
     const portHtml =
       '<table class="port-table">' +
-      `<tr><th>Power In</th><td>${format(ports.powerIn)}</td></tr>` +
-      `<tr><th>Power Out</th><td>${format(ports.powerOut)}</td></tr>` +
-      `<tr><th>FIZ</th><td>${format(ports.fiz)}</td></tr>` +
-      `<tr><th>Video In</th><td>${format(ports.videoIn)}</td></tr>` +
-      `<tr><th>Video Out</th><td>${format(ports.videoOut)}</td></tr>` +
+      `<tr class="power-row"><th>Power In</th><td>${format(ports.powerIn)}</td></tr>` +
+      `<tr class="power-row"><th>Power Out</th><td>${format(ports.powerOut)}</td></tr>` +
+      `<tr class="fiz-row"><th>FIZ</th><td>${format(ports.fiz)}</td></tr>` +
+      `<tr class="video-row"><th>Video In</th><td>${format(ports.videoIn)}</td></tr>` +
+      `<tr class="video-row"><th>Video Out</th><td>${format(ports.videoOut)}</td></tr>` +
       '</table>';
     const html = `<strong>${escapeHtml(info.name)}</strong><br>` +
       portHtml + connectors + details;
@@ -5172,6 +5172,7 @@ function generatePrintableOverview() {
                   margin-bottom: 10px;
                   flex: 1 1 calc((100% - 20px) / 3);
                   box-sizing: border-box;
+                  box-shadow: 0 2px 6px rgba(0,0,0,0.1);
                 }
                 .device-category h3 {
                   margin-top: 0;
@@ -5194,6 +5195,7 @@ function generatePrintableOverview() {
                   border-radius: 4px;
                   border: 2px solid;
                   font-size: 0.85em;
+                  background-color: rgba(0,0,0,0.03);
                 }
                 .power-conn { border-color: #f44336; }
                 .fiz-conn { border-color: #4caf50; }
@@ -5268,6 +5270,7 @@ function generatePrintableOverview() {
                       margin-bottom: 10px;
                       flex: 1 1 calc((100% - 20px) / 3);
                       box-sizing: border-box;
+                      box-shadow: 0 2px 6px rgba(0,0,0,0.1);
                     }
                     .device-category h3 {
                       margin-top: 0;
@@ -5290,6 +5293,7 @@ function generatePrintableOverview() {
                       border-radius: 4px;
                       border: 2px solid;
                       font-size: 0.85em;
+                      background-color: rgba(0,0,0,0.03);
                     }
                     .power-conn { border-color: #f44336 !important; }
                     .fiz-conn { border-color: #4caf50 !important; }

--- a/style.css
+++ b/style.css
@@ -284,6 +284,7 @@ button:disabled {
   border: 1px solid #eee;
   border-radius: 5px;
   padding: 10px;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
 }
 
 .device-category h4 {
@@ -459,10 +460,11 @@ body.dark-mode #diagramHint {
   background: rgba(255, 255, 255, 0.95);
   border: 1px solid #333;
   font-size: 12px;
-  padding: 4px 8px;
-  border-radius: 4px;
+  padding: 6px 10px;
+  border-radius: 6px;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.25);
   z-index: 10;
-  max-width: 300px;
+  max-width: 320px;
   overflow: auto;
 }
 
@@ -470,6 +472,7 @@ body.dark-mode .diagram-popup {
   background: rgba(51, 51, 51, 0.95);
   color: #fff;
   border-color: #888;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.4);
 }
 
 /* Device info lists inside diagram popups */
@@ -486,6 +489,7 @@ body.dark-mode .diagram-popup {
   border-radius: 3px;
   border: 1px solid;
   font-size: 0.75em;
+  background-color: rgba(0,0,0,0.03);
 }
 
 .port-table {
@@ -503,10 +507,29 @@ body.dark-mode .diagram-popup {
   padding: 2px 0;
 }
 
+.port-table .power-row th,
+.port-table .power-row td {
+  color: #f44336;
+}
+
+.port-table .fiz-row th,
+.port-table .fiz-row td {
+  color: #4caf50;
+}
+
+.port-table .video-row th,
+.port-table .video-row td {
+  color: #2196f3;
+}
+
 .power-conn { border-color: #f44336; }
 .fiz-conn { border-color: #4caf50; }
 .video-conn { border-color: #2196f3; }
 .neutral-conn { border-color: #9e9e9e; }
+
+body.dark-mode .connector-block {
+  background-color: rgba(255,255,255,0.1);
+}
 
 .device-data { margin-left: 10px; }
 .device-data ul { list-style: disc; margin-left: 20px; }
@@ -707,6 +730,7 @@ body.dark-mode .device-category,
 body.dark-mode #batteryComparison {
   background-color: #1e1e1e;
   border-color: #333;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.5);
 }
 
 body.dark-mode fieldset {


### PR DESCRIPTION
## Summary
- restyle diagram popups with subtle shadow and colour-coded port rows
- give device overview boxes a floating look
- use consistent connector styling in overview and dark mode tweaks

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6883e67703b48320a377f07878de399b