### PR TITLE
Unify hover diagram box styling

### DIFF
--- a/script.js
+++ b/script.js
@@ -5335,28 +5335,21 @@ function generatePrintableOverview() {
                   .power-conn { background-color: rgba(244,67,54,0.3); }
                   .fiz-conn { background-color: rgba(76,175,80,0.3); }
                   .video-conn { background-color: rgba(33,150,243,0.3); }
+                  .neutral-conn { background-color: rgba(158,158,158,0.3); }
                 }
                 .connector-summary {
                   margin-top: 5px;
                   display: flex;
                   flex-wrap: wrap;
                 }
-                .connector-block {
-                  display: inline-block;
-                  padding: 2px 6px;
-                  margin: 2px;
-                  border-radius: 4px;
-                  border: 2px solid;
-                  font-size: 0.85em;
-                  background-color: rgba(0,0,0,0.03);
-                }
+                .connector-block,
                 .info-box {
                   display: inline-block;
                   padding: 2px 6px;
                   margin: 2px;
                   border-radius: 3px;
                   border: 1px solid;
-                  background: rgba(0,0,0,0.03);
+                  background-color: rgba(0,0,0,0.03);
                   font-size: 0.75em;
                 }
                 .lens-mount-box {
@@ -5380,7 +5373,10 @@ function generatePrintableOverview() {
                   border-color: #2196f3;
                   background-color: rgba(33,150,243,0.15);
                 }
-                .neutral-conn { border-color: #9e9e9e; }
+                .neutral-conn {
+                  border-color: #9e9e9e;
+                  background-color: rgba(158,158,158,0.15);
+                }
                 ${diagramCss}
                 #diagramArea { margin-top: 0.5em; position: relative; }
                 #diagramArea svg { width: 100%; height: auto; }
@@ -5490,22 +5486,14 @@ function generatePrintableOverview() {
                       display: flex;
                       flex-wrap: wrap;
                     }
-                    .connector-block {
-                      display: inline-block;
-                      padding: 2px 6px;
-                      margin: 2px;
-                      border-radius: 4px;
-                      border: 2px solid;
-                      font-size: 0.85em;
-                      background-color: rgba(0,0,0,0.03);
-                    }
+                    .connector-block,
                     .info-box {
                       display: inline-block;
                       padding: 2px 6px;
                       margin: 2px;
                       border-radius: 3px;
                       border: 1px solid;
-                      background: rgba(0,0,0,0.03) !important;
+                      background-color: rgba(0,0,0,0.03) !important;
                       font-size: 0.75em;
                     }
                     .lens-mount-box {
@@ -5529,7 +5517,10 @@ function generatePrintableOverview() {
                       border-color: #2196f3 !important;
                       background-color: rgba(33,150,243,0.15) !important;
                     }
-                    .neutral-conn { border-color: #9e9e9e !important; }
+                    .neutral-conn {
+                      border-color: #9e9e9e !important;
+                      background-color: rgba(158,158,158,0.15) !important;
+                    }
                     /* Styles for Battery Comparison Bars in Overview for Print */
                     .barContainer {
                       width: 100%;

--- a/style.css
+++ b/style.css
@@ -525,23 +525,14 @@ button:disabled {
   flex-wrap: wrap;
 }
 
-.connector-block {
-  display: inline-block;
-  padding: 1px 4px;
-  margin: 2px;
-  border-radius: 3px;
-  border: 1px solid;
-  font-size: 0.75em;
-  background-color: rgba(0,0,0,0.03);
-}
-
+.connector-block,
 .info-box {
   display: inline-block;
   padding: 2px 6px;
   margin: 2px;
   border-radius: 3px;
   border: 1px solid;
-  background: rgba(0,0,0,0.03);
+  background-color: rgba(0,0,0,0.03);
   font-size: 0.75em;
 }
 
@@ -607,7 +598,10 @@ button:disabled {
   border-color: #2196f3;
   background-color: rgba(33, 150, 243, 0.15);
 }
-.neutral-conn { border-color: #9e9e9e; }
+.neutral-conn {
+  border-color: #9e9e9e;
+  background-color: rgba(158, 158, 158, 0.15);
+}
 
 
 .device-data { margin-left: 10px; }
@@ -806,11 +800,12 @@ body.dark-mode.pink-mode h2 {
   border-color: #888;
   box-shadow: 0 4px 10px rgba(0, 0, 0, 0.4);
 }
-.dark-mode .connector-block { background-color: rgba(255,255,255,0.1); }
+.dark-mode .connector-block,
+.dark-mode .info-box { background-color: rgba(255,255,255,0.1); }
 .dark-mode .power-conn { background-color: rgba(244, 67, 54, 0.3); }
 .dark-mode .fiz-conn { background-color: rgba(76, 175, 80, 0.3); }
 .dark-mode .video-conn { background-color: rgba(33, 150, 243, 0.3); }
-.dark-mode .info-box,
+.dark-mode .neutral-conn { background-color: rgba(158, 158, 158, 0.3); }
 .dark-mode .tray-box { background-color: rgba(255,255,255,0.1); }
 .dark-mode #setupDiagram .node-box { fill: #333; stroke: none; }
 .dark-mode #setupDiagram .node-box.first-fiz { stroke: none; }
@@ -901,11 +896,12 @@ body.dark-mode.pink-mode .help-content { border-color: var(--accent-color); }
     border-color: #888;
     box-shadow: 0 4px 10px rgba(0, 0, 0, 0.4);
   }
-  body:not(.light-mode) .connector-block { background-color: rgba(255,255,255,0.1); }
+  body:not(.light-mode) .connector-block,
+  body:not(.light-mode) .info-box { background-color: rgba(255,255,255,0.1); }
   body:not(.light-mode) .power-conn { background-color: rgba(244, 67, 54, 0.3); }
   body:not(.light-mode) .fiz-conn { background-color: rgba(76, 175, 80, 0.3); }
   body:not(.light-mode) .video-conn { background-color: rgba(33, 150, 243, 0.3); }
-  body:not(.light-mode) .info-box,
+  body:not(.light-mode) .neutral-conn { background-color: rgba(158, 158, 158, 0.3); }
   body:not(.light-mode) .tray-box { background-color: rgba(255,255,255,0.1); }
   body:not(.light-mode) #setupDiagram .node-box { fill: #333; stroke: none; }
   body:not(.light-mode) #setupDiagram .node-box.first-fiz { stroke: none; }


### PR DESCRIPTION
## Summary
- Standardize diagram popup boxes so connector and info items share identical padding, borders and font sizing
- Add background color for neutral connectors and ensure power, video and FIZ boxes differ only by color
- Apply the same styling in generated print/export CSS for consistency

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b2c8bce99c8320a9725de98a577bb6