### PR TITLE
feat: add directors monitor dropdown and receivers

### DIFF
--- a/devices/gearList.js
+++ b/devices/gearList.js
@@ -1606,6 +1606,25 @@ const gear = {
   ]
 };
 
+// Automatically add a matching wireless receiver entry for every
+// transmitter defined in the video devices. This ensures the list of
+// receivers always covers all available transmitters without having to
+// manually maintain a separate list.
+const videoDevices = globalThis.devices && globalThis.devices.video ? globalThis.devices.video : {};
+for (const [txName, txData] of Object.entries(videoDevices)) {
+  const rxName = txName.replace(/\bTX\b/, 'RX');
+  if (!gear.wirelessReceivers[rxName]) {
+    gear.wirelessReceivers[rxName] = {
+      powerDrawWatts: txData.powerDrawWatts,
+      videoInputs: [],
+      videoOutputs: txData.videoOutputs || txData.videoInputs || [],
+      frequency: txData.frequency,
+      latencyMs: txData.latencyMs,
+      power: txData.power
+    };
+  }
+}
+
 if (typeof registerDevice === 'function') {
   registerDevice('viewfinders', gear.viewfinders);
   registerDevice('directorMonitors', gear.directorMonitors);

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -996,6 +996,22 @@ describe('script.js functions', () => {
     expect(html).not.toContain('MonA, VidA');
   });
 
+  test('Directors handheld monitor adds dropdown, batteries and grip items', () => {
+    const { generateGearListHtml } = script;
+    global.devices.monitors = {
+      'SmallHD Ultra 7': { screenSizeInches: 7 },
+      MonA: { screenSizeInches: 7 }
+    };
+    const html = generateGearListHtml({ monitoringPreferences: 'Directors Monitor 7 inch handheld' });
+    expect(html).toContain('<select id="gearListDirectorsMonitor7"');
+    expect(html).toContain('SmallHD Ultra 7');
+    expect(html).toContain('Directors cage, shoulder strap, sunhood, rigging for teradeks');
+    expect(html).toContain('3x Bebob 98 Micros');
+    expect(html).toContain('C-Stand 20"');
+    expect(html).toContain('Lite-Tite Swivel Aluminium Umbrella Adapter');
+    expect(html).toContain('2x spigot');
+  });
+
   test('gear list includes battery count in camera batteries row', () => {
     const { generateGearListHtml } = script;
     const addOpt = (id, value) => {


### PR DESCRIPTION
## Summary
- Allow choosing handheld director monitors with a 7" monitor dropdown
- Auto-generate matching wireless receivers and include them in gear list
- Pre-fill monitoring batteries and grip items for director monitors

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b604d83af08320a04f605b4a648ee9