### PR TITLE
Categorize monitor cables as monitoring support

### DIFF
--- a/script.js
+++ b/script.js
@@ -6893,17 +6893,17 @@ function collectAccessories() {
     }
 
     const powerCableDb = acc.cables?.power || {};
-    const gatherPower = (data) => {
+    const gatherPower = (data, target = misc) => {
         const input = data?.power?.input?.type;
         const types = Array.isArray(input) ? input : input ? [input] : [];
         types.forEach(t => {
             for (const [name, cable] of Object.entries(powerCableDb)) {
-                if (cable.to === t && !excludedCables.has(name)) misc.push(name);
+                if (cable.to === t && !excludedCables.has(name)) target.push(name);
             }
         });
     };
     gatherPower(devices.cameras[cameraSelect.value]);
-    gatherPower(devices.monitors[monitorSelect.value]);
+    gatherPower(devices.monitors[monitorSelect.value], monitoringSupport);
     gatherPower(devices.video[videoSelect.value]);
     if (videoSelect.value) {
         const rxName = videoSelect.value.replace(/ TX\b/, ' RX');
@@ -7022,11 +7022,9 @@ function generateGearListHtml(info = {}) {
     const monitoringEquipmentPrefs = monitoringPrefs.filter(p => monitorEquipOptions.includes(p));
     const monitoringSupportPrefs = monitoringPrefs.filter(p => !monitorEquipOptions.includes(p));
     if (monitoringPrefs.includes('Directors Monitor 7" handheld')) {
-        miscAcc.push(
-            'D-Tap to Lemo-2-pin Cable 0,3m',
-            'D-Tap to Lemo-2-pin Cable 0,3m'
-        );
         monitoringSupportAcc.push(
+            'D-Tap to Lemo-2-pin Cable 0,3m',
+            'D-Tap to Lemo-2-pin Cable 0,3m',
             'Ultraslim BNC 0.3 m',
             'Ultraslim BNC 0.3 m'
         );

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -1021,6 +1021,10 @@ describe('script.js functions', () => {
     expect(html).toContain('2x spigot');
     expect(html).toContain('2x Ultraslim BNC 0.3 m');
     expect(html).toContain('2x D-Tap to Lemo-2-pin Cable 0,3m');
+    const msSection = html.slice(html.indexOf('Monitoring support'), html.indexOf('Power'));
+    expect(msSection).toContain('2x D-Tap to Lemo-2-pin Cable 0,3m');
+    const miscSection = html.slice(html.indexOf('Miscellaneous'), html.indexOf('Consumables'));
+    expect(miscSection).not.toContain('D-Tap to Lemo-2-pin Cable 0,3m');
   });
 
   test('motor adds focus monitor and related accessories to gear list', () => {


### PR DESCRIPTION
## Summary
- Route monitor power cables to monitoring support by allowing `collectAccessories` to assign cables to that category
- Ensure Directors Monitor 7" handheld adds its D-Tap and BNC cables to monitoring support
- Add regression test verifying monitor cables appear only under monitoring support

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b6cf83819c8320a72fcc2f7008831b