### PR TITLE
Organize FIZ cables and chargers into dedicated gear list categories

### DIFF
--- a/script.js
+++ b/script.js
@@ -6588,6 +6588,8 @@ function generatePrintableOverview() {
 function collectAccessories() {
     const cameraSupport = [];
     const misc = [];
+    const chargers = [];
+    const fizCables = [];
     const acc = devices.accessories || {};
 
     if (batterySelect.value) {
@@ -6601,7 +6603,7 @@ function collectAccessories() {
         }
         if (acc.chargers) {
             for (const [name, charger] of Object.entries(acc.chargers)) {
-                if (!charger.mount || charger.mount === mount) misc.push(name);
+                if (!charger.mount || charger.mount === mount) chargers.push(name);
             }
         }
     }
@@ -6658,7 +6660,7 @@ function collectAccessories() {
                 cConns.forEach(cc => {
                     if (mc === cc) {
                         for (const [name, cable] of Object.entries(fizCableDb)) {
-                            if (cable.from === mc && cable.to === cc) misc.push(name);
+                            if (cable.from === mc && cable.to === cc) fizCables.push(name);
                         }
                     }
                 });
@@ -6668,6 +6670,8 @@ function collectAccessories() {
 
     return {
         cameraSupport: [...new Set(cameraSupport)],
+        chargers: [...new Set(chargers)],
+        fizCables: [...new Set(fizCables)],
         misc: [...new Set(misc)]
     };
 }
@@ -6707,7 +6711,7 @@ function generateGearListHtml(info = {}) {
         batteryPlate: batteryPlateSelect && batteryPlateSelect.value && batteryPlateSelect.value !== 'None' ? batteryPlateSelect.options[batteryPlateSelect.selectedIndex].text : '',
         battery: batterySelect && batterySelect.value && batterySelect.value !== 'None' ? batterySelect.options[batterySelect.selectedIndex].text : ''
     };
-    const { cameraSupport: cameraSupportAcc, misc: miscAcc } = collectAccessories();
+    const { cameraSupport: cameraSupportAcc, chargers: chargersAcc, fizCables: fizCableAcc, misc: miscAcc } = collectAccessories();
     const projectTitle = escapeHtml(info.projectName || setupNameInput.value);
     const allowedInfo = ['dop','firstDay','lastDay','deliveryResolution','recordingResolution','aspectRatio','codec','baseFrameRate','lenses'];
     const labels = {
@@ -6736,10 +6740,10 @@ function generateGearListHtml(info = {}) {
     addRow('Lens', escapeHtml(info.lenses || ''));
     addRow('Lens Support', '');
     addRow('Matte box + filter', escapeHtml(info.filters || ''));
-    addRow('LDS (FIZ)', join([...selectedNames.motors, ...selectedNames.controllers, selectedNames.distance]));
+    addRow('LDS (FIZ)', join([...selectedNames.motors, ...selectedNames.controllers, selectedNames.distance, ...fizCableAcc]));
     addRow('Camera Batteries', escapeHtml(selectedNames.battery || ''));
     addRow('Monitoring Batteries', '');
-    addRow('Chargers', '');
+    addRow('Chargers', join(chargersAcc));
     let monitoringItems = '';
     if (selectedNames.monitor) {
         monitoringItems += `<strong>Onboard Monitor</strong><br>- ${escapeHtml(selectedNames.monitor)}<br>- incl. Sunhood`;

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -800,6 +800,10 @@ describe('script.js functions', () => {
       expect(html).toContain('CamA');
       expect(html).toContain('Camera Support');
       expect(html).toContain('Universal Cage');
+      expect(html).toContain('LDS (FIZ)');
+      expect(html).toContain('LBUS to LBUS');
+      expect(html).toContain('Chargers');
+      expect(html).toContain('Dual V-Mount Charger');
       expect(html).toContain('Miscellaneous');
       expect(html).toContain('BNC SDI Cable');
     });
@@ -814,7 +818,7 @@ describe('script.js functions', () => {
     addOpt('monitorSelect', 'MonA');
     addOpt('videoSelect', 'VidA');
     const html = generateGearListHtml({ projectName: 'Proj' });
-    expect(html).toContain('MonA<br>VidA');
+    expect(html).toContain('MonA<br>- incl. Sunhood<br>VidA');
     expect(html).not.toContain('MonA, VidA');
   });
 


### PR DESCRIPTION
## Summary
- separate chargers and FIZ cables from miscellaneous accessories
- include FIZ cables in the LDS (FIZ) list and list chargers in their own category
- update tests for new gear list categories

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5672fe6b48320b004db17624a1047