### PR TITLE
Add 10h battery count calculation

### DIFF
--- a/index.html
+++ b/index.html
@@ -155,6 +155,7 @@
     <p><strong><span id="totalCurrent144Label">Total Current (at 14.4V):</span></strong> <span id="totalCurrent144">0.00</span> A</p>
     <p><strong><span id="totalCurrent12Label">Total Current (at 12V):</span></strong> <span id="totalCurrent12">0.00</span> A</p>
     <p><strong><span id="batteryLifeLabel">Runtime (estimated):</span></strong> <span id="batteryLife">0.00</span> <span id="batteryLifeUnit">hrs</span></p>
+    <p><strong><span id="batteryCountLabel">Batteries for 10h shoot (incl. spare):</span></strong> <span id="batteryCount">–</span></p>
     <p id="pinWarning" role="status" aria-live="polite" aria-describedby="batteryLabel"></p>
   <p id="dtapWarning" role="status" aria-live="polite" aria-describedby="batteryLabel"></p>
   </section>

--- a/script.js
+++ b/script.js
@@ -861,6 +861,7 @@ function setLanguage(lang) {
   document.getElementById("totalCurrent144Label").textContent = texts[lang].totalCurrent144Label;
   document.getElementById("totalCurrent12Label").textContent = texts[lang].totalCurrent12Label;
   document.getElementById("batteryLifeLabel").textContent = texts[lang].batteryLifeLabel;
+  document.getElementById("batteryCountLabel").textContent = texts[lang].batteryCountLabel;
   const unitElem = document.getElementById("batteryLifeUnit");
   if (unitElem) unitElem.textContent = texts[lang].batteryLifeUnit;
   // Device manager category headings
@@ -1041,6 +1042,7 @@ const totalPowerElem      = document.getElementById("totalPower");
 const totalCurrent144Elem = document.getElementById("totalCurrent144");
 const totalCurrent12Elem  = document.getElementById("totalCurrent12");
 const batteryLifeElem     = document.getElementById("batteryLife");
+const batteryCountElem    = document.getElementById("batteryCount");
 const pinWarnElem         = document.getElementById("pinWarning");
 const dtapWarnElem        = document.getElementById("dtapWarning");
 
@@ -2953,6 +2955,7 @@ function updateCalculations() {
 // Wenn kein Akku oder "None" ausgewählt ist: Laufzeit = nicht berechenbar, keine Warnungen
 if (!battery || battery === "None" || !devices.batteries[battery]) {
   batteryLifeElem.textContent = "–";
+  batteryCountElem.textContent = "–";
   pinWarnElem.textContent = "";
   pinWarnElem.style.color = "";
   dtapWarnElem.textContent = "";
@@ -2964,12 +2967,17 @@ if (!battery || battery === "None" || !devices.batteries[battery]) {
     const maxDtapA = battData.dtapA;
     totalCurrent144Elem.textContent = totalCurrentHigh.toFixed(2);
     totalCurrent12Elem.textContent = totalCurrentLow.toFixed(2);
+    let hours;
     if (totalWatt === 0) {
+      hours = Infinity;
       batteryLifeElem.textContent = "∞";
     } else {
-      const hours = capacityWh / totalWatt;
+      hours = capacityWh / totalWatt;
       batteryLifeElem.textContent = hours.toFixed(2);
     }
+    // Round up total batteries (including one spare) to the next full number
+    const batteriesNeeded = Math.ceil(10 / hours + 1);
+    batteryCountElem.textContent = batteriesNeeded.toString();
     // Warnings about current draw vs battery limits
     pinWarnElem.textContent = "";
     dtapWarnElem.textContent = "";
@@ -5137,6 +5145,7 @@ function generatePrintableOverview() {
         <p><strong>${t.totalCurrent144Label}</strong> ${totalCurrent144Elem.textContent} A</p>
         <p><strong>${t.totalCurrent12Label}</strong> ${totalCurrent12Elem.textContent} A</p>
         <p><strong>${t.batteryLifeLabel}</strong> ${batteryLifeElem.textContent} ${batteryLifeUnitElem ? batteryLifeUnitElem.textContent : ''}</p>
+        <p><strong>${t.batteryCountLabel}</strong> ${batteryCountElem.textContent}</p>
     `;
 
     // Get current warning messages with their colors

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -59,6 +59,7 @@ describe('script.js functions', () => {
     expect(document.getElementById('totalPower').textContent).toBe('23.0');
     expect(document.getElementById('totalCurrent12').textContent).toBe('1.92');
     expect(document.getElementById('batteryLife').textContent).toBe('4.35');
+    expect(document.getElementById('batteryCount').textContent).toBe('4');
     expect(document.getElementById('pinWarning').textContent)
       .toBe(texts.en.pinOk.replace('{max}', '10'));
     expect(document.getElementById('dtapWarning').textContent)

--- a/translations.js
+++ b/translations.js
@@ -47,6 +47,7 @@ const texts = {
     totalCurrent336Label: "Total Current (at 33.6V):",
     totalCurrent216Label: "Total Current (at 21.6V):",
     batteryLifeLabel: "Runtime (estimated):",
+    batteryCountLabel: "Batteries for 10h shoot (incl. spare):",
 
     methodPinsOnly: "pins only!",
     methodPinsAndDTap: "both pins and D-Tap",
@@ -255,6 +256,7 @@ const texts = {
     totalCurrent336Label: "Corrente totale (a 33,6 V):",
     totalCurrent216Label: "Corrente totale (a 21,6 V):",
     batteryLifeLabel: "Autonomia (stimata):",
+    batteryCountLabel: "Batterie per ripresa di 10h (incl. scorta):",
     methodPinsOnly: "solo pin!",
     methodPinsAndDTap: "sia pin che D-Tap",
     methodInfinite: "infinito",
@@ -453,6 +455,7 @@ const texts = {
     totalCurrent336Label: "Corriente Total (a 33.6V):",
     totalCurrent216Label: "Corriente Total (a 21.6V):",
     batteryLifeLabel: "Autonomía (estimada):",
+    batteryCountLabel: "Baterías para rodaje de 10h (incl. repuesto):",
 
     methodPinsOnly: "solo pines!",
     methodPinsAndDTap: "pines y D-Tap",
@@ -664,6 +667,7 @@ const texts = {
     totalCurrent336Label: "Courant Total (à 33,6V):",
     totalCurrent216Label: "Courant Total (à 21,6V):",
     batteryLifeLabel: "Autonomie (estimée):",
+    batteryCountLabel: "Batteries pour tournage de 10h (incl. de rechange):",
 
     methodPinsOnly: "broches seulement!",
     methodPinsAndDTap: "broches et D-Tap",
@@ -875,6 +879,7 @@ const texts = {
     totalCurrent336Label: "Gesamtstrom (bei 33,6V):",
     totalCurrent216Label: "Gesamtstrom (bei 21,6V):",
     batteryLifeLabel: "Akkulaufzeit (geschätzt):",
+    batteryCountLabel: "Akkus für 10h Dreh (inkl. Reserve):",
 
     methodPinsOnly: "nur Pins!",
     methodPinsAndDTap: "Pins und D-Tap",


### PR DESCRIPTION
## Summary
- show required batteries for a 10h shoot including one spare
- round battery total up to the next full number
- translate label and add test coverage

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2e271d0b48320a412a0114f80e01d