### PR TITLE
fix: avoid video type initialization error

### DIFF
--- a/script.js
+++ b/script.js
@@ -39,20 +39,20 @@ function storeSession(state) {
   }
 }
 
-const VIDEO_TYPE_PATTERNS = [
-  { needles: ['12g'], value: '12G-SDI' },
-  { needles: ['6g'], value: '6G-SDI' },
-  { needles: ['3g'], value: '3G-SDI' },
-  { needles: ['hd-sdi'], value: '3G-SDI' },
-  { needles: ['mini', 'bnc'], value: 'Mini BNC' },
-  { needles: ['micro', 'hdmi'], value: 'Micro HDMI' },
-  { needles: ['mini', 'hdmi'], value: 'Mini HDMI' },
-  { needles: ['hdmi'], value: 'HDMI' }
-];
 function normalizeVideoType(type) {
   if (!type) return '';
+  const patterns = [
+    { needles: ['12g'], value: '12G-SDI' },
+    { needles: ['6g'], value: '6G-SDI' },
+    { needles: ['3g'], value: '3G-SDI' },
+    { needles: ['hd-sdi'], value: '3G-SDI' },
+    { needles: ['mini', 'bnc'], value: 'Mini BNC' },
+    { needles: ['micro', 'hdmi'], value: 'Micro HDMI' },
+    { needles: ['mini', 'hdmi'], value: 'Mini HDMI' },
+    { needles: ['hdmi'], value: 'HDMI' }
+  ];
   const t = String(type).toLowerCase();
-  for (const { needles, value } of VIDEO_TYPE_PATTERNS) {
+  for (const { needles, value } of patterns) {
     if (needles.every(n => t.includes(n))) return value;
   }
   return '';


### PR DESCRIPTION
## Summary
- inline video type patterns inside `normalizeVideoType` to prevent uninitialized variable errors

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2f62c25f883209070d55a7ed35245