### PR TITLE
Reduce shared setup link length

### DIFF
--- a/script.js
+++ b/script.js
@@ -5273,7 +5273,7 @@ shareSetupBtn.addEventListener('click', () => {
   if (feedback.length) {
     currentSetup.feedback = feedback;
   }
-  const encoded = btoa(encodeURIComponent(JSON.stringify(currentSetup)));
+  const encoded = btoa(unescape(encodeURIComponent(JSON.stringify(currentSetup))));
   const link = `${window.location.origin}${window.location.pathname}?shared=${encoded}`;
   prompt(texts[currentLang].shareSetupPrompt, link);
 });
@@ -6308,7 +6308,7 @@ function applySharedSetupFromUrl() {
   const shared = params.get('shared');
   if (!shared) return;
   try {
-    const decoded = JSON.parse(decodeURIComponent(atob(shared)));
+    const decoded = JSON.parse(decodeURIComponent(escape(atob(shared))));
     if (setupNameInput && decoded.setupName) setupNameInput.value = decoded.setupName;
     if (cameraSelect && decoded.camera) cameraSelect.value = decoded.camera;
     updateBatteryPlateVisibility();

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -1368,7 +1368,7 @@ describe('script.js functions', () => {
     expect(global.prompt).toHaveBeenCalled();
     const link = global.prompt.mock.calls[0][1];
     const encoded = new URL(link).searchParams.get('shared');
-    const decoded = JSON.parse(decodeURIComponent(Buffer.from(encoded, 'base64').toString('utf-8')));
+    const decoded = JSON.parse(Buffer.from(encoded, 'base64').toString('utf-8'));
     expect(decoded.setupName).toBe('My Setup');
   });
 
@@ -1397,14 +1397,14 @@ describe('script.js functions', () => {
     btn.click();
     const link = global.prompt.mock.calls[0][1];
     const encoded = new URL(link).searchParams.get('shared');
-    const decoded = JSON.parse(decodeURIComponent(Buffer.from(encoded, 'base64').toString('utf-8')));
+    const decoded = JSON.parse(Buffer.from(encoded, 'base64').toString('utf-8'));
     expect(decoded.changedDevices.cameras.CamA.powerDrawWatts).toBe(20);
     expect(decoded.feedback[0].runtime).toBe('1h');
   });
 
   test('applySharedSetupFromUrl restores setup name', () => {
     const data = { setupName: 'Shared Setup' };
-    const encoded = Buffer.from(encodeURIComponent(JSON.stringify(data))).toString('base64');
+    const encoded = Buffer.from(JSON.stringify(data)).toString('base64');
     window.history.pushState({}, '', `/?shared=${encoded}`);
     const nameInput = document.getElementById('setupName');
     nameInput.value = '';


### PR DESCRIPTION
## Summary
- Compress shared setup data more efficiently to keep share URLs shorter
- Update shared setup parsing to match new encoding
- Adjust tests for new share link format

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b32182ee74832088373b43d5872bf8