### PR TITLE
Add theme controls to overview and match warning colors

### DIFF
--- a/script.js
+++ b/script.js
@@ -5042,6 +5042,7 @@ function generatePrintableOverview() {
     const locale = localeMap[currentLang] || 'en-US';
     const dateTimeString = now.toLocaleDateString(locale) + ' ' + now.toLocaleTimeString();
     const t = texts[currentLang];
+    const langSelectorHtml = document.getElementById("langSelector").innerHTML;
 
     let deviceListHtml = '<div class="device-category-container">';
     const sections = {};
@@ -5102,11 +5103,11 @@ function generatePrintableOverview() {
     let warningHtml = '';
     // Check if pinWarnElem has content that is not just "OK"
     if (pinWarnElem.textContent.trim() !== '' && !pinWarnElem.textContent.includes("OK")) {
-        warningHtml += `<p class="warning">${pinWarnElem.textContent}</p>`;
+        warningHtml += `<p class="warning" style="color: ${pinWarnElem.style.color || 'red'};">${pinWarnElem.textContent}</p>`;
     }
     // Check if dtapWarnElem has content that is not just "OK"
     if (dtapWarnElem.textContent.trim() !== '' && !dtapWarnElem.textContent.includes("OK")) {
-        warningHtml += `<p class="warning">${dtapWarnElem.textContent}</p>`;
+        warningHtml += `<p class="warning" style="color: ${dtapWarnElem.style.color || 'red'};">${dtapWarnElem.textContent}</p>`;
     }
     if (warningHtml !== '') {
         warningHtml = `<h2>Warnings</h2>${warningHtml}`;
@@ -5260,6 +5261,7 @@ function generatePrintableOverview() {
         <head>
             <meta charset="UTF-8">
             <title>${t.overviewTitle} - ${safeSetupName}</title>
+            <link rel="stylesheet" href="style.css">
             <style>
                 body { font-family: 'Open Sans', sans-serif; margin: 25px; color: #333; font-size: 0.9em; -webkit-print-color-adjust: exact; print-color-adjust: exact; }
                 h1, h2, h3 { font-family: 'Open Sans', sans-serif; font-weight: 500; color: #001589; }
@@ -5376,7 +5378,7 @@ function generatePrintableOverview() {
                 }
                 @media print {
                     .print-btn { display: none; }
-                    body { margin: 1cm; -webkit-print-color-adjust: exact; print-color-adjust: exact; }
+                    body, body.dark-mode, body.pink-mode, body.dark-mode.pink-mode { margin: 1cm; -webkit-print-color-adjust: exact; print-color-adjust: exact; background: #fff !important; color: #000 !important; }
                     .device-overview { list-style: none; margin-left: 0; padding-left: 0; }
                     .device-item { margin: 5px 0; }
                     .device-data { margin-left: 15px; }
@@ -5477,6 +5479,7 @@ function generatePrintableOverview() {
             </style>
         </head>
         <body>
+            <div id="langSelector">${langSelectorHtml}</div>
             <button onclick="window.print()" class="print-btn">Print</button>
             <h1>${t.overviewTitle}</h1>
             <p><strong>${t.setupNameLabel}</strong> ${safeSetupName}</p>
@@ -5492,6 +5495,14 @@ function generatePrintableOverview() {
             ${diagramHtml}
 
             ${batteryTableHtml}
+            <script>
+            document.getElementById('darkModeToggle').addEventListener('click', function() {
+                document.body.classList.toggle('dark-mode');
+            });
+            document.getElementById('pinkModeToggle').addEventListener('click', function() {
+                document.body.classList.toggle('pink-mode');
+            });
+            </script>
         </body>
         </html>
     `;

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -416,6 +416,36 @@ describe('script.js functions', () => {
     expect(document.getElementById('dtapWarning').style.color).toBe('orange');
   });
 
+  test('overview reuses warning colors and shows theme controls', () => {
+    global.devices.batteries.NoteBatt = { capacity: 50, pinA: 2.3, dtapA: 2.3, mount_type: 'V-Mount' };
+    const addOpt = (id, value) => {
+      const sel = document.getElementById(id);
+      sel.innerHTML = `<option value="${value}">${value}</option>`;
+      sel.value = value;
+    };
+    addOpt('cameraSelect', 'CamA');
+    addOpt('monitorSelect', 'MonA');
+    addOpt('videoSelect', 'VidA');
+    addOpt('motor1Select', 'MotorA');
+    addOpt('controller1Select', 'ControllerA');
+    addOpt('distanceSelect', 'DistA');
+    addOpt('batterySelect', 'NoteBatt');
+    script.setLanguage('fr');
+    script.updateCalculations();
+    const pinColor = document.getElementById('pinWarning').style.color;
+    const dtapColor = document.getElementById('dtapWarning').style.color;
+    let writtenHtml = '';
+    window.open = jest.fn().mockReturnValue({
+      document: { write: html => { writtenHtml = html; }, close: jest.fn() }
+    });
+    script.generatePrintableOverview();
+    expect(writtenHtml).toContain(`<p class="warning" style="color: ${pinColor};">`);
+    expect(writtenHtml).toContain(`<p class="warning" style="color: ${dtapColor};">`);
+    expect(writtenHtml).toContain('id="langSelector"');
+    expect(writtenHtml).toContain('id="darkModeToggle"');
+    expect(writtenHtml).toContain('id="pinkModeToggle"');
+  });
+
   test('missing FIZ controller shows error', () => {
     jest.resetModules();
 


### PR DESCRIPTION
## Summary
- Mirror result warning colors in printable overview
- Show language selector with dark and pink mode toggles in overview
- Ensure overview prints with a white background regardless of theme
- Test that overview HTML contains correct warning colors and controls

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b0a47f24c883208e743bfd54d53bf9