### PR TITLE
Label spec details in diagram hover popups

### DIFF
--- a/script.js
+++ b/script.js
@@ -4962,40 +4962,40 @@ function generateConnectorSummary(data) {
 
     let specHtml = '';
     if (typeof data.powerDrawWatts === 'number') {
-        specHtml += `<span class="info-box neutral-conn">⚡ ${data.powerDrawWatts} W</span>`;
+        specHtml += `<span class="info-box neutral-conn">⚡ Power: ${data.powerDrawWatts} W</span>`;
     }
     if (data.power?.input?.voltageRange) {
-        specHtml += `<span class="info-box neutral-conn">🔋 ${escapeHtml(String(data.power.input.voltageRange))}V</span>`;
+        specHtml += `<span class="info-box neutral-conn">🔋 Voltage: ${escapeHtml(String(data.power.input.voltageRange))}V</span>`;
     }
     if (typeof data.capacity === 'number') {
-        specHtml += `<span class="info-box neutral-conn">🔋 ${data.capacity} Wh</span>`;
+        specHtml += `<span class="info-box neutral-conn">🔋 Capacity: ${data.capacity} Wh</span>`;
     }
     if (typeof data.pinA === 'number') {
-        specHtml += `<span class="info-box power-conn">Pins ${data.pinA}A</span>`;
+        specHtml += `<span class="info-box power-conn">Pins: ${data.pinA}A</span>`;
     }
     if (typeof data.dtapA === 'number') {
-        specHtml += `<span class="info-box power-conn">D-Tap ${data.dtapA}A</span>`;
+        specHtml += `<span class="info-box power-conn">D-Tap: ${data.dtapA}A</span>`;
     }
     if (data.mount_type) {
-        specHtml += `<span class="info-box neutral-conn">${escapeHtml(String(data.mount_type))}</span>`;
+        specHtml += `<span class="info-box neutral-conn">Mount: ${escapeHtml(String(data.mount_type))}</span>`;
     }
     if (typeof data.screenSizeInches === 'number') {
-        specHtml += `<span class="info-box neutral-conn">📐 ${data.screenSizeInches}"</span>`;
+        specHtml += `<span class="info-box neutral-conn">📐 Screen: ${data.screenSizeInches}"</span>`;
     }
     if (typeof data.brightnessNits === 'number') {
-        specHtml += `<span class="info-box neutral-conn">💡 ${data.brightnessNits} nits</span>`;
+        specHtml += `<span class="info-box neutral-conn">💡 Brightness: ${data.brightnessNits} nits</span>`;
     }
     if (data.wirelessTx !== undefined) {
-        specHtml += `<span class="info-box neutral-conn">📡 ${data.wirelessTx ? 'TX' : 'RX'}</span>`;
+        specHtml += `<span class="info-box neutral-conn">📡 Wireless: ${data.wirelessTx ? 'TX' : 'RX'}</span>`;
     }
     if (data.internalController) {
-        specHtml += `<span class="info-box neutral-conn">🎛️ Internal</span>`;
+        specHtml += `<span class="info-box neutral-conn">🎛️ Controller: Internal</span>`;
     }
     if (typeof data.torqueNm === 'number') {
-        specHtml += `<span class="info-box neutral-conn">⚙️ ${data.torqueNm} Nm</span>`;
+        specHtml += `<span class="info-box neutral-conn">⚙️ Torque: ${data.torqueNm} Nm</span>`;
     }
     if (data.power_source) {
-        specHtml += `<span class="info-box neutral-conn">🔌 ${escapeHtml(String(data.power_source))}</span>`;
+        specHtml += `<span class="info-box neutral-conn">🔌 Power Source: ${escapeHtml(String(data.power_source))}</span>`;
     }
 
     let extraHtml = '';

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -965,6 +965,7 @@ describe('script.js functions', () => {
     node.dispatchEvent(new MouseEvent('mousemove', { clientX: 0, clientY: 0 }));
     const popup = document.getElementById('diagramPopup');
     expect(popup.innerHTML).toContain('FIZ Port: LBUS');
+    expect(popup.innerHTML).toContain('Power: 2 W');
   });
 
   test('help dialog toggles with keyboard and overlay click', () => {


### PR DESCRIPTION
## Summary
- Include descriptive labels (Power, Voltage, Capacity, etc.) in the Specs section of diagram hover popups
- Test diagram popup to ensure spec labels appear alongside connector labels

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0b2d013708320ab82dd8f62eee88a