### PR TITLE
Localize offline indicator text

### DIFF
--- a/script.js
+++ b/script.js
@@ -917,6 +917,8 @@ function setLanguage(lang) {
   document.getElementById("mainTitle").textContent = texts[lang].appHeading;
   document.getElementById("tagline").textContent = texts[lang].tagline;
   if (skipLink) skipLink.textContent = texts[lang].skipToContent;
+  const offlineElem = document.getElementById("offlineIndicator");
+  if (offlineElem) offlineElem.textContent = texts[lang].offlineIndicator;
   // Section headings with descriptive hover help
   const setupManageHeadingElem = document.getElementById("setupManageHeading");
   setupManageHeadingElem.textContent = texts[lang].setupManageHeading;

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -531,6 +531,7 @@ describe('script.js functions', () => {
     expect(document.documentElement.lang).toBe('de');
     expect(localStorage.getItem('language')).toBe('de');
     expect(document.getElementById('mainTitle').textContent).toBe('Kamera-Stromverbrauchs-App');
+    expect(document.getElementById('offlineIndicator').textContent).toBe(texts.de.offlineIndicator);
   });
 
   test('setLanguage supports Spanish', () => {
@@ -538,6 +539,7 @@ describe('script.js functions', () => {
     expect(document.documentElement.lang).toBe('es');
     expect(localStorage.getItem('language')).toBe('es');
     expect(document.getElementById('mainTitle').textContent).toBe('Aplicación de Consumo de Energía para Cámaras');
+    expect(document.getElementById('offlineIndicator').textContent).toBe(texts.es.offlineIndicator);
   });
 
   test('defaults to browser language when no preference saved', () => {

--- a/translations.js
+++ b/translations.js
@@ -6,6 +6,7 @@ const texts = {
     appHeading: "Camera Power Consumption App",
     tagline: "Plan your film rig and calculate power consumption & battery life.",
     skipToContent: "Skip to content",
+    offlineIndicator: "Offline",
 
     setupManageHeading: "Manage Setup",
     deviceSelectionHeading: "Device Selection",
@@ -345,6 +346,7 @@ const texts = {
     appHeading: "App per consumo di energia della fotocamera",
     tagline: "Pianifica la tua attrezzatura da set e calcola il consumo di energia e l'autonomia delle batterie.",
     skipToContent: "Vai al contenuto",
+    offlineIndicator: "Offline",
     setupManageHeading: "Gestisci la configurazione",
     deviceSelectionHeading: "Selezione del dispositivo",
     resultsHeading: "Risultati",
@@ -658,6 +660,7 @@ const texts = {
     appHeading: "Aplicación de Consumo de Energía para Cámaras",
     tagline: "Planifica tu equipo de rodaje y calcula el consumo de energía y la autonomía de las baterías.",
     skipToContent: "Saltar al contenido",
+    offlineIndicator: "Sin conexión",
 
     setupManageHeading: "Gestionar Configuración",
     deviceSelectionHeading: "Selección de Dispositivos",
@@ -988,6 +991,7 @@ const texts = {
     appHeading: "Application de Consommation Caméra",
     tagline: "Planifiez votre équipement de tournage et calculez la consommation et l'autonomie des batteries.",
     skipToContent: "Aller au contenu",
+    offlineIndicator: "Hors ligne",
 
     setupManageHeading: "Gérer la Configuration",
     deviceSelectionHeading: "Sélection des Appareils",
@@ -1320,6 +1324,7 @@ const texts = {
     appHeading: "Kamera-Stromverbrauchs-App",
     tagline: "Plane dein Dreh-Setup und berechne Stromverbrauch und Akkulaufzeit.",
     skipToContent: "Zum Inhalt springen",
+    offlineIndicator: "Offline",
 
     setupManageHeading: "Setup verwalten",
     deviceSelectionHeading: "Geräte-Auswahl",


### PR DESCRIPTION
## Summary
- Localize the offline indicator through new translation strings.
- Update language switching to translate the offline status label.
- Cover offline indicator localization with tests.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4bd9be3cc832097e5b348d71fa991