### PR TITLE
Normalize HD SDI video port variant

### DIFF
--- a/script.js
+++ b/script.js
@@ -72,7 +72,8 @@ const VIDEO_TYPE_PATTERNS = [
   { needles: ['12g'], value: '12G-SDI' },
   { needles: ['6g'], value: '6G-SDI' },
   { needles: ['3g'], value: '3G-SDI' },
-  { needles: ['hd-sdi'], value: '3G-SDI' },
+  // Accept both "HD-SDI" and "HD SDI" spellings
+  { needles: ['hd', 'sdi'], value: '3G-SDI' },
   { needles: ['mini', 'bnc'], value: 'Mini BNC' },
   { needles: ['micro', 'hdmi'], value: 'Micro HDMI' },
   { needles: ['mini', 'hdmi'], value: 'Mini HDMI' },

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -102,6 +102,12 @@ describe('utility function tests', () => {
     expect(normalizeVideoType('DP')).toBe('DisplayPort');
   });
 
+  test('normalizeVideoType maps HD-SDI variants to 3G-SDI', () => {
+    const { normalizeVideoType } = utils;
+    expect(normalizeVideoType('HD-SDI')).toBe('3G-SDI');
+    expect(normalizeVideoType('HD SDI')).toBe('3G-SDI');
+  });
+
   test('normalizeViewfinderType handles case-insensitive mappings', () => {
     const { normalizeViewfinderType } = utils;
     expect(normalizeViewfinderType('lcd touchscreen')).toBe('LCD touchscreen');


### PR DESCRIPTION
## Summary
- allow video port normalization to treat "HD SDI" and "HD-SDI" the same, mapping both to 3G-SDI
- add regression tests for the additional HD-SDI form

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b49a0192e48320b3d29fba2249d0f4