### PR TITLE
fix: retain monitor name during edit

### DIFF
--- a/script.js
+++ b/script.js
@@ -4110,11 +4110,12 @@ deviceManagerSection.addEventListener("click", (event) => {
     const categoryKey = event.target.dataset.category;
 
     // Set form for editing
-    newNameInput.value = name;
     newCategorySelect.value = categoryKey;
     newCategorySelect.disabled = true; // Prevent changing category during edit
     // Trigger change handler so correct fields are shown and others cleared
     newCategorySelect.dispatchEvent(new Event('change'));
+    // After the change handler runs, restore the device name for editing
+    newNameInput.value = name;
 
     let deviceData;
     if (categoryKey.includes('.')) {


### PR DESCRIPTION
## Summary
- Restore device name after category change when editing to ensure monitor names remain visible

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0b1a99464832081cd21876c769e6c