### PR TITLE
Expand gear dataset

### DIFF
--- a/devices/batteries.js
+++ b/devices/batteries.js
@@ -16,13 +16,15 @@ const batteryData = {
     "capacity": 95,
     "pinA": 10,
     "dtapA": 5,
-    "mount_type": "V-Mount"
+    "mount_type": "V-Mount",
+    "weight_g": 550
   },
   "Bebob V150micro": {
     "capacity": 143,
     "pinA": 10,
     "dtapA": 5,
-    "mount_type": "V-Mount"
+    "mount_type": "V-Mount",
+    "weight_g": 770
   },
   "Bebob V200micro": {
     "capacity": 190,
@@ -52,7 +54,8 @@ const batteryData = {
     "capacity": 285,
     "pinA": 20,
     "dtapA": 5,
-    "mount_type": "V-Mount"
+    "mount_type": "V-Mount",
+    "weight_g": 1390
   },
   "Bebob B90cine": {
     "capacity": 86,
@@ -64,7 +67,8 @@ const batteryData = {
     "capacity": 155,
     "pinA": 20,
     "dtapA": 5,
-    "mount_type": "B-Mount"
+    "mount_type": "B-Mount",
+    "weight_g": 1000
   },
   "Bebob B290cine": {
     "capacity": 294,

--- a/devices/cameras.js
+++ b/devices/cameras.js
@@ -236,21 +236,46 @@ const cameraData = {
         "notes": "No ARRI LDS or Cooke /i lens data"
       }
     ],
-    "timecode": [
-      {
-        "type": "LEMO 5-pin",
-        "notes": "LTC Timecode In/Out"
-      },
-      {
-        "type": "SYNC",
-        "notes": "Black burst/tri-level sync"
-      },
-      {
-        "type": "EXT LEMO 7-pin",
-        "notes": "For multi-camera sync with ARRI EDB-2 EXT Distribution Box"
-      }
-    ]
-  },
+      "timecode": [
+        {
+          "type": "LEMO 5-pin",
+          "notes": "LTC Timecode In/Out"
+        },
+        {
+          "type": "SYNC",
+          "notes": "Black burst/tri-level sync"
+        },
+        {
+          "type": "EXT LEMO 7-pin",
+          "notes": "For multi-camera sync with ARRI EDB-2 EXT Distribution Box"
+        }
+      ],
+      "weight_g": 2300,
+      "recordingCodecs": [
+        "ARRIRAW",
+        "ProRes 4444 XQ",
+        "ProRes 4444",
+        "ProRes 422 HQ",
+        "ProRes 422",
+        "ProRes 422 LT"
+      ],
+      "sensorModes": [
+        "S16 HD 1600×900",
+        "HD 2880×1620",
+        "2K 2868×1612",
+        "3.2K 3200×1800",
+        "UHD 3840×2160 (upsampled from 3.2K)",
+        "4:3 2.8K 2880×2160",
+        "ARRIRAW 16:9 2.8K 2880×1620",
+        "ARRIRAW Open Gate 3.4K 3424×2202"
+      ],
+      "resolutions": [
+        "HD 1920×1080",
+        "2K 2048×1152",
+        "3.2K 3200×1800",
+        "UHD 3840×2160"
+      ]
+    },
   "Arri Alexa 35": {
     "powerDrawWatts": 110,
     "power": {
@@ -473,6 +498,27 @@ const cameraData = {
         "type": "BNC",
         "notes": "Yes"
       }
+    ],
+    "weight_g": 4100,
+    "recordingCodecs": [
+      "ProRes 4444",
+      "ProRes 422 HQ",
+      "ProRes 422",
+      "ProRes 422 LT",
+      "MPEG-2 (AMIRA only)"
+    ],
+    "sensorModes": [
+      "S16 HD 1600×900",
+      "HD 2880×1620",
+      "2K 2868×1612",
+      "3.2K 3200×1800",
+      "ARRIRAW 16:9 2.8K 2880×1620"
+    ],
+    "resolutions": [
+      "HD 1920×1080",
+      "2K 2048×1152",
+      "3.2K 3200×1800",
+      "UHD 3840×2160 (via 3.2K upsample; option)"
     ]
   },
   "Sony Venice 2": {
@@ -1173,13 +1219,30 @@ const cameraData = {
         "notes": "No ARRI LDS or Cooke /i lens data"
       }
     ],
