### PR TITLE
feat: add Easyrig stabiliser options

### DIFF
--- a/devices/gearList.js
+++ b/devices/gearList.js
@@ -1550,6 +1550,15 @@ const gear = {
         "brand": "Hudson Spider"
       }
     },
+    "cameraStabiliser": {
+      "Easyrig 5 Vario": {
+        "brand": "Easyrig",
+        "options": [
+          "FlowCine Serene Spring Arm",
+          "Easyrig - STABIL G3"
+        ]
+      }
+    },
     "grip": {
       "Cinekinetic Cinesaddle": {
         "brand": "Cinekinetic"

--- a/script.js
+++ b/script.js
@@ -1591,6 +1591,7 @@ if (gearListOutput) {
     gearListOutput.classList.remove('hidden');
     ensureGearListActions();
     bindGearListCageListener();
+    bindGearListEasyrigListener();
   }
 }
 
@@ -5275,6 +5276,7 @@ setupSelect.addEventListener("change", (event) => {
           gearListOutput.classList.remove('hidden');
           ensureGearListActions();
           bindGearListCageListener();
+          bindGearListEasyrigListener();
           if (typeof saveGearList === 'function') {
             saveGearList(setup.gearList);
           }
@@ -6162,6 +6164,7 @@ if (projectForm) {
             gearListOutput.classList.remove('hidden');
             ensureGearListActions();
             bindGearListCageListener();
+            bindGearListEasyrigListener();
             saveCurrentGearList();
         }
         projectDialog.close();
@@ -7042,6 +7045,14 @@ function generateGearListHtml(info = {}) {
         ? info.requiredScenarios.split(',').map(s => s.trim()).filter(Boolean)
         : [];
     const gripItems = [];
+    let easyrigSelectHtml = '';
+    if (scenarios.includes('Easyrig')) {
+        const stabiliser = devices && devices.accessories && devices.accessories.cameraStabiliser && devices.accessories.cameraStabiliser['Easyrig 5 Vario'];
+        const opts = stabiliser && Array.isArray(stabiliser.options) ? stabiliser.options : [];
+        const options = ['no further stabilisation', ...opts];
+        const optsHtml = options.map(o => `<option value="${escapeHtml(o)}">${escapeHtml(o)}</option>`).join('');
+        easyrigSelectHtml = `1x Easyrig 5 Vario <select id="gearListEasyrig">${optsHtml}</select>`;
+    }
     if (scenarios.includes('Cine Saddle')) gripItems.push('Cinekinetic Cinesaddle');
     if (scenarios.includes('Steadybag')) gripItems.push('Steadybag');
     if (scenarios.includes('Slider')) {
@@ -7063,7 +7074,7 @@ function generateGearListHtml(info = {}) {
     addRow('Monitoring support', monitoringSupportItems);
     addRow('Power', '');
     addRow('Rigging', escapeHtml(info.rigging || ''));
-    addRow('Grip', formatItems(gripItems));
+    addRow('Grip', [formatItems(gripItems), easyrigSelectHtml].filter(Boolean).join('<br>'));
     addRow('Carts and Transportation', '');
     addRow('Miscellaneous', formatItems(miscAcc));
     addRow('Consumables', '');
@@ -7084,6 +7095,18 @@ function getCurrentGearListHtml() {
         const originalSel = gearListOutput.querySelector('#gearListCage');
         const val = originalSel ? originalSel.value : cageSel.value;
         Array.from(cageSel.options).forEach(opt => {
+            if (opt.value === val) {
+                opt.setAttribute('selected', '');
+            } else {
+                opt.removeAttribute('selected');
+            }
+        });
+    }
+    const easyrigSel = clone.querySelector('#gearListEasyrig');
+    if (easyrigSel) {
+        const originalSel = gearListOutput.querySelector('#gearListEasyrig');
+        const val = originalSel ? originalSel.value : easyrigSel.value;
+        Array.from(easyrigSel.options).forEach(opt => {
             if (opt.value === val) {
                 opt.setAttribute('selected', '');
             } else {
@@ -7135,6 +7158,7 @@ function handleImportGearList(e) {
                 gearListOutput.classList.remove('hidden');
                 ensureGearListActions();
                 bindGearListCageListener();
+                bindGearListEasyrigListener();
                 saveCurrentGearList();
             }
         } catch {
@@ -7215,12 +7239,23 @@ function bindGearListCageListener() {
     }
 }
 
+function bindGearListEasyrigListener() {
+    if (!gearListOutput) return;
+    const sel = gearListOutput.querySelector('#gearListEasyrig');
+    if (sel) {
+        sel.addEventListener('change', () => {
+            saveCurrentGearList();
+        });
+    }
+}
+
 function refreshGearListIfVisible() {
     if (!gearListOutput || gearListOutput.classList.contains('hidden') || !currentProjectInfo) return;
     const html = generateGearListHtml(currentProjectInfo);
     gearListOutput.innerHTML = html;
     ensureGearListActions();
     bindGearListCageListener();
+    bindGearListEasyrigListener();
     saveCurrentGearList();
 }
 

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -3,6 +3,15 @@ const fs = require('fs');
 const path = require('path');
 const LZString = require('lz-string');
 
+test('Easyrig stabiliser data exposes attachments', () => {
+  const gear = require('../devices/gearList.js');
+  const stabiliser = gear.accessories.cameraStabiliser['Easyrig 5 Vario'];
+  expect(stabiliser.options).toEqual([
+    'FlowCine Serene Spring Arm',
+    'Easyrig - STABIL G3'
+  ]);
+});
+
 describe('script.js functions', () => {
   let script;
 
@@ -70,6 +79,11 @@ describe('script.js functions', () => {
           power: { 'D-Tap to LEMO 2-pin': { to: 'LEMO 2-pin' } },
           fiz: { 'LBUS to LBUS': { from: 'LBUS (LEMO 4-pin)', to: 'LBUS (LEMO 4-pin)' } },
           video: { 'BNC SDI Cable': { type: '3G-SDI' } }
+        },
+        cameraStabiliser: {
+          'Easyrig 5 Vario': {
+            options: ['FlowCine Serene Spring Arm', 'Easyrig - STABIL G3']
+          }
         }
       }
     };
@@ -988,6 +1002,21 @@ describe('script.js functions', () => {
     expect(text).toContain('1x Satz Paganinis');
     expect(text).toContain('2x Sandsack');
     expect(text).toContain('3x Bodenmatte');
+  });
+
+  test('Easyrig scenario adds stabiliser with dropdown options', () => {
+    const { generateGearListHtml } = script;
+    const html = generateGearListHtml({ requiredScenarios: 'Easyrig' });
+    const wrap = document.createElement('div');
+    wrap.innerHTML = html;
+    const sel = wrap.querySelector('#gearListEasyrig');
+    expect(sel).not.toBeNull();
+    const optionTexts = Array.from(sel.options).map(o => o.textContent);
+    expect(optionTexts).toEqual([
+      'no further stabilisation',
+      'FlowCine Serene Spring Arm',
+      'Easyrig - STABIL G3'
+    ]);
   });
 
   test('monitoring support cables grouped by type', () => {


### PR DESCRIPTION
## Summary
- add Easyrig 5 Vario to accessories as a camera stabiliser with Serene and STABIL G3 attachments
- show Easyrig 5 Vario in Grip list when Easyrig scenario selected with dropdown for extra stabilisation options
- persist Easyrig choice and test data coverage for stabiliser options

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b5e49e4ea88320b44f3b4f83e8238a