### PR TITLE
Improve service worker caching

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -4,6 +4,8 @@ const ASSETS = [
   './',
   './index.html',
   './style.css',
+  './overview.css',
+  './overview-print.css',
   './script.js',
   './data.js',
   './translations.js',
@@ -14,22 +16,30 @@ const ASSETS = [
   './manifest.webmanifest'
 ];
 
-self.addEventListener('install', event => {
-  event.waitUntil(
-    caches.open(CACHE_NAME).then(cache => cache.addAll(ASSETS))
-  );
-});
+if (typeof self !== 'undefined') {
+  self.addEventListener('install', event => {
+    event.waitUntil(
+      caches.open(CACHE_NAME).then(cache => cache.addAll(ASSETS))
+    );
+    self.skipWaiting();
+  });
 
-self.addEventListener('activate', event => {
-  event.waitUntil(
-    caches.keys().then(keys =>
-      Promise.all(keys.filter(key => key !== CACHE_NAME).map(key => caches.delete(key)))
-    )
-  );
-});
+  self.addEventListener('activate', event => {
+    event.waitUntil(
+      caches.keys().then(keys =>
+        Promise.all(keys.filter(key => key !== CACHE_NAME).map(key => caches.delete(key)))
+      )
+    );
+    self.clients.claim();
+  });
 
-self.addEventListener('fetch', event => {
-  event.respondWith(
-    caches.match(event.request).then(resp => resp || fetch(event.request))
-  );
-});
+  self.addEventListener('fetch', event => {
+    event.respondWith(
+      caches.match(event.request).then(resp => resp || fetch(event.request))
+    );
+  });
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = { ASSETS, CACHE_NAME };
+}

--- a/tests/service-worker.test.js
+++ b/tests/service-worker.test.js
@@ -1,0 +1,12 @@
+const { ASSETS, CACHE_NAME } = require('../service-worker.js');
+
+describe('service worker configuration', () => {
+  test('caches overview styles for offline usage', () => {
+    expect(ASSETS).toEqual(expect.arrayContaining(['./overview.css', './overview-print.css']));
+  });
+
+  test('exposes a cache name', () => {
+    expect(typeof CACHE_NAME).toBe('string');
+    expect(CACHE_NAME).not.toBe('');
+  });
+});


### PR DESCRIPTION
## Summary
- Cache overview styles in the service worker so printable layouts work offline
- Ensure new service worker versions activate immediately and expose config for tests
- Test the exported service worker asset list

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b362aca47883209963938216c07081