### PR TITLE
Add current location button to runtime feedback form

### DIFF
--- a/index.html
+++ b/index.html
@@ -689,7 +689,10 @@
         <legend>📋 Basic Info</legend>
         <div class="form-row"><label>User:<input type="text" id="fbUsername" required></label></div>
         <div class="form-row"><label>Date:<input type="date" id="fbDate" required></label></div>
-        <div class="form-row"><label>Location:<input type="text" id="fbLocation"></label></div>
+        <div class="form-row">
+          <label>Location:<input type="text" id="fbLocation"></label>
+          <button type="button" id="fbUseLocationBtn">Use Current Location</button>
+        </div>
       </fieldset>
 
       <fieldset>

--- a/script.js
+++ b/script.js
@@ -1164,6 +1164,7 @@ const runtimeFeedbackBtn = document.getElementById("runtimeFeedbackBtn");
 const feedbackDialog = document.getElementById("feedbackDialog");
 const feedbackForm = document.getElementById("feedbackForm");
 const feedbackCancelBtn = document.getElementById("fbCancel");
+const feedbackUseLocationBtn = document.getElementById("fbUseLocationBtn");
 const loadFeedbackSafe = typeof loadFeedback === 'function' ? loadFeedback : () => ({});
 const saveFeedbackSafe = typeof saveFeedback === 'function' ? saveFeedback : () => {};
 const setupDiagramContainer = document.getElementById("diagramArea");
@@ -5125,6 +5126,28 @@ if (runtimeFeedbackBtn && feedbackDialog && feedbackForm) {
   feedbackCancelBtn.addEventListener('click', () => {
     feedbackDialog.close();
   });
+
+  if (feedbackUseLocationBtn) {
+    feedbackUseLocationBtn.addEventListener('click', () => {
+      const locationInput = document.getElementById('fbLocation');
+      if (!navigator.geolocation) {
+        alert('Geolocation is not supported by your browser');
+        return;
+      }
+      feedbackUseLocationBtn.disabled = true;
+      navigator.geolocation.getCurrentPosition(
+        pos => {
+          const { latitude, longitude } = pos.coords;
+          locationInput.value = `${latitude.toFixed(5)}, ${longitude.toFixed(5)}`;
+          feedbackUseLocationBtn.disabled = false;
+        },
+        () => {
+          feedbackUseLocationBtn.disabled = false;
+          alert('Unable to retrieve your location');
+        }
+      );
+    });
+  }
 
   feedbackForm.addEventListener('submit', e => {
     e.preventDefault();


### PR DESCRIPTION
## Summary
- add "Use Current Location" button in runtime feedback form
- wire up geolocation lookup to populate location field automatically

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b306b37c6c8320aefcfe509230fe62