### PR TITLE
Document hover help mode in help dialog and README

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -18,7 +18,7 @@ You can switch the language in the top right corner. The choice is remembered fo
 ## 🆕 Recent Features
 - Interactive setup diagram that lets you drag devices, zoom, snap nodes to a grid and export the layout as SVG or JPG.
 - Playful pink accent theme that persists between visits.
-- Searchable help dialog with step-by-step sections and a FAQ.
+- Searchable help dialog with step-by-step sections, FAQ and an optional hover help mode.
 - Support for cameras with both V- and B-Mount battery plates.
 - Submit user runtime feedback with temperature for better estimates.
 - Visual runtime weighting dashboard to inspect how settings influence each report, now sorted by weight and showing exact share percentages.

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Recent updates include:
 
 - **Interactive setup diagram** – drag devices, zoom with dedicated controls, optionally snap nodes to a grid, and export the layout as SVG or JPG.
 - **Pink accent theme** – toggle a playful pink highlight that persists between visits or press **P** to switch quickly.
-- **Searchable help dialog** – open with the ? button or keyboard shortcuts, filter topics instantly and browse the built-in FAQ.
+- **Searchable help dialog** – open with the ? button or keyboard shortcuts, filter topics instantly, browse the built-in FAQ and enable a hover help mode for quick tooltips.
 - **Dual V‑/B‑Mount support** – choose between plate types on supported cameras and the battery list updates automatically.
 - **User runtime feedback** – submit real-world runtimes with environment details to refine estimates.
 - **Visual runtime weighting dashboard** – see how temperature, resolution, frame rate and codec affect each runtime report, now sorted by weight with exact share percentages.
@@ -53,7 +53,7 @@ See the language-specific README files for full details.
 - Visualize power and video connections with an interactive diagram.
 - Customize the device database with your own gear.
 - Switch languages, toggle dark or playful pink themes, and swap between V‑ and B‑Mount plates on supported cameras.
-- Works completely offline and offers a searchable help dialog.
+- Works completely offline and offers a searchable help dialog with an optional hover help mode.
 
 ## Runtime Data Weighting
 

--- a/index.html
+++ b/index.html
@@ -529,6 +529,7 @@
             <li>Compare battery runtimes and check against safe output limits.</li>
             <li>Customize the device database with your own gear.</li>
             <li>Open a searchable help dialog with step-by-step guides and FAQ.</li>
+            <li>Activate a hover help mode to reveal brief explanations by moving the cursor over controls.</li>
             <li>Switch languages, toggle dark or playful pink themes and work fully offline. Theme settings persist.</li>
             <li>Cameras with both V- and B-Mount plates let you swap battery types; the list updates automatically.</li>
           </ul>
@@ -636,6 +637,7 @@
           <ul>
             <li>Open with the <strong>?</strong> button or press <kbd>?</kbd>, <kbd>H</kbd> or <kbd>F1</kbd>.</li>
             <li>Use the search field to filter topics; the query resets when closed.</li>
+            <li>Click "Hover for help" to close the dialog and reveal tooltips when you move the cursor over controls.</li>
             <li>Close the dialog with <kbd>Escape</kbd> or by clicking outside.</li>
           </ul>
         </section>


### PR DESCRIPTION
## Summary
- Mention hover help mode in the main feature list and help dialog instructions
- Highlight optional hover help in the main and English README files for quick tooltips

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b402d34fc88320848ac704f8c39cae