### PR TITLE
Fix shared link field display in non-PWA browsers

### DIFF
--- a/style.css
+++ b/style.css
@@ -43,7 +43,8 @@ body {
 }
 
 .hidden {
-  display: none;
+  /* Ensure hidden elements stay hidden even if other classes set display */
+  display: none !important;
 }
 
 /* Improve keyboard accessibility by clearly showing focus on interactive elements */


### PR DESCRIPTION
## Summary
- Ensure elements with the `hidden` class stay hidden by overriding display styles

## Testing
- `npm test`
- `npx jest tests/script.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b36def24d08320845fc98b03f8a6d8