### PR TITLE
Improve responsive design for control and device manager

### DIFF
--- a/style.css
+++ b/style.css
@@ -455,6 +455,12 @@ button:disabled {
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
 }
 
+@media (max-width: 900px) {
+  .device-category {
+    flex: 1 1 calc(50% - 15px);
+  }
+}
+
 .device-category h4 {
   color: var(--accent-color);
   margin-top: 0;
@@ -1133,6 +1139,16 @@ body.dark-mode.pink-mode .help-content { border-color: var(--accent-color); }
   #langSelector {
     position: static;
     margin-bottom: 10px;
+    flex-wrap: wrap;
+  }
+
+  #langSelector select {
+    flex: 1 1 100%;
+    margin-bottom: 5px;
+  }
+
+  #langSelector button {
+    flex: 0 0 auto;
   }
 
   .form-row {


### PR DESCRIPTION
## Summary
- Allow language selector controls to wrap on narrow screens for improved accessibility
- Display device manager categories in two columns on medium-width viewports

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4135b5aa8832082b690c24cfa3dde