### PR TITLE
Fix Italian zoom control translations

### DIFF
--- a/translations.js
+++ b/translations.js
@@ -411,8 +411,8 @@ const texts = {
     helpClose: "Chiudi",
     helpTitle: "Come usare",
     helpNoResults: "Nessun risultato trovato.",
-    zoomInLabel: "Zoom in",
-    zoomOutLabel: "Zoom out",
+    zoomInLabel: "Ingrandisci",
+    zoomOutLabel: "Rimpicciolisci",
     diagramMoveHint: "Trascina i nodi per spostarli.",
   },
   es: {


### PR DESCRIPTION
## Summary
- translate zoom control labels into Italian for a consistent UI

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b2e57344208320beccb04bc9ebb9d8