### PR TITLE
feat: detect browser language automatically

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -11,7 +11,7 @@ This browser based tool helps plan professional camera setups powered by V‑Mou
 - 🇮🇹 Italiano
 - 🇫🇷 Français
 
-You can switch the language in the top right corner. The choice is remembered for your next visit.
+The app automatically uses your browser language on first load, and you can switch the language in the top right corner. The choice is remembered for your next visit.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ See the language-specific README files for full details.
 - Save, load, share and clear setups; import/export them as JSON, and generate a printable overview.
 - Visualize power and video connections with an interactive diagram.
 - Customize the device database with your own gear.
-- Switch languages, toggle dark or playful pink themes, and swap between V‑ and B‑Mount plates on supported cameras.
+- Automatically selects your browser language on first load, lets you switch languages, toggle dark or playful pink themes, and swap between V‑ and B‑Mount plates on supported cameras.
 - Works completely offline and offers a searchable help dialog with hover help for every button, field, dropdown and header.
 
 ## Runtime Data Weighting

--- a/script.js
+++ b/script.js
@@ -870,6 +870,17 @@ try {
   const supported = ["en", "de", "es", "fr", "it"];
   if (savedLang && supported.includes(savedLang)) {
     currentLang = savedLang;
+  } else if (typeof navigator !== "undefined") {
+    const navLangs = Array.isArray(navigator.languages)
+      ? navigator.languages
+      : [navigator.language];
+    for (const lang of navLangs) {
+      const short = String(lang).slice(0, 2).toLowerCase();
+      if (supported.includes(short)) {
+        currentLang = short;
+        break;
+      }
+    }
   }
 } catch (e) {
   console.warn("Could not load language from localStorage", e);

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -540,6 +540,39 @@ describe('script.js functions', () => {
     expect(document.getElementById('mainTitle').textContent).toBe('Aplicación de Consumo de Energía para Cámaras');
   });
 
+  test('defaults to browser language when no preference saved', () => {
+    jest.resetModules();
+
+    global.alert = jest.fn();
+    global.prompt = jest.fn();
+    Object.assign(navigator, { clipboard: { writeText: jest.fn().mockResolvedValue() } });
+
+    const html = fs.readFileSync(path.join(__dirname, '../index.html'), 'utf8');
+    const body = html.split('<body>')[1].split('</body>')[0];
+    document.body.innerHTML = body;
+    document.head.innerHTML = '<meta name="theme-color" content="#ffffff">';
+
+    global.loadDeviceData = jest.fn(() => null);
+    global.saveDeviceData = jest.fn();
+    global.loadSetups = jest.fn(() => ({}));
+    global.saveSetups = jest.fn();
+    global.saveSetup = jest.fn();
+    global.loadSetup = jest.fn();
+    global.deleteSetup = jest.fn();
+    global.loadFeedback = jest.fn(() => ({}));
+    global.saveFeedback = jest.fn();
+
+    localStorage.removeItem('language');
+    Object.defineProperty(navigator, 'language', { value: 'fr-FR', configurable: true });
+    Object.defineProperty(navigator, 'languages', { value: ['fr-FR'], configurable: true });
+
+    require('../translations.js');
+    require('../script.js');
+
+    expect(document.documentElement.lang).toBe('fr');
+    expect(localStorage.getItem('language')).toBe('fr');
+  });
+
   test('unifyDevices normalizes videoOutputs', () => {
     jest.resetModules();
 


### PR DESCRIPTION
## Summary
- detect browser language on first load when no preference is saved
- document automatic language detection in README files
- test browser language default behavior

## Testing
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4bc19c0d8832088d9a603cf2fd2bb