### PR TITLE
Fix missing connection labels in exported diagram

### DIFF
--- a/script.js
+++ b/script.js
@@ -5717,18 +5717,28 @@ if (pinkModeToggle) {
   });
 }
 
+function exportDiagramSvg() {
+  if (!setupDiagramContainer) return '';
+  const svgEl = setupDiagramContainer.querySelector('svg');
+  if (!svgEl) return '';
+
+  const clone = svgEl.cloneNode(true);
+  const labels = svgEl.querySelectorAll('.edge-label');
+  const cloneLabels = clone.querySelectorAll('.edge-label');
+  labels.forEach((lbl, idx) => {
+    if (cloneLabels[idx]) cloneLabels[idx].textContent = lbl.textContent;
+  });
+  const style = document.createElementNS('http://www.w3.org/2000/svg', 'style');
+  style.textContent = getDiagramCss();
+  clone.insertBefore(style, clone.firstChild);
+  const serializer = new XMLSerializer();
+  return serializer.serializeToString(clone);
+}
+
 if (downloadDiagramBtn) {
   downloadDiagramBtn.addEventListener('click', (e) => {
-    const svgEl = setupDiagramContainer.querySelector('svg');
-    if (!svgEl) return;
-
-    const clone = svgEl.cloneNode(true);
-    const style = document.createElementNS('http://www.w3.org/2000/svg', 'style');
-    style.textContent = getDiagramCss();
-    clone.insertBefore(style, clone.firstChild);
-
-    const serializer = new XMLSerializer();
-    const source = serializer.serializeToString(clone);
+    const source = exportDiagramSvg();
+    if (!source) return;
 
     navigator.clipboard.writeText(source).catch(() => {});
 
@@ -5872,5 +5882,6 @@ if (typeof module !== "undefined" && module.exports) {
     detectBrand,
     connectionLabel,
     generateConnectorSummary,
+    exportDiagramSvg,
   };
 }

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -1120,6 +1120,24 @@ describe('script.js functions', () => {
     expect(html).toContain('Gear: 0.6 mod, 0.8 mod');
     expect(html).toContain('FIZ Port: LBUS, LEMO 7-pin');
   });
+
+  test('exportDiagramSvg includes connection labels', () => {
+    global.devices.cameras.CamA.videoOutputs = [{ type: 'HDMI' }];
+    global.devices.monitors.MonA.videoInputs = [{ type: 'HDMI' }];
+
+    const addOpt = (id, value) => {
+      const sel = document.getElementById(id);
+      sel.innerHTML = `<option value="${value}">${value}</option>`;
+      sel.value = value;
+    };
+    addOpt('cameraSelect', 'CamA');
+    addOpt('monitorSelect', 'MonA');
+
+    script.renderSetupDiagram();
+    const svg = script.exportDiagramSvg();
+    expect(svg).toContain('edge-label');
+    expect(svg).toContain('HDMI');
+  });
 });
 
 describe('monitor wireless metadata', () => {


### PR DESCRIPTION
## Summary
- ensure `exportDiagramSvg` clones edge labels and styles so saved diagrams retain connection labels
- add regression test verifying exported SVG includes labels

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b0c251f9648320982d56e3d9c506a0