### PR TITLE
Add tripod head selection based on camera size

### DIFF
--- a/devices/gearList.js
+++ b/devices/gearList.js
@@ -1526,6 +1526,11 @@ const gear = {
         "brand": "OConnor",
         "bowlSizeMm": 150,
         "material": "Aluminum"
+      },
+      "Sachtler FSB 8 Head": {
+        "brand": "Sachtler",
+        "bowlSizeMm": 75,
+        "material": "Aluminum"
       }
     },
     "tripods": {

--- a/script.js
+++ b/script.js
@@ -7084,6 +7084,17 @@ function generateGearListHtml(info = {}) {
     if (scenarios.includes('Slider') && scenarios.includes('Undersling mode')) {
         gripItems.push('Tango Beam');
     }
+    const needsTripodHead = ['Tripod', 'Dolly', 'Slider', 'Car Mount', 'Jib'].some(s => scenarios.includes(s));
+    if (needsTripodHead) {
+        const cam = devices && devices.cameras && selectedNames.camera ? devices.cameras[selectedNames.camera] : null;
+        const weight = cam && cam.weight_g ? cam.weight_g : 0;
+        const HEAVY_THRESHOLD_G = 2000;
+        if (weight > HEAVY_THRESHOLD_G) {
+            gripItems.push('OConnor 2560 Head');
+        } else {
+            gripItems.push('Sachtler FSB 8 Head');
+        }
+    }
     addRow('Monitoring support', monitoringSupportItems);
     addRow('Power', '');
     addRow('Rigging', escapeHtml(info.rigging || ''));

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -1030,6 +1030,42 @@ describe('script.js functions', () => {
     });
   });
 
+  test('Tripod scenario adds OConnor head for heavy camera', () => {
+    const { generateGearListHtml } = script;
+    global.devices.cameras['Arri Alexa Mini LF'] = { weight_g: 2600 };
+    const addOpt = (id, value) => {
+      const sel = document.getElementById(id);
+      sel.innerHTML = `<option value="${value}">${value}</option>`;
+      sel.value = value;
+    };
+    addOpt('cameraSelect', 'Arri Alexa Mini LF');
+    const html = generateGearListHtml({ requiredScenarios: 'Tripod' });
+    const wrap = document.createElement('div');
+    wrap.innerHTML = html;
+    const rows = Array.from(wrap.querySelectorAll('.gear-table tr'));
+    const gripIdx = rows.findIndex(r => r.textContent === 'Grip');
+    const itemsRow = rows[gripIdx + 1];
+    expect(itemsRow.textContent).toContain('OConnor 2560 Head');
+  });
+
+  test('Tripod scenario adds 75mm head for light camera', () => {
+    const { generateGearListHtml } = script;
+    global.devices.cameras['Blackmagic BMPCC 4K'] = { weight_g: 680 };
+    const addOpt = (id, value) => {
+      const sel = document.getElementById(id);
+      sel.innerHTML = `<option value="${value}">${value}</option>`;
+      sel.value = value;
+    };
+    addOpt('cameraSelect', 'Blackmagic BMPCC 4K');
+    const html = generateGearListHtml({ requiredScenarios: 'Tripod' });
+    const wrap = document.createElement('div');
+    wrap.innerHTML = html;
+    const rows = Array.from(wrap.querySelectorAll('.gear-table tr'));
+    const gripIdx = rows.findIndex(r => r.textContent === 'Grip');
+    const itemsRow = rows[gripIdx + 1];
+    expect(itemsRow.textContent).toContain('Sachtler FSB 8 Head');
+  });
+
   test('Easyrig scenario adds stabiliser with dropdown options', () => {
     const { generateGearListHtml } = script;
     const html = generateGearListHtml({ requiredScenarios: 'Easyrig' });


### PR DESCRIPTION
## Summary
- auto-include tripod head in grip gear when Tripod, Dolly, Slider, Car Mount, or Jib scenarios are selected
- choose OConnor 2560 for heavy cameras, Sachtler FSB 8 for light rigs
- document Sachtler FSB 8 head in gear list data

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b5ee87b5a08320966093adf52cd311