### PR TITLE
Rename Hollyland Mars M1 Enhanced to include RX/TX

### DIFF
--- a/data.js
+++ b/data.js
@@ -5194,7 +5194,7 @@ let devices={
         }
       ]
     },
-    "Hollyland Mars M1 Enhanced": {
+    "Hollyland Mars M1 Enhanced (RX/TX)": {
       "screenSizeInches": 5.5,
       "brightnessNits": 1000,
       "powerDrawWatts": 16,

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -1183,8 +1183,10 @@ describe('monitor wireless metadata', () => {
     expect(devices.monitors['SmallHD Ultra 7'].wirelessTx).toBe(false);
   });
 
-  test('Hollyland Mars M1 Enhanced retains wirelessTx flag', () => {
+  test('Hollyland Mars M1 Enhanced (RX/TX) retains wirelessTx flag', () => {
     const devices = require('../data.js');
-    expect(devices.monitors['Hollyland Mars M1 Enhanced'].wirelessTx).toBe(false);
+    expect(
+      devices.monitors['Hollyland Mars M1 Enhanced (RX/TX)'].wirelessTx,
+    ).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- clarify device name to "Hollyland Mars M1 Enhanced (RX/TX)"
- update wireless metadata test to reference new name

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b2ccb2d6c08320a89048ba3f06ed7f