### PR TITLE
Document hover help mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Recent updates include:
 
 - **Interactive setup diagram** – drag devices, zoom, snap nodes to a grid, and export layouts as SVG or JPG.
 - **Pink accent theme** – toggle a playful pink highlight that persists between visits or press **P** to switch quickly.
-- **Searchable help dialog** – open with ? or keyboard shortcuts, filter topics instantly and browse the built-in FAQ.
+- **Searchable help dialog with optional hover help mode** – open with ? or keyboard shortcuts, filter topics instantly, browse the built-in FAQ and reveal brief tooltips on controls.
 - **Dual V‑/B‑Mount support** – choose between plate types on supported cameras and the battery list updates automatically.
 - **User runtime feedback** – submit real-world runtimes with environment details to refine estimates.
 - **Visual runtime weighting dashboard** – see how temperature, resolution, frame rate and codec affect each runtime report, now sorted by weight with exact share percentages.
@@ -55,7 +55,7 @@ See the language-specific README files for full details.
 - Visualize power and video connections with an interactive diagram.
 - Customize the device database with your own gear.
 - Switch languages, toggle dark or playful pink themes, and swap between V‑ and B‑Mount plates on supported cameras.
-- Works completely offline and offers a searchable help dialog.
+- Works completely offline and offers a searchable help dialog with an optional hover help mode.
 
 ## Runtime Data Weighting
 

--- a/index.html
+++ b/index.html
@@ -637,6 +637,7 @@
           <ul>
             <li>Open with the <strong>?</strong> button or press <kbd>?</kbd>, <kbd>H</kbd> or <kbd>F1</kbd>.</li>
             <li>Use the search field to filter topics; the query resets when closed.</li>
+            <li>Click <strong>Hover for help</strong> to show brief explanations when moving the cursor over controls.</li>
             <li>Close the dialog with <kbd>Escape</kbd> or by clicking outside.</li>
           </ul>
         </section>


### PR DESCRIPTION
## Summary
- highlight optional hover help mode in README
- mention hover help button within the Help dialog

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b41152d5588320ac3aaf7f14930806