### PR TITLE
Use numeric dropdown for temperature feedback

### DIFF
--- a/index.html
+++ b/index.html
@@ -723,7 +723,26 @@
 
       <fieldset>
         <legend>🌡️ Environment</legend>
-        <div class="form-row"><label>Temp:<input type="text" id="fbTemperature"></label></div>
+        <div class="form-row"><label>Temp:
+          <select id="fbTemperature">
+            <option value="">--</option>
+            <option value="-20">-20</option>
+            <option value="-15">-15</option>
+            <option value="-10">-10</option>
+            <option value="-5">-5</option>
+            <option value="0">0</option>
+            <option value="5">5</option>
+            <option value="10">10</option>
+            <option value="15">15</option>
+            <option value="20">20</option>
+            <option value="25">25</option>
+            <option value="30">30</option>
+            <option value="35">35</option>
+            <option value="40">40</option>
+            <option value="45">45</option>
+            <option value="50">50</option>
+          </select>
+        </label></div>
         <div class="form-row"><label>Humidity:<input type="text" id="fbHumidity"></label></div>
         <div class="form-row"><label>Charging:<select id="fbCharging"><option value="yes">Yes</option><option value="no">No</option></select></label></div>
         <div class="form-row"><label>Runtime (hrs):<input type="number" step="0.01" id="fbRuntime" required></label></div>


### PR DESCRIPTION
## Summary
- Replace free text temperature field with a numeric dropdown in runtime feedback form

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b3088b3a288320b9d31cb5cbab138c