### PR TITLE
refactor: streamline port cleaning

### DIFF
--- a/unifyPorts.js
+++ b/unifyPorts.js
@@ -119,9 +119,9 @@ function normalizeCamera(cam) {
     }
     cleanPowerInput(cam.power.input);
   }
-  if (Array.isArray(cam.power?.powerDistributionOutputs)) cam.power.powerDistributionOutputs.forEach(cleanPort);
-  if (Array.isArray(cam.videoOutputs)) cam.videoOutputs.forEach(cleanPort);
-  if (Array.isArray(cam.fizConnectors)) cam.fizConnectors.forEach(cleanPort);
+  cleanPort(cam.power?.powerDistributionOutputs);
+  cleanPort(cam.videoOutputs);
+  cleanPort(cam.fizConnectors);
   if (Array.isArray(cam.lensMount)) {
     cam.lensMount.forEach(m => {
       if (m.mount === 'adapted' && /LDS|Cooke/i.test(m.notes || '')) {
@@ -224,7 +224,7 @@ function normalizeFiz(dev) {
     delete dev.fizConnector;
   }
   if (dev.power?.input) cleanPowerInput(dev.power.input);
-  if (Array.isArray(dev.fizConnectors)) dev.fizConnectors.forEach(cleanPort);
+  cleanPort(dev.fizConnectors);
 }
 
 function normalizeCollection(collection, fn) {


### PR DESCRIPTION
## Summary
- simplify port normalization by delegating array checks to `cleanPort`
- apply helper to camera and FIZ device normalization

## Testing
- `npm test` *(fails: Parsing error in data.js line 8691)*
- `npx eslint unifyPorts.js`


------
https://chatgpt.com/codex/tasks/task_e_68b58ecd584883209bdc2f499906efe8