### PR TITLE
Improve setup save usability

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Recent updates include:
 - **Dual V‑/B‑Mount support** – choose between plate types on supported cameras and the battery list updates automatically.
 - **User runtime feedback** – submit real-world runtimes with environment details to refine estimates.
 - **Visual runtime weighting dashboard** – see how temperature, resolution, frame rate and codec affect each runtime report, now sorted by weight with exact share percentages.
+- **Quick setup saving** – press Enter to save a setup and the Save button stays disabled until a name is entered.
 
 See the language-specific README files for full details.
 

--- a/script.js
+++ b/script.js
@@ -6423,6 +6423,20 @@ motorSelects.forEach(sel => { if (sel) sel.addEventListener("change", saveCurren
 controllerSelects.forEach(sel => { if (sel) sel.addEventListener("change", saveCurrentSession); });
 if (setupNameInput) setupNameInput.addEventListener("input", saveCurrentSession);
 
+// Enable Save button only when a setup name is entered and allow Enter to save
+if (setupNameInput && saveSetupBtn) {
+  const toggleSaveSetupBtn = () => {
+    saveSetupBtn.disabled = !setupNameInput.value.trim();
+  };
+  toggleSaveSetupBtn();
+  setupNameInput.addEventListener("input", toggleSaveSetupBtn);
+  setupNameInput.addEventListener("keydown", (e) => {
+    if (e.key === "Enter" && !saveSetupBtn.disabled) {
+      saveSetupBtn.click();
+    }
+  });
+}
+
 // Dark mode handling
 function updateThemeColor(isDark) {
   const meta = document.querySelector('meta[name="theme-color"]');

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -696,7 +696,9 @@ describe('script.js functions', () => {
     plateSel.value = 'B-Mount';
     addOpt('batterySelect', 'BBatt');
 
-    document.getElementById('setupName').value = 'TestSetup';
+    const nameInput = document.getElementById('setupName');
+    nameInput.value = 'TestSetup';
+    nameInput.dispatchEvent(new Event('input', { bubbles: true }));
     document.getElementById('saveSetupBtn').click();
 
     const saved = global.saveSetups.mock.calls[0][0];
@@ -710,6 +712,20 @@ describe('script.js functions', () => {
     sel.dispatchEvent(new Event('change'));
 
     expect(document.getElementById('batteryPlateSelect').value).toBe('B-Mount');
+  });
+
+  test('Save button enables on input and Enter key saves setup', () => {
+    const saveSpy = global.saveSetups;
+    const nameInput = document.getElementById('setupName');
+    const saveBtn = document.getElementById('saveSetupBtn');
+    expect(saveBtn.disabled).toBe(true);
+
+    nameInput.value = 'QuickSave';
+    nameInput.dispatchEvent(new Event('input', { bubbles: true }));
+    expect(saveBtn.disabled).toBe(false);
+
+    nameInput.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+    expect(saveSpy).toHaveBeenCalled();
   });
 
   test('warning colors are applied in Spanish', () => {


### PR DESCRIPTION
## Summary
- Disable save button until a setup name is entered
- Allow pressing Enter in the setup name field to save
- Document quick setup saving in README
- Add tests for save button behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b41e15dddc83209e5c3a8c2eba30a8