### PR TITLE
feat(storage): support renaming setups

### DIFF
--- a/storage.js
+++ b/storage.js
@@ -128,6 +128,24 @@ function deleteSetup(name) {
   saveSetups(setups);
 }
 
+function renameSetup(oldName, newName) {
+  const setups = loadSetups();
+  if (!Object.prototype.hasOwnProperty.call(setups, oldName)) {
+    return null;
+  }
+  if (oldName === newName) {
+    return newName;
+  }
+  let target = newName;
+  let suffix = 2;
+  while (Object.prototype.hasOwnProperty.call(setups, target)) {
+    target = `${newName} (${suffix++})`;
+  }
+  setups[target] = setups[oldName];
+  delete setups[oldName];
+  saveSetups(setups);
+  return target;
+}
 // --- User Feedback Storage ---
 function loadFeedback() {
   try {
@@ -175,6 +193,7 @@ if (typeof module !== "undefined" && module.exports) {
     saveSetup,
     loadSetup,
     deleteSetup,
+    renameSetup,
     loadSessionState,
     saveSessionState,
     loadFeedback,

--- a/tests/storage.test.js
+++ b/tests/storage.test.js
@@ -3,14 +3,15 @@ const {
   saveDeviceData,
   loadSetups,
   saveSetups,
-  saveSetup,
-  loadSetup,
-  deleteSetup,
-  loadSessionState,
-  saveSessionState,
-  loadFeedback,
-  saveFeedback,
-  clearAllData,
+    saveSetup,
+    loadSetup,
+    deleteSetup,
+    renameSetup,
+    loadSessionState,
+    saveSessionState,
+    loadFeedback,
+    saveFeedback,
+    clearAllData,
 } = require('../storage');
 
 const DEVICE_KEY = 'cameraPowerPlanner_devices';
@@ -124,13 +125,36 @@ describe('setup storage', () => {
     expect(loadSetup('A')).toEqual({foo:1});
   });
 
-  test('deleteSetup removes named setup', () => {
-    const setups = {A:{foo:1}, B:{bar:2}};
-    localStorage.setItem(SETUP_KEY, JSON.stringify(setups));
-    deleteSetup('A');
-    expect(JSON.parse(localStorage.getItem(SETUP_KEY))).toEqual({B:{bar:2}});
+    test('deleteSetup removes named setup', () => {
+      const setups = {A:{foo:1}, B:{bar:2}};
+      localStorage.setItem(SETUP_KEY, JSON.stringify(setups));
+      deleteSetup('A');
+      expect(JSON.parse(localStorage.getItem(SETUP_KEY))).toEqual({B:{bar:2}});
+    });
+
+    test('renameSetup renames setup to a new unique name', () => {
+      const setups = {A:{foo:1}, B:{bar:2}};
+      localStorage.setItem(SETUP_KEY, JSON.stringify(setups));
+      const newName = renameSetup('A', 'C');
+      expect(newName).toBe('C');
+      expect(JSON.parse(localStorage.getItem(SETUP_KEY))).toEqual({C:{foo:1}, B:{bar:2}});
+    });
+
+    test('renameSetup appends suffix when target exists', () => {
+      const setups = {A:{foo:1}, C:{bar:2}};
+      localStorage.setItem(SETUP_KEY, JSON.stringify(setups));
+      const newName = renameSetup('A', 'C');
+      expect(newName).toBe('C (2)');
+      expect(JSON.parse(localStorage.getItem(SETUP_KEY))).toEqual({'C (2)':{foo:1}, C:{bar:2}});
+    });
+
+    test('renameSetup returns null when original missing', () => {
+      localStorage.setItem(SETUP_KEY, JSON.stringify({A:{foo:1}}));
+      const result = renameSetup('B', 'C');
+      expect(result).toBeNull();
+      expect(JSON.parse(localStorage.getItem(SETUP_KEY))).toEqual({A:{foo:1}});
+    });
   });
-});
 
 describe('session state storage', () => {
   beforeEach(() => {


### PR DESCRIPTION
## Summary
- allow renaming stored setups while avoiding name collisions
- cover setup rename behaviour with new tests

## Testing
- `npm run lint`
- `npm run check-consistency`
- `CI=true npx jest tests/storage.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68b40dfb1568832081276e13cedd80a3