### PR TITLE
refactor: centralize FIZ connector handling

### DIFF
--- a/script.js
+++ b/script.js
@@ -497,21 +497,28 @@ function formatConnLabel(from, to) {
 const hasCamConnector = str => /CAM/i.test(str);
 const hasLemo7PinConnector = str => /7-pin/i.test(str);
 
+// Collect a list of FIZ connector type strings from a device definition.
+function getFizConnectorTypes(device) {
+  if (!device) return [];
+  if (Array.isArray(device.fizConnectors)) {
+    return device.fizConnectors.map(fc => fc.type);
+  }
+  return device.fizConnector ? [device.fizConnector] : [];
+}
+
 function controllerCamPort(name) {
   const isRf = /cforce.*rf/i.test(name) || /RIA-1/i.test(name);
   if (isRf) return 'Cam';
   const c = devices.fiz?.controllers?.[name];
   if (c) {
     if (/UMC-4/i.test(name)) return '3-Pin R/S';
-    const connStr = c.fizConnectors
-      ? c.fizConnectors.map(fc => fc.type).join(', ')
-      : c.fizConnector || '';
+    const connStr = getFizConnectorTypes(c).join(', ');
     if (hasCamConnector(connStr)) return 'Cam';
     if (hasLemo7PinConnector(connStr)) return 'LEMO 7-pin';
   }
   const m = devices.fiz?.motors?.[name];
   if (m) {
-    const connStr = m.fizConnector || (m.fizConnectors || []).map(fc => fc.type).join(', ');
+    const connStr = getFizConnectorTypes(m).join(', ');
     if (hasCamConnector(connStr)) return 'Cam';
     if (hasLemo7PinConnector(connStr)) return 'LEMO 7-pin';
   }
@@ -522,7 +529,7 @@ function controllerCamPort(name) {
 function controllerDistancePort(name) {
   const c = devices.fiz?.controllers?.[name];
   if (/RIA-1/i.test(name) || /UMC-4/i.test(name)) return 'Serial';
-  if (c && (c.fizConnectors || []).some(fc => /SERIAL/i.test(fc.type))) return 'Serial';
+  if (getFizConnectorTypes(c).some(type => /SERIAL/i.test(type))) return 'Serial';
   return 'LBUS';
 }
 
@@ -7905,6 +7912,7 @@ if (typeof module !== "undefined" && module.exports) {
     updateDiagramLegend,
     cameraFizPort,
     controllerCamPort,
+    controllerDistancePort,
     detectBrand,
     connectionLabel,
     generateConnectorSummary,

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -1329,6 +1329,15 @@ describe('script.js functions', () => {
     expect(controllerCamPort('Generic FIZ Device')).toBe('FIZ Port');
   });
 
+  test('controller distance port detects Serial connectors', () => {
+    const { controllerDistancePort } = script;
+    global.devices.fiz.controllers['Serial Controller'] = {
+      fizConnectors: [{ type: 'Serial' }]
+    };
+    expect(controllerDistancePort('Serial Controller')).toBe('Serial');
+    expect(controllerDistancePort('ControllerA')).toBe('LBUS');
+  });
+
   test('ARRI camera with LBUS avoids distance warning', () => {
     jest.resetModules();
 


### PR DESCRIPTION
## Summary
- centralize extraction of FIZ connector types
- simplify controller port selection logic using the new helper
- test controller distance port detection

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5e98b4f6c8320ac0d3b9b607d4cbe