### PR TITLE
Clarify Hollyland Pyro monitor names

### DIFF
--- a/data.js
+++ b/data.js
@@ -5139,7 +5139,7 @@ let devices={
       ],
       "videoOutputs": []
     },
-    "Hollyland Pyro 7 (TX)": {
+    "Hollyland Pyro 7 (RX/TX)": {
       "screenSizeInches": 7,
       "brightnessNits": 1200,
       "powerDrawWatts": 22,
@@ -5168,7 +5168,7 @@ let devices={
         }
       ]
     },
-    "Hollyland Pyro 5": {
+    "Hollyland Pyro 5 (RX/TX)": {
       "screenSizeInches": 5,
       "brightnessNits": 1500,
       "powerDrawWatts": 16.5,


### PR DESCRIPTION
## Summary
- label Hollyland Pyro 5 and Pyro 7 as (RX/TX)

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2cc8bb28c8320b9ed2bb69d626b75