### PR TITLE
Add Easyrig grip option and camera stabiliser data

### DIFF
--- a/devices/gearList.js
+++ b/devices/gearList.js
@@ -512,6 +512,15 @@ const gear = {
         "brand": "ULCS"
       }
     },
+    "cameraStabiliser": {
+      "Easyrig 5 Vario": {
+        "brand": "Easyrig",
+        "options": [
+          "FlowCine Serene Spring Arm",
+          "Easyrig - STABIL G3"
+        ]
+      }
+    },
     "batteries": {
       "Sony NP-F970": {
         "capacity": 47,

--- a/script.js
+++ b/script.js
@@ -7044,10 +7044,10 @@ function generateGearListHtml(info = {}) {
     if (scenarios.includes('Easyrig')) {
         const stabiliser = (typeof gear !== 'undefined' && gear.cameraStabiliser && gear.cameraStabiliser['Easyrig 5 Vario']) || { options: ['FlowCine Serene Spring Arm', 'Easyrig - STABIL G3'] };
         const opts = [
-            { value: '', label: 'no further stabilisation' },
-            ...stabiliser.options.map(o => ({ value: o, label: o }))
-        ].map((o, i) => `<option value="${escapeHtml(o.value)}"${i === 0 ? ' selected' : ''}>${escapeHtml(o.label)}</option>`).join('');
-        gripItems = `1x Easyrig 5 Vario <select id="gearListEasyrig">${opts}</select>`;
+            ...stabiliser.options.map(o => `<option value="${escapeHtml(o)}">${escapeHtml(o)}</option>`),
+            `<option value="" selected>none</option>`
+        ].join('');
+        gripItems = `1x Easyrig 5 Vario <select id="gearListEasyrig">${opts}</select>`; 
     }
     addRow('Grip', gripItems);
     addRow('Carts and Transportation', '');

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -953,9 +953,9 @@ describe('script.js functions', () => {
     expect(html).toContain('Grip');
     expect(html).toContain('1x Easyrig 5 Vario');
     expect(html).toContain('<select id="gearListEasyrig"');
-    expect(html).toContain('no further stabilisation');
     expect(html).toContain('FlowCine Serene Spring Arm');
     expect(html).toContain('Easyrig - STABIL G3');
+    expect(html).toContain('none');
   });
 
   test('camera stabiliser database lists Easyrig 5 Vario with options', () => {

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -2,6 +2,7 @@
 const fs = require('fs');
 const path = require('path');
 const LZString = require('lz-string');
+const gear = require('../devices/gearList.js');
 
 describe('script.js functions', () => {
   let script;
@@ -944,6 +945,25 @@ describe('script.js functions', () => {
     document.getElementById('batteryCount').textContent = '6';
     const html = generateGearListHtml();
     expect(html).toContain('6x BattA');
+  });
+
+  test('Easyrig scenario adds stabiliser with options to grip section', () => {
+    const { generateGearListHtml } = script;
+    const html = generateGearListHtml({ requiredScenarios: 'Easyrig' });
+    expect(html).toContain('Grip');
+    expect(html).toContain('1x Easyrig 5 Vario');
+    expect(html).toContain('<select id="gearListEasyrig"');
+    expect(html).toContain('no further stabilisation');
+    expect(html).toContain('FlowCine Serene Spring Arm');
+    expect(html).toContain('Easyrig - STABIL G3');
+  });
+
+  test('camera stabiliser database lists Easyrig 5 Vario with options', () => {
+    const stabilisers = gear.accessories.cameraStabiliser;
+    expect(Object.keys(stabilisers)).toEqual(['Easyrig 5 Vario']);
+    expect(stabilisers['Easyrig 5 Vario'].options).toEqual(
+      expect.arrayContaining(['FlowCine Serene Spring Arm', 'Easyrig - STABIL G3'])
+    );
   });
 
   test('monitoring support cables grouped by type', () => {


### PR DESCRIPTION
## Summary
- Store Easyrig 5 Vario as the stabiliser with optional Serene and STABIL G3 attachments
- Persist Easyrig stabilisation dropdown selections and derive options from gear data
- Test stabiliser database structure and dropdown generation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5d7def72483208372f00c71adfc89