### PR TITLE
feat: highlight help search matches

### DIFF
--- a/script.js
+++ b/script.js
@@ -6245,7 +6245,7 @@ if (setupNameInput) setupNameInput.addEventListener("input", saveCurrentSession)
 function updateThemeColor(isDark) {
   const meta = document.querySelector('meta[name="theme-color"]');
   if (meta) {
-    meta.setAttribute('content', isDark ? '#1a1a1a' : '#ffffff');
+    meta.setAttribute('content', isDark ? '#121212' : '#ffffff');
   }
 }
 
@@ -6415,9 +6415,19 @@ if (helpButton && helpDialog) {
     const items = Array.from(helpDialog.querySelectorAll('.faq-item'));
     const elements = sections.concat(items);
     let anyVisible = false;
+    const escapeRegExp = str => str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const regex = query ? new RegExp(`(${escapeRegExp(query)})`, 'ig') : null;
     elements.forEach(el => {
+      if (!el.dataset.origHtml) {
+        el.dataset.origHtml = el.innerHTML;
+      } else {
+        el.innerHTML = el.dataset.origHtml;
+      }
       const text = el.textContent.toLowerCase();
       if (!query || text.includes(query)) {
+        if (query && regex) {
+          el.innerHTML = el.innerHTML.replace(regex, '<mark>$1</mark>');
+        }
         el.removeAttribute('hidden');
         anyVisible = true;
       } else {

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -1395,9 +1395,11 @@ describe('script.js functions', () => {
     const helpNoResults = document.getElementById('helpNoResults');
 
     document.dispatchEvent(new KeyboardEvent('keydown', { key: 'F1' }));
-    helpSearch.value = 'nonexistent';
+    helpSearch.value = 'battery';
     helpSearch.dispatchEvent(new Event('input', { bubbles: true }));
     expect(helpSearchClear.hasAttribute('hidden')).toBe(false);
+    const mark = helpDialog.querySelector('mark');
+    expect(mark).not.toBeNull();
     helpSearchClear.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     expect(helpSearch.value).toBe('');
     const sections = helpDialog.querySelectorAll('[data-help-section]');
@@ -1405,6 +1407,7 @@ describe('script.js functions', () => {
     expect(visible.length).toBe(sections.length);
     expect(helpNoResults.hasAttribute('hidden')).toBe(true);
     expect(helpSearchClear.hasAttribute('hidden')).toBe(true);
+    expect(helpDialog.querySelector('mark')).toBeNull();
     expect(document.activeElement).toBe(helpSearch);
   });
 


### PR DESCRIPTION
## Summary
- highlight keywords in help search results for easier scanning
- fix dark mode theme color meta tag
- test help search highlighting

## Testing
- `npm run lint`
- `npm run check-consistency`
- `npx jest tests/script.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b3f5a68d1483208c124f3bd98e560a