### PR TITLE
Improve printable overview page breaks

### DIFF
--- a/overview-print.css
+++ b/overview-print.css
@@ -29,6 +29,16 @@ h2, h3, table, .device-block, .device-category {
   break-inside: avoid;
 }
 
+.device-category-container,
+.device-block-grid {
+  page-break-inside: avoid;
+  break-inside: avoid;
+}
+
+.device-category-container {
+  display: block;
+}
+
 h2, h3 { page-break-after: avoid; }
 
 table, th, td {
@@ -70,11 +80,12 @@ table, th, td {
 }
 
 .device-category {
-  flex: 1 1 50%;
+  flex: 1 1 100%;
+  page-break-after: always;
 }
 
-.device-category:nth-of-type(2n) {
-  page-break-after: always;
+.device-category:last-child {
+  page-break-after: auto;
 }
 
 .device-block-grid.two-column {


### PR DESCRIPTION
## Summary
- ensure device category containers and grids avoid breaking across pages
- force each device category onto a new page in printable overviews

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3747237208320ba587be4570258eb