### PR TITLE
feat: add hover summaries for device manager

### DIFF
--- a/script.js
+++ b/script.js
@@ -4762,6 +4762,12 @@ function createDeviceDetailsList(deviceData) {
   return list;
 }
 
+const escapeDiv = document.createElement('div');
+function escapeHtml(str) {
+  escapeDiv.textContent = str;
+  return escapeDiv.innerHTML;
+}
+
 // Helper to render existing devices in the manager section
 function renderDeviceList(categoryKey, ulElement) {
   ulElement.innerHTML = "";
@@ -4782,6 +4788,16 @@ function renderDeviceList(categoryKey, ulElement) {
 
     const nameSpan = document.createElement("span");
     nameSpan.textContent = name;
+    // Add a hover description summarizing connectors and notes
+    let summary = generateConnectorSummary(deviceData);
+    summary = summary ? summary.replace(/<[^>]+>/g, '').replace(/\s+/g, ' ').trim() : '';
+    if (deviceData.notes) {
+      summary = summary ? `${summary}; Notes: ${deviceData.notes}` : deviceData.notes;
+    }
+    if (summary) {
+      nameSpan.setAttribute('title', summary);
+      nameSpan.setAttribute('data-help', summary);
+    }
     header.appendChild(nameSpan);
 
     const toggleBtn = document.createElement("button");
@@ -5943,12 +5959,6 @@ if (runtimeFeedbackBtn && feedbackDialog && feedbackForm) {
     feedbackDialog.close();
     updateCalculations();
   });
-}
-
-const escapeDiv = document.createElement('div');
-function escapeHtml(str) {
-    escapeDiv.textContent = str;
-    return escapeDiv.innerHTML;
 }
 
 

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -2036,6 +2036,12 @@ describe('monitor wireless metadata', () => {
     expect(toggleBtn.textContent).toBe(texts.en.toggleDeviceManager);
   });
 
+  test('device manager lists include hover descriptions', () => {
+    const span = document.querySelector('#cameraList .device-summary span');
+    expect(span.getAttribute('title')).toContain('Power: 10 W');
+    expect(span.getAttribute('data-help')).toContain('Power: 10 W');
+  });
+
   test('detail toggle responds to keyboard events', () => {
     const detailToggle = document.querySelector('#device-manager .detail-toggle');
     const details = detailToggle.closest('li').querySelector('.device-details');


### PR DESCRIPTION
## Summary
- show connector and note summary when hovering devices in database editor
- test hover description for device manager entries

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b497301ae8832097c653ee81a58b0e