### PR TITLE
fix: restore setups from legacy storage

### DIFF
--- a/storage.js
+++ b/storage.js
@@ -72,8 +72,19 @@ function loadSetups() {
     const data = localStorage.getItem(SETUP_STORAGE_KEY);
     if (data) {
       const parsedData = JSON.parse(data);
-      // Ensure it's a plain object, not an array or primitive
-      if (parsedData && typeof parsedData === 'object' && !Array.isArray(parsedData)) {
+      if (Array.isArray(parsedData)) {
+        const obj = {};
+        parsedData.forEach((item, idx) => {
+          if (item && typeof item === 'object') {
+            const key = item.name || item.setupName || `Setup ${idx + 1}`;
+            obj[key] = item;
+          }
+        });
+        localStorage.setItem(SETUP_STORAGE_KEY, JSON.stringify(obj));
+        return obj;
+      }
+      // Ensure it's a plain object, not a primitive
+      if (parsedData && typeof parsedData === 'object') {
         return parsedData;
       }
     }

--- a/tests/storage.test.js
+++ b/tests/storage.test.js
@@ -88,9 +88,11 @@ describe('setup storage', () => {
     expect(loadSetups()).toEqual(setups);
   });
 
-  test('loadSetups returns empty object for array data', () => {
-    localStorage.setItem(SETUP_KEY, JSON.stringify([1,2,3]));
-    expect(loadSetups()).toEqual({});
+  test('loadSetups converts array data into an object', () => {
+    const arr = [{ name: 'A', foo: 1 }, { name: 'B', bar: 2 }];
+    localStorage.setItem(SETUP_KEY, JSON.stringify(arr));
+    expect(loadSetups()).toEqual({ A: { name: 'A', foo: 1 }, B: { name: 'B', bar: 2 } });
+    expect(JSON.parse(localStorage.getItem(SETUP_KEY))).toEqual({ A: { name: 'A', foo: 1 }, B: { name: 'B', bar: 2 } });
   });
 
   test('loadSetups returns empty object for primitive data', () => {


### PR DESCRIPTION
## Summary
- convert array-based setup data into an object and persist the migration
- test array migration to ensure saved setups reappear

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2f2a4a5a4832099e26bd37f28b360