### PR TITLE
Add User Buttons monitoring option to project form

### DIFF
--- a/index.html
+++ b/index.html
@@ -933,6 +933,7 @@
           <option value="AM Opacity 50%">AM Opacity 50%</option>
           <option value="AM Opacity 25%">AM Opacity 25%</option>
           <option value="AM Opacity 0%">AM Opacity 0%</option>
+          <option value="User Buttons">User Buttons</option>
           <option value="Directors Monitor 7 inch handheld">Directors Monitor 7 inch handheld</option>
           <option value="Directors Monitor 15-19 inch">Directors Monitor 15-19 inch</option>
           <option value="Combo Monitor 15-19 inch">Combo Monitor 15-19 inch</option>

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -152,6 +152,12 @@ describe('script.js functions', () => {
     expect(copyBtn.nextElementSibling).toBe(generateBtn);
   });
 
+  test('project form includes User Buttons monitoring option', () => {
+    const select = document.getElementById('monitoringPreferences');
+    const hasOption = Array.from(select.options).some(o => o.value === 'User Buttons');
+    expect(hasOption).toBe(true);
+  });
+
   test('populateLensDropdown fills lens list without duplicates', () => {
     const sel = document.getElementById('lenses');
     sel.innerHTML = '<option value="Existing">Existing</option>';
@@ -1238,10 +1244,10 @@ describe('script.js functions', () => {
     const { generateGearListHtml } = script;
     const html = generateGearListHtml({
       rigging: 'Shoulder rig, Hand Grips',
-      monitoringPreferences: 'VF Clean Feed, Onboard Clean Feed'
+      monitoringPreferences: 'VF Clean Feed, Onboard Clean Feed, User Buttons'
     });
     expect(html).toContain('Rigging: Shoulder rig, Hand Grips');
-    expect(html).toContain('Monitoring support: VF Clean Feed, Onboard Clean Feed');
+    expect(html).toContain('Monitoring support: VF Clean Feed, Onboard Clean Feed, User Buttons');
     expect(html).not.toContain('<td>Rigging</td>');
     expect(html).not.toContain('<td>Monitoring support</td>');
   });


### PR DESCRIPTION
## Summary
- add "User Buttons" to monitoring support options in Project Requirements
- test for new option and gear list rendering

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b600c2c2f883209e4572e80d1b783e