### PR TITLE
refactor: streamline video type normalization

### DIFF
--- a/script.js
+++ b/script.js
@@ -102,16 +102,14 @@ const VIDEO_TYPE_PATTERNS = [
 const videoTypeCache = new Map();
 function normalizeVideoType(type) {
   if (!type) return '';
-  const t = String(type).toLowerCase();
-  if (videoTypeCache.has(t)) return videoTypeCache.get(t);
-  for (const { needles, value } of VIDEO_TYPE_PATTERNS) {
-    if (needles.every(n => t.includes(n))) {
-      videoTypeCache.set(t, value);
-      return value;
-    }
+  const key = String(type).toLowerCase();
+  if (!videoTypeCache.has(key)) {
+    const match = VIDEO_TYPE_PATTERNS.find(({ needles }) =>
+      needles.every(n => key.includes(n))
+    );
+    videoTypeCache.set(key, match ? match.value : '');
   }
-  videoTypeCache.set(t, '');
-  return '';
+  return videoTypeCache.get(key);
 }
 
 const FIZ_CONNECTOR_MAP = {
@@ -156,7 +154,7 @@ const createMapNormalizer = (map, cache) => type => {
   return normalized;
 };
 
-const normalizeFizConnectorType = createMapNormalizer(FIZ_CONNECTOR_MAP);
+const normalizeFizConnectorType = createMapNormalizer(FIZ_CONNECTOR_MAP, new Map());
 
 const VIEWFINDER_TYPE_MAP = {
   'dsmc3 red touch 7" lcd (optional)': 'RED Touch 7" LCD (Optional)',


### PR DESCRIPTION
## Summary
- refactor normalizeVideoType to use cached lookups
- cache FIZ connector normalization for repeated calls

## Testing
- `npm run lint`
- `npm run check-consistency`
- `npx jest tests/utils.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b5d022094c8320beb90754adc905d8