### PR TITLE
Add detailed monitoring preference options

### DIFF
--- a/index.html
+++ b/index.html
@@ -816,10 +816,24 @@
       </label></div>
       <div class="form-row"><label for="monitoringPreferences">Monitoring Preferences:
         <select id="monitoringPreferences" name="monitoringPreferences" multiple>
-          <option value="Onboard Monitor">Onboard Monitor</option>
-          <option value="Director's Monitor">Director's Monitor</option>
-          <option value="Wireless Video">Wireless Video</option>
-          <option value="Focus Puller Monitor">Focus Puller Monitor</option>
+          <option value="VF Clean Feed">VF Clean Feed</option>
+          <option value="Onboard Clean Feed">Onboard Clean Feed</option>
+          <option value="Surroundview (if available)">Surroundview (if available)</option>
+          <option value="Frame Guide: Center Dot">Frame Guide: Center Dot</option>
+          <option value="Frame Guides: Center Cross">Frame Guides: Center Cross</option>
+          <option value="Frame Guide: Rule of Thirds">Frame Guide: Rule of Thirds</option>
+          <option value="Frame Guide: User Box">Frame Guide: User Box</option>
+          <option value="Frame Guide: 90% marker">Frame Guide: 90% marker</option>
+          <option value="Aspect Mask Opacity 100%">Aspect Mask Opacity 100%</option>
+          <option value="AM Opacity 75%">AM Opacity 75%</option>
+          <option value="AM Opacity 50%">AM Opacity 50%</option>
+          <option value="AM Opacity 25%">AM Opacity 25%</option>
+          <option value="AM Opacity 0%">AM Opacity 0%</option>
+          <option value="Onboard 5 inch">Onboard 5 inch</option>
+          <option value="Onboard 7 inch">Onboard 7 inch</option>
+          <option value="Directors Monitor 7 inch handheld">Directors Monitor 7 inch handheld</option>
+          <option value="Directors Monitor 15-19 inch">Directors Monitor 15-19 inch</option>
+          <option value="Combo Monitor 15-19 inch">Combo Monitor 15-19 inch</option>
         </select>
       </label></div>
       <div class="form-row"><label for="tripodPreferences">Tripod Preferences:


### PR DESCRIPTION
## Summary
- expand monitoring preferences dropdown with clean feed, frame guide, aspect mask opacity, and monitor size options

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b4c67b56808320a77065a6a69bce50