### PR TITLE
Handle non-ARRI motor connections via FIZ port

### DIFF
--- a/script.js
+++ b/script.js
@@ -411,7 +411,8 @@ function formatConnLabel(from, to) {
 
 
 function controllerCamPort(name) {
-  if (/cforce.*rf/i.test(name) || /RIA-1/i.test(name)) return 'Cam';
+  const isRf = /cforce.*rf/i.test(name) || /RIA-1/i.test(name);
+  if (isRf) return 'Cam';
   const c = devices.fiz?.controllers?.[name];
   if (c) {
     if (/UMC-4/i.test(name)) return '3-Pin R/S';
@@ -429,7 +430,8 @@ function controllerCamPort(name) {
     if (/CAM/i.test(connStr)) return 'Cam';
     if (/7-pin/i.test(connStr)) return 'LEMO 7-pin';
   }
-  return isArriOrCmotion(name) ? 'LBUS' : 'FIZ';
+  if (isArriOrCmotion(name) && !isRf) return 'LBUS';
+  return 'FIZ';
 }
 
 function controllerDistancePort(name) {

--- a/script.js
+++ b/script.js
@@ -415,16 +415,21 @@ function controllerCamPort(name) {
   const c = devices.fiz?.controllers?.[name];
   if (c) {
     if (/UMC-4/i.test(name)) return '3-Pin R/S';
-    const connStr = (c.fizConnectors || []).map(fc => fc.type).join(', ');
+    const connStr = (
+      c.fizConnectors ? c.fizConnectors.map(fc => fc.type).join(', ') : c.fizConnector || ''
+    );
     if (/CAM/i.test(connStr)) return 'Cam';
     if (/7-pin/i.test(connStr)) return 'LEMO 7-pin';
   }
   const m = devices.fiz?.motors?.[name];
   if (m) {
-    if (/CAM/i.test(m.fizConnector || '')) return 'Cam';
-    if (/7-pin/i.test(m.fizConnector || '')) return 'LEMO 7-pin';
+    const connStr = (
+      m.fizConnector || (m.fizConnectors || []).map(fc => fc.type).join(', ')
+    );
+    if (/CAM/i.test(connStr)) return 'Cam';
+    if (/7-pin/i.test(connStr)) return 'LEMO 7-pin';
   }
-  return 'LBUS';
+  return isArriOrCmotion(name) ? 'LBUS' : 'FIZ';
 }
 
 function controllerDistancePort(name) {

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -546,6 +546,7 @@ describe('script.js functions', () => {
     const { controllerCamPort } = script;
     expect(controllerCamPort('Arri cforce mini RF (KK.0040345)')).toBe('Cam');
     expect(controllerCamPort('Arri RIA-1')).toBe('Cam');
+    expect(controllerCamPort('Arri cforceRF')).toBe('Cam');
     expect(controllerCamPort('Arri Master Grip (single unit)')).toBe('LBUS');
   });
 

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -549,6 +549,15 @@ describe('script.js functions', () => {
     expect(controllerCamPort('Arri Master Grip (single unit)')).toBe('LBUS');
   });
 
+  test('Tilta motors use the camera\'s FIZ port', () => {
+    const { controllerCamPort } = script;
+    global.devices.fiz.motors['Tilta Nucleus M'] = {
+      internalController: true,
+      fizConnectors: [{ type: 'LEMO 7-pin' }]
+    };
+    expect(controllerCamPort('Tilta Nucleus M')).toBe('LEMO 7-pin');
+  });
+
   test('ARRI camera with LBUS avoids distance warning', () => {
     jest.resetModules();
 


### PR DESCRIPTION
## Summary
- Ensure `controllerCamPort` only defaults to LBUS for ARRI and cmotion devices
- Test that Tilta motors use a camera's FIZ port instead of LBUS

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0c19b512083208076f362a131612c