### PR TITLE
Normalize gear list item names and counts

### DIFF
--- a/script.js
+++ b/script.js
@@ -6838,16 +6838,23 @@ function collectProjectFormData() {
 }
 
 function generateGearListHtml(info = {}) {
+    const getText = sel => sel && sel.options && sel.selectedIndex >= 0
+        ? sel.options[sel.selectedIndex].text.trim()
+        : '';
     const selectedNames = {
-        camera: cameraSelect && cameraSelect.value && cameraSelect.value !== 'None' ? cameraSelect.options[cameraSelect.selectedIndex].text : '',
-        monitor: monitorSelect && monitorSelect.value && monitorSelect.value !== 'None' ? monitorSelect.options[monitorSelect.selectedIndex].text : '',
-        video: videoSelect && videoSelect.value && videoSelect.value !== 'None' ? videoSelect.options[videoSelect.selectedIndex].text : '',
-        motors: motorSelects.map(sel => sel && sel.value && sel.value !== 'None' ? sel.options[sel.selectedIndex].text : '').filter(Boolean),
-        controllers: controllerSelects.map(sel => sel && sel.value && sel.value !== 'None' ? sel.options[sel.selectedIndex].text : '').filter(Boolean),
-        distance: distanceSelect && distanceSelect.value && distanceSelect.value !== 'None' ? distanceSelect.options[distanceSelect.selectedIndex].text : '',
-        cage: cageSelect && cageSelect.value && cageSelect.value !== 'None' ? cageSelect.options[cageSelect.selectedIndex].text : '',
-        batteryPlate: batteryPlateSelect && batteryPlateSelect.value && batteryPlateSelect.value !== 'None' ? batteryPlateSelect.options[batteryPlateSelect.selectedIndex].text : '',
-        battery: batterySelect && batterySelect.value && batterySelect.value !== 'None' ? batterySelect.options[batterySelect.selectedIndex].text : ''
+        camera: cameraSelect && cameraSelect.value && cameraSelect.value !== 'None' ? getText(cameraSelect) : '',
+        monitor: monitorSelect && monitorSelect.value && monitorSelect.value !== 'None' ? getText(monitorSelect) : '',
+        video: videoSelect && videoSelect.value && videoSelect.value !== 'None' ? getText(videoSelect) : '',
+        motors: motorSelects
+            .map(sel => sel && sel.value && sel.value !== 'None' ? getText(sel) : '')
+            .filter(Boolean),
+        controllers: controllerSelects
+            .map(sel => sel && sel.value && sel.value !== 'None' ? getText(sel) : '')
+            .filter(Boolean),
+        distance: distanceSelect && distanceSelect.value && distanceSelect.value !== 'None' ? getText(distanceSelect) : '',
+        cage: cageSelect && cageSelect.value && cageSelect.value !== 'None' ? getText(cageSelect) : '',
+        batteryPlate: batteryPlateSelect && batteryPlateSelect.value && batteryPlateSelect.value !== 'None' ? getText(batteryPlateSelect) : '',
+        battery: batterySelect && batterySelect.value && batterySelect.value !== 'None' ? getText(batterySelect) : ''
     };
     if (["Arri Alexa Mini", "Arri Amira"].includes(selectedNames.camera)) {
         selectedNames.viewfinder = "ARRI K2.75004.0 MVF-1 Viewfinder";
@@ -6874,7 +6881,8 @@ function generateGearListHtml(info = {}) {
     const formatItems = arr => {
         const counts = {};
         arr.filter(Boolean).forEach(n => {
-            counts[n] = (counts[n] || 0) + 1;
+            const key = n.trim();
+            counts[key] = (counts[key] || 0) + 1;
         });
         return Object.entries(counts)
             .map(([n, c]) => `${c}x ${escapeHtml(n)}`)

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -940,6 +940,19 @@ describe('script.js functions', () => {
     expect(html).toContain('2x MotorA');
   });
 
+  test('motor names with extra whitespace are trimmed and aggregated', () => {
+    const { generateGearListHtml } = script;
+    const addOpt = (id, value, text) => {
+      const sel = document.getElementById(id);
+      sel.innerHTML = `<option value="${value}">${text}</option>`;
+      sel.value = value;
+    };
+    addOpt('motor1Select', 'MotorA1', 'MotorA ');
+    addOpt('motor2Select', 'MotorA2', 'MotorA');
+    const html = generateGearListHtml({ projectName: 'Proj' });
+    expect(html).toContain('2x MotorA');
+  });
+
   test('alert shown if battery cannot power setup over pins when generating gear list', () => {
     const addOpt = (id, value) => {
       const sel = document.getElementById(id);


### PR DESCRIPTION
## Summary
- Trim selected gear names and count duplicates when generating gear lists
- Aggregate motors even when option text contains extra whitespace
- Add regression test for whitespace handling in gear list

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b595cb792c83209bc95b4532cd5264