### PR TITLE
style: standardize setup manager buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,21 +60,21 @@
     <div class="form-row">
       <label for="setupName" id="setupNameLabel">Setup Name:</label>
       <input type="text" id="setupName" placeholder="Setup name" aria-labelledby="setupNameLabel" />
-      <button id="saveSetupBtn" class="btn-primary">Save</button>
+      <button id="saveSetupBtn">Save</button>
     </div>
     <!-- Moved Setup Actions here -->
     <h3 id="setupActionsHeading">Setup Actions</h3>
     <button id="exportSetupsBtn">Export All Setups</button>
     <button id="importSetupsBtn">Import Setups</button>
     <input type="file" id="importSetupsInput" accept=".json" class="hidden" />
-    <button id="generateOverviewBtn" class="btn-primary">Generate Overview</button>
-    <button id="shareSetupBtn" class="btn-primary">Share Setup Link</button>
+    <button id="generateOverviewBtn">Generate Overview</button>
+    <button id="shareSetupBtn">Share Setup Link</button>
     <div class="form-row hidden" id="sharedLinkRow">
       <label for="sharedLinkInput" id="sharedLinkLabel">Shared Link:</label>
       <input type="url" id="sharedLinkInput" placeholder="Paste shared link" aria-labelledby="sharedLinkLabel" />
-      <button id="applySharedLinkBtn" class="btn-primary">Load</button>
+      <button id="applySharedLinkBtn">Load</button>
     </div>
-    <button id="clearSetupBtn" class="btn-primary">Clear Current Setup</button>
+    <button id="clearSetupBtn">Clear Current Setup</button>
   </section>
 
   <section id="setup-config">

--- a/style.css
+++ b/style.css
@@ -466,21 +466,6 @@ button:disabled {
   cursor: not-allowed;
 }
 
-/* Accent-style buttons for key actions */
-button.btn-primary {
-  background-color: var(--accent-color);
-  color: var(--inverse-text-color);
-  border-color: var(--accent-color);
-}
-
-button.btn-primary:hover {
-  filter: brightness(1.1);
-}
-
-button.btn-primary:active {
-  filter: brightness(0.9);
-}
-
 
 /* Device Manager specific styles */
 .device-list-container {


### PR DESCRIPTION
## Summary
- remove primary styling from setup manager buttons to match global button design
- drop unused `.btn-primary` rules from styles

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5a5a32b188320bf677a62d588fe13