### PR TITLE
Format wireless transmitter and include cables

### DIFF
--- a/data.js
+++ b/data.js
@@ -8421,6 +8421,20 @@ let devices={
       },
       "cables": {
         "LBUS to LBUS": { "from": "LBUS (LEMO 4-pin)", "to": "LBUS (LEMO 4-pin)" },
+        "D-Tap to Lemo-2-pin Cable 0,3m": {
+          "lengthM": 0.3,
+          "connectors": ["D-Tap", "Lemo 2-pin"],
+          "orientation": "straight",
+          "useCase": ["Power"]
+        },
+        "ultra slim 3G-SDI BNC cable 0,5m": {
+          "lengthM": 0.5,
+          "connectors": ["BNC", "BNC"],
+          "orientation": "straight",
+          "type": "3G-SDI",
+          "notes": "ultra slim",
+          "useCase": ["Video"]
+        },
         "Cable CAM (10-pin) – EXT (7-pin)": {
           "brand": "ARRI",
           "kNumber": "K2.0007730",

--- a/script.js
+++ b/script.js
@@ -6823,7 +6823,7 @@ function generateGearListHtml(info = {}) {
         monitoringItems += (monitoringItems ? '<br>' : '') + `<strong>Onboard Monitor</strong> - ${escapeHtml(selectedNames.monitor)} - incl. Sunhood`;
     }
     if (selectedNames.video) {
-        monitoringItems += (monitoringItems ? '<br>' : '') + escapeHtml(selectedNames.video);
+        monitoringItems += (monitoringItems ? '<br>' : '') + `<strong>Wireless Transmitter</strong> - ${escapeHtml(selectedNames.video)}`;
     }
     addRow('Monitoring', monitoringItems);
 
@@ -6835,6 +6835,10 @@ function generateGearListHtml(info = {}) {
     addCable('D-Tap to Lemo-2-pin Cable 0,5m', 'for onboard monitor');
     addCable('D-Tap to Lemo-2-pin Cable 0,5m', 'spare');
     addCable('ultra slim 3G-SDI BNC cable 0,5m', 'for onboard monitor');
+    addCable('ultra slim 3G-SDI BNC cable 0,5m', 'spare');
+    addCable('D-Tap to Lemo-2-pin Cable 0,3m', 'for wireless transmitter');
+    addCable('D-Tap to Lemo-2-pin Cable 0,3m', 'spare');
+    addCable('ultra slim 3G-SDI BNC cable 0,5m', 'for wireless transmitter');
     addCable('ultra slim 3G-SDI BNC cable 0,5m', 'spare');
     const formatCableUsage = usageMap => {
         return Object.entries(usageMap).map(([name, uses]) => {

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -861,7 +861,7 @@ describe('script.js functions', () => {
     addOpt('monitorSelect', 'MonA');
     addOpt('videoSelect', 'VidA');
     const html = generateGearListHtml({ projectName: 'Proj' });
-    expect(html).toContain('MonA - incl. Sunhood<br>VidA');
+    expect(html).toContain('<strong>Onboard Monitor</strong> - MonA - incl. Sunhood<br><strong>Wireless Transmitter</strong> - VidA');
     expect(html).not.toContain('MonA, VidA');
   });
 


### PR DESCRIPTION
## Summary
- Format wireless video transmitter entry like the onboard monitor in gear list
- Track D-Tap to Lemo-2-pin 0.3m and ultra slim 3G-SDI BNC 0.5m cables for wireless transmitter
- Extend cable database and adjust tests for new formatting

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b5800ec5c48320bf60bb519ffa3ccd