### PR TITLE
Preserve connector colors in print overview

### DIFF
--- a/overview-print.css
+++ b/overview-print.css
@@ -52,29 +52,23 @@ tr:nth-child(even) { background-color: #f9f9f9; }
 
 .device-block,
 .device-category {
-  background: #fff !important;
   border: 1px solid #000;
   box-shadow: none;
 }
 
 .power-conn {
-  background: #fff !important;
   border: 1px solid #000;
-  border-style: solid;
 }
 
 .fiz-conn {
-  background: #fff !important;
   border: 1px dashed #000;
 }
 
 .video-conn {
-  background: #fff !important;
   border: 1px dotted #000;
 }
 
 .neutral-conn {
-  background: #fff !important;
   border: 1px double #000;
 }
 


### PR DESCRIPTION
## Summary
- remove forced white backgrounds in print stylesheet to keep connector colors

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b498d79a848320b6ac7203187b8ca0