### PR TITLE
feat: add cables category to device editor

### DIFF
--- a/index.html
+++ b/index.html
@@ -236,6 +236,7 @@
         <option value="fiz.cables">FIZ Cable</option>
         <option value="batteries">V-Mount Battery</option>
         <option value="accessories.batteries">Accessory Battery</option>
+        <option value="accessories.cables">Cable</option>
         <option value="accessories.cages">Camera Support</option>
         <option value="accessories.chargers">Charger</option>
       </select>
@@ -544,6 +545,11 @@
         <h4 id="category_accessory_batteries">Accessory Batteries</h4>
         <input type="search" id="accessoryBatteryListFilter" class="list-filter" placeholder="Filter..." aria-label="Filter" inputmode="search" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" />
         <ul id="accessoryBatteryList" class="device-ul"></ul>
+      </div>
+      <div class="device-category">
+        <h4 id="category_cables">Cables</h4>
+        <input type="search" id="cableListFilter" class="list-filter" placeholder="Filter..." aria-label="Filter" inputmode="search" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" />
+        <ul id="cableList" class="device-ul"></ul>
       </div>
       <div class="device-category">
         <h4 id="category_camera_support">Camera Support</h4>

--- a/script.js
+++ b/script.js
@@ -1173,6 +1173,8 @@ function setLanguage(lang) {
   document.getElementById("category_fiz_distance").textContent = texts[lang].category_fiz_distance;
   document.getElementById("category_fiz_cables").textContent = texts[lang].category_fiz_cables;
   document.getElementById("category_batteries").textContent = texts[lang].category_batteries;
+  document.getElementById("category_accessory_batteries").textContent = texts[lang].category_accessory_batteries;
+  document.getElementById("category_cables").textContent = texts[lang].category_cables;
   document.getElementById("category_camera_support").textContent = texts[lang].category_camera_support;
   document.getElementById("category_chargers").textContent = texts[lang].category_chargers;
   // Add device form labels and button
@@ -1263,6 +1265,7 @@ function setLanguage(lang) {
     {input: distanceListFilterInput, label: texts[lang].category_fiz_distance},
     {input: batteryListFilterInput, label: texts[lang].category_batteries},
     {input: accessoryBatteryListFilterInput, label: texts[lang].category_accessory_batteries},
+    {input: cableListFilterInput, label: texts[lang].category_cables},
     {input: fizCableListFilterInput, label: texts[lang].category_fiz_cables},
     {input: cameraSupportListFilterInput, label: texts[lang].category_camera_support},
     {input: chargerListFilterInput, label: texts[lang].category_chargers}
@@ -1496,6 +1499,7 @@ const distanceListElem   = document.getElementById("distanceList");
 const batteryListElem    = document.getElementById("batteryList");
 const fizCableListElem    = document.getElementById("fizCableList");
 const accessoryBatteryListElem = document.getElementById("accessoryBatteryList");
+const cableListElem = document.getElementById("cableList");
 const cameraSupportListElem = document.getElementById("cameraSupportList");
 const chargerListElem       = document.getElementById("chargerList");
 const newCategorySelect  = document.getElementById("newCategory");
@@ -1770,6 +1774,7 @@ const fizCableListFilterInput = document.getElementById("fizCableListFilter");
 const cameraSupportListFilterInput = document.getElementById("cameraSupportListFilter");
 const chargerListFilterInput = document.getElementById("chargerListFilter");
 const accessoryBatteryListFilterInput = document.getElementById("accessoryBatteryListFilter");
+const cableListFilterInput = document.getElementById("cableListFilter");
 
 // NEW SETUP MANAGEMENT DOM ELEMENTS
 const exportSetupsBtn = document.getElementById('exportSetupsBtn');
@@ -3392,6 +3397,7 @@ function applyFilters() {
   filterDeviceList(distanceListElem, distanceListFilterInput.value);
   filterDeviceList(batteryListElem, batteryListFilterInput.value);
   filterDeviceList(accessoryBatteryListElem, accessoryBatteryListFilterInput.value);
+  filterDeviceList(cableListElem, cableListFilterInput.value);
   filterDeviceList(fizCableListElem, fizCableListFilterInput.value);
   filterDeviceList(cameraSupportListElem, cameraSupportListFilterInput.value);
   filterDeviceList(chargerListElem, chargerListFilterInput.value);
@@ -5103,6 +5109,7 @@ function refreshDeviceLists() {
   renderDeviceList("fiz.cables", fizCableListElem);
   renderDeviceList("batteries", batteryListElem);
   renderDeviceList("accessories.batteries", accessoryBatteryListElem);
+  renderDeviceList("accessories.cables", cableListElem);
   renderDeviceList("accessories.cages", cameraSupportListElem);
   renderDeviceList("accessories.chargers", chargerListElem);
 
@@ -5116,6 +5123,7 @@ function refreshDeviceLists() {
   filterDeviceList(fizCableListElem, fizCableListFilterInput.value);
   filterDeviceList(batteryListElem, batteryListFilterInput.value);
   filterDeviceList(accessoryBatteryListElem, accessoryBatteryListFilterInput.value);
+  filterDeviceList(cableListElem, cableListFilterInput.value);
   filterDeviceList(cameraSupportListElem, cameraSupportListFilterInput.value);
   filterDeviceList(chargerListElem, chargerListFilterInput.value);
 }
@@ -5167,6 +5175,7 @@ bindFilterInput(controllerListFilterInput, () => filterDeviceList(controllerList
 bindFilterInput(distanceListFilterInput, () => filterDeviceList(distanceListElem, distanceListFilterInput.value));
 bindFilterInput(batteryListFilterInput, () => filterDeviceList(batteryListElem, batteryListFilterInput.value));
 bindFilterInput(accessoryBatteryListFilterInput, () => filterDeviceList(accessoryBatteryListElem, accessoryBatteryListFilterInput.value));
+bindFilterInput(cableListFilterInput, () => filterDeviceList(cableListElem, cableListFilterInput.value));
 bindFilterInput(fizCableListFilterInput, () => filterDeviceList(fizCableListElem, fizCableListFilterInput.value));
 bindFilterInput(cameraSupportListFilterInput, () => filterDeviceList(cameraSupportListElem, cameraSupportListFilterInput.value));
 bindFilterInput(chargerListFilterInput, () => filterDeviceList(chargerListElem, chargerListFilterInput.value));

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -158,6 +158,12 @@ describe('script.js functions', () => {
     expect(hasOption).toBe(true);
   });
 
+  test('new device form includes cable category option', () => {
+    const select = document.getElementById('newCategory');
+    const hasCable = Array.from(select.options).some(o => o.value === 'accessories.cables');
+    expect(hasCable).toBe(true);
+  });
+
   test('populateLensDropdown fills lens list without duplicates', () => {
     const sel = document.getElementById('lenses');
     sel.innerHTML = '<option value="Existing">Existing</option>';

--- a/translations.js
+++ b/translations.js
@@ -138,6 +138,7 @@ const texts = {
     category_fiz_cables: "FIZ Cables",
     category_batteries: "V-Mount Batteries",
     category_accessory_batteries: "Accessory Batteries",
+    category_cables: "Cables",
     category_camera_support: "Camera Support",
     category_chargers: "Chargers",
 
@@ -483,6 +484,7 @@ const texts = {
     category_fiz_cables: "Cavi FIZ",
     category_batteries: "Batterie a V-Mount",
     category_accessory_batteries: "Batterie accessorie",
+    category_cables: "Cavi",
     category_camera_support: "Supporto camera",
     category_chargers: "Caricatori",
     addDeviceHeading: "Aggiungi nuovo dispositivo",
@@ -819,6 +821,7 @@ const texts = {
     category_fiz_cables: "Cables FIZ",
     category_batteries: "Baterías V-Mount",
     category_accessory_batteries: "Baterías de accesorios",
+    category_cables: "Cables",
     category_camera_support: "Soporte de cámara",
     category_chargers: "Cargadores",
 
@@ -1164,6 +1167,7 @@ const texts = {
     category_fiz_cables: "Câbles FIZ",
     category_batteries: "Batteries V-Mount",
     category_accessory_batteries: "Batteries accessoires",
+    category_cables: "Câbles",
     category_camera_support: "Support caméra",
     category_chargers: "Chargeurs",
 
@@ -1511,6 +1515,7 @@ const texts = {
     category_fiz_cables: "FIZ-Kabel",
     category_batteries: "V-Mount Akkus",
     category_accessory_batteries: "Zubehör-Akkus",
+    category_cables: "Kabel",
     category_camera_support: "Kamera-Support",
     category_chargers: "Ladegeräte",
 
@@ -1737,6 +1742,7 @@ const categoryNames = {
     "fiz.cables": "FIZ Cable",
     "batteries": "V-Mount Battery",
     "accessories.batteries": "Accessory Battery",
+    "accessories.cables": "Cable",
     "accessories.cages": "Camera Support",
     "accessories.chargers": "Charger"
   },
@@ -1751,6 +1757,7 @@ const categoryNames = {
     "fiz.cables": "Cavo FIZ",
     "batteries": "Batteria V-Mount",
     "accessories.batteries": "Batteria accessorio",
+    "accessories.cables": "Cavo",
     "accessories.cages": "Supporto camera",
     "accessories.chargers": "Caricatore"
   },
@@ -1765,6 +1772,7 @@ const categoryNames = {
     "fiz.cables": "Cable FIZ",
     "batteries": "Batería V-Mount",
     "accessories.batteries": "Batería de accesorios",
+    "accessories.cables": "Cable",
     "accessories.cages": "Soporte de cámara",
     "accessories.chargers": "Cargador"
   },
@@ -1779,6 +1787,7 @@ const categoryNames = {
     "fiz.cables": "Câble FIZ",
     "batteries": "Batterie V-Mount",
     "accessories.batteries": "Batterie accessoire",
+    "accessories.cables": "Câble",
     "accessories.cages": "Support caméra",
     "accessories.chargers": "Chargeur"
   },
@@ -1793,6 +1802,7 @@ const categoryNames = {
     "fiz.cables": "FIZ-Kabel",
     "batteries": "V-Mount Akku",
     "accessories.batteries": "Zubehör-Akku",
+    "accessories.cables": "Kabel",
     "accessories.cages": "Kamera-Support",
     "accessories.chargers": "Ladegerät"
   },


### PR DESCRIPTION
## Summary
- add Cables option to device editor and device manager
- localize new Cables category across languages
- test presence of cables in device categories

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b6cf64e39483208b845e6efe58d563