### PR TITLE
Fix lens dropdown by exposing lens data

### DIFF
--- a/devices/gearList.js
+++ b/devices/gearList.js
@@ -1606,6 +1606,9 @@ const gear = {
   ]
 };
 
+// Expose lenses at the top level for easier access
+gear.lenses = gear.accessories.lenses;
+
 // Automatically add a matching wireless receiver entry for every
 // transmitter defined in the video devices. This ensures the list of
 // receivers always covers all available transmitters without having to

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -8,7 +8,14 @@ beforeAll(() => {
   const body = html.split('<body>')[1].split('</body>')[0];
   document.body.innerHTML = body;
 
-  global.devices = { cameras: {}, monitors: {}, video: {}, fiz: { motors: {}, controllers: {}, distance: {} }, batteries: {} };
+  global.devices = {
+    cameras: {},
+    monitors: {},
+    video: {},
+    fiz: { motors: {}, controllers: {}, distance: {} },
+    batteries: {},
+    lenses: { Dummy: {} }
+  };
   global.loadDeviceData = jest.fn(() => null);
   global.saveDeviceData = jest.fn();
   global.loadSetups = jest.fn(() => ({}));


### PR DESCRIPTION
## Summary
- expose lenses as a top-level dataset so the dropdown can populate
- quiet tests by providing dummy lens data in utils test setup

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6096f61948320a2b130de1d090047