### PR TITLE
feat: add dark mode shortcut

### DIFF
--- a/index.html
+++ b/index.html
@@ -650,7 +650,7 @@
         <section data-help-section id="darkModeHelp">
           <h3><span class="help-icon" aria-hidden="true">🌓</span>Dark Mode</h3>
           <ul>
-            <li>Click the moon button to toggle dark mode.</li>
+            <li>Click the moon button or press <kbd>D</kbd> to toggle dark mode.</li>
             <li>The setting persists between visits.</li>
           </ul>
         </section>
@@ -667,6 +667,7 @@
           <ul>
             <li><kbd>?</kbd>, <kbd>H</kbd> or <kbd>F1</kbd> – toggle help</li>
             <li><kbd>Escape</kbd> – close dialogs</li>
+            <li><kbd>D</kbd> – toggle dark mode</li>
             <li><kbd>P</kbd> – toggle pink mode</li>
             <li>Type in dropdowns to filter options</li>
           </ul>

--- a/script.js
+++ b/script.js
@@ -6666,6 +6666,16 @@ if (helpButton && helpDialog) {
                document.activeElement.tagName !== 'TEXTAREA') {
       if (e.key === 'F1') e.preventDefault();
       toggleHelp();
+    } else if (e.key.toLowerCase() === 'd' &&
+               document.activeElement.tagName !== 'INPUT' &&
+               document.activeElement.tagName !== 'TEXTAREA') {
+      darkModeEnabled = !document.body.classList.contains('dark-mode');
+      applyDarkMode(darkModeEnabled);
+      try {
+        localStorage.setItem('darkMode', darkModeEnabled);
+      } catch (err) {
+        console.warn('Could not save dark mode preference', err);
+      }
     } else if (e.key.toLowerCase() === 'p' &&
                document.activeElement.tagName !== 'INPUT' &&
                document.activeElement.tagName !== 'TEXTAREA') {

--- a/translations.js
+++ b/translations.js
@@ -35,7 +35,7 @@ const texts = {
     darkModeLabel: "Toggle dark mode",
     pinkModeLabel: "Toggle pink mode",
     darkModeHelp:
-      "Switch between light and dark themes for comfortable viewing. The preference is saved.",
+      "Switch between light and dark themes for comfortable viewing. Press D to toggle. The preference is saved.",
     pinkModeHelp:
       "Add a playful pink accent theme. Works with light or dark mode and is remembered for next time.",
 
@@ -335,7 +335,7 @@ const texts = {
     darkModeLabel: "Attiva modalità scura",
     pinkModeLabel: "Attiva modalità rosa",
     darkModeHelp:
-      "Passa tra tema chiaro e scuro; la scelta viene ricordata.",
+      "Passa tra tema chiaro e scuro; premi D per attivarlo. La scelta viene ricordata.",
     pinkModeHelp:
       "Attiva un tema rosa giocoso; funziona con modalità chiara o scura e viene salvato.",
     savedSetupsLabel: "Configurazioni salvate:",
@@ -611,7 +611,7 @@ const texts = {
     darkModeLabel: "Alternar modo oscuro",
     pinkModeLabel: "Alternar modo rosa",
     darkModeHelp:
-      "Alterna entre temas claro y oscuro; la preferencia se guarda.",
+      "Alterna entre temas claro y oscuro; pulsa D para cambiar. La preferencia se guarda.",
     pinkModeHelp:
       "Aplica un tema rosa divertido; funciona con modo claro u oscuro y se recuerda la próxima vez.",
 
@@ -904,7 +904,7 @@ const texts = {
     darkModeLabel: "Basculer en mode sombre",
     pinkModeLabel: "Basculer en mode rose",
     darkModeHelp:
-      "Basculer entre thème clair et sombre; le choix est mémorisé.",
+      "Basculer entre thème clair et sombre; appuyez sur D pour changer. Le choix est mémorisé.",
     pinkModeHelp:
       "Active un thème rose ludique; fonctionne en mode clair ou sombre et est enregistré.",
 
@@ -1199,7 +1199,7 @@ const texts = {
     darkModeLabel: "Dunkelmodus umschalten",
     pinkModeLabel: "Pinkmodus umschalten",
     darkModeHelp:
-      "Zwischen hellem und dunklem Design wechseln; die Einstellung wird gespeichert.",
+      "Zwischen hellem und dunklem Design wechseln; mit D umschalten. Die Einstellung wird gespeichert.",
     pinkModeHelp:
       "Aktiviere ein verspieltes pinkes Design; funktioniert mit hellen oder dunklen Modi und wird gemerkt.",
 


### PR DESCRIPTION
## Summary
- allow pressing "D" to toggle dark mode
- document dark mode shortcut in help dialog and keyboard shortcuts list
- mention dark mode shortcut in translations for all supported languages

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4134a90c8832095c558ba66d3bb5b