### PR TITLE
Document comprehensive hover help

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -19,6 +19,7 @@ Die Sprache kann oben rechts umgeschaltet werden und wird für den nächsten Bes
 - Interaktives Setup-Diagramm, mit dem Geräte verschoben, gezoomt und als SVG oder JPG exportiert werden können.
 - Verspieltes pinkes Akzent-Thema, das zwischen Besuchen erhalten bleibt.
 - Durchsuchbarer Hilfedialog mit Schritt-für-Schritt-Anleitung und FAQ.
+- Kontextbezogene Hover-Hilfe für Schaltflächen, Felder, Dropdowns und Überschriften.
 - Unterstützung für Kameras mit V- und B-Mount-Akkuplatten.
 
 ---

--- a/README.en.md
+++ b/README.en.md
@@ -19,6 +19,7 @@ You can switch the language in the top right corner. The choice is remembered fo
 - Interactive setup diagram that lets you drag devices, zoom, snap nodes to a grid and export the layout as SVG or JPG.
 - Playful pink accent theme that persists between visits.
 - Searchable help dialog with step-by-step sections and a FAQ.
+- Contextual hover help for buttons, fields, dropdowns and headers.
 - Support for cameras with both V- and B-Mount battery plates.
 - Submit user runtime feedback with temperature for better estimates.
 - Visual runtime weighting dashboard to inspect how settings influence each report, now sorted by weight and showing exact share percentages.

--- a/README.es.md
+++ b/README.es.md
@@ -19,6 +19,7 @@ El idioma puede cambiarse en la esquina superior derecha y se recuerda para la p
 - Diagrama de configuración interactivo que permite arrastrar dispositivos, hacer zoom y exportar el diseño en SVG o JPG.
 - Tema rosa divertido que se mantiene entre visitas.
 - Diálogo de ayuda con búsqueda, secciones paso a paso y una FAQ.
+- Ayuda contextual al pasar el cursor por botones, campos, menús desplegables y encabezados.
 - Compatibilidad con cámaras que aceptan placas de batería V y B‑Mount.
 
 ---

--- a/README.fr.md
+++ b/README.fr.md
@@ -19,6 +19,7 @@ La langue se change en haut à droite et est mémorisée pour la prochaine visit
 - Diagramme interactif de configuration permettant de faire glisser les appareils, de zoomer et d'exporter la mise en page en SVG ou JPG.
 - Thème rose ludique qui persiste entre les visites.
 - Fenêtre d'aide consultable avec sections pas à pas et FAQ.
+- Aide contextuelle au survol pour les boutons, champs, menus déroulants et en-têtes.
 - Prise en charge des caméras avec plaques batterie V et B‑Mount.
 
 ---

--- a/README.it.md
+++ b/README.it.md
@@ -18,6 +18,7 @@ Puoi cambiare lingua nell'angolo in alto a destra. La scelta viene memorizzata p
 - Diagramma interattivo della configurazione che consente di trascinare i dispositivi, zoomare ed esportare il layout in SVG o JPG.
 - Tema rosa giocoso che persiste tra una visita e l'altra.
 - Finestra di aiuto ricercabile con sezioni passo passo e FAQ.
+- Aiuto contestuale al passaggio del mouse su pulsanti, campi, menu a discesa e intestazioni.
 - Supporto per fotocamere con piastre batteria V e B‑Mount.
 
 ---

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Recent updates include:
 
 - **Interactive setup diagram** – drag devices, zoom, snap nodes to a grid, and export layouts as SVG or JPG.
 - **Pink accent theme** – toggle a playful pink highlight that persists between visits or press **P** to switch quickly.
-- **Searchable help dialog** – open with ? or keyboard shortcuts, filter topics instantly and browse the built-in FAQ.
+- **Searchable help dialog and hover hints** – open with ? or keyboard shortcuts, filter topics instantly, browse the built-in FAQ, and hover over any button, field, dropdown or header for a quick explanation.
 - **Dual V‑/B‑Mount support** – choose between plate types on supported cameras and the battery list updates automatically.
 - **User runtime feedback** – submit real-world runtimes with environment details to refine estimates.
 - **Visual runtime weighting dashboard** – see how temperature, resolution, frame rate and codec affect each runtime report, now sorted by weight with exact share percentages.
