### PR TITLE
Clear filter inputs after device selection

### DIFF
--- a/script.js
+++ b/script.js
@@ -3132,6 +3132,22 @@ function bindFilterInput(inputElem, callback) {
   });
 }
 
+function clearFilterOnSelect(selectElem, filterInput, resetCallback) {
+  if (!selectElem || !filterInput) {
+    return;
+  }
+  selectElem.addEventListener("change", () => {
+    if (filterInput.value !== "") {
+      filterInput.value = "";
+      if (typeof resetCallback === "function") {
+        resetCallback();
+      } else {
+        filterSelect(selectElem, "");
+      }
+    }
+  });
+}
+
 function clearAllFilters() {
   [cameraFilterInput, monitorFilterInput, videoFilterInput, motorFilterInput,
    controllerFilterInput, distanceFilterInput, batteryFilterInput].forEach(input => {
@@ -4890,6 +4906,14 @@ bindFilterInput(motorFilterInput, () => motorSelects.forEach(sel => filterSelect
 bindFilterInput(controllerFilterInput, () => controllerSelects.forEach(sel => filterSelect(sel, controllerFilterInput.value)));
 bindFilterInput(distanceFilterInput, () => filterSelect(distanceSelect, distanceFilterInput.value));
 bindFilterInput(batteryFilterInput, () => filterSelect(batterySelect, batteryFilterInput.value));
+
+clearFilterOnSelect(cameraSelect, cameraFilterInput);
+clearFilterOnSelect(monitorSelect, monitorFilterInput);
+clearFilterOnSelect(videoSelect, videoFilterInput);
+motorSelects.forEach(sel => clearFilterOnSelect(sel, motorFilterInput, () => motorSelects.forEach(s => filterSelect(s, ""))));
+controllerSelects.forEach(sel => clearFilterOnSelect(sel, controllerFilterInput, () => controllerSelects.forEach(s => filterSelect(s, ""))));
+clearFilterOnSelect(distanceSelect, distanceFilterInput);
+clearFilterOnSelect(batterySelect, batteryFilterInput);
 
 clearFiltersBtn.addEventListener("click", clearAllFilters);
 

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -371,6 +371,21 @@ describe('script.js functions', () => {
     expect(camSel.options[1].hidden).toBe(false);
   });
 
+  test('filter input clears after selecting an option', () => {
+    const camSel = document.getElementById('cameraSelect');
+    camSel.innerHTML = '<option value="CamA">CamA</option><option value="CamB">CamB</option>';
+
+    const filterInput = document.getElementById('cameraFilter');
+    filterInput.value = 'CamA';
+    filterInput.dispatchEvent(new Event('input'));
+    expect(camSel.options[1].hidden).toBe(true);
+
+    camSel.value = 'CamA';
+    camSel.dispatchEvent(new Event('change'));
+    expect(filterInput.value).toBe('');
+    expect(camSel.options[1].hidden).toBe(false);
+  });
+
   test('clear filters button resets all filter fields', () => {
     const camSel = document.getElementById('cameraSelect');
     camSel.innerHTML = '<option value="CamA">CamA</option><option value="CamB">CamB</option>';


### PR DESCRIPTION
## Summary
- Reset filter inputs when an option is chosen to restore full dropdown lists
- Test automatic clearing of filters after selecting a device

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b49cb582008320b811436c6f85dfb3