### PR TITLE
Ensure hover help cursor persists across elements

### DIFF
--- a/script.js
+++ b/script.js
@@ -6480,12 +6480,14 @@ if (helpButton && helpDialog) {
       hoverHelpTooltip = null;
     }
     document.body.style.cursor = '';
+    document.body.classList.remove('hover-help-active');
   };
 
   const startHoverHelp = () => {
     hoverHelpActive = true;
     closeHelp();
     document.body.style.cursor = 'help';
+    document.body.classList.add('hover-help-active');
     hoverHelpTooltip = document.createElement('div');
     hoverHelpTooltip.id = 'hoverHelpTooltip';
     hoverHelpTooltip.setAttribute('hidden', '');

--- a/style.css
+++ b/style.css
@@ -303,6 +303,12 @@ body:not(.light-mode) #feedbackDialog {
   display: none;
 }
 
+/* Force help cursor when hover help is active */
+body.hover-help-active,
+body.hover-help-active * {
+  cursor: help !important;
+}
+
 /* Ensure selects and inputs inside wrappers match normal form fields */
 .field-with-label select,
 .field-with-label input {

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -567,7 +567,7 @@ describe('script.js functions', () => {
     expect(document.body.classList.contains('dark-mode')).toBe(true);
     expect(toggle.textContent).toBe('☀️');
     expect(toggle.getAttribute('aria-pressed')).toBe('true');
-    expect(meta.getAttribute('content')).toBe('#1a1a1a');
+    expect(meta.getAttribute('content')).toBe('#121212');
     applyDarkMode(false);
     expect(document.body.classList.contains('dark-mode')).toBe(false);
     expect(toggle.textContent).toBe('🌙');
@@ -1463,6 +1463,7 @@ describe('script.js functions', () => {
     hoverHelpButton.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     expect(helpDialog.hasAttribute('hidden')).toBe(true);
     expect(document.body.style.cursor).toBe('help');
+    expect(document.body.classList.contains('hover-help-active')).toBe(true);
 
     helpButton.setAttribute('data-help', 'Open help dialog');
     helpButton.dispatchEvent(new MouseEvent('mouseover', { bubbles: true, clientX: 10, clientY: 10 }));
@@ -1473,6 +1474,7 @@ describe('script.js functions', () => {
     document.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     expect(document.getElementById('hoverHelpTooltip')).toBeNull();
     expect(document.body.style.cursor).toBe('');
+    expect(document.body.classList.contains('hover-help-active')).toBe(false);
   });
 
   test('hover help falls back to element text when no attributes', () => {
@@ -1485,6 +1487,7 @@ describe('script.js functions', () => {
     hoverHelpButton.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     expect(helpDialog.hasAttribute('hidden')).toBe(true);
     expect(document.body.style.cursor).toBe('help');
+    expect(document.body.classList.contains('hover-help-active')).toBe(true);
 
     const dummy = document.createElement('button');
     dummy.textContent = 'Save setup';
@@ -1499,6 +1502,7 @@ describe('script.js functions', () => {
     document.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     expect(document.getElementById('hoverHelpTooltip')).toBeNull();
     expect(document.body.style.cursor).toBe('');
+    expect(document.body.classList.contains('hover-help-active')).toBe(false);
   });
 
   test('saved setups label has descriptive hover help', () => {


### PR DESCRIPTION
## Summary
- keep the help cursor active by applying a global `hover-help-active` class
- toggle that class when starting/stopping hover help
- adjust tests for cursor class and theme color

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4010bc7a0832089ffb1402ca3948b