### PR TITLE
Optimize power input parsing for single connectors

### DIFF
--- a/tests/unifyPorts.test.js
+++ b/tests/unifyPorts.test.js
@@ -82,6 +82,13 @@ describe('parsePowerInput', () => {
       { type: 'USB-C' }
     ]);
   });
+
+  it('handles single connector without delimiter', () => {
+    const input = 'LEMO';
+    expect(parsePowerInput(input)).toEqual([
+      { type: 'LEMO' }
+    ]);
+  });
 });
 
 describe('normalizeVideoDevice', () => {

--- a/unifyPorts.js
+++ b/unifyPorts.js
@@ -150,6 +150,9 @@ function normalizeMonitor(mon) {
  * @returns {string[]} Array of string segments.
  */
 function splitOutside(str, delimiter = '/') {
+  if (typeof str !== 'string' || !str.includes(delimiter)) {
+    return [str];
+  }
   const parts = [];
   let buf = '';
   let depth = 0;


### PR DESCRIPTION
## Summary
- Avoid unnecessary iteration in `splitOutside` by returning early when no delimiter is present
- Add unit test verifying parsing works for single connector strings

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b608f596f483208b9dda0df9811a38