### PR TITLE
Add baseline consumables with shoot-duration scaling

### DIFF
--- a/script.js
+++ b/script.js
@@ -7278,6 +7278,45 @@ function generateGearListHtml(info = {}) {
         ...Array(3).fill('Power Three Way Splitter')
     );
     const consumables = [];
+    const baseConsumables = [
+        { name: 'Kimtech Wipes', count: 1 },
+        { name: 'Lasso Rot 24mm', count: 1 },
+        { name: 'Lasso Blau 24mm', count: 1 },
+        { name: 'Sprigs rot 1/4“', count: 1, noScale: true },
+        { name: 'Augenleder Large Oval Farbe rot', count: 2 },
+        { name: 'Klappenstift', count: 2, klappen: true }
+    ];
+    let shootDays = 0;
+    if (info.shootingDays) {
+        const parts = info.shootingDays.split(' to ');
+        if (parts.length === 2) {
+            const start = new Date(parts[0]);
+            const end = new Date(parts[1]);
+            if (!isNaN(start) && !isNaN(end)) {
+                shootDays = Math.floor((end - start) / (1000 * 60 * 60 * 24)) + 1;
+            }
+        }
+    }
+    let multiplier = 1;
+    if (shootDays > 21) {
+        multiplier = 4;
+    } else if (shootDays > 14) {
+        multiplier = 3;
+    } else if (shootDays > 7) {
+        multiplier = 2;
+    }
+    const klappenMultiplier = multiplier % 2 === 0 ? multiplier : Math.max(1, multiplier - 1);
+    for (const item of baseConsumables) {
+        let count = item.count;
+        if (item.noScale) {
+            // no scaling
+        } else if (item.klappen) {
+            count *= klappenMultiplier;
+        } else {
+            count *= multiplier;
+        }
+        for (let i = 0; i < count; i++) consumables.push(item.name);
+    }
     if (scenarios.includes('Outdoor')) {
         if (selectedNames.camera) miscItems.push(`Rain Cover "${selectedNames.camera}"`);
         miscItems.push('Umbrella for Focus Monitor');

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -1364,6 +1364,43 @@ describe('script.js functions', () => {
     expect(consumText).toContain('3x CapIt Medium');
   });
 
+  test('base consumables added with correct counts for short shoot', () => {
+    const { generateGearListHtml } = script;
+    const html = generateGearListHtml({ shootingDays: '2024-05-01 to 2024-05-05' });
+    const wrap = document.createElement('div');
+    wrap.innerHTML = html;
+    const rows = Array.from(wrap.querySelectorAll('.gear-table tr'));
+    const consumIdx = rows.findIndex(r => r.textContent === 'Consumables');
+    const consumText = rows[consumIdx + 1].textContent;
+    expect(consumText).toContain('1x Kimtech Wipes');
+    expect(consumText).toContain('1x Lasso Rot 24mm');
+    expect(consumText).toContain('1x Lasso Blau 24mm');
+    expect(consumText).toContain('1x Sprigs rot 1/4“');
+    expect(consumText).toContain('2x Augenleder Large Oval Farbe rot');
+    expect(consumText).toContain('2x Klappenstift');
+  });
+
+  test('consumables scale with shooting days and special rules', () => {
+    const { generateGearListHtml } = script;
+    const scenarios = [
+      ['2024-05-01 to 2024-05-10', '2x Kimtech Wipes', '4x Klappenstift', '4x Augenleder Large Oval Farbe rot'],
+      ['2024-05-01 to 2024-05-16', '3x Kimtech Wipes', '4x Klappenstift', '6x Augenleder Large Oval Farbe rot'],
+      ['2024-05-01 to 2024-05-22', '4x Kimtech Wipes', '8x Klappenstift', '8x Augenleder Large Oval Farbe rot']
+    ];
+    scenarios.forEach(([range, wipes, klappen, augen]) => {
+      const html = generateGearListHtml({ shootingDays: range });
+      const wrap = document.createElement('div');
+      wrap.innerHTML = html;
+      const rows = Array.from(wrap.querySelectorAll('.gear-table tr'));
+      const consumIdx = rows.findIndex(r => r.textContent === 'Consumables');
+      const consumText = rows[consumIdx + 1].textContent;
+      expect(consumText).toContain(wipes);
+      expect(consumText).toContain('1x Sprigs rot 1/4“');
+      expect(consumText).toContain(klappen);
+      expect(consumText).toContain(augen);
+    });
+  });
+
   test('rigging appears in project requirements and gear table', () => {
     const { generateGearListHtml } = script;
     const html = generateGearListHtml({


### PR DESCRIPTION
## Summary
- Always include consumables like Kimtech Wipes, Lasso tapes, Sprigs, Augenleder, and Klappenstift in gear lists
- Scale consumable counts by shoot length, skipping Sprigs and only scaling Klappenstift on even multipliers
- Add tests covering base counts and scaling rules

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6d5cc71188320a0c1737d4649933f