### PR TITLE
Scroll to device form when editing

### DIFF
--- a/script.js
+++ b/script.js
@@ -4267,6 +4267,7 @@ deviceManagerSection.addEventListener("click", (event) => {
     addDeviceBtn.dataset.originalName = name; // Store original name for update
     cancelEditBtn.textContent = texts[currentLang].cancelEditBtn;
     cancelEditBtn.style.display = "inline";
+    document.getElementById("addDeviceHeading").scrollIntoView({ behavior: "smooth", block: "start" });
   } else if (event.target.classList.contains("delete-btn")) {
     const name = event.target.dataset.name;
     const categoryKey = event.target.dataset.category;


### PR DESCRIPTION
## Summary
- Scroll the page to the device form when editing a device so the form is immediately visible

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2cb82febc8320a03899d717bb7d3c