### PR TITLE
Colorize hover diagram info boxes

### DIFF
--- a/script.js
+++ b/script.js
@@ -5350,6 +5350,7 @@ function generatePrintableOverview() {
                   padding: 2px 6px;
                   margin: 2px;
                   border-radius: 3px;
+                  border: 1px solid;
                   background: rgba(0,0,0,0.03);
                   font-size: 0.75em;
                 }
@@ -5498,6 +5499,7 @@ function generatePrintableOverview() {
                       padding: 2px 6px;
                       margin: 2px;
                       border-radius: 3px;
+                      border: 1px solid;
                       background: rgba(0,0,0,0.03) !important;
                       font-size: 0.75em;
                     }

--- a/style.css
+++ b/style.css
@@ -530,6 +530,7 @@ button:disabled {
   padding: 2px 6px;
   margin: 2px;
   border-radius: 3px;
+  border: 1px solid;
   background: rgba(0,0,0,0.03);
   font-size: 0.75em;
 }


### PR DESCRIPTION
## Summary
- add category-colored borders to diagram info boxes for clearer hover popups
- include new border styling in printable overview CSS

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b2c600c8e08320bf2c2a31b16a5edd