### PR TITLE
Add outdoor scenario gear and consumables

### DIFF
--- a/script.js
+++ b/script.js
@@ -7079,8 +7079,30 @@ function generateGearListHtml(info = {}) {
     addRow('Rigging', escapeHtml(info.rigging || ''));
     addRow('Grip', [formatItems(gripItems), easyrigSelectHtml].filter(Boolean).join('<br>'));
     addRow('Carts and Transportation', '');
-    addRow('Miscellaneous', formatItems(miscAcc));
-    addRow('Consumables', '');
+    const miscItems = [...miscAcc];
+    const consumables = [];
+    if (scenarios.includes('Outdoor')) {
+        if (selectedNames.camera) miscItems.push(`Rain Cover "${selectedNames.camera}"`);
+        miscItems.push('Umbrella for Focus Monitor');
+        miscItems.push('Super Clamp');
+        miscItems.push('Super Clamp');
+        miscItems.push('Spigot');
+        miscItems.push('Umbrella Magliner incl Mounting to Magliner');
+        const monitorSizes = [];
+        if (monitorSelect && monitorSelect.value) {
+            const m = devices.monitors[monitorSelect.value];
+            if (m && m.screenSizeInches) monitorSizes.push(m.screenSizeInches);
+        }
+        const monitorsAbove10 = monitorSizes.filter(s => s > 10).length;
+        const monitorsUnder10 = monitorSizes.filter(s => s <= 10).length;
+        for (let i = 0; i < monitorsAbove10 + 2; i++) consumables.push('CapIt Large');
+        for (let i = 0; i < monitorsUnder10 + 3; i++) consumables.push('CapIt Medium');
+        for (let i = 0; i < 3; i++) consumables.push('CapIt Small');
+        for (let i = 0; i < 10; i++) consumables.push('Duschhaube');
+        consumables.push('Magliner Rain Cover Transparent');
+    }
+    addRow('Miscellaneous', formatItems(miscItems));
+    addRow('Consumables', formatItems(consumables));
     let body = `<h2>${projectTitle}</h2>`;
     if (infoHtml) body += infoHtml;
     body += '<h3>Gear List</h3><table class="gear-table">' + rows.join('') + '</table>';

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -39,6 +39,7 @@ describe('script.js functions', () => {
         MonA: {
           powerDrawWatts: 5,
           brightnessNits: 2300,
+          screenSizeInches: 7,
           power: { input: { type: 'LEMO 2-pin' } },
           videoInputs: [{ type: '3G-SDI' }]
         }
@@ -1029,6 +1030,60 @@ describe('script.js functions', () => {
       'FlowCine Serene Spring Arm',
       'Easyrig - STABIL G3'
     ]);
+  });
+
+  test('Outdoor scenario adds weather protection gear and consumables for small monitor', () => {
+    const { generateGearListHtml } = script;
+    const addOpt = (id, value) => {
+      const sel = document.getElementById(id);
+      sel.innerHTML = `<option value="${value}">${value}</option>`;
+      sel.value = value;
+    };
+    addOpt('cameraSelect', 'CamA');
+    addOpt('monitorSelect', 'MonA');
+    const html = generateGearListHtml({ requiredScenarios: 'Outdoor' });
+    const wrap = document.createElement('div');
+    wrap.innerHTML = html;
+    const rows = Array.from(wrap.querySelectorAll('.gear-table tr'));
+    const miscIdx = rows.findIndex(r => r.textContent === 'Miscellaneous');
+    const miscText = rows[miscIdx + 1].textContent;
+    expect(miscText).toContain('Rain Cover "CamA"');
+    expect(miscText).toContain('1x Umbrella for Focus Monitor');
+    expect(miscText).toContain('2x Super Clamp');
+    expect(miscText).toContain('1x Spigot');
+    expect(miscText).toContain('1x Umbrella Magliner incl Mounting to Magliner');
+    const consumIdx = rows.findIndex(r => r.textContent === 'Consumables');
+    const consumText = rows[consumIdx + 1].textContent;
+    expect(consumText).toContain('2x CapIt Large');
+    expect(consumText).toContain('4x CapIt Medium');
+    expect(consumText).toContain('3x CapIt Small');
+    expect(consumText).toContain('10x Duschhaube');
+    expect(consumText).toContain('1x Magliner Rain Cover Transparent');
+  });
+
+  test('Outdoor scenario calculates CapIt sizes for large monitors', () => {
+    const { generateGearListHtml } = script;
+    devices.monitors.MonB = {
+      powerDrawWatts: 5,
+      brightnessNits: 1000,
+      screenSizeInches: 13,
+      power: { input: { type: 'LEMO 2-pin' } },
+      videoInputs: []
+    };
+    const sel = document.getElementById('monitorSelect');
+    sel.innerHTML = '<option value="MonB">MonB</option>';
+    sel.value = 'MonB';
+    const camSel = document.getElementById('cameraSelect');
+    camSel.innerHTML = '<option value="CamA">CamA</option>';
+    camSel.value = 'CamA';
+    const html = generateGearListHtml({ requiredScenarios: 'Outdoor' });
+    const wrap = document.createElement('div');
+    wrap.innerHTML = html;
+    const rows = Array.from(wrap.querySelectorAll('.gear-table tr'));
+    const consumIdx = rows.findIndex(r => r.textContent === 'Consumables');
+    const consumText = rows[consumIdx + 1].textContent;
+    expect(consumText).toContain('3x CapIt Large');
+    expect(consumText).toContain('3x CapIt Medium');
   });
 
   test('monitoring support cables grouped by type', () => {


### PR DESCRIPTION
## Summary
- add outdoor scenario items to Miscellaneous and Consumables sections
- compute CapIt consumable counts based on monitor size
- test outdoor gear and consumable logic

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5e816322c8320b90473ab1bf52973