### PR TITLE
feat: add keyboard shortcut for pink mode

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -100,7 +100,7 @@ You can switch the language in the top right corner. The choice is remembered fo
 - Preference is stored in your browser.
 
 ### 🦄 Pink Mode
-- Click the unicorn button for a playful pink accent.
+- Click the unicorn button or press **P** for a playful pink accent.
 - Works in both light and dark themes and persists between visits.
 
 ### 📝 User Runtime Feedback

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Choose your preferred language above.
 Recent updates include:
 
 - **Interactive setup diagram** – drag devices, zoom with dedicated controls, optionally snap nodes to a grid, and export the layout as SVG or JPG.
-- **Pink accent theme** – toggle a playful pink highlight that persists between visits.
+- **Pink accent theme** – toggle a playful pink highlight that persists between visits or press **P** to switch quickly.
 - **Searchable help dialog** – open with the ? button or keyboard shortcuts, filter topics instantly and browse the built-in FAQ.
 - **Dual V‑/B‑Mount support** – choose between plate types on supported cameras and the battery list updates automatically.
 - **User runtime feedback** – submit real-world runtimes with environment details to refine estimates.

--- a/index.html
+++ b/index.html
@@ -659,6 +659,7 @@
           <ul>
             <li>Click the horse button for a pink unicorn theme that accents buttons and headings.</li>
             <li>The setting persists between visits and works in light or dark mode.</li>
+            <li>Press <kbd>P</kbd> to toggle pink mode.</li>
           </ul>
         </section>
         <section data-help-section id="shortcuts">
@@ -666,6 +667,7 @@
           <ul>
             <li><kbd>?</kbd>, <kbd>H</kbd> or <kbd>F1</kbd> – toggle help</li>
             <li><kbd>Escape</kbd> – close dialogs</li>
+            <li><kbd>P</kbd> – toggle pink mode</li>
             <li>Type in dropdowns to filter options</li>
           </ul>
         </section>

--- a/script.js
+++ b/script.js
@@ -6516,6 +6516,16 @@ if (helpButton && helpDialog) {
                document.activeElement.tagName !== 'TEXTAREA') {
       if (e.key === 'F1') e.preventDefault();
       toggleHelp();
+    } else if (e.key.toLowerCase() === 'p' &&
+               document.activeElement.tagName !== 'INPUT' &&
+               document.activeElement.tagName !== 'TEXTAREA') {
+      pinkModeEnabled = !document.body.classList.contains('pink-mode');
+      applyPinkMode(pinkModeEnabled);
+      try {
+        localStorage.setItem('pinkMode', pinkModeEnabled);
+      } catch (err) {
+        console.warn('Could not save pink mode preference', err);
+      }
     }
   });
 


### PR DESCRIPTION
## Summary
- allow pressing `P` to toggle pink accent theme
- document new keyboard shortcut in help sections and README

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3797dcb508320bb83e60c003d10d2