### PR TITLE
Add standard BNC cable bundle for every project

### DIFF
--- a/script.js
+++ b/script.js
@@ -6781,7 +6781,13 @@ function suggestChargerCounts(total) {
 
 function collectAccessories() {
     const cameraSupport = [];
-    const misc = [];
+    const misc = [
+        'BNC Cable 0.5 m',
+        'BNC Cable 1 m',
+        'BNC Cable 5 m',
+        'BNC Cable 10 m',
+        'BNC Drum 25 m'
+    ];
     const chargers = [];
     const fizCables = [];
     const acc = devices.accessories || {};
@@ -6848,24 +6854,6 @@ function collectAccessories() {
     controllerSelects.forEach(sel => gatherPower(devices.fiz.controllers[sel.value]));
     gatherPower(devices.fiz.distance[distanceSelect.value]);
 
-    const videoCableDb = acc.cables?.video || {};
-    const cameraOutputs = devices.cameras[cameraSelect.value]?.videoOutputs || [];
-    const matchVideo = device => {
-        if (!device) return;
-        const inputs = device.videoInputs || [];
-        cameraOutputs.forEach(out => {
-            inputs.forEach(inp => {
-                if (out.type === inp.type) {
-                    for (const [name, cable] of Object.entries(videoCableDb)) {
-                        if (cable.type === out.type && !excludedCables.has(name)) misc.push(name);
-                    }
-                }
-            });
-        });
-    };
-    matchVideo(devices.monitors[monitorSelect.value]);
-    matchVideo(devices.video[videoSelect.value]);
-
     const fizCableDb = devices.fiz?.cables || acc.cables?.fiz || {};
     const motorDatas = motorSelects.map(sel => devices.fiz.motors[sel.value]).filter(Boolean);
     const controllerDatas = controllerSelects.map(sel => devices.fiz.controllers[sel.value]).filter(Boolean);
@@ -6885,11 +6873,13 @@ function collectAccessories() {
         });
     });
 
+    const miscUnique = [...new Set(misc)];
+    for (let i = 0; i < 4; i++) miscUnique.push('BNC Connector');
     return {
         cameraSupport: [...new Set(cameraSupport)],
         chargers,
         fizCables: [...new Set(fizCables)],
-        misc: [...new Set(misc)]
+        misc: miscUnique
     };
 }
 

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -79,7 +79,14 @@ describe('script.js functions', () => {
         cables: {
           power: { 'D-Tap to LEMO 2-pin': { to: 'LEMO 2-pin' } },
           fiz: { 'LBUS to LBUS': { from: 'LBUS (LEMO 4-pin)', to: 'LBUS (LEMO 4-pin)' } },
-          video: { 'BNC SDI Cable': { type: '3G-SDI' }, 'HDMI Cable': { type: 'HDMI' } }
+          video: {
+            'HDMI Cable': { type: 'HDMI' },
+            'BNC Cable 0.5 m': { type: '3G-SDI' },
+            'BNC Cable 1 m': { type: '3G-SDI' },
+            'BNC Cable 5 m': { type: '3G-SDI' },
+            'BNC Cable 10 m': { type: '3G-SDI' },
+            'BNC Drum 25 m': { type: '3G-SDI' }
+          }
         },
         cameraStabiliser: {
           'Easyrig 5 Vario': {
@@ -951,7 +958,15 @@ describe('script.js functions', () => {
       expect(html).toContain('Chargers');
       expect(html).toContain('1x Dual V-Mount Charger');
       expect(html).toContain('Miscellaneous');
-      expect(html).toContain('1x BNC SDI Cable');
+      expect(html).toContain('1x BNC Cable 0.5 m');
+      expect(html).toContain('1x BNC Cable 1 m');
+      expect(html).toContain('1x BNC Cable 5 m');
+      expect(html).toContain('1x BNC Cable 10 m');
+      expect(html).toContain('1x BNC Drum 25 m');
+      expect(html).toContain('4x BNC Connector');
+      expect(html).not.toContain('BNC SDI Cable');
+      expect(html).not.toContain('Ultraslim BNC 0.3 m');
+      expect(html).not.toContain('Ultraslim BNC 0.5 m');
       expect(html).not.toContain('D-Tap to LEMO 2-pin');
       expect(html).not.toContain('HDMI Cable');
     });


### PR DESCRIPTION
## Summary
- Always include a standard set of BNC cables and 4x BNC connectors in miscellaneous gear
- Remove automatic video cable suggestions from accessories collection
- Update tests for new default misc items

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5fc349c508320946271e1c286bcef