### PR TITLE
docs: clarify offline usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ checks that batteries can safely deliver the required output and estimates how
 long your setup will run. The tool runs entirely in the browser and even works
 offline.
 
+No build step is required—open `index.html` in your browser and start planning
+immediately. Serving the repository over HTTP(S) installs a service worker so
+that future visits work offline and pick up updates automatically.
+
 ## Table of Contents
 
 - [Documentation](#documentation)


### PR DESCRIPTION
## Summary
- mention no build step to run planner
- explain service worker offline behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b41365d21c832093cf335b47deb8f6