### PR TITLE
fix(it): correct pink mode label translation

### DIFF
--- a/translations.js
+++ b/translations.js
@@ -245,7 +245,7 @@ const texts = {
     downloadDiagramBtn: "Scarica diagramma",
     existingDevicesHeading: "Dispositivi esistenti",
     darkModeLabel: "Attiva modalità scura",
-    pinkModeLabel: "Attiva in modalità rosa",
+    pinkModeLabel: "Attiva modalità rosa",
     savedSetupsLabel: "Setup salvati:",
     newSetupOption: "-- Nuova configurazione --",
     setupNameLabel: "Nome di configurazione:",


### PR DESCRIPTION
## Summary
- fix Italian translation for the pink mode toggle label

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b3408baf408320878d28946b147a59