### PR TITLE
Label Nucleus M battery cable as D-Tap to 7-pin

### DIFF
--- a/script.js
+++ b/script.js
@@ -500,7 +500,8 @@ function controllerFizPort(name) {
 
 function motorFizPort(name) {
   const m = devices.fiz?.motors?.[name];
-  const port = firstConnector(m?.fizConnector);
+  const portStr = m?.fizConnector || m?.fizConnectors?.[0]?.type;
+  const port = firstConnector(portStr);
   if (port) return port;
   return isArriOrCmotion(name) ? 'LBUS' : 'Proprietary';
 }
@@ -3411,7 +3412,7 @@ function renderSetupDiagram() {
   if (powerTarget && fizNeedsPower(powerTarget.name)) {
     const { id: fizId, name } = powerTarget;
     const powerSrc = batteryName && batteryName !== 'None' ? 'battery' : null;
-    const label = formatConnLabel(fizPowerPort(name), 'D-Tap');
+    const label = formatConnLabel('D-Tap', fizPowerPort(name));
     const skipBatt = isArri(camName) && isArriOrCmotion(name);
     if (powerSrc && !skipBatt) {
       pushEdge({

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -778,6 +778,28 @@ describe('script.js functions', () => {
     expect(labels.some(l => l.includes('D-Tap'))).toBe(true);
   });
 
+  test('Nucleus M battery cable labeled D-Tap to LEMO 7-pin', () => {
+    global.devices.fiz.motors['Tilta Nucleus M'] = {
+      powerDrawWatts: 20,
+      internalController: true,
+      fizConnectors: [{ type: 'LEMO 7-pin' }]
+    };
+
+    const addOpt = (id, value) => {
+      const sel = document.getElementById(id);
+      sel.innerHTML = `<option value="${value}">${value}</option>`;
+      sel.value = value;
+    };
+    addOpt('cameraSelect', 'CamA');
+    addOpt('motor1Select', 'Tilta Nucleus M');
+    addOpt('batterySelect', 'BattA');
+
+    script.renderSetupDiagram();
+
+    const labels = Array.from(document.querySelectorAll('.edge-label')).map(el => el.textContent);
+    expect(labels).toContain('D-Tap to LEMO 7-pin');
+  });
+
   test('motor with internal controller is first FIZ device', () => {
     global.devices.fiz.motors.IntMotor = {
       powerDrawWatts: 2,


### PR DESCRIPTION
## Summary
- handle `fizConnectors` when resolving motor power port
- show battery-to-motor cable as `D-Tap to LEMO 7-pin`
- test Nucleus M battery cable label

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0c018c4d4832087f7576c0ae9f7c4