### PR TITLE
Hide ultraslim BNC cables from gear table

### DIFF
--- a/script.js
+++ b/script.js
@@ -7156,7 +7156,13 @@ function generateGearListHtml(info = {}) {
         ...Array(20).fill('Airliner Ösen')
     ];
     addRow('Carts and Transportation', formatItems(cartsTransportationItems));
-    const miscExcluded = new Set(['D-Tap to LEMO 2-pin', 'HDMI Cable']);
+    const miscExcluded = new Set([
+        'D-Tap to LEMO 2-pin',
+        'HDMI Cable',
+        'BNC SDI Cable',
+        'Ultraslim BNC 0.3 m',
+        'Ultraslim BNC 0.5 m'
+    ]);
     const miscItems = [...miscAcc].filter(item => !miscExcluded.has(item));
     const consumables = [];
     if (scenarios.includes('Outdoor')) {


### PR DESCRIPTION
## Summary
- restore BNC SDI and ultraslim BNC cable definitions in gear data
- exclude those cables from the Miscellaneous gear table so they remain hidden

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b60a2cb8748320a8228566fd798f09