### PR TITLE
Normalize audio ports

### DIFF
--- a/tests/unifyPorts.test.js
+++ b/tests/unifyPorts.test.js
@@ -36,6 +36,18 @@ describe('normalizeMonitor', () => {
     normalizeMonitor(monitor);
     expect(monitor.power.input.voltageRange).toBe('12-24');
   });
+
+  it('normalizes audio connector fields', () => {
+    const monitor = {
+      audioOutput: { portType: '3.5mm Headphone Jack' },
+      audioInput: { portType: '3.5mm Mic/Line' },
+      audioIo: { portType: '10-pin LEMO (analog audio)' }
+    };
+    normalizeMonitor(monitor);
+    expect(monitor.audioOutput).toEqual({ type: '3.5mm Headphone Jack' });
+    expect(monitor.audioInput).toEqual({ type: '3.5mm Mic/Line' });
+    expect(monitor.audioIo).toEqual({ type: '10-pin LEMO (analog audio)' });
+  });
 });
 
 describe('parsePowerInput', () => {
@@ -73,6 +85,18 @@ describe('normalizeVideoDevice', () => {
     normalizeVideoDevice(dev);
     expect(dev.power.input[0].voltageRange).toBe('5-16');
     expect(dev.power.input[1].voltageRange).toBe('14');
+  });
+
+  it('normalizes audio connector fields', () => {
+    const dev = {
+      audioOutput: { portType: '3.5mm Headphone Jack' },
+      audioInput: { portType: '3.5mm Mic/Line' },
+      audioIo: { portType: '10-pin LEMO (analog audio)' }
+    };
+    normalizeVideoDevice(dev);
+    expect(dev.audioOutput).toEqual({ type: '3.5mm Headphone Jack' });
+    expect(dev.audioInput).toEqual({ type: '3.5mm Mic/Line' });
+    expect(dev.audioIo).toEqual({ type: '10-pin LEMO (analog audio)' });
   });
 });
 

--- a/unifyPorts.js
+++ b/unifyPorts.js
@@ -134,6 +134,9 @@ function normalizeCamera(cam) {
 function normalizeMonitor(mon) {
   if (mon.power?.input) cleanPowerInput(mon.power.input);
   if (mon.power?.output) cleanPort(mon.power.output);
+  cleanPort(mon.audioInput);
+  cleanPort(mon.audioOutput);
+  cleanPort(mon.audioIo);
   normalizeVideoPorts(mon);
 }
 
@@ -216,6 +219,9 @@ function normalizeVideoDevice(dev) {
   }
   normalizeVideoPorts(dev);
   if (dev.power?.input) cleanPowerInput(dev.power.input);
+  cleanPort(dev.audioInput);
+  cleanPort(dev.audioOutput);
+  cleanPort(dev.audioIo);
 
 }
 function normalizeFiz(dev) {


### PR DESCRIPTION
## Summary
- normalize audioInput, audioOutput, and audioIo fields for monitors and video devices
- test normalization of new audio connector categories

## Testing
- `npm run lint`
- `npm run check-consistency`
- `npx jest --runInBand --forceExit`


------
https://chatgpt.com/codex/tasks/task_e_68b590bc265083209e1071f1697e18b0