### PR TITLE
Ensure shared links restore setup names

### DIFF
--- a/script.js
+++ b/script.js
@@ -5085,19 +5085,22 @@ generateOverviewBtn.addEventListener('click', () => {
 });
 
 shareSetupBtn.addEventListener('click', () => {
-    const currentSetup = {
-        camera: cameraSelect.value,
-        monitor: monitorSelect.value,
-        video: videoSelect.value,
-        motors: motorSelects.map(sel => sel.value),
-        controllers: controllerSelects.map(sel => sel.value),
-        distance: distanceSelect.value,
-        batteryPlate: batteryPlateSelect.value,
-        battery: batterySelect.value
-    };
-    const encoded = btoa(encodeURIComponent(JSON.stringify(currentSetup)));
-    const link = `${window.location.origin}${window.location.pathname}?shared=${encoded}`;
-    prompt(texts[currentLang].shareSetupPrompt, link);
+  const setupName = (setupNameInput && setupNameInput.value.trim()) ||
+    (setupSelect && setupSelect.value) || '';
+  const currentSetup = {
+    setupName,
+    camera: cameraSelect.value,
+    monitor: monitorSelect.value,
+    video: videoSelect.value,
+    motors: motorSelects.map(sel => sel.value),
+    controllers: controllerSelects.map(sel => sel.value),
+    distance: distanceSelect.value,
+    batteryPlate: batteryPlateSelect.value,
+    battery: batterySelect.value
+  };
+  const encoded = btoa(encodeURIComponent(JSON.stringify(currentSetup)));
+  const link = `${window.location.origin}${window.location.pathname}?shared=${encoded}`;
+  prompt(texts[currentLang].shareSetupPrompt, link);
 });
 
 // Open feedback dialog and handle submission
@@ -6073,6 +6076,7 @@ function applySharedSetupFromUrl() {
   if (!shared) return;
   try {
     const decoded = JSON.parse(decodeURIComponent(atob(shared)));
+    if (setupNameInput && decoded.setupName) setupNameInput.value = decoded.setupName;
     if (cameraSelect && decoded.camera) cameraSelect.value = decoded.camera;
     updateBatteryPlateVisibility();
     if (batteryPlateSelect && decoded.batteryPlate) batteryPlateSelect.value = decoded.batteryPlate;
@@ -6344,6 +6348,7 @@ if (typeof module !== "undefined" && module.exports) {
     getRecordingMedia,
     applyPinkMode,
     generatePrintableOverview,
+    applySharedSetupFromUrl,
     updateBatteryPlateVisibility,
     updateBatteryOptions,
     renderSetupDiagram,

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -1183,6 +1183,29 @@ describe('script.js functions', () => {
     expect(svg).toContain('edge-label');
     expect(svg).toContain('HDMI');
   });
+
+  test('shareSetupBtn encodes setup name in link', () => {
+    const nameInput = document.getElementById('setupName');
+    nameInput.value = 'My Setup';
+    global.prompt = jest.fn();
+    const btn = document.getElementById('shareSetupBtn');
+    btn.click();
+    expect(global.prompt).toHaveBeenCalled();
+    const link = global.prompt.mock.calls[0][1];
+    const encoded = new URL(link).searchParams.get('shared');
+    const decoded = JSON.parse(decodeURIComponent(Buffer.from(encoded, 'base64').toString('utf-8')));
+    expect(decoded.setupName).toBe('My Setup');
+  });
+
+  test('applySharedSetupFromUrl restores setup name', () => {
+    const data = { setupName: 'Shared Setup' };
+    const encoded = Buffer.from(encodeURIComponent(JSON.stringify(data))).toString('base64');
+    window.history.pushState({}, '', `/?shared=${encoded}`);
+    const nameInput = document.getElementById('setupName');
+    nameInput.value = '';
+    script.applySharedSetupFromUrl();
+    expect(nameInput.value).toBe('Shared Setup');
+  });
 });
 
 describe('monitor wireless metadata', () => {


### PR DESCRIPTION
## Summary
- include setup name when generating share links
- restore setup name when loading shared link
- add regression tests for sharing and restoring setup names

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3056e45a08320886e19ed28d09b57