### PR TITLE
Persist user selections with session storage

### DIFF
--- a/storage.js
+++ b/storage.js
@@ -2,6 +2,26 @@
 
 const DEVICE_STORAGE_KEY = 'cameraPowerPlanner_devices';
 const SETUP_STORAGE_KEY = 'cameraPowerPlanner_setups';
+const SESSION_STATE_KEY = 'cameraPowerPlanner_session';
+
+// --- Session State Storage ---
+function loadSessionState() {
+  try {
+    const data = sessionStorage.getItem(SESSION_STATE_KEY);
+    return data ? JSON.parse(data) : null;
+  } catch (e) {
+    console.error("Error loading session state from sessionStorage:", e);
+    return null;
+  }
+}
+
+function saveSessionState(state) {
+  try {
+    sessionStorage.setItem(SESSION_STATE_KEY, JSON.stringify(state));
+  } catch (e) {
+    console.error("Error saving session state to sessionStorage:", e);
+  }
+}
 
 // --- Device Data Storage ---
 function loadDeviceData() {
@@ -97,6 +117,8 @@ if (typeof module !== "undefined" && module.exports) {
     saveSetups,
     saveSetup,
     loadSetup,
-    deleteSetup
+    deleteSetup,
+    loadSessionState,
+    saveSessionState
   };
 }

--- a/tests/storage.test.js
+++ b/tests/storage.test.js
@@ -6,10 +6,13 @@ const {
   saveSetup,
   loadSetup,
   deleteSetup,
+  loadSessionState,
+  saveSessionState,
 } = require('../storage');
 
 const DEVICE_KEY = 'cameraPowerPlanner_devices';
 const SETUP_KEY = 'cameraPowerPlanner_setups';
+const SESSION_KEY = 'cameraPowerPlanner_session';
 
 const validDeviceData = {
   cameras: {},
@@ -114,5 +117,27 @@ describe('setup storage', () => {
     localStorage.setItem(SETUP_KEY, JSON.stringify(setups));
     deleteSetup('A');
     expect(JSON.parse(localStorage.getItem(SETUP_KEY))).toEqual({B:{bar:2}});
+  });
+});
+
+describe('session state storage', () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  test('saveSessionState stores JSON in sessionStorage', () => {
+    const state = { camera: 'CamA' };
+    saveSessionState(state);
+    expect(sessionStorage.getItem(SESSION_KEY)).toBe(JSON.stringify(state));
+  });
+
+  test('loadSessionState returns parsed object when present', () => {
+    const state = { camera: 'CamA' };
+    sessionStorage.setItem(SESSION_KEY, JSON.stringify(state));
+    expect(loadSessionState()).toEqual(state);
+  });
+
+  test('loadSessionState returns null when none', () => {
+    expect(loadSessionState()).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- add session storage helpers to preserve temporary setup data
- auto-save UI selections to session storage and restore them on load
- cover session storage logic with new unit tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2ca76690c8320aba35c6f6008b6b7