### PR TITLE
Ensure accessories appear in proper gear list categories

### DIFF
--- a/script.js
+++ b/script.js
@@ -6587,6 +6587,8 @@ function generatePrintableOverview() {
 
 function collectAccessories() {
     const cameraSupport = [];
+    const chargers = [];
+    const fiz = [];
     const misc = [];
     const acc = devices.accessories || {};
 
@@ -6601,7 +6603,7 @@ function collectAccessories() {
         }
         if (acc.chargers) {
             for (const [name, charger] of Object.entries(acc.chargers)) {
-                if (!charger.mount || charger.mount === mount) misc.push(name);
+                if (!charger.mount || charger.mount === mount) chargers.push(name);
             }
         }
     }
@@ -6658,7 +6660,7 @@ function collectAccessories() {
                 cConns.forEach(cc => {
                     if (mc === cc) {
                         for (const [name, cable] of Object.entries(fizCableDb)) {
-                            if (cable.from === mc && cable.to === cc) misc.push(name);
+                            if (cable.from === mc && cable.to === cc) fiz.push(name);
                         }
                     }
                 });
@@ -6668,6 +6670,8 @@ function collectAccessories() {
 
     return {
         cameraSupport: [...new Set(cameraSupport)],
+        chargers: [...new Set(chargers)],
+        fiz: [...new Set(fiz)],
         misc: [...new Set(misc)]
     };
 }
@@ -6707,7 +6711,7 @@ function generateGearListHtml(info = {}) {
         batteryPlate: batteryPlateSelect && batteryPlateSelect.value && batteryPlateSelect.value !== 'None' ? batteryPlateSelect.options[batteryPlateSelect.selectedIndex].text : '',
         battery: batterySelect && batterySelect.value && batterySelect.value !== 'None' ? batterySelect.options[batterySelect.selectedIndex].text : ''
     };
-    const { cameraSupport: cameraSupportAcc, misc: miscAcc } = collectAccessories();
+    const { cameraSupport: cameraSupportAcc, chargers: chargersAcc, fiz: fizAcc, misc: miscAcc } = collectAccessories();
     const projectTitle = escapeHtml(info.projectName || setupNameInput.value);
     const allowedInfo = ['dop','firstDay','lastDay','deliveryResolution','recordingResolution','aspectRatio','codec','baseFrameRate','lenses'];
     const labels = {
@@ -6736,10 +6740,10 @@ function generateGearListHtml(info = {}) {
     addRow('Lens', escapeHtml(info.lenses || ''));
     addRow('Lens Support', '');
     addRow('Matte box + filter', escapeHtml(info.filters || ''));
-    addRow('LDS (FIZ)', join([...selectedNames.motors, ...selectedNames.controllers, selectedNames.distance]));
+    addRow('LDS (FIZ)', join([...selectedNames.motors, ...selectedNames.controllers, selectedNames.distance, ...fizAcc]));
     addRow('Camera Batteries', escapeHtml(selectedNames.battery || ''));
     addRow('Monitoring Batteries', '');
-    addRow('Chargers', '');
+    addRow('Chargers', join(chargersAcc));
     addRow('Monitoring', join([selectedNames.monitor, selectedNames.video]));
     addRow('Monitoring support', escapeHtml(info.monitoringPreferences || ''));
     addRow('Power', '');

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -800,8 +800,14 @@ describe('script.js functions', () => {
       expect(html).toContain('CamA');
       expect(html).toContain('Camera Support');
       expect(html).toContain('Universal Cage');
+      expect(html).toContain('LDS (FIZ)');
+      expect(html).toContain('LBUS to LBUS');
+      expect(html).toContain('Chargers');
+      expect(html).toContain('Dual V-Mount Charger');
       expect(html).toContain('Miscellaneous');
       expect(html).toContain('BNC SDI Cable');
+      expect(html).not.toMatch(/Miscellaneous[\s\S]*LBUS to LBUS/);
+      expect(html).not.toMatch(/Miscellaneous[\s\S]*Dual V-Mount Charger/);
     });
 
   test('battery plate selection is saved and loaded with setups', () => {


### PR DESCRIPTION
## Summary
- Separate chargers and FIZ cables when collecting accessories
- List FIZ cables in the FIZ row and chargers in their own row in generated gear lists
- Test gear list generation for correct category placement of chargers and FIZ cables

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b565782f4483208d494ddcbce4f7d8