### PR TITLE
feat: show runtime weighting in table

### DIFF
--- a/style.css
+++ b/style.css
@@ -810,21 +810,10 @@ body:not(.light-mode) #userFeedbackTable td {
   background-color: #FF9800; /* Orange color for pins only */
 }
 
-/* Runtime weighting dashboard */
-#weightingDashboard {
-  margin-top: 1em;
-  display: inline-block;
-  transform: scale(0.8);
-  transform-origin: top left;
-}
+/* Runtime weighting */
 .weightingRow {
   display: flex;
   align-items: center;
-  margin-bottom: 4px;
-}
-.weightingLabel {
-  width: 2em;
-  font-size: 0.9em;
 }
 .weightBar {
   height: 100%;


### PR DESCRIPTION
## Summary
- add a weight column to the user feedback table
- display each runtime's weighting as a bar chart within the table
- simplify runtime weighting styles

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3604ee1dc83209bcb610ac617edaa