### PR TITLE
Handle duplicate setup names

### DIFF
--- a/storage.js
+++ b/storage.js
@@ -75,9 +75,16 @@ function loadSetups() {
       const parsedData = JSON.parse(data);
       if (Array.isArray(parsedData)) {
         const obj = {};
+        const used = new Set();
         parsedData.forEach((item, idx) => {
           if (item && typeof item === 'object') {
-            const key = item.name || item.setupName || `Setup ${idx + 1}`;
+            const base = item.name || item.setupName || `Setup ${idx + 1}`;
+            let key = base;
+            let suffix = 2;
+            while (used.has(key)) {
+              key = `${base} (${suffix++})`;
+            }
+            used.add(key);
             obj[key] = item;
           }
         });

--- a/tests/storage.test.js
+++ b/tests/storage.test.js
@@ -99,6 +99,12 @@ describe('setup storage', () => {
     expect(JSON.parse(localStorage.getItem(SETUP_KEY))).toEqual({ A: { name: 'A', foo: 1 }, B: { name: 'B', bar: 2 } });
   });
 
+  test('loadSetups ensures unique keys when names duplicate', () => {
+    const arr = [{ name: 'A', foo: 1 }, { name: 'A', bar: 2 }];
+    localStorage.setItem(SETUP_KEY, JSON.stringify(arr));
+    expect(loadSetups()).toEqual({ A: { name: 'A', foo: 1 }, 'A (2)': { name: 'A', bar: 2 } });
+  });
+
   test('loadSetups returns empty object for primitive data', () => {
     localStorage.setItem(SETUP_KEY, JSON.stringify(5));
     expect(loadSetups()).toEqual({});


### PR DESCRIPTION
## Summary
- ensure `loadSetups` generates unique keys when converting array-based setups
- add regression test for duplicate setup names

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b37ca61e648320b63137a02fa48f53