### PR TITLE
fix: make help search compatible with non-iterable NodeLists

### DIFF
--- a/script.js
+++ b/script.js
@@ -6445,11 +6445,14 @@ if (gridSnapToggleBtn) {
 if (helpButton && helpDialog) {
   const filterHelp = () => {
     if (!helpSearch) return;
-    const query = helpSearch.value.toLowerCase();
-    const sections = helpDialog.querySelectorAll('[data-help-section]');
-    const items = helpDialog.querySelectorAll('.faq-item');
+    const query = helpSearch.value.trim().toLowerCase();
+    const sections = Array.from(
+      helpDialog.querySelectorAll('[data-help-section]')
+    );
+    const items = Array.from(helpDialog.querySelectorAll('.faq-item'));
+    const elements = sections.concat(items);
     let anyVisible = false;
-    [...sections, ...items].forEach(el => {
+    elements.forEach(el => {
       const text = el.textContent.toLowerCase();
       if (!query || text.includes(query)) {
         el.removeAttribute('hidden');

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -1405,6 +1405,27 @@ describe('script.js functions', () => {
     expect(document.activeElement).toBe(helpSearch);
   });
 
+  test('help search works when NodeList lacks iterator', () => {
+    const helpDialog = document.getElementById('helpDialog');
+    const helpSearch = document.getElementById('helpSearch');
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'F1' }));
+
+    const originalIterator = NodeList.prototype[Symbol.iterator];
+    NodeList.prototype[Symbol.iterator] = undefined;
+
+    expect(() => {
+      helpSearch.value = 'battery';
+      helpSearch.dispatchEvent(new Event('input', { bubbles: true }));
+    }).not.toThrow();
+
+    const sections = Array.from(helpDialog.querySelectorAll('[data-help-section]'));
+    const visible = sections.filter(s => !s.hasAttribute('hidden'));
+    expect(visible.length).toBeGreaterThan(0);
+
+    NodeList.prototype[Symbol.iterator] = originalIterator;
+  });
+
   test('help search controls are localized', () => {
     const helpSearch = document.getElementById('helpSearch');
     const helpSearchClear = document.getElementById('helpSearchClear');


### PR DESCRIPTION
## Summary
- Robustify help search by converting NodeLists to arrays and trimming queries
- Add regression test ensuring search works when NodeList lacks iterator

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3772b363c8320946efdf52686f4d1