### PR TITLE
Show overview in dialog and refine print styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,6 +14,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;500&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="style.css" />
+  <link rel="stylesheet" href="overview-print.css" media="print" />
   <link rel="icon" href="icon.svg" type="image/svg+xml" />
   <link rel="icon" href="icon.png" type="image/png" />
   <link rel="apple-touch-icon" href="icon.png" />
@@ -718,7 +719,7 @@
           </details>
           <details class="faq-item">
             <summary>How can I print a setup overview?</summary>
-            <p>Save the setup, then click <em>Generate Overview</em> in Setup Actions and print from the new tab.</p>
+            <p>Save the setup, then click <em>Generate Overview</em> in Setup Actions and print from the dialog.</p>
           </details>
           <details class="faq-item">
             <summary>How do I compare different batteries?</summary>
@@ -841,7 +842,7 @@
       <option value="HEVC"></option>
       <option value="X-OCN"></option>
     </datalist>
-    <datalist id="framerateOptions">
+  <datalist id="framerateOptions">
       <option value="23.98"></option>
       <option value="24"></option>
       <option value="25"></option>
@@ -851,6 +852,7 @@
       <option value="120"></option>
     </datalist>
   </dialog>
+  <dialog id="overviewDialog"></dialog>
   <script src="data.js"></script>
   <script src="storage.js"></script>
   <script src="translations.js"></script>

--- a/overview-print.css
+++ b/overview-print.css
@@ -45,6 +45,8 @@ table, th, td {
   word-break: break-word;
   hyphens: auto;
 }
