### PR TITLE
feat: enable keyboard access for device detail toggles

### DIFF
--- a/script.js
+++ b/script.js
@@ -4479,6 +4479,8 @@ function renderDeviceList(categoryKey, ulElement) {
 
     const toggleBtn = document.createElement("button");
     toggleBtn.className = "detail-toggle";
+    toggleBtn.type = "button";
+    toggleBtn.setAttribute("aria-expanded", "false");
     toggleBtn.textContent = texts[currentLang].showDetails;
     header.appendChild(toggleBtn);
 
@@ -4700,20 +4702,24 @@ if (toggleDeviceBtn) {
 }
 
 
+function toggleDeviceDetails(button) {
+  const details = button.closest('li').querySelector('.device-details');
+  const expanded = button.getAttribute('aria-expanded') === 'true';
+  if (expanded) {
+    details.style.display = 'none';
+    button.textContent = texts[currentLang].showDetails;
+    button.setAttribute('aria-expanded', 'false');
+  } else {
+    details.style.display = 'block';
+    button.textContent = texts[currentLang].hideDetails;
+    button.setAttribute('aria-expanded', 'true');
+  }
+}
+
 // Handle "Edit" and "Delete" buttons in device lists (event delegation)
 deviceManagerSection.addEventListener("click", (event) => {
   if (event.target.classList.contains("detail-toggle")) {
-    const details = event.target.closest('li').querySelector('.device-details');
-    const expanded = event.target.dataset.expanded === 'true';
-    if (expanded) {
-      details.style.display = 'none';
-      event.target.textContent = texts[currentLang].showDetails;
-      event.target.dataset.expanded = 'false';
-    } else {
-      details.style.display = 'block';
-      event.target.textContent = texts[currentLang].hideDetails;
-      event.target.dataset.expanded = 'true';
-    }
+    toggleDeviceDetails(event.target);
   } else if (event.target.classList.contains("edit-btn")) {
     const name = event.target.dataset.name;
     const categoryKey = event.target.dataset.category;
@@ -4904,6 +4910,13 @@ deviceManagerSection.addEventListener("click", (event) => {
       applyFilters();
       updateCalculations();
     }
+  }
+});
+
+deviceManagerSection.addEventListener('keydown', (event) => {
+  if (event.target.classList.contains('detail-toggle') && (event.key === 'Enter' || event.key === ' ')) {
+    event.preventDefault();
+    toggleDeviceDetails(event.target);
   }
 });
 

--- a/style.css
+++ b/style.css
@@ -444,7 +444,17 @@ button:disabled {
 }
 
 .detail-toggle {
-  margin-right: 5px;
+  margin: 0 5px 0 0;
+  background: none;
+  border: 2px solid transparent;
+  padding: 0;
+  cursor: pointer;
+}
+
+.detail-toggle:focus,
+.detail-toggle[aria-expanded="true"] {
+  border-color: var(--accent-color);
+  outline: none;
 }
 
 .device-details {

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -1729,4 +1729,23 @@ describe('monitor wireless metadata', () => {
     expect(deviceManager.classList.contains('hidden')).toBe(true);
     expect(toggleBtn.textContent).toBe(texts.en.toggleDeviceManager);
   });
+
+  test('detail toggle responds to keyboard events', () => {
+    const detailToggle = document.querySelector('#device-manager .detail-toggle');
+    const details = detailToggle.closest('li').querySelector('.device-details');
+
+    // Initially collapsed
+    expect(detailToggle.getAttribute('aria-expanded')).toBe('false');
+    expect(details.style.display).toBe('none');
+
+    // Activate with Enter key
+    detailToggle.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    expect(detailToggle.getAttribute('aria-expanded')).toBe('true');
+    expect(details.style.display).toBe('block');
+
+    // Collapse with Space key
+    detailToggle.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', bubbles: true }));
+    expect(detailToggle.getAttribute('aria-expanded')).toBe('false');
+    expect(details.style.display).toBe('none');
+  });
 });


### PR DESCRIPTION
## Summary
- add `aria-expanded` and type to device manager detail toggles
- handle Enter/Space key presses so details can toggle via keyboard
- highlight active detail toggles with an accent border for clarity
- add tests covering keyboard accessibility

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b37388371c8320a0890e5520d77216