### PR TITLE
Improve hover help to cover all elements

### DIFF
--- a/script.js
+++ b/script.js
@@ -6503,19 +6503,32 @@ if (helpButton && helpDialog) {
 
   document.addEventListener('mouseover', e => {
     if (!hoverHelpActive || !hoverHelpTooltip) return;
-    const el = e.target.closest('[data-help], [aria-label], [title]');
-    if (!el) {
-      hoverHelpTooltip.setAttribute('hidden', '');
-      return;
+    const el =
+      e.target.closest(
+        '[data-help], [aria-label], [title], [aria-labelledby], [alt]' +
+          ', button, a, input, select, textarea, label'
+      ) || e.target;
+    let text =
+      el.getAttribute('data-help') ||
+      el.getAttribute('aria-label') ||
+      el.getAttribute('title');
+    if (!text) {
+      const labelled = el.getAttribute('aria-labelledby');
+      if (labelled) {
+        const labelEl = document.getElementById(labelled);
+        if (labelEl) text = labelEl.textContent.trim();
+      }
     }
-    const text = el.getAttribute('data-help') || el.getAttribute('aria-label') || el.getAttribute('title');
+    if (!text) text = el.getAttribute('alt');
+    if (!text) text = el.textContent.trim();
     if (!text) {
       hoverHelpTooltip.setAttribute('hidden', '');
       return;
     }
-    hoverHelpTooltip.textContent = text;
-    hoverHelpTooltip.style.top = `${e.clientY + 10}px`;
-    hoverHelpTooltip.style.left = `${e.clientX + 10}px`;
+    hoverHelpTooltip.textContent = text.slice(0, 200);
+    const rect = el.getBoundingClientRect();
+    hoverHelpTooltip.style.top = `${rect.bottom + window.scrollY + 10}px`;
+    hoverHelpTooltip.style.left = `${rect.left + window.scrollX}px`;
     hoverHelpTooltip.removeAttribute('hidden');
   });
 

--- a/style.css
+++ b/style.css
@@ -276,6 +276,8 @@ body:not(.light-mode) #feedbackDialog {
   border-radius: 4px;
   font-size: 0.8rem;
   pointer-events: none;
+  max-width: 200px;
+  white-space: normal;
 }
 
 #hoverHelpTooltip[hidden] {

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -1449,6 +1449,30 @@ describe('script.js functions', () => {
     expect(document.getElementById('hoverHelpTooltip')).toBeNull();
   });
 
+  test('hover help falls back to element text when no attributes', () => {
+    const helpDialog = document.getElementById('helpDialog');
+    const hoverHelpButton = document.getElementById('hoverHelpButton');
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'F1' }));
+    expect(helpDialog.hasAttribute('hidden')).toBe(false);
+
+    hoverHelpButton.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(helpDialog.hasAttribute('hidden')).toBe(true);
+
+    const dummy = document.createElement('button');
+    dummy.textContent = 'Save setup';
+    document.body.appendChild(dummy);
+
+    dummy.dispatchEvent(
+      new MouseEvent('mouseover', { bubbles: true, clientX: 10, clientY: 10 })
+    );
+    const tooltip = document.getElementById('hoverHelpTooltip');
+    expect(tooltip.textContent).toBe('Save setup');
+
+    document.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(document.getElementById('hoverHelpTooltip')).toBeNull();
+  });
+
   test('generateConnectorSummary labels extras', () => {
     const data = {
       power: { batteryPlateSupport: [{ type: 'V-Mount', mount: 'native' }] },


### PR DESCRIPTION
## Summary
- Expand hover-help to show tooltips for any hovered element with fallbacks to aria labels or text content
- Style hover tooltip as a readable box
- Add tests for new hover-help behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b370fdc6cc8320a27809bae89d3ce5