### PR TITLE
Include user modifications and feedback in share links

### DIFF
--- a/script.js
+++ b/script.js
@@ -3424,6 +3424,53 @@ function renderFeedbackTable(currentKey) {
   return null;
 }
 
+// Determine differences between the default device database and the current
+// in-memory `devices` object. Only changed, added or removed entries are
+// returned so they can be shared in a generated link.
+function getDeviceChanges() {
+  if (!window.defaultDevices) return {};
+  const diff = {};
+  const record = (cat, name, val, sub) => {
+    if (sub) {
+      diff.fiz = diff.fiz || {};
+      diff.fiz[sub] = diff.fiz[sub] || {};
+      diff.fiz[sub][name] = val;
+    } else {
+      diff[cat] = diff[cat] || {};
+      diff[cat][name] = val;
+    }
+  };
+  const compare = (cat, defCat, curCat, sub) => {
+    Object.keys(curCat).forEach(name => {
+      const cur = curCat[name];
+      const def = defCat[name];
+      if (!def || JSON.stringify(cur) !== JSON.stringify(def)) {
+        record(cat, name, cur, sub);
+      }
+    });
+    Object.keys(defCat).forEach(name => {
+      if (!curCat[name]) record(cat, name, null, sub);
+    });
+  };
+  compare('cameras', window.defaultDevices.cameras || {}, devices.cameras || {});
+  compare('monitors', window.defaultDevices.monitors || {}, devices.monitors || {});
+  compare('video', window.defaultDevices.video || {}, devices.video || {});
+  compare('batteries', window.defaultDevices.batteries || {}, devices.batteries || {});
+  ['motors', 'controllers', 'distance'].forEach(sub => {
+    const defCat = window.defaultDevices.fiz ? (window.defaultDevices.fiz[sub] || {}) : {};
+    const curCat = devices.fiz ? (devices.fiz[sub] || {}) : {};
+    compare('fiz', defCat, curCat, sub);
+    if (diff.fiz && diff.fiz[sub] && !Object.keys(diff.fiz[sub]).length) {
+      delete diff.fiz[sub];
+    }
+  });
+  if (diff.fiz && !Object.keys(diff.fiz).length) delete diff.fiz;
+  Object.keys(diff).forEach(cat => {
+    if (cat !== 'fiz' && !Object.keys(diff[cat]).length) delete diff[cat];
+  });
+  return diff;
+}
+
 function renderSetupDiagram() {
   if (!setupDiagramContainer) return;
 
@@ -5202,6 +5249,15 @@ shareSetupBtn.addEventListener('click', () => {
     batteryPlate: batteryPlateSelect.value,
     battery: batterySelect.value
   };
+  const deviceChanges = getDeviceChanges();
+  if (Object.keys(deviceChanges).length) {
+    currentSetup.changedDevices = deviceChanges;
+  }
+  const key = getCurrentSetupKey();
+  const feedback = loadFeedbackSafe()[key] || [];
+  if (feedback.length) {
+    currentSetup.feedback = feedback;
+  }
   const encoded = btoa(encodeURIComponent(JSON.stringify(currentSetup)));
   const link = `${window.location.origin}${window.location.pathname}?shared=${encoded}`;
   prompt(texts[currentLang].shareSetupPrompt, link);

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -1,4 +1,4 @@
-/* global texts */
+/* global texts devices */
 const fs = require('fs');
 const path = require('path');
 
@@ -1326,6 +1326,36 @@ describe('script.js functions', () => {
     const encoded = new URL(link).searchParams.get('shared');
     const decoded = JSON.parse(decodeURIComponent(Buffer.from(encoded, 'base64').toString('utf-8')));
     expect(decoded.setupName).toBe('My Setup');
+  });
+
+  test('shareSetupBtn includes device changes and feedback', () => {
+    const addOpt = (id, value) => {
+      const sel = document.getElementById(id);
+      sel.innerHTML = `<option value="${value}">${value}</option>`;
+      sel.value = value;
+    };
+    addOpt('cameraSelect', 'CamA');
+    addOpt('monitorSelect', 'MonA');
+    addOpt('videoSelect', 'VidA');
+    addOpt('motor1Select', 'MotorA');
+    addOpt('controller1Select', 'ControllerA');
+    addOpt('distanceSelect', 'DistA');
+    addOpt('batterySelect', 'BattA');
+    addOpt('batteryPlateSelect', 'PlateX');
+    // modify device data
+    devices.cameras.CamA.powerDrawWatts = 20;
+    const key = script.getCurrentSetupKey();
+    global.loadFeedback.mockReturnValue({ [key]: [{ runtime: '1h' }] });
+    const nameInput = document.getElementById('setupName');
+    nameInput.value = 'ShareAll';
+    global.prompt = jest.fn();
+    const btn = document.getElementById('shareSetupBtn');
+    btn.click();
+    const link = global.prompt.mock.calls[0][1];
+    const encoded = new URL(link).searchParams.get('shared');
+    const decoded = JSON.parse(decodeURIComponent(Buffer.from(encoded, 'base64').toString('utf-8')));
+    expect(decoded.changedDevices.cameras.CamA.powerDrawWatts).toBe(20);
+    expect(decoded.feedback[0].runtime).toBe('1h');
   });
 
   test('applySharedSetupFromUrl restores setup name', () => {


### PR DESCRIPTION
## Summary
- Track differences between default device data and current session
- Extend setup sharing to include user feedback and database edits
- Test share link carries changed devices and feedback entries

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b31ce223008320be83f63d45d706a0