### PR TITLE
Validate feedback data in storage

### DIFF
--- a/storage.js
+++ b/storage.js
@@ -125,11 +125,16 @@ function deleteSetup(name) {
 function loadFeedback() {
   try {
     const data = localStorage.getItem(FEEDBACK_STORAGE_KEY);
-    return data ? JSON.parse(data) : {};
+    if (data) {
+      const parsed = JSON.parse(data);
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        return parsed;
+      }
+    }
   } catch (e) {
     console.error("Error loading feedback from localStorage:", e);
-    return {};
   }
+  return {};
 }
 
 function saveFeedback(feedback) {

--- a/tests/storage.test.js
+++ b/tests/storage.test.js
@@ -8,6 +8,7 @@ const {
   deleteSetup,
   loadSessionState,
   saveSessionState,
+  loadFeedback,
   saveFeedback,
   clearAllData,
 } = require('../storage');
@@ -144,6 +145,31 @@ describe('session state storage', () => {
 
   test('loadSessionState returns null when none', () => {
     expect(loadSessionState()).toBeNull();
+  });
+});
+
+describe('feedback storage', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  test('saveFeedback stores JSON', () => {
+    const fb = { note: 'hi' };
+    saveFeedback(fb);
+    expect(localStorage.getItem(FEEDBACK_KEY)).toBe(JSON.stringify(fb));
+  });
+
+  test('loadFeedback returns parsed object when present', () => {
+    const fb = { note: 'hi' };
+    localStorage.setItem(FEEDBACK_KEY, JSON.stringify(fb));
+    expect(loadFeedback()).toEqual(fb);
+  });
+
+  test('loadFeedback returns empty object for non-object data', () => {
+    localStorage.setItem(FEEDBACK_KEY, JSON.stringify(5));
+    expect(loadFeedback()).toEqual({});
+    localStorage.setItem(FEEDBACK_KEY, JSON.stringify([ { runtime: '1h' } ]));
+    expect(loadFeedback()).toEqual({});
   });
 });
 


### PR DESCRIPTION
## Summary
- Guard feedback loading against malformed or non-object data
- Test feedback storage to ensure invalid data falls back to an empty object

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b3658c0c4c8320b2cdf3b48d263a9e