### PR TITLE
Expand 'OK' limit message

### DIFF
--- a/script.js
+++ b/script.js
@@ -2886,7 +2886,8 @@ if (!battery || battery === "None" || !devices.batteries[battery]) {
     }
     // Show max current capability and status (OK/Warning) for Pin and D-Tap
     if (pinWarnElem.textContent === "") {
-      pinWarnElem.textContent = (currentLang === "de") ? `${maxPinA}A max – OK` : `${maxPinA}A max – OK`;
+      pinWarnElem.textContent = texts[currentLang].pinOk
+        .replace("{max}", maxPinA);
       pinWarnElem.style.color = "green";
     } else {
       if (pinSeverity === "warning") {
@@ -2899,7 +2900,8 @@ if (!battery || battery === "None" || !devices.batteries[battery]) {
     }
     if (!bMountCam) {
       if (dtapWarnElem.textContent === "") {
-        dtapWarnElem.textContent = (currentLang === "de") ? `${maxDtapA}A max – OK` : `${maxDtapA}A max – OK`;
+        dtapWarnElem.textContent = texts[currentLang].dtapOk
+          .replace("{max}", maxDtapA);
         dtapWarnElem.style.color = "green";
       } else {
         if (dtapSeverity === "warning") {

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -59,8 +59,10 @@ describe('script.js functions', () => {
     expect(document.getElementById('totalPower').textContent).toBe('23.0');
     expect(document.getElementById('totalCurrent12').textContent).toBe('1.92');
     expect(document.getElementById('batteryLife').textContent).toBe('4.35');
-    expect(document.getElementById('pinWarning').textContent).toBe('10A max – OK');
-    expect(document.getElementById('dtapWarning').textContent).toBe('5A max – OK');
+    expect(document.getElementById('pinWarning').textContent)
+      .toBe(texts.en.pinOk.replace('{max}', '10'));
+    expect(document.getElementById('dtapWarning').textContent)
+      .toBe(texts.en.dtapOk.replace('{max}', '5'));
   });
 
   test('B-Mount camera uses high-voltage current labels', () => {

--- a/translations.js
+++ b/translations.js
@@ -49,6 +49,8 @@ const texts = {
     methodPinsOnly: "pins only!",
     methodPinsAndDTap: "both pins and D-Tap",
     methodInfinite: "infinite",
+    pinOk: "Battery pins can supply up to {max}A \u2013 current draw is within limits.",
+    dtapOk: "D-Tap can supply up to {max}A \u2013 current draw is within limits.",
 
     warnPinExceededLevel: "warning",
     warnPinNearLevel: "note",
@@ -250,6 +252,8 @@ const texts = {
     methodPinsOnly: "solo pin!",
     methodPinsAndDTap: "sia pin che D-Tap",
     methodInfinite: "infinito",
+    pinOk: "I pin della batteria possono fornire fino a {max}A - assorbimento nei limiti.",
+    dtapOk: "L'uscita D-Tap pu\u00f2 fornire fino a {max}A - assorbimento nei limiti.",
     warnPinExceededLevel: "avvertimento",
     warnPinNearLevel: "nota",
     warnDTapExceededLevel: "avvertimento",
@@ -443,6 +447,8 @@ const texts = {
     methodPinsOnly: "solo pines!",
     methodPinsAndDTap: "pines y D-Tap",
     methodInfinite: "infinito",
+    pinOk: "Los pines de la bater\u00eda pueden suministrar hasta {max}A \u2013 consumo dentro del l\u00edmite.",
+    dtapOk: "La salida D-Tap puede suministrar hasta {max}A \u2013 consumo dentro del l\u00edmite.",
 
     warnPinExceededLevel: "warning",
     warnPinNearLevel: "note",
@@ -648,6 +654,8 @@ const texts = {
     methodPinsOnly: "broches seulement!",
     methodPinsAndDTap: "broches et D-Tap",
     methodInfinite: "infini",
+    pinOk: "Les broches de la batterie peuvent fournir jusqu'\u00e0 {max}A \u2013 consommation dans la limite.",
+    dtapOk: "La sortie D-Tap peut fournir jusqu'\u00e0 {max}A \u2013 consommation dans la limite.",
 
     warnPinExceededLevel: "warning",
     warnPinNearLevel: "note",
@@ -853,6 +861,8 @@ const texts = {
     methodPinsOnly: "nur Pins!",
     methodPinsAndDTap: "Pins und D-Tap",
     methodInfinite: "unendlich",
+    pinOk: "Die Akku-Pins liefern bis zu {max}A \u2013 Strombedarf innerhalb des Limits.",
+    dtapOk: "Die D-Tap-Buchse liefert bis zu {max}A \u2013 Strombedarf innerhalb des Limits.",
 
     warnPinExceededLevel: "warning",
     warnPinNearLevel: "note",


### PR DESCRIPTION
## Summary
- add explicit OK messages for pin and D-Tap current limits
- show the translated OK notice in UI
- update tests for new text

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6883e821c3cc83208909910ad625af58