### PR TITLE
Improve storage validation for null or array data

### DIFF
--- a/storage.js
+++ b/storage.js
@@ -9,16 +9,18 @@ function loadDeviceData() {
     const data = localStorage.getItem(DEVICE_STORAGE_KEY);
     if (data) {
       const parsedData = JSON.parse(data);
-      // Validate that top-level categories exist and are objects
-      const isValid = parsedData && typeof parsedData === 'object' &&
-                      typeof parsedData.cameras === 'object' &&
-                      typeof parsedData.monitors === 'object' &&
-                      typeof parsedData.video === 'object' &&
-                      typeof parsedData.batteries === 'object' &&
-                      typeof parsedData.fiz === 'object' && // Check fiz is an object
-                      typeof parsedData.fiz.motors === 'object' && // Check nested fiz categories
-                      typeof parsedData.fiz.controllers === 'object' &&
-                      typeof parsedData.fiz.distance === 'object';
+      // Helper to ensure a value is a non-null object
+      const isObject = (val) => val !== null && typeof val === 'object';
+      // Validate that top-level categories exist and are non-null objects
+      const isValid = isObject(parsedData) &&
+                      isObject(parsedData.cameras) &&
+                      isObject(parsedData.monitors) &&
+                      isObject(parsedData.video) &&
+                      isObject(parsedData.batteries) &&
+                      isObject(parsedData.fiz) && // Check fiz is an object
+                      isObject(parsedData.fiz.motors) && // Check nested fiz categories
+                      isObject(parsedData.fiz.controllers) &&
+                      isObject(parsedData.fiz.distance);
 
       if (isValid) {
         console.log("Device data loaded from localStorage.");
@@ -50,8 +52,8 @@ function loadSetups() {
     const data = localStorage.getItem(SETUP_STORAGE_KEY);
     if (data) {
       const parsedData = JSON.parse(data);
-      // Ensure it's an object, not just a primitive or array
-      if (typeof parsedData === 'object' && parsedData !== null) {
+      // Ensure it's a plain object, not an array or primitive
+      if (parsedData && typeof parsedData === 'object' && !Array.isArray(parsedData)) {
         return parsedData;
       }
     }

--- a/tests/storage.test.js
+++ b/tests/storage.test.js
@@ -38,6 +38,18 @@ describe('device data storage', () => {
     localStorage.setItem(DEVICE_KEY, JSON.stringify({cameras:{}}));
     expect(loadDeviceData()).toBeNull();
   });
+
+  test('loadDeviceData returns null when any category is null', () => {
+    const corrupted = {
+      cameras: null,
+      monitors: {},
+      video: {},
+      batteries: {},
+      fiz: { motors: {}, controllers: {}, distance: {} }
+    };
+    localStorage.setItem(DEVICE_KEY, JSON.stringify(corrupted));
+    expect(loadDeviceData()).toBeNull();
+  });
 });
 
 describe('setup storage', () => {
@@ -59,6 +71,16 @@ describe('setup storage', () => {
     const setups = {A: {foo: 1}};
     localStorage.setItem(SETUP_KEY, JSON.stringify(setups));
     expect(loadSetups()).toEqual(setups);
+  });
+
+  test('loadSetups returns empty object for array data', () => {
+    localStorage.setItem(SETUP_KEY, JSON.stringify([1,2,3]));
+    expect(loadSetups()).toEqual({});
+  });
+
+  test('loadSetups returns empty object for primitive data', () => {
+    localStorage.setItem(SETUP_KEY, JSON.stringify(5));
+    expect(loadSetups()).toEqual({});
   });
 
   test('saveSetup adds and persists single setup', () => {


### PR DESCRIPTION
## Summary
- ensure stored device data categories are non-null objects
- reject array/primitive setup data when loading from storage
- cover storage edge cases with additional tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b1aedcff54832092a0e9a356b379fd