### PR TITLE
Add app installation guidance to FAQ

### DIFF
--- a/index.html
+++ b/index.html
@@ -688,6 +688,10 @@
             <p>Yes. Once the fonts and database are cached on first load, all features continue to work without an internet connection.</p>
           </details>
           <details class="faq-item">
+            <summary>Can I install the planner as an app?</summary>
+            <p>Most browsers offer an <em>Install</em> or <em>Add to Home Screen</em> option in the address bar or menu. The installed version runs offline and updates automatically.</p>
+          </details>
+          <details class="faq-item">
             <summary>How do I reset everything to the defaults?</summary>
             <p>Open the device editor and choose <em>Export and Revert</em> to restore the default database. Delete setups individually using the Delete button.</p>
           </details>


### PR DESCRIPTION
## Summary
- Explain how users can install the planner as an app from their browser

## Testing
- `npm run lint`
- `npm run check-consistency`
- `npx jest --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_68b35ada5c588320ad80b3069258898d