### PR TITLE
Add temperature runtime note

### DIFF
--- a/index.html
+++ b/index.html
@@ -156,7 +156,8 @@
     <p><strong><span id="totalCurrent12Label">Total Current (at 12V):</span></strong> <span id="totalCurrent12">0.00</span> A</p>
     <p><strong><span id="batteryLifeLabel">Runtime (estimated):</span></strong> <span id="batteryLife">0.00</span> <span id="batteryLifeUnit">hrs</span></p>
     <p id="pinWarning" role="status" aria-live="polite" aria-describedby="batteryLabel"></p>
-  <p id="dtapWarning" role="status" aria-live="polite" aria-describedby="batteryLabel"></p>
+    <p id="dtapWarning" role="status" aria-live="polite" aria-describedby="batteryLabel"></p>
+    <div id="temperatureNote"></div>
   </section>
 
   <section id="setupDiagram">

--- a/script.js
+++ b/script.js
@@ -863,6 +863,8 @@ function setLanguage(lang) {
   document.getElementById("batteryLifeLabel").textContent = texts[lang].batteryLifeLabel;
   const unitElem = document.getElementById("batteryLifeUnit");
   if (unitElem) unitElem.textContent = texts[lang].batteryLifeUnit;
+  const tempNote = document.getElementById("temperatureNote");
+  if (tempNote) tempNote.innerHTML = texts[lang].temperatureNote;
   // Device manager category headings
   document.getElementById("category_cameras").textContent = texts[lang].category_cameras;
   document.getElementById("category_monitors").textContent = texts[lang].category_monitors;

--- a/translations.js
+++ b/translations.js
@@ -177,6 +177,7 @@ const texts = {
     batteryTableLabel: "Battery",
     runtimeLabel: "Estimated Runtime (h)",
     batteryLifeUnit: "hrs",
+    temperatureNote: "Temperature impact on runtime:<br>+25 °C (room temp): ~2 h runtime (100%)<br>0 °C: ~1.6 h (80%)<br>–10 °C: ~1.2–1.3 h (60–65%)<br>–20 °C: ~1 h or less (50% or lower, plus voltage sag issues)<br>+40 °C: ~2 h runtime, but battery ages much faster (loses total Wh capacity over weeks/months)",
 
     noBatterySupports: "No battery can supply this load.",
 
@@ -376,6 +377,7 @@ const texts = {
     batteryTableLabel: "Batteria",
     runtimeLabel: "Autonomia stimata (h)",
     batteryLifeUnit: "ore",
+    temperatureNote: "Impatto della temperatura sull'autonomia:<br>+25 °C (temperatura ambiente): ~2 h di autonomia (100%)<br>0 °C: ~1,6 h (80%)<br>–10 °C: ~1,2–1,3 h (60–65%)<br>–20 °C: ~1 h o meno (50% o meno, oltre a cadute di tensione)<br>+40 °C: ~2 h di autonomia, ma la batteria invecchia molto più rapidamente (perde capacità in Wh nel giro di settimane/mesi)",
     noBatterySupports: "Nessuna batteria può fornire questo carico.",
     alertSetupName: "Immettere un nome per l'installazione.",
     alertSetupSaved: "Setup \"{name}\" salvato.",
@@ -583,6 +585,7 @@ const texts = {
     batteryTableLabel: "Batería",
     runtimeLabel: "Autonomía Estimada (h)",
     batteryLifeUnit: "h",
+    temperatureNote: "Efecto de la temperatura en la autonomía:<br>+25 °C (temperatura ambiente): ~2 h de autonomía (100%)<br>0 °C: ~1,6 h (80%)<br>–10 °C: ~1,2–1,3 h (60–65%)<br>–20 °C: ~1 h o menos (50 % o menos, además problemas de caída de tensión)<br>+40 °C: ~2 h de autonomía, pero la batería envejece mucho más rápido (pierde capacidad total en Wh en semanas/meses)",
 
     noBatterySupports: "Ninguna batería puede suministrar esta carga.",
 
@@ -794,6 +797,7 @@ const texts = {
     batteryTableLabel: "Batterie",
     runtimeLabel: "Autonomie Estimée (h)",
     batteryLifeUnit: "h",
+    temperatureNote: "Impact de la température sur l’autonomie :<br>+25 °C (température ambiante) : ~2 h d’autonomie (100 %)<br>0 °C : ~1,6 h (80 %)<br>–10 °C : ~1,2–1,3 h (60–65 %)<br>–20 °C : ~1 h ou moins (50 % ou moins, avec chute de tension)<br>+40 °C : ~2 h d’autonomie, mais la batterie vieillit beaucoup plus vite (perd de la capacité totale en Wh en quelques semaines/mois)",
 
     noBatterySupports: "Aucune batterie ne peut fournir cette charge.",
 
@@ -1005,6 +1009,7 @@ const texts = {
     batteryTableLabel: "Akku",
     runtimeLabel: "Geschätzte Laufzeit (h)",
     batteryLifeUnit: "Std.",
+    temperatureNote: "Temperatureinfluss auf die Laufzeit:<br>+25 °C (Raumtemperatur): ~2 h Laufzeit (100 %)<br>0 °C: ~1,6 h (80 %)<br>–10 °C: ~1,2–1,3 h (60–65 %)<br>–20 °C: ~1 h oder weniger (50 % oder weniger, dazu Spannungsabfall)<br>+40 °C: ~2 h Laufzeit, aber der Akku altert viel schneller (verliert Wh-Kapazität innerhalb von Wochen/Monaten)",
 
     noBatterySupports: "Kein Akku kann diese Last liefern.",
 


### PR DESCRIPTION
## Summary
- Show temperature-dependent runtime note in the results section.
- Translate the new note for English, Italian, Spanish, French and German.
- Load the note text dynamically when the language changes.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b2e340d0cc8320a01871b23e7173e2