### PR TITLE
Show gear list items on separate lines

### DIFF
--- a/script.js
+++ b/script.js
@@ -6724,7 +6724,7 @@ function generateGearListHtml(info = {}) {
     const infoPairs = Object.entries(info).filter(([k,v]) => v && allowedInfo.includes(k));
     const infoHtml = infoPairs.length ? '<h3>Project Requirements</h3><ul>' +
         infoPairs.map(([k,v]) => `<li>${escapeHtml(labels[k]||k)}: ${escapeHtml(v)}</li>`).join('') + '</ul>' : '';
-    const join = arr => arr.filter(Boolean).map(n => escapeHtml(n)).join(', ');
+    const join = arr => arr.filter(Boolean).map(n => escapeHtml(n)).join('<br>');
     const rows = [];
     const addRow = (cat, items) => {
         rows.push(`<tr class="category-row"><td>${cat}</td></tr>`);

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -804,6 +804,20 @@ describe('script.js functions', () => {
       expect(html).toContain('BNC SDI Cable');
     });
 
+  test('gear list separates multiple items with line breaks', () => {
+    const { generateGearListHtml } = script;
+    const addOpt = (id, value) => {
+      const sel = document.getElementById(id);
+      sel.innerHTML = `<option value="${value}">${value}</option>`;
+      sel.value = value;
+    };
+    addOpt('monitorSelect', 'MonA');
+    addOpt('videoSelect', 'VidA');
+    const html = generateGearListHtml({ projectName: 'Proj' });
+    expect(html).toContain('MonA<br>VidA');
+    expect(html).not.toContain('MonA, VidA');
+  });
+
   test('battery plate selection is saved and loaded with setups', () => {
     // Add camera supporting both plates and matching batteries
     global.devices.cameras.BothCam = {


### PR DESCRIPTION
## Summary
- Render each gear list item on its own line in the gear list table
- Test that multiple items in the gear list are separated by line breaks

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b563acf5c083209e92638e62fd730d