### PR TITLE
feat: include standard rigging accessories

### DIFF
--- a/script.js
+++ b/script.js
@@ -6843,6 +6843,7 @@ function collectAccessories() {
         'BNC Cable 10 m',
         'BNC Drum 25 m'
     ];
+    const rigging = [];
     const chargers = [];
     const fizCables = [];
     const acc = devices.accessories || {};
@@ -6936,13 +6937,15 @@ function collectAccessories() {
 
     const miscUnique = [...new Set(misc)];
     const monitoringSupportUnique = [...new Set(monitoringSupport)];
+    const riggingUnique = [...new Set(rigging)];
     for (let i = 0; i < 4; i++) monitoringSupportUnique.push('BNC Connector');
     return {
         cameraSupport: [...new Set(cameraSupport)],
         chargers,
         fizCables: [...new Set(fizCables)],
         misc: miscUnique,
-        monitoringSupport: monitoringSupportUnique
+        monitoringSupport: monitoringSupportUnique,
+        rigging: riggingUnique
     };
 }
 
@@ -6998,7 +7001,14 @@ function generateGearListHtml(info = {}) {
     } else {
         selectedNames.viewfinder = "";
     }
-    const { cameraSupport: cameraSupportAcc, chargers: chargersAcc, fizCables: fizCableAcc, misc: miscAcc, monitoringSupport: monitoringSupportAcc } = collectAccessories();
+    const { cameraSupport: cameraSupportAcc, chargers: chargersAcc, fizCables: fizCableAcc, misc: miscAcc, monitoringSupport: monitoringSupportAcc, rigging: riggingAcc } = collectAccessories();
+    for (let i = 0; i < 2; i++) riggingAcc.push('ULCS Bracket with 1/4 to 1/4');
+    for (let i = 0; i < 2; i++) riggingAcc.push('ULCS Bracket with 3/8 to 1/4');
+    for (let i = 0; i < 2; i++) riggingAcc.push('Noga Arm');
+    for (let i = 0; i < 2; i++) riggingAcc.push('Mini Magic Arm');
+    for (let i = 0; i < 4; i++) riggingAcc.push('Cine Quick Release');
+    riggingAcc.push('SmallRig - Super lightweight 15mm RailBlock');
+    for (let i = 0; i < 3; i++) riggingAcc.push('stud 5/8" with male 3/8" and 1/4"');
     const cagesDb = devices.accessories?.cages || {};
     const compatibleCages = [];
     if (cameraSelect && cameraSelect.value && cameraSelect.value !== 'None') {
@@ -7173,6 +7183,8 @@ function generateGearListHtml(info = {}) {
         monitoringSupportItems = [monitoringSupportItems, monitoringSupportHardware].filter(Boolean).join('<br>');
     }
     addRow('Monitoring support', monitoringSupportItems);
+    const riggingItems = formatItems(riggingAcc);
+    addRow('Rigging', riggingItems);
     const gripItems = [];
     let sliderSelectHtml = '';
     let easyrigSelectHtml = '';

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -991,6 +991,19 @@ describe('script.js functions', () => {
       expect(html).not.toContain('HDMI Cable');
     });
 
+  test('standard rigging accessories are always included', () => {
+    const { generateGearListHtml } = script;
+    const html = generateGearListHtml({});
+    const rigSection = html.slice(html.indexOf('Rigging'), html.indexOf('Power'));
+    expect(rigSection).toContain('2x ULCS Bracket with 1/4 to 1/4');
+    expect(rigSection).toContain('2x ULCS Bracket with 3/8 to 1/4');
+    expect(rigSection).toContain('2x Noga Arm');
+    expect(rigSection).toContain('2x Mini Magic Arm');
+    expect(rigSection).toContain('4x Cine Quick Release');
+    expect(rigSection).toContain('1x SmallRig - Super lightweight 15mm RailBlock');
+    expect(rigSection).toContain('3x stud 5/8" with male 3/8" and 1/4"');
+  });
+
   test('gear list separates multiple items with line breaks', () => {
     const { generateGearListHtml } = script;
     const addOpt = (id, value) => {
@@ -1314,14 +1327,14 @@ describe('script.js functions', () => {
     expect(consumText).toContain('3x CapIt Medium');
   });
 
-  test('rigging appears only in project requirements while monitoring support also appears in gear table', () => {
+  test('rigging appears in project requirements and gear table', () => {
     const { generateGearListHtml } = script;
     const html = generateGearListHtml({
       rigging: 'Shoulder rig, Hand Grips',
       monitoringPreferences: 'VF Clean Feed, Onboard Clean Feed, User Buttons'
     });
     expect(html).toContain('Rigging: Shoulder rig, Hand Grips');
-    expect(html).not.toContain('<td>Rigging</td>');
+    expect(html).toContain('<td>Rigging</td>');
     expect(html).toContain('Monitoring support: VF Clean Feed, Onboard Clean Feed, User Buttons');
     expect(html).toContain('<td>Monitoring support</td>');
   });


### PR DESCRIPTION
## Summary
- always include common rigging hardware in generated gear lists
- test default gear list includes new rigging items and rigging section appears in project requirements and gear table

## Testing
- `npm run lint`
- `npm run check-consistency`
- `npx jest tests/unifyPorts.test.js tests/cliHelp.test.js tests/utils.test.js tests/checkConsistency.test.js tests/service-worker.test.js tests/storage.test.js`
- `npx jest tests/script.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b6d057d12c8320a10eefbd896f88f7