### PR TITLE
Use FIZ Port for default motor-camera label

### DIFF
--- a/script.js
+++ b/script.js
@@ -431,7 +431,7 @@ function controllerCamPort(name) {
     if (/7-pin/i.test(connStr)) return 'LEMO 7-pin';
   }
   if (isArriOrCmotion(name) && !isRf) return 'LBUS';
-  return 'FIZ';
+  return 'FIZ Port';
 }
 
 function controllerDistancePort(name) {

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -559,6 +559,11 @@ describe('script.js functions', () => {
     expect(controllerCamPort('Tilta Nucleus M')).toBe('LEMO 7-pin');
   });
 
+  test('default motor uses FIZ Port label to camera', () => {
+    const { controllerCamPort } = script;
+    expect(controllerCamPort('Generic FIZ Device')).toBe('FIZ Port');
+  });
+
   test('ARRI camera with LBUS avoids distance warning', () => {
     jest.resetModules();
 


### PR DESCRIPTION
## Summary
- Show "FIZ Port" as the default camera connection label for FIZ devices
- Cover default label in tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b16c9cf1f08320b579ede131e4bb2d