### PR TITLE
feat: add DisplayPort video type

### DIFF
--- a/script.js
+++ b/script.js
@@ -35,7 +35,8 @@ const VIDEO_OUTPUT_TYPES = [
   'Mini BNC',
   'HDMI',
   'Mini HDMI',
-  'Micro HDMI'
+  'Micro HDMI',
+  'DisplayPort'
 ];
 
 const collator = new Intl.Collator(undefined, { numeric: true, sensitivity: 'base' });
@@ -76,7 +77,10 @@ function normalizeVideoType(type) {
     { needles: ['mini', 'bnc'], value: 'Mini BNC' },
     { needles: ['micro', 'hdmi'], value: 'Micro HDMI' },
     { needles: ['mini', 'hdmi'], value: 'Mini HDMI' },
-    { needles: ['hdmi'], value: 'HDMI' }
+    { needles: ['hdmi'], value: 'HDMI' },
+    { needles: ['displayport'], value: 'DisplayPort' },
+    { needles: ['display', 'port'], value: 'DisplayPort' },
+    { needles: ['dp'], value: 'DisplayPort' }
   ];
   const t = String(type).toLowerCase();
   for (const { needles, value } of patterns) {

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -95,6 +95,13 @@ describe('utility function tests', () => {
     expect(normalizePowerPortType('battery slot / usb type-c®')).toEqual(['Battery Slot', 'USB-C']);
   });
 
+  test('normalizeVideoType recognizes DisplayPort variants', () => {
+    const { normalizeVideoType } = utils;
+    expect(normalizeVideoType('DisplayPort')).toBe('DisplayPort');
+    expect(normalizeVideoType('display port')).toBe('DisplayPort');
+    expect(normalizeVideoType('DP')).toBe('DisplayPort');
+  });
+
   test('normalizeViewfinderType handles case-insensitive mappings', () => {
     const { normalizeViewfinderType } = utils;
     expect(normalizeViewfinderType('lcd touchscreen')).toBe('LCD touchscreen');


### PR DESCRIPTION
## Summary
- support DisplayPort in video output types and normalization
- test DisplayPort normalization variants

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b35ad549448320ba66e7de0d111f02