### PR TITLE
feat: improve PWA status bar styling on iOS

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,12 +3,14 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="apple-mobile-web-app-capable" content="yes" />
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
   <meta name="description" content="Plan your camera setup and calculate power consumption &amp; battery life." />
   <meta property="og:title" content="Camera Power Planner" />
   <meta property="og:description" content="Plan your camera setup and calculate power consumption &amp; battery life." />
   <meta property="og:type" content="website" />
   <meta property="og:image" content="icon.png" />
-  <meta name="theme-color" content="#ffffff" />
+  <meta name="theme-color" content="#1a1a1a" />
   <title>Camera Power Planner</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/manifest.webmanifest
+++ b/manifest.webmanifest
@@ -3,8 +3,8 @@
   "short_name": "Power Planner",
   "start_url": ".",
   "display": "standalone",
-  "background_color": "#ffffff",
-  "theme_color": "#ffffff",
+  "background_color": "#1a1a1a",
+  "theme_color": "#1a1a1a",
   "icons": [
     {
       "src": "icon.svg",

--- a/script.js
+++ b/script.js
@@ -6212,7 +6212,7 @@ if (setupNameInput) setupNameInput.addEventListener("input", saveCurrentSession)
 function updateThemeColor(isDark) {
   const meta = document.querySelector('meta[name="theme-color"]');
   if (meta) {
-    meta.setAttribute('content', isDark ? '#121212' : '#ffffff');
+    meta.setAttribute('content', isDark ? '#1a1a1a' : '#ffffff');
   }
 }
 

--- a/style.css
+++ b/style.css
@@ -6,6 +6,14 @@
 body.pink-mode {
   --accent-color: #ff69b4;
 }
+
+html,
+body {
+  background: #1a1a1a;
+  height: 100%;
+  margin: 0;
+}
+
 /* Ensure predictable sizing */
 *, *::before, *::after {
   box-sizing: border-box;
@@ -18,6 +26,16 @@ body {
   background-color: #ffffff;
   color: #000000;
   font-size: 0.9em;
+}
+
+@supports (padding: env(safe-area-inset-top)) {
+  body {
+    padding:
+      env(safe-area-inset-top)
+      env(safe-area-inset-right)
+      env(safe-area-inset-bottom)
+      env(safe-area-inset-left);
+  }
 }
 
 .skip-link {


### PR DESCRIPTION
## Summary
- set iOS PWA meta tags for status bar customization
- add dark background and safe-area padding to html/body
- align manifest and script theme colors with dark PWA style

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b37aacb5188320a4243f780ae2e955