### PR TITLE
Add prep day field to gear list form

### DIFF
--- a/index.html
+++ b/index.html
@@ -796,6 +796,7 @@
       <h3>Project Requirements</h3>
       <div class="form-row"><label for="projectName">Project Name:<input type="text" id="projectName" name="projectName"></label></div>
       <div class="form-row"><label for="dop">DoP:<input type="text" id="dop" name="dop"></label></div>
+      <div class="form-row"><label for="prepDay">Prep Day:<input type="date" id="prepDay" name="prepDay"></label></div>
       <div class="form-row"><label for="firstDay">First Day of Shooting:<input type="date" id="firstDay" name="firstDay"></label></div>
       <div class="form-row"><label for="lastDay">Last Day of Shooting:<input type="date" id="lastDay" name="lastDay"></label></div>
       <div class="form-row"><label for="deliveryResolution">Delivery Resolution:<input type="text" id="deliveryResolution" name="deliveryResolution"></label></div>

--- a/script.js
+++ b/script.js
@@ -6725,6 +6725,7 @@ function collectProjectFormData() {
     return {
         projectName: val('projectName'),
         dop: val('dop'),
+        prepDay: val('prepDay'),
         firstDay: val('firstDay'),
         lastDay: val('lastDay'),
         deliveryResolution: val('deliveryResolution'),
@@ -6755,9 +6756,10 @@ function generateGearListHtml(info = {}) {
     };
     const { cameraSupport: cameraSupportAcc, chargers: chargersAcc, fizCables: fizCableAcc, misc: miscAcc } = collectAccessories();
     const projectTitle = escapeHtml(info.projectName || setupNameInput.value);
-    const allowedInfo = ['dop','firstDay','lastDay','deliveryResolution','recordingResolution','aspectRatio','codec','baseFrameRate','lenses'];
+    const allowedInfo = ['dop','prepDay','firstDay','lastDay','deliveryResolution','recordingResolution','aspectRatio','codec','baseFrameRate','lenses'];
     const labels = {
         dop: 'DoP',
+        prepDay: 'Prep Day',
         firstDay: 'First Day of Shooting',
         lastDay: 'Last Day of Shooting',
         deliveryResolution: 'Delivery Resolution',


### PR DESCRIPTION
## Summary
- Add Prep Day field to project requirements dialog
- Include Prep Day in gear list generation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5725a28108320bdbf5efce3fba635