### PR TITLE
Add runtime feedback email button

### DIFF
--- a/index.html
+++ b/index.html
@@ -156,6 +156,7 @@
     <p id="pinWarning" role="status" aria-live="polite" aria-describedby="batteryLabel"></p>
     <p id="dtapWarning" role="status" aria-live="polite" aria-describedby="batteryLabel"></p>
     <div id="temperatureNote"></div>
+    <button id="runtimeFeedbackBtn" type="button">Submit User Runtime Feedback</button>
   </section>
 
   <section id="setupDiagram">

--- a/script.js
+++ b/script.js
@@ -863,6 +863,7 @@ function setLanguage(lang) {
   document.getElementById("totalCurrent12Label").textContent = texts[lang].totalCurrent12Label;
   document.getElementById("batteryLifeLabel").textContent = texts[lang].batteryLifeLabel;
   document.getElementById("batteryCountLabel").textContent = texts[lang].batteryCountLabel;
+  document.getElementById("runtimeFeedbackBtn").textContent = texts[lang].runtimeFeedbackBtn;
   const unitElem = document.getElementById("batteryLifeUnit");
   if (unitElem) unitElem.textContent = texts[lang].batteryLifeUnit;
   renderTemperatureNote(lastRuntimeHours);
@@ -1151,6 +1152,7 @@ const existingDevicesHeading = document.getElementById("existingDevicesHeading")
 const batteryComparisonSection = document.getElementById("batteryComparison");
 const batteryTableElem = document.getElementById("batteryTable");
 const breakdownListElem = document.getElementById("breakdownList");
+const runtimeFeedbackBtn = document.getElementById("runtimeFeedbackBtn");
 const setupDiagramContainer = document.getElementById("diagramArea");
 const diagramLegend = document.getElementById("diagramLegend");
 const downloadDiagramBtn = document.getElementById("downloadDiagram");
@@ -4966,6 +4968,35 @@ generateOverviewBtn.addEventListener('click', () => {
     }
     generatePrintableOverview();
 });
+
+// Prepare an email with current setup details for runtime feedback
+if (runtimeFeedbackBtn) {
+    runtimeFeedbackBtn.addEventListener('click', () => {
+        const lines = [];
+        lines.push('Camera Power Planner runtime feedback');
+        lines.push('');
+        lines.push(`Camera: ${cameraSelect.value || 'None'}`);
+        lines.push(`Monitor: ${monitorSelect.value || 'None'}`);
+        lines.push(`Wireless Video: ${videoSelect.value || 'None'}`);
+        const motors = motorSelects.map(sel => sel.value).filter(v => v && v !== 'None');
+        lines.push(`FIZ Motors: ${motors.length ? motors.join(', ') : 'None'}`);
+        const controllers = controllerSelects.map(sel => sel.value).filter(v => v && v !== 'None');
+        lines.push(`FIZ Controllers: ${controllers.length ? controllers.join(', ') : 'None'}`);
+        lines.push(`Distance Sensor: ${distanceSelect.value || 'None'}`);
+        lines.push(`Battery: ${batterySelect.value || 'None'}`);
+        lines.push('');
+        lines.push(`Total Consumption: ${totalPowerElem.textContent} W`);
+        const unit = document.getElementById('batteryLifeUnit')?.textContent || 'hrs';
+        lines.push(`Estimated Runtime: ${batteryLifeElem.textContent} ${unit}`);
+        lines.push('');
+        lines.push('Actual Runtime:');
+        lines.push('');
+        lines.push('Additional Notes:');
+        const subject = encodeURIComponent('Camera Power Planner Runtime Feedback');
+        const body = encodeURIComponent(lines.join('\n'));
+        window.location.href = `mailto:?subject=${subject}&body=${body}`;
+    });
+}
 
 function escapeHtml(str) {
     const div = document.createElement('div');

--- a/translations.js
+++ b/translations.js
@@ -48,6 +48,7 @@ const texts = {
     totalCurrent216Label: "Total Current (at 21.6V):",
     batteryLifeLabel: "Runtime (estimated):",
     batteryCountLabel: "Batteries for 10h shoot (incl. spare):",
+    runtimeFeedbackBtn: "Submit User Runtime Feedback",
 
     methodPinsOnly: "pins only!",
     methodPinsAndDTap: "both pins and D-Tap",
@@ -264,6 +265,7 @@ const texts = {
     totalCurrent216Label: "Corrente totale (a 21,6 V):",
     batteryLifeLabel: "Autonomia (stimata):",
     batteryCountLabel: "Batterie per ripresa di 10h (incl. scorta):",
+    runtimeFeedbackBtn: "Invia feedback runtime utente",
     methodPinsOnly: "solo pin!",
     methodPinsAndDTap: "sia pin che D-Tap",
     methodInfinite: "infinito",
@@ -470,6 +472,7 @@ const texts = {
     totalCurrent216Label: "Corriente Total (a 21.6V):",
     batteryLifeLabel: "Autonomía (estimada):",
     batteryCountLabel: "Baterías para rodaje de 10h (incl. repuesto):",
+    runtimeFeedbackBtn: "Enviar comentarios de tiempo de ejecución del usuario",
 
     methodPinsOnly: "solo pines!",
     methodPinsAndDTap: "pines y D-Tap",
@@ -689,6 +692,7 @@ const texts = {
     totalCurrent216Label: "Courant Total (à 21,6V):",
     batteryLifeLabel: "Autonomie (estimée):",
     batteryCountLabel: "Batteries pour tournage de 10h (incl. de rechange):",
+    runtimeFeedbackBtn: "Envoyer des commentaires sur la durée d'utilisation",
 
     methodPinsOnly: "broches seulement!",
     methodPinsAndDTap: "broches et D-Tap",
@@ -908,6 +912,7 @@ const texts = {
     totalCurrent216Label: "Gesamtstrom (bei 21,6V):",
     batteryLifeLabel: "Akkulaufzeit (geschätzt):",
     batteryCountLabel: "Akkus für 10h Dreh (inkl. Reserve):",
+    runtimeFeedbackBtn: "Laufzeit-Feedback senden",
 
     methodPinsOnly: "nur Pins!",
     methodPinsAndDTap: "Pins und D-Tap",


### PR DESCRIPTION
## Summary
- Add "Submit User Runtime Feedback" button to results section
- Generate prefilled email with current setup stats for runtime feedback
- Localize button text for all supported languages

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2f08693b083209875f1abfb2eb703