### PR TITLE
Expose gear list generator in setup actions

### DIFF
--- a/index.html
+++ b/index.html
@@ -61,6 +61,7 @@
     <button id="importSetupsBtn">Import Setups</button>
     <input type="file" id="importSetupsInput" accept=".json" class="hidden" />
     <button id="generateOverviewBtn">Generate Overview</button>
+    <button id="generateGearListBtn" type="button">Generate Gear List and Project Requirements</button>
     <button id="shareSetupBtn">Share Setup Link</button>
     <div class="form-row hidden" id="sharedLinkRow">
       <label for="sharedLinkInput" id="sharedLinkLabel">Shared Link:</label>
@@ -171,7 +172,6 @@
     <p id="dtapWarning" role="status" aria-live="polite" aria-describedby="batteryLabel"></p>
     <div id="temperatureNote"></div>
     <button id="runtimeFeedbackBtn" type="button">Submit User Runtime Feedback</button>
-    <button id="generateGearListBtn" type="button">Generate Gear List and Project Requirements</button>
     <div id="gearListOutput" class="hidden"></div>
     <button id="copySummaryBtn" type="button">Copy Summary</button>
     <div id="feedbackTableContainer" class="hidden">
@@ -556,6 +556,7 @@
             <li><strong>Share Setup Link</strong> copies a URL for the current configuration.</li>
             <li><strong>Clear Current Setup</strong> removes all selected devices.</li>
             <li><strong>Generate Overview</strong> produces a printable summary of any saved setup.</li>
+            <li><strong>Generate Gear List</strong> compiles selected gear and project requirements.</li>
           </ul>
         </section>
         <section data-help-section id="powerCalculator">


### PR DESCRIPTION
## Summary
- Move Gear List generation control into Setup Actions for better visibility
- Document Gear List functionality in the Managing Setups help section

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4b460d6ac8320b93fd1cfeffecf2c