### PR TITLE
Improve layout for setup sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,6 +46,7 @@
 
   <p id="tagline">Plan your camera setup and calculate power consumption &amp; battery life.</p>
 
+  <div id="setupContainer">
   <section id="setup-manager">
     <h2 id="setupManageHeading">Manage Setup</h2>
     <div class="form-row">
@@ -169,6 +170,7 @@
       </div>
     </div>
   </section>
+  </div>
 
   <section id="results">
     <h2 id="resultsHeading">Results</h2>

--- a/style.css
+++ b/style.css
@@ -367,6 +367,23 @@ body.hover-help-active * {
   display: none;
 }
 
+#setupContainer {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+@media (min-width: 900px) {
+  #setupContainer {
+    flex-direction: row;
+    align-items: flex-start;
+  }
+  #setup-manager,
+  #setup-config {
+    flex: 1;
+  }
+}
+
 
 .device-category .list-filter {
   width: 100%;


### PR DESCRIPTION
## Summary
- Display Manage Setup and Device Selection sections side by side on large screens by wrapping them in a new flex container.
- Add responsive CSS to stack sections on small screens and arrange them in a row above 900px.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5908ead588320819b95b4e1fe88ea