### PR TITLE
Group monitoring support cables by type

### DIFF
--- a/script.js
+++ b/script.js
@@ -6946,19 +6946,19 @@ function generateGearListHtml(info = {}) {
     }
     addRow('Monitoring', monitoringItems);
 
-    const cableUsage = {};
-    const addCable = (name, use) => {
-        if (!cableUsage[name]) cableUsage[name] = {};
-        cableUsage[name][use] = (cableUsage[name][use] || 0) + 1;
+    const cableUsage = { power: {}, video: {} };
+    const addCable = (name, use, type) => {
+        if (!cableUsage[type][name]) cableUsage[type][name] = {};
+        cableUsage[type][name][use] = (cableUsage[type][name][use] || 0) + 1;
     };
-    addCable('D-Tap to Lemo-2-pin Cable 0,5m', 'for onboard monitor');
-    addCable('D-Tap to Lemo-2-pin Cable 0,5m', 'spare');
-    addCable('ultra slim 3G-SDI BNC cable 0,5m', 'for onboard monitor');
-    addCable('ultra slim 3G-SDI BNC cable 0,5m', 'spare');
-    addCable('D-Tap to Lemo-2-pin Cable 0,3m', 'for wireless transmitter');
-    addCable('D-Tap to Lemo-2-pin Cable 0,3m', 'spare');
-    addCable('ultra slim 3G-SDI BNC cable 0,3m', 'for wireless transmitter');
-    addCable('ultra slim 3G-SDI BNC cable 0,3m', 'spare');
+    addCable('D-Tap to Lemo-2-pin Cable 0,5m', 'for onboard monitor', 'power');
+    addCable('D-Tap to Lemo-2-pin Cable 0,5m', 'spare', 'power');
+    addCable('ultra slim 3G-SDI BNC cable 0,5m', 'for onboard monitor', 'video');
+    addCable('ultra slim 3G-SDI BNC cable 0,5m', 'spare', 'video');
+    addCable('D-Tap to Lemo-2-pin Cable 0,3m', 'for wireless transmitter', 'power');
+    addCable('D-Tap to Lemo-2-pin Cable 0,3m', 'spare', 'power');
+    addCable('ultra slim 3G-SDI BNC cable 0,3m', 'for wireless transmitter', 'video');
+    addCable('ultra slim 3G-SDI BNC cable 0,3m', 'spare', 'video');
     const formatCableUsage = usageMap => {
         return Object.entries(usageMap).map(([name, uses]) => {
             const total = Object.values(uses).reduce((sum, n) => sum + n, 0);
@@ -6966,7 +6966,11 @@ function generateGearListHtml(info = {}) {
             return `${total}x ${escapeHtml(name)} (${escapeHtml(notes)})`;
         }).join('<br>');
     };
-    let monitoringSupportItems = formatCableUsage(cableUsage);
+    const powerUsage = formatCableUsage(cableUsage.power);
+    const videoUsage = formatCableUsage(cableUsage.video);
+    let monitoringSupportItems = '';
+    if (powerUsage) monitoringSupportItems += `<strong>Power</strong><br>${powerUsage}`;
+    if (videoUsage) monitoringSupportItems += (monitoringSupportItems ? '<br>' : '') + `<strong>Video</strong><br>${videoUsage}`;
     if (info.monitoringPreferences) {
         monitoringSupportItems = `${escapeHtml(info.monitoringPreferences)}<br>${monitoringSupportItems}`;
     }

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -934,6 +934,29 @@ describe('script.js functions', () => {
     expect(html).toContain('6x BattA');
   });
 
+  test('monitoring support cables grouped by type', () => {
+    const { generateGearListHtml } = script;
+    const html = generateGearListHtml();
+    document.body.innerHTML = html;
+    const rows = document.querySelectorAll('table.gear-table tr');
+    let monitoringHtml = '';
+    rows.forEach((tr, idx) => {
+      if (tr.textContent === 'Monitoring support' && rows[idx + 1]) {
+        monitoringHtml = rows[idx + 1].innerHTML;
+      }
+    });
+    expect(monitoringHtml).toContain('<strong>Power</strong>');
+    expect(monitoringHtml).toContain('<strong>Video</strong>');
+    const powerIdx = monitoringHtml.indexOf('<strong>Power</strong>');
+    const videoIdx = monitoringHtml.indexOf('<strong>Video</strong>');
+    const dtapIdx = monitoringHtml.indexOf('D-Tap to Lemo-2-pin Cable 0,5m');
+    const bncIdx = monitoringHtml.indexOf('ultra slim 3G-SDI BNC cable 0,5m');
+    expect(powerIdx).toBeLessThan(videoIdx);
+    expect(dtapIdx).toBeGreaterThan(powerIdx);
+    expect(dtapIdx).toBeLessThan(videoIdx);
+    expect(bncIdx).toBeGreaterThan(videoIdx);
+  });
+
   test('duplicate motors are aggregated with count in gear list', () => {
     const { generateGearListHtml } = script;
     const addOpt = (id, value) => {


### PR DESCRIPTION
## Summary
- Organize monitoring support cables into power and video groups in gear list
- Add tests verifying cable grouping

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5a3725524832086f88066c3a2f1dc