### PR TITLE
Add Cine Saddle and Steadybag grip options

### DIFF
--- a/devices/gearList.js
+++ b/devices/gearList.js
@@ -1550,6 +1550,14 @@ const gear = {
         "brand": "Hudson Spider"
       }
     },
+    "grip": {
+      "Cinekinetic Cinesaddle": {
+        "brand": "Cinekinetic"
+      },
+      "Steadybag": {
+        "brand": "Steadybag"
+      }
+    },
     "carts": {
       "Magliner Senior Videomagliner": {
         "brand": "Magliner"

--- a/script.js
+++ b/script.js
@@ -7033,10 +7033,16 @@ function generateGearListHtml(info = {}) {
     if (info.monitoringPreferences) {
         monitoringSupportItems = `${escapeHtml(info.monitoringPreferences)}<br>${monitoringSupportItems}`;
     }
+    const scenarios = info.requiredScenarios
+        ? info.requiredScenarios.split(',').map(s => s.trim()).filter(Boolean)
+        : [];
+    const gripItems = [];
+    if (scenarios.includes('Cine Saddle')) gripItems.push('Cinekinetic Cinesaddle');
+    if (scenarios.includes('Steadybag')) gripItems.push('Steadybag');
     addRow('Monitoring support', monitoringSupportItems);
     addRow('Power', '');
     addRow('Rigging', escapeHtml(info.rigging || ''));
-    addRow('Grip', '');
+    addRow('Grip', formatItems(gripItems));
     addRow('Carts and Transportation', '');
     addRow('Miscellaneous', formatItems(miscAcc));
     addRow('Consumables', '');

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -959,6 +959,19 @@ describe('script.js functions', () => {
     expect(html).toContain('6x BattA');
   });
 
+  test('Cine Saddle and Steadybag scenarios populate grip section', () => {
+    const { generateGearListHtml } = script;
+    const html = generateGearListHtml({ requiredScenarios: 'Cine Saddle, Steadybag' });
+    const wrap = document.createElement('div');
+    wrap.innerHTML = html;
+    const rows = Array.from(wrap.querySelectorAll('.gear-table tr'));
+    const gripIdx = rows.findIndex(r => r.textContent === 'Grip');
+    expect(gripIdx).toBeGreaterThanOrEqual(0);
+    const itemsRow = rows[gripIdx + 1];
+    expect(itemsRow.textContent).toContain('Cinekinetic Cinesaddle');
+    expect(itemsRow.textContent).toContain('Steadybag');
+  });
+
   test('monitoring support cables grouped by type', () => {
     const { generateGearListHtml } = script;
     const html = generateGearListHtml();


### PR DESCRIPTION
## Summary
- add Cinekinetic Cinesaddle and Steadybag entries to grip accessories database
- populate Grip section from required scenarios, mapping Cine Saddle and Steadybag selections to gear items
- test that selecting Cine Saddle and Steadybag populates grip section

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5db370b248320bd713669af27a0bc