### PR TITLE
Fix unicorn mode styling in dark mode

### DIFF
--- a/style.css
+++ b/style.css
@@ -142,6 +142,10 @@ body.dark-mode .help-content {
   border-color: #555;
 }
 
+body.dark-mode.pink-mode .help-content {
+  border-color: var(--accent-color);
+}
+
 #helpSearch {
   width: 100%;
   margin: 10px 0;
@@ -757,6 +761,16 @@ body.dark-mode h3 {
 
 body.dark-mode h2 {
   border-bottom: 2px solid #ffffff;
+}
+
+body.dark-mode.pink-mode h1,
+body.dark-mode.pink-mode h2,
+body.dark-mode.pink-mode h3 {
+  color: var(--accent-color);
+}
+
+body.dark-mode.pink-mode h2 {
+  border-bottom: 2px solid var(--accent-color);
 }
 
 body.dark-mode section,


### PR DESCRIPTION
## Summary
- Make pink/unicorn mode override dark mode heading and dialog styles so pink accent appears even when dark mode is active

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0a1d83ca48320b268b72cd1d96802