### PR TITLE
Fix top background color

### DIFF
--- a/script.js
+++ b/script.js
@@ -6245,7 +6245,7 @@ if (setupNameInput) setupNameInput.addEventListener("input", saveCurrentSession)
 function updateThemeColor(isDark) {
   const meta = document.querySelector('meta[name="theme-color"]');
   if (meta) {
-    meta.setAttribute('content', isDark ? '#1a1a1a' : '#ffffff');
+    meta.setAttribute('content', isDark ? '#121212' : '#ffffff');
   }
 }
 

--- a/style.css
+++ b/style.css
@@ -21,7 +21,8 @@ body {
 body {
   font-family: system-ui, sans-serif;
   font-weight: 400;
-  margin: 20px auto;
+  margin: 0 auto;
+  padding: 20px 0;
   max-width: 1200px;
   background-color: #ffffff;
   color: #000000;
@@ -31,9 +32,9 @@ body {
 @supports (padding: env(safe-area-inset-top)) {
   body {
     padding:
-      env(safe-area-inset-top)
+      calc(env(safe-area-inset-top) + 20px)
       env(safe-area-inset-right)
-      env(safe-area-inset-bottom)
+      calc(env(safe-area-inset-bottom) + 20px)
       env(safe-area-inset-left);
   }
 }


### PR DESCRIPTION
## Summary
- Prevent top margin from showing a different background color by switching body margin to padding and accounting for safe areas
- Correct dark mode theme color to match page background

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b3f56dcef4832089985e057d540945