### PR TITLE
Add data export/import helpers

### DIFF
--- a/storage.js
+++ b/storage.js
@@ -201,6 +201,33 @@ function clearAllData() {
   }
 }
 
+// --- Export/Import All Planner Data ---
+function exportAllData() {
+  return {
+    devices: loadDeviceData(),
+    setups: loadSetups(),
+    session: loadSessionState(),
+    feedback: loadFeedback(),
+  };
+}
+
+function importAllData(data) {
+  if (data && typeof data === 'object') {
+    if (data.devices) {
+      saveDeviceData(data.devices);
+    }
+    if (data.setups) {
+      saveSetups(data.setups);
+    }
+    if (data.session) {
+      saveSessionState(data.session);
+    }
+    if (data.feedback) {
+      saveFeedback(data.feedback);
+    }
+  }
+}
+
 if (typeof module !== "undefined" && module.exports) {
   module.exports = {
     loadDeviceData,
@@ -215,6 +242,8 @@ if (typeof module !== "undefined" && module.exports) {
     saveSessionState,
     loadFeedback,
     saveFeedback,
-    clearAllData
+    clearAllData,
+    exportAllData,
+    importAllData
   };
 }

--- a/tests/storage.test.js
+++ b/tests/storage.test.js
@@ -12,6 +12,8 @@ const {
     loadFeedback,
     saveFeedback,
     clearAllData,
+    exportAllData,
+    importAllData,
 } = require('../storage');
 
 const DEVICE_KEY = 'cameraPowerPlanner_devices';
@@ -219,5 +221,39 @@ describe('clearAllData', () => {
     expect(localStorage.getItem(SETUP_KEY)).toBeNull();
     expect(localStorage.getItem(FEEDBACK_KEY)).toBeNull();
     expect(sessionStorage.getItem(SESSION_KEY)).toBeNull();
+  });
+});
+
+describe('export/import all data', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    sessionStorage.clear();
+  });
+
+  test('exportAllData collects all planner data', () => {
+    saveDeviceData(validDeviceData);
+    saveSetups({ A: { foo: 1 } });
+    saveSessionState({ camera: 'CamA' });
+    saveFeedback({ note: 'hi' });
+    expect(exportAllData()).toEqual({
+      devices: validDeviceData,
+      setups: { A: { foo: 1 } },
+      session: { camera: 'CamA' },
+      feedback: { note: 'hi' }
+    });
+  });
+
+  test('importAllData restores planner data', () => {
+    const data = {
+      devices: validDeviceData,
+      setups: { A: { foo: 1 } },
+      session: { camera: 'CamA' },
+      feedback: { note: 'hi' }
+    };
+    importAllData(data);
+    expect(loadDeviceData()).toEqual(validDeviceData);
+    expect(loadSetups()).toEqual({ A: { foo: 1 } });
+    expect(loadSessionState()).toEqual({ camera: 'CamA' });
+    expect(loadFeedback()).toEqual({ note: 'hi' });
   });
 });


### PR DESCRIPTION
## Summary
- add export/import functions for all planner data
- test exporting and restoring stored data

## Testing
- `npm run lint`
- `npm run check-consistency`
- `CI=true npx jest --runInBand --ci --forceExit` *(exited early due to open handles; tests passed as shown)*

------
https://chatgpt.com/codex/tasks/task_e_68b4186a64cc8320bfeeed1838241774