### PR TITLE
Add default cart and transportation items

### DIFF
--- a/script.js
+++ b/script.js
@@ -7110,7 +7110,13 @@ function generateGearListHtml(info = {}) {
     addRow('Power', '');
     addRow('Rigging', escapeHtml(info.rigging || ''));
     addRow('Grip', [formatItems(gripItems), easyrigSelectHtml].filter(Boolean).join('<br>'));
-    addRow('Carts and Transportation', '');
+    const cartsTransportationItems = [
+        'Magliner Senior - with quick release mount + tripod holder + utility tray + O‘Connor-Aufhängung',
+        ...Array(10).fill('Securing Straps (25mm wide)'),
+        'Loading Ramp (pair, 420kg)',
+        ...Array(20).fill('Airliner Ösen')
+    ];
+    addRow('Carts and Transportation', formatItems(cartsTransportationItems));
     const miscItems = [...miscAcc];
     const consumables = [];
     if (scenarios.includes('Outdoor')) {

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -1006,6 +1006,20 @@ describe('script.js functions', () => {
     expect(itemsRow.textContent).toContain('SHAPE Telescopic Handle ARRI Rosette Kit 12"');
   });
 
+  test('Carts and Transportation category includes default items', () => {
+    const { generateGearListHtml } = script;
+    const html = generateGearListHtml();
+    const wrap = document.createElement('div');
+    wrap.innerHTML = html;
+    const rows = Array.from(wrap.querySelectorAll('.gear-table tr'));
+    const cartsIdx = rows.findIndex(r => r.textContent === 'Carts and Transportation');
+    const itemsText = rows[cartsIdx + 1].textContent;
+    expect(itemsText).toContain('1x Magliner Senior - with quick release mount + tripod holder + utility tray + O‘Connor-Aufhängung');
+    expect(itemsText).toContain('10x Securing Straps (25mm wide)');
+    expect(itemsText).toContain('1x Loading Ramp (pair, 420kg)');
+    expect(itemsText).toContain('20x Airliner Ösen');
+  });
+
   test('Slider scenario adds Tango Roller and accessories', () => {
     const { generateGearListHtml } = script;
     const html = generateGearListHtml({ requiredScenarios: 'Slider', sliderBowl: '75er bowl' });


### PR DESCRIPTION
## Summary
- Automatically include Magliner cart setup and accessories in the Carts and Transportation section
- Cover new gear with dedicated tests for the generated gear list

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b5f2aaab188320953d41d1cbec8f70