### PR TITLE
Improve language selector responsiveness for small screens

### DIFF
--- a/style.css
+++ b/style.css
@@ -552,7 +552,8 @@ button:disabled {
   display: flex;
   gap: 5px;
   align-items: center;
-
+  flex-wrap: wrap;
+  max-width: 100%;
 }
 #langSelector select,
 #langSelector button {
@@ -1132,16 +1133,17 @@ body.dark-mode.pink-mode .help-content { border-color: var(--accent-color); }
 }
 
 /* Responsive layout adjustments */
+@media (max-width: 768px) {
+  #langSelector {
+    position: static;
+    margin-bottom: 10px;
+  }
+}
+
 @media (max-width: 600px) {
   body {
     margin: 10px;
     font-size: 0.85em;
-  }
-
-  #langSelector {
-    position: static;
-    margin-bottom: 10px;
-    flex-wrap: wrap;
   }
 
   #langSelector select {


### PR DESCRIPTION
## Summary
- Allow language selector controls to wrap and stay within viewport
- Reposition language selector on tablets and refine small-screen styles

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b418786dc8832094792f0fe5da42f8