### PR TITLE
Add Hollyland Pyro 5 monitor

### DIFF
--- a/data.js
+++ b/data.js
@@ -5168,6 +5168,32 @@ let devices={
         }
       ]
     },
+    "Hollyland Pyro 5": {
+      "screenSizeInches": 5,
+      "brightnessNits": 1500,
+      "powerDrawWatts": 16.5,
+      "power": {
+        "input": {
+          "voltageRange": "7-16",
+          "type": "DC Barrel"
+        },
+        "output": null
+      },
+      "wirelessTx": true,
+      "videoInputs": [
+        {
+          "type": "HDMI"
+        },
+        {
+          "type": "3G-SDI"
+        }
+      ],
+      "videoOutputs": [
+        {
+          "type": "HDMI"
+        }
+      ]
+    },
     "Hollyland Mars M1 Enhanced": {
       "screenSizeInches": 5.5,
       "brightnessNits": 1000,


### PR DESCRIPTION
## Summary
- add Hollyland Pyro 5 monitor with 16.5W draw, DC barrel input, HDMI/SDI ports and wireless TX

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0ae112cf08320b9f76f80daabba2d