### PR TITLE
Move BNC devices to monitoring support

### DIFF
--- a/script.js
+++ b/script.js
@@ -6805,13 +6805,14 @@ function suggestChargerCounts(total) {
 
 function collectAccessories() {
     const cameraSupport = [];
-    const misc = [
+    const monitoringSupport = [
         'BNC Cable 0.5 m',
         'BNC Cable 1 m',
         'BNC Cable 5 m',
         'BNC Cable 10 m',
         'BNC Drum 25 m'
     ];
+    const misc = [];
     const chargers = [];
     const fizCables = [];
     const acc = devices.accessories || {};
@@ -6904,11 +6905,13 @@ function collectAccessories() {
     });
 
     const miscUnique = [...new Set(misc)];
-    for (let i = 0; i < 4; i++) miscUnique.push('BNC Connector');
+    const monitoringSupportUnique = [...new Set(monitoringSupport)];
+    for (let i = 0; i < 4; i++) monitoringSupportUnique.push('BNC Connector');
     return {
         cameraSupport: [...new Set(cameraSupport)],
         chargers,
         fizCables: [...new Set(fizCables)],
+        monitoringSupport: monitoringSupportUnique,
         misc: miscUnique
     };
 }
@@ -6964,7 +6967,7 @@ function generateGearListHtml(info = {}) {
     } else {
         selectedNames.viewfinder = "";
     }
-    const { cameraSupport: cameraSupportAcc, chargers: chargersAcc, fizCables: fizCableAcc, misc: miscAcc } = collectAccessories();
+    const { cameraSupport: cameraSupportAcc, chargers: chargersAcc, fizCables: fizCableAcc, monitoringSupport: monitoringSupportAcc, misc: miscAcc } = collectAccessories();
     const cagesDb = devices.accessories?.cages || {};
     const compatibleCages = [];
     if (cameraSelect && cameraSelect.value && cameraSelect.value !== 'None') {
@@ -7077,6 +7080,7 @@ function generateGearListHtml(info = {}) {
         monitoringBatteryItems = '3x Bebob 98 Micros';
     }
     addRow('Monitoring Batteries', monitoringBatteryItems);
+    addRow('Monitoring support', formatItems(monitoringSupportAcc));
     addRow('Chargers', formatItems(chargersAcc));
     let monitoringItems = '';
     if (selectedNames.viewfinder) {

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -966,15 +966,16 @@ describe('script.js functions', () => {
       expect(html).toContain('<option value="Universal Cage"');
       expect(html).toContain('LDS (FIZ)');
       expect(html).toContain('1x LBUS to LBUS');
-      expect(html).toContain('Chargers');
-      expect(html).toContain('1x Dual V-Mount Charger');
-      expect(html).toContain('Miscellaneous');
+      expect(html).toContain('Monitoring support');
       expect(html).toContain('1x BNC Cable 0.5 m');
       expect(html).toContain('1x BNC Cable 1 m');
       expect(html).toContain('1x BNC Cable 5 m');
       expect(html).toContain('1x BNC Cable 10 m');
       expect(html).toContain('1x BNC Drum 25 m');
       expect(html).toContain('4x BNC Connector');
+      expect(html).toContain('Chargers');
+      expect(html).toContain('1x Dual V-Mount Charger');
+      expect(html).toContain('Miscellaneous');
       expect(html).not.toContain('BNC SDI Cable');
       expect(html).not.toContain('Ultraslim BNC 0.3 m');
       expect(html).not.toContain('Ultraslim BNC 0.5 m');
@@ -1260,7 +1261,7 @@ describe('script.js functions', () => {
     expect(consumText).toContain('3x CapIt Medium');
   });
 
-  test('rigging and monitoring support appear only in project requirements', () => {
+  test('rigging appears only in project requirements while monitoring support also listed in gear', () => {
     const { generateGearListHtml } = script;
     const html = generateGearListHtml({
       rigging: 'Shoulder rig, Hand Grips',
@@ -1269,7 +1270,7 @@ describe('script.js functions', () => {
     expect(html).toContain('Rigging: Shoulder rig, Hand Grips');
     expect(html).toContain('Monitoring support: VF Clean Feed, Onboard Clean Feed, User Buttons');
     expect(html).not.toContain('<td>Rigging</td>');
-    expect(html).not.toContain('<td>Monitoring support</td>');
+    expect(html).toContain('<td>Monitoring support</td>');
   });
 
   test('Directors handheld monitor appears under monitoring in project requirements', () => {


### PR DESCRIPTION
## Summary
- add dedicated monitoring support category for BNC cables and connectors
- update gear list to list BNC accessories under Monitoring support instead of Miscellaneous
- adjust tests for new monitoring support section

## Testing
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6c2e2b08c83208a9c8448964d0d6a