### PR TITLE
feat: focus help search via keyboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Recent updates include:
 
 - **Interactive setup diagram** – drag devices, zoom, snap nodes to a grid, and export layouts as SVG or JPG.
 - **Pink accent theme** – toggle a playful pink highlight that persists between visits or press **P** to switch quickly.
-- **Searchable help dialog and hover hints** – open with ?, H, F1 or Ctrl+/ (even while typing), filter topics instantly, browse the built-in FAQ, and hover over any button, field, dropdown or header for a quick explanation.
+- **Searchable help dialog and hover hints** – open with ?, H, F1 or Ctrl+/ (even while typing), filter topics instantly, press / or Ctrl+F to jump to the search box, browse the built-in FAQ, and hover over any button, field, dropdown or header for a quick explanation.
 - **Dual V‑/B‑Mount support** – choose between plate types on supported cameras and the battery list updates automatically.
 - **User runtime feedback** – submit real-world runtimes with environment details to refine estimates.
 - **Visual runtime weighting dashboard** – see how temperature, resolution, frame rate and codec affect each runtime report, now sorted by weight with exact share percentages.

--- a/script.js
+++ b/script.js
@@ -6831,6 +6831,12 @@ if (helpButton && helpDialog) {
       toggleHelp();
     } else if ((e.key === '?' || e.key.toLowerCase() === 'h') && !isTextField) {
       toggleHelp();
+    } else if (
+      !helpDialog.hasAttribute('hidden') &&
+      ((e.key === '/' && !isTextField) || (e.key.toLowerCase() === 'f' && (e.ctrlKey || e.metaKey)))
+    ) {
+      e.preventDefault();
+      if (helpSearch) helpSearch.focus();
     } else if (e.key.toLowerCase() === 'd' && !isTextField) {
       darkModeEnabled = !document.body.classList.contains('dark-mode');
       applyDarkMode(darkModeEnabled);

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -1478,6 +1478,23 @@ describe('script.js functions', () => {
     expect(helpDialog.hasAttribute('hidden')).toBe(true);
   });
 
+  test('slash or Ctrl+F focuses help search', () => {
+    const helpDialog = document.getElementById('helpDialog');
+    const helpSearch = document.getElementById('helpSearch');
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'F1' }));
+    expect(helpDialog.hasAttribute('hidden')).toBe(false);
+    helpDialog.focus();
+    expect(document.activeElement).toBe(helpDialog);
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: '/' }));
+    expect(document.activeElement).toBe(helpSearch);
+
+    helpDialog.focus();
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'f', ctrlKey: true }));
+    expect(document.activeElement).toBe(helpSearch);
+  });
+
   test('help search filters and resets on reopen', () => {
     const helpDialog = document.getElementById('helpDialog');
     const helpSearch = document.getElementById('helpSearch');

--- a/translations.js
+++ b/translations.js
@@ -270,7 +270,8 @@ const texts = {
     helpSearchLabel: "Search help topics",
     helpNoResults: "No results found.",
     helpSearchClear: "Clear search",
-    helpSearchHelp: "Type keywords to instantly filter the help topics list.",
+    helpSearchHelp:
+      "Type keywords to instantly filter the help topics list. Press '/' or Ctrl+F (Cmd+F on Mac) to focus the search box quickly.",
     helpSearchClearHelp: "Clear the search box and show all help topics again.",
     hoverHelpButtonLabel: "Hover for help",
     hoverHelpButtonHelp:
@@ -571,7 +572,8 @@ const texts = {
     helpSearchLabel: "Cerca negli argomenti dell'aiuto",
     helpNoResults: "Nessun risultato trovato.",
     helpSearchClear: "Cancella ricerca",
-    helpSearchHelp: "Digita parole chiave per cercare gli argomenti dell'aiuto.",
+    helpSearchHelp:
+      "Digita parole chiave per cercare gli argomenti dell'aiuto. Premi '/' o Ctrl+F (Cmd+F su Mac) per focalizzare rapidamente la casella di ricerca.",
     helpSearchClearHelp: "Cancella la ricerca corrente.",
     hoverHelpButtonLabel: "Passa il mouse per aiuto",
     hoverHelpButtonHelp:
@@ -882,7 +884,8 @@ const texts = {
     helpSearchLabel: "Buscar temas de ayuda",
     helpNoResults: "No se encontraron resultados.",
     helpSearchClear: "Borrar búsqueda",
-    helpSearchHelp: "Escribe palabras clave para buscar temas de ayuda.",
+    helpSearchHelp:
+      "Escribe palabras clave para buscar temas de ayuda. Pulsa '/' o Ctrl+F (Cmd+F en Mac) para enfocar rápidamente el campo de búsqueda.",
     helpSearchClearHelp: "Borra la consulta de búsqueda actual.",
     hoverHelpButtonLabel: "Pasa el cursor para ayuda",
     hoverHelpButtonHelp:
@@ -1194,7 +1197,8 @@ const texts = {
     helpSearchLabel: "Rechercher des sujets d'aide",
     helpNoResults: "Aucun résultat trouvé.",
     helpSearchClear: "Effacer la recherche",
-    helpSearchHelp: "Tapez des mots-clés pour rechercher des sujets d'aide.",
+    helpSearchHelp:
+      "Tapez des mots-clés pour rechercher des sujets d'aide. Appuyez sur '/' ou Ctrl+F (Cmd+F sur Mac) pour cibler rapidement le champ de recherche.",
     helpSearchClearHelp: "Effacer la requête de recherche en cours.",
     hoverHelpButtonLabel: "Survoler pour obtenir de l'aide",
     hoverHelpButtonHelp:
@@ -1507,7 +1511,8 @@ const texts = {
     helpSearchLabel: "Hilfe-Themen durchsuchen",
     helpNoResults: "Keine Ergebnisse gefunden.",
     helpSearchClear: "Suche löschen",
-    helpSearchHelp: "Gib Stichwörter ein, um Hilfethemen zu durchsuchen.",
+    helpSearchHelp:
+      "Gib Stichwörter ein, um Hilfethemen zu durchsuchen. Drücke '/' oder Strg+F (Cmd+F auf dem Mac), um das Suchfeld schnell zu fokussieren.",
     helpSearchClearHelp: "Lösche die aktuelle Suchanfrage.",
     hoverHelpButtonLabel: "Für Hilfe darüberfahren",
     hoverHelpButtonHelp:


### PR DESCRIPTION
## Summary
- allow `/` or `Ctrl+F` (Cmd+F on Mac) to focus the help dialog's search box
- document shortcut in README and translations
- add regression test for focusing the help search

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4999cf96083208117ca0b232e23a8