### PR TITLE
Fix dark mode background for Safari

### DIFF
--- a/script.js
+++ b/script.js
@@ -6330,21 +6330,25 @@ if (setupNameInput) setupNameInput.addEventListener("input", saveCurrentSession)
 function updateThemeColor(isDark) {
   const meta = document.querySelector('meta[name="theme-color"]');
   if (meta) {
-    meta.setAttribute('content', isDark ? '#121212' : '#ffffff');
+    meta.setAttribute('content', isDark ? '#1c1c1e' : '#ffffff');
   }
 }
 
 function applyDarkMode(enabled) {
   if (enabled) {
     document.body.classList.add("dark-mode");
+    document.documentElement.classList.add("dark-mode");
     document.body.classList.remove("light-mode");
+    document.documentElement.classList.remove("light-mode");
     if (darkModeToggle) {
       darkModeToggle.textContent = "☀️";
       darkModeToggle.setAttribute("aria-pressed", "true");
     }
   } else {
     document.body.classList.remove("dark-mode");
+    document.documentElement.classList.remove("dark-mode");
     document.body.classList.add("light-mode");
+    document.documentElement.classList.add("light-mode");
     if (darkModeToggle) {
       darkModeToggle.textContent = "🌙";
       darkModeToggle.setAttribute("aria-pressed", "false");

--- a/style.css
+++ b/style.css
@@ -215,9 +215,9 @@ p {
   background: rgba(0, 0, 0, 0.6);
 }
 
-body.dark-mode #feedbackDialog,
-body:not(.light-mode) #feedbackDialog {
-  background: #1e1e1e;
+.dark-mode #feedbackDialog,
+html:not(.light-mode) #feedbackDialog {
+  background: #1c1c1e;
   color: #f0f0f0;
 }
 
@@ -927,8 +927,9 @@ body:not(.light-mode) #userFeedbackTable td {
     font-weight: bold;
 }
 
+html.dark-mode,
 body.dark-mode {
-  background-color: #1e1e1e;
+  background-color: #1c1c1e;
   color: #f0f0f0;
 }
 .dark-mode h1,
@@ -950,7 +951,7 @@ body.dark-mode.pink-mode h2 {
 .dark-mode section,
 .dark-mode .device-category,
 .dark-mode #batteryComparison {
-  background-color: #1e1e1e;
+  background-color: #1c1c1e;
   border-color: #333;
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.5);
 }
@@ -1016,15 +1017,16 @@ body.dark-mode.pink-mode h2 {
 .dark-mode #setupDiagram marker polygon { fill: #fff; }
 .dark-mode #setupDiagram .diagram-placeholder { color: #bbb; }
 .dark-mode .help-content {
-  background: #1e1e1e;
+  background: #1c1c1e;
   color: #f0f0f0;
   border-color: #555;
 }
 body.dark-mode.pink-mode .help-content { border-color: var(--accent-color); }
 
 @media (prefers-color-scheme: dark) {
+  html:not(.light-mode),
   body:not(.light-mode) {
-    background-color: #1e1e1e;
+    background-color: #1c1c1e;
     color: #f0f0f0;
   }
   body:not(.light-mode) h1,
@@ -1046,7 +1048,7 @@ body.dark-mode.pink-mode .help-content { border-color: var(--accent-color); }
   body:not(.light-mode) section,
   body:not(.light-mode) .device-category,
   body:not(.light-mode) #batteryComparison {
-    background-color: #1e1e1e;
+    background-color: #1c1c1e;
     border-color: #333;
     box-shadow: 0 2px 6px rgba(0, 0, 0, 0.5);
   }
@@ -1116,7 +1118,7 @@ body.dark-mode.pink-mode .help-content { border-color: var(--accent-color); }
                       linear-gradient(90deg, #444 1px, transparent 1px);
   }
   body:not(.light-mode) .help-content {
-    background: #1e1e1e;
+    background: #1c1c1e;
     color: #f0f0f0;
     border-color: #555;
   }
@@ -1296,7 +1298,7 @@ body.dark-mode.pink-mode .help-content { border-color: var(--accent-color); }
   background-color: #1a1a1a;
 }
 #overviewDialogContent.dark-mode .device-category {
-  background: #1e1e1e;
+  background: #1c1c1e;
   border-color: #333;
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.5);
 }

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -623,11 +623,13 @@ describe('script.js functions', () => {
     const meta = document.querySelector('meta[name="theme-color"]');
     applyDarkMode(true);
     expect(document.body.classList.contains('dark-mode')).toBe(true);
+    expect(document.documentElement.classList.contains('dark-mode')).toBe(true);
     expect(toggle.textContent).toBe('☀️');
     expect(toggle.getAttribute('aria-pressed')).toBe('true');
-    expect(meta.getAttribute('content')).toBe('#121212');
+    expect(meta.getAttribute('content')).toBe('#1c1c1e');
     applyDarkMode(false);
     expect(document.body.classList.contains('dark-mode')).toBe(false);
+    expect(document.documentElement.classList.contains('dark-mode')).toBe(false);
     expect(toggle.textContent).toBe('🌙');
     expect(toggle.getAttribute('aria-pressed')).toBe('false');
     expect(meta.getAttribute('content')).toBe('#ffffff');


### PR DESCRIPTION
## Summary
- Sync dark-mode styling across the `<html>` and `<body>` elements
- Match Safari’s dark grey (#1c1c1e) and update meta theme-color
- Extend tests for dark-mode toggling

## Testing
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b413e1fe3c8320bc5022293b3518af