### PR TITLE
Relax CSP to permit eval

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,6 +13,7 @@
   <meta name="theme-color" content="#f9f9f9" />
   <meta name="application-name" content="Camera Power Planner" />
   <meta name="apple-mobile-web-app-title" content="Camera Power Planner" />
+  <meta http-equiv="Content-Security-Policy" content="script-src 'self' 'unsafe-eval';" />
   <title>Camera Power Planner</title>
   <link href="https://fonts.googleapis.com/css2?family=Ubuntu:wght@300;700&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="style.css" />


### PR DESCRIPTION
## Summary
- allow use of `eval` by adding `'unsafe-eval'` directive to Content Security Policy

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b5a099c1cc8320b6358387e72a0525