### PR TITLE
Add cables for director's handheld monitor

### DIFF
--- a/script.js
+++ b/script.js
@@ -6987,6 +6987,14 @@ function generateGearListHtml(info = {}) {
     const monitorEquipOptions = ['Directors Monitor 7" handheld', 'Directors Monitor 15-19 inch', 'Combo Monitor 15-19 inch'];
     const monitoringEquipmentPrefs = monitoringPrefs.filter(p => monitorEquipOptions.includes(p));
     const monitoringSupportPrefs = monitoringPrefs.filter(p => !monitorEquipOptions.includes(p));
+    if (monitoringPrefs.includes('Directors Monitor 7" handheld')) {
+        miscAcc.push(
+            'D-Tap to Lemo-2-pin Cable 0,3m',
+            'D-Tap to Lemo-2-pin Cable 0,3m',
+            'Ultraslim BNC 0.3 m',
+            'Ultraslim BNC 0.3 m'
+        );
+    }
     const handleName = 'SHAPE Telescopic Handle ARRI Rosette Kit 12"';
     const addHandle = () => {
         if (!supportAccNoCages.includes(handleName)) {
@@ -7172,7 +7180,6 @@ function generateGearListHtml(info = {}) {
         'D-Tap to LEMO 2-pin',
         'HDMI Cable',
         'BNC SDI Cable',
-        'Ultraslim BNC 0.3 m',
         'Ultraslim BNC 0.5 m'
     ]);
     const miscItems = [...miscAcc].filter(item => !miscExcluded.has(item));

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -1010,6 +1010,8 @@ describe('script.js functions', () => {
     expect(html).toContain('C-Stand 20"');
     expect(html).toContain('Lite-Tite Swivel Aluminium Umbrella Adapter');
     expect(html).toContain('2x spigot');
+    expect(html).toContain('2x Ultraslim BNC 0.3 m');
+    expect(html).toContain('2x D-Tap to Lemo-2-pin Cable 0,3m');
   });
 
   test('gear list includes battery count in camera batteries row', () => {


### PR DESCRIPTION
## Summary
- add two Ultraslim BNC and D-Tap to Lemo-2-pin cables when a Directors Monitor 7" handheld is selected
- allow Ultraslim BNC 0.3 m to appear in misc items
- test gear list now ensures cables are included for the handheld monitor option

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6c28c55908320a33c265a59a8b133