### PR TITLE
Use light theme styling in print overview

### DIFF
--- a/overview-print.css
+++ b/overview-print.css
@@ -3,12 +3,24 @@
   margin: 1cm;
 }
 
-body {
+body,
+body.dark-mode {
   background: #fff;
   color: #000;
   font-size: 12pt;
   -webkit-print-color-adjust: exact;
   print-color-adjust: exact;
+}
+
+#overviewDialogContent,
+#overviewDialogContent * {
+  color: #000 !important;
+}
+
+#overviewDialogContent h1,
+#overviewDialogContent h2,
+#overviewDialogContent h3 {
+  border-color: #000 !important;
 }
 
 h1 {
@@ -52,29 +64,23 @@ tr:nth-child(even) { background-color: #f9f9f9; }
 
 .device-block,
 .device-category {
-  background: #fff !important;
   border: 1px solid #000;
   box-shadow: none;
 }
 
 .power-conn {
-  background: #fff !important;
   border: 1px solid #000;
-  border-style: solid;
 }
 
 .fiz-conn {
-  background: #fff !important;
   border: 1px dashed #000;
 }
 
 .video-conn {
-  background: #fff !important;
   border: 1px dotted #000;
 }
 
 .neutral-conn {
-  background: #fff !important;
   border: 1px double #000;
 }
 

--- a/script.js
+++ b/script.js
@@ -6326,14 +6326,27 @@ function generatePrintableOverview() {
     const overviewDialog = document.getElementById('overviewDialog');
     overviewDialog.innerHTML = overviewHtml;
     const content = overviewDialog.querySelector('#overviewDialogContent');
-    ['dark-mode', 'pink-mode'].forEach(cls => {
-        if (document.body.classList.contains(cls)) {
-            content.classList.add(cls);
+
+    const darkModeActive = document.body.classList.contains('dark-mode');
+    if (darkModeActive) {
+        document.body.classList.remove('dark-mode');
+    }
+    if (document.body.classList.contains('pink-mode')) {
+        content.classList.add('pink-mode');
+    }
+
+    const restoreTheme = () => {
+        if (darkModeActive) {
+            document.body.classList.add('dark-mode');
         }
-    });
+    };
+
     const closeBtn = overviewDialog.querySelector('#closeOverviewBtn');
     if (closeBtn) {
-        closeBtn.addEventListener('click', () => overviewDialog.close());
+        closeBtn.addEventListener('click', () => {
+            restoreTheme();
+            overviewDialog.close();
+        });
     }
     if (typeof overviewDialog.showModal === 'function') {
         overviewDialog.showModal();
@@ -6341,7 +6354,10 @@ function generatePrintableOverview() {
         overviewDialog.setAttribute('open', '');
     }
 
-    const closeAfterPrint = () => { overviewDialog.close(); };
+    const closeAfterPrint = () => {
+        restoreTheme();
+        overviewDialog.close();
+    };
     if (typeof window.matchMedia === 'function') {
         const mql = window.matchMedia('print');
         const mqlListener = e => {


### PR DESCRIPTION
## Summary
- remove dark-mode class during print to force light theme fonts
- ensure print stylesheet always uses dark text regardless of active theme

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b498d79a848320b6ac7203187b8ca0