### PR TITLE
Preserve pink accent in dark mode

### DIFF
--- a/style.css
+++ b/style.css
@@ -789,6 +789,14 @@ body.dark-mode legend {
   color: #ffffff;
 }
 
+body.dark-mode.pink-mode fieldset {
+  border-color: var(--accent-color);
+}
+
+body.dark-mode.pink-mode legend {
+  color: var(--accent-color);
+}
+
 body.dark-mode button,
 body.dark-mode #langSelector select,
 body.dark-mode input,
@@ -849,6 +857,11 @@ body.dark-mode .selectedBatteryRow {
 body.dark-mode .device-category h4 {
   color: #ffffff;
   border-bottom: 1px solid #ffffff;
+}
+
+body.dark-mode.pink-mode .device-category h4 {
+  color: var(--accent-color);
+  border-bottom: 1px solid var(--accent-color);
 }
 
 body.dark-mode .device-ul li {

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -327,6 +327,16 @@ describe('script.js functions', () => {
     expect(toggle.textContent).toBe('🐴');
   });
 
+  test('pink mode can toggle while dark mode is active', () => {
+    const { applyDarkMode, applyPinkMode } = script;
+    applyDarkMode(true);
+    applyPinkMode(true);
+    expect(document.body.classList.contains('dark-mode')).toBe(true);
+    expect(document.body.classList.contains('pink-mode')).toBe(true);
+    applyPinkMode(false);
+    expect(document.body.classList.contains('pink-mode')).toBe(false);
+  });
+
   test('generatePrintableOverview opens window with content', () => {
     const { generatePrintableOverview } = script;
     window.open = jest.fn(() => ({ document: { write: jest.fn(), close: jest.fn() } }));


### PR DESCRIPTION
## Summary
- Restore pink accent styling when dark mode is active by adding dark-mode.pink-mode overrides.
- Add regression test ensuring pink mode toggles correctly while in dark mode.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b0a36b14d48320a87c5bb91f6d0f82