### PR TITLE
docs: expand server options and add support info

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ that future visits work offline and pick up updates automatically.
 - [Install as an App](#install-as-an-app)
 - [Browser Support](#browser-support)
 - [Development](#development)
+- [Feedback and Support](#feedback-and-support)
 - [Contributing](#contributing)
 - [Acknowledgements](#acknowledgements)
 - [License](#license)
@@ -81,9 +82,11 @@ User-submitted battery runtimes are combined using a weighted average to better 
 
 1. Download or clone this repository.
 2. Open `index.html` in a modern browser.
-3. (Optional) Serve the folder over HTTP to enable the service worker and other Progressive Web App features:
+3. (Optional) Serve the folder over HTTP to enable the service worker and other Progressive Web App features. You can use any static file server, for example:
    ```bash
    npx http-server
+   # or
+   python -m http.server
    ```
    The planner then works fully offline and updates automatically.
 
@@ -152,6 +155,10 @@ npm run check-consistency
 ```
 
 `npm run normalize` applies various cleanup routines to unify connector names and expand shorthand entries. `npm run check-consistency` confirms that required fields are present and raises an error if anything is missing.
+
+## Feedback and Support
+
+If you run into problems, have questions, or want to suggest new features, please open an issue on GitHub. Community feedback helps improve the planner for everyone.
 
 ## Contributing
 


### PR DESCRIPTION
## Summary
- document optional Python HTTP server in Quick Start
- add Feedback and Support section with issue reporting guidance

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5cdb6a62c832091f1527e73d1945a