### PR TITLE
Improve accessibility for theme toggles

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,8 +28,8 @@
       <option value="fr">Français</option>
       <option value="it">Italiano</option>
     </select>
-    <button id="darkModeToggle" title="Toggle dark mode" aria-label="Toggle dark mode">🌙</button>
-    <button id="pinkModeToggle" title="Toggle pink mode" aria-label="Toggle pink mode">🐴</button>
+    <button id="darkModeToggle" title="Toggle dark mode" aria-label="Toggle dark mode" aria-pressed="false">🌙</button>
+    <button id="pinkModeToggle" title="Toggle pink mode" aria-label="Toggle pink mode" aria-pressed="false">🐴</button>
     <button id="helpButton" aria-haspopup="dialog" aria-controls="helpDialog" title="Help (press ? or H)">?</button>
   </div>
 

--- a/script.js
+++ b/script.js
@@ -6273,11 +6273,17 @@ function applyDarkMode(enabled) {
   if (enabled) {
     document.body.classList.add("dark-mode");
     document.body.classList.remove("light-mode");
-    if (darkModeToggle) darkModeToggle.textContent = "☀️";
+    if (darkModeToggle) {
+      darkModeToggle.textContent = "☀️";
+      darkModeToggle.setAttribute("aria-pressed", "true");
+    }
   } else {
     document.body.classList.remove("dark-mode");
     document.body.classList.add("light-mode");
-    if (darkModeToggle) darkModeToggle.textContent = "🌙";
+    if (darkModeToggle) {
+      darkModeToggle.textContent = "🌙";
+      darkModeToggle.setAttribute("aria-pressed", "false");
+    }
   }
 }
 
@@ -6310,10 +6316,16 @@ if (darkModeToggle) {
 function applyPinkMode(enabled) {
   if (enabled) {
     document.body.classList.add("pink-mode");
-    if (pinkModeToggle) pinkModeToggle.textContent = "🦄";
+    if (pinkModeToggle) {
+      pinkModeToggle.textContent = "🦄";
+      pinkModeToggle.setAttribute("aria-pressed", "true");
+    }
   } else {
     document.body.classList.remove("pink-mode");
-    if (pinkModeToggle) pinkModeToggle.textContent = "🐴";
+    if (pinkModeToggle) {
+      pinkModeToggle.textContent = "🐴";
+      pinkModeToggle.setAttribute("aria-pressed", "false");
+    }
   }
 }
 
@@ -6604,6 +6616,7 @@ if (typeof module !== "undefined" && module.exports) {
     getBatteryPlates,
     setRecordingMedia,
     getRecordingMedia,
+    applyDarkMode,
     applyPinkMode,
     generatePrintableOverview,
     applySharedSetupFromUrl,

--- a/style.css
+++ b/style.css
@@ -506,6 +506,14 @@ button:disabled {
   border: 0px solid #ccc; /* Light grey border */
   border-radius: 5px;
 }
+#langSelector button {
+  min-width: 44px;
+  min-height: 44px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+}
 #helpButton {
   min-width: 32px;
   padding: 2px 4px;

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -556,15 +556,30 @@ describe('script.js functions', () => {
     ]);
   });
 
-  test('applyPinkMode toggles class', () => {
+  test('applyDarkMode toggles class and aria-pressed', () => {
+    const { applyDarkMode } = script;
+    const toggle = document.getElementById('darkModeToggle');
+    applyDarkMode(true);
+    expect(document.body.classList.contains('dark-mode')).toBe(true);
+    expect(toggle.textContent).toBe('☀️');
+    expect(toggle.getAttribute('aria-pressed')).toBe('true');
+    applyDarkMode(false);
+    expect(document.body.classList.contains('dark-mode')).toBe(false);
+    expect(toggle.textContent).toBe('🌙');
+    expect(toggle.getAttribute('aria-pressed')).toBe('false');
+  });
+
+  test('applyPinkMode toggles class and aria-pressed', () => {
     const { applyPinkMode } = script;
     const toggle = document.getElementById('pinkModeToggle');
     applyPinkMode(true);
     expect(document.body.classList.contains('pink-mode')).toBe(true);
     expect(toggle.textContent).toBe('🦄');
+    expect(toggle.getAttribute('aria-pressed')).toBe('true');
     applyPinkMode(false);
     expect(document.body.classList.contains('pink-mode')).toBe(false);
     expect(toggle.textContent).toBe('🐴');
+    expect(toggle.getAttribute('aria-pressed')).toBe('false');
   });
 
   test('generatePrintableOverview includes diagram and device blocks', () => {


### PR DESCRIPTION
## Summary
- make dark and pink mode buttons accessible to tap tools with 44x44 targets
- expose toggle state via `aria-pressed` and export `applyDarkMode`
- add tests for dark/pink mode toggle state

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b36d9697dc8320ae2a01c05c18d69b