### PR TITLE
fix: bump service worker cache to show gear list button

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -1,5 +1,5 @@
 /* eslint-env serviceworker */
-const CACHE_NAME = 'camera-power-planner-v4';
+const CACHE_NAME = 'camera-power-planner-v5';
 const ASSETS = [
   './',
   './index.html',


### PR DESCRIPTION
## Summary
- bump service worker cache version to v5 to invalidate old cached assets so the generate gear list button appears

## Testing
- `npm test -- tests/service-worker.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b4b7b1247083209697e3d50b625b23