### PR TITLE
Improve lens dropdown population

### DIFF
--- a/script.js
+++ b/script.js
@@ -7774,17 +7774,25 @@ function populateEnvironmentDropdowns() {
 
 function populateLensDropdown() {
   const lensSelect = document.getElementById('lenses');
-  if (lensSelect && devices && devices.lenses) {
-    const emptyOpt = document.createElement('option');
-    emptyOpt.value = '';
-    lensSelect.appendChild(emptyOpt);
-    Object.keys(devices.lenses).sort(localeSort).forEach(name => {
-      const opt = document.createElement('option');
-      opt.value = name;
-      opt.textContent = name;
-      lensSelect.appendChild(opt);
-    });
+  if (!lensSelect) return;
+
+  lensSelect.innerHTML = '';
+  const lensData = devices && devices.lenses;
+
+  if (!lensData || Object.keys(lensData).length === 0) {
+    console.warn('No lens data available to populate dropdown');
+    return;
   }
+
+  const emptyOpt = document.createElement('option');
+  emptyOpt.value = '';
+  lensSelect.appendChild(emptyOpt);
+  Object.keys(lensData).sort(localeSort).forEach(name => {
+    const opt = document.createElement('option');
+    opt.value = name;
+    opt.textContent = name;
+    lensSelect.appendChild(opt);
+  });
 }
 
 function populateFilterDropdown() {
@@ -7844,5 +7852,6 @@ if (typeof module !== "undefined" && module.exports) {
     renderFeedbackTable,
     clearAllFilters,
     saveCurrentGearList,
+    populateLensDropdown,
   };
 }

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -41,6 +41,9 @@ describe('script.js functions', () => {
           videoInputs: [{ type: '3G-SDI' }]
         }
       },
+      lenses: {
+        LensA: { brand: 'TestBrand', tStop: 2.0 }
+      },
       fiz: {
         motors: {
           MotorA: { powerDrawWatts: 2, fizConnectors: [{ type: 'LBUS (LEMO 4-pin)' }], power: { input: { type: 'LEMO 2-pin' } } }
@@ -120,6 +123,16 @@ describe('script.js functions', () => {
     const copyBtn = document.getElementById('copySummaryBtn');
     const generateBtn = document.getElementById('generateGearListBtn');
     expect(copyBtn.nextElementSibling).toBe(generateBtn);
+  });
+
+  test('populateLensDropdown fills lens list without duplicates', () => {
+    const sel = document.getElementById('lenses');
+    sel.innerHTML = '<option value="Existing">Existing</option>';
+    script.populateLensDropdown();
+    expect(Array.from(sel.options).map(o => o.value)).toEqual(['', 'LensA']);
+    // Call again to ensure no duplication occurs
+    script.populateLensDropdown();
+    expect(Array.from(sel.options).map(o => o.value)).toEqual(['', 'LensA']);
   });
 
   test('selected cage appears in camera support category of gear list', () => {


### PR DESCRIPTION
## Summary
- Clear and repopulate lens selector, warn when data missing
- Cover lens dropdown in tests with sample lens data

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5d56499e48320bb6eca8ae4ae143e