### PR TITLE
Add gimbal selection to grip category

### DIFF
--- a/devices/gearList.js
+++ b/devices/gearList.js
@@ -1560,6 +1560,12 @@ const gear = {
           "FlowCine Serene Spring Arm",
           "Easyrig - STABIL G3"
         ]
+      },
+      "DJI Ronin RS4 Pro Combo": {
+        "brand": "DJI"
+      },
+      "DJI Ronin 2": {
+        "brand": "DJI"
       }
     },
     "grip": {

--- a/script.js
+++ b/script.js
@@ -7063,6 +7063,12 @@ function generateGearListHtml(info = {}) {
         const optsHtml = options.map(o => `<option value="${escapeHtml(o)}">${escapeHtml(o)}</option>`).join('');
         easyrigSelectHtml = `1x Easyrig 5 Vario <select id="gearListEasyrig">${optsHtml}</select>`;
     }
+    if (scenarios.includes('Gimbal')) {
+        const cam = devices && devices.cameras && devices.cameras[selectedNames.camera];
+        const weight = cam && cam.weight_g;
+        const isSmall = weight != null ? weight < 2000 : /(FX3|FX6|R5)/i.test(selectedNames.camera);
+        gripItems.push(isSmall ? 'DJI Ronin RS4 Pro Combo' : 'DJI Ronin 2');
+    }
     if (scenarios.includes('Cine Saddle')) gripItems.push('Cinekinetic Cinesaddle');
     if (scenarios.includes('Steadybag')) gripItems.push('Steadybag');
     if (scenarios.includes('Slider')) {


### PR DESCRIPTION
## Summary
- add DJI Ronin gimbals to camera stabiliser gear list
- auto-select gimbal based on camera size when "Gimbal" scenario chosen

## Testing
- `npm run lint`
- `npm run check-consistency`
- `CI=1 npx jest tests/utils.test.js --runInBand`


------
https://chatgpt.com/codex/tasks/task_e_68b5ecfba6f88320bb6e37062494b30f