### PR TITLE
feat: refresh gear list with device changes

### DIFF
--- a/script.js
+++ b/script.js
@@ -1556,6 +1556,7 @@ if (gearListOutput) {
   }
 }
 
+let currentProjectInfo = null;
 let loadedSetupState = null;
 
 function getCurrentSetupState() {
@@ -3778,6 +3779,7 @@ if (!battery || battery === "None" || !devices.batteries[battery]) {
   checkFizController();
   checkArriCompatibility();
   if (setupDiagramContainer) renderSetupDiagram();
+  refreshGearListIfVisible();
 }
 
 function getCurrentSetupKey() {
@@ -6050,6 +6052,7 @@ if (projectForm) {
     projectForm.addEventListener('submit', e => {
         e.preventDefault();
         const info = collectProjectFormData();
+        currentProjectInfo = info;
         const html = generateGearListHtml(info);
         if (gearListOutput) {
             gearListOutput.innerHTML = html;
@@ -6978,6 +6981,13 @@ function ensureGearListActions() {
     deleteBtn.textContent = texts[currentLang].deleteGearListBtn;
 }
 
+function refreshGearListIfVisible() {
+    if (!gearListOutput || gearListOutput.classList.contains('hidden') || !currentProjectInfo) return;
+    const html = generateGearListHtml(currentProjectInfo);
+    gearListOutput.innerHTML = html;
+    ensureGearListActions();
+    saveCurrentGearList();
+}
 
 // --- SESSION STATE HANDLING ---
 function saveCurrentSession() {

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -138,6 +138,25 @@ describe('script.js functions', () => {
     expect(itemsRow.textContent).toContain('Universal Cage');
   });
 
+  test('gear list updates when device selection changes', () => {
+    const projectDialog = document.getElementById('projectDialog');
+    projectDialog.close = jest.fn();
+    const cameraSelect = document.getElementById('cameraSelect');
+    cameraSelect.innerHTML = '<option value="CamA">CamA</option>';
+    cameraSelect.value = 'CamA';
+    const cageSelect = document.getElementById('cageSelect');
+    cageSelect.innerHTML = '<option value="Cage1">Cage1</option><option value="Cage2">Cage2</option>';
+    cageSelect.value = 'Cage1';
+    document.getElementById('projectName').value = 'Proj';
+    const projectForm = document.getElementById('projectForm');
+    projectForm.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+    const gearList = document.getElementById('gearListOutput');
+    expect(gearList.innerHTML).toContain('Cage1');
+    cageSelect.value = 'Cage2';
+    cageSelect.dispatchEvent(new Event('change', { bubbles: true }));
+    expect(gearList.innerHTML).toContain('Cage2');
+  });
+
   test('shows runtime average note when more than four user entries', () => {
     const addOpt = (id, value) => {
       const sel = document.getElementById(id);


### PR DESCRIPTION
## Summary
- refresh gear list whenever a device selection changes
- store project info for regenerating the gear list
- test dynamic gear list updates

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b58a571fb88320b1d65b39f459f72a