### PR TITLE
Remove rigging and monitoring rows from gear table

### DIFF
--- a/index.html
+++ b/index.html
@@ -921,7 +921,7 @@
           <option value="Film magazines">Film magazines</option>
         </select>
       </label></div>
-      <div class="form-row"><label for="monitoringPreferences">Monitoring Preferences:
+      <div class="form-row"><label for="monitoringPreferences">Monitoring support:
         <select id="monitoringPreferences" name="monitoringPreferences" multiple size="18">
           <option value="VF Clean Feed">VF Clean Feed</option>
           <option value="Onboard Clean Feed">Onboard Clean Feed</option>

--- a/script.js
+++ b/script.js
@@ -6973,7 +6973,7 @@ function generateGearListHtml(info = {}) {
         lenses: 'Lenses',
         requiredScenarios: 'Required Scenarios',
         rigging: 'Rigging',
-        monitoringPreferences: 'Monitoring Preferences',
+        monitoringPreferences: 'Monitoring support',
         tripodPreferences: 'Tripod Preferences',
         sliderBowl: 'Tango Roller Mount',
         filter: 'Filter'
@@ -7031,35 +7031,6 @@ function generateGearListHtml(info = {}) {
         monitoringItems += (monitoringItems ? '<br>' : '') + `1x <strong>Wireless Transmitter</strong> - ${escapeHtml(selectedNames.video)}`;
     }
     addRow('Monitoring', monitoringItems);
-
-    const cableUsage = { power: {}, video: {} };
-    const addCable = (name, use, type) => {
-        if (!cableUsage[type][name]) cableUsage[type][name] = {};
-        cableUsage[type][name][use] = (cableUsage[type][name][use] || 0) + 1;
-    };
-    addCable('D-Tap to Lemo-2-pin Cable 0,5m', 'for onboard monitor', 'power');
-    addCable('D-Tap to Lemo-2-pin Cable 0,5m', 'spare', 'power');
-    addCable('ultra slim 3G-SDI BNC cable 0,5m', 'for onboard monitor', 'video');
-    addCable('ultra slim 3G-SDI BNC cable 0,5m', 'spare', 'video');
-    addCable('D-Tap to Lemo-2-pin Cable 0,3m', 'for wireless transmitter', 'power');
-    addCable('D-Tap to Lemo-2-pin Cable 0,3m', 'spare', 'power');
-    addCable('ultra slim 3G-SDI BNC cable 0,3m', 'for wireless transmitter', 'video');
-    addCable('ultra slim 3G-SDI BNC cable 0,3m', 'spare', 'video');
-    const formatCableUsage = usageMap => {
-        return Object.entries(usageMap).map(([name, uses]) => {
-            const total = Object.values(uses).reduce((sum, n) => sum + n, 0);
-            const notes = Object.entries(uses).map(([use, count]) => `${count}x ${use}`).join('; ');
-            return `${total}x ${escapeHtml(name)} (${escapeHtml(notes)})`;
-        }).join('<br>');
-    };
-    const powerUsage = formatCableUsage(cableUsage.power);
-    const videoUsage = formatCableUsage(cableUsage.video);
-    let monitoringSupportItems = '';
-    if (powerUsage) monitoringSupportItems += `<strong>Power</strong><br>${powerUsage}`;
-    if (videoUsage) monitoringSupportItems += (monitoringSupportItems ? '<br>' : '') + `<strong>Video</strong><br>${videoUsage}`;
-    if (info.monitoringPreferences) {
-        monitoringSupportItems = `${escapeHtml(info.monitoringPreferences)}<br>${monitoringSupportItems}`;
-    }
     const gripItems = [];
     let easyrigSelectHtml = '';
     if (scenarios.includes('Easyrig')) {
@@ -7107,9 +7078,7 @@ function generateGearListHtml(info = {}) {
             gripItems.push('Sachtler FSB 8 Head');
         }
     }
-    addRow('Monitoring support', monitoringSupportItems);
     addRow('Power', '');
-    addRow('Rigging', escapeHtml(info.rigging || ''));
     addRow('Grip', [formatItems(gripItems), easyrigSelectHtml].filter(Boolean).join('<br>'));
     const cartsTransportationItems = [
         'Magliner Senior - with quick release mount + tripod holder + utility tray + O‘Connor-Aufhängung',
@@ -7118,7 +7087,8 @@ function generateGearListHtml(info = {}) {
         ...Array(20).fill('Airliner Ösen')
     ];
     addRow('Carts and Transportation', formatItems(cartsTransportationItems));
-    const miscItems = [...miscAcc];
+    const miscExcluded = new Set(['D-Tap to LEMO 2-pin', 'HDMI Cable']);
+    const miscItems = [...miscAcc].filter(item => !miscExcluded.has(item));
     const consumables = [];
     if (scenarios.includes('Outdoor')) {
         if (selectedNames.camera) miscItems.push(`Rain Cover "${selectedNames.camera}"`);

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -1158,27 +1158,16 @@ describe('script.js functions', () => {
     expect(consumText).toContain('3x CapIt Medium');
   });
 
-  test('monitoring support cables grouped by type', () => {
+  test('rigging and monitoring support appear only in project requirements', () => {
     const { generateGearListHtml } = script;
-    const html = generateGearListHtml();
-    document.body.innerHTML = html;
-    const rows = document.querySelectorAll('table.gear-table tr');
-    let monitoringHtml = '';
-    rows.forEach((tr, idx) => {
-      if (tr.textContent === 'Monitoring support' && rows[idx + 1]) {
-        monitoringHtml = rows[idx + 1].innerHTML;
-      }
+    const html = generateGearListHtml({
+      rigging: 'Shoulder rig, Hand Grips',
+      monitoringPreferences: 'VF Clean Feed, Onboard 7 inch'
     });
-    expect(monitoringHtml).toContain('<strong>Power</strong>');
-    expect(monitoringHtml).toContain('<strong>Video</strong>');
-    const powerIdx = monitoringHtml.indexOf('<strong>Power</strong>');
-    const videoIdx = monitoringHtml.indexOf('<strong>Video</strong>');
-    const dtapIdx = monitoringHtml.indexOf('D-Tap to Lemo-2-pin Cable 0,5m');
-    const bncIdx = monitoringHtml.indexOf('ultra slim 3G-SDI BNC cable 0,5m');
-    expect(powerIdx).toBeLessThan(videoIdx);
-    expect(dtapIdx).toBeGreaterThan(powerIdx);
-    expect(dtapIdx).toBeLessThan(videoIdx);
-    expect(bncIdx).toBeGreaterThan(videoIdx);
+    expect(html).toContain('Rigging: Shoulder rig, Hand Grips');
+    expect(html).toContain('Monitoring support: VF Clean Feed, Onboard 7 inch');
+    expect(html).not.toContain('<td>Rigging</td>');
+    expect(html).not.toContain('<td>Monitoring support</td>');
   });
 
   test('duplicate motors are aggregated with count in gear list', () => {


### PR DESCRIPTION
## Summary
- Present rigging and monitoring choices only in project requirements
- Rename monitoring preferences label to "Monitoring support"
- Exclude D-Tap and HDMI cables from miscellaneous items
- Add regression test to ensure rigging and monitoring rows absent from gear table

## Testing
- `npx jest tests/script.test.js --runTestsByPath --runInBand`


------
https://chatgpt.com/codex/tasks/task_e_68b5f72d9e6883208275c5b54a422bbe