### PR TITLE
Restore toggle button dimensions

### DIFF
--- a/style.css
+++ b/style.css
@@ -527,6 +527,11 @@ button:disabled {
   justify-content: center;
   padding: 0;
 }
+#darkModeToggle,
+#pinkModeToggle {
+  min-width: 32px;
+  min-height: 32px;
+}
 #helpButton {
   min-width: 32px;
   padding: 2px 4px;


### PR DESCRIPTION
## Summary
- Reduce dark and pink mode toggle button sizes to standard 32px minimum

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b379edb98c83208bede2125b1b8bdc