### PR TITLE
Document gear list feature and quick save

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -23,17 +23,19 @@ The app automatically uses your browser language on first load, and you can swit
 - Support for cameras with both V- and B-Mount battery plates.
 - Submit user runtime feedback with temperature for better estimates.
 - Visual runtime weighting dashboard to inspect how settings influence each report, now sorted by weight and showing exact share percentages.
+- Generate gear lists to compile selected gear and project requirements.
 
 ---
 
 ## 🔧 Features
 
 ### ✅ Setup Management
-- Save, load and delete multiple camera setups
+- Save, load and delete multiple camera setups (press Enter or Ctrl+S to save quickly; the Save button stays disabled until a name is entered)
 - Share a setup via link or clear the current configuration
 - Data is stored locally via `localStorage`
 - Import and export setups as JSON
 - Generate a printable overview for any saved setup
+- Generate gear lists for selected equipment and project requirements
 - Works fully offline – language, dark mode, setups and device data persist
 - Choose a **B‑Mount** or **V‑Mount** plate on supported cameras; the battery list adapts automatically
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Recent updates include:
 - **Dual V‑/B‑Mount support** – choose between plate types on supported cameras and the battery list updates automatically.
 - **User runtime feedback** – submit real-world runtimes with environment details to refine estimates.
 - **Visual runtime weighting dashboard** – see how temperature, resolution, frame rate and codec affect each runtime report, now sorted by weight with exact share percentages.
+- **Gear list generator** – compile selected gear and project requirements with one click.
 - **Quick setup saving** – press Enter or Ctrl+S (⌘S on macOS) to save a setup and the Save button stays disabled until a name is entered.
 
 See the language-specific README files for full details.
@@ -57,7 +58,7 @@ See the language-specific README files for full details.
 - Check that selected batteries can supply the required output.
 - See required battery counts for a 10 h shoot and adjust runtimes for temperature.
 - Compare runtimes across all batteries with an optional battery comparison panel.
-- Save, load, share and clear setups; import/export them as JSON, and generate a printable overview.
+- Save, load, share and clear setups; import/export them as JSON, and generate gear lists and printable overviews.
 - Visualize power and video connections with an interactive diagram.
 - Customize the device database with your own gear.
 - Automatically selects your browser language on first load, lets you switch languages, toggle dark or playful pink themes, and swap between V‑ and B‑Mount plates on supported cameras.

--- a/index.html
+++ b/index.html
@@ -596,7 +596,7 @@
         <section data-help-section id="managingSetups">
           <h3><span class="help-icon" aria-hidden="true">🗂️</span>Managing Setups</h3>
           <ul>
-            <li>Use <strong>Save</strong> to store the current configuration in your browser.</li>
+            <li>Use <strong>Save</strong> to store the current configuration in your browser. Press Enter or Ctrl+S (⌘S on macOS) to save quickly; the Save button stays disabled until a name is entered.</li>
             <li>Import, export or delete setups via the <em>Setup Actions</em> section.</li>
             <li><strong>Share Setup Link</strong> copies a URL for the current configuration.</li>
             <li><strong>Clear Current Setup</strong> removes all selected devices.</li>

--- a/translations.js
+++ b/translations.js
@@ -314,7 +314,7 @@ const texts = {
     deleteSetupHelp:
       "Remove the highlighted saved setup permanently from your browser.",
     saveSetupHelp:
-      "Store the devices and battery you have selected so the setup can be recalled later. Press Ctrl+S (Cmd+S on Mac) to save quickly.",
+      "Store the devices and battery you have selected so the setup can be recalled later. Press Enter or Ctrl+S (Cmd+S on Mac) to save quickly; the Save button stays disabled until a name is entered.",
     exportSetupsHelp:
       "Download every saved configuration as a JSON file for backup or sharing.",
     importSetupsHelp:
@@ -646,7 +646,7 @@ const texts = {
       "Scegli una configurazione salvata da caricare o inizia una nuova.",
     setupNameHelp: "Inserisci un nome per la configurazione corrente.",
     deleteSetupHelp: "Elimina la configurazione salvata selezionata.",
-    saveSetupHelp: "Salva la configurazione corrente. Premi Ctrl+S (Cmd+S su Mac) per salvare rapidamente.",
+    saveSetupHelp: "Salva la configurazione corrente. Premi Invio o Ctrl+S (Cmd+S su Mac) per salvare rapidamente; il pulsante Salva rimane disabilitato finché non viene inserito un nome.",
     exportSetupsHelp:
       "Scarica tutte le configurazioni salvate come file JSON.",
     importSetupsHelp: "Carica configurazioni da un file JSON.",
@@ -990,7 +990,7 @@ const texts = {
       "Elige una configuración guardada para cargarla o comienza una nueva.",
     setupNameHelp: "Introduce un nombre para la configuración actual.",
     deleteSetupHelp: "Elimina la configuración guardada seleccionada.",
-    saveSetupHelp: "Guarda la configuración actual. Pulsa Ctrl+S (Cmd+S en Mac) para guardar rápidamente.",
+    saveSetupHelp: "Guarda la configuración actual. Pulsa Intro o Ctrl+S (Cmd+S en Mac) para guardar rápidamente; el botón Guardar permanece desactivado hasta que se introduce un nombre.",
     exportSetupsHelp:
       "Descarga todas las configuraciones guardadas como archivo JSON.",
     importSetupsHelp: "Carga configuraciones desde un archivo JSON.",
@@ -1335,7 +1335,7 @@ const texts = {
       "Choisissez une configuration enregistrée à charger ou commencez-en une nouvelle.",
     setupNameHelp: "Saisissez un nom pour la configuration actuelle.",
     deleteSetupHelp: "Supprime la configuration enregistrée sélectionnée.",
-    saveSetupHelp: "Enregistre la configuration actuelle. Appuyez sur Ctrl+S (Cmd+S sur Mac) pour enregistrer rapidement.",
+    saveSetupHelp: "Enregistre la configuration actuelle. Appuyez sur Entrée ou Ctrl+S (Cmd+S sur Mac) pour enregistrer rapidement ; le bouton Enregistrer reste désactivé tant qu'aucun nom n'est saisi.",
     exportSetupsHelp:
       "Télécharge toutes les configurations enregistrées au format JSON.",
     importSetupsHelp: "Charge des configurations depuis un fichier JSON.",
@@ -1681,7 +1681,7 @@ const texts = {
       "Wähle eine gespeicherte Konfiguration zum Laden oder starte eine neue.",
     setupNameHelp: "Gib einen Namen für die aktuelle Konfiguration ein.",
     deleteSetupHelp: "Löscht die ausgewählte gespeicherte Konfiguration.",
-    saveSetupHelp: "Speichert die aktuelle Konfiguration. Drücke Strg+S (Cmd+S auf dem Mac), um schnell zu speichern.",
+    saveSetupHelp: "Speichert die aktuelle Konfiguration. Drücke Eingabe oder Strg+S (Cmd+S auf dem Mac), um schnell zu speichern; der Speichern-Button bleibt deaktiviert, bis ein Name eingegeben ist.",
     exportSetupsHelp:
       "Lade alle gespeicherten Konfigurationen als JSON-Datei herunter.",
     importSetupsHelp: "Lade Konfigurationen aus einer JSON-Datei.",


### PR DESCRIPTION
## Summary
- mention new gear list generator in README and English docs
- document quick setup saving shortcut and update help text
- revise save button translations to cover Enter/Ctrl+S and disabled state

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b5c07d02d083208cf96de64bddeea6