### PR TITLE
Allow eval under CSP to fix blocked scripts

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,6 +14,7 @@
   <meta name="theme-color" content="#f9f9f9" />
   <meta name="application-name" content="Camera Power Planner" />
   <meta name="apple-mobile-web-app-title" content="Camera Power Planner" />
+  <!-- Enables features that rely on eval(); revisit if security requirements change -->
   <meta http-equiv="Content-Security-Policy" content="script-src 'self' 'unsafe-eval';" />
   <title>Camera Power Planner</title>
   <link href="https://fonts.googleapis.com/css2?family=Ubuntu:wght@300;700&display=swap" rel="stylesheet" />

--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
   <meta name="theme-color" content="#f9f9f9" />
   <meta name="application-name" content="Camera Power Planner" />
   <meta name="apple-mobile-web-app-title" content="Camera Power Planner" />
-  <meta http-equiv="Content-Security-Policy" content="script-src 'self';" />
+  <meta http-equiv="Content-Security-Policy" content="script-src 'self' 'unsafe-eval';" />
   <title>Camera Power Planner</title>
   <link href="https://fonts.googleapis.com/css2?family=Ubuntu:wght@300;700&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="style.css" />


### PR DESCRIPTION
## Summary
- relax Content Security Policy to include 'unsafe-eval'

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5c02b7ff48320a34e561d6d3e77a7