### PR TITLE
fix: improve Italian translation for add button

### DIFF
--- a/translations.js
+++ b/translations.js
@@ -401,7 +401,7 @@ const texts = {
     notesLabel: "Note:",
     monitorDetailsHeading: "Dettagli monitor",
     monitorPowerHeading: "Input di potenza",
-    addDeviceBtn: "Aggiungere",
+    addDeviceBtn: "Aggiungi",
     updateDeviceBtn: "Aggiorna",
     editBtn: "Modifica",
     deleteDeviceBtn: "Elimina",


### PR DESCRIPTION
## Summary
- refine Italian translation for add device button

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b37cf232848320838f964fe40229b0