### PR TITLE
docs: translate share setup bullet in README locales

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -30,6 +30,7 @@ Die Sprache kann oben rechts umgeschaltet werden und wird für den nächsten Bes
 
 ### ✅ Setup-Verwaltung
 - Mehrere Setups speichern, laden oder löschen
+- Ein Setup per Link teilen oder die aktuelle Konfiguration zurücksetzen
 - Daten werden lokal im Browser gespeichert (`localStorage`)
 - Setups als JSON importieren und exportieren
 - Druckbare Übersicht für jedes gespeicherte Setup erstellen

--- a/README.es.md
+++ b/README.es.md
@@ -30,6 +30,7 @@ El idioma puede cambiarse en la esquina superior derecha y se recuerda para la p
 
 ### ✅ Gestión de Configuraciones
 - Guardar, cargar y borrar múltiples configuraciones
+- Compartir una configuración mediante un enlace o limpiar la configuración actual
 - Todos los datos se guardan localmente mediante `localStorage`
 - Importar y exportar configuraciones en JSON
 - Generar un resumen imprimible de cualquier configuración guardada

--- a/README.fr.md
+++ b/README.fr.md
@@ -30,6 +30,7 @@ La langue se change en haut à droite et est mémorisée pour la prochaine visit
 
 ### ✅ Gestion des Configurations
 - Enregistrer, charger et supprimer plusieurs configurations
+- Partager une configuration via un lien ou effacer la configuration actuelle
 - Toutes les données sont stockées localement via `localStorage`
 - Importer et exporter les configurations en JSON
 - Générer un aperçu imprimable de toute configuration enregistrée

--- a/README.it.md
+++ b/README.it.md
@@ -29,6 +29,7 @@ Puoi cambiare lingua nell'angolo in alto a destra. La scelta viene memorizzata p
 
 ### ✅ Gestione delle configurazioni
 - Salvare, caricare ed eliminare più configurazioni di camera
+- Condividere una configurazione tramite link o azzerare la configurazione corrente
 - Tutti i dati sono memorizzati localmente tramite `localStorage`
 - Importare ed esportare le configurazioni in formato JSON
 - Generare una panoramica stampabile di qualsiasi configurazione salvata


### PR DESCRIPTION
## Summary
- document how to share a setup link or clear the current configuration in DE, ES, FR and IT READMEs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b41b4bed608320a63de322b5b72262