### PR TITLE
Fix blank PDF when printing overview

### DIFF
--- a/script.js
+++ b/script.js
@@ -6330,7 +6330,27 @@ function generatePrintableOverview() {
     } else {
         overviewDialog.setAttribute('open', '');
     }
-    window.addEventListener('afterprint', () => { overviewDialog.close(); }, { once: true });
+
+    const closeAfterPrint = () => { overviewDialog.close(); };
+    if (typeof window.matchMedia === 'function') {
+        const mql = window.matchMedia('print');
+        const mqlListener = e => {
+            if (!e.matches) {
+                if (mql.removeEventListener) {
+                    mql.removeEventListener('change', mqlListener);
+                } else if (mql.removeListener) {
+                    mql.removeListener(mqlListener);
+                }
+                closeAfterPrint();
+            }
+        };
+        if (mql.addEventListener) {
+            mql.addEventListener('change', mqlListener);
+        } else if (mql.addListener) {
+            mql.addListener(mqlListener);
+        }
+    }
+    window.addEventListener('afterprint', closeAfterPrint, { once: true });
 }
 
 


### PR DESCRIPTION
## Summary
- keep overview dialog open during printing to avoid empty PDF output
- close overview dialog after printing using `matchMedia` or `afterprint`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4977c0ed88320ad339e81a78c3a16