### PR TITLE
Populate codec dropdown from camera data

### DIFF
--- a/index.html
+++ b/index.html
@@ -869,7 +869,7 @@
           <option value="9:16">9:16</option>
           <option value="21:9">21:9</option>
         </select></label></div>
-      <div class="form-row"><label for="codec">Codec:<input type="text" id="codec" name="codec"></label></div>
+      <div class="form-row"><label for="codec">Codec:<select id="codec" name="codec"></select></label></div>
       <div class="form-row"><label for="baseFrameRate">Base Frame Rate:<select id="baseFrameRate" name="baseFrameRate">
           <option value=""></option>
           <option value="23.976">23.976</option>

--- a/script.js
+++ b/script.js
@@ -6206,6 +6206,7 @@ generateGearListBtn.addEventListener('click', () => {
         return;
     }
     populateSensorModeDropdown(currentProjectInfo && currentProjectInfo.sensorMode);
+    populateCodecDropdown(currentProjectInfo && currentProjectInfo.codec);
     projectDialog.showModal();
 });
 
@@ -8122,6 +8123,31 @@ function populateSensorModeDropdown(selected = '') {
   }
 }
 
+function populateCodecDropdown(selected = '') {
+  const codecSelect = document.getElementById('codec');
+  if (!codecSelect) return;
+
+  codecSelect.innerHTML = '';
+  const emptyOpt = document.createElement('option');
+  emptyOpt.value = '';
+  codecSelect.appendChild(emptyOpt);
+
+  const camKey = cameraSelect && cameraSelect.value;
+  const codecs =
+    camKey && devices && devices.cameras && devices.cameras[camKey]
+      ? devices.cameras[camKey].recordingCodecs
+      : null;
+  if (Array.isArray(codecs)) {
+    codecs.forEach(c => {
+      const opt = document.createElement('option');
+      opt.value = c;
+      opt.textContent = c;
+      if (c === selected) opt.selected = true;
+      codecSelect.appendChild(opt);
+    });
+  }
+}
+
 function populateFilterDropdown() {
   const filterSelect = document.getElementById('filter');
   if (filterSelect && devices && Array.isArray(devices.filterOptions)) {
@@ -8182,5 +8208,6 @@ if (typeof module !== "undefined" && module.exports) {
     saveCurrentGearList,
     populateLensDropdown,
     populateSensorModeDropdown,
+    populateCodecDropdown,
   };
 }

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -1376,6 +1376,22 @@ describe('script.js functions', () => {
     expect(html).toContain('Sensor Mode: S35 3:2');
   });
 
+  test('codec dropdown populates from camera recording codecs', () => {
+    devices.cameras.CamA.recordingCodecs = ['CodecA', 'CodecB'];
+    const camSel = document.getElementById('cameraSelect');
+    camSel.innerHTML = '<option value="CamA">CamA</option>';
+    camSel.value = 'CamA';
+    const setupSelectElem = document.getElementById('setupSelect');
+    setupSelectElem.innerHTML = '<option value="Test">Test</option>';
+    setupSelectElem.value = 'Test';
+    const projectDialog = document.getElementById('projectDialog');
+    projectDialog.showModal = jest.fn();
+    document.getElementById('generateGearListBtn').click();
+    const codecSelect = document.getElementById('codec');
+    const opts = Array.from(codecSelect.options).map(o => o.value);
+    expect(opts).toEqual(['', 'CodecA', 'CodecB']);
+  });
+
   test('duplicate motors are aggregated with count in gear list', () => {
     const { generateGearListHtml } = script;
     const addOpt = (id, value) => {


### PR DESCRIPTION
## Summary
- Populate codec selection with recording codecs from the chosen camera
- Convert project codec input to a dropdown and expose helper to populate it
- Test codec dropdown population

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b6d36b9d248320b752545da520df7b