### PR TITLE
Enable real-time node dragging with cleanup

### DIFF
--- a/script.js
+++ b/script.js
@@ -1223,6 +1223,7 @@ const diagramHint = document.getElementById("diagramHint");
 let manualPositions = {};
 let lastDiagramPositions = {};
 let gridSnap = false;
+let cleanupDiagramInteractions = null;
 
 // CSS used when exporting the setup diagram
 const diagramCssLight = `
@@ -4173,6 +4174,9 @@ function enableDiagramInteractions() {
   if (!setupDiagramContainer) return;
   const svg = setupDiagramContainer.querySelector('svg');
   if (!svg) return;
+
+  if (cleanupDiagramInteractions) cleanupDiagramInteractions();
+
   const root = svg.querySelector('#diagramRoot') || svg;
   let pan = { x: 0, y: 0 };
   let scale = 1;
@@ -4193,29 +4197,48 @@ function enableDiagramInteractions() {
       apply();
     };
   }
-  svg.addEventListener('mousedown', e => {
+  const onSvgMouseDown = e => {
     if (e.target.closest('.diagram-node')) return;
     panning = true;
     panStart = { x: e.clientX - pan.x, y: e.clientY - pan.y };
-  });
-  window.addEventListener('mousemove', e => {
+  };
+  const onPanMove = e => {
     if (!panning) return;
     pan.x = e.clientX - panStart.x;
     pan.y = e.clientY - panStart.y;
     apply();
-  });
-  window.addEventListener('mouseup', () => { panning = false; });
+  };
+  const stopPanning = () => { panning = false; };
 
   let dragId = null;
   let dragStart = null;
-  svg.addEventListener('mousedown', e => {
+  let dragNode = null;
+  const onDragStart = e => {
     const node = e.target.closest('.diagram-node');
     if (!node) return;
     dragId = node.getAttribute('data-node');
+    dragNode = node;
     dragStart = { x: e.clientX, y: e.clientY };
     e.stopPropagation();
-  });
-  window.addEventListener('mouseup', e => {
+  };
+  const onDragMove = e => {
+    if (!dragId) return;
+    const start = lastDiagramPositions[dragId];
+    if (!start) return;
+    const dx = (e.clientX - dragStart.x) / scale;
+    const dy = (e.clientY - dragStart.y) / scale;
+    let newX = start.x + dx;
+    let newY = start.y + dy;
+    if (gridSnap) {
+      const g = 20 / scale;
+      newX = Math.round(newX / g) * g;
+      newY = Math.round(newY / g) * g;
+    }
+    const tx = newX - start.x;
+    const ty = newY - start.y;
+    if (dragNode) dragNode.setAttribute('transform', `translate(${tx},${ty})`);
+  };
+  const onDragEnd = e => {
     if (!dragId) return;
     const start = lastDiagramPositions[dragId];
     if (start) {
@@ -4231,8 +4254,25 @@ function enableDiagramInteractions() {
       manualPositions[dragId] = { x: newX, y: newY };
     }
     dragId = null;
+    dragNode = null;
     renderSetupDiagram();
-  });
+  };
+
+  svg.addEventListener('mousedown', onSvgMouseDown);
+  window.addEventListener('mousemove', onPanMove);
+  window.addEventListener('mouseup', stopPanning);
+  svg.addEventListener('mousedown', onDragStart);
+  window.addEventListener('mousemove', onDragMove);
+  window.addEventListener('mouseup', onDragEnd);
+
+  cleanupDiagramInteractions = () => {
+    svg.removeEventListener('mousedown', onSvgMouseDown);
+    window.removeEventListener('mousemove', onPanMove);
+    window.removeEventListener('mouseup', stopPanning);
+    svg.removeEventListener('mousedown', onDragStart);
+    window.removeEventListener('mousemove', onDragMove);
+    window.removeEventListener('mouseup', onDragEnd);
+  };
 }
 
 function updateDiagramLegend() {

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -1254,6 +1254,24 @@ describe('script.js functions', () => {
     expect(endY).toBe(snap(startY + 27));
   });
 
+  test('nodes move while dragging', () => {
+    const addOpt = (id, value) => {
+      const sel = document.getElementById(id);
+      sel.innerHTML = `<option value="${value}">${value}</option>`;
+      sel.value = value;
+    };
+    addOpt('cameraSelect', 'CamA');
+    addOpt('batterySelect', 'BattA');
+
+    script.renderSetupDiagram();
+
+    const node = document.querySelector('#diagramArea .diagram-node[data-node="battery"]');
+    node.dispatchEvent(new MouseEvent('mousedown', { clientX: 0, clientY: 0, bubbles: true }));
+    window.dispatchEvent(new MouseEvent('mousemove', { clientX: 15, clientY: 25, bubbles: true }));
+    expect(node.getAttribute('transform')).toBe('translate(15,25)');
+    window.dispatchEvent(new MouseEvent('mouseup', { clientX: 15, clientY: 25, bubbles: true }));
+  });
+
   test('grid snap respects zoom level', () => {
     const addOpt = (id, value) => {
       const sel = document.getElementById(id);


### PR DESCRIPTION
## Summary
- Allow diagram nodes to move with the cursor by updating their transform on mousemove
- Clean up diagram interaction listeners between renders to avoid duplicates
- Test that dragging updates node position before mouseup

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b3569aa7c48320aebf9724516924ad