### PR TITLE
Improve printable overview formatting

### DIFF
--- a/overview-print.css
+++ b/overview-print.css
@@ -9,8 +9,18 @@ body {
   font-size: 12pt;
 }
 
+h1 {
+  text-align: center;
+  margin-bottom: 0.5em;
+}
+
+p {
+  margin: 0.3em 0;
+}
+
 #langSelector,
-.print-btn {
+.print-btn,
+.back-btn {
   display: none;
 }
 
@@ -69,4 +79,9 @@ table, th, td {
 
 .device-block-grid.two-column {
   grid-template-columns: 1fr;
+}
+
+.page-break {
+  break-before: page;
+  page-break-before: always;
 }

--- a/script.js
+++ b/script.js
@@ -5965,6 +5965,8 @@ function generatePrintableOverview() {
     const diagramHintHtml = diagramHint ? diagramHint.outerHTML : '';
     const diagramDescHtml = document.getElementById('diagramDesc') ? document.getElementById('diagramDesc').outerHTML : '';
     const diagramSectionHtml = diagramAreaHtml ? `<section id="setupDiagram"><h2>${t.setupDiagramHeading}</h2>${diagramDescHtml}${diagramAreaHtml}${diagramLegendHtml}${diagramControlsHtml}${diagramHintHtml}</section>` : '';
+    const diagramSectionHtmlWithBreak = diagramSectionHtml ? `<div class="page-break"></div>${diagramSectionHtml}` : '';
+    const batteryTableHtmlWithBreak = batteryTableHtml ? `<div class="page-break"></div>${batteryTableHtml}` : '';
 
     const overviewHtml = `
         <!DOCTYPE html>
@@ -5997,12 +5999,14 @@ function generatePrintableOverview() {
             <h2>${t.deviceSelectionHeading}</h2>
             ${deviceListHtml}
 
+            <div class="page-break"></div>
+
             <h2>${t.resultsHeading}</h2>
             ${resultsHtml}
             ${warningHtml}
 
-            ${diagramSectionHtml}
-            ${batteryTableHtml}
+            ${diagramSectionHtmlWithBreak}
+            ${batteryTableHtmlWithBreak}
             <script>
             (function(){
                 const pinkToggle = document.getElementById('pinkModeToggle');


### PR DESCRIPTION
## Summary
- Center printed overview title and tighten paragraph spacing
- Hide navigation buttons during printing
- Insert explicit page breaks before major sections for cleaner print layout

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b3719ce1388320a0be125d8c3d4b51