### PR TITLE
Relocate Generate Gear List button

### DIFF
--- a/index.html
+++ b/index.html
@@ -61,7 +61,6 @@
     <button id="importSetupsBtn">Import Setups</button>
     <input type="file" id="importSetupsInput" accept=".json" class="hidden" />
     <button id="generateOverviewBtn">Generate Overview</button>
-    <button id="generateGearListBtn" type="button">Generate Gear List and Project Requirements</button>
     <button id="shareSetupBtn">Share Setup Link</button>
     <div class="form-row hidden" id="sharedLinkRow">
       <label for="sharedLinkInput" id="sharedLinkLabel">Shared Link:</label>
@@ -172,6 +171,7 @@
     <p id="dtapWarning" role="status" aria-live="polite" aria-describedby="batteryLabel"></p>
     <div id="temperatureNote"></div>
     <button id="runtimeFeedbackBtn" type="button">Submit User Runtime Feedback</button>
+    <button id="generateGearListBtn" type="button">Generate Gear List and Project Requirements</button>
     <div id="gearListOutput" class="hidden"></div>
     <button id="copySummaryBtn" type="button">Copy Summary</button>
     <div id="feedbackTableContainer" class="hidden">


### PR DESCRIPTION
## Summary
- Move the **Generate Gear List** button from Setup Actions to the Results section so it's visible alongside generated data

## Testing
- `npm test > /tmp/test.log 2>&1 && tail -n 20 /tmp/test.log`


------
https://chatgpt.com/codex/tasks/task_e_68b4b5ce597c8320b4086f573efb5142