### PR TITLE
Hide legacy cables from gear list output

### DIFF
--- a/script.js
+++ b/script.js
@@ -6785,6 +6785,7 @@ function collectAccessories() {
     const chargers = [];
     const fizCables = [];
     const acc = devices.accessories || {};
+    const excludedCables = new Set(['D-Tap to LEMO 2-pin', 'HDMI Cable']);
 
     if (batterySelect.value) {
         const mount = devices.batteries[batterySelect.value]?.mount_type;
@@ -6836,7 +6837,7 @@ function collectAccessories() {
         const types = Array.isArray(input) ? input : input ? [input] : [];
         types.forEach(t => {
             for (const [name, cable] of Object.entries(powerCableDb)) {
-                if (cable.to === t) misc.push(name);
+                if (cable.to === t && !excludedCables.has(name)) misc.push(name);
             }
         });
     };
@@ -6856,7 +6857,7 @@ function collectAccessories() {
             inputs.forEach(inp => {
                 if (out.type === inp.type) {
                     for (const [name, cable] of Object.entries(videoCableDb)) {
-                        if (cable.type === out.type) misc.push(name);
+                        if (cable.type === out.type && !excludedCables.has(name)) misc.push(name);
                     }
                 }
             });

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -79,7 +79,7 @@ describe('script.js functions', () => {
         cables: {
           power: { 'D-Tap to LEMO 2-pin': { to: 'LEMO 2-pin' } },
           fiz: { 'LBUS to LBUS': { from: 'LBUS (LEMO 4-pin)', to: 'LBUS (LEMO 4-pin)' } },
-          video: { 'BNC SDI Cable': { type: '3G-SDI' } }
+          video: { 'BNC SDI Cable': { type: '3G-SDI' }, 'HDMI Cable': { type: 'HDMI' } }
         },
         cameraStabiliser: {
           'Easyrig 5 Vario': {
@@ -945,6 +945,8 @@ describe('script.js functions', () => {
       expect(html).toContain('1x Dual V-Mount Charger');
       expect(html).toContain('Miscellaneous');
       expect(html).toContain('1x BNC SDI Cable');
+      expect(html).not.toContain('D-Tap to LEMO 2-pin');
+      expect(html).not.toContain('HDMI Cable');
     });
 
   test('gear list separates multiple items with line breaks', () => {


### PR DESCRIPTION
## Summary
- restore D-Tap to LEMO 2-pin and HDMI Cable entries to accessory database
- filter these cables from gear list generation so they no longer appear in Miscellaneous
- update tests to cover hidden cable behavior

## Testing
- `CI=true npm test -- --runInBand --forceExit > /tmp/unit.log 2>&1 && tail -n 20 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_68b5ef727ee48320a60fca5df5c52022