### PR TITLE
Add icons to help dialog categories

### DIFF
--- a/index.html
+++ b/index.html
@@ -489,7 +489,7 @@
       <input type="text" id="helpSearch" placeholder="Search..." aria-label="Search help" />
       <div id="helpSections">
         <section data-help-section id="featuresOverview">
-          <h3>Features at a Glance</h3>
+          <h3><span class="help-icon" aria-hidden="true">✨</span>Features at a Glance</h3>
           <ul>
             <li>Plan complete camera rigs and compute power draw and battery life.</li>
             <li>Save multiple setups, export or import them and print overviews.</li>
@@ -500,7 +500,7 @@
           </ul>
         </section>
         <section data-help-section id="gettingStarted">
-          <h3>Getting Started</h3>
+          <h3><span class="help-icon" aria-hidden="true">🚀</span>Getting Started</h3>
           <ol>
             <li>Select a camera, monitor and other devices from the dropdown menus.</li>
             <li>Use the search boxes inside each dropdown to quickly filter the lists.</li>
@@ -508,7 +508,7 @@
           </ol>
         </section>
         <section data-help-section id="managingSetups">
-          <h3>Managing Setups</h3>
+          <h3><span class="help-icon" aria-hidden="true">🗂️</span>Managing Setups</h3>
           <ul>
             <li>Use <strong>Save</strong> to store the current configuration in your browser.</li>
             <li>Import, export or delete setups via the <em>Setup Actions</em> section.</li>
@@ -516,7 +516,7 @@
           </ul>
         </section>
         <section data-help-section id="powerCalculator">
-          <h3>Power Calculator</h3>
+          <h3><span class="help-icon" aria-hidden="true">⚡</span>Power Calculator</h3>
           <ul>
             <li>Select a battery to see estimated runtime and current draw.</li>
             <li>Warnings appear if the configuration exceeds battery output limits.</li>
@@ -524,7 +524,7 @@
           </ul>
         </section>
         <section data-help-section id="calculationDetails">
-          <h3>Calculation Details</h3>
+          <h3><span class="help-icon" aria-hidden="true">🧮</span>Calculation Details</h3>
           <ul>
             <li>Each device contributes its power draw in watts to <em>Total Consumption</em>.</li>
             <li>Current at 14.4 V (33.6 V for B‑Mount) and 12 V (21.6 V for B‑Mount) equals total watts divided by voltage.</li>
@@ -533,7 +533,7 @@
           </ul>
         </section>
         <section data-help-section id="setupDiagramHelp">
-          <h3>Setup Diagram</h3>
+          <h3><span class="help-icon" aria-hidden="true">🗺️</span>Setup Diagram</h3>
           <ul>
             <li>Visualizes power and video connections between selected devices.</li>
             <li>Icons denote device types and warn when FIZ brands are incompatible.</li>
@@ -542,7 +542,7 @@
           </ul>
         </section>
         <section data-help-section id="deviceEditorHelp">
-          <h3>Device Database Editor</h3>
+          <h3><span class="help-icon" aria-hidden="true">🛠️</span>Device Database Editor</h3>
           <ul>
             <li>Open with <em>Edit Device Data…</em> to add, modify or remove devices.</li>
             <li>Changes are stored locally; use <em>Export</em> and <em>Import</em> to share databases.</li>
@@ -550,7 +550,7 @@
           </ul>
         </section>
         <section data-help-section id="deviceCategoriesHelp">
-          <h3>Device Categories</h3>
+          <h3><span class="help-icon" aria-hidden="true">📁</span>Device Categories</h3>
           <ul>
             <li><strong>Camera</strong> (1)</li>
             <li><strong>Monitor</strong> (optional)</li>
@@ -564,28 +564,28 @@
           <p>The number in parentheses shows how many of that type you can select.</p>
         </section>
         <section data-help-section id="searchFiltering">
-          <h3>Search & Filtering</h3>
+          <h3><span class="help-icon" aria-hidden="true">🔍</span>Search & Filtering</h3>
           <ul>
             <li>Every dropdown and list can be filtered via its search box.</li>
             <li>The help dialog itself is searchable using the field at the top.</li>
           </ul>
         </section>
         <section data-help-section id="darkModeHelp">
-          <h3>Dark Mode</h3>
+          <h3><span class="help-icon" aria-hidden="true">🌙</span>Dark Mode</h3>
           <ul>
             <li>Toggle the moon button next to the language selector.</li>
             <li>Your choice is remembered for the next visit.</li>
           </ul>
         </section>
         <section data-help-section id="pinkModeHelp">
-          <h3>Pink Mode</h3>
+          <h3><span class="help-icon" aria-hidden="true">🦄</span>Pink Mode</h3>
           <ul>
             <li>Click the horse button for a pink unicorn theme.</li>
             <li>The setting persists just like dark mode.</li>
           </ul>
         </section>
         <section data-help-section id="shortcuts">
-          <h3>Keyboard Shortcuts</h3>
+          <h3><span class="help-icon" aria-hidden="true">⌨️</span>Keyboard Shortcuts</h3>
           <ul>
             <li><kbd>?</kbd>, <kbd>H</kbd> or <kbd>F1</kbd> – toggle help</li>
             <li><kbd>Escape</kbd> – close dialogs</li>
@@ -593,7 +593,7 @@
           </ul>
         </section>
         <section data-help-section id="faq">
-          <h3>FAQ</h3>
+          <h3><span class="help-icon" aria-hidden="true">❓</span>FAQ</h3>
           <details class="faq-item">
             <summary>How do I save a setup?</summary>
             <p>Enter a name in the Setup Name field and click Save. It will then appear in the Saved Setups list.</p>

--- a/style.css
+++ b/style.css
@@ -158,6 +158,10 @@ body.dark-mode.pink-mode .help-content {
   display: none;
 }
 
+.help-icon {
+  margin-right: 0.3em;
+}
+
 /* Ensure selects and inputs inside wrappers match normal form fields */
 .field-with-label select,
 .field-with-label input {


### PR DESCRIPTION
## Summary
- Add emoji icons to each help dialog category heading to improve visual identification
- Style new icons with a dedicated `.help-icon` class

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0ac2f06c88320aa371c1089887335