@@ -55,7 +55,7 @@ See the language-specific README files for full details.
 - Visualize power and video connections with an interactive diagram.
 - Customize the device database with your own gear.
 - Switch languages, toggle dark or playful pink themes, and swap between V‑ and B‑Mount plates on supported cameras.
-- Works completely offline and offers a searchable help dialog.
+- Works completely offline and offers a searchable help dialog with hover help for every button, field, dropdown and header.
 
 ## Runtime Data Weighting
 

--- a/translations.js
+++ b/translations.js
@@ -256,7 +256,7 @@ const texts = {
     helpSearchClearHelp: "Clear the search box and show all help topics again.",
     hoverHelpButtonLabel: "Hover for help",
     hoverHelpButtonHelp:
-      "Activate hover help so moving the cursor over buttons and labels reveals brief explanations.",
+      "Activate hover help so moving the cursor over buttons, fields, dropdowns or headers reveals brief explanations.",
     setupSelectHelp:
       "Pick a previously saved configuration or select '-- New Setup --' to start from scratch.",
     setupNameHelp:
@@ -537,7 +537,7 @@ const texts = {
     helpSearchClearHelp: "Cancella la ricerca corrente.",
     hoverHelpButtonLabel: "Passa il mouse per aiuto",
     hoverHelpButtonHelp:
-      "Attiva la modalità di aiuto al passaggio e sposta il cursore sugli elementi per saperne di più.",
+      "Attiva l'aiuto al passaggio del mouse così, spostando il cursore su pulsanti, campi, menu a discesa o intestazioni, vengono mostrate brevi spiegazioni.",
     setupSelectHelp:
       "Scegli una configurazione salvata da caricare o inizia una nuova.",
     setupNameHelp: "Inserisci un nome per la configurazione corrente.",
@@ -829,7 +829,7 @@ const texts = {
     helpSearchClearHelp: "Borra la consulta de búsqueda actual.",
     hoverHelpButtonLabel: "Pasa el cursor para ayuda",
     hoverHelpButtonHelp:
-      "Activa la ayuda al pasar el cursor y muévelo sobre los elementos para saber de ellos.",
+      "Activa la ayuda al pasar el cursor para que al moverlo sobre botones, campos, menús desplegables o encabezados aparezcan breves explicaciones.",
     setupSelectHelp:
       "Elige una configuración guardada para cargarla o comienza una nueva.",
     setupNameHelp: "Introduce un nombre para la configuración actual.",
@@ -1122,7 +1122,7 @@ const texts = {
     helpSearchClearHelp: "Effacer la requête de recherche en cours.",
     hoverHelpButtonLabel: "Survoler pour obtenir de l'aide",
     hoverHelpButtonHelp:
-      "Activez l'aide au survol et déplacez le curseur sur les éléments pour en savoir plus.",
+      "Active l'aide au survol pour qu'en déplaçant le curseur sur les boutons, champs, menus déroulants ou en-têtes, des explications brèves apparaissent.",
     setupSelectHelp:
       "Choisissez une configuration enregistrée à charger ou commencez-en une nouvelle.",
     setupNameHelp: "Saisissez un nom pour la configuration actuelle.",
@@ -1416,7 +1416,7 @@ const texts = {
     helpSearchClearHelp: "Lösche die aktuelle Suchanfrage.",
     hoverHelpButtonLabel: "Für Hilfe darüberfahren",
     hoverHelpButtonHelp:
-      "Aktiviere den Hover-Hilfemodus und fahre mit dem Cursor über Elemente, um mehr zu erfahren.",
+      "Aktiviere die Hover-Hilfe, damit beim Überfahren von Schaltflächen, Feldern, Dropdowns oder Überschriften kurze Erklärungen erscheinen.",
     setupSelectHelp:
       "Wähle eine gespeicherte Konfiguration zum Laden oder starte eine neue.",
     setupNameHelp: "Gib einen Namen für die aktuelle Konfiguration ein.",


### PR DESCRIPTION
## Summary
- Broaden hover help description to include buttons, fields, dropdowns and headers
- Mention contextual hover help in primary and translated READMEs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b410f6f7bc8320a675472c7530d00e