### PR TITLE
Improve PWA metadata and cache busting

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,8 @@
   <meta property="og:type" content="website" />
   <meta property="og:image" content="icon.png" />
   <meta name="theme-color" content="#f9f9f9" />
+  <meta name="application-name" content="Camera Power Planner" />
+  <meta name="apple-mobile-web-app-title" content="Camera Power Planner" />
   <title>Camera Power Planner</title>
   <link rel="stylesheet" href="style.css" />
   <link rel="stylesheet" href="overview-print.css" media="print" />

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,5 +1,5 @@
 /* eslint-env serviceworker */
-const CACHE_NAME = 'camera-power-planner-v3';
+const CACHE_NAME = 'camera-power-planner-v4';
 const ASSETS = [
   './',
   './index.html',


### PR DESCRIPTION
## Summary
- add application-name and apple-mobile-web-app-title meta tags for better PWA install names
- bump service worker cache to v4 to ensure updated assets

## Testing
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b41b187bbc83208255156a2211859e