### PR TITLE
Add default media cards to gear list

### DIFF
--- a/script.js
+++ b/script.js
@@ -7136,7 +7136,40 @@ function generateGearListHtml(info = {}) {
         cageSelectHtml = `1x <select id="gearListCage">${options}</select>`;
     }
     addRow('Camera Support', [cameraSupportText, cageSelectHtml].filter(Boolean).join('<br>'));
-    addRow('Media', '');
+    let mediaItems = '';
+    const cam = devices && devices.cameras && selectedNames.camera ? devices.cameras[selectedNames.camera] : null;
+    if (cam && Array.isArray(cam.recordingMedia) && cam.recordingMedia.length) {
+        const sizeMap = {
+            'CFexpress Type A': '320GB',
+            'CFast 2.0': '512GB',
+            'CFexpress Type B': '512GB',
+            'Codex Compact Drive': '1TB',
+            'AXS Memory A-Series slot': '1TB',
+            'SD': '128GB',
+            'SD Card': '128GB',
+            'SDXC': '128GB',
+            'XQD Card': '120GB',
+            'RED MINI-MAG': '512GB',
+            'REDMAG 1.8" SSD': '512GB',
+            'Blackmagic Media Module': '8TB',
+            'DJI PROSSD': '1TB',
+            'USB-C 3.1 Gen 1 expansion port for external media': '1TB',
+            'USB-C 3.1 Gen 2 expansion port for external media': '1TB',
+            'USB-C to external SSD/HDD': '1TB'
+        };
+        mediaItems = cam.recordingMedia.map(m => {
+            const type = m && m.type ? m.type : '';
+            if (!type) return '';
+            let size = '';
+            if (m.notes) {
+                const match = m.notes.match(/(\d+(?:\.\d+)?\s*(?:TB|GB))/i);
+                if (match) size = match[1].toUpperCase();
+            }
+            if (!size) size = sizeMap[type] || '512GB';
+            return `4x ${escapeHtml(size)} ${escapeHtml(type)}`;
+        }).filter(Boolean).join('<br>');
+    }
+    addRow('Media', mediaItems);
     addRow('Lens', '');
     addRow('Lens Support', '');
     addRow('Matte box + filter', '');

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -1135,6 +1135,19 @@ describe('script.js functions', () => {
     expect(html).toContain('1x Hotswap Plate B-Mount');
   });
 
+  test('gear list lists 4x media cards with usable size', () => {
+    const { generateGearListHtml } = script;
+    devices.cameras.CamA.recordingMedia = [{ type: 'CFast 2.0' }];
+    const addOpt = (id, value) => {
+      const sel = document.getElementById(id);
+      sel.innerHTML = `<option value="${value}">${value}</option>`;
+      sel.value = value;
+    };
+    addOpt('cameraSelect', 'CamA');
+    const html = generateGearListHtml();
+    expect(html).toContain('4x 512GB CFast 2.0');
+  });
+
   test('Cine Saddle and Steadybag scenarios populate grip section', () => {
     const { generateGearListHtml } = script;
     const html = generateGearListHtml({ requiredScenarios: 'Cine Saddle, Steadybag' });


### PR DESCRIPTION
## Summary
- Auto-populate the Media row with four appropriately sized cards based on the selected camera's recording media type
- Add Jest test verifying gear list includes default media cards

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6d8f7708c8320be866bdef95b5c3b