### PR TITLE
docs: document battery comparison and language switch

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -48,6 +48,8 @@ You can switch the language in the top right corner. The choice is remembered fo
 - Total consumption in watts
 - Current draw at 14.4 V and 12 V
 - Estimated battery runtime in hours using weighted user feedback
+- Required battery count for a 10 h shoot (incl. spare)
+- Temperature note to adjust runtime for hot or cold conditions
 
 ### 🔋 Battery Output Check
 - Warns if current draw exceeds the battery output (Pin or D‑Tap)

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ See the language-specific README files for full details.
 - Calculate total power consumption, current draw at 14.4 V and 12 V, and estimated battery runtime.
 - Runtime estimates draw on a weighted average of user-submitted runtimes for greater accuracy.
 - Check that selected batteries can supply the required output.
+- See required battery counts for a 10 h shoot and adjust runtimes for temperature.
+- Compare runtimes across all batteries with an optional battery comparison panel.
 - Save, load, share and clear setups; import/export them as JSON, and generate a printable overview.
 - Visualize power and video connections with an interactive diagram.
 - Customize the device database with your own gear.

--- a/index.html
+++ b/index.html
@@ -616,6 +616,13 @@
             <li>Close the dialog with <kbd>Escape</kbd> or by clicking outside.</li>
           </ul>
         </section>
+        <section data-help-section id="languageHelp">
+          <h3><span class="help-icon" aria-hidden="true">🌐</span>Language</h3>
+          <ul>
+            <li>Use the dropdown in the top right to switch languages.</li>
+            <li>Your choice is remembered for the next visit.</li>
+          </ul>
+        </section>
         <section data-help-section id="darkModeHelp">
           <h3><span class="help-icon" aria-hidden="true">🌓</span>Dark Mode</h3>
           <ul>


### PR DESCRIPTION
## Summary
- mention battery comparison panel and temperature-adjusted runtimes in root README
- clarify power calculations in English README with 10h battery count and temperature note
- add language selector instructions to the in-app help dialog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b340d7d2308320a7d626cc5aa0502d