### PR TITLE
Prefill feedback resolution and codec from camera data

### DIFF
--- a/script.js
+++ b/script.js
@@ -6283,6 +6283,9 @@ if (runtimeFeedbackBtn && feedbackDialog && feedbackForm) {
     document.getElementById('fbBattery').value = batterySelect.value || '';
     document.getElementById('fbWirelessVideo').value = videoSelect.value || '';
     document.getElementById('fbMonitor').value = monitorSelect.value || '';
+    const cam = devices?.cameras?.[cameraSelect.value];
+    document.getElementById('fbResolution').value = cam?.resolutions?.[0] || '';
+    document.getElementById('fbCodec').value = cam?.recordingCodecs?.[0] || '';
     document.getElementById('fbControllers').value = ctrlVals.join(', ');
     document.getElementById('fbMotors').value = motVals.join(', ');
     const fbDistance = document.getElementById('fbDistance');

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -2716,6 +2716,20 @@ describe('monitor wireless metadata', () => {
     expect(global.devices.monitors.MonA.latencyMs).toBe('10ms');
   });
 
+  test('runtime feedback dialog pre-fills resolution and codec', () => {
+    const cam = devices.cameras.CamA;
+    cam.resolutions = ['1920x1080'];
+    cam.recordingCodecs = ['ProRes'];
+    const camSelect = document.getElementById('cameraSelect');
+    camSelect.innerHTML = '<option value="CamA">CamA</option>';
+    camSelect.value = 'CamA';
+    const dialog = document.getElementById('feedbackDialog');
+    dialog.showModal = jest.fn();
+    document.getElementById('runtimeFeedbackBtn').click();
+    expect(document.getElementById('fbResolution').value).toBe('1920x1080');
+    expect(document.getElementById('fbCodec').value).toBe('ProRes');
+  });
+
   test('device manager toggle button reflects visibility', () => {
     const toggleBtn = document.getElementById('toggleDeviceManager');
     const deviceManager = document.getElementById('device-manager');


### PR DESCRIPTION
## Summary
- When submitting runtime feedback, prefill resolution and codec from the selected camera's defaults
- Test coverage for auto-populating resolution and codec in feedback dialog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b6066380e08320938f2a3c73a465f4