### PR TITLE
Ensure downloaded diagrams use light theme

### DIFF
--- a/script.js
+++ b/script.js
@@ -6345,7 +6345,8 @@ function exportDiagramSvg() {
     if (cloneLabels[idx]) cloneLabels[idx].innerHTML = lbl.innerHTML;
   });
   const style = document.createElementNS('http://www.w3.org/2000/svg', 'style');
-  style.textContent = getDiagramCss();
+  // Always export using the bright theme regardless of the current mode
+  style.textContent = getDiagramCss(false);
   clone.insertBefore(style, clone.firstChild);
   const serializer = new XMLSerializer();
   return serializer.serializeToString(clone);

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -1340,6 +1340,25 @@ describe('script.js functions', () => {
     expect(svg).toContain('HDMI');
   });
 
+  test('exportDiagramSvg always uses light theme', () => {
+    global.devices.cameras.CamA.videoOutputs = [{ type: 'HDMI' }];
+    global.devices.monitors.MonA.videoInputs = [{ type: 'HDMI' }];
+
+    const addOpt = (id, value) => {
+      const sel = document.getElementById(id);
+      sel.innerHTML = `<option value="${value}">${value}</option>`;
+      sel.value = value;
+    };
+    addOpt('cameraSelect', 'CamA');
+    addOpt('monitorSelect', 'MonA');
+
+    document.body.classList.add('dark-mode');
+    script.renderSetupDiagram();
+    const svg = script.exportDiagramSvg();
+    expect(svg).not.toContain('prefers-color-scheme: dark');
+    expect(svg).toContain('.node-box{fill:#e8f0fe');
+  });
+
   test('shareSetupBtn encodes setup name in link', () => {
     const nameInput = document.getElementById('setupName');
     nameInput.value = 'My Setup';


### PR DESCRIPTION
## Summary
- Force exported setup diagrams to always embed light theme styles
- Test that downloads remain bright even when dark mode is active

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b31e465c9883209a3d078553b116bd