### PR TITLE
chore: bump service worker cache version

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -1,5 +1,5 @@
 /* eslint-env serviceworker */
-const CACHE_NAME = 'camera-power-planner-v9';
+const CACHE_NAME = 'camera-power-planner-v10';
 const ASSETS = [
   './',
   './index.html',


### PR DESCRIPTION
## Summary
- update service worker cache name to version 10

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b571be555c8320ab82a2902f17b303