### PR TITLE
Add handle extension set for rigging selections

### DIFF
--- a/devices/gearList.js
+++ b/devices/gearList.js
@@ -398,7 +398,7 @@ const gear = {
         "brand": "ARRI",
         "kNumber": "K2.0014957"
       },
-      "ARRI Handle Extension Set": {
+      "ARRI KK.0037820 Handle Extension Set": {
         "brand": "ARRI",
         "kNumber": "KK.0037820"
       },

--- a/script.js
+++ b/script.js
@@ -6950,6 +6950,12 @@ function generateGearListHtml(info = {}) {
     if (scenarios.includes('Handheld') && scenarios.includes('Easyrig')) {
         supportAccNoCages.push('SHAPE Telescopic Handle ARRI Rosette Kit 12"');
     }
+    const riggingSelections = info.rigging
+        ? info.rigging.split(',').map(s => s.trim())
+        : [];
+    if (riggingSelections.includes('Top handle extension') || riggingSelections.includes('Rear Handle')) {
+        supportAccNoCages.push('ARRI KK.0037820 Handle Extension Set');
+    }
     const projectTitle = escapeHtml(info.projectName || setupNameInput.value);
     const labels = {
         dop: 'DoP',

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -1028,6 +1028,20 @@ describe('script.js functions', () => {
     expect(itemsRow.textContent).toContain('SHAPE Telescopic Handle ARRI Rosette Kit 12"');
   });
 
+  test('Top handle extension or Rear Handle rigging adds handle extension set', () => {
+    const { generateGearListHtml } = script;
+    ['Top handle extension', 'Rear Handle'].forEach(rig => {
+      const html = generateGearListHtml({ rigging: rig });
+      const wrap = document.createElement('div');
+      wrap.innerHTML = html;
+      const rows = Array.from(wrap.querySelectorAll('.gear-table tr'));
+      const cameraSupportIndex = rows.findIndex(r => r.textContent === 'Camera Support');
+      expect(cameraSupportIndex).toBeGreaterThanOrEqual(0);
+      const itemsRow = rows[cameraSupportIndex + 1];
+      expect(itemsRow.textContent).toContain('ARRI KK.0037820 Handle Extension Set');
+    });
+  });
+
   test('Carts and Transportation category includes default items', () => {
     const { generateGearListHtml } = script;
     const html = generateGearListHtml();


### PR DESCRIPTION
## Summary
- add ARRI KK.0037820 Handle Extension Set to camera support gear database
- include handle extension set when selecting Top handle extension or Rear Handle
- test rigging options add the handle extension set

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5fecb972c83209af9b88f0dd63fbf