### PR TITLE
Handle arrays in FIZ power input normalization

### DIFF
--- a/tests/unifyPorts.test.js
+++ b/tests/unifyPorts.test.js
@@ -2,7 +2,8 @@ const {
   normalizeMonitor,
   parsePowerInput,
   normalizeVideoDevice,
-  cleanVoltageRange
+  cleanVoltageRange,
+  normalizeFiz
 } = require('../unifyPorts.js');
 
 describe('cleanVoltageRange', () => {
@@ -44,5 +45,21 @@ describe('normalizeVideoDevice', () => {
     normalizeVideoDevice(dev);
     expect(dev.power.input[0].voltageRange).toBe('5-16');
     expect(dev.power.input[1].voltageRange).toBe('14');
+  });
+});
+
+describe('normalizeFiz', () => {
+  it('cleans voltageRange for array power inputs', () => {
+    const dev = {
+      power: {
+        input: [
+          { type: 'LEMO', voltageRange: 'DC 5-16V' },
+          { type: 'D-Tap', voltageRange: '11 - 17V DC' }
+        ]
+      }
+    };
+    normalizeFiz(dev);
+    expect(dev.power.input[0].voltageRange).toBe('5-16');
+    expect(dev.power.input[1].voltageRange).toBe('11-17');
   });
 });

--- a/unifyPorts.js
+++ b/unifyPorts.js
@@ -151,7 +151,13 @@ function normalizeFiz(dev) {
   }
   if (dev.power?.input) {
     cleanPort(dev.power.input);
-    if (dev.power.input.voltageRange) dev.power.input.voltageRange = cleanVoltageRange(dev.power.input.voltageRange);
+    if (Array.isArray(dev.power.input)) {
+      dev.power.input.forEach(i => {
+        if (i.voltageRange) i.voltageRange = cleanVoltageRange(i.voltageRange);
+      });
+    } else if (dev.power.input.voltageRange) {
+      dev.power.input.voltageRange = cleanVoltageRange(dev.power.input.voltageRange);
+    }
   }
   if (Array.isArray(dev.fizConnectors)) dev.fizConnectors.forEach(cleanPort);
 }


### PR DESCRIPTION
## Summary
- fix normalizeFiz so each power input entry has its voltageRange cleaned
- add tests covering FIZ devices with multiple power inputs

## Testing
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b343804bf48320a919e3adf6b57943