### PR TITLE
Align wireless video consumption field

### DIFF
--- a/script.js
+++ b/script.js
@@ -1076,6 +1076,14 @@ const videoVideoInputsContainer = document.getElementById("videoVideoInputsConta
 const videoVideoOutputsContainer = document.getElementById("videoVideoOutputsContainer");
 const videoFrequencyInput = document.getElementById("videoFrequency");
 const videoLatencyInput = document.getElementById("videoLatency");
+const addDeviceForm = wattFieldDiv.parentNode;
+function placeWattField(category) {
+  if (category === "video") {
+    videoFieldsDiv.insertBefore(wattFieldDiv, videoFieldsDiv.firstChild);
+  } else {
+    addDeviceForm.insertBefore(wattFieldDiv, cameraFieldsDiv);
+  }
+}
 const motorFieldsDiv = document.getElementById("motorFields");
 const motorConnectorInput = document.getElementById("motorConnector");
 const motorInternalInput = document.getElementById("motorInternal");
@@ -4147,6 +4155,7 @@ deviceManagerSection.addEventListener("click", (event) => {
     } else {
       deviceData = devices[categoryKey][name];
     }
+    placeWattField(categoryKey);
 
     if (categoryKey === "batteries") {
       wattFieldDiv.style.display = "none";
@@ -4322,6 +4331,7 @@ deviceManagerSection.addEventListener("click", (event) => {
 // Category selection in add device form
 newCategorySelect.addEventListener("change", () => {
   const val = newCategorySelect.value;
+  placeWattField(val);
   if (val === "batteries") {
     wattFieldDiv.style.display = "none";
     cameraFieldsDiv.style.display = "none";


### PR DESCRIPTION
## Summary
- Move the generic "Consumption (W)" input into the wireless video section when editing or adding video devices
- Restore the field to its original position for other categories

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2cc29319883209ae48e6c9c289277