### PR TITLE
Fix hover help to avoid dropdown content popups

### DIFF
--- a/script.js
+++ b/script.js
@@ -6591,11 +6591,13 @@ if (helpButton && helpDialog) {
 
   document.addEventListener('mouseover', e => {
     if (!hoverHelpActive || !hoverHelpTooltip) return;
-    const el =
-      e.target.closest(
-        '[data-help], [aria-label], [title], [aria-labelledby], [alt]' +
-          ', button, a, input, select, textarea, label'
-      ) || e.target;
+    const el = e.target.closest(
+      '[data-help], [aria-label], [title], [aria-labelledby], [alt]'
+    );
+    if (!el) {
+      hoverHelpTooltip.setAttribute('hidden', '');
+      return;
+    }
     let text =
       el.getAttribute('data-help') ||
       el.getAttribute('aria-label') ||
@@ -6604,7 +6606,12 @@ if (helpButton && helpDialog) {
       const labelled = el.getAttribute('aria-labelledby');
       if (labelled) {
         const labelEl = document.getElementById(labelled);
-        if (labelEl) text = labelEl.textContent.trim();
+        if (labelEl)
+          text =
+            labelEl.getAttribute('data-help') ||
+            labelEl.getAttribute('aria-label') ||
+            labelEl.getAttribute('title') ||
+            labelEl.textContent.trim();
       }
     }
     if (!text) text = el.getAttribute('alt');

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -1579,6 +1579,19 @@ describe('script.js functions', () => {
     document.dispatchEvent(new MouseEvent('click', { bubbles: true }));
   });
 
+  test('hover help uses label help text for aria-labelledby controls', () => {
+    const hoverHelpButton = document.getElementById('hoverHelpButton');
+    const cameraSelect = document.getElementById('cameraSelect');
+
+    hoverHelpButton.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    cameraSelect.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
+
+    const tooltip = document.getElementById('hoverHelpTooltip');
+    expect(tooltip.textContent).toBe(texts.en.cameraSelectHelp);
+
+    document.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+  });
+
   test('saved setups label has descriptive hover help', () => {
     const label = document.getElementById('savedSetupsLabel');
     expect(label.getAttribute('data-help')).toBe(texts.en.setupSelectHelp);


### PR DESCRIPTION
## Summary
- show hover help text from label attributes instead of label text
- add regression test for aria-labelledby hover help

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b410ccfdd48320a1d885e8967e5675