### PR TITLE
Handle missing option objects in select population

### DIFF
--- a/script.js
+++ b/script.js
@@ -3173,7 +3173,8 @@ function clearTimecodes() {
 
 
 // Populate dropdowns with device options
-function populateSelect(selectElem, optionsObj, includeNone=true) {
+function populateSelect(selectElem, optionsObj = {}, includeNone = true) {
+  if (!selectElem) return;
   selectElem.innerHTML = "";
   if (includeNone) {
     const noneOpt = document.createElement("option");


### PR DESCRIPTION
## Summary
- Avoid runtime error when a select's option data is missing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b5a322398c8320b6813219b7f4c95a