### PR TITLE
Show all project form selections in requirements

### DIFF
--- a/script.js
+++ b/script.js
@@ -6960,7 +6960,6 @@ function generateGearListHtml(info = {}) {
         supportAccNoCages.push('SHAPE Telescopic Handle ARRI Rosette Kit 12"');
     }
     const projectTitle = escapeHtml(info.projectName || setupNameInput.value);
-    const allowedInfo = ['dop','prepDays','shootingDays','deliveryResolution','recordingResolution','aspectRatio','codec','baseFrameRate','lenses','sliderBowl'];
     const labels = {
         dop: 'DoP',
         prepDays: 'Prep Days',
@@ -6971,11 +6970,17 @@ function generateGearListHtml(info = {}) {
         codec: 'Codec',
         baseFrameRate: 'Base Frame Rate',
         lenses: 'Lenses',
-        sliderBowl: 'Tango Roller Mount'
+        requiredScenarios: 'Required Scenarios',
+        rigging: 'Rigging',
+        monitoringPreferences: 'Monitoring Preferences',
+        tripodPreferences: 'Tripod Preferences',
+        sliderBowl: 'Tango Roller Mount',
+        filter: 'Filter'
     };
-    const infoPairs = Object.entries(info).filter(([k,v]) => v && allowedInfo.includes(k));
+    const infoPairs = Object.entries(info)
+        .filter(([k, v]) => v && k !== 'projectName');
     const infoHtml = infoPairs.length ? '<h3>Project Requirements</h3><ul>' +
-        infoPairs.map(([k,v]) => `<li>${escapeHtml(labels[k]||k)}: ${escapeHtml(v)}</li>`).join('') + '</ul>' : '';
+        infoPairs.map(([k, v]) => `<li>${escapeHtml(labels[k] || k)}: ${escapeHtml(v)}</li>`).join('') + '</ul>' : '';
     const formatItems = arr => {
         const counts = {};
         arr.filter(Boolean).forEach(n => {
@@ -7000,9 +7005,9 @@ function generateGearListHtml(info = {}) {
     }
     addRow('Camera Support', [cameraSupportText, cageSelectHtml].filter(Boolean).join('<br>'));
     addRow('Media', '');
-    addRow('Lens', escapeHtml(info.lenses || ''));
+    addRow('Lens', '');
     addRow('Lens Support', '');
-    addRow('Matte box + filter', escapeHtml(info.filter || ''));
+    addRow('Matte box + filter', '');
     addRow('LDS (FIZ)', formatItems([...selectedNames.motors, ...selectedNames.controllers, selectedNames.distance, ...fizCableAcc]));
     let batteryItems = '';
     if (selectedNames.battery) {

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -929,10 +929,17 @@ describe('script.js functions', () => {
       addOpt('distanceSelect', 'DistA');
       addOpt('batterySelect', 'BattA');
       document.getElementById('batteryCount').textContent = '1';
-      const html = generateGearListHtml({ projectName: 'Proj', dop: 'DopName' });
+      const html = generateGearListHtml({
+        projectName: 'Proj',
+        dop: 'DopName',
+        requiredScenarios: 'Handheld, Slider',
+        filter: 'ND'
+      });
       expect(html).toContain('<h2>Proj</h2>');
       expect(html).toContain('<h3>Project Requirements</h3>');
       expect(html).toContain('DoP: DopName');
+      expect(html).toContain('Required Scenarios: Handheld, Slider');
+      expect(html).toContain('Filter: ND');
       expect(html).toContain('<table class="gear-table">');
       expect(html).toContain('Camera');
       expect(html).toContain('1x CamA');


### PR DESCRIPTION
## Summary
- include every project form selection in the Project Requirements list and label new fields
- avoid adding freeform answers like lenses or filters to the gear table
- update gear list test to cover new requirements output

## Testing
- `npm run lint`
- `npm run check-consistency`
- `npx jest tests/script.test.js --runInBand`


------
https://chatgpt.com/codex/tasks/task_e_68b5ef24e3188320a0116917c529c6be