### PR TITLE
Move overview diagram below results section

### DIFF
--- a/script.js
+++ b/script.js
@@ -5530,7 +5530,6 @@ function generatePrintableOverview() {
             <p><strong>${t.setupNameLabel}</strong> ${safeSetupName}</p>
             <p><em>Generated on: ${dateTimeString}</em></p>
 
-            ${diagramSectionHtml}
             <h2>${t.deviceSelectionHeading}</h2>
             ${deviceListHtml}
 
@@ -5538,6 +5537,7 @@ function generatePrintableOverview() {
             ${resultsHtml}
             ${warningHtml}
 
+            ${diagramSectionHtml}
             ${batteryTableHtml}
         </body>
         </html>


### PR DESCRIPTION
## Summary
- Show device table and results before the setup diagram in the printable overview

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0b4c7253c83209532f25abb00a1ba