### PR TITLE
Change cursor to question mark in hover help mode

### DIFF
--- a/script.js
+++ b/script.js
@@ -6494,11 +6494,13 @@ if (helpButton && helpDialog) {
       hoverHelpTooltip.remove();
       hoverHelpTooltip = null;
     }
+    document.body.style.cursor = '';
   };
 
   const startHoverHelp = () => {
     hoverHelpActive = true;
     closeHelp();
+    document.body.style.cursor = 'help';
     hoverHelpTooltip = document.createElement('div');
     hoverHelpTooltip.id = 'hoverHelpTooltip';
     hoverHelpTooltip.setAttribute('hidden', '');

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -1438,6 +1438,7 @@ describe('script.js functions', () => {
 
     hoverHelpButton.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     expect(helpDialog.hasAttribute('hidden')).toBe(true);
+    expect(document.body.style.cursor).toBe('help');
 
     helpButton.setAttribute('data-help', 'Open help dialog');
     helpButton.dispatchEvent(new MouseEvent('mouseover', { bubbles: true, clientX: 10, clientY: 10 }));
@@ -1447,6 +1448,7 @@ describe('script.js functions', () => {
 
     document.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     expect(document.getElementById('hoverHelpTooltip')).toBeNull();
+    expect(document.body.style.cursor).toBe('');
   });
 
   test('hover help falls back to element text when no attributes', () => {
@@ -1458,6 +1460,7 @@ describe('script.js functions', () => {
 
     hoverHelpButton.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     expect(helpDialog.hasAttribute('hidden')).toBe(true);
+    expect(document.body.style.cursor).toBe('help');
 
     const dummy = document.createElement('button');
     dummy.textContent = 'Save setup';
@@ -1471,6 +1474,7 @@ describe('script.js functions', () => {
 
     document.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     expect(document.getElementById('hoverHelpTooltip')).toBeNull();
+    expect(document.body.style.cursor).toBe('');
   });
 
   test('generateConnectorSummary labels extras', () => {


### PR DESCRIPTION
## Summary
- show a help cursor when hover-help mode is active
- reset cursor after hover-help mode ends
- test cursor changes in hover-help mode

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b373e6ebcc8320b7dfd5932b5745f5