### PR TITLE
Replace shooting and prep day fields with date ranges

### DIFF
--- a/index.html
+++ b/index.html
@@ -797,9 +797,8 @@
       <h3>Project Requirements</h3>
       <div class="form-row"><label for="projectName">Project Name:<input type="text" id="projectName" name="projectName"></label></div>
       <div class="form-row"><label for="dop">DoP:<input type="text" id="dop" name="dop"></label></div>
-      <div class="form-row"><label for="prepDay">Prep Day:<input type="date" id="prepDay" name="prepDay"></label></div>
-      <div class="form-row"><label for="firstDay">First Day of Shooting:<input type="date" id="firstDay" name="firstDay"></label></div>
-      <div class="form-row"><label for="lastDay">Last Day of Shooting:<input type="date" id="lastDay" name="lastDay"></label></div>
+      <div class="form-row"><label for="prepStart">Prep Days:<input type="date" id="prepStart" name="prepStart"> to <input type="date" id="prepEnd" name="prepEnd"></label></div>
+      <div class="form-row"><label for="shootStart">Shooting Days:<input type="date" id="shootStart" name="shootStart"> to <input type="date" id="shootEnd" name="shootEnd"></label></div>
       <div class="form-row"><label for="deliveryResolution">Delivery Resolution:<input type="text" id="deliveryResolution" name="deliveryResolution"></label></div>
       <div class="form-row"><label for="recordingResolution">Recording Resolution:<input type="text" id="recordingResolution" name="recordingResolution"></label></div>
       <div class="form-row"><label for="aspectRatio">Aspect Ratio:<input type="text" id="aspectRatio" name="aspectRatio"></label></div>

--- a/script.js
+++ b/script.js
@@ -6731,12 +6731,12 @@ function collectProjectFormData() {
     const val = name => (projectForm.querySelector(`[name="${name}"]`)?.value || '').trim();
     const multi = name => Array.from(projectForm.querySelector(`[name="${name}"]`)?.selectedOptions || [])
         .map(o => o.value).join(', ');
+    const range = (start, end) => [val(start), val(end)].filter(Boolean).join(' to ');
     return {
         projectName: val('projectName'),
         dop: val('dop'),
-        prepDay: val('prepDay'),
-        firstDay: val('firstDay'),
-        lastDay: val('lastDay'),
+        prepDays: range('prepStart','prepEnd'),
+        shootingDays: range('shootStart','shootEnd'),
         deliveryResolution: val('deliveryResolution'),
         recordingResolution: val('recordingResolution'),
         aspectRatio: val('aspectRatio'),
@@ -6765,12 +6765,11 @@ function generateGearListHtml(info = {}) {
     };
     const { cameraSupport: cameraSupportAcc, chargers: chargersAcc, fizCables: fizCableAcc, misc: miscAcc } = collectAccessories();
     const projectTitle = escapeHtml(info.projectName || setupNameInput.value);
-    const allowedInfo = ['dop','prepDay','firstDay','lastDay','deliveryResolution','recordingResolution','aspectRatio','codec','baseFrameRate','lenses'];
+    const allowedInfo = ['dop','prepDays','shootingDays','deliveryResolution','recordingResolution','aspectRatio','codec','baseFrameRate','lenses'];
     const labels = {
         dop: 'DoP',
-        prepDay: 'Prep Day',
-        firstDay: 'First Day of Shooting',
-        lastDay: 'Last Day of Shooting',
+        prepDays: 'Prep Days',
+        shootingDays: 'Shooting Days',
         deliveryResolution: 'Delivery Resolution',
         recordingResolution: 'Recording Resolution',
         aspectRatio: 'Aspect Ratio',


### PR DESCRIPTION
## Summary
- Merge separate prep/shoot day fields into date range selectors
- Update project form data handling to capture prep and shooting ranges
- Adjust gear list generation to show new date range fields

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b57633ba9883209fd1a1ef4877c195