### PR TITLE
chore: bump service worker cache version

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -1,5 +1,5 @@
 /* eslint-env serviceworker */
-const CACHE_NAME = 'camera-power-planner-v6';
+const CACHE_NAME = 'camera-power-planner-v7';
 const ASSETS = [
   './',
   './index.html',


### PR DESCRIPTION
## Summary
- update service worker cache name to version 7 to ensure clients load fresh assets

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b4ce96bb6c83208eb285a8ef2820f4