### PR TITLE
Interpolate temperature weighting between thresholds

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -67,10 +67,10 @@ You can switch the language in the top right corner. The choice is remembered fo
 
 ### 🧮 Runtime data weighting
 - User-submitted battery runtimes refine the runtime estimate.
-- Each entry is adjusted for temperature:
-  - ×2 at ≤−20 °C
-  - ×1.6 at ≤−10 °C
-  - ×1.25 at ≤0 °C
+- Each entry is adjusted for temperature, scaling from ×1 at 25 °C to:
+  - ×1.25 at 0 °C
+  - ×1.6 at −10 °C
+  - ×2 at −20 °C
 - Camera settings influence the weight:
   - Resolution multipliers: ≥12K ×3, ≥8K ×2, ≥4K ×1.5, ≥1080p ×1, lower scaled to 1080p
   - Frame rate scales linearly from 24 fps (e.g. 48 fps = ×2)

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ See the language-specific README files for full details.
 
 User-submitted battery runtimes are combined using a weighted average to better match your setup:
 
-- Entries are adjusted for temperature: ×2 at ≤−20 °C, ×1.6 at ≤−10 °C, ×1.25 at ≤0 °C.
+- Entries are adjusted for temperature, scaling from ×1 at 25 °C to ×1.25 at 0 °C, ×1.6 at −10 °C and ×2 at −20 °C.
 - Resolution multipliers: ≥12K ×3, ≥8K ×2, ≥4K ×1.5, ≥1080p ×1, lower scaled relative to 1080p.
 - Frame rate scales linearly from a base of 24 fps (e.g. 48 fps = ×2).
 - Wi‑Fi enabled adds 10 %.

--- a/script.js
+++ b/script.js
@@ -3346,10 +3346,11 @@ function renderFeedbackTable(currentKey) {
   };
   const tempFactor = temp => {
     if (Number.isNaN(temp)) return 1;
-    if (temp <= -20) return 2;
-    if (temp <= -10) return 1 / 0.625; // ~1.6
-    if (temp <= 0) return 1 / 0.8; // 1.25
-    return 1;
+    if (temp >= 25) return 1;
+    if (temp >= 0) return 1 + (25 - temp) * 0.01;
+    if (temp >= -10) return 1.25 + (-temp) * 0.035;
+    if (temp >= -20) return 1.6 + (-10 - temp) * 0.04;
+    return 2;
   };
 
   const resolutionWeight = res => {

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -115,6 +115,35 @@ describe('script.js functions', () => {
     expect(document.getElementById('batteryLife').textContent).toBe('1.25');
   });
 
+  test('interpolates temperature scaling between points', () => {
+    const addOpt = (id, value) => {
+      const sel = document.getElementById(id);
+      sel.innerHTML = `<option value="${value}">${value}</option>`;
+      sel.value = value;
+    };
+    addOpt('cameraSelect', 'CamA');
+    addOpt('monitorSelect', 'MonA');
+    addOpt('videoSelect', 'VidA');
+    addOpt('motor1Select', 'MotorA');
+    addOpt('controller1Select', 'ControllerA');
+    addOpt('distanceSelect', 'DistA');
+    addOpt('batterySelect', 'BattA');
+    const key = script.getCurrentSetupKey();
+
+    const cases = [
+      { temp: '5', expected: '1.20' },
+      { temp: '-5', expected: '1.43' },
+      { temp: '-15', expected: '1.80' }
+    ];
+
+    cases.forEach(({ temp, expected }) => {
+      const entries = Array.from({ length: 5 }, () => ({ runtime: '1', temperature: temp }));
+      global.loadFeedback.mockReturnValue({ [key]: entries });
+      script.updateCalculations();
+      expect(document.getElementById('batteryLife').textContent).toBe(expected);
+    });
+  });
+
   test('uses user runtime for temperature table', () => {
     const addOpt = (id, value) => {
       const sel = document.getElementById(id);


### PR DESCRIPTION
## Summary
- Smoothly scale user runtime adjustments based on temperature between 25 °C, 0 °C, −10 °C and −20 °C
- Document new temperature weighting behaviour
- Add tests verifying interpolation across temperature ranges

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b321eaaf30832085c7ec18d93e23b2