### PR TITLE
Optimize connector summarization performance

### DIFF
--- a/script.js
+++ b/script.js
@@ -5709,24 +5709,26 @@ if (runtimeFeedbackBtn && feedbackDialog && feedbackForm) {
   });
 }
 
+const escapeDiv = document.createElement('div');
 function escapeHtml(str) {
-    const div = document.createElement('div');
-    div.textContent = str;
-    return div.innerHTML;
+    escapeDiv.textContent = str;
+    return escapeDiv.innerHTML;
 }
 
 
 function summarizeByType(list) {
     const counts = {};
-    (list || []).forEach(it => {
+    if (!Array.isArray(list)) return counts;
+    for (const it of list) {
         if (it && it.type) {
             counts[it.type] = (counts[it.type] || 0) + 1;
         }
-    });
+    }
     return counts;
 }
 
 function connectorBlocks(items, icon, cls = 'neutral-conn', label = '', dir = '') {
+    if (!Array.isArray(items) || items.length === 0) return '';
     const counts = summarizeByType(items);
     const entries = Object.entries(counts).map(([type, count]) => {
         return `${escapeHtml(type)}${count > 1 ? ` ×${count}` : ''}`;
@@ -6222,7 +6224,7 @@ if (setupNameInput) setupNameInput.addEventListener("input", saveCurrentSession)
 function updateThemeColor(isDark) {
   const meta = document.querySelector('meta[name="theme-color"]');
   if (meta) {
-    meta.setAttribute('content', isDark ? '#121212' : '#ffffff');
+    meta.setAttribute('content', isDark ? '#1a1a1a' : '#ffffff');
   }
 }
 


### PR DESCRIPTION
## Summary
- reuse a single DOM element for HTML escaping to reduce allocations
- streamline connector summarization with iterative loops and early exits
- align dark mode meta theme color with expected value

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b3ef860d7483208bb349b28870b7e0