### PR TITLE
Add weights and specs for new gear

### DIFF
--- a/devices/batteries.js
+++ b/devices/batteries.js
@@ -16,13 +16,15 @@ const batteryData = {
     "capacity": 95,
     "pinA": 10,
     "dtapA": 5,
-    "mount_type": "V-Mount"
+    "mount_type": "V-Mount",
+    "weight_g": 550
   },
   "Bebob V150micro": {
     "capacity": 143,
     "pinA": 10,
     "dtapA": 5,
-    "mount_type": "V-Mount"
+    "mount_type": "V-Mount",
+    "weight_g": 770
   },
   "Bebob V200micro": {
     "capacity": 190,
@@ -52,7 +54,8 @@ const batteryData = {
     "capacity": 285,
     "pinA": 20,
     "dtapA": 5,
-    "mount_type": "V-Mount"
+    "mount_type": "V-Mount",
+    "weight_g": 1390
   },
   "Bebob B90cine": {
     "capacity": 86,
@@ -64,7 +67,8 @@ const batteryData = {
     "capacity": 155,
     "pinA": 20,
     "dtapA": 5,
-    "mount_type": "B-Mount"
+    "mount_type": "B-Mount",
+    "weight_g": 1000
   },
   "Bebob B290cine": {
     "capacity": 294,

--- a/devices/cameras.js
+++ b/devices/cameras.js
@@ -133,6 +133,24 @@ const cameraData = {
   },
   "Arri Alexa Mini": {
     "powerDrawWatts": 84,
+    "weight_g": 2300,
+    "recordingCodecs": ["ARRIRAW", "ProRes 4444 XQ", "ProRes 4444", "ProRes 422 HQ", "ProRes 422", "ProRes 422 LT"],
+    "sensorModes": [
+      "S16 HD 1600×900",
+      "HD 2880×1620",
+      "2K 2868×1612",
+      "3.2K 3200×1800",
+      "UHD 3840×2160 (upsampled from 3.2K)",
+      "4:3 2.8K 2880×2160",
+      "ARRIRAW 16:9 2.8K 2880×1620",
+      "ARRIRAW Open Gate 3.4K 3424×2202"
+    ],
+    "resolutions": [
+      "HD 1920×1080",
+      "2K 2048×1152",
+      "3.2K 3200×1800",
+      "UHD 3840×2160"
+    ],
     "power": {
       "input": {
         "voltageRange": "11-34",
@@ -370,6 +388,21 @@ const cameraData = {
   },
   "Arri Amira": {
     "powerDrawWatts": 50,
+    "weight_g": 4100,
+    "recordingCodecs": ["ProRes 4444", "ProRes 422 HQ", "ProRes 422", "ProRes 422 LT", "MPEG-2 (AMIRA only)"],
+    "sensorModes": [
+      "S16 HD 1600×900",
+      "HD 2880×1620",
+      "2K 2868×1612",
+      "3.2K 3200×1800",
+      "ARRIRAW 16:9 2.8K 2880×1620"
+    ],
+    "resolutions": [
+      "HD 1920×1080",
+      "2K 2048×1152",
+      "3.2K 3200×1800",
+      "UHD 3840×2160 (via 3.2K upsample; option)"
+    ],
     "power": {
       "input": {
         "voltageRange": "10.5-34",
@@ -1071,6 +1104,19 @@ const cameraData = {
   },
   "Sony FX9": {
     "powerDrawWatts": 35.2,
+    "weight_g": 2000,
+    "recordingCodecs": ["XAVC-I 10-bit 4:2:2", "XAVC-L 10-bit 4:2:2", "MPEG HD 422"],
+    "sensorModes": [
+      "Full-Frame 6K oversample to 4K",
+      "Super35 4K (DCI 4096×2160)",
+      "Full-Frame HD",
+      "Super35 UHD"
+    ],
+    "resolutions": [
+      "DCI 4K 4096×2160 (S35)*",
+      "UHD 3840×2160",
+      "HD 1920×1080"
+    ],
     "power": {
       "input": {
         "voltageRange": "19.5",

--- a/devices/gearList.js
+++ b/devices/gearList.js
@@ -1130,6 +1130,120 @@ const gear = {
         "clampOn": true,
         "tStop": 3.5,
         "mount": "PL"
+      },
+      "ARRI/ZEISS Ultra Prime 16mm T1.9": {
+        "brand": "ARRI/ZEISS",
+        "frontDiameterMm": 95,
+        "clampOn": true,
+        "tStop": 1.9
+      },
+      "ARRI/ZEISS Ultra Prime 20mm T1.9": {
+        "brand": "ARRI/ZEISS",
+        "frontDiameterMm": 95,
+        "clampOn": true,
+        "tStop": 1.9
+      },
+      "ARRI/ZEISS Ultra Prime 24mm T1.9": {
+        "brand": "ARRI/ZEISS",
+        "frontDiameterMm": 95,
+        "clampOn": true,
+        "tStop": 1.9
+      },
+      "ARRI/ZEISS Ultra Prime 32mm T1.9": {
+        "brand": "ARRI/ZEISS",
+        "frontDiameterMm": 95,
+        "clampOn": true,
+        "tStop": 1.9
+      },
+      "ARRI/ZEISS Ultra Prime 40mm T1.9": {
+        "brand": "ARRI/ZEISS",
+        "frontDiameterMm": 95,
+        "clampOn": true,
+        "tStop": 1.9
+      },
+      "ARRI/ZEISS Ultra Prime 50mm T1.9": {
+        "brand": "ARRI/ZEISS",
+        "frontDiameterMm": 95,
+        "clampOn": true,
+        "tStop": 1.9
+      },
+      "ARRI/ZEISS Ultra Prime 65mm T1.9": {
+        "brand": "ARRI/ZEISS",
+        "frontDiameterMm": 95,
+        "clampOn": true,
+        "tStop": 1.9
+      },
+      "ARRI/ZEISS Ultra Prime 85mm T1.9": {
+        "brand": "ARRI/ZEISS",
+        "frontDiameterMm": 95,
+        "clampOn": true,
+        "tStop": 1.9
+      },
+      "ARRI/ZEISS Ultra Prime 100mm T1.9": {
+        "brand": "ARRI/ZEISS",
+        "frontDiameterMm": 95,
+        "clampOn": true,
+        "tStop": 1.9
+      },
+      "ZEISS Compact Zoom CZ.2 28–80mm T2.9": {
+        "brand": "ZEISS",
+        "frontDiameterMm": 95,
+        "clampOn": true,
+        "tStop": 2.9
+      },
+      "ZEISS Compact Zoom CZ.2 70–200mm T2.9": {
+        "brand": "ZEISS",
+        "frontDiameterMm": 95,
+        "clampOn": true,
+        "tStop": 2.9
+      },
+      "ZEISS Supreme Prime Radiance 50mm T1.5": {
+        "brand": "ZEISS",
+        "frontDiameterMm": 95,
+        "clampOn": true,
+        "tStop": 1.5
+      },
+      "ZEISS Supreme Prime Radiance 85mm T1.5": {
+        "brand": "ZEISS",
+        "frontDiameterMm": 95,
+        "clampOn": true,
+        "tStop": 1.5
+      },
+      "Cooke Speed Panchro 18mm (P+S rehousing)": {
+        "brand": "Cooke (P+S rehoused)",
+        "frontDiameterMm": 100,
+        "clampOn": true,
+        "tStop": 2.3
+      },
+      "Cooke Speed Panchro 25mm (P+S rehousing)": {
+        "brand": "Cooke (P+S rehoused)",
+        "frontDiameterMm": 100,
+        "clampOn": true,
+        "tStop": 2.3
+      },
+      "Cooke Speed Panchro 35mm (P+S rehousing)": {
+        "brand": "Cooke (P+S rehoused)",
+        "frontDiameterMm": 100,
+        "clampOn": true,
+        "tStop": 2.3
+      },
+      "Cooke Speed Panchro 40mm (P+S rehousing)": {
+        "brand": "Cooke (P+S rehoused)",
+        "frontDiameterMm": 100,
+        "clampOn": true,
+        "tStop": 2.3
+      },
+      "Cooke Speed Panchro 75mm (P+S rehousing)": {
+        "brand": "Cooke (P+S rehoused)",
+        "frontDiameterMm": 100,
+        "clampOn": true,
+        "tStop": 2.3
+      },
+      "Laowa 24mm T8 2× Pro2be (3-lens set: Direct / 35° / Periscope)": {
+        "brand": "Laowa",
+        "frontDiameterMm": 30,
+        "clampOn": true,
+        "tStop": 8
       }
     },
     "tripodHeads": {


### PR DESCRIPTION
## Summary
- add weight data for Bebob V-mount and B-mount batteries
- extend camera records for ARRI Amira, ARRI Alexa Mini, and Sony FX9 with weights, codecs, sensor modes and resolutions
- populate lens list with Ultra Prime, Compact Zoom, Supreme Prime Radiance, Speed Panchro and Laowa Pro2be models

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b5ae3ee8948320aa1f659836c4a3be