### PR TITLE
Improve project requirement selectors and filter dropdown

### DIFF
--- a/data.js
+++ b/data.js
@@ -8696,4 +8696,5 @@ let devices={
     }
   }
 };
-if (typeof module !== "undefined" && module.exports) { module.exports = devices; }
+const filterOptions = ['ND', 'Polarizer', 'Diffusion', 'Clear'];
+if (typeof module !== "undefined" && module.exports) { module.exports = { ...devices, filterOptions }; }

--- a/index.html
+++ b/index.html
@@ -834,8 +834,8 @@
       <div class="form-row"><label for="codec">Codec:<input type="text" id="codec" name="codec"></label></div>
       <div class="form-row"><label for="baseFrameRate">Base Frame Rate:<input type="text" id="baseFrameRate" name="baseFrameRate"></label></div>
       <div class="form-row"><label for="lenses">Lenses:<input type="text" id="lenses" name="lenses"></label></div>
-      <div class="form-row"><label for="requiredScenarios">16. What required scenarios do we have for this shoot?
-        <select id="requiredScenarios" name="requiredScenarios" multiple size="8">
+      <div class="form-row"><label for="requiredScenarios">What required scenarios do we have for this shoot?
+        <select id="requiredScenarios" name="requiredScenarios" multiple size="25">
           <option value="Indoor">Indoor</option>
           <option value="Outdoor">Outdoor</option>
           <option value="Studio">Studio</option>
@@ -863,8 +863,8 @@
           <option value="Dolly Remote handle">Dolly Remote handle</option>
         </select>
       </label></div>
-      <div class="form-row"><label for="rigging">17. How would you like to have your camera rigged?
-        <select id="rigging" name="rigging" multiple size="8">
+      <div class="form-row"><label for="rigging">How would you like to have your camera rigged?
+        <select id="rigging" name="rigging" multiple size="15">
           <option value="Shoulder rig">Shoulder rig</option>
           <option value="Hand Grips">Hand Grips</option>
           <option value="Teradek and Battery belt">Teradek and Battery belt</option>
@@ -883,7 +883,7 @@
         </select>
       </label></div>
       <div class="form-row"><label for="monitoringPreferences">Monitoring Preferences:
-        <select id="monitoringPreferences" name="monitoringPreferences" multiple size="8">
+        <select id="monitoringPreferences" name="monitoringPreferences" multiple size="18">
           <option value="VF Clean Feed">VF Clean Feed</option>
           <option value="Onboard Clean Feed">Onboard Clean Feed</option>
           <option value="Surroundview (if available)">Surroundview (if available)</option>
@@ -912,13 +912,8 @@
           <option value="Slider">Slider</option>
         </select>
       </label></div>
-      <div class="form-row"><label for="filters">Filters:
-        <select id="filters" name="filters" multiple size="4">
-          <option value="ND">ND</option>
-          <option value="Polarizer">Polarizer</option>
-          <option value="Diffusion">Diffusion</option>
-          <option value="Clear">Clear</option>
-        </select>
+      <div class="form-row"><label for="filter">Filter:
+        <select id="filter" name="filter"></select>
       </label></div>
       <menu>
         <button type="reset" id="projectCancel">Cancel</button>

--- a/script.js
+++ b/script.js
@@ -6,6 +6,7 @@
 // would attempt to create a new lexical binding and throw a SyntaxError in
 // browsers that already have the global property. `var` simply reuses the
 // existing global variable if present.
+/* global filterOptions */
 var LZString;
 try {
   LZString = require('lz-string');
@@ -6761,7 +6762,7 @@ function collectProjectFormData() {
         rigging: multi('rigging'),
         monitoringPreferences: multi('monitoringPreferences'),
         tripodPreferences: multi('tripodPreferences'),
-        filters: multi('filters')
+        filter: val('filter')
     };
 }
 
@@ -6810,7 +6811,7 @@ function generateGearListHtml(info = {}) {
     addRow('Media', '');
     addRow('Lens', escapeHtml(info.lenses || ''));
     addRow('Lens Support', '');
-    addRow('Matte box + filter', escapeHtml(info.filters || ''));
+    addRow('Matte box + filter', escapeHtml(info.filter || ''));
     addRow('LDS (FIZ)', join([...selectedNames.motors, ...selectedNames.controllers, selectedNames.distance, ...fizCableAcc]));
     addRow('Camera Batteries', escapeHtml(selectedNames.battery || ''));
     addRow('Monitoring Batteries', '');
@@ -7529,6 +7530,7 @@ function initApp() {
     }
   }
   populateEnvironmentDropdowns();
+  populateFilterDropdown();
   setLanguage(currentLang);
   resetDeviceForm();
   restoreSessionState();
@@ -7550,6 +7552,21 @@ function populateEnvironmentDropdowns() {
     }
   }
 
+}
+
+function populateFilterDropdown() {
+  const filterSelect = document.getElementById('filter');
+  if (filterSelect && typeof filterOptions !== 'undefined' && Array.isArray(filterOptions)) {
+    const emptyOpt = document.createElement('option');
+    emptyOpt.value = '';
+    filterSelect.appendChild(emptyOpt);
+    filterOptions.forEach(f => {
+      const opt = document.createElement('option');
+      opt.value = f;
+      opt.textContent = f;
+      filterSelect.appendChild(opt);
+    });
+  }
 }
 
 if (document.readyState === "loading") {


### PR DESCRIPTION
## Summary
- Enlarge project requirement selectors and drop numbering for cleaner labels
- Populate filter selector from database instead of hard-coded values

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b5891d896c8320bd2692bbdb4231fd