### PR TITLE
feat: unify theme color and use CSS variables

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
   <meta property="og:description" content="Plan your camera setup and calculate power consumption &amp; battery life." />
   <meta property="og:type" content="website" />
   <meta property="og:image" content="icon.png" />
-  <meta name="theme-color" content="#1a1a1a" />
+  <meta name="theme-color" content="#121212" />
   <title>Camera Power Planner</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/manifest.webmanifest
+++ b/manifest.webmanifest
@@ -3,8 +3,8 @@
   "short_name": "Power Planner",
   "start_url": ".",
   "display": "standalone",
-  "background_color": "#1a1a1a",
-  "theme_color": "#1a1a1a",
+  "background_color": "#121212",
+  "theme_color": "#121212",
   "icons": [
     {
       "src": "icon.svg",

--- a/script.js
+++ b/script.js
@@ -6212,7 +6212,9 @@ if (setupNameInput) setupNameInput.addEventListener("input", saveCurrentSession)
 function updateThemeColor(isDark) {
   const meta = document.querySelector('meta[name="theme-color"]');
   if (meta) {
-    meta.setAttribute('content', isDark ? '#1a1a1a' : '#ffffff');
+    const colorVar = isDark ? '--bg-color-dark' : '--bg-color-light';
+    const color = getComputedStyle(document.body).getPropertyValue(colorVar).trim();
+    meta.setAttribute('content', color || (isDark ? '#121212' : '#ffffff'));
   }
 }
 

--- a/style.css
+++ b/style.css
@@ -2,6 +2,8 @@
 /* General styles */
 :root {
   --accent-color: #001589;
+  --bg-color-light: #ffffff;
+  --bg-color-dark: #121212;
 }
 body.pink-mode {
   --accent-color: #ff69b4;
@@ -9,7 +11,7 @@ body.pink-mode {
 
 html,
 body {
-  background: #1a1a1a;
+  background: var(--bg-color-dark);
   height: 100%;
   margin: 0;
 }
@@ -24,7 +26,7 @@ body {
   font-weight: 300;
   margin: 20px auto;
   max-width: 1200px;
-  background-color: #ffffff;
+  background-color: var(--bg-color-light);
   color: #000000;
   font-size: 0.9em;
 }
@@ -912,7 +914,7 @@ body:not(.light-mode) #userFeedbackTable td {
 }
 
 body.dark-mode {
-  background-color: #121212;
+  background-color: var(--bg-color-dark);
   color: #f0f0f0;
 }
 .dark-mode h1,
@@ -1008,7 +1010,7 @@ body.dark-mode.pink-mode .help-content { border-color: var(--accent-color); }
 
 @media (prefers-color-scheme: dark) {
   body:not(.light-mode) {
-    background-color: #121212;
+    background-color: var(--bg-color-dark);
     color: #f0f0f0;
   }
   body:not(.light-mode) h1,
@@ -1264,7 +1266,7 @@ body.dark-mode.pink-mode .help-content { border-color: var(--accent-color); }
   --accent-color: #ff69b4;
 }
 #overviewDialogContent.dark-mode {
-  background-color: #121212;
+  background-color: var(--bg-color-dark);
   color: #f0f0f0;
 }
 #overviewDialogContent.dark-mode h1,
@@ -1277,7 +1279,7 @@ body.dark-mode.pink-mode .help-content { border-color: var(--accent-color); }
   background-color: #333;
 }
 #overviewDialogContent.dark-mode tr:nth-child(even) {
-  background-color: #1a1a1a;
+  background-color: #1e1e1e;
 }
 #overviewDialogContent.dark-mode .device-category {
   background: #1e1e1e;


### PR DESCRIPTION
## Summary
- define CSS variables for light and dark background colors
- update theme-color meta via `updateThemeColor` using CSS variables and unify dark mode color to `#121212`
- sync manifest and index meta with consistent theme color

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b3ed6aced483208a56ec51351f84b0