### PR TITLE
Label connectors in diagram popups

### DIFF
--- a/script.js
+++ b/script.js
@@ -4911,18 +4911,11 @@ function summarizeByType(list) {
     return counts;
 }
 
-function withDirection(label, dir) {
-    if (!dir) return label;
-    const lower = label.toLowerCase();
-    const d = dir.toLowerCase();
-    return lower.includes(d) ? label : `${label} ${dir}`;
-}
-
-function connectorBlocks(items, icon, cls = 'neutral-conn', dir = '') {
+function connectorBlocks(items, icon, cls = 'neutral-conn', label = '', dir = '') {
     const counts = summarizeByType(items);
     return Object.entries(counts).map(([type, count]) => {
-        const text = withDirection(escapeHtml(type), dir);
-        return `<span class="connector-block ${cls}">${icon} ${text}${count > 1 ? ` ×${count}` : ''}</span>`;
+        const prefix = label ? `${label}${dir ? ` ${dir}` : ''}: ` : '';
+        return `<span class="connector-block ${cls}">${icon} ${prefix}${escapeHtml(type)}${count > 1 ? ` ×${count}` : ''}</span>`;
     }).join('');
 }
 
@@ -4932,35 +4925,35 @@ function generateConnectorSummary(data) {
     let portHtml = '';
     if (data.power) {
         if (Array.isArray(data.power.powerDistributionOutputs)) {
-            portHtml += connectorBlocks(data.power.powerDistributionOutputs, '⚡', 'power-conn', 'Out');
+            portHtml += connectorBlocks(data.power.powerDistributionOutputs, '⚡', 'power-conn', 'Power', 'Out');
         }
         const inputs = powerInputTypes(data).map(t => ({ type: t }));
         if (inputs.length) {
-            portHtml += connectorBlocks(inputs, '🔌', 'power-conn', 'In');
+            portHtml += connectorBlocks(inputs, '🔌', 'power-conn', 'Power', 'In');
         }
     }
     if (Array.isArray(data.fizConnectors)) {
-        portHtml += connectorBlocks(data.fizConnectors, '🎚️', 'fiz-conn');
+        portHtml += connectorBlocks(data.fizConnectors, '🎚️', 'fiz-conn', 'FIZ Port');
     }
     const videoIn = (data.video && data.video.inputs) || data.videoInputs;
     if (Array.isArray(videoIn)) {
-        portHtml += connectorBlocks(videoIn, '📺', 'video-conn', 'In');
+        portHtml += connectorBlocks(videoIn, '📺', 'video-conn', 'Video', 'In');
     }
     const videoOut = (data.video && data.video.outputs) || data.videoOutputs;
     if (Array.isArray(videoOut)) {
-        portHtml += connectorBlocks(videoOut, '📺', 'video-conn', 'Out');
+        portHtml += connectorBlocks(videoOut, '📺', 'video-conn', 'Video', 'Out');
     }
     if (Array.isArray(data.timecode)) {
-        portHtml += connectorBlocks(data.timecode, '⏱️');
+        portHtml += connectorBlocks(data.timecode, '⏱️', 'neutral-conn', 'Timecode');
     }
     if (data.audioInput && data.audioInput.portType) {
-        portHtml += connectorBlocks([{ type: data.audioInput.portType }], '🎤', 'neutral-conn', 'In');
+        portHtml += connectorBlocks([{ type: data.audioInput.portType }], '🎤', 'neutral-conn', 'Audio', 'In');
     }
     if (data.audioOutput && data.audioOutput.portType) {
-        portHtml += connectorBlocks([{ type: data.audioOutput.portType }], '🔊', 'neutral-conn', 'Out');
+        portHtml += connectorBlocks([{ type: data.audioOutput.portType }], '🔊', 'neutral-conn', 'Audio', 'Out');
     }
     if (data.audioIo && data.audioIo.portType) {
-        portHtml += connectorBlocks([{ type: data.audioIo.portType }], '🎚️', 'neutral-conn', 'I/O');
+        portHtml += connectorBlocks([{ type: data.audioIo.portType }], '🎚️', 'neutral-conn', 'Audio', 'I/O');
     }
 
     let specHtml = '';

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -947,6 +947,26 @@ describe('script.js functions', () => {
     expect(labels.some(l => l.includes('D-Tap'))).toBe(false);
   });
 
+  test('diagram popup shows labeled connector names', () => {
+    global.devices.fiz.controllers.ControllerA.fizConnectors = [{ type: 'LBUS' }];
+
+    const addOpt = (id, value) => {
+      const sel = document.getElementById(id);
+      sel.innerHTML = `<option value="${value}">${value}</option>`;
+      sel.value = value;
+    };
+    addOpt('cameraSelect', 'CamA');
+    addOpt('controller1Select', 'ControllerA');
+    addOpt('batterySelect', 'BattA');
+
+    script.renderSetupDiagram();
+
+    const node = document.querySelector('#diagramArea .diagram-node[data-node="controller0"]');
+    node.dispatchEvent(new MouseEvent('mousemove', { clientX: 0, clientY: 0 }));
+    const popup = document.getElementById('diagramPopup');
+    expect(popup.innerHTML).toContain('FIZ Port: LBUS');
+  });
+
   test('help dialog toggles with keyboard and overlay click', () => {
     const helpDialog = document.getElementById('helpDialog');
     const helpSearch = document.getElementById('helpSearch');


### PR DESCRIPTION
## Summary
- Show connector category names in setup diagram popups (e.g., "FIZ Port: LBUS")
- Test diagram popup to ensure labeled connector names

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b0ace4eb6c832097f66cc38ba12477