### PR TITLE
Combine onboard monitor details into one line

### DIFF
--- a/script.js
+++ b/script.js
@@ -6820,7 +6820,7 @@ function generateGearListHtml(info = {}) {
         monitoringItems += `<strong>Viewfinder</strong><br>- ${escapeHtml(selectedNames.viewfinder)}`;
     }
     if (selectedNames.monitor) {
-        monitoringItems += (monitoringItems ? '<br>' : '') + `<strong>Onboard Monitor</strong><br>- ${escapeHtml(selectedNames.monitor)}<br>- incl. Sunhood`;
+        monitoringItems += (monitoringItems ? '<br>' : '') + `<strong>Onboard Monitor</strong> - ${escapeHtml(selectedNames.monitor)} - incl. Sunhood`;
     }
     if (selectedNames.video) {
         monitoringItems += (monitoringItems ? '<br>' : '') + escapeHtml(selectedNames.video);

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -861,7 +861,7 @@ describe('script.js functions', () => {
     addOpt('monitorSelect', 'MonA');
     addOpt('videoSelect', 'VidA');
     const html = generateGearListHtml({ projectName: 'Proj' });
-    expect(html).toContain('MonA<br>- incl. Sunhood<br>VidA');
+    expect(html).toContain('MonA - incl. Sunhood<br>VidA');
     expect(html).not.toContain('MonA, VidA');
   });
 


### PR DESCRIPTION
## Summary
- display onboard monitor and sunhood in a single line
- adjust tests for new gear list format

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b57b5552bc832099e77adfd968671d