### PR TITLE
Remove Onboard 5" and 7" monitor options

### DIFF
--- a/index.html
+++ b/index.html
@@ -936,8 +936,6 @@
           <option value="AM Opacity 50%">AM Opacity 50%</option>
           <option value="AM Opacity 25%">AM Opacity 25%</option>
           <option value="AM Opacity 0%">AM Opacity 0%</option>
-          <option value="Onboard 5 inch">Onboard 5 inch</option>
-          <option value="Onboard 7 inch">Onboard 7 inch</option>
           <option value="Directors Monitor 7 inch handheld">Directors Monitor 7 inch handheld</option>
           <option value="Directors Monitor 15-19 inch">Directors Monitor 15-19 inch</option>
           <option value="Combo Monitor 15-19 inch">Combo Monitor 15-19 inch</option>

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -1196,10 +1196,10 @@ describe('script.js functions', () => {
     const { generateGearListHtml } = script;
     const html = generateGearListHtml({
       rigging: 'Shoulder rig, Hand Grips',
-      monitoringPreferences: 'VF Clean Feed, Onboard 7 inch'
+      monitoringPreferences: 'VF Clean Feed, Onboard Clean Feed'
     });
     expect(html).toContain('Rigging: Shoulder rig, Hand Grips');
-    expect(html).toContain('Monitoring support: VF Clean Feed, Onboard 7 inch');
+    expect(html).toContain('Monitoring support: VF Clean Feed, Onboard Clean Feed');
     expect(html).not.toContain('<td>Rigging</td>');
     expect(html).not.toContain('<td>Monitoring support</td>');
   });


### PR DESCRIPTION
## Summary
- Drop "Onboard 5 inch" and "Onboard 7 inch" selections from the project requirements form.
- Update tests to reflect available monitoring options.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5ff2953ac83208a6aa3dcc3ff956a