### PR TITLE
chore: bump cache version

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -1,5 +1,5 @@
 /* eslint-env serviceworker */
-const CACHE_NAME = 'camera-power-planner-v7';
+const CACHE_NAME = 'camera-power-planner-v8';
 const ASSETS = [
   './',
   './index.html',


### PR DESCRIPTION
## Summary
- bump service worker cache name to v8 to force refresh of cached assets

## Testing
- `npm run lint`
- `npm run check-consistency`
- `npx jest --runInBand`


------
https://chatgpt.com/codex/tasks/task_e_68b55ecfa04c83209979e5d30db4dc8e