### PR TITLE
Add sticky top bar for global controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,22 +24,24 @@
 <body>
   <a href="#mainContent" class="skip-link" id="skipLink">Skip to content</a>
   <div id="offlineIndicator" role="status" aria-live="polite">Offline</div>
-  <div id="langSelector">
-    <select id="languageSelect" aria-label="Select language">
-      <option value="en">English</option>
-      <option value="de">Deutsch</option>
-      <option value="es">Español</option>
-      <option value="fr">Français</option>
-      <option value="it">Italiano</option>
-    </select>
-    <button id="darkModeToggle" title="Toggle dark mode" aria-label="Toggle dark mode" aria-pressed="false">🌙</button>
-    <button id="pinkModeToggle" title="Toggle pink mode" aria-label="Toggle pink mode" aria-pressed="false">🐴</button>
-    <button id="helpButton" aria-haspopup="dialog" aria-controls="helpDialog" title="Help (press ?, H, F1 or Ctrl+/)">?</button>
-  </div>
+  <header id="topBar">
+    <h1 id="mainTitle">Camera Power Consumption App</h1>
+    <div class="controls">
+      <select id="languageSelect" aria-label="Select language">
+        <option value="en">English</option>
+        <option value="de">Deutsch</option>
+        <option value="es">Español</option>
+        <option value="fr">Français</option>
+        <option value="it">Italiano</option>
+      </select>
+      <button id="darkModeToggle" title="Toggle dark mode" aria-label="Toggle dark mode" aria-pressed="false">🌙</button>
+      <button id="pinkModeToggle" title="Toggle pink mode" aria-label="Toggle pink mode" aria-pressed="false">🐴</button>
+      <button id="helpButton" aria-haspopup="dialog" aria-controls="helpDialog" title="Help (press ?, H, F1 or Ctrl+/)">?</button>
+    </div>
+  </header>
 
   <main id="mainContent" tabindex="-1">
 
-  <h1 id="mainTitle">Camera Power Consumption App</h1>
   <p id="tagline">Plan your camera setup and calculate power consumption &amp; battery life.</p>
 
   <section id="setup-manager">

--- a/overview-print.css
+++ b/overview-print.css
@@ -32,7 +32,7 @@ p {
   margin: 0.3em 0;
 }
 
-#langSelector,
+#topBar,
 .print-btn,
 .back-btn {
   display: none;

--- a/style.css
+++ b/style.css
@@ -563,28 +563,45 @@ button:disabled {
 }
 
 
-/* Language Selector */
-#langSelector {
-  position: absolute;
-  top: 10px;
-  right: 10px;
-  padding: 2px 5px;
+/* Top bar with language selector and theme toggles */
+#topBar {
+  position: sticky;
+  top: 0;
+  padding: 5px 10px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  flex-wrap: wrap;
+  background: var(--surface-color);
+  box-shadow: var(--panel-shadow);
+  z-index: 100;
+}
+
+#topBar h1 {
+  font-size: 1.3em;
+  margin: 0;
+}
+
+#topBar .controls {
   display: flex;
   gap: 5px;
   align-items: center;
   flex-wrap: wrap;
-  max-width: 100%;
 }
-#langSelector select,
-#langSelector button {
+
+#topBar select,
+#topBar button {
   height: 32px;
   margin: 0;
 }
-#langSelector select {
+
+#topBar select {
   font-size: 1em;
   padding: 2px 4px;
 }
-#langSelector button {
+
+#topBar button {
   min-width: 32px;
   width: 32px;
   display: inline-flex;
@@ -593,6 +610,7 @@ button:disabled {
   padding: 0;
   border-radius: 50%;
 }
+
 #helpButton {
   padding: 0 4px;
   font-size: 1em;
@@ -1126,9 +1144,9 @@ body.dark-mode.pink-mode .help-content { border-color: var(--accent-color); }
 
 /* Responsive layout adjustments */
 @media (max-width: 768px) {
-  #langSelector {
-    position: static;
-    margin-bottom: 10px;
+  #topBar {
+    flex-direction: column;
+    align-items: flex-start;
   }
 }
 
@@ -1138,12 +1156,12 @@ body.dark-mode.pink-mode .help-content { border-color: var(--accent-color); }
     font-size: 0.85em;
   }
 
-  #langSelector select {
+  #topBar .controls select {
     flex: 1 1 100%;
     margin-bottom: 5px;
   }
 
-  #langSelector button {
+  #topBar .controls button {
     flex: 0 0 auto;
   }
 


### PR DESCRIPTION
## Summary
- add sticky header with app title, language selector and theme toggles
- adjust styles for responsive layout and printing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5609ac40c8320be7b2b2dfe40192b