### PR TITLE
Add reset view control for setup diagram

### DIFF
--- a/index.html
+++ b/index.html
@@ -187,6 +187,7 @@
     <div class="diagram-controls">
       <button id="zoomOut" type="button" title="Zoom out" aria-label="Zoom out">-</button>
       <button id="zoomIn" type="button" title="Zoom in" aria-label="Zoom in">+</button>
+      <button id="resetView" type="button">Reset View</button>
       <button id="downloadDiagram" type="button">Download Diagram</button>
       <button id="gridSnapToggle" type="button">Snap to Grid</button>
     </div>

--- a/script.js
+++ b/script.js
@@ -1322,6 +1322,12 @@ function setLanguage(lang) {
     gridSnapToggleBtn.setAttribute("aria-label", texts[lang].gridSnapToggle);
     gridSnapToggleBtn.setAttribute("data-help", texts[lang].gridSnapToggleHelp);
   }
+  if (resetViewBtn) {
+    resetViewBtn.textContent = texts[lang].resetViewBtn;
+    resetViewBtn.setAttribute("title", texts[lang].resetViewBtn);
+    resetViewBtn.setAttribute("aria-label", texts[lang].resetViewBtn);
+    resetViewBtn.setAttribute("data-help", texts[lang].resetViewHelp);
+  }
   if (zoomInBtn) {
     zoomInBtn.setAttribute("title", texts[lang].zoomInLabel);
     zoomInBtn.setAttribute("aria-label", texts[lang].zoomInLabel);
@@ -1485,6 +1491,7 @@ const diagramLegend = document.getElementById("diagramLegend");
 const downloadDiagramBtn = document.getElementById("downloadDiagram");
 const zoomInBtn = document.getElementById("zoomIn");
 const zoomOutBtn = document.getElementById("zoomOut");
+const resetViewBtn = document.getElementById("resetView");
 const gridSnapToggleBtn = document.getElementById("gridSnapToggle");
 const diagramHint = document.getElementById("diagramHint");
 
@@ -4577,6 +4584,13 @@ function enableDiagramInteractions() {
   if (zoomOutBtn) {
     zoomOutBtn.onclick = () => {
       scale *= 0.9;
+      apply();
+    };
+  }
+  if (resetViewBtn) {
+    resetViewBtn.onclick = () => {
+      pan = { x: 0, y: 0 };
+      scale = 1;
       apply();
     };
   }

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -1416,6 +1416,32 @@ describe('script.js functions', () => {
     expect(endY).toBeCloseTo(snap(startY + 27 / scale));
   });
 
+  test('reset view restores default pan and zoom', () => {
+    const addOpt = (id, value) => {
+      const sel = document.getElementById(id);
+      sel.innerHTML = `<option value="${value}">${value}</option>`;
+      sel.value = value;
+    };
+    addOpt('cameraSelect', 'CamA');
+    addOpt('batterySelect', 'BattA');
+
+    script.renderSetupDiagram();
+
+    const zoomBtn = document.getElementById('zoomIn');
+    const resetBtn = document.getElementById('resetView');
+    const svg = document.querySelector('#diagramArea svg');
+
+    zoomBtn.click();
+    svg.dispatchEvent(new MouseEvent('mousedown', { clientX: 0, clientY: 0, bubbles: true }));
+    window.dispatchEvent(new MouseEvent('mousemove', { clientX: 50, clientY: 40, bubbles: true }));
+    window.dispatchEvent(new MouseEvent('mouseup', { clientX: 50, clientY: 40, bubbles: true }));
+
+    const root = svg.querySelector('#diagramRoot') || svg;
+    expect(root.getAttribute('transform')).toBe('translate(50,40) scale(1.1)');
+    resetBtn.click();
+    expect(root.getAttribute('transform')).toBe('translate(0,0) scale(1)');
+  });
+
   test('help dialog toggles with keyboard and overlay click', () => {
     const helpDialog = document.getElementById('helpDialog');
     const helpSearch = document.getElementById('helpSearch');

--- a/translations.js
+++ b/translations.js
@@ -311,6 +311,8 @@ const texts = {
       "Download the current setup diagram as an SVG or JPG image.",
     gridSnapToggleHelp:
       "Turn grid snapping on or off to help align items in the diagram.",
+    resetViewBtn: "Reset View",
+    resetViewHelp: "Reset zoom and pan to their defaults.",
     toggleDeviceManagerHelp:
       "Open the editor where you can add, modify, export or import device data.",
     hideDeviceManagerHelp:
@@ -607,6 +609,8 @@ const texts = {
       "Scarica il diagramma di configurazione come immagine.",
     gridSnapToggleHelp:
       "Attiva/disattiva l'allineamento alla griglia dei nodi del diagramma.",
+    resetViewBtn: "Reimposta vista",
+    resetViewHelp: "Ripristina lo zoom e il movimento del diagramma.",
     toggleDeviceManagerHelp: "Apri l'editor del database dei dispositivi.",
     hideDeviceManagerHelp: "Nascondi l'editor del database dei dispositivi.",
     zoomInLabel: "Ingrandisci",
@@ -916,6 +920,8 @@ const texts = {
       "Descarga el diagrama de configuración como imagen.",
     gridSnapToggleHelp:
       "Activa o desactiva el ajuste a la cuadrícula de los nodos del diagrama.",
+    resetViewBtn: "Restablecer vista",
+    resetViewHelp: "Restablece el zoom y la posición del diagrama.",
     toggleDeviceManagerHelp: "Abre el editor de la base de datos de dispositivos.",
     hideDeviceManagerHelp: "Oculta el editor de la base de datos de dispositivos.",
     zoomInLabel: "Acercar",
@@ -1228,6 +1234,8 @@ const texts = {
       "Télécharge le diagramme de configuration comme image.",
     gridSnapToggleHelp:
       "Active/désactive l'alignement des nœuds du diagramme sur la grille.",
+    resetViewBtn: "Réinitialiser la vue",
+    resetViewHelp: "Réinitialise le zoom et le panoramique du diagramme.",
     toggleDeviceManagerHelp: "Ouvre l'éditeur de la base de données des appareils.",
     hideDeviceManagerHelp: "Masque l'éditeur de la base de données des appareils.",
     zoomInLabel: "Zoom avant",
@@ -1537,6 +1545,8 @@ const texts = {
       "Lädt das Setup-Diagramm als Bild herunter.",
     gridSnapToggleHelp:
       "Schaltet das Einrasten der Diagrammknoten am Raster um.",
+    resetViewBtn: "Ansicht zurücksetzen",
+    resetViewHelp: "Setzt Zoom und Verschiebung des Diagramms zurück.",
     toggleDeviceManagerHelp: "Öffnet den Gerätedatenbank-Editor.",
     hideDeviceManagerHelp: "Blendet den Gerätedatenbank-Editor aus.",
     zoomInLabel: "Hineinzoomen",


### PR DESCRIPTION
## Summary
- add a "Reset View" control to the setup diagram
- store translations for all locales
- test that pan/zoom reset works

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68b42089fcf08320ae34e711b31b4d2b