### PR TITLE
Improve filter usability and theme color

### DIFF
--- a/script.js
+++ b/script.js
@@ -2970,6 +2970,19 @@ function attachSelectSearch(selectElem) {
   });
 }
 
+function bindFilterInput(inputElem, callback) {
+  if (!inputElem) {
+    return;
+  }
+  inputElem.addEventListener("input", callback);
+  inputElem.addEventListener("keydown", (e) => {
+    if (e.key === "Escape") {
+      inputElem.value = "";
+      callback();
+    }
+  });
+}
+
 function applyFilters() {
   filterSelect(cameraSelect, cameraFilterInput.value);
   filterSelect(monitorSelect, monitorFilterInput.value);
@@ -4640,21 +4653,21 @@ languageSelect.addEventListener("change", (event) => {
 });
 
 // Filtering inputs
-cameraFilterInput.addEventListener("input", () => filterSelect(cameraSelect, cameraFilterInput.value));
-monitorFilterInput.addEventListener("input", () => filterSelect(monitorSelect, monitorFilterInput.value));
-videoFilterInput.addEventListener("input", () => filterSelect(videoSelect, videoFilterInput.value));
-motorFilterInput.addEventListener("input", () => motorSelects.forEach(sel => filterSelect(sel, motorFilterInput.value)));
-controllerFilterInput.addEventListener("input", () => controllerSelects.forEach(sel => filterSelect(sel, controllerFilterInput.value)));
-distanceFilterInput.addEventListener("input", () => filterSelect(distanceSelect, distanceFilterInput.value));
-batteryFilterInput.addEventListener("input", () => filterSelect(batterySelect, batteryFilterInput.value));
+bindFilterInput(cameraFilterInput, () => filterSelect(cameraSelect, cameraFilterInput.value));
+bindFilterInput(monitorFilterInput, () => filterSelect(monitorSelect, monitorFilterInput.value));
+bindFilterInput(videoFilterInput, () => filterSelect(videoSelect, videoFilterInput.value));
+bindFilterInput(motorFilterInput, () => motorSelects.forEach(sel => filterSelect(sel, motorFilterInput.value)));
+bindFilterInput(controllerFilterInput, () => controllerSelects.forEach(sel => filterSelect(sel, controllerFilterInput.value)));
+bindFilterInput(distanceFilterInput, () => filterSelect(distanceSelect, distanceFilterInput.value));
+bindFilterInput(batteryFilterInput, () => filterSelect(batterySelect, batteryFilterInput.value));
 
-cameraListFilterInput.addEventListener("input", () => filterDeviceList(cameraListElem, cameraListFilterInput.value));
-monitorListFilterInput.addEventListener("input", () => filterDeviceList(monitorListElem, monitorListFilterInput.value));
-videoListFilterInput.addEventListener("input", () => filterDeviceList(videoListElem, videoListFilterInput.value));
-motorListFilterInput.addEventListener("input", () => filterDeviceList(motorListElem, motorListFilterInput.value));
-controllerListFilterInput.addEventListener("input", () => filterDeviceList(controllerListElem, controllerListFilterInput.value));
-distanceListFilterInput.addEventListener("input", () => filterDeviceList(distanceListElem, distanceListFilterInput.value));
-batteryListFilterInput.addEventListener("input", () => filterDeviceList(batteryListElem, batteryListFilterInput.value));
+bindFilterInput(cameraListFilterInput, () => filterDeviceList(cameraListElem, cameraListFilterInput.value));
+bindFilterInput(monitorListFilterInput, () => filterDeviceList(monitorListElem, monitorListFilterInput.value));
+bindFilterInput(videoListFilterInput, () => filterDeviceList(videoListElem, videoListFilterInput.value));
+bindFilterInput(motorListFilterInput, () => filterDeviceList(motorListElem, motorListFilterInput.value));
+bindFilterInput(controllerListFilterInput, () => filterDeviceList(controllerListElem, controllerListFilterInput.value));
+bindFilterInput(distanceListFilterInput, () => filterDeviceList(distanceListElem, distanceListFilterInput.value));
+bindFilterInput(batteryListFilterInput, () => filterDeviceList(batteryListElem, batteryListFilterInput.value));
 
 // Setup management
 saveSetupBtn.addEventListener("click", () => {
@@ -6245,7 +6258,7 @@ if (setupNameInput) setupNameInput.addEventListener("input", saveCurrentSession)
 function updateThemeColor(isDark) {
   const meta = document.querySelector('meta[name="theme-color"]');
   if (meta) {
-    meta.setAttribute('content', isDark ? '#1a1a1a' : '#ffffff');
+    meta.setAttribute('content', isDark ? '#121212' : '#ffffff');
   }
 }
 

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -341,6 +341,20 @@ describe('script.js functions', () => {
     expect(optionsB).not.toContain('VBatt');
   });
 
+  test('filter input clears on Escape key press', () => {
+    const camSel = document.getElementById('cameraSelect');
+    camSel.innerHTML = '<option value="CamA">CamA</option><option value="CamB">CamB</option>';
+
+    const filterInput = document.getElementById('cameraFilter');
+    filterInput.value = 'CamA';
+    filterInput.dispatchEvent(new Event('input'));
+    expect(camSel.options[1].hidden).toBe(true);
+
+    filterInput.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    expect(filterInput.value).toBe('');
+    expect(camSel.options[1].hidden).toBe(false);
+  });
+
   test('battery comparison excludes B-Mount when camera lacks support', () => {
     global.devices.cameras.NoPlateCam = { powerDrawWatts: 10 };
     global.devices.batteries.VBatt = { capacity: 100, pinA: 10, dtapA: 5, mount_type: 'V-Mount' };


### PR DESCRIPTION
## Summary
- Allow Escape key to clear any filter input for quick reset
- Align dark mode theme color with stylesheet for consistency
- Test Escape-based filter clearing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3f6261f9c8320a22877913cfdd245