### PR TITLE
Display quantity prefixes for monitor and cage selections

### DIFF
--- a/script.js
+++ b/script.js
@@ -6916,7 +6916,7 @@ function generateGearListHtml(info = {}) {
     let cageSelectHtml = '';
     if (compatibleCages.length) {
         const options = compatibleCages.map(c => `<option value="${escapeHtml(c)}"${c === selectedNames.cage ? ' selected' : ''}>${escapeHtml(c)}</option>`).join('');
-        cageSelectHtml = `<select id="gearListCage">${options}</select>`;
+        cageSelectHtml = `1x <select id="gearListCage">${options}</select>`;
     }
     addRow('Camera Support', [cameraSupportText, cageSelectHtml].filter(Boolean).join('<br>'));
     addRow('Media', '');
@@ -6936,13 +6936,13 @@ function generateGearListHtml(info = {}) {
     addRow('Chargers', formatItems(chargersAcc));
     let monitoringItems = '';
     if (selectedNames.viewfinder) {
-        monitoringItems += `<strong>Viewfinder</strong><br>- 1x ${escapeHtml(selectedNames.viewfinder)}`;
+        monitoringItems += `1x <strong>Viewfinder</strong> - ${escapeHtml(selectedNames.viewfinder)}`;
     }
     if (selectedNames.monitor) {
-        monitoringItems += (monitoringItems ? '<br>' : '') + `<strong>Onboard Monitor</strong> - 1x ${escapeHtml(selectedNames.monitor)} - incl. Sunhood`;
+        monitoringItems += (monitoringItems ? '<br>' : '') + `1x <strong>Onboard Monitor</strong> - ${escapeHtml(selectedNames.monitor)} - incl. Sunhood`;
     }
     if (selectedNames.video) {
-        monitoringItems += (monitoringItems ? '<br>' : '') + `<strong>Wireless Transmitter</strong> - 1x ${escapeHtml(selectedNames.video)}`;
+        monitoringItems += (monitoringItems ? '<br>' : '') + `1x <strong>Wireless Transmitter</strong> - ${escapeHtml(selectedNames.video)}`;
     }
     addRow('Monitoring', monitoringItems);
 

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -897,7 +897,7 @@ describe('script.js functions', () => {
       expect(html).toContain('Camera');
       expect(html).toContain('1x CamA');
       expect(html).toContain('Camera Support');
-      expect(html).toContain('<select id="gearListCage"');
+      expect(html).toContain('1x <select id="gearListCage"');
       expect(html).toContain('<option value="Universal Cage"');
       expect(html).toContain('LDS (FIZ)');
       expect(html).toContain('1x LBUS to LBUS');
@@ -917,7 +917,7 @@ describe('script.js functions', () => {
     addOpt('monitorSelect', 'MonA');
     addOpt('videoSelect', 'VidA');
     const html = generateGearListHtml({ projectName: 'Proj' });
-    expect(html).toContain('<strong>Onboard Monitor</strong> - 1x MonA - incl. Sunhood<br><strong>Wireless Transmitter</strong> - 1x VidA');
+    expect(html).toContain('1x <strong>Onboard Monitor</strong> - MonA - incl. Sunhood<br>1x <strong>Wireless Transmitter</strong> - VidA');
     expect(html).not.toContain('MonA, VidA');
   });
 


### PR DESCRIPTION
## Summary
- Show `1x` quantity before cage selector
- Prefix monitoring items with `1x` for clarity
- Update gear list tests accordingly

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5a3a3836483209ea0f94305670b7d