### PR TITLE
Document runtime weighting and update README features

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -67,8 +67,17 @@ You can switch the language in the top right corner. The choice is remembered fo
 
 ### 🧮 Runtime data weighting
 - User-submitted battery runtimes refine the runtime estimate.
-- Each entry is adjusted for temperature effects.
-- Camera resolution, frame rate, codec and Wi‑Fi, plus monitor brightness, determine how strongly an entry is weighted.
+- Each entry is adjusted for temperature:
+  - ×2 at ≤−20 °C
+  - ×1.6 at ≤−10 °C
+  - ×1.25 at ≤0 °C
+- Camera settings influence the weight:
+  - Resolution multipliers: ≥12K ×3, ≥8K ×2, ≥4K ×1.5, ≥1080p ×1, lower scaled to 1080p
+  - Frame rate scales linearly from 24 fps (e.g. 48 fps = ×2)
+  - Wi‑Fi enabled adds 10 %
+  - Codec factors: RAW/BRAW/ARRIRAW/R3D/CinemaDNG/Canon RAW/X‑OCN ×1; ProRes ×1.1; DNx/AVID ×1.2; All‑Intra ×1.3; H.264/AVC ×1.5; H.265/HEVC ×1.7
+  - Monitor entries below the specified brightness are weighted by their brightness ratio
+- The final weight reflects each device's share of the total power draw, so matching setups count more.
 - The weighted average is used once at least three entries are available.
 
 ### 🔍 Search & Filtering

--- a/README.md
+++ b/README.md
@@ -26,7 +26,21 @@ See the language-specific README files for full details.
 - Check that selected batteries can supply the required output.
 - Save and load setups, import/export them as JSON, and generate a printable overview.
 - Visualize power and video connections with an interactive diagram.
+- Customize the device database with your own gear.
+- Switch languages, toggle dark or playful pink themes, and swap between V‑ and B‑Mount plates on supported cameras.
 - Works completely offline and offers a searchable help dialog.
+
+## Runtime Data Weighting
+
+User-submitted battery runtimes are combined using a weighted average to better match your setup:
+
+- Entries are adjusted for temperature: ×2 at ≤−20 °C, ×1.6 at ≤−10 °C, ×1.25 at ≤0 °C.
+- Resolution multipliers: ≥12K ×3, ≥8K ×2, ≥4K ×1.5, ≥1080p ×1, lower scaled relative to 1080p.
+- Frame rate scales linearly from a base of 24 fps (e.g. 48 fps = ×2).
+- Wi‑Fi enabled adds 10 %.
+- Codec factors: RAW/BRAW/ARRIRAW/R3D/CinemaDNG/Canon RAW/X‑OCN ×1; ProRes ×1.1; DNx/AVID ×1.2; All‑Intra ×1.3; H.264/AVC ×1.5; H.265/HEVC ×1.7.
+- Monitor entries below the specified brightness are weighted by their brightness ratio.
+- The final weight reflects how much of the total power draw comes from the camera, monitor and other devices so that similar rigs count more.
 
 ## Quick Start
 

--- a/index.html
+++ b/index.html
@@ -549,7 +549,21 @@
             <li>Each device contributes its power draw in watts to <em>Total Consumption</em>.</li>
             <li>Current at 14.4 V (33.6 V for B‑Mount) and 12 V (21.6 V for B‑Mount) equals total watts divided by voltage.</li>
             <li>Runtime&nbsp;=&nbsp;battery capacity (Wh)&nbsp;÷&nbsp;total consumption.</li>
-            <li>User-submitted runtimes are weighted by camera settings, monitor brightness and temperature before averaging.</li>
+            <li>
+              User-submitted runtimes are adjusted for temperature and weighted before
+              averaging:
+              <ul>
+                <li>Temperature: ×2 at ≤−20 °C, ×1.6 at ≤−10 °C, ×1.25 at ≤0 °C.</li>
+                <li>Resolution: ≥12K ×3, ≥8K ×2, ≥4K ×1.5, ≥1080p ×1; lower scales with 1080p.</li>
+                <li>Frame rate scales linearly from 24 fps (e.g. 48 fps = ×2).</li>
+                <li>Wi‑Fi adds 10 %; monitor entries below spec are weighted by their brightness ratio.</li>
+                <li>
+                  Codec factors: RAW/BRAW/ARRIRAW/R3D/CinemaDNG/Canon RAW/X‑OCN ×1;
+                  ProRes ×1.1; DNx/AVID ×1.2; All‑Intra ×1.3; H.264/AVC ×1.5; H.265/HEVC ×1.7.
+                </li>
+                <li>The final weight reflects each device's share of total power draw.</li>
+              </ul>
+            </li>
             <li>Warnings highlight when current approaches or exceeds main or D‑Tap output ratings.</li>
           </ul>
         </section>


### PR DESCRIPTION
## Summary
- Explain runtime weighting factors for temperature, resolution, frame rate, codec, Wi-Fi and brightness in help dialog and READMEs
- List customizable database, theme/language switching and V-/B-Mount swapping in README features

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3203c080c8320a6e6148e04eb0a53