### PR TITLE
feat: add clear current setup button

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,6 +48,9 @@
       <input type="text" id="setupName" placeholder="Setup name" />
       <button id="saveSetupBtn">Save</button>
     </div>
+    <div class="form-row">
+      <button id="clearSetupBtn">Clear Current Setup</button>
+    </div>
 
     <!-- Moved Setup Actions here -->
     <h3 id="setupActionsHeading">Setup Actions</h3>

--- a/script.js
+++ b/script.js
@@ -835,6 +835,7 @@ function setLanguage(lang) {
   document.getElementById("setupNameLabel").textContent = texts[lang].setupNameLabel;
   saveSetupBtn.textContent = texts[lang].saveSetupBtn;
   deleteSetupBtn.textContent = texts[lang].deleteSetupBtn;
+  clearSetupBtn.textContent = texts[lang].clearSetupBtn;
   // Update the "-- New Setup --" option text
   if (setupSelect.options.length > 0) {
     setupSelect.options[0].textContent = texts[lang].newSetupOption;
@@ -1043,6 +1044,7 @@ const setupSelect     = document.getElementById("setupSelect");
 const setupNameInput  = document.getElementById("setupName");
 const saveSetupBtn    = document.getElementById("saveSetupBtn");
 const deleteSetupBtn  = document.getElementById("deleteSetupBtn");
+const clearSetupBtn   = document.getElementById("clearSetupBtn");
 const deviceManagerSection = document.getElementById("device-manager");
 const toggleDeviceBtn = document.getElementById("toggleDeviceManager");
 const cameraListElem  = document.getElementById("cameraList");
@@ -4052,6 +4054,28 @@ deleteSetupBtn.addEventListener("click", () => {
     controllerSelects.forEach(sel => { if (sel.options.length) sel.value = "None"; });
     updateCalculations(); // Recalculate after clearing setup
   }
+});
+
+clearSetupBtn.addEventListener("click", () => {
+  if (typeof sessionStorage !== 'undefined') {
+    sessionStorage.removeItem('cameraPowerPlanner_session');
+  }
+  setupSelect.value = "";
+  setupNameInput.value = "";
+  [cameraSelect, monitorSelect, videoSelect, distanceSelect, batterySelect, batteryPlateSelect].forEach(sel => {
+    if (!sel) return;
+    const noneOption = Array.from(sel.options).find(opt => opt.value === "None");
+    if (noneOption) {
+      sel.value = "None";
+    } else {
+      sel.selectedIndex = 0;
+    }
+  });
+  motorSelects.forEach(sel => { if (sel.options.length) sel.value = "None"; });
+  controllerSelects.forEach(sel => { if (sel.options.length) sel.value = "None"; });
+  updateBatteryPlateVisibility();
+  updateBatteryOptions();
+  updateCalculations();
 });
 
 setupSelect.addEventListener("change", (event) => {

--- a/translations.js
+++ b/translations.js
@@ -27,6 +27,7 @@ const texts = {
     setupNameLabel: "Setup Name:",
     deleteSetupBtn: "Delete",
     saveSetupBtn: "Save",
+    clearSetupBtn: "Clear Current Setup",
 
     cameraLabel: "Camera:",
     monitorLabel: "Monitor:",
@@ -236,6 +237,7 @@ const texts = {
     setupNameLabel: "Nome di configurazione:",
     deleteSetupBtn: "Eliminare",
     saveSetupBtn: "Salva",
+    clearSetupBtn: "Cancella configurazione corrente",
     cameraLabel: "Telecamera:",
     monitorLabel: "Monitor:",
     videoLabel: "Video wireless:",
@@ -429,6 +431,7 @@ const texts = {
     setupNameLabel: "Nombre de Configuración:",
     deleteSetupBtn: "Eliminar",
     saveSetupBtn: "Guardar",
+    clearSetupBtn: "Borrar configuración actual",
 
     cameraLabel: "Cámara:",
     monitorLabel: "Monitor:",
@@ -638,6 +641,7 @@ const texts = {
     setupNameLabel: "Nom de la Configuration:",
     deleteSetupBtn: "Supprimer",
     saveSetupBtn: "Enregistrer",
+    clearSetupBtn: "Effacer la configuration actuelle",
 
     cameraLabel: "Caméra:",
     monitorLabel: "Moniteur:",
@@ -847,6 +851,7 @@ const texts = {
     setupNameLabel: "Setup-Name:",
     deleteSetupBtn: "Löschen",
     saveSetupBtn: "Speichern",
+    clearSetupBtn: "Aktuelles Setup zurücksetzen",
 
     cameraLabel: "Kamera:",
     monitorLabel: "Monitor:",


### PR DESCRIPTION
## Summary
- add "Clear Current Setup" button to manage setup
- clear session storage and reset selectors
- translate button label for all languages

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2d954c3108320b672f09b307448ba