### PR TITLE
Align overview battery comparison with main logic

### DIFF
--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -171,6 +171,36 @@ describe('script.js functions', () => {
     expect(html).not.toContain('BBatt');
   });
 
+  test('overview battery comparison excludes B-Mount when camera lacks support', () => {
+    global.devices.cameras.NoPlateCam = { powerDrawWatts: 10 };
+    global.devices.batteries.VBatt = { capacity: 100, pinA: 10, dtapA: 5, mount_type: 'V-Mount' };
+    global.devices.batteries.BBatt = { capacity: 100, pinA: 10, dtapA: 5, mount_type: 'B-Mount' };
+
+    const addOpt = (id, value) => {
+      const sel = document.getElementById(id);
+      sel.innerHTML = `<option value="${value}">${value}</option>`;
+      sel.value = value;
+    };
+
+    addOpt('cameraSelect', 'NoPlateCam');
+    addOpt('monitorSelect', 'MonA');
+    addOpt('videoSelect', 'VidA');
+    addOpt('motor1Select', 'MotorA');
+    addOpt('controller1Select', 'ControllerA');
+    addOpt('distanceSelect', 'DistA');
+    script.updateBatteryPlateVisibility();
+    script.updateBatteryOptions();
+    document.getElementById('batterySelect').value = 'VBatt';
+    script.updateCalculations();
+
+    const writeMock = jest.fn();
+    window.open = jest.fn(() => ({ document: { write: writeMock, close: jest.fn() } }));
+    script.generatePrintableOverview();
+    const html = writeMock.mock.calls[0][0];
+    expect(html).toContain('VBatt');
+    expect(html).not.toContain('BBatt');
+  });
+
   test('setLanguage updates language and saves preference', () => {
     script.setLanguage('de');
     expect(document.documentElement.lang).toBe('de');


### PR DESCRIPTION
## Summary
- Synchronize the setup overview's battery comparison with the main UI logic, including plate filtering, B‑Mount support checks and bar rendering
- Add regression test ensuring overview battery comparison excludes unsupported B‑Mount batteries

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b0b9c8ac6c8320b6d8bcd94b90a1f3