### PR TITLE
Add Tango Beam for undersling slider mode

### DIFF
--- a/script.js
+++ b/script.js
@@ -7059,6 +7059,9 @@ function generateGearListHtml(info = {}) {
         gripItems.push('Bodenmatte');
         gripItems.push('Bodenmatte');
         gripItems.push('Bodenmatte');
+        if (scenarios.includes('Undersling mode')) {
+            gripItems.push('Tango Beam');
+        }
     }
     addRow('Monitoring support', monitoringSupportItems);
     addRow('Power', '');

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -990,6 +990,18 @@ describe('script.js functions', () => {
     expect(text).toContain('3x Bodenmatte');
   });
 
+  test('Slider with undersling mode includes Tango Beam', () => {
+    const { generateGearListHtml } = script;
+    const html = generateGearListHtml({ requiredScenarios: 'Slider, Undersling mode', sliderBowl: '75er bowl' });
+    const wrap = document.createElement('div');
+    wrap.innerHTML = html;
+    const rows = Array.from(wrap.querySelectorAll('.gear-table tr'));
+    const gripIdx = rows.findIndex(r => r.textContent === 'Grip');
+    const itemsRow = rows[gripIdx + 1];
+    const text = itemsRow.textContent;
+    expect(text).toContain('1x Tango Beam');
+  });
+
   test('monitoring support cables grouped by type', () => {
     const { generateGearListHtml } = script;
     const html = generateGearListHtml();


### PR DESCRIPTION
## Summary
- include Tango Beam in gear list when undersling mode is selected with slider
- test slider undersling scenario for Tango Beam

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b5e51e01bc83208697de88ead5df20