### PR TITLE
feat: highlight primary actions with accent buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -58,21 +58,21 @@
     <div class="form-row">
       <label for="setupName" id="setupNameLabel">Setup Name:</label>
       <input type="text" id="setupName" placeholder="Setup name" aria-labelledby="setupNameLabel" />
-      <button id="saveSetupBtn">Save</button>
+      <button id="saveSetupBtn" class="btn-primary">Save</button>
     </div>
     <!-- Moved Setup Actions here -->
     <h3 id="setupActionsHeading">Setup Actions</h3>
     <button id="exportSetupsBtn">Export All Setups</button>
     <button id="importSetupsBtn">Import Setups</button>
     <input type="file" id="importSetupsInput" accept=".json" class="hidden" />
-    <button id="generateOverviewBtn">Generate Overview</button>
-    <button id="shareSetupBtn">Share Setup Link</button>
+    <button id="generateOverviewBtn" class="btn-primary">Generate Overview</button>
+    <button id="shareSetupBtn" class="btn-primary">Share Setup Link</button>
     <div class="form-row hidden" id="sharedLinkRow">
       <label for="sharedLinkInput" id="sharedLinkLabel">Shared Link:</label>
       <input type="url" id="sharedLinkInput" placeholder="Paste shared link" aria-labelledby="sharedLinkLabel" />
-      <button id="applySharedLinkBtn">Load</button>
+      <button id="applySharedLinkBtn" class="btn-primary">Load</button>
     </div>
-    <button id="clearSetupBtn">Clear Current Setup</button>
+    <button id="clearSetupBtn" class="btn-primary">Clear Current Setup</button>
   </section>
 
   <section id="setup-config">

--- a/style.css
+++ b/style.css
@@ -466,6 +466,21 @@ button:disabled {
   cursor: not-allowed;
 }
 
+/* Accent-style buttons for key actions */
+button.btn-primary {
+  background-color: var(--accent-color);
+  color: var(--inverse-text-color);
+  border-color: var(--accent-color);
+}
+
+button.btn-primary:hover {
+  filter: brightness(1.1);
+}
+
+button.btn-primary:active {
+  filter: brightness(0.9);
+}
+
 
 /* Device Manager specific styles */
 .device-list-container {


### PR DESCRIPTION
## Summary
- add btn-primary styles to emphasize key actions
- apply new accent styling to setup management buttons

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b59b3c04b0832088f157654006b246