### PR TITLE
feat: scale grid snapping with zoom

### DIFF
--- a/script.js
+++ b/script.js
@@ -4218,7 +4218,7 @@ function enableDiagramInteractions() {
       let newX = start.x + dx;
       let newY = start.y + dy;
       if (gridSnap) {
-        const g = 20;
+        const g = 20 / scale;
         newX = Math.round(newX / g) * g;
         newY = Math.round(newY / g) * g;
       }

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -1254,6 +1254,47 @@ describe('script.js functions', () => {
     expect(endY).toBe(snap(startY + 27));
   });
 
+  test('grid snap respects zoom level', () => {
+    const addOpt = (id, value) => {
+      const sel = document.getElementById(id);
+      sel.innerHTML = `<option value="${value}">${value}</option>`;
+      sel.value = value;
+    };
+    addOpt('cameraSelect', 'CamA');
+    addOpt('batterySelect', 'BattA');
+
+    script.renderSetupDiagram();
+
+    const gridBtn = document.getElementById('gridSnapToggle');
+    const zoomBtn = document.getElementById('zoomIn');
+    gridBtn.click();
+    zoomBtn.click();
+
+    const node = document.querySelector('#diagramArea .diagram-node[data-node="battery"]');
+    const rect = node.querySelector('rect');
+    const w = parseFloat(rect.getAttribute('width'));
+    const h = parseFloat(rect.getAttribute('height'));
+    const startX = parseFloat(rect.getAttribute('x')) + w / 2;
+    const startY = parseFloat(rect.getAttribute('y')) + h / 2;
+
+    node.dispatchEvent(new MouseEvent('mousedown', { clientX: 0, clientY: 0, bubbles: true }));
+    window.dispatchEvent(new MouseEvent('mouseup', { clientX: 13, clientY: 27, bubbles: true }));
+
+    const rect2 = document.querySelector('#diagramArea .diagram-node[data-node="battery"] rect');
+    const w2 = parseFloat(rect2.getAttribute('width'));
+    const h2 = parseFloat(rect2.getAttribute('height'));
+    const endX = parseFloat(rect2.getAttribute('x')) + w2 / 2;
+    const endY = parseFloat(rect2.getAttribute('y')) + h2 / 2;
+
+    const scale = 1.1;
+    const snap = v => {
+      const g = 20 / scale;
+      return Math.round(v / g) * g;
+    };
+    expect(endX).toBeCloseTo(snap(startX + 13 / scale));
+    expect(endY).toBeCloseTo(snap(startY + 27 / scale));
+  });
+
   test('help dialog toggles with keyboard and overlay click', () => {
     const helpDialog = document.getElementById('helpDialog');
     const helpSearch = document.getElementById('helpSearch');


### PR DESCRIPTION
## Summary
- scale grid snap spacing based on zoom level so nodes align with the visual grid
- test grid snapping behavior when zoomed

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b35558ef4c83209811ebd88c4e1392