### PR TITLE
Add shareable setup link generator

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,6 +54,7 @@
     <button id="importSetupsBtn">Import Setups</button>
     <input type="file" id="importSetupsInput" accept=".json" class="hidden" />
     <button id="generateOverviewBtn">Generate Overview</button>
+    <button id="shareSetupBtn">Share Setup Link</button>
     <button id="clearSetupBtn">Clear Current Setup</button>
   </section>
 

--- a/script.js
+++ b/script.js
@@ -1014,6 +1014,7 @@ function setLanguage(lang) {
   document.getElementById("exportSetupsBtn").textContent = texts[lang].exportSetupsBtn;
   document.getElementById("importSetupsBtn").textContent = texts[lang].importSetupsBtn;
   document.getElementById("generateOverviewBtn").textContent = texts[lang].generateOverviewBtn;
+  document.getElementById("shareSetupBtn").textContent = texts[lang].shareSetupBtn;
   const exportRevert = document.getElementById("exportAndRevertBtn");
   if (exportRevert) exportRevert.textContent = texts[lang].exportAndRevertBtn;
 
@@ -1064,6 +1065,7 @@ const setupNameInput  = document.getElementById("setupName");
 const saveSetupBtn    = document.getElementById("saveSetupBtn");
 const deleteSetupBtn  = document.getElementById("deleteSetupBtn");
 const clearSetupBtn   = document.getElementById("clearSetupBtn");
+const shareSetupBtn   = document.getElementById("shareSetupBtn");
 const deviceManagerSection = document.getElementById("device-manager");
 const toggleDeviceBtn = document.getElementById("toggleDeviceManager");
 const cameraListElem  = document.getElementById("cameraList");
@@ -5081,6 +5083,22 @@ generateOverviewBtn.addEventListener('click', () => {
     generatePrintableOverview();
 });
 
+shareSetupBtn.addEventListener('click', () => {
+    const currentSetup = {
+        camera: cameraSelect.value,
+        monitor: monitorSelect.value,
+        video: videoSelect.value,
+        motors: motorSelects.map(sel => sel.value),
+        controllers: controllerSelects.map(sel => sel.value),
+        distance: distanceSelect.value,
+        batteryPlate: batteryPlateSelect.value,
+        battery: batterySelect.value
+    };
+    const encoded = btoa(encodeURIComponent(JSON.stringify(currentSetup)));
+    const link = `${window.location.origin}${window.location.pathname}?shared=${encoded}`;
+    prompt(texts[currentLang].shareSetupPrompt, link);
+});
+
 // Open feedback dialog and handle submission
 if (runtimeFeedbackBtn && feedbackDialog && feedbackForm) {
   runtimeFeedbackBtn.addEventListener('click', () => {
@@ -6047,6 +6065,36 @@ function restoreSessionState() {
   if (setupSelect && state.setupSelect) setupSelect.value = state.setupSelect;
 }
 
+function applySharedSetupFromUrl() {
+  const params = new URLSearchParams(window.location.search);
+  const shared = params.get('shared');
+  if (!shared) return;
+  try {
+    const decoded = JSON.parse(decodeURIComponent(atob(shared)));
+    if (cameraSelect && decoded.camera) cameraSelect.value = decoded.camera;
+    updateBatteryPlateVisibility();
+    if (batteryPlateSelect && decoded.batteryPlate) batteryPlateSelect.value = decoded.batteryPlate;
+    updateBatteryOptions();
+    if (monitorSelect && decoded.monitor) monitorSelect.value = decoded.monitor;
+    if (videoSelect && decoded.video) videoSelect.value = decoded.video;
+    if (distanceSelect && decoded.distance) distanceSelect.value = decoded.distance;
+    if (Array.isArray(decoded.motors)) {
+      decoded.motors.forEach((val, i) => { if (motorSelects[i]) motorSelects[i].value = val; });
+    }
+    if (Array.isArray(decoded.controllers)) {
+      decoded.controllers.forEach((val, i) => { if (controllerSelects[i]) controllerSelects[i].value = val; });
+    }
+    if (batterySelect && decoded.battery) batterySelect.value = decoded.battery;
+    saveCurrentSession();
+  } catch (e) {
+    console.error('Failed to apply shared setup', e);
+  } finally {
+    if (window.history && window.history.replaceState) {
+      history.replaceState(null, '', window.location.pathname);
+    }
+  }
+}
+
 // --- EVENT LISTENERS FÜR NEUBERECHNUNG ---
 
 // Sicherstellen, dass Änderungen an den Selects auch neu berechnen
@@ -6273,6 +6321,7 @@ function initApp() {
   setLanguage(currentLang);
   resetDeviceForm();
   restoreSessionState();
+  applySharedSetupFromUrl();
   updateCalculations();
 }
 

--- a/translations.js
+++ b/translations.js
@@ -28,6 +28,8 @@ const texts = {
     deleteSetupBtn: "Delete",
     saveSetupBtn: "Save",
     clearSetupBtn: "Clear Current Setup",
+    shareSetupBtn: "Share Setup Link",
+    shareSetupPrompt: "Copy this link to share your setup:",
 
     cameraLabel: "Camera:",
     monitorLabel: "Monitor:",
@@ -248,6 +250,8 @@ const texts = {
     deleteSetupBtn: "Eliminare",
     saveSetupBtn: "Salva",
     clearSetupBtn: "Cancella configurazione corrente",
+    shareSetupBtn: "Condividi link della configurazione",
+    shareSetupPrompt: "Copia questo link per condividere la configurazione:",
     cameraLabel: "Telecamera:",
     monitorLabel: "Monitor:",
     videoLabel: "Video wireless:",
@@ -452,6 +456,8 @@ const texts = {
     deleteSetupBtn: "Eliminar",
     saveSetupBtn: "Guardar",
     clearSetupBtn: "Borrar configuración actual",
+    shareSetupBtn: "Compartir enlace de configuración",
+    shareSetupPrompt: "Copia este enlace para compartir tu configuración:",
 
     cameraLabel: "Cámara:",
     monitorLabel: "Monitor:",
@@ -672,6 +678,8 @@ const texts = {
     deleteSetupBtn: "Supprimer",
     saveSetupBtn: "Enregistrer",
     clearSetupBtn: "Effacer la configuration actuelle",
+    shareSetupBtn: "Partager le lien de configuration",
+    shareSetupPrompt: "Copiez ce lien pour partager votre configuration :",
 
     cameraLabel: "Caméra:",
     monitorLabel: "Moniteur:",
@@ -892,6 +900,8 @@ const texts = {
     deleteSetupBtn: "Löschen",
     saveSetupBtn: "Speichern",
     clearSetupBtn: "Aktuelles Setup zurücksetzen",
+    shareSetupBtn: "Link zum Setup teilen",
+    shareSetupPrompt: "Diesen Link kopieren, um das Setup zu teilen:",
 
     cameraLabel: "Kamera:",
     monitorLabel: "Monitor:",


### PR DESCRIPTION
## Summary
- add Share Setup Link button to setup actions
- allow generating URLs that reproduce current selections
- parse shared URLs on load and localize button text

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b30217d7b88320a7719836414c59e9