### PR TITLE
fix: improve print experience

### DIFF
--- a/overview-print.css
+++ b/overview-print.css
@@ -58,3 +58,15 @@ table, th, td {
   color: #000;
   font-weight: bold;
 }
+
+.device-category {
+  flex: 1 1 50%;
+}
+
+.device-category:nth-of-type(2n) {
+  page-break-after: always;
+}
+
+.device-block-grid.two-column {
+  grid-template-columns: 1fr;
+}

--- a/script.js
+++ b/script.js
@@ -6107,6 +6107,7 @@ function generatePrintableOverview() {
                 };
                 window.addEventListener('beforeprint', applyPrintStyles);
                 window.addEventListener('afterprint', restorePrintStyles);
+                window.addEventListener('afterprint', () => { window.close(); });
 
                 const downloadBtn = document.getElementById('downloadDiagram');
                 if (downloadBtn) {


### PR DESCRIPTION
## Summary
- Auto-close printable overview window after printing
- Limit printed overview to two categories per page
- Render FIZ motors and controllers in a single column for clearer printouts

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b36e934f2c8320ab70cbc7ee970f7b