### PR TITLE
Refine print view styling

### DIFF
--- a/overview-print.css
+++ b/overview-print.css
@@ -3,6 +3,17 @@
   margin: 1cm;
 }
 
+body {
+  background: #fff;
+  color: #000;
+  font-size: 12pt;
+}
+
+#langSelector,
+.print-btn {
+  display: none;
+}
+
 h2, h3, table, .device-block, .device-category {
   page-break-inside: avoid;
   break-inside: avoid;
@@ -13,6 +24,13 @@ h2, h3 { page-break-after: avoid; }
 table, th, td {
   word-break: break-word;
   hyphens: auto;
+}
+
+.device-block,
+.device-category {
+  background: #fff !important;
+  border: 1px solid #000;
+  box-shadow: none;
 }
 
 .power-conn {


### PR DESCRIPTION
## Summary
- Simplify print stylesheet with black text on white background
- Hide language selector and print button during printing
- Remove shadows and add solid borders for device sections

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b35f1098d88320863bcea353aa58ce