### PR TITLE
Improve detail toggle focus visibility

### DIFF
--- a/style.css
+++ b/style.css
@@ -454,7 +454,6 @@ button:disabled {
 .detail-toggle:focus,
 .detail-toggle[aria-expanded="true"] {
   border-color: var(--accent-color);
-  outline: none;
 }
 
 .device-details {


### PR DESCRIPTION
## Summary
- Maintain default focus outlines for detail toggle buttons to aid keyboard navigation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b37cd54dd48320a43b969bc283cf79