-    "timecode": [
-      {
-        "type": "BNC",
-        "notes": "Timecode In/Out"
-      }
-    ]
-  },
+      "timecode": [
+        {
+          "type": "BNC",
+          "notes": "Timecode In/Out"
+        }
+      ],
+      "weight_g": 2000,
+      "recordingCodecs": [
+        "XAVC-I 10-bit 4:2:2",
+        "XAVC-L 10-bit 4:2:2",
+        "MPEG HD 422"
+      ],
+      "sensorModes": [
+        "Full-Frame 6K oversample to 4K",
+        "Super35 4K (DCI 4096×2160)",
+        "Full-Frame HD",
+        "Super35 UHD"
+      ],
+      "resolutions": [
+        "DCI 4K 4096×2160 (S35)*",
+        "UHD 3840×2160",
+        "HD 1920×1080"
+      ]
+    },
   "Canon C70": {
     "powerDrawWatts": 14.6,
     "power": {

--- a/devices/gearList.js
+++ b/devices/gearList.js
@@ -1322,6 +1322,120 @@ const gear = {
         "frontDiameterMm": 114,
         "clampOn": true,
         "tStop": 1.8
+      },
+      "ARRI/ZEISS Ultra Prime 16mm T1.9": {
+        "brand": "ARRI/ZEISS",
+        "frontDiameterMm": 95,
+        "clampOn": true,
+        "tStop": 1.9
+      },
+      "ARRI/ZEISS Ultra Prime 20mm T1.9": {
+        "brand": "ARRI/ZEISS",
+        "frontDiameterMm": 95,
+        "clampOn": true,
+        "tStop": 1.9
+      },
+      "ARRI/ZEISS Ultra Prime 24mm T1.9": {
+        "brand": "ARRI/ZEISS",
+        "frontDiameterMm": 95,
+        "clampOn": true,
+        "tStop": 1.9
+      },
+      "ARRI/ZEISS Ultra Prime 32mm T1.9": {
+        "brand": "ARRI/ZEISS",
+        "frontDiameterMm": 95,
+        "clampOn": true,
+        "tStop": 1.9
+      },
+      "ARRI/ZEISS Ultra Prime 40mm T1.9": {
+        "brand": "ARRI/ZEISS",
+        "frontDiameterMm": 95,
+        "clampOn": true,
+        "tStop": 1.9
+      },
+      "ARRI/ZEISS Ultra Prime 50mm T1.9": {
+        "brand": "ARRI/ZEISS",
+        "frontDiameterMm": 95,
+        "clampOn": true,
+        "tStop": 1.9
+      },
+      "ARRI/ZEISS Ultra Prime 65mm T1.9": {
+        "brand": "ARRI/ZEISS",
+        "frontDiameterMm": 95,
+        "clampOn": true,
+        "tStop": 1.9
+      },
+      "ARRI/ZEISS Ultra Prime 85mm T1.9": {
+        "brand": "ARRI/ZEISS",
+        "frontDiameterMm": 95,
+        "clampOn": true,
+        "tStop": 1.9
+      },
+      "ARRI/ZEISS Ultra Prime 100mm T1.9": {
+        "brand": "ARRI/ZEISS",
+        "frontDiameterMm": 95,
+        "clampOn": true,
+        "tStop": 1.9
+      },
+      "ZEISS Compact Zoom CZ.2 28-80mm T2.9": {
+        "brand": "ZEISS",
+        "frontDiameterMm": 95,
+        "clampOn": true,
+        "tStop": 2.9
+      },
+      "ZEISS Compact Zoom CZ.2 70-200mm T2.9": {
+        "brand": "ZEISS",
+        "frontDiameterMm": 95,
+        "clampOn": true,
+        "tStop": 2.9
+      },
+      "ZEISS Supreme Prime Radiance 50mm T1.5": {
+        "brand": "ZEISS",
+        "frontDiameterMm": 95,
+        "clampOn": true,
+        "tStop": 1.5
+      },
+      "ZEISS Supreme Prime Radiance 85mm T1.5": {
+        "brand": "ZEISS",
+        "frontDiameterMm": 95,
+        "clampOn": true,
+        "tStop": 1.5
+      },
+      "Cooke Speed Panchro 18mm (P+S rehousing)": {
+        "brand": "Cooke (P+S rehoused)",
+        "frontDiameterMm": 100,
+        "clampOn": true,
+        "tStop": 2.3
+      },
+      "Cooke Speed Panchro 25mm (P+S rehousing)": {
+        "brand": "Cooke (P+S rehoused)",
+        "frontDiameterMm": 100,
+        "clampOn": true,
+        "tStop": 2.3
+      },
+      "Cooke Speed Panchro 35mm (P+S rehousing)": {
+        "brand": "Cooke (P+S rehoused)",
+        "frontDiameterMm": 100,
+        "clampOn": true,
+        "tStop": 2.3
+      },
+      "Cooke Speed Panchro 40mm (P+S rehousing)": {
+        "brand": "Cooke (P+S rehoused)",
+        "frontDiameterMm": 100,
+        "clampOn": true,
+        "tStop": 2.3
+      },
+      "Cooke Speed Panchro 75mm (P+S rehousing)": {
+        "brand": "Cooke (P+S rehoused)",
+        "frontDiameterMm": 100,
+        "clampOn": true,
+        "tStop": 2.3
+      },
+      "Laowa 24mm T8 2× Pro2be (3-lens set: Direct / 35° / Periscope)": {
+        "brand": "Laowa",
+        "frontDiameterMm": 30,
+        "clampOn": true,
+        "tStop": 8
       }
     },
     "tripodHeads": {


### PR DESCRIPTION
## Summary
- add weight specs to Bebob batteries
- enrich Alexa Mini, Amira, and FX9 camera records with codecs, sensor modes, and resolutions
- include Ultra Prime, Compact Zoom, Supreme Prime Radiance, Cooke Speed Panchro, and Laowa Pro2be lenses

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5b2df263483209ffc81a840c3771f