### PR TITLE
Show thread link input only when installed as PWA

### DIFF
--- a/script.js
+++ b/script.js
@@ -6456,11 +6456,21 @@ if (helpButton && helpDialog) {
 // Initial calculation and language set after DOM is ready
 // Initialize immediately if DOM is already loaded (e.g. when scripts are
 // injected after `DOMContentLoaded` fired). Otherwise wait for the event.
+
+function isRunningPWA() {
+  return (
+    (window.matchMedia && window.matchMedia('(display-mode: standalone)').matches) ||
+    window.navigator.standalone === true
+  );
+}
+
 function initApp() {
-  const isStandalone = window.matchMedia && window.matchMedia('(display-mode: standalone)').matches;
-  const isIOSStandalone = window.navigator.standalone;
-  if (sharedLinkRow && (isStandalone || isIOSStandalone)) {
-    sharedLinkRow.classList.remove('hidden');
+  if (sharedLinkRow) {
+    if (isRunningPWA()) {
+      sharedLinkRow.classList.remove('hidden');
+    } else {
+      sharedLinkRow.classList.add('hidden');
+    }
   }
   populateEnvironmentDropdowns();
   setLanguage(currentLang);


### PR DESCRIPTION
## Summary
- encapsulate PWA detection in `isRunningPWA`
- hide thread/share link field unless running as a standalone PWA

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b365da3ef8832092bbf9b4012b3a07