### PR TITLE
Document save shortcut

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Recent updates include:
 - **Dual V‑/B‑Mount support** – choose between plate types on supported cameras and the battery list updates automatically.
 - **User runtime feedback** – submit real-world runtimes with environment details to refine estimates.
 - **Visual runtime weighting dashboard** – see how temperature, resolution, frame rate and codec affect each runtime report, now sorted by weight with exact share percentages.
-- **Quick setup saving** – press Enter or Ctrl+S to save a setup and the Save button stays disabled until a name is entered.
+- **Quick setup saving** – press Enter or Ctrl+S (⌘S on macOS) to save a setup and the Save button stays disabled until a name is entered.
 
 See the language-specific README files for full details.
 

--- a/index.html
+++ b/index.html
@@ -672,6 +672,7 @@
             <li><kbd>Escape</kbd> – close dialogs</li>
             <li><kbd>D</kbd> – toggle dark mode</li>
             <li><kbd>P</kbd> – toggle pink mode</li>
+            <li><kbd>Enter</kbd> or <kbd>Ctrl</kbd>+<kbd>S</kbd> (<kbd>⌘</kbd>+<kbd>S</kbd> on macOS) – save setup</li>
             <li>Type in dropdowns to filter options</li>
           </ul>
         </section>


### PR DESCRIPTION
## Summary
- mention Enter/Ctrl+S (⌘S) shortcut in help dialog's keyboard shortcuts
- clarify quick setup saving in README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4596a8b1c8320aa2208a5bc930047