### PR TITLE
feat: add global filter reset

### DIFF
--- a/index.html
+++ b/index.html
@@ -70,6 +70,7 @@
 
   <section id="setup-config">
     <h2 id="deviceSelectionHeading">Device Selection</h2>
+    <button id="clearFiltersBtn" aria-label="Clear All Filters" title="Clear All Filters">&times;</button>
       <div class="form-row">
         <label for="cameraSelect" id="cameraLabel">Camera:</label>
         <div class="select-wrapper">

--- a/script.js
+++ b/script.js
@@ -963,6 +963,10 @@ function setLanguage(lang) {
   batteryPlateLabelElem.setAttribute("data-help", texts[lang].batteryPlateSelectHelp);
 
   updateBatteryLabel();
+  clearFiltersBtn.textContent = "\u00d7";
+  clearFiltersBtn.setAttribute("aria-label", texts[lang].clearFiltersBtn);
+  clearFiltersBtn.setAttribute("title", texts[lang].clearFiltersBtn);
+  clearFiltersBtn.setAttribute("data-help", texts[lang].clearFiltersHelp);
   // FIZ legend
   document.getElementById("fizLegend").textContent = texts[lang].fizLegend;
   document.querySelectorAll('#motorNotesLabel,#controllerNotesLabel,#distanceNotesLabel').forEach(el => {
@@ -1244,6 +1248,7 @@ const setupNameInput  = document.getElementById("setupName");
 const saveSetupBtn    = document.getElementById("saveSetupBtn");
 const deleteSetupBtn  = document.getElementById("deleteSetupBtn");
 const clearSetupBtn   = document.getElementById("clearSetupBtn");
+const clearFiltersBtn = document.getElementById("clearFiltersBtn");
 const shareSetupBtn   = document.getElementById("shareSetupBtn");
 const sharedLinkRow   = document.getElementById("sharedLinkRow");
 const sharedLinkInput = document.getElementById("sharedLinkInput");
@@ -2989,6 +2994,20 @@ function bindFilterInput(inputElem, callback) {
   });
 }
 
+function clearAllFilters() {
+  [cameraFilterInput, monitorFilterInput, videoFilterInput, motorFilterInput,
+   controllerFilterInput, distanceFilterInput, batteryFilterInput].forEach(input => {
+    if (input) input.value = "";
+  });
+  filterSelect(cameraSelect, "");
+  filterSelect(monitorSelect, "");
+  filterSelect(videoSelect, "");
+  motorSelects.forEach(sel => filterSelect(sel, ""));
+  controllerSelects.forEach(sel => filterSelect(sel, ""));
+  filterSelect(distanceSelect, "");
+  filterSelect(batterySelect, "");
+}
+
 function applyFilters() {
   filterSelect(cameraSelect, cameraFilterInput.value);
   filterSelect(monitorSelect, monitorFilterInput.value);
@@ -4666,6 +4685,8 @@ bindFilterInput(motorFilterInput, () => motorSelects.forEach(sel => filterSelect
 bindFilterInput(controllerFilterInput, () => controllerSelects.forEach(sel => filterSelect(sel, controllerFilterInput.value)));
 bindFilterInput(distanceFilterInput, () => filterSelect(distanceSelect, distanceFilterInput.value));
 bindFilterInput(batteryFilterInput, () => filterSelect(batterySelect, batteryFilterInput.value));
+
+clearFiltersBtn.addEventListener("click", clearAllFilters);
 
 bindFilterInput(cameraListFilterInput, () => filterDeviceList(cameraListElem, cameraListFilterInput.value));
 bindFilterInput(monitorListFilterInput, () => filterDeviceList(monitorListElem, monitorListFilterInput.value));
@@ -6694,5 +6715,6 @@ if (typeof module !== "undefined" && module.exports) {
     normalizePowerPortType,
     getCurrentSetupKey,
     renderFeedbackTable,
+    clearAllFilters,
   };
 }

--- a/style.css
+++ b/style.css
@@ -356,6 +356,18 @@ select {
   appearance: none;
 }
 
+#clearFiltersBtn {
+  float: right;
+  background: transparent;
+  border: none;
+  font-size: 1.2em;
+  cursor: pointer;
+}
+
+#setup-config .form-row:first-of-type {
+  clear: both;
+}
+
 /* Specific style for the setupSelect dropdown */
 #setupSelect {
   flex: 1; /* Allow it to grow */

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -355,6 +355,25 @@ describe('script.js functions', () => {
     expect(camSel.options[1].hidden).toBe(false);
   });
 
+  test('clear filters button resets all filter fields', () => {
+    const camSel = document.getElementById('cameraSelect');
+    camSel.innerHTML = '<option value="CamA">CamA</option><option value="CamB">CamB</option>';
+
+    const ids = ['cameraFilter','monitorFilter','videoFilter','motorFilter','controllerFilter','distanceFilter','batteryFilter'];
+    ids.forEach(id => {
+      const inp = document.getElementById(id);
+      inp.value = 'x';
+      inp.dispatchEvent(new Event('input'));
+    });
+
+    document.getElementById('clearFiltersBtn').click();
+
+    ids.forEach(id => {
+      expect(document.getElementById(id).value).toBe('');
+    });
+    expect(camSel.options[1].hidden).toBe(false);
+  });
+
   test('battery comparison excludes B-Mount when camera lacks support', () => {
     global.devices.cameras.NoPlateCam = { powerDrawWatts: 10 };
     global.devices.batteries.VBatt = { capacity: 100, pinA: 10, dtapA: 5, mount_type: 'V-Mount' };

--- a/translations.js
+++ b/translations.js
@@ -33,6 +33,7 @@ const texts = {
     deleteSetupBtn: "Delete",
     saveSetupBtn: "Save",
     clearSetupBtn: "Clear Current Setup",
+    clearFiltersBtn: "Clear All Filters",
     shareSetupBtn: "Share Setup Link",
     shareSetupPrompt: "Copy this link to share your setup:",
     shareLinkCopied: "Link copied to clipboard.",
@@ -271,6 +272,7 @@ const texts = {
     batterySelectHelp: "Choose the battery model that will power the entire rig.",
     batteryPlateSelectHelp: "Choose the battery plate or adapter that connects the battery to the camera.",
     clearSetupHelp: "Reset the planner by removing every selected device.",
+    clearFiltersHelp: "Remove text from all filter fields to show all options.",
     runtimeFeedbackBtnHelp:
       "Open a form where you can submit real-world runtime data for this configuration.",
     zoomOutHelp: "Zoom out of the setup diagram to view more of the layout.",
@@ -318,6 +320,7 @@ const texts = {
     deleteSetupBtn: "Eliminare",
     saveSetupBtn: "Salva",
     clearSetupBtn: "Cancella configurazione corrente",
+    clearFiltersBtn: "Cancella tutti i filtri",
     shareSetupBtn: "Condividi link della configurazione",
     shareSetupPrompt: "Copia questo link per condividere la configurazione:",
     shareLinkCopied: "Link copiato negli appunti.",
@@ -534,6 +537,8 @@ const texts = {
     batteryPlateSelectHelp: "Seleziona la piastra o l'adattatore della batteria.",
     clearSetupHelp:
       "Rimuove tutti i dispositivi dalla configurazione corrente.",
+    clearFiltersHelp:
+      "Rimuove il testo da tutti i campi filtro per mostrare tutte le opzioni.",
     runtimeFeedbackBtnHelp:
       "Invia il runtime misurato per questa configurazione.",
     zoomOutHelp: "Allontana il diagramma di configurazione.",
@@ -580,6 +585,7 @@ const texts = {
     deleteSetupBtn: "Eliminar",
     saveSetupBtn: "Guardar",
     clearSetupBtn: "Borrar configuración actual",
+    clearFiltersBtn: "Limpiar todos los filtros",
     shareSetupBtn: "Compartir enlace de configuración",
     shareSetupPrompt: "Copia este enlace para compartir tu configuración:",
     shareLinkCopied: "Enlace copiado al portapapeles.",
@@ -811,6 +817,8 @@ const texts = {
     batteryPlateSelectHelp: "Selecciona la placa o adaptador de batería.",
     clearSetupHelp:
       "Borra todos los dispositivos de la configuración actual.",
+    clearFiltersHelp:
+      "Borra el texto de todos los campos de filtro para mostrar todas las opciones.",
     runtimeFeedbackBtnHelp:
       "Envía tu tiempo de funcionamiento medido para esta configuración.",
     zoomOutHelp: "Alejar el diagrama de configuración.",
@@ -858,6 +866,7 @@ const texts = {
     deleteSetupBtn: "Supprimer",
     saveSetupBtn: "Enregistrer",
     clearSetupBtn: "Effacer la configuration actuelle",
+    clearFiltersBtn: "Effacer tous les filtres",
     shareSetupBtn: "Partager le lien de configuration",
     shareSetupPrompt: "Copiez ce lien pour partager votre configuration :",
     shareLinkCopied: "Lien copié dans le presse-papiers.",
@@ -1091,6 +1100,8 @@ const texts = {
       "Sélectionnez la plaque ou l'adaptateur de batterie utilisé.",
     clearSetupHelp:
       "Efface tous les appareils de la configuration actuelle.",
+    clearFiltersHelp:
+      "Supprime le texte de tous les champs de filtre pour afficher toutes les options.",
     runtimeFeedbackBtnHelp:
       "Soumettez votre durée mesurée pour cette configuration.",
     zoomOutHelp: "Réduit le diagramme de configuration.",
@@ -1138,6 +1149,7 @@ const texts = {
     deleteSetupBtn: "Löschen",
     saveSetupBtn: "Speichern",
     clearSetupBtn: "Aktuelles Setup zurücksetzen",
+    clearFiltersBtn: "Alle Filter zurücksetzen",
     shareSetupBtn: "Link zum Setup teilen",
     shareSetupPrompt: "Diesen Link kopieren, um das Setup zu teilen:",
     shareLinkCopied: "Link in die Zwischenablage kopiert.",
@@ -1368,6 +1380,8 @@ const texts = {
     batteryPlateSelectHelp: "Wähle die Batterieplatte oder den Adapter aus.",
     clearSetupHelp:
       "Entfernt alle Geräte aus der aktuellen Konfiguration.",
+    clearFiltersHelp:
+      "Entfernt den Text aus allen Filterfeldern, um wieder alle Optionen anzuzeigen.",
     runtimeFeedbackBtnHelp:
       "Sende deine gemessene Laufzeit für diese Konfiguration.",
     zoomOutHelp: "Verkleinert das Setup-Diagramm.",


### PR DESCRIPTION
## Summary
- add a Clear All Filters button to Device Selection
- reset all device filters at once and translate button text
- replace button text with right-aligned X icon for compact layout

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b402ce066483208915f0315810606a