### PR TITLE
Add CLI help to maintenance scripts

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -179,6 +179,7 @@ Requires Node.js 18 or later.
    npm run normalize
    npm run check-consistency
    ```
+   Append `--help` to either command for usage details.
 
 ## 🤝 Contributing
 Contributions are welcome! Feel free to open an issue or submit a pull request on GitHub.

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ npm run normalize
 npm run check-consistency
 ```
 
-`npm run normalize` applies various cleanup routines to unify connector names and expand shorthand entries. `npm run check-consistency` confirms that required fields are present and raises an error if anything is missing.
+`npm run normalize` applies various cleanup routines to unify connector names and expand shorthand entries. `npm run check-consistency` confirms that required fields are present and raises an error if anything is missing. Append `--help` to either command for usage details.
 
 ## Contributing
 

--- a/checkConsistency.js
+++ b/checkConsistency.js
@@ -28,6 +28,16 @@ function checkConsistency(devices = require('./data.js')) {
 }
 
 if (require.main === module) {
+  const args = process.argv.slice(2);
+  if (args.includes('--help') || args.includes('-h')) {
+    console.log(
+      'Usage: node checkConsistency.js\n' +
+        '\nChecks that device entries contain required fields. ' +
+        'Exits with code 1 when missing fields are found.'
+    );
+    process.exit(0);
+  }
+
   const result = checkConsistency();
   if (result.length) {
     console.log('Devices missing fields:', result);

--- a/normalizeData.js
+++ b/normalizeData.js
@@ -374,5 +374,17 @@ function normalizeAll() {
   updateVideoOutputs();
 }
 
-normalizeAll();
-save();
+if (require.main === module) {
+  const args = process.argv.slice(2);
+  if (args.includes('--help') || args.includes('-h')) {
+    console.log(
+      'Usage: node normalizeData.js\n' +
+        '\nCleans and expands device data, then overwrites data.js with the result.'
+    );
+    process.exit(0);
+  }
+  normalizeAll();
+  save();
+} else {
+  module.exports = { normalizeAll, save };
+}

--- a/tests/cliHelp.test.js
+++ b/tests/cliHelp.test.js
@@ -1,0 +1,17 @@
+const { spawnSync } = require('child_process');
+
+function run(script) {
+  return spawnSync('node', [script, '--help'], { encoding: 'utf8' });
+}
+
+test('checkConsistency CLI --help', () => {
+  const { stdout, status } = run('checkConsistency.js');
+  expect(stdout).toMatch(/Usage: node checkConsistency\.js/);
+  expect(status).toBe(0);
+});
+
+test('normalizeData CLI --help', () => {
+  const { stdout, status } = run('normalizeData.js');
+  expect(stdout).toMatch(/Usage: node normalizeData\.js/);
+  expect(status).toBe(0);
+});


### PR DESCRIPTION
## Summary
- Add `--help` flag to checkConsistency.js and normalizeData.js
- Document help flag in README files
- Cover CLI help with tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5cd92f6fc8320b12b63bd3f7516ea