### PR TITLE
Fix dark mode styling for overview page

### DIFF
--- a/script.js
+++ b/script.js
@@ -6573,6 +6573,7 @@ function generatePrintableOverview() {
 
     const darkModeActive = document.body.classList.contains('dark-mode');
     if (darkModeActive) {
+        content.classList.add('dark-mode');
         document.body.classList.remove('dark-mode');
     }
     if (document.body.classList.contains('pink-mode')) {

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -797,6 +797,22 @@ describe('script.js functions', () => {
     expect(html).toContain(`<strong>${texts.en.cameraLabel}</strong>`);
   });
 
+  test('generatePrintableOverview applies dark mode styling when active', () => {
+    const { generatePrintableOverview } = script;
+    document.body.classList.add('dark-mode');
+    document.getElementById('setupName').value = 'Test';
+    const addOpt = (id, value) => {
+      const sel = document.getElementById(id);
+      sel.innerHTML = `<option value="${value}">${value}</option>`;
+      sel.value = value;
+    };
+    addOpt('cameraSelect', 'CamA');
+    script.updateCalculations();
+    generatePrintableOverview();
+    const content = document.querySelector('#overviewDialogContent');
+    expect(content.classList.contains('dark-mode')).toBe(true);
+  });
+
   test('generateGearListHtml returns table with categories and accessories', () => {
       const { generateGearListHtml } = script;
       const addOpt = (id, value) => {


### PR DESCRIPTION
## Summary
- Apply dark mode class to generated overview content when dark mode is enabled
- Add regression test ensuring overview respects dark mode

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b570e5bee48320a4569bced99b75e9