### PR TITLE
Fix monitor normalization for missing power data

### DIFF
--- a/tests/unifyPorts.test.js
+++ b/tests/unifyPorts.test.js
@@ -1,0 +1,15 @@
+const { normalizeMonitor } = require('../unifyPorts.js');
+
+describe('normalizeMonitor', () => {
+  it('does not throw when power is missing', () => {
+    const monitor = { model: 'Test Monitor' };
+    expect(() => normalizeMonitor(monitor)).not.toThrow();
+    expect(monitor).toEqual({ model: 'Test Monitor' });
+  });
+
+  it('cleans voltageRange when present', () => {
+    const monitor = { power: { input: { voltageRange: 'DC 12-24V' } } };
+    normalizeMonitor(monitor);
+    expect(monitor.power.input.voltageRange).toBe('12-24');
+  });
+});

--- a/unifyPorts.js
+++ b/unifyPorts.js
@@ -57,7 +57,7 @@ function normalizeCamera(cam) {
 
 function normalizeMonitor(mon) {
   if (mon.power?.input) cleanPort(mon.power.input);
-  if (mon.power.input.voltageRange) mon.power.input.voltageRange = cleanVoltageRange(mon.power.input.voltageRange);
+  if (mon.power?.input?.voltageRange) mon.power.input.voltageRange = cleanVoltageRange(mon.power.input.voltageRange);
   if (mon.power?.output) cleanPort(mon.power.output);
 
   if (mon.video) {
@@ -120,24 +120,45 @@ function normalizeFiz(dev) {
   if (Array.isArray(dev.fizConnectors)) dev.fizConnectors.forEach(cleanPort);
 }
 
-for (const cam of Object.values(devices.cameras)) {
-  normalizeCamera(cam);
+if (require.main === module) {
+  for (const cam of Object.values(devices.cameras)) {
+    normalizeCamera(cam);
+  }
+  for (const mon of Object.values(devices.monitors)) {
+    normalizeMonitor(mon);
+  }
+  for (const vd of Object.values(devices.video)) {
+    normalizeVideoDevice(vd);
+  }
+  for (const motor of Object.values(devices.fiz.motors)) {
+    normalizeFiz(motor);
+  }
+  for (const ctrl of Object.values(devices.fiz.controllers)) {
+    normalizeFiz(ctrl);
+  }
+  for (const dist of Object.values(devices.fiz.distance)) {
+    normalizeFiz(dist);
+  }
+  deepClean(devices);
+  fs.writeFileSync(
+    'data.js',
+    'let devices=' +
+      JSON.stringify(devices, null, 2) +
+      ';\nif (typeof module !== "undefined" && module.exports) { module.exports = devices; }\n'
+  );
 }
-for (const mon of Object.values(devices.monitors)) {
-  normalizeMonitor(mon);
-}
-for (const vd of Object.values(devices.video)) {
-  normalizeVideoDevice(vd);
-}
-for (const motor of Object.values(devices.fiz.motors)) {
-  normalizeFiz(motor);
-}
-for (const ctrl of Object.values(devices.fiz.controllers)) {
-  normalizeFiz(ctrl);
-}
-for (const dist of Object.values(devices.fiz.distance)) {
-  normalizeFiz(dist);
-}
-deepClean(devices);
 
-fs.writeFileSync('data.js', 'let devices=' + JSON.stringify(devices, null, 2) + ';\nif (typeof module !== "undefined" && module.exports) { module.exports = devices; }\n');
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = {
+    cleanTypeName,
+    cleanVoltageRange,
+    deepClean,
+    cleanPort,
+    normalizeCamera,
+    normalizeMonitor,
+    normalizeVideoDevice,
+    normalizeFiz,
+    parsePowerInput,
+    devices,
+  };
+}


### PR DESCRIPTION
## Summary
- Prevent crashes when normalizing monitors lacking power info by guarding voltage range access
- Run port normalization only when unifyPorts.js is executed directly and export helpers for testing
- Add tests covering monitor normalization edge cases

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b1ad619390832093615587d5d491ae