### PR TITLE
Add gimbal selection to grip category

### DIFF
--- a/devices/gearList.js
+++ b/devices/gearList.js
@@ -1566,6 +1566,12 @@ const gear = {
       "Cinekinetic Cinesaddle": {
         "brand": "Cinekinetic"
       },
+      "DJI Ronin 2": {
+        "brand": "DJI"
+      },
+      "DJI Ronin RS4 Pro Combo": {
+        "brand": "DJI"
+      },
       "Steadybag": {
         "brand": "Steadybag"
       }

--- a/script.js
+++ b/script.js
@@ -7074,6 +7074,14 @@ function generateGearListHtml(info = {}) {
         gripItems.push('Bodenmatte');
         gripItems.push('Bodenmatte');
     }
+    if (scenarios.includes('Gimbal')) {
+        const camData = cameraSelect && cameraSelect.value && cameraSelect.value !== 'None'
+            ? devices.cameras[cameraSelect.value]
+            : null;
+        const weight = camData?.weight_g;
+        const gimbal = weight >= 2000 ? 'DJI Ronin 2' : 'DJI Ronin RS4 Pro Combo';
+        gripItems.push(gimbal);
+    }
     addRow('Monitoring support', monitoringSupportItems);
     addRow('Power', '');
     addRow('Rigging', escapeHtml(info.rigging || ''));

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -1017,6 +1017,36 @@ describe('script.js functions', () => {
     expect(text).toContain('3x Bodenmatte');
   });
 
+  test('Gimbal scenario adds RS4 Pro for lightweight camera', () => {
+    const { generateGearListHtml } = script;
+    devices.cameras.SmallCam = { weight_g: 1000 };
+    const camSel = document.getElementById('cameraSelect');
+    camSel.innerHTML = '<option value="SmallCam">SmallCam</option>';
+    camSel.value = 'SmallCam';
+    const html = generateGearListHtml({ requiredScenarios: 'Gimbal' });
+    const wrap = document.createElement('div');
+    wrap.innerHTML = html;
+    const rows = Array.from(wrap.querySelectorAll('.gear-table tr'));
+    const gripIdx = rows.findIndex(r => r.textContent === 'Grip');
+    const itemsRow = rows[gripIdx + 1];
+    expect(itemsRow.textContent).toContain('DJI Ronin RS4 Pro Combo');
+  });
+
+  test('Gimbal scenario adds Ronin 2 for heavy camera', () => {
+    const { generateGearListHtml } = script;
+    devices.cameras.BigCam = { weight_g: 3000 };
+    const camSel = document.getElementById('cameraSelect');
+    camSel.innerHTML = '<option value="BigCam">BigCam</option>';
+    camSel.value = 'BigCam';
+    const html = generateGearListHtml({ requiredScenarios: 'Gimbal' });
+    const wrap = document.createElement('div');
+    wrap.innerHTML = html;
+    const rows = Array.from(wrap.querySelectorAll('.gear-table tr'));
+    const gripIdx = rows.findIndex(r => r.textContent === 'Grip');
+    const itemsRow = rows[gripIdx + 1];
+    expect(itemsRow.textContent).toContain('DJI Ronin 2');
+  });
+
   test('Easyrig scenario adds stabiliser with dropdown options', () => {
     const { generateGearListHtml } = script;
     const html = generateGearListHtml({ requiredScenarios: 'Easyrig' });


### PR DESCRIPTION
## Summary
- Include DJI Ronin RS4 Pro Combo or DJI Ronin 2 in Grip section when "Gimbal" scenario is selected, based on camera weight
- List DJI Ronin RS4 Pro Combo and DJI Ronin 2 as Grip accessories
- Test gimbal scenario for both lightweight and heavy cameras

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b5ead9f5988320b5bd11e87fc5c5b9