### PR TITLE
Hide location column from feedback table

### DIFF
--- a/script.js
+++ b/script.js
@@ -3695,7 +3695,12 @@ function renderFeedbackTable(currentKey) {
   const container = document.getElementById('feedbackTableContainer');
   const table = document.getElementById('userFeedbackTable');
   const data = loadFeedbackSafe();
-  const entries = data[currentKey] || [];
+  // Filter out any stored location information to keep the table column hidden
+  const entries = (data[currentKey] || []).map(entry => {
+    const rest = { ...entry };
+    delete rest.location;
+    return rest;
+  });
 
   if (!entries.length) {
     if (table) {


### PR DESCRIPTION
## Summary
- Filter out `location` field when rendering user feedback to keep location column hidden

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4b8456124832096d6ad7b359fdc58