### PR TITLE
feat: sort runtime weights and display share

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -21,7 +21,7 @@ You can switch the language in the top right corner. The choice is remembered fo
 - Searchable help dialog with step-by-step sections and a FAQ.
 - Support for cameras with both V- and B-Mount battery plates.
 - Submit user runtime feedback with temperature and humidity for better estimates.
-- Visual runtime weighting dashboard to inspect how settings influence each report.
+- Visual runtime weighting dashboard to inspect how settings influence each report, now sorted by weight and showing exact share percentages.
 
 ---
 
@@ -84,6 +84,7 @@ You can switch the language in the top right corner. The choice is remembered fo
   - Monitor entries below the specified brightness are weighted by their brightness ratio
 - The final weight reflects each device's share of the total power draw, so matching setups count more.
 - The weighted average is used once at least three entries are available.
+- A dashboard orders entries by weight and displays each one's share percentage for quick comparison.
 
 ### 🔍 Search & Filtering
 - Filter every dropdown and device list with a search box

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Recent updates include:
 - **Searchable help dialog** – open with the ? button or keyboard shortcuts, filter topics instantly and browse the built-in FAQ.
 - **Dual V‑/B‑Mount support** – choose between plate types on supported cameras and the battery list updates automatically.
 - **User runtime feedback** – submit real-world runtimes with environment details to refine estimates.
-- **Visual runtime weighting dashboard** – see how temperature, resolution, frame rate and codec affect each runtime report.
+- **Visual runtime weighting dashboard** – see how temperature, resolution, frame rate and codec affect each runtime report, now sorted by weight with exact share percentages.
 
 See the language-specific README files for full details.
 
@@ -45,6 +45,7 @@ User-submitted battery runtimes are combined using a weighted average to better 
 - Codec factors: RAW/BRAW/ARRIRAW/R3D/CinemaDNG/Canon RAW/X‑OCN ×1; ProRes ×1.1; DNx/AVID ×1.2; All‑Intra ×1.3; H.264/AVC ×1.5; H.265/HEVC ×1.7.
 - Monitor entries below the specified brightness are weighted by their brightness ratio.
 - The final weight reflects how much of the total power draw comes from the camera, monitor and other devices so that similar rigs count more.
+- A dedicated dashboard orders entries by weight and shows the share percentage for each runtime entry.
 
 ## Quick Start
 

--- a/script.js
+++ b/script.js
@@ -3486,10 +3486,13 @@ function renderFeedbackTable(currentKey) {
     count++;
   });
   if (barsContainer && dashboard) {
-    const maxWeight = Math.max(...breakdown.map(b => b.weight));
+    // Sort entries by weight so the most significant runtimes appear first
+    breakdown.sort((a, b) => b.weight - a.weight);
+    const maxWeight = breakdown.length ? breakdown[0].weight : 0;
     let chartHtml = '';
     breakdown.forEach((b, i) => {
       const percent = maxWeight ? (b.weight / maxWeight) * 100 : 0;
+      const share = b.weight * 100;
       const tooltip =
         `Temp ×${b.temperature.toFixed(2)}\n` +
         `Res ×${b.resolution.toFixed(2)}\n` +
@@ -3497,8 +3500,11 @@ function renderFeedbackTable(currentKey) {
         `Codec ×${b.codec.toFixed(2)}\n` +
         `Wi-Fi ×${b.wifi.toFixed(2)}\n` +
         `Monitor ×${b.monitor.toFixed(2)}\n` +
-        `Share ${(b.weight * 100).toFixed(1)}%`;
-      chartHtml += `<div class="weightingRow"><span class="weightingLabel">${i + 1}</span><div class="barContainer"><div class="weightBar" style="width:${percent}%" title="${escapeHtml(tooltip)}"></div></div></div>`;
+        `Share ${share.toFixed(1)}%`;
+      chartHtml +=
+        `<div class="weightingRow"><span class="weightingLabel">${i + 1}</span>` +
+        `<div class="barContainer"><div class="weightBar" style="width:${percent}%" title="${escapeHtml(tooltip)}"></div></div>` +
+        `<span class="weightingPercent">${share.toFixed(1)}%</span></div>`;
     });
     barsContainer.innerHTML = chartHtml;
     dashboard.classList.remove('hidden');

--- a/style.css
+++ b/style.css
@@ -830,6 +830,11 @@ body:not(.light-mode) #userFeedbackTable td {
   transition: width 0.5s ease-out;
 }
 
+.weightingPercent {
+  margin-left: 0.5em;
+  font-size: 0.9em;
+}
+
 .selectedBatteryRow {
     background-color: #e6f7ff; /* Light blue background for selected row */
     font-weight: bold;


### PR DESCRIPTION
## Summary
- sort runtime weighting breakdown by influence and show each entry's share percentage
- add styles and documentation for the weighting dashboard

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b3551e01f88320b4bf87169559fcd7