### PR TITLE
Include results breakdown in printable overview

### DIFF
--- a/script.js
+++ b/script.js
@@ -5058,7 +5058,9 @@ function generatePrintableOverview() {
       });
       deviceListHtml += '</div>';
 
+    const breakdownHtml = breakdownListElem.innerHTML;
     const resultsHtml = `
+        <ul id="breakdownList">${breakdownHtml}</ul>
         <p><strong>${t.totalPowerLabel}</strong> ${totalPowerElem.textContent}</p>
         <p><strong>${t.totalCurrent144Label}</strong> ${totalCurrent144Elem.textContent}</p>
         <p><strong>${t.totalCurrent12Label}</strong> ${totalCurrent12Elem.textContent}</p>

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -375,6 +375,8 @@ describe('script.js functions', () => {
     expect(html).toContain('id="darkModeToggle"');
     expect(html).toContain('id="pinkModeToggle"');
     expect(html).toContain('id="languageSelect"');
+    expect(html).toContain('id="breakdownList"');
+    expect(html).toContain(`<strong>${texts.en.cameraLabel}</strong>`);
   });
 
   test('battery plate selection is saved and loaded with setups', () => {


### PR DESCRIPTION
## Summary
- Add results breakdown list to the printable setup overview
- Test that printable overview includes results section

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0ba696a508320af98cfb4bea44dff