### PR TITLE
Add grip items for focus monitor

### DIFF
--- a/script.js
+++ b/script.js
@@ -7190,6 +7190,10 @@ function generateGearListHtml(info = {}) {
         gripItems.push('spigot');
         gripItems.push('spigot');
     }
+    if (hasMotor) {
+        gripItems.push('Avenger C-Stand Sliding Leg 20"');
+        gripItems.push('Lite-Tite Swivel Aluminium Umbrella Adapter');
+    }
     if (scenarios.includes('Tripod')) {
         const tripodDb = devices && devices.accessories && devices.accessories.tripods;
         if (tripodDb) {

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -1062,6 +1062,8 @@ describe('script.js functions', () => {
     expect(html).toContain('2x Ultraslim BNC 0.3 m');
     expect(html).toContain('2x D-Tap to Mini XLR 3-pin Cable 0,3m');
     expect(html).toContain('1x <strong>Wireless Receiver</strong> - VidA RX');
+    expect(html).toContain('Avenger C-Stand Sliding Leg 20"');
+    expect(html).toContain('Lite-Tite Swivel Aluminium Umbrella Adapter');
   });
 
   test('director handheld and focus monitor each get wireless receiver', () => {


### PR DESCRIPTION
## Summary
- include Avenger C-Stand Sliding Leg 20" and Lite-Tite Swivel in grip gear when focus monitor is present
- test focus monitor grip items

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6d0e2516883209391e363d5cb69a4