### PR TITLE
Persist gear list cage selection

### DIFF
--- a/script.js
+++ b/script.js
@@ -6994,6 +6994,18 @@ function getCurrentGearListHtml() {
     const clone = gearListOutput.cloneNode(true);
     const actions = clone.querySelector('#gearListActions');
     if (actions) actions.remove();
+    const cageSel = clone.querySelector('#gearListCage');
+    if (cageSel) {
+        const originalSel = gearListOutput.querySelector('#gearListCage');
+        const val = originalSel ? originalSel.value : cageSel.value;
+        Array.from(cageSel.options).forEach(opt => {
+            if (opt.value === val) {
+                opt.setAttribute('selected', '');
+            } else {
+                opt.removeAttribute('selected');
+            }
+        });
+    }
     return clone.innerHTML.trim();
 }
 
@@ -7110,8 +7122,9 @@ function bindGearListCageListener() {
         sel.addEventListener('change', e => {
             if (cageSelect) {
                 cageSelect.value = e.target.value;
-                refreshGearListIfVisible();
+                cageSelect.dispatchEvent(new Event('change'));
             }
+            saveCurrentGearList();
         });
     }
 }
@@ -7771,5 +7784,6 @@ if (typeof module !== "undefined" && module.exports) {
     getCurrentSetupKey,
     renderFeedbackTable,
     clearAllFilters,
+    saveCurrentGearList,
   };
 }

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -166,6 +166,18 @@ describe('script.js functions', () => {
     expect(cageSelEl.value).toBe('Cage2');
   });
 
+  test('gear list cage selection is stored with selected attribute', () => {
+    global.saveGearList = jest.fn();
+    const gear = document.getElementById('gearListOutput');
+    gear.innerHTML = '1x <select id="gearListCage"><option value="Cage1">Cage1</option><option value="Cage2">Cage2</option></select>';
+    gear.classList.remove('hidden');
+    const cageSel = gear.querySelector('#gearListCage');
+    cageSel.value = 'Cage2';
+    script.saveCurrentGearList();
+    const savedHtml = global.saveGearList.mock.calls[0][0];
+    expect(savedHtml).toContain('<option value="Cage2" selected');
+  });
+
   test('suggests chargers based on total batteries', () => {
     const addOpt = (id, value) => {
       const sel = document.getElementById(id);


### PR DESCRIPTION
## Summary
- Preserve selected cage in gear list HTML so selection persists across reloads
- Synchronize gear list cage selector with main cage select and storage
- Test persistence of cage selection

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5a5e5b63c8320a5d003f1c8431fc0