### PR TITLE
fix LZString redeclaration error

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,7 +1,12 @@
 // script.js – Main logic for the Camera Power Planner app
 /* global texts, categoryNames, loadSessionState, saveSessionState */
 
-let LZString;
+// Use `var` here instead of `let` because `index.html` loads the lz-string
+// library from a CDN which defines a global `LZString` variable. Using `let`
+// would attempt to create a new lexical binding and throw a SyntaxError in
+// browsers that already have the global property. `var` simply reuses the
+// existing global variable if present.
+var LZString;
 try {
   LZString = require('lz-string');
 } catch {


### PR DESCRIPTION
## Summary
- prevent duplicate `LZString` variable declaration causing SyntaxError in browsers by using `var`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b352527c1c8320a3e187fc20a63479