### PR TITLE
Add runtime weighting dashboard with visual breakdown

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -21,6 +21,7 @@ You can switch the language in the top right corner. The choice is remembered fo
 - Searchable help dialog with step-by-step sections and a FAQ.
 - Support for cameras with both V- and B-Mount battery plates.
 - Submit user runtime feedback with temperature and humidity for better estimates.
+- Visual runtime weighting dashboard to inspect how settings influence each report.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Recent updates include:
 - **Searchable help dialog** – open with the ? button or keyboard shortcuts, filter topics instantly and browse the built-in FAQ.
 - **Dual V‑/B‑Mount support** – choose between plate types on supported cameras and the battery list updates automatically.
 - **User runtime feedback** – submit real-world runtimes with environment details to refine estimates.
+- **Visual runtime weighting dashboard** – see how temperature, resolution, frame rate and codec affect each runtime report.
 
 See the language-specific README files for full details.
 

--- a/index.html
+++ b/index.html
@@ -161,6 +161,10 @@
     <div id="feedbackTableContainer" class="hidden">
       <table id="userFeedbackTable" class="hidden"></table>
     </div>
+    <div id="weightingDashboard" class="hidden">
+      <h3 id="weightingHeading">Runtime Weighting Breakdown</h3>
+      <div id="weightingBars"></div>
+    </div>
   </section>
 
   <section id="setupDiagram">

