### PR TITLE
chore: bump service worker cache version

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -1,5 +1,5 @@
 /* eslint-env serviceworker */
-const CACHE_NAME = 'camera-power-planner-v8';
+const CACHE_NAME = 'camera-power-planner-v9';
 const ASSETS = [
   './',
   './index.html',


### PR DESCRIPTION
## Summary
- bump service worker cache version to v9 to ensure clients fetch latest assets

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5686652148320b9e9379c3d2fe49d