### PR TITLE
feat: expand tripod preference options

### DIFF
--- a/index.html
+++ b/index.html
@@ -941,11 +941,20 @@
         </select>
       </label></div>
       <div class="form-row"><label for="tripodPreferences">Tripod Preferences:
-        <select id="tripodPreferences" name="tripodPreferences" multiple size="4">
-          <option value="Lightweight">Lightweight</option>
-          <option value="Heavy-duty">Heavy-duty</option>
-          <option value="Hi-Hat">Hi-Hat</option>
-          <option value="Slider">Slider</option>
+        <select id="tripodPreferences" name="tripodPreferences" multiple size="13">
+          <option value="O'Connor">O'Connor</option>
+          <option value="Sachtler">Sachtler</option>
+          <option value="Other Head Brand">Other Head Brand</option>
+          <option value="75er bowl">75er bowl</option>
+          <option value="100er bowl">100er bowl</option>
+          <option value="150 bowl">150 bowl</option>
+          <option value="Mitchell Mount">Mitchell Mount</option>
+          <option value="Bodenstern">Bodenstern</option>
+          <option value="Frosch">Frosch</option>
+          <option value="Baby">Baby</option>
+          <option value="Normal">Normal</option>
+          <option value="Bodenspinne">Bodenspinne</option>
+          <option value="Mittelspinne">Mittelspinne</option>
         </select>
       </label></div>
       <div class="form-row"><label for="sliderBowl">Tango Roller Mount:


### PR DESCRIPTION
## Summary
- broaden Tripod Preferences multi-select to include common head brands, bowl sizes, and spreader types

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5fffecd0483208c8c7e1dcba32757