### PR TITLE
Add categories for FIZ cables, camera support, and chargers

### DIFF
--- a/data.js
+++ b/data.js
@@ -7112,6 +7112,9 @@ let devices={
         "output_display": "DJI RS gimbal screen, DJI Focus Motor (visual focus assist), DJI RS Focus Motor, Ronin App",
         "notes": "Integrated LiDAR sensor designed for DJI RS series gimbals. It provides accurate and fast distance measurements, enabling autofocus for manual lenses (when paired with a DJI Focus Motor). Features a built-in camera that can recognize the subject and track focus. Ideal for solo operators seeking precise autofocus capabilities with cinema lenses."
       }
+    },
+    "cables": {
+      "LBUS to LBUS": { "from": "LBUS (LEMO 4-pin)", "to": "LBUS (LEMO 4-pin)" }
     }
   },
   "batteries": {
@@ -8404,9 +8407,6 @@ let devices={
     "cables": {
       "power": {
         "D-Tap to LEMO 2-pin": { "from": "D-Tap", "to": "LEMO 2-pin" }
-      },
-      "fiz": {
-        "LBUS to LBUS": { "from": "LBUS (LEMO 4-pin)", "to": "LBUS (LEMO 4-pin)" }
       },
       "video": {
         "BNC SDI Cable": { "type": "3G-SDI" },

--- a/index.html
+++ b/index.html
@@ -223,7 +223,10 @@
         <option value="fiz.motors">FIZ Motor</option>
         <option value="fiz.controllers">FIZ Controller</option>
         <option value="fiz.distance">FIZ Distance</option>
+        <option value="fiz.cables">FIZ Cable</option>
         <option value="batteries">V-Mount Battery</option>
+        <option value="accessories.cages">Camera Support</option>
+        <option value="accessories.chargers">Charger</option>
       </select>
     </div>
     <div class="form-row">
@@ -512,9 +515,24 @@
         <ul id="distanceList" class="device-ul"></ul>
       </div>
       <div class="device-category">
+        <h4 id="category_fiz_cables">FIZ Cables</h4>
+        <input type="search" id="fizCableListFilter" class="list-filter" placeholder="Filter..." aria-label="Filter" inputmode="search" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" />
+        <ul id="fizCableList" class="device-ul"></ul>
+      </div>
+      <div class="device-category">
         <h4 id="category_batteries">V-Mount Batteries</h4>
         <input type="search" id="batteryListFilter" class="list-filter" placeholder="Filter..." aria-label="Filter" inputmode="search" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" />
         <ul id="batteryList" class="device-ul"></ul>
+      </div>
+      <div class="device-category">
+        <h4 id="category_camera_support">Camera Support</h4>
+        <input type="search" id="cameraSupportListFilter" class="list-filter" placeholder="Filter..." aria-label="Filter" inputmode="search" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" />
+        <ul id="cameraSupportList" class="device-ul"></ul>
+      </div>
+      <div class="device-category">
+        <h4 id="category_chargers">Chargers</h4>
+        <input type="search" id="chargerListFilter" class="list-filter" placeholder="Filter..." aria-label="Filter" inputmode="search" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" />
+        <ul id="chargerList" class="device-ul"></ul>
       </div>
     </div>
   </section>

--- a/script.js
+++ b/script.js
@@ -1140,7 +1140,10 @@ function setLanguage(lang) {
   document.getElementById("category_fiz_motors").textContent = texts[lang].category_fiz_motors;
   document.getElementById("category_fiz_controllers").textContent = texts[lang].category_fiz_controllers;
   document.getElementById("category_fiz_distance").textContent = texts[lang].category_fiz_distance;
+  document.getElementById("category_fiz_cables").textContent = texts[lang].category_fiz_cables;
   document.getElementById("category_batteries").textContent = texts[lang].category_batteries;
+  document.getElementById("category_camera_support").textContent = texts[lang].category_camera_support;
+  document.getElementById("category_chargers").textContent = texts[lang].category_chargers;
   // Add device form labels and button
   document.getElementById("addDeviceHeading").textContent = texts[lang].addDeviceHeading;
   document.getElementById("categoryLabel").textContent = texts[lang].categoryLabel;
@@ -1216,7 +1219,7 @@ function setLanguage(lang) {
    controllerFilterInput, distanceFilterInput, batteryFilterInput,
    cameraListFilterInput, monitorListFilterInput, videoListFilterInput,
    motorListFilterInput, controllerListFilterInput, distanceListFilterInput,
-   batteryListFilterInput].forEach(input => {
+   batteryListFilterInput, fizCableListFilterInput, cameraSupportListFilterInput, chargerListFilterInput].forEach(input => {
    if (input) {
       input.placeholder = filterPlaceholder;
       input.setAttribute('aria-label', filterPlaceholder);
@@ -1430,6 +1433,9 @@ const motorListElem   = document.getElementById("motorList");
 const controllerListElem = document.getElementById("controllerList");
 const distanceListElem   = document.getElementById("distanceList");
 const batteryListElem    = document.getElementById("batteryList");
+const fizCableListElem    = document.getElementById("fizCableList");
+const cameraSupportListElem = document.getElementById("cameraSupportList");
+const chargerListElem       = document.getElementById("chargerList");
 const newCategorySelect  = document.getElementById("newCategory");
 const newNameInput    = document.getElementById("newName");
 const newWattInput    = document.getElementById("newWatt");
@@ -1674,6 +1680,9 @@ const motorListFilterInput = document.getElementById("motorListFilter");
 const controllerListFilterInput = document.getElementById("controllerListFilter");
 const distanceListFilterInput = document.getElementById("distanceListFilter");
 const batteryListFilterInput = document.getElementById("batteryListFilter");
+const fizCableListFilterInput = document.getElementById("fizCableListFilter");
+const cameraSupportListFilterInput = document.getElementById("cameraSupportListFilter");
+const chargerListFilterInput = document.getElementById("chargerListFilter");
 
 // NEW SETUP MANAGEMENT DOM ELEMENTS
 const exportSetupsBtn = document.getElementById('exportSetupsBtn');
@@ -3263,6 +3272,9 @@ function applyFilters() {
   filterDeviceList(controllerListElem, controllerListFilterInput.value);
   filterDeviceList(distanceListElem, distanceListFilterInput.value);
   filterDeviceList(batteryListElem, batteryListFilterInput.value);
+  filterDeviceList(fizCableListElem, fizCableListFilterInput.value);
+  filterDeviceList(cameraSupportListElem, cameraSupportListFilterInput.value);
+  filterDeviceList(chargerListElem, chargerListFilterInput.value);
 }
 
 // Initialize device selection dropdowns
@@ -4963,7 +4975,10 @@ function refreshDeviceLists() {
   renderDeviceList("fiz.motors", motorListElem);
   renderDeviceList("fiz.controllers", controllerListElem);
   renderDeviceList("fiz.distance", distanceListElem);
+  renderDeviceList("fiz.cables", fizCableListElem);
   renderDeviceList("batteries", batteryListElem);
+  renderDeviceList("accessories.cages", cameraSupportListElem);
+  renderDeviceList("accessories.chargers", chargerListElem);
 
   filterDeviceList(cameraListElem, cameraListFilterInput.value);
   filterDeviceList(monitorListElem, monitorListFilterInput.value);
@@ -4971,7 +4986,10 @@ function refreshDeviceLists() {
   filterDeviceList(motorListElem, motorListFilterInput.value);
   filterDeviceList(controllerListElem, controllerListFilterInput.value);
   filterDeviceList(distanceListElem, distanceListFilterInput.value);
+  filterDeviceList(fizCableListElem, fizCableListFilterInput.value);
   filterDeviceList(batteryListElem, batteryListFilterInput.value);
+  filterDeviceList(cameraSupportListElem, cameraSupportListFilterInput.value);
+  filterDeviceList(chargerListElem, chargerListFilterInput.value);
 }
 
 // Initial render of device lists
@@ -5017,6 +5035,9 @@ bindFilterInput(motorListFilterInput, () => filterDeviceList(motorListElem, moto
 bindFilterInput(controllerListFilterInput, () => filterDeviceList(controllerListElem, controllerListFilterInput.value));
 bindFilterInput(distanceListFilterInput, () => filterDeviceList(distanceListElem, distanceListFilterInput.value));
 bindFilterInput(batteryListFilterInput, () => filterDeviceList(batteryListElem, batteryListFilterInput.value));
+bindFilterInput(fizCableListFilterInput, () => filterDeviceList(fizCableListElem, fizCableListFilterInput.value));
+bindFilterInput(cameraSupportListFilterInput, () => filterDeviceList(cameraSupportListElem, cameraSupportListFilterInput.value));
+bindFilterInput(chargerListFilterInput, () => filterDeviceList(chargerListElem, chargerListFilterInput.value));
 
 // Setup management
 saveSetupBtn.addEventListener("click", () => {
@@ -6649,7 +6670,7 @@ function collectAccessories() {
     matchVideo(devices.monitors[monitorSelect.value]);
     matchVideo(devices.video[videoSelect.value]);
 
-    const fizCableDb = acc.cables?.fiz || {};
+    const fizCableDb = devices.fiz?.cables || acc.cables?.fiz || {};
     const motorDatas = motorSelects.map(sel => devices.fiz.motors[sel.value]).filter(Boolean);
     const controllerDatas = controllerSelects.map(sel => devices.fiz.controllers[sel.value]).filter(Boolean);
     motorDatas.forEach(m => {

--- a/translations.js
+++ b/translations.js
@@ -129,7 +129,10 @@ const texts = {
     category_fiz_motors: "FIZ Motors",
     category_fiz_controllers: "FIZ Controllers",
     category_fiz_distance: "FIZ Distance",
+    category_fiz_cables: "FIZ Cables",
     category_batteries: "V-Mount Batteries",
+    category_camera_support: "Camera Support",
+    category_chargers: "Chargers",
 
     addDeviceHeading: "Add New Device",
     categoryLabel: "Category:",
@@ -464,7 +467,10 @@ const texts = {
     category_fiz_motors: "Motori FIZ",
     category_fiz_controllers: "Controller FIZ",
     category_fiz_distance: "Distanza FIZ",
+    category_fiz_cables: "Cavi FIZ",
     category_batteries: "Batterie a V-Mount",
+    category_camera_support: "Supporto camera",
+    category_chargers: "Caricatori",
     addDeviceHeading: "Aggiungi nuovo dispositivo",
     categoryLabel: "Categoria:",
     deviceNameLabel: "Nome:",
@@ -791,7 +797,10 @@ const texts = {
     category_fiz_motors: "Motores FIZ",
     category_fiz_controllers: "Controles FIZ",
     category_fiz_distance: "Distancia FIZ",
+    category_fiz_cables: "Cables FIZ",
     category_batteries: "Baterías V-Mount",
+    category_camera_support: "Soporte de cámara",
+    category_chargers: "Cargadores",
 
     addDeviceHeading: "Añadir Nuevo Dispositivo",
     categoryLabel: "Categoría:",
@@ -1127,7 +1136,10 @@ const texts = {
     category_fiz_motors: "Moteurs FIZ",
     category_fiz_controllers: "Contrôleurs FIZ",
     category_fiz_distance: "Distance FIZ",
+    category_fiz_cables: "Câbles FIZ",
     category_batteries: "Batteries V-Mount",
+    category_camera_support: "Support caméra",
+    category_chargers: "Chargeurs",
 
     addDeviceHeading: "Ajouter un Nouvel Appareil",
     categoryLabel: "Catégorie:",
@@ -1465,7 +1477,10 @@ const texts = {
     category_fiz_motors: "FIZ Motoren",
     category_fiz_controllers: "FIZ Controller",
     category_fiz_distance: "FIZ Distanz",
+    category_fiz_cables: "FIZ-Kabel",
     category_batteries: "V-Mount Akkus",
+    category_camera_support: "Kamera-Support",
+    category_chargers: "Ladegeräte",
 
     addDeviceHeading: "Neues Gerät hinzufügen",
     categoryLabel: "Kategorie:",
@@ -1685,7 +1700,10 @@ const categoryNames = {
     "fiz.motors": "FIZ Motor",
     "fiz.controllers": "FIZ Controller",
     "fiz.distance": "FIZ Distance",
-    "batteries": "V-Mount Battery"
+    "fiz.cables": "FIZ Cable",
+    "batteries": "V-Mount Battery",
+    "accessories.cages": "Camera Support",
+    "accessories.chargers": "Charger"
   },
   it: {
     "cameras": "Camera",
@@ -1694,7 +1712,10 @@ const categoryNames = {
     "fiz.motors": "Motore FIZ",
     "fiz.controllers": "Controller FIZ",
     "fiz.distance": "Distanza FIZ",
-    "batteries": "Batteria V-Mount"
+    "fiz.cables": "Cavo FIZ",
+    "batteries": "Batteria V-Mount",
+    "accessories.cages": "Supporto camera",
+    "accessories.chargers": "Caricatore"
   },
   es: {
     "cameras": "Cámara",
@@ -1703,7 +1724,10 @@ const categoryNames = {
     "fiz.motors": "Motor FIZ",
     "fiz.controllers": "Control FIZ",
     "fiz.distance": "Distancia FIZ",
-    "batteries": "Batería V-Mount"
+    "fiz.cables": "Cable FIZ",
+    "batteries": "Batería V-Mount",
+    "accessories.cages": "Soporte de cámara",
+    "accessories.chargers": "Cargador"
   },
   fr: {
     "cameras": "Caméra",
@@ -1712,7 +1736,10 @@ const categoryNames = {
     "fiz.motors": "Moteur FIZ",
     "fiz.controllers": "Contrôleur FIZ",
     "fiz.distance": "Distance FIZ",
-    "batteries": "Batterie V-Mount"
+    "fiz.cables": "Câble FIZ",
+    "batteries": "Batterie V-Mount",
+    "accessories.cages": "Support caméra",
+    "accessories.chargers": "Chargeur"
   },
   de: {
     "cameras": "Kamera",
@@ -1721,7 +1748,10 @@ const categoryNames = {
     "fiz.motors": "FIZ Motoren",
     "fiz.controllers": "FIZ Controller",
     "fiz.distance": "FIZ Distanz",
-    "batteries": "V-Mount Akku"
+    "fiz.cables": "FIZ-Kabel",
+    "batteries": "V-Mount Akku",
+    "accessories.cages": "Kamera-Support",
+    "accessories.chargers": "Ladegerät"
   },
 };
 


### PR DESCRIPTION
## Summary
- Move FIZ cable definitions into the FIZ device section
- Add camera support and charger device categories to the manager
- Expand translations and UI to show new categories

## Testing
- `CI=1 npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b569714b4083208ed2fa5c7db56dda