### PR TITLE
feat: add sensor mode to project form

### DIFF
--- a/index.html
+++ b/index.html
@@ -847,6 +847,7 @@
           <option value="12K">12K</option>
           <option value="16K">16K</option>
         </select></label></div>
+      <div class="form-row"><label for="sensorMode">Sensor Mode:<select id="sensorMode" name="sensorMode"></select></label></div>
       <div class="form-row"><label for="aspectRatio">Aspect Ratio:<select id="aspectRatio" name="aspectRatio">
           <option value=""></option>
           <option value="16:9">16:9</option>

--- a/script.js
+++ b/script.js
@@ -6166,6 +6166,7 @@ generateGearListBtn.addEventListener('click', () => {
         alertPinExceeded();
         return;
     }
+    populateSensorModeDropdown(currentProjectInfo && currentProjectInfo.sensorMode);
     projectDialog.showModal();
 });
 
@@ -6919,6 +6920,7 @@ function collectProjectFormData() {
         aspectRatio: val('aspectRatio'),
         codec: val('codec'),
         baseFrameRate: val('baseFrameRate'),
+        sensorMode: val('sensorMode'),
         lenses: val('lenses'),
         requiredScenarios: multi('requiredScenarios'),
         rigging: multi('rigging'),
@@ -6998,6 +7000,7 @@ function generateGearListHtml(info = {}) {
         aspectRatio: 'Aspect Ratio',
         codec: 'Codec',
         baseFrameRate: 'Base Frame Rate',
+        sensorMode: 'Sensor Mode',
         lenses: 'Lenses',
         requiredScenarios: 'Required Scenarios',
         rigging: 'Rigging',
@@ -7955,6 +7958,31 @@ function populateLensDropdown() {
   });
 }
 
+function populateSensorModeDropdown(selected = '') {
+  const sensorSelect = document.getElementById('sensorMode');
+  if (!sensorSelect) return;
+
+  sensorSelect.innerHTML = '';
+  const emptyOpt = document.createElement('option');
+  emptyOpt.value = '';
+  sensorSelect.appendChild(emptyOpt);
+
+  const camKey = cameraSelect && cameraSelect.value;
+  const modes =
+    camKey && devices && devices.cameras && devices.cameras[camKey]
+      ? devices.cameras[camKey].sensorModes
+      : null;
+  if (Array.isArray(modes)) {
+    modes.forEach(m => {
+      const opt = document.createElement('option');
+      opt.value = m;
+      opt.textContent = m;
+      if (m === selected) opt.selected = true;
+      sensorSelect.appendChild(opt);
+    });
+  }
+}
+
 function populateFilterDropdown() {
   const filterSelect = document.getElementById('filter');
   if (filterSelect && devices && Array.isArray(devices.filterOptions)) {
@@ -8014,5 +8042,6 @@ if (typeof module !== "undefined" && module.exports) {
     clearAllFilters,
     saveCurrentGearList,
     populateLensDropdown,
+    populateSensorModeDropdown,
   };
 }

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -1256,6 +1256,12 @@ describe('script.js functions', () => {
     expect(html).not.toContain('<td>Monitoring support</td>');
   });
 
+  test('sensor mode appears in project requirements when provided', () => {
+    const { generateGearListHtml } = script;
+    const html = generateGearListHtml({ sensorMode: 'S35 3:2' });
+    expect(html).toContain('Sensor Mode: S35 3:2');
+  });
+
   test('duplicate motors are aggregated with count in gear list', () => {
     const { generateGearListHtml } = script;
     const addOpt = (id, value) => {


### PR DESCRIPTION
## Summary
- add sensor mode select field to project requirements dialog
- populate sensor mode options from selected camera data
- include chosen sensor mode in gear list output and tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6065a51f48320add09e1e1364a133