### PR TITLE
Ensure frequency info is styled as video in diagram popups

### DIFF
--- a/script.js
+++ b/script.js
@@ -3721,7 +3721,7 @@ function attachDiagramPopups(map) {
       (data && data.latencyMs ?
         `<div class="info-box video-conn"><strong>Latency:</strong> ${escapeHtml(String(data.latencyMs))}</div>` : '') +
       (data && data.frequency ?
-        `<div class="info-box"><strong>Frequency:</strong> ${escapeHtml(String(data.frequency))}</div>` : '');
+        `<div class="info-box video-conn"><strong>Frequency:</strong> ${escapeHtml(String(data.frequency))}</div>` : '');
     const html = `<strong>${escapeHtml(info.name)}</strong>` +
       connectors + infoHtml;
 
@@ -5050,7 +5050,7 @@ function generatePrintableOverview() {
                 const connectors = generateConnectorSummary(data);
                 const infoBoxes =
                     (data.latencyMs !== undefined ? `<div class="info-box video-conn"><strong>Latency:</strong> ${escapeHtml(String(data.latencyMs))}</div>` : '') +
-                    (data.frequency ? `<div class="info-box"><strong>Frequency:</strong> ${escapeHtml(String(data.frequency))}</div>` : '');
+                    (data.frequency ? `<div class="info-box video-conn"><strong>Frequency:</strong> ${escapeHtml(String(data.frequency))}</div>` : '');
                 details = connectors + infoBoxes;
             }
             addToSection(headingKey, `<div class="device-block"><strong>${safeName}</strong>${details}</div>`);


### PR DESCRIPTION
## Summary
- Apply video-connection styling to frequency information so it displays blue alongside latency in setup diagram popups and printable overviews

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2cad7e90c83209c906b776e523466