### PR TITLE
feat: sync theme color with dark mode

### DIFF
--- a/script.js
+++ b/script.js
@@ -6154,6 +6154,13 @@ controllerSelects.forEach(sel => { if (sel) sel.addEventListener("change", saveC
 if (setupNameInput) setupNameInput.addEventListener("input", saveCurrentSession);
 
 // Dark mode handling
+function updateThemeColor(isDark) {
+  const meta = document.querySelector('meta[name="theme-color"]');
+  if (meta) {
+    meta.setAttribute('content', isDark ? '#121212' : '#ffffff');
+  }
+}
+
 function applyDarkMode(enabled) {
   if (enabled) {
     document.body.classList.add("dark-mode");
@@ -6170,6 +6177,7 @@ function applyDarkMode(enabled) {
       darkModeToggle.setAttribute("aria-pressed", "false");
     }
   }
+  updateThemeColor(enabled);
 }
 
 let darkModeEnabled = false;

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -14,6 +14,7 @@ describe('script.js functions', () => {
     const html = fs.readFileSync(path.join(__dirname, '../index.html'), 'utf8');
     const body = html.split('<body>')[1].split('</body>')[0];
     document.body.innerHTML = body;
+    document.head.innerHTML = '<meta name="theme-color" content="#ffffff">';
 
     global.devices = {
       cameras: { CamA: { powerDrawWatts: 10 } },
@@ -556,17 +557,20 @@ describe('script.js functions', () => {
     ]);
   });
 
-  test('applyDarkMode toggles class and aria-pressed', () => {
+  test('applyDarkMode toggles class, aria-pressed and theme color', () => {
     const { applyDarkMode } = script;
     const toggle = document.getElementById('darkModeToggle');
+    const meta = document.querySelector('meta[name="theme-color"]');
     applyDarkMode(true);
     expect(document.body.classList.contains('dark-mode')).toBe(true);
     expect(toggle.textContent).toBe('☀️');
     expect(toggle.getAttribute('aria-pressed')).toBe('true');
+    expect(meta.getAttribute('content')).toBe('#121212');
     applyDarkMode(false);
     expect(document.body.classList.contains('dark-mode')).toBe(false);
     expect(toggle.textContent).toBe('🌙');
     expect(toggle.getAttribute('aria-pressed')).toBe('false');
+    expect(meta.getAttribute('content')).toBe('#ffffff');
   });
 
   test('applyPinkMode toggles class and aria-pressed', () => {


### PR DESCRIPTION
## Summary
- update the app's theme color meta tag when switching dark mode
- cover theme color updates in tests

## Testing
- `npm run lint`
- `npm run check-consistency`
- `CI=true npx jest --runInBand tests/checkConsistency.test.js tests/service-worker.test.js tests/unifyPorts.test.js tests/storage.test.js tests/utils.test.js tests/script.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b3795b81e08320be911605a75a8dc7