### PR TITLE
Fix power input parsing and storage validation

### DIFF
--- a/storage.js
+++ b/storage.js
@@ -10,7 +10,7 @@ function loadDeviceData() {
     if (data) {
       const parsedData = JSON.parse(data);
       // Helper to ensure a value is a non-null object
-      const isObject = (val) => val !== null && typeof val === 'object';
+      const isObject = (val) => val !== null && typeof val === 'object' && !Array.isArray(val);
       // Validate that top-level categories exist and are non-null objects
       const isValid = isObject(parsedData) &&
                       isObject(parsedData.cameras) &&

--- a/tests/storage.test.js
+++ b/tests/storage.test.js
@@ -50,6 +50,18 @@ describe('device data storage', () => {
     localStorage.setItem(DEVICE_KEY, JSON.stringify(corrupted));
     expect(loadDeviceData()).toBeNull();
   });
+
+  test('loadDeviceData returns null when any category is an array', () => {
+    const corrupted = {
+      cameras: [],
+      monitors: {},
+      video: {},
+      batteries: {},
+      fiz: { motors: {}, controllers: {}, distance: {} }
+    };
+    localStorage.setItem(DEVICE_KEY, JSON.stringify(corrupted));
+    expect(loadDeviceData()).toBeNull();
+  });
 });
 
 describe('setup storage', () => {

--- a/tests/unifyPorts.test.js
+++ b/tests/unifyPorts.test.js
@@ -1,4 +1,4 @@
-const { normalizeMonitor } = require('../unifyPorts.js');
+const { normalizeMonitor, parsePowerInput, normalizeVideoDevice } = require('../unifyPorts.js');
 
 describe('normalizeMonitor', () => {
   it('does not throw when power is missing', () => {
@@ -11,5 +11,27 @@ describe('normalizeMonitor', () => {
     const monitor = { power: { input: { voltageRange: 'DC 12-24V' } } };
     normalizeMonitor(monitor);
     expect(monitor.power.input.voltageRange).toBe('12-24');
+  });
+});
+
+describe('parsePowerInput', () => {
+  it('does not split slashes inside parentheses', () => {
+    const input = 'LEMO (5V/3A) / D-Tap';
+    expect(parsePowerInput(input)).toEqual([
+      { type: 'LEMO', notes: '5V/3A' },
+      { type: 'D-Tap' }
+    ]);
+  });
+});
+
+describe('normalizeVideoDevice', () => {
+  it('cleans voltageRange for each power input entry', () => {
+    const dev = { power: { input: [
+      { type: 'LEMO', voltageRange: 'DC 5-16V' },
+      { type: 'D-Tap', voltageRange: '14V DC' }
+    ] } };
+    normalizeVideoDevice(dev);
+    expect(dev.power.input[0].voltageRange).toBe('5-16');
+    expect(dev.power.input[1].voltageRange).toBe('14');
   });
 });

--- a/unifyPorts.js
+++ b/unifyPorts.js
@@ -87,23 +87,23 @@ function normalizeMonitor(mon) {
 function parsePowerInput(str) {
   if (!str) return null;
   const parts = [];
-  let current = '';
+  let buf = "";
   let depth = 0;
   for (const ch of str) {
-    if (ch === '(') depth++;
-    if (ch === ')') depth = Math.max(0, depth - 1);
-    if (ch === '/' && depth === 0) {
-      parts.push(current);
-      current = '';
-    } else {
-      current += ch;
+    if (ch === "(") depth++;
+    else if (ch === ")") depth = Math.max(0, depth - 1);
+    if (ch === "/" && depth === 0) {
+      parts.push(buf);
+      buf = "";
+      continue;
     }
+    buf += ch;
   }
-  if (current) parts.push(current);
+  if (buf) parts.push(buf);
   return parts.map(p => {
-    const m = p.trim().match(/^(.+?)(\(([^)]+)\))?$/);
-    const type = String(m ? m[1].trim() : p.trim());
-    const notes = m && m[3] ? m[3].trim() : '';
+    const m = p.trim().match(/^(.+?)(?:\(([^)]+)\))?$/);
+    const type = m ? m[1].trim() : p.trim();
+    const notes = m && m[2] ? m[2].trim() : "";
     const obj = { type };
     if (notes) obj.notes = notes;
     return obj;
@@ -127,7 +127,13 @@ function normalizeVideoDevice(dev) {
   if (Array.isArray(dev.videoOutputs)) dev.videoOutputs.forEach(cleanPort);
   if (dev.power?.input) {
     cleanPort(dev.power.input);
-    if (dev.power.input.voltageRange) dev.power.input.voltageRange = cleanVoltageRange(dev.power.input.voltageRange);
+    if (Array.isArray(dev.power.input)) {
+      dev.power.input.forEach(i => {
+        if (i.voltageRange) i.voltageRange = cleanVoltageRange(i.voltageRange);
+      });
+    } else if (dev.power.input.voltageRange) {
+      dev.power.input.voltageRange = cleanVoltageRange(dev.power.input.voltageRange);
+    }
   }
 
 }


### PR DESCRIPTION
## Summary
- handle top-level slashes in `parsePowerInput`
- clean voltage range for array-based power inputs in `normalizeVideoDevice`
- reject arrays when validating stored device data

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2c0957c3c8320a898ecaf256d605a