--- a/script.js
+++ b/script.js
@@ -886,6 +886,8 @@ function setLanguage(lang) {
   document.getElementById("batteryLifeLabel").textContent = texts[lang].batteryLifeLabel;
   document.getElementById("batteryCountLabel").textContent = texts[lang].batteryCountLabel;
   document.getElementById("runtimeFeedbackBtn").textContent = texts[lang].runtimeFeedbackBtn;
+  const weightHeadingEl = document.getElementById("weightingHeading");
+  if (weightHeadingEl) weightHeadingEl.textContent = texts[lang].weightingHeading;
   const unitElem = document.getElementById("batteryLifeUnit");
   if (unitElem) unitElem.textContent = texts[lang].batteryLifeUnit;
   const fb = renderFeedbackTable(getCurrentSetupKey());
@@ -3291,6 +3293,8 @@ function deleteFeedbackEntry(key, index) {
 function renderFeedbackTable(currentKey) {
   const container = document.getElementById('feedbackTableContainer');
   const table = document.getElementById('userFeedbackTable');
+  const dashboard = document.getElementById('weightingDashboard');
+  const barsContainer = document.getElementById('weightingBars');
   const data = loadFeedbackSafe();
   const entries = data[currentKey] || [];
 
@@ -3300,6 +3304,8 @@ function renderFeedbackTable(currentKey) {
       table.classList.add('hidden');
     }
     if (container) container.classList.add('hidden');
+    if (dashboard) dashboard.classList.add('hidden');
+    if (barsContainer) barsContainer.innerHTML = '';
     return null;
   }
 
@@ -3411,6 +3417,7 @@ function renderFeedbackTable(currentKey) {
   let weightedSum = 0;
   let weightTotal = 0;
   let count = 0;
+  const breakdown = [];
   entries.forEach(e => {
     const rt = parseFloat(e.runtime);
     if (Number.isNaN(rt)) return;
@@ -3444,12 +3451,40 @@ function renderFeedbackTable(currentKey) {
     }
 
     const temp = parseFloat(e.temperature);
-    const adjustedRuntime = rt * tempFactor(temp);
+    const tempMul = tempFactor(temp);
+    const adjustedRuntime = rt * tempMul;
 
     weightedSum += adjustedRuntime * weight;
     weightTotal += weight;
+    breakdown.push({
+      temperature: tempMul,
+      resolution: res ? resolutionWeight(res) : 1,
+      framerate: fps ? fps / 24 : 1,
+      wifi: wifi.includes('on') ? 1.1 : 1,
+      codec: codec ? codecWeight(codec) : 1,
+      monitor: monitorFactor,
+      weight
+    });
     count++;
   });
+  if (barsContainer && dashboard) {
+    const maxWeight = Math.max(...breakdown.map(b => b.weight));
+    let chartHtml = '';
+    breakdown.forEach((b, i) => {
+      const percent = maxWeight ? (b.weight / maxWeight) * 100 : 0;
+      const tooltip =
+        `Temp ×${b.temperature.toFixed(2)}\n` +
+        `Res ×${b.resolution.toFixed(2)}\n` +
+        `FPS ×${b.framerate.toFixed(2)}\n` +
+        `Codec ×${b.codec.toFixed(2)}\n` +
+        `Wi-Fi ×${b.wifi.toFixed(2)}\n` +
+        `Monitor ×${b.monitor.toFixed(2)}\n` +
+        `Share ${(b.weight * 100).toFixed(1)}%`;
+      chartHtml += `<div class="weightingRow"><span class="weightingLabel">${i + 1}</span><div class="barContainer"><div class="weightBar" style="width:${percent}%" title="${escapeHtml(tooltip)}"></div></div></div>`;
+    });
+    barsContainer.innerHTML = chartHtml;
+    dashboard.classList.remove('hidden');
+  }
   if (count >= 3 && weightTotal > 0) {
     return { runtime: weightedSum / weightTotal, count };
   }

--- a/style.css
+++ b/style.css
@@ -800,6 +800,26 @@ body:not(.light-mode) #userFeedbackTable td {
   background-color: #FF9800; /* Orange color for pins only */
 }
 
+/* Runtime weighting dashboard */
+#weightingDashboard {
+  margin-top: 1em;
+}
+.weightingRow {
+  display: flex;
+  align-items: center;
+  margin-bottom: 4px;
+}
+.weightingLabel {
+  width: 2em;
+  font-size: 0.9em;
+}
+.weightBar {
+  height: 100%;
+  background-color: #2196F3;
+  border-radius: 3px;
+  transition: width 0.5s ease-out;
+}
+
 .selectedBatteryRow {
     background-color: #e6f7ff; /* Light blue background for selected row */
     font-weight: bold;

--- a/translations.js
+++ b/translations.js
@@ -51,6 +51,7 @@ const texts = {
     batteryLifeLabel: "Runtime (estimated):",
     batteryCountLabel: "Batteries for 10h shoot (incl. spare):",
     runtimeFeedbackBtn: "Submit User Runtime Feedback",
+    weightingHeading: "Runtime Weighting Breakdown",
 
     methodPinsOnly: "pins only!",
     methodPinsAndDTap: "both pins and D-Tap",
@@ -272,6 +273,7 @@ const texts = {
     batteryLifeLabel: "Autonomia (stimata):",
     batteryCountLabel: "Batterie per ripresa di 10h (incl. scorta):",
     runtimeFeedbackBtn: "Invia feedback runtime utente",
+    weightingHeading: "Suddivisione ponderazione runtime",
     methodPinsOnly: "solo pin!",
     methodPinsAndDTap: "sia pin che D-Tap",
     methodInfinite: "infinito",
@@ -483,7 +485,7 @@ const texts = {
     batteryLifeLabel: "Autonomía (estimada):",
     batteryCountLabel: "Baterías para rodaje de 10h (incl. repuesto):",
     runtimeFeedbackBtn: "Enviar comentarios de tiempo de ejecución del usuario",
-
+    weightingHeading: "Desglose de ponderación del tiempo de ejecución",
     methodPinsOnly: "solo pines!",
     methodPinsAndDTap: "pines y D-Tap",
     methodInfinite: "infinito",
@@ -707,7 +709,7 @@ const texts = {
     batteryLifeLabel: "Autonomie (estimée):",
     batteryCountLabel: "Batteries pour tournage de 10h (incl. de rechange):",
     runtimeFeedbackBtn: "Envoyer des commentaires sur la durée d'utilisation",
-
+    weightingHeading: "Répartition de la pondération de la durée d'utilisation",
     methodPinsOnly: "broches seulement!",
     methodPinsAndDTap: "broches et D-Tap",
     methodInfinite: "infini",
@@ -931,7 +933,7 @@ const texts = {
     batteryLifeLabel: "Akkulaufzeit (geschätzt):",
     batteryCountLabel: "Akkus für 10h Dreh (inkl. Reserve):",
     runtimeFeedbackBtn: "Laufzeit-Feedback senden",
-
+    weightingHeading: "Aufschlüsselung der Laufzeitgewichtung",
     methodPinsOnly: "nur Pins!",
     methodPinsAndDTap: "Pins und D-Tap",
     methodInfinite: "unendlich",


### PR DESCRIPTION
## Summary
- Add runtime weighting dashboard to visualize how temperature, resolution, frame rate and codec influence user runtime entries
- Localize new dashboard heading across languages
- Document dashboard in readmes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b352dc96d0832080151ae042030270