### PR TITLE
Fix hover help showing dropdown contents

### DIFF
--- a/script.js
+++ b/script.js
@@ -6548,7 +6548,6 @@ if (helpButton && helpDialog) {
       }
     }
     if (!text) text = el.getAttribute('alt');
-    if (!text) text = el.textContent.trim();
     if (!text) {
       hoverHelpTooltip.setAttribute('hidden', '');
       return;

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -1494,7 +1494,7 @@ describe('script.js functions', () => {
     expect(document.body.classList.contains('hover-help-active')).toBe(false);
   });
 
-  test('hover help falls back to element text when no attributes', () => {
+  test('hover help ignores elements without descriptive attributes', () => {
     const helpDialog = document.getElementById('helpDialog');
     const hoverHelpButton = document.getElementById('hoverHelpButton');
 
@@ -1514,7 +1514,7 @@ describe('script.js functions', () => {
       new MouseEvent('mouseover', { bubbles: true, clientX: 10, clientY: 10 })
     );
     const tooltip = document.getElementById('hoverHelpTooltip');
-    expect(tooltip.textContent).toBe('Save setup');
+    expect(tooltip.hasAttribute('hidden')).toBe(true);
 
     document.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     expect(document.getElementById('hoverHelpTooltip')).toBeNull();


### PR DESCRIPTION
## Summary
- prevent hover help from showing raw dropdown options by skipping textContent fallback
- adjust hover help test to ignore elements without descriptive text

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b40325e6248320948d82fb8433321b