### PR TITLE
Make feedback device fields read-only

### DIFF
--- a/index.html
+++ b/index.html
@@ -697,8 +697,8 @@
 
       <fieldset>
         <legend>🎥 Camera Setup</legend>
-        <div class="form-row"><label>Camera:<input type="text" id="fbCamera"></label></div>
-        <div class="form-row"><label>Battery Plate:<input type="text" id="fbBatteryPlate"></label></div>
+        <div class="form-row"><label>Camera:<input type="text" id="fbCamera" readonly></label></div>
+        <div class="form-row"><label>Battery Plate:<input type="text" id="fbBatteryPlate" readonly></label></div>
         <div class="form-row"><label>Lens Mount:<input list="mountOptions" id="fbLensMount"></label></div>
         <div class="form-row"><label>Res:<input list="resolutionOptions" id="fbResolution"></label></div>
         <div class="form-row"><label>Codec:<input list="codecOptions" id="fbCodec"></label></div>
@@ -709,16 +709,16 @@
 
       <fieldset>
         <legend>🔋 Power &amp; Accessories</legend>
-        <div class="form-row"><label>Battery:<input type="text" id="fbBattery"></label></div>
+        <div class="form-row"><label>Battery:<input type="text" id="fbBattery" readonly></label></div>
         <div class="form-row"><label>Battery Age:<input type="number" id="fbBatteryAge"></label></div>
-        <div class="form-row"><label>Wireless Video:<input type="text" id="fbWirelessVideo"></label></div>
-        <div class="form-row"><label>Monitor:<input type="text" id="fbMonitor"></label></div>
+        <div class="form-row"><label>Wireless Video:<input type="text" id="fbWirelessVideo" readonly></label></div>
+        <div class="form-row"><label>Monitor:<input type="text" id="fbMonitor" readonly></label></div>
         <div class="form-row"><label>Monitor Brightness:<input type="text" id="fbMonitorBrightness"></label></div>
         <div class="form-row"><label>Lens:<input type="text" id="fbLens"></label></div>
         <div class="form-row"><label>Lens Data:<select id="fbLensData"><option value="">--</option><option value="on">On</option><option value="off">Off</option></select></label></div>
-        <div class="form-row"><label>FIZ Controllers:<input type="text" id="fbControllers"></label></div>
-        <div class="form-row"><label>FIZ Motors:<input type="text" id="fbMotors"></label></div>
-        <div class="form-row"><label>FIZ Distance:<select id="fbDistance"></select></label></div>
+        <div class="form-row"><label>FIZ Controllers:<input type="text" id="fbControllers" readonly></label></div>
+        <div class="form-row"><label>FIZ Motors:<input type="text" id="fbMotors" readonly></label></div>
+        <div class="form-row"><label>FIZ Distance:<select id="fbDistance" disabled></select></label></div>
       </fieldset>
 
       <fieldset>


### PR DESCRIPTION
## Summary
- Prevent editing of camera, battery, video, monitor and FIZ selections in the runtime feedback form by marking them read-only or disabled.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3082a60e88320acf875c7938ad629