### PR TITLE
fix: align dark mode theme color

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
   <meta property="og:description" content="Plan your camera setup and calculate power consumption &amp; battery life." />
   <meta property="og:type" content="website" />
   <meta property="og:image" content="icon.png" />
-  <meta name="theme-color" content="#1a1a1a" />
+  <meta name="theme-color" content="#ffffff" />
   <title>Camera Power Planner</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/script.js
+++ b/script.js
@@ -6212,7 +6212,7 @@ if (setupNameInput) setupNameInput.addEventListener("input", saveCurrentSession)
 function updateThemeColor(isDark) {
   const meta = document.querySelector('meta[name="theme-color"]');
   if (meta) {
-    meta.setAttribute('content', isDark ? '#1a1a1a' : '#ffffff');
+    meta.setAttribute('content', isDark ? '#121212' : '#ffffff');
   }
 }
 


### PR DESCRIPTION
## Summary
- Align dark mode `theme-color` meta tag with site's dark background
- Update `updateThemeColor` helper to use consistent `#121212` dark color

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3ed73bd248320991b6765709d7027