### PR TITLE
Fix camera port label for cforce RF motor and RIA controller

### DIFF
--- a/script.js
+++ b/script.js
@@ -411,6 +411,7 @@ function formatConnLabel(from, to) {
 
 
 function controllerCamPort(name) {
+  if (/cforce.*rf/i.test(name) || /RIA-1/i.test(name)) return 'Cam';
   const c = devices.fiz?.controllers?.[name];
   if (c) {
     if (/UMC-4/i.test(name)) return '3-Pin R/S';
@@ -5795,6 +5796,7 @@ if (typeof module !== "undefined" && module.exports) {
     enableDiagramInteractions,
     updateDiagramLegend,
     cameraFizPort,
+    controllerCamPort,
     detectBrand,
     connectionLabel,
   };

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -505,6 +505,13 @@ describe('script.js functions', () => {
     expect(port).toBe('EXT LEMO 7-pin');
   });
 
+  test('cforce RF motor and RIA use Cam port to camera', () => {
+    const { controllerCamPort } = script;
+    expect(controllerCamPort('Arri cforce mini RF (KK.0040345)')).toBe('Cam');
+    expect(controllerCamPort('Arri RIA-1')).toBe('Cam');
+    expect(controllerCamPort('Arri Master Grip (single unit)')).toBe('LBUS');
+  });
+
   test('ARRI camera with LBUS avoids distance warning', () => {
     jest.resetModules();
 


### PR DESCRIPTION
## Summary
- ensure cforce RF motors and RIA controllers use the Cam port when linking to cameras
- export controllerCamPort for testing and cover with unit tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0a8041b9c83208247d0bb84576d77