### PR TITLE
Add basic PWA support with service worker

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,11 +8,13 @@
   <meta property="og:description" content="Plan your camera setup and calculate power consumption &amp; battery life." />
   <meta property="og:type" content="website" />
   <meta property="og:image" content="favicon.ico" />
+  <meta name="theme-color" content="#ffffff" />
   <title>Camera Power Planner</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;500&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="style.css" />
+  <link rel="manifest" href="manifest.webmanifest">
 </head>
 <body>
   <a href="#mainContent" class="skip-link" id="skipLink">Skip to content</a>

--- a/manifest.webmanifest
+++ b/manifest.webmanifest
@@ -1,0 +1,20 @@
+{
+  "name": "Camera Power Planner",
+  "short_name": "Power Planner",
+  "start_url": ".",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#ffffff",
+  "icons": [
+    {
+      "src": "favicon.ico",
+      "sizes": "64x64",
+      "type": "image/x-icon"
+    },
+    {
+      "src": "favicon.ico",
+      "sizes": "512x512",
+      "type": "image/x-icon"
+    }
+  ]
+}

--- a/script.js
+++ b/script.js
@@ -22,6 +22,12 @@ try {
   }
 }
 
+if (typeof window !== 'undefined' && 'serviceWorker' in navigator) {
+  window.addEventListener('load', () => {
+    navigator.serviceWorker.register('service-worker.js');
+  });
+}
+
 const VIDEO_OUTPUT_TYPES = [
   '3G-SDI',
   '6G-SDI',

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,0 +1,35 @@
+/* eslint-env serviceworker */
+const CACHE_NAME = 'camera-power-planner-v1';
+const ASSETS = [
+  '/',
+  '/index.html',
+  '/style.css',
+  '/script.js',
+  '/data.js',
+  '/translations.js',
+  '/storage.js',
+  '/normalizeData.js',
+  '/unifyPorts.js',
+  '/favicon.ico',
+  '/manifest.webmanifest'
+];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(ASSETS))
+  );
+});
+
+self.addEventListener('activate', event => {
+  event.waitUntil(
+    caches.keys().then(keys =>
+      Promise.all(keys.filter(key => key !== CACHE_NAME).map(key => caches.delete(key)))
+    )
+  );
+});
+
+self.addEventListener('fetch', event => {
+  event.respondWith(
+    caches.match(event.request).then(resp => resp || fetch(event.request))
+  );
+});


### PR DESCRIPTION
## Summary
- add `manifest.webmanifest` with app metadata and icon
- cache core assets via new `service-worker.js`
- register service worker and link manifest in `index.html`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b351f4d5a48320b565915f8e180053