### PR TITLE
Add spare antennas for wireless video devices

### DIFF
--- a/script.js
+++ b/script.js
@@ -6843,7 +6843,7 @@ function suggestChargerCounts(total) {
     return { quad, dual, single };
 }
 
-function collectAccessories() {
+function collectAccessories(info = {}) {
     const cameraSupport = [];
     const misc = [];
     const monitoringSupport = [
@@ -6858,6 +6858,7 @@ function collectAccessories() {
     const fizCables = [];
     const acc = devices.accessories || {};
     const excludedCables = new Set(['D-Tap to LEMO 2-pin', 'HDMI Cable']);
+    let antennaCount = 0;
 
     if (batterySelect.value) {
         const mount = devices.batteries[batterySelect.value]?.mount_type;
@@ -6917,6 +6918,18 @@ function collectAccessories() {
     gatherPower(devices.monitors[monitorSelect.value], monitoringSupport);
     gatherPower(devices.video[videoSelect.value]);
     if (videoSelect.value) {
+        antennaCount += 1;
+        let monitoringPrefs = [];
+        if (info.monitoringPreferences) {
+            monitoringPrefs = info.monitoringPreferences.split(',').map(s => s.trim()).filter(Boolean);
+        } else {
+            const monitoringSelect = document.getElementById('monitoringPreferences');
+            monitoringPrefs = Array.from(monitoringSelect?.selectedOptions || []).map(o => o.value);
+        }
+        const hasMotor = motorSelects.some(sel => sel.value && sel.value !== 'None');
+        let receiverCount = (monitoringPrefs.includes('Directors Monitor 7" handheld') ? 1 : 0) + (hasMotor ? 1 : 0);
+        if (!receiverCount) receiverCount = 1;
+        antennaCount += receiverCount;
         const rxName = videoSelect.value.replace(/ TX\b/, ' RX');
         if (devices.wirelessReceivers && devices.wirelessReceivers[rxName]) {
             gatherPower(devices.wirelessReceivers[rxName]);
@@ -6948,6 +6961,7 @@ function collectAccessories() {
     const miscUnique = [...new Set(misc)];
     const monitoringSupportUnique = [...new Set(monitoringSupport)];
     const riggingUnique = [...new Set(rigging)];
+    for (let i = 0; i < antennaCount; i++) monitoringSupportUnique.push('Antenna 5,8GHz 5dBi Long (spare)');
     for (let i = 0; i < 4; i++) monitoringSupportUnique.push('BNC Connector');
     return {
         cameraSupport: [...new Set(cameraSupport)],
@@ -7011,7 +7025,7 @@ function generateGearListHtml(info = {}) {
     } else {
         selectedNames.viewfinder = "";
     }
-    const { cameraSupport: cameraSupportAcc, chargers: chargersAcc, fizCables: fizCableAcc, misc: miscAcc, monitoringSupport: monitoringSupportAcc, rigging: riggingAcc } = collectAccessories();
+    const { cameraSupport: cameraSupportAcc, chargers: chargersAcc, fizCables: fizCableAcc, misc: miscAcc, monitoringSupport: monitoringSupportAcc, rigging: riggingAcc } = collectAccessories(info);
     for (let i = 0; i < 2; i++) riggingAcc.push('ULCS Bracket with 1/4 to 1/4');
     for (let i = 0; i < 2; i++) riggingAcc.push('ULCS Bracket with 3/8 to 1/4');
     for (let i = 0; i < 2; i++) riggingAcc.push('Noga Arm');

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -1034,6 +1034,24 @@ describe('script.js functions', () => {
     expect(html).not.toContain('MonA, VidA');
   });
 
+  test('monitoring support includes spare antennas for wireless video devices', () => {
+    const { generateGearListHtml } = script;
+    global.devices.video = {
+      'VidA TX': {
+        powerDrawWatts: 3,
+        power: { input: { type: 'LEMO 2-pin' } },
+        videoInputs: [{ type: '3G-SDI' }]
+      }
+    };
+    global.devices.wirelessReceivers = { 'VidA RX': {} };
+    const sel = document.getElementById('videoSelect');
+    sel.innerHTML = '<option value="VidA TX">VidA TX</option>';
+    sel.value = 'VidA TX';
+    const html = generateGearListHtml();
+    const msSection = html.slice(html.indexOf('Monitoring support'), html.indexOf('Power'));
+    expect(msSection).toContain('2x Antenna 5,8GHz 5dBi Long (spare)');
+  });
+
   test('Directors handheld monitor adds dropdown, batteries and grip items', () => {
     const { generateGearListHtml } = script;
     global.devices.monitors = {
@@ -1081,6 +1099,8 @@ describe('script.js functions', () => {
     expect(html).toContain('1x <strong>Wireless Receiver</strong> - VidA RX');
     expect(html).toContain('Avenger C-Stand Sliding Leg 20"');
     expect(html).toContain('Lite-Tite Swivel Aluminium Umbrella Adapter');
+    const msSection = html.slice(html.indexOf('Monitoring support'), html.indexOf('Power'));
+    expect(msSection).toContain('2x Antenna 5,8GHz 5dBi Long (spare)');
   });
 
   test('director handheld and focus monitor each get wireless receiver', () => {
@@ -1102,6 +1122,8 @@ describe('script.js functions', () => {
     addOpt('videoSelect', 'VidA TX');
     const html = generateGearListHtml({ monitoringPreferences: 'Directors Monitor 7" handheld' });
     expect(html).toContain('2x <strong>Wireless Receiver</strong> - VidA RX');
+    const msSection = html.slice(html.indexOf('Monitoring support'), html.indexOf('Power'));
+    expect(msSection).toContain('3x Antenna 5,8GHz 5dBi Long (spare)');
   });
 
   test('gear list includes battery count in camera batteries row', () => {


### PR DESCRIPTION
## Summary
- add spare antenna per wireless video transmitter and receiver to monitoring support
- test antenna counts for different monitoring setups

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b6d808e4648320a8e8070c310a6385