### PR TITLE
Disable hover help on section containers

### DIFF
--- a/script.js
+++ b/script.js
@@ -6588,7 +6588,7 @@ if (helpButton && helpDialog) {
     const el = e.target.closest(
       '[data-help], [aria-label], [title], [aria-labelledby], [alt]'
     );
-    if (!el) {
+    if (!el || el.tagName === 'SECTION') {
       hoverHelpTooltip.setAttribute('hidden', '');
       return;
     }


### PR DESCRIPTION
## Summary
- Ignore section elements in hover-help logic so containers no longer show tooltips

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b41340545c8320a9cf654addd661ef