### PR TITLE
Fix Safari globalThis error with polyfill

### DIFF
--- a/index.html
+++ b/index.html
@@ -1063,6 +1063,14 @@
     </datalist>
   </dialog>
   <dialog id="overviewDialog"></dialog>
+  <script>
+    // Polyfill globalThis for older Safari versions
+    if (typeof globalThis === 'undefined') {
+      // `var` ensures we create a global property without throwing
+      // even when the identifier does not yet exist.
+      var globalThis = (function () { return this; })();
+    }
+  </script>
   <script src="devices/index.js"></script>
   <script src="devices/cameras.js"></script>
   <script src="devices/monitors.js"></script>

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,5 +1,5 @@
 /* eslint-env serviceworker */
-const CACHE_NAME = 'camera-power-planner-v10';
+const CACHE_NAME = 'camera-power-planner-v11';
 const ASSETS = [
   './',
   './index.html',


### PR DESCRIPTION
## Summary
- polyfill `globalThis` to prevent Safari crashes when loading device scripts
- bump service worker cache to v11 so updated HTML is cached

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b5bf2ec28083209c91577c9fe4bf31