### PR TITLE
Use dropdowns for temp and humidity

### DIFF
--- a/index.html
+++ b/index.html
@@ -723,8 +723,8 @@
 
       <fieldset>
         <legend>🌡️ Environment</legend>
-        <div class="form-row"><label>Temp (°C):<input type="text" id="fbTemperature"></label></div>
-        <div class="form-row"><label>Humidity:<input type="text" id="fbHumidity"></label></div>
+        <div class="form-row"><label>Temp (°C):<select id="fbTemperature"></select></label></div>
+        <div class="form-row"><label>Humidity:<select id="fbHumidity"></select></label></div>
         <div class="form-row"><label>Charging:<select id="fbCharging"><option value="yes">Yes</option><option value="no">No</option></select></label></div>
         <div class="form-row"><label>Runtime (hrs):<input type="number" step="0.01" id="fbRuntime" required></label></div>
         <div class="form-row"><label>Batteries Used per Day:<input type="number" id="fbBatteriesPerDay"></label></div>

--- a/script.js
+++ b/script.js
@@ -6347,11 +6347,40 @@ if (helpButton && helpDialog) {
 // Initialize immediately if DOM is already loaded (e.g. when scripts are
 // injected after `DOMContentLoaded` fired). Otherwise wait for the event.
 function initApp() {
+  populateEnvironmentDropdowns();
   setLanguage(currentLang);
   resetDeviceForm();
   restoreSessionState();
   applySharedSetupFromUrl();
   updateCalculations();
+}
+
+function populateEnvironmentDropdowns() {
+  const tempSelect = document.getElementById('fbTemperature');
+  if (tempSelect) {
+    const emptyOpt = document.createElement('option');
+    emptyOpt.value = '';
+    tempSelect.appendChild(emptyOpt);
+    for (let i = -20; i <= 50; i++) {
+      const opt = document.createElement('option');
+      opt.value = String(i);
+      opt.textContent = i;
+      tempSelect.appendChild(opt);
+    }
+  }
+
+  const humiditySelect = document.getElementById('fbHumidity');
+  if (humiditySelect) {
+    const emptyOpt = document.createElement('option');
+    emptyOpt.value = '';
+    humiditySelect.appendChild(emptyOpt);
+    for (let i = 0; i <= 100; i++) {
+      const opt = document.createElement('option');
+      opt.value = String(i);
+      opt.textContent = `${i}%`;
+      humiditySelect.appendChild(opt);
+    }
+  }
 }
 
 if (document.readyState === "loading") {


### PR DESCRIPTION
## Summary
- Replace text inputs with dropdowns for temperature and humidity fields
- Populate dropdown options programmatically for temperature (-20 to 50°C) and humidity (0–100%)

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b30a2656e48320ad2dc43adb361e16