### PR TITLE
Add hotswap plate to gear list based on battery mount

### DIFF
--- a/script.js
+++ b/script.js
@@ -7090,7 +7090,14 @@ function generateGearListHtml(info = {}) {
         rows.push(`<tr><td>${items}</td></tr>`);
     };
     addRow('Camera', formatItems([selectedNames.camera]));
-    const cameraSupportText = formatItems([selectedNames.batteryPlate, ...supportAccNoCages]);
+    const cameraSupportItems = [selectedNames.batteryPlate, ...supportAccNoCages];
+    if (selectedNames.battery && batterySelect && batterySelect.value) {
+        const mount = devices.batteries?.[batterySelect.value]?.mount_type;
+        if (mount === 'V-Mount' || mount === 'B-Mount') {
+            cameraSupportItems.push(`Hotswap Plate ${mount}`);
+        }
+    }
+    const cameraSupportText = formatItems(cameraSupportItems);
     let cageSelectHtml = '';
     if (compatibleCages.length) {
         const options = compatibleCages.map(c => `<option value="${escapeHtml(c)}"${c === selectedNames.cage ? ' selected' : ''}>${escapeHtml(c)}</option>`).join('');

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -1027,6 +1027,24 @@ describe('script.js functions', () => {
     expect(html).toContain('6x BattA');
   });
 
+  test('gear list adds hotswap plate matching battery mount', () => {
+    const { generateGearListHtml } = script;
+    const addOpt = (id, value) => {
+      const sel = document.getElementById(id);
+      sel.innerHTML = `<option value="${value}">${value}</option>`;
+      sel.value = value;
+    };
+    // V-Mount battery
+    addOpt('batterySelect', 'BattA');
+    let html = generateGearListHtml();
+    expect(html).toContain('1x Hotswap Plate V-Mount');
+    // B-Mount battery
+    devices.batteries.BattB = { capacity: 100, pinA: 10, dtapA: 5, mount_type: 'B-Mount' };
+    addOpt('batterySelect', 'BattB');
+    html = generateGearListHtml();
+    expect(html).toContain('1x Hotswap Plate B-Mount');
+  });
+
   test('Cine Saddle and Steadybag scenarios populate grip section', () => {
     const { generateGearListHtml } = script;
     const html = generateGearListHtml({ requiredScenarios: 'Cine Saddle, Steadybag' });


### PR DESCRIPTION
## Summary
- Include a matching Hotswap Plate entry in Camera Support depending on selected battery's mount
- Test gear list to ensure Hotswap Plate is added for V-Mount and B-Mount batteries

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6c76d17e483209d5962f8f76f1b2d