+th { background-color: #e0e0e0; }
+tr:nth-child(even) { background-color: #f9f9f9; }
 
 .device-block,
 .device-category {

--- a/script.js
+++ b/script.js
@@ -5982,28 +5982,8 @@ function generatePrintableOverview() {
     const batteryTableHtmlWithBreak = batteryTableHtml ? `<div class="page-break"></div>${batteryTableHtml}` : '';
 
     const overviewHtml = `
-        <!DOCTYPE html>
-        <html lang="${currentLang}">
-        <head>
-            <meta charset="UTF-8">
-            <title>${t.overviewTitle} - ${safeSetupName}</title>
-            <link rel="stylesheet" href="style.css">
-            <link rel="stylesheet" href="overview.css">
-            <link rel="stylesheet" href="overview-print.css" media="print">
-        </head>
-        <body>
-            <div id="langSelector">
-                <select id="languageSelect">
-                    <option value="en" ${currentLang === 'en' ? 'selected' : ''}>English</option>
-                    <option value="de" ${currentLang === 'de' ? 'selected' : ''}>Deutsch</option>
-                    <option value="es" ${currentLang === 'es' ? 'selected' : ''}>Español</option>
-                    <option value="fr" ${currentLang === 'fr' ? 'selected' : ''}>Français</option>
-                    <option value="it" ${currentLang === 'it' ? 'selected' : ''}>Italiano</option>
-                </select>
-                <button id="darkModeToggle" title="${t.darkModeLabel}" aria-label="${t.darkModeLabel}">🌙</button>
-                <button id="pinkModeToggle" title="${t.pinkModeLabel}" aria-label="${t.pinkModeLabel}">🐴</button>
-            </div>
-            <button onclick="window.close()" class="back-btn">${t.backToAppBtn}</button>
+        <div id="overviewDialogContent">
+            <button id="closeOverviewBtn" class="back-btn">${t.backToAppBtn}</button>
             <button onclick="window.print()" class="print-btn">Print</button>
             <h1>${t.overviewTitle}</h1>
             <p><strong>${t.setupNameLabel}</strong> ${safeSetupName}</p>
@@ -6020,165 +6000,27 @@ function generatePrintableOverview() {
 
             ${diagramSectionHtmlWithBreak}
             ${batteryTableHtmlWithBreak}
-            <script>
-            (function(){
-                const pinkToggle = document.getElementById('pinkModeToggle');
-                const darkToggle = document.getElementById('darkModeToggle');
-                const langSelect = document.getElementById('languageSelect');
-
-                function applyPinkMode(enabled){
-                    if(enabled){
-                        document.body.classList.add('pink-mode');
-                        pinkToggle.textContent = '🦄';
-                    } else {
-                        document.body.classList.remove('pink-mode');
-                        pinkToggle.textContent = '🐴';
-                    }
-                }
-
-                function applyDarkMode(enabled){
-                    if(enabled){
-                        document.body.classList.add('dark-mode');
-                        document.body.classList.remove('light-mode');
-                        darkToggle.textContent = '☀️';
-                    } else {
-                        document.body.classList.remove('dark-mode');
-                        document.body.classList.add('light-mode');
-                        darkToggle.textContent = '🌙';
-                    }
-                }
-
-                let darkEnabled = false;
-                try {
-                    const stored = localStorage.getItem('darkMode');
-                    if(stored !== null){
-                        darkEnabled = stored === 'true';
-                    } else if (typeof window.matchMedia === 'function') {
-                        darkEnabled = window.matchMedia('(prefers-color-scheme: dark)').matches;
-                    }
-                } catch(e) {}
-                applyDarkMode(darkEnabled);
-                darkToggle.addEventListener('click', () => {
-                    darkEnabled = !document.body.classList.contains('dark-mode');
-                    applyDarkMode(darkEnabled);
-                    try { localStorage.setItem('darkMode', darkEnabled); } catch(e) {}
-                    if(window.opener && typeof window.opener.applyDarkMode === 'function'){
-                        window.opener.applyDarkMode(darkEnabled);
-                    }
-                });
-
-                let pinkEnabled = false;
-                try { pinkEnabled = localStorage.getItem('pinkMode') === 'true'; } catch(e) {}
-                applyPinkMode(pinkEnabled);
-                pinkToggle.addEventListener('click', () => {
-                    pinkEnabled = !document.body.classList.contains('pink-mode');
-                    applyPinkMode(pinkEnabled);
-                    try { localStorage.setItem('pinkMode', pinkEnabled); } catch(e) {}
-                    if(window.opener && typeof window.opener.applyPinkMode === 'function'){
-                        window.opener.applyPinkMode(pinkEnabled);
-                    }
-                });
-
-                langSelect.addEventListener('change', () => {
-                    const newLang = langSelect.value;
-                    try { localStorage.setItem('language', newLang); } catch(e) {}
-                    if(window.opener && typeof window.opener.setLanguage === 'function' && typeof window.opener.generatePrintableOverview === 'function'){
-                        window.opener.setLanguage(newLang);
-                        window.opener.generatePrintableOverview();
-                        window.close();
-                    }
-                });
-
-                let printState = null;
-                const applyPrintStyles = () => {
-                    const diagramArea = document.getElementById('diagramArea');
-                    const diagramSvg = diagramArea ? diagramArea.querySelector('svg') : null;
-                    printState = {
-                        dark: document.body.classList.contains('dark-mode'),
-                        pink: document.body.classList.contains('pink-mode'),
-                        light: document.body.classList.contains('light-mode'),
-                        bodyBg: document.body.style.backgroundColor,
-                        bodyColor: document.body.style.color,
-                        diagramBg: diagramArea ? diagramArea.style.backgroundColor : '',
-                        svgBg: diagramSvg ? diagramSvg.style.backgroundColor : ''
-                    };
-                    document.body.classList.add('light-mode');
-                    document.body.classList.remove('dark-mode');
-                    document.body.style.backgroundColor = '#ffffff';
-                    document.body.style.color = '#000000';
-                    if (diagramArea) diagramArea.style.backgroundColor = '#ffffff';
-                    if (diagramSvg) diagramSvg.style.backgroundColor = '#ffffff';
-                };
-                const restorePrintStyles = () => {
-                    if (!printState) return;
-                    const { dark, pink, light, bodyBg, bodyColor, diagramBg, svgBg } = printState;
-                    document.body.style.backgroundColor = bodyBg;
-                    document.body.style.color = bodyColor;
-                    const diagramArea = document.getElementById('diagramArea');
-                    const diagramSvg = diagramArea ? diagramArea.querySelector('svg') : null;
-                    if (diagramArea) diagramArea.style.backgroundColor = diagramBg;
-                    if (diagramSvg) diagramSvg.style.backgroundColor = svgBg;
-                    if (!light) document.body.classList.remove('light-mode');
-                    if (dark) document.body.classList.add('dark-mode');
-                    if (pink) document.body.classList.add('pink-mode');
-                };
-                window.addEventListener('beforeprint', applyPrintStyles);
-                window.addEventListener('afterprint', restorePrintStyles);
-                window.addEventListener('afterprint', () => { window.close(); });
-
-                const downloadBtn = document.getElementById('downloadDiagram');
-                if (downloadBtn) {
-                    downloadBtn.addEventListener('click', (e) => {
-                        let source = '';
-                        if (window.opener && typeof window.opener.exportDiagramSvg === 'function') {
-                            source = window.opener.exportDiagramSvg();
-                        }
-                        if (!source) return;
-
-                        navigator.clipboard.writeText(source).catch(() => {});
-
-                        const saveSvg = () => {
-                            const blob = new Blob([source], { type: 'image/svg+xml;charset=utf-8' });
-                            const url = URL.createObjectURL(blob);
-                            const a = document.createElement('a');
-                            a.href = url;
-                            a.download = 'setup-diagram.svg';
-                            a.click();
-                            URL.revokeObjectURL(url);
-                        };
-
-                        if (e.shiftKey) {
-                            const img = new Image();
-                            img.onload = () => {
-                                const canvas = document.createElement('canvas');
-                                canvas.width = img.width;
-                                canvas.height = img.height;
-                                const ctx = canvas.getContext('2d');
-                                ctx.drawImage(img, 0, 0);
-                                canvas.toBlob(blob => {
-                                    const url = URL.createObjectURL(blob);
-                                    const a = document.createElement('a');
-                                    a.href = url;
-                                    a.download = 'setup-diagram.jpg';
-                                    a.click();
-                                    URL.revokeObjectURL(url);
-                                }, 'image/jpeg', 0.95);
-                            };
-                            img.src = 'data:image/svg+xml;charset=utf-8,' + encodeURIComponent(source);
-                        } else {
-                            saveSvg();
-                        }
-                    });
-                }
-            })();
-            </script>
-        </body>
-        </html>
+        </div>
     `;
 
-    const overviewWindow = window.open('', '_blank');
-    overviewWindow.document.write(overviewHtml);
-    overviewWindow.document.close();
+    const overviewDialog = document.getElementById('overviewDialog');
+    overviewDialog.innerHTML = overviewHtml;
+    const content = overviewDialog.querySelector('#overviewDialogContent');
+    ['dark-mode', 'pink-mode'].forEach(cls => {
+        if (document.body.classList.contains(cls)) {
+            content.classList.add(cls);
+        }
+    });
+    const closeBtn = overviewDialog.querySelector('#closeOverviewBtn');
+    if (closeBtn) {
+        closeBtn.addEventListener('click', () => overviewDialog.close());
+    }
+    if (typeof overviewDialog.showModal === 'function') {
+        overviewDialog.showModal();
+    } else {
+        overviewDialog.setAttribute('open', '');
+    }
+    window.addEventListener('afterprint', () => { overviewDialog.close(); }, { once: true });
 }
 
 

--- a/style.css
+++ b/style.css
@@ -1134,3 +1134,150 @@ body.dark-mode.pink-mode .help-content { border-color: var(--accent-color); }
     min-height: 300px;
   }
 }
+
+/* Overview dialog */
+#overviewDialog {
+  width: 90%;
+  max-width: 900px;
+  padding: 0;
+  border: none;
+}
+#overviewDialog::backdrop {
+  background: rgba(0, 0, 0, 0.5);
+}
+#overviewDialogContent {
+  padding: 20px;
+  max-height: 80vh;
+  overflow-y: auto;
+  background: #fff;
+  color: #333;
+  font-family: 'Open Sans', sans-serif;
+}
+#overviewDialogContent h1,
+#overviewDialogContent h2,
+#overviewDialogContent h3 {
+  font-weight: 500;
+  color: var(--accent-color);
+}
+#overviewDialogContent h1 {
+  font-size: 1.8em;
+  margin-bottom: 0.2em;
+}
+#overviewDialogContent h2 {
+  font-size: 1.4em;
+  margin-top: 1.3em;
+  border-bottom: 2px solid var(--accent-color);
+  padding-bottom: 5px;
+}
+#overviewDialogContent h3 {
+  font-size: 1.1em;
+  margin-top: 1em;
+}
+#overviewDialogContent table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 5px;
+  table-layout: fixed;
+}
+#overviewDialogContent th,
+#overviewDialogContent td {
+  border: 1px solid #ddd;
+  padding: 8px;
+  text-align: left;
+  font-size: 0.9em;
+  overflow: hidden;
+}
+#overviewDialogContent th {
+  background-color: #f2f2f2;
+}
+#overviewDialogContent tr:nth-child(even) {
+  background-color: #f9f9f9;
+}
+#overviewDialogContent .device-block {
+  background: rgba(255, 255, 255, 0.95);
+  border: 1px solid #333;
+  border-radius: 6px;
+  padding: 6px 10px;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.25);
+  font-size: 12px;
+}
+#overviewDialogContent .device-block strong {
+  display: block;
+  margin-bottom: 4px;
+}
+#overviewDialogContent .device-category-container {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+#overviewDialogContent .device-category {
+  background: #f9f9f9;
+  border: 1px solid #ddd;
+  border-radius: 5px;
+  padding: 10px;
+  margin-bottom: 10px;
+  flex: 1 1 calc((100% - 20px) / 3);
+  box-sizing: border-box;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
+}
+#overviewDialogContent .device-category h3 {
+  margin-top: 0;
+  margin-bottom: 5px;
+  border-bottom: 1px solid #eee;
+  padding-bottom: 3px;
+}
+#overviewDialogContent .device-block-grid {
+  display: grid;
+  gap: 8px;
+}
+#overviewDialogContent .device-block-grid.single-column {
+  grid-template-columns: 1fr;
+}
+#overviewDialogContent .device-block-grid.two-column {
+  grid-template-columns: repeat(2, 1fr);
+}
+#overviewDialogContent.pink-mode {
+  --accent-color: #ff69b4;
+}
+#overviewDialogContent.dark-mode {
+  background-color: #121212;
+  color: #f0f0f0;
+}
+#overviewDialogContent.dark-mode h1,
+#overviewDialogContent.dark-mode h2,
+#overviewDialogContent.dark-mode h3 {
+  color: #fff;
+  border-color: #fff;
+}
+#overviewDialogContent.dark-mode th {
+  background-color: #333;
+}
+#overviewDialogContent.dark-mode tr:nth-child(even) {
+  background-color: #1a1a1a;
+}
+#overviewDialogContent.dark-mode .device-category {
+  background: #1e1e1e;
+  border-color: #333;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.5);
+}
+#overviewDialogContent.dark-mode .device-block {
+  background: rgba(255, 255, 255, 0.1);
+  border-color: #555;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.5);
+}
+
+@media print {
+  body *:not(#overviewDialog):not(#overviewDialog *) {
+    display: none !important;
+  }
+  #overviewDialog {
+    display: block;
+    position: static;
+    width: auto;
+    max-width: none;
+  }
+  #overviewDialogContent {
+    max-height: none;
+    overflow: visible;
+  }
+}

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -387,10 +387,10 @@ describe('script.js functions', () => {
     document.getElementById('batterySelect').value = 'VBatt';
     script.updateCalculations();
 
-    const writeMock = jest.fn();
-    window.open = jest.fn(() => ({ document: { write: writeMock, close: jest.fn() } }));
     script.generatePrintableOverview();
-    const html = writeMock.mock.calls[0][0];
+    const dialog = document.getElementById('overviewDialog');
+    expect(dialog.open).toBe(true);
+    const html = dialog.innerHTML;
     expect(html).toContain('VBatt');
     expect(html).not.toContain('BBatt');
   });
@@ -584,8 +584,6 @@ describe('script.js functions', () => {
 
   test('generatePrintableOverview includes diagram and device blocks', () => {
     const { generatePrintableOverview } = script;
-    const writeMock = jest.fn();
-    window.open = jest.fn(() => ({ document: { write: writeMock, close: jest.fn() } }));
     document.getElementById('setupName').value = 'Test';
     const addOpt = (id, value) => {
       const sel = document.getElementById(id);
@@ -595,13 +593,12 @@ describe('script.js functions', () => {
     addOpt('cameraSelect', 'CamA');
     script.updateCalculations();
     generatePrintableOverview();
-    expect(window.open).toHaveBeenCalled();
-    const html = writeMock.mock.calls[0][0];
+    const dialog = document.getElementById('overviewDialog');
+    expect(dialog.open).toBe(true);
+    const html = dialog.innerHTML;
     expect(html).toContain('id="diagramArea"');
     expect(html).toContain('<svg');
     expect(html).toContain('class="device-block"');
-    expect(html).toContain('id="pinkModeToggle"');
-    expect(html).toContain('id="languageSelect"');
     expect(html).toContain('id="breakdownList"');
     expect(html).toContain(`<strong>${texts.en.cameraLabel}</strong>`);
   });


### PR DESCRIPTION
## Summary
- Replace new-tab printing with in-page modal dialog for setup overviews
- Improve print styling with additional CSS and FAQ updates
- Adjust tests for dialog-based printing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b377d068748320b8c09155e3331bdb