### PR TITLE
Add latency metadata for wireless monitors

### DIFF
--- a/data.js
+++ b/data.js
@@ -4817,6 +4817,7 @@ let devices={
         "output": null
       },
       "wirelessTx": true,
+      "latencyMs": "< 1ms",
       "videoInputs": [
         {
           "type": "HDMI"
@@ -4875,6 +4876,7 @@ let devices={
         "output": null
       },
       "wirelessTx": true,
+      "latencyMs": "< 1ms",
       "videoInputs": [
         {
           "type": "HDMI"
@@ -4933,6 +4935,7 @@ let devices={
         "output": null
       },
       "wirelessTx": true,
+      "latencyMs": "< 1ms",
       "videoInputs": [
         {
           "type": "HDMI"
@@ -5013,6 +5016,7 @@ let devices={
         "output": null
       },
       "wirelessTx": true,
+      "latencyMs": "< 1ms",
       "videoInputs": [
         {
           "type": "HDMI"
@@ -5071,6 +5075,7 @@ let devices={
         "output": null
       },
       "wirelessTx": true,
+      "latencyMs": "< 1ms",
       "videoInputs": [
         {
           "type": "HDMI"
@@ -5151,6 +5156,7 @@ let devices={
         "output": null
       },
       "wirelessTx": true,
+      "latencyMs": "50ms",
       "videoInputs": [
         {
           "type": "HDMI"
@@ -5180,6 +5186,7 @@ let devices={
         "output": null
       },
       "wirelessTx": true,
+      "latencyMs": "50ms",
       "videoInputs": [
         {
           "type": "HDMI"
@@ -5205,7 +5212,8 @@ let devices={
         },
         "output": null
       },
-      "wirelessTx": false,
+      "wirelessTx": true,
+      "latencyMs": "< 80ms",
       "audioOutput": {
         "portType": "3.5mm Headphone Jack"
       },

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -1183,8 +1183,19 @@ describe('monitor wireless metadata', () => {
     expect(devices.monitors['SmallHD Ultra 7'].wirelessTx).toBe(false);
   });
 
-  test('Hollyland Mars M1 Enhanced retains wirelessTx flag', () => {
+  test('SmallHD Cine 7 Bolt 4K TX reports latency', () => {
     const devices = require('../data.js');
-    expect(devices.monitors['Hollyland Mars M1 Enhanced'].wirelessTx).toBe(false);
+    expect(devices.monitors['SmallHD Cine 7 Bolt 4K TX'].latencyMs).toBe('< 1ms');
+  });
+
+  test('Hollyland Pyro 5 reports latency', () => {
+    const devices = require('../data.js');
+    expect(devices.monitors['Hollyland Pyro 5'].latencyMs).toBe('50ms');
+  });
+
+  test('Hollyland Mars M1 Enhanced exposes wirelessTx and latency', () => {
+    const devices = require('../data.js');
+    expect(devices.monitors['Hollyland Mars M1 Enhanced'].wirelessTx).toBe(true);
+    expect(devices.monitors['Hollyland Mars M1 Enhanced'].latencyMs).toBe('< 80ms');
   });
 });


### PR DESCRIPTION
## Summary
- add latency information to all wireless monitors
- mark Hollyland Mars M1 Enhanced as wireless TX with <80ms latency
- test latency metadata for SmallHD, Pyro, and Mars M1 monitors

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b2cd409a708320b4702d9849aa1f7b