### PR TITLE
Fix camera to CforceRF connection label

### DIFF
--- a/script.js
+++ b/script.js
@@ -3348,10 +3348,10 @@ function renderSetupDiagram() {
     }
     const port = first === 'distance' ? 'LBUS' : controllerCamPort(firstName);
     const camPort = cameraFizPort(camName, port, firstName);
-    pushEdge({ from: 'camera', to: first, label: formatConnLabel(camPort, port), noArrow: true }, 'fiz');
+    pushEdge({ from: 'camera', to: first, label: formatConnLabel(port, camPort), noArrow: true }, 'fiz');
   } else if (motorIds.length && cam) {
     const camPort = cameraFizPort(camName, motorFizPort(motors[0]), motors[0]);
-    pushEdge({ from: 'camera', to: motorIds[0], label: formatConnLabel(camPort, motorFizPort(motors[0])), noArrow: true }, 'fiz');
+    pushEdge({ from: 'camera', to: motorIds[0], label: formatConnLabel(motorFizPort(motors[0]), camPort), noArrow: true }, 'fiz');
   }
 
   for (let i = 0; i < chain.length - 1; i++) {

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -734,6 +734,30 @@ describe('script.js functions', () => {
     expect(firstNode.getAttribute('data-node')).toBe('motor0');
   });
 
+  test('camera to cforce RF connection label uses Cam to camera port', () => {
+    global.devices.cameras.CamA.fizConnectors = [{ type: 'LBUS (LEMO 4-pin)' }];
+    global.devices.fiz.motors['cforce mini RF'] = {
+      powerDrawWatts: 2,
+      internalController: true,
+      fizConnector: 'LBUS (LEMO 4-pin), CAM (LEMO 7-pin)'
+    };
+
+    const addOpt = (id, value) => {
+      const sel = document.getElementById(id);
+      sel.innerHTML = `<option value="${value}">${value}</option>`;
+      sel.value = value;
+    };
+    addOpt('cameraSelect', 'CamA');
+    addOpt('motor1Select', 'cforce mini RF');
+    addOpt('batterySelect', 'BattA');
+
+    script.renderSetupDiagram();
+
+    const labels = Array.from(document.querySelectorAll('.edge-label')).map(el => el.textContent.trim());
+    expect(labels).toContain('Cam to LBUS');
+    expect(labels).not.toContain('LBUS to Cam');
+  });
+
   test('UMC-4 controller is first FIZ device over Master Grip', () => {
     global.devices.fiz.controllers['Arri UMC-4'] = {
       powerDrawWatts: 1,


### PR DESCRIPTION
## Summary
- ensure camera-to-cforce RF connections label the motor's Cam port first
- add regression test for cforce RF connection labeling

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0a5629d3c8320a01563cbc03128c6