### PR TITLE
Add manual gear list generation

### DIFF
--- a/index.html
+++ b/index.html
@@ -171,7 +171,8 @@
     <p id="dtapWarning" role="status" aria-live="polite" aria-describedby="batteryLabel"></p>
     <div id="temperatureNote"></div>
     <button id="runtimeFeedbackBtn" type="button">Submit User Runtime Feedback</button>
-    <button id="generateGearListBtn" type="button">Generate Gear List</button>
+    <button id="generateGearListBtn" type="button">Generate Gear List and Project Requirements</button>
+    <div id="gearListOutput" class="hidden"></div>
     <button id="copySummaryBtn" type="button">Copy Summary</button>
     <div id="feedbackTableContainer" class="hidden">
       <table id="userFeedbackTable" class="hidden"></table>

--- a/script.js
+++ b/script.js
@@ -1492,6 +1492,7 @@ const breakdownListElem = document.getElementById("breakdownList");
 const copySummaryBtn = document.getElementById("copySummaryBtn");
 const runtimeFeedbackBtn = document.getElementById("runtimeFeedbackBtn");
 const generateGearListBtn = document.getElementById("generateGearListBtn");
+const gearListOutput = document.getElementById("gearListOutput");
 const feedbackDialog = document.getElementById("feedbackDialog");
 const feedbackForm = document.getElementById("feedbackForm");
 const feedbackCancelBtn = document.getElementById("fbCancel");
@@ -5862,7 +5863,11 @@ generateGearListBtn.addEventListener('click', () => {
         alert(texts[currentLang].alertSelectSetupForOverview);
         return;
     }
-    generateGearList();
+    const html = generateGearListHtml();
+    if (gearListOutput) {
+        gearListOutput.innerHTML = html;
+        gearListOutput.classList.remove('hidden');
+    }
 });
 
 shareSetupBtn.addEventListener('click', () => {
@@ -6565,7 +6570,7 @@ function collectGearListInfo() {
     };
 }
 
-function generateGearList() {
+function generateGearListHtml() {
     const t = texts[currentLang];
     const info = collectGearListInfo();
     const selected = [];
@@ -6588,7 +6593,7 @@ function generateGearList() {
     const accessoriesHtml = accessories.map(n => `<li>${escapeHtml(n)}</li>`).join('');
     const setupName = escapeHtml(setupNameInput.value);
     const infoPairs = Object.entries(info).filter(([, v]) => v);
-    const infoHtml = infoPairs.length ? '<h2>Project Details</h2><ul>' +
+    const infoHtml = infoPairs.length ? '<h3>Project Details</h3><ul>' +
         infoPairs.map(([k, v]) => {
             const labels = {
                 projectName: 'Project Name',
@@ -6618,17 +6623,13 @@ function generateGearList() {
             const label = labels[k] || k;
             return `<li>${escapeHtml(label)}: ${escapeHtml(v)}</li>`;
         }).join('') + '</ul>' : '';
-    const win = window.open('', '_blank');
-    if (win) {
-        let body = `<button onclick="window.print()" class="print-btn">Print</button><h1>${setupName}</h1>`;
-        if (infoHtml) body += infoHtml;
-        body += `<h2>${escapeHtml(t.selectedGearHeading)}</h2><ul>${selectedHtml}</ul>`;
-        if (accessories.length) {
-            body += `<h2>${escapeHtml(t.recommendationsHeading)}</h2><ul>${accessoriesHtml}</ul>`;
-        }
-        win.document.write(`<!DOCTYPE html><html><head><title>${t.generateGearListBtn}</title><link rel="stylesheet" href="overview-print.css" media="print" /></head><body>${body}</body></html>`);
-        win.document.close();
+    let body = `<h2>${setupName}</h2>`;
+    if (infoHtml) body += infoHtml;
+    body += `<h3>${escapeHtml(t.selectedGearHeading)}</h3><ul>${selectedHtml}</ul>`;
+    if (accessories.length) {
+        body += `<h3>${escapeHtml(t.recommendationsHeading)}</h3><ul>${accessoriesHtml}</ul>`;
     }
+    return body;
 }
 
 
@@ -7195,7 +7196,7 @@ if (typeof module !== "undefined" && module.exports) {
     applyDarkMode,
     applyPinkMode,
     generatePrintableOverview,
-    generateGearList,
+    generateGearListHtml,
     applySharedSetupFromUrl,
     applySharedSetup,
     updateBatteryPlateVisibility,

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -739,8 +739,8 @@ describe('script.js functions', () => {
     expect(html).toContain(`<strong>${texts.en.cameraLabel}</strong>`);
   });
 
-  test('generateGearList lists selected devices and accessories', () => {
-      const { generateGearList } = script;
+  test('generateGearListHtml returns selected devices and accessories', () => {
+      const { generateGearListHtml } = script;
       const addOpt = (id, value) => {
         const sel = document.getElementById(id);
         sel.innerHTML = `<option value="${value}">${value}</option>`;
@@ -753,13 +753,9 @@ describe('script.js functions', () => {
       addOpt('controller1Select', 'ControllerA');
       addOpt('distanceSelect', 'DistA');
       addOpt('batterySelect', 'BattA');
-      const mockWin = { document: { write: jest.fn(), close: jest.fn() } };
-      global.open = jest.fn(() => mockWin);
-      generateGearList();
-      expect(global.open).toHaveBeenCalled();
-      const html = mockWin.document.write.mock.calls[0][0];
-      expect(html).toContain('<h2>Selected Gear</h2>');
-      expect(html).toContain('<h2>Recommended Accessories</h2>');
+      const html = generateGearListHtml();
+      expect(html).toContain('<h3>Selected Gear</h3>');
+      expect(html).toContain('<h3>Recommended Accessories</h3>');
       expect(html).toContain('<li>CamA</li>');
       expect(html).toContain('<li>BNC SDI Cable</li>');
       expect(html).toContain('<li>Universal Cage</li>');

--- a/translations.js
+++ b/translations.js
@@ -258,7 +258,7 @@ const texts = {
     exportSetupsBtn: "Export All Setups",
     importSetupsBtn: "Import Setups",
     generateOverviewBtn: "Generate Overview",
-    generateGearListBtn: "Generate Gear List",
+    generateGearListBtn: "Generate Gear List and Project Requirements",
     alertNoSetupsToExport: "There are no saved setups to export.",
     alertImportSetupsSuccess: "Successfully imported {num_setups} setups.",
     alertImportSetupsError: "Error: Could not import setups. The file may be invalid or corrupted.",
@@ -298,7 +298,7 @@ const texts = {
     generateOverviewHelp:
       "Generate a print-ready summary of any saved setup, including power and connection details.",
     generateGearListHelp:
-      "Open a printable list of selected gear and recommended accessories.",
+      "Show a list of selected gear and project requirements.",
     shareSetupHelp:
       "Copy a unique link representing the current setup that others can open to load the same configuration.",
     applySharedLinkHelp:
@@ -570,7 +570,7 @@ const texts = {
     exportSetupsBtn: "Esporta tutte le configurazioni",
     importSetupsBtn: "Importa configurazioni",
     generateOverviewBtn: "Generare panoramica",
-    generateGearListBtn: "Genera elenco attrezzatura",
+    generateGearListBtn: "Genera elenco attrezzatura e requisiti del progetto",
     alertNoSetupsToExport: "Non ci sono configurazioni salvate per l'esportazione.",
     alertImportSetupsSuccess: "Importate correttamente {num_setups} configurazioni.",
     alertImportSetupsError: "Errore: non è stato in grado di importare configurazioni. Il file può essere non valido o corrotto.",
@@ -605,7 +605,7 @@ const texts = {
     generateOverviewHelp:
       "Crea un riepilogo stampabile delle configurazioni salvate.",
     generateGearListHelp:
-      "Apri un elenco stampabile dell'attrezzatura selezionata e degli accessori consigliati.",
+      "Mostra l'elenco dell'attrezzatura selezionata e i requisiti del progetto.",
     shareSetupHelp:
       "Copia un link che rappresenta la configurazione corrente.",
     applySharedLinkHelp: "Carica la configurazione dal link condiviso.",
@@ -890,7 +890,7 @@ const texts = {
     exportSetupsBtn: "Exportar todas las configuraciones",
     importSetupsBtn: "Importar configuraciones",
     generateOverviewBtn: "Generar resumen",
-    generateGearListBtn: "Generar lista de equipo",
+    generateGearListBtn: "Generar lista de equipo y requisitos del proyecto",
     alertNoSetupsToExport: "No hay configuraciones para exportar.",
     alertImportSetupsSuccess: "{num_setups} configuraciones importadas.",
     alertImportSetupsError: "Error: no se pudieron importar las configuraciones.",
@@ -926,7 +926,7 @@ const texts = {
     generateOverviewHelp:
       "Crea un resumen imprimible de las configuraciones guardadas.",
     generateGearListHelp:
-      "Abre una lista imprimible del equipo seleccionado y accesorios recomendados.",
+      "Muestra la lista del equipo seleccionado y los requisitos del proyecto.",
     shareSetupHelp:
       "Copia un enlace que representa la configuración actual.",
     applySharedLinkHelp: "Carga la configuración desde el enlace compartido.",
@@ -1212,7 +1212,7 @@ const texts = {
     exportSetupsBtn: "Exporter toutes les configurations",
     importSetupsBtn: "Importer des configurations",
     generateOverviewBtn: "Générer un résumé",
-    generateGearListBtn: "Générer la liste du matériel",
+    generateGearListBtn: "Générer la liste du matériel et les exigences du projet",
     alertNoSetupsToExport: "Aucune configuration à exporter.",
     alertImportSetupsSuccess: "{num_setups} configurations importées.",
     alertImportSetupsError: "Erreur : import impossible.",
@@ -1248,7 +1248,7 @@ const texts = {
     generateOverviewHelp:
       "Crée un aperçu imprimable des configurations enregistrées.",
     generateGearListHelp:
-      "Ouvre une liste imprimable de tout l'équipement sélectionné et des accessoires recommandés.",
+      "Affiche la liste du matériel sélectionné et les exigences du projet.",
     shareSetupHelp:
       "Copie un lien représentant la configuration actuelle.",
     applySharedLinkHelp: "Charge la configuration depuis le lien partagé.",
@@ -1536,7 +1536,7 @@ const texts = {
     exportSetupsBtn: "Alle Setups exportieren",
     importSetupsBtn: "Setups importieren",
     generateOverviewBtn: "Übersicht erstellen",
-    generateGearListBtn: "Gear-Liste erstellen",
+    generateGearListBtn: "Gear-Liste und Projektanforderungen erstellen",
     alertNoSetupsToExport: "Es gibt keine gespeicherten Setups zum Exportieren.",
     alertImportSetupsSuccess: "{num_setups} Setups erfolgreich importiert.",
     alertImportSetupsError: "Fehler: Setups konnten nicht importiert werden. Die Datei ist möglicherweise ungültig oder beschädigt.",
@@ -1571,7 +1571,7 @@ const texts = {
     generateOverviewHelp:
       "Erstellt eine druckbare Übersicht der gespeicherten Konfigurationen.",
     generateGearListHelp:
-      "Öffnet eine druckbare Liste aller ausgewählten Geräte und empfohlenen Zubehörteile.",
+      "Zeigt die Liste der ausgewählten Geräte und die Projektanforderungen.",
     shareSetupHelp:
       "Kopiert einen Link, der die aktuelle Konfiguration repräsentiert.",
     applySharedLinkHelp: "Lädt die Konfiguration aus dem geteilten Link.",


### PR DESCRIPTION
## Summary
- add "Generate Gear List and Project Requirements" button and output container
- compute gear list HTML on demand instead of auto-opening a new window
- update translations and tests for new gear list flow

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b4ae50fe148320b9ca26db165e936d