### PR TITLE
Auto-add focus monitor kit when motors are selected

### DIFF
--- a/script.js
+++ b/script.js
@@ -6989,6 +6989,7 @@ function generateGearListHtml(info = {}) {
         batteryPlate: batteryPlateSelect && batteryPlateSelect.value && batteryPlateSelect.value !== 'None' ? getText(batteryPlateSelect) : '',
         battery: batterySelect && batterySelect.value && batterySelect.value !== 'None' ? getText(batterySelect) : ''
     };
+    const hasMotor = selectedNames.motors.length > 0;
     if (["Arri Alexa Mini", "Arri Amira"].includes(selectedNames.camera)) {
         selectedNames.viewfinder = "ARRI K2.75004.0 MVF-1 Viewfinder";
     } else {
@@ -7021,6 +7022,14 @@ function generateGearListHtml(info = {}) {
         miscAcc.push(
             'D-Tap to Lemo-2-pin Cable 0,3m',
             'D-Tap to Lemo-2-pin Cable 0,3m',
+            'Ultraslim BNC 0.3 m',
+            'Ultraslim BNC 0.3 m'
+        );
+    }
+    if (hasMotor) {
+        miscAcc.push(
+            'D-Tap to Mini XLR 3-pin Cable 0,3m',
+            'D-Tap to Mini XLR 3-pin Cable 0,3m',
             'Ultraslim BNC 0.3 m',
             'Ultraslim BNC 0.3 m'
         );
@@ -7110,11 +7119,14 @@ function generateGearListHtml(info = {}) {
         batteryItems = `${count}x ${safeBatt}`;
     }
     addRow('Camera Batteries', batteryItems);
-    let monitoringBatteryItems = '';
+    let monitoringBatteryItems = [];
     if (monitoringPrefs.includes('Directors Monitor 7" handheld')) {
-        monitoringBatteryItems = '3x Bebob 98 Micros';
+        monitoringBatteryItems.push('3x Bebob 98 Micros');
     }
-    addRow('Monitoring Batteries', monitoringBatteryItems);
+    if (hasMotor) {
+        monitoringBatteryItems.push('3x Bebob 150micro');
+    }
+    addRow('Monitoring Batteries', monitoringBatteryItems.join('<br>'));
     addRow('Chargers', formatItems(chargersAcc));
     let monitoringItems = '';
     if (selectedNames.viewfinder) {
@@ -7128,6 +7140,9 @@ function generateGearListHtml(info = {}) {
         const sevenInchNames = Object.keys(monitorsDb).filter(n => monitorsDb[n].screenSizeInches === 7).sort(localeSort);
         const opts = sevenInchNames.map(n => `<option value="${escapeHtml(n)}"${n === 'SmallHD Ultra 7' ? ' selected' : ''}>${escapeHtml(n)}</option>`).join('');
         monitoringItems += (monitoringItems ? '<br>' : '') + `1x <strong>Directors Handheld Monitor</strong> - <select id="gearListDirectorsMonitor7">${opts}</select> incl. Directors cage, shoulder strap, sunhood, rigging for teradeks`;
+    }
+    if (hasMotor) {
+        monitoringItems += (monitoringItems ? '<br>' : '') + '1x <strong>Focus Monitor</strong> - 7&quot; - TV Logic F7HS incl Directors cage, shoulder strap, sunhood, rigging for teradeks';
     }
     if (selectedNames.video) {
         monitoringItems += (monitoringItems ? '<br>' : '') + `1x <strong>Wireless Transmitter</strong> - ${escapeHtml(selectedNames.video)}`;

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -976,9 +976,9 @@ describe('script.js functions', () => {
       expect(html).toContain('1x BNC Drum 25 m');
       expect(html).toContain('4x BNC Connector');
       expect(html).not.toContain('BNC SDI Cable');
-      expect(html).not.toContain('Ultraslim BNC 0.3 m');
+      expect(html).toContain('2x Ultraslim BNC 0.3 m');
       expect(html).not.toContain('Ultraslim BNC 0.5 m');
-      expect(html).not.toContain('D-Tap to LEMO 2-pin');
+      expect(html).toContain('2x D-Tap to Mini XLR 3-pin Cable 0,3m');
       expect(html).not.toContain('HDMI Cable');
     });
 
@@ -1012,6 +1012,31 @@ describe('script.js functions', () => {
     expect(html).toContain('2x spigot');
     expect(html).toContain('2x Ultraslim BNC 0.3 m');
     expect(html).toContain('2x D-Tap to Lemo-2-pin Cable 0,3m');
+  });
+
+  test('motor adds focus monitor and related accessories to gear list', () => {
+    const { generateGearListHtml } = script;
+    global.devices.video = {
+      'VidA TX': {
+        powerDrawWatts: 3,
+        power: { input: { type: 'LEMO 2-pin' } },
+        videoInputs: [{ type: '3G-SDI' }]
+      }
+    };
+    global.devices.wirelessReceivers = { 'VidA RX': {} };
+    const addOpt = (id, value) => {
+      const sel = document.getElementById(id);
+      sel.innerHTML = `<option value="${value}">${value}</option>`;
+      sel.value = value;
+    };
+    addOpt('motor1Select', 'MotorA');
+    addOpt('videoSelect', 'VidA TX');
+    const html = generateGearListHtml();
+    expect(html).toContain('Focus Monitor</strong> - 7&quot; - TV Logic F7HS incl Directors cage, shoulder strap, sunhood, rigging for teradeks');
+    expect(html).toContain('3x Bebob 150micro');
+    expect(html).toContain('2x Ultraslim BNC 0.3 m');
+    expect(html).toContain('2x D-Tap to Mini XLR 3-pin Cable 0,3m');
+    expect(html).toContain('1x <strong>Wireless Receiver</strong> - VidA RX');
   });
 
   test('gear list includes battery count in camera batteries row', () => {


### PR DESCRIPTION
## Summary
- Automatically detect motor usage and append focus monitor kit with TV Logic F7HS, Bebob 150micro batteries, BNC and D-Tap cables
- Include matching wireless receiver when a transmitter is present
- Cover new behavior with unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b6c5ec0be88320899d78abc42a268c