### PR TITLE
Include tennis balls for every light stand

### DIFF
--- a/script.js
+++ b/script.js
@@ -7258,6 +7258,10 @@ function generateGearListHtml(info = {}) {
             gripItems.push('Sachtler FSB 8 Head');
         }
     }
+    const standCount = gripItems.filter(item => /\bstand\b/i.test(item)).length;
+    if (standCount) {
+        gripItems.push(...Array(standCount * 3).fill('Tennisball'));
+    }
     const powerItems = [
         'Power Cable Drum 25-50 m',
         ...Array(2).fill('Power Cable 10 m'),

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -1048,6 +1048,7 @@ describe('script.js functions', () => {
     expect(html).toContain('C-Stand 20"');
     expect(html).toContain('Lite-Tite Swivel Aluminium Umbrella Adapter');
     expect(html).toContain('2x spigot');
+    expect(html).toContain('3x Tennisball');
     expect(html).toContain('2x Ultraslim BNC 0.3 m');
     expect(html).toContain('2x D-Tap to Lemo-2-pin Cable 0,3m');
     const msSection = html.slice(html.indexOf('Monitoring support'), html.indexOf('Power'));
@@ -1081,6 +1082,7 @@ describe('script.js functions', () => {
     expect(html).toContain('1x <strong>Wireless Receiver</strong> - VidA RX');
     expect(html).toContain('Avenger C-Stand Sliding Leg 20"');
     expect(html).toContain('Lite-Tite Swivel Aluminium Umbrella Adapter');
+    expect(html).toContain('3x Tennisball');
   });
 
   test('director handheld and focus monitor each get wireless receiver', () => {
@@ -1236,6 +1238,7 @@ describe('script.js functions', () => {
     expect(text).toContain('1x Satz Paganinis');
     expect(text).toContain('2x Sandsack');
     expect(text).toContain('3x Bodenmatte');
+    expect(text).toContain('12x Tennisball');
   });
 
   test('Slider with undersling mode adds Tango Beam regardless of order', () => {


### PR DESCRIPTION
## Summary
- add automatic 3x Tennisball per light stand in grip gear list
- test director handheld, motor, and slider scenarios for Tennisballs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b6d747ebb48320add2b7bb9ca64f21