### PR TITLE
Update diagram popups

### DIFF
--- a/script.js
+++ b/script.js
@@ -3649,19 +3649,20 @@ function attachDiagramPopups(map) {
     }
     const ports = getDevicePorts(info.category, info.name) ||
       { powerIn: [], powerOut: [], fiz: [], videoIn: [], videoOut: [] };
-    const format = list => list && list.length ? list.join(', ') : '-';
+    const format = list => list && list.length ? list.join(', ') : '';
     const connectors = data ? generateConnectorSummary(data) : '';
     const details = data ? formatDeviceDataHtml(data) : '';
+    const box = (label, items, cls) => items && items.length ?
+      `<div class="info-box ${cls}"><strong>${label}:</strong> ${format(items)}</div>` : '';
     const portHtml =
-      '<table class="port-table">' +
-      `<tr class="power-row"><th>Power In</th><td>${format(ports.powerIn)}</td></tr>` +
-      `<tr class="power-row"><th>Power Out</th><td>${format(ports.powerOut)}</td></tr>` +
-      `<tr class="fiz-row"><th>FIZ</th><td>${format(ports.fiz)}</td></tr>` +
-      `<tr class="video-row"><th>Video In</th><td>${format(ports.videoIn)}</td></tr>` +
-      `<tr class="video-row"><th>Video Out</th><td>${format(ports.videoOut)}</td></tr>` +
-      '</table>';
-    const html = `<strong>${escapeHtml(info.name)}</strong><br>` +
-      portHtml + connectors + details;
+      box('Power In', ports.powerIn, 'power') +
+      box('Power Out', ports.powerOut, 'power') +
+      box('FIZ', ports.fiz, 'fiz') +
+      box('Video In', ports.videoIn, 'video') +
+      box('Video Out', ports.videoOut, 'video');
+    const tray = details ? `<div class="tray-box">${details}</div>` : '';
+    const html = `<strong>${escapeHtml(info.name)}</strong>` +
+      portHtml + connectors + tray;
 
     const show = e => {
       popup.innerHTML = html;

--- a/style.css
+++ b/style.css
@@ -492,6 +492,23 @@ body.dark-mode .diagram-popup {
   background-color: rgba(0,0,0,0.03);
 }
 
+.info-box {
+  display: inline-block;
+  padding: 2px 6px;
+  margin: 2px;
+  border-radius: 3px;
+  background: rgba(0,0,0,0.03);
+  font-size: 0.75em;
+}
+
+.tray-box {
+  margin-top: 4px;
+  padding: 4px;
+  border-radius: 3px;
+  background: rgba(0,0,0,0.05);
+  font-size: 0.75em;
+}
+
 .port-table {
   width: 100%;
   border-collapse: collapse;
@@ -528,6 +545,11 @@ body.dark-mode .diagram-popup {
 .neutral-conn { border-color: #9e9e9e; }
 
 body.dark-mode .connector-block {
+  background-color: rgba(255,255,255,0.1);
+}
+
+body.dark-mode .info-box,
+body.dark-mode .tray-box {
   background-color: rgba(255,255,255,0.1);
 }
 


### PR DESCRIPTION
## Summary
- show device info in simple floating boxes instead of a table
- wrap detailed fields inside a tray box
- style new info boxes and tray boxes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6883ed628cc883208215df1418ebed8f