### PR TITLE
Fix print overview by simplifying print-only CSS

### DIFF
--- a/style.css
+++ b/style.css
@@ -1300,15 +1300,18 @@ body.dark-mode.pink-mode .help-content { border-color: var(--accent-color); }
 }
 
 @media print {
-  body *:not(#overviewDialog):not(#overviewDialog *) {
+  /* Hide everything except the overview dialog when printing */
+  body > :not(#overviewDialog) {
     display: none !important;
   }
+
   #overviewDialog {
     display: block;
     position: static;
     width: auto;
     max-width: none;
   }
+
   #overviewDialogContent {
     max-height: none;
     overflow: visible;


### PR DESCRIPTION
## Summary
- ensure only the overview dialog is visible when printing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b4b87257148320bf67b1b69f3b1422