### PR TITLE
Include device edits in shared setup links

### DIFF
--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -1491,6 +1491,24 @@ describe('script.js functions', () => {
     script.applySharedSetupFromUrl();
     expect(nameInput.value).toBe('Shared Setup');
   });
+
+  test('applySharedSetupFromUrl applies device changes and feedback', () => {
+    const payload = {
+      camera: 'CamB',
+      changedDevices: { cameras: { CamB: { powerDrawWatts: 15 } } },
+      feedback: [{ runtime: '2h' }]
+    };
+    const encoded = LZString.compressToEncodedURIComponent(JSON.stringify(payload));
+    window.history.pushState({}, '', `/?shared=${encoded}`);
+    script.applySharedSetupFromUrl();
+    expect(devices.cameras.CamB.powerDrawWatts).toBe(15);
+    const camSelect = document.getElementById('cameraSelect');
+    const hasCamB = Array.from(camSelect.options).some(o => o.value === 'CamB');
+    expect(hasCamB).toBe(true);
+    expect(camSelect.value).toBe('CamB');
+    const key = script.getCurrentSetupKey();
+    expect(global.saveFeedback).toHaveBeenCalledWith({ [key]: [{ runtime: '2h' }] });
+  });
 });
 
 describe('monitor wireless metadata', () => {


### PR DESCRIPTION
## Summary
- Share links now apply custom device database edits when opened
- Save any shared runtime feedback along with device changes
- Test applying shared device changes and feedback

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b355ad989c8320a54ef17ca066de45