### PR TITLE
fix: externalize globalThis polyfill to satisfy CSP

### DIFF
--- a/globalthis-polyfill.js
+++ b/globalthis-polyfill.js
@@ -1,0 +1,6 @@
+// Polyfill globalThis for older Safari versions
+if (typeof globalThis === 'undefined') {
+  // `var` ensures we create a global property without throwing
+  // even when the identifier does not yet exist.
+  var globalThis = (function () { return this; })(); // eslint-disable-line no-redeclare
+}

--- a/index.html
+++ b/index.html
@@ -1064,14 +1064,7 @@
     </datalist>
   </dialog>
   <dialog id="overviewDialog"></dialog>
-  <script>
-    // Polyfill globalThis for older Safari versions
-    if (typeof globalThis === 'undefined') {
-      // `var` ensures we create a global property without throwing
-      // even when the identifier does not yet exist.
-      var globalThis = (function () { return this; })();
-    }
-  </script>
+  <script src="globalthis-polyfill.js"></script>
   <script src="devices/index.js"></script>
   <script src="devices/cameras.js"></script>
   <script src="devices/monitors.js"></script>


### PR DESCRIPTION
## Summary
- move globalThis polyfill into its own file
- load the polyfill via a script tag to avoid inline script CSP violations

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b5cdf803a883208a942bb5ae3b39eb