### PR TITLE
feat: restore monitoring support gear category

### DIFF
--- a/script.js
+++ b/script.js
@@ -7129,6 +7129,11 @@ function generateGearListHtml(info = {}) {
         }
     }
     addRow('Monitoring', monitoringItems);
+    let monitoringSupportItems = '';
+    if (monitoringSupportPrefs.length) {
+        monitoringSupportItems = escapeHtml(monitoringSupportPrefs.join(', '));
+    }
+    addRow('Monitoring support', monitoringSupportItems);
     const gripItems = [];
     let sliderSelectHtml = '';
     let easyrigSelectHtml = '';

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -1260,16 +1260,16 @@ describe('script.js functions', () => {
     expect(consumText).toContain('3x CapIt Medium');
   });
 
-  test('rigging and monitoring support appear only in project requirements', () => {
+  test('rigging appears only in project requirements while monitoring support also appears in gear table', () => {
     const { generateGearListHtml } = script;
     const html = generateGearListHtml({
       rigging: 'Shoulder rig, Hand Grips',
       monitoringPreferences: 'VF Clean Feed, Onboard Clean Feed, User Buttons'
     });
     expect(html).toContain('Rigging: Shoulder rig, Hand Grips');
-    expect(html).toContain('Monitoring support: VF Clean Feed, Onboard Clean Feed, User Buttons');
     expect(html).not.toContain('<td>Rigging</td>');
-    expect(html).not.toContain('<td>Monitoring support</td>');
+    expect(html).toContain('Monitoring support: VF Clean Feed, Onboard Clean Feed, User Buttons');
+    expect(html).toContain('<td>Monitoring support</td>');
   });
 
   test('Directors handheld monitor appears under monitoring in project requirements', () => {


### PR DESCRIPTION
## Summary
- show monitoring support as a gear category again
- list selected monitoring support in project requirements and gear list
- update tests for restored monitoring support row

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6c2a306648320bd7f2c46b1b97fb4