### PR TITLE
Add SHAPE handle for handheld and Easyrig scenarios

### DIFF
--- a/devices/gearList.js
+++ b/devices/gearList.js
@@ -465,6 +465,9 @@ const gear = {
       "ARRI Heated Eyecup HE-7": {
         "brand": "ARRI",
         "kNumber": "K2.0003898"
+      },
+      "SHAPE Telescopic Handle ARRI Rosette Kit 12\"": {
+        "brand": "SHAPE"
       }
     },
     "matteboxes": {

--- a/script.js
+++ b/script.js
@@ -6943,6 +6943,12 @@ function generateGearListHtml(info = {}) {
         }
     }
     const supportAccNoCages = cameraSupportAcc.filter(item => !compatibleCages.includes(item));
+    const scenarios = info.requiredScenarios
+        ? info.requiredScenarios.split(',').map(s => s.trim()).filter(Boolean)
+        : [];
+    if (scenarios.includes('Handheld') && scenarios.includes('Easyrig')) {
+        supportAccNoCages.push('SHAPE Telescopic Handle ARRI Rosette Kit 12"');
+    }
     const projectTitle = escapeHtml(info.projectName || setupNameInput.value);
     const allowedInfo = ['dop','prepDays','shootingDays','deliveryResolution','recordingResolution','aspectRatio','codec','baseFrameRate','lenses','sliderBowl'];
     const labels = {
@@ -7038,9 +7044,6 @@ function generateGearListHtml(info = {}) {
     if (info.monitoringPreferences) {
         monitoringSupportItems = `${escapeHtml(info.monitoringPreferences)}<br>${monitoringSupportItems}`;
     }
-    const scenarios = info.requiredScenarios
-        ? info.requiredScenarios.split(',').map(s => s.trim()).filter(Boolean)
-        : [];
     const gripItems = [];
     if (scenarios.includes('Cine Saddle')) gripItems.push('Cinekinetic Cinesaddle');
     if (scenarios.includes('Steadybag')) gripItems.push('Steadybag');

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -972,6 +972,18 @@ describe('script.js functions', () => {
     expect(itemsRow.textContent).toContain('Steadybag');
   });
 
+  test('Handheld and Easyrig scenarios add telescopic handle to camera support', () => {
+    const { generateGearListHtml } = script;
+    const html = generateGearListHtml({ requiredScenarios: 'Handheld, Easyrig' });
+    const wrap = document.createElement('div');
+    wrap.innerHTML = html;
+    const rows = Array.from(wrap.querySelectorAll('.gear-table tr'));
+    const cameraSupportIndex = rows.findIndex(r => r.textContent === 'Camera Support');
+    expect(cameraSupportIndex).toBeGreaterThanOrEqual(0);
+    const itemsRow = rows[cameraSupportIndex + 1];
+    expect(itemsRow.textContent).toContain('SHAPE Telescopic Handle ARRI Rosette Kit 12"');
+  });
+
   test('Slider scenario adds Tango Roller and accessories', () => {
     const { generateGearListHtml } = script;
     const html = generateGearListHtml({ requiredScenarios: 'Slider', sliderBowl: '75er bowl' });


### PR DESCRIPTION
## Summary
- include SHAPE Telescopic Handle ARRI Rosette Kit 12" in camera support gear data
- automatically add telescopic handle when both Handheld and Easyrig scenarios are selected
- test coverage for new camera support scenario

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b5e49acccc8320abf6feca9e86c648