### PR TITLE
Add lens support planning to gear list

### DIFF
--- a/devices/gearList.js
+++ b/devices/gearList.js
@@ -1615,6 +1615,20 @@ const gear = {
 // Expose lenses at the top level for easier access
 gear.lenses = gear.accessories.lenses;
 
+// Ensure every lens has lens support metadata and add specific overrides
+for (const lens of Object.values(gear.lenses)) {
+  if (!lens.lensSupport) {
+    lens.lensSupport = { rodType: '15mm', rodLengthCm: 30, required: false };
+  }
+}
+if (gear.lenses['Angénieux Optimo Ultra 12x 36-435mm T4.2 (FF/VV)']) {
+  gear.lenses['Angénieux Optimo Ultra 12x 36-435mm T4.2 (FF/VV)'].lensSupport = {
+    rodType: '19mm',
+    rodLengthCm: 45,
+    required: true,
+  };
+}
+
 // Automatically add a matching wireless receiver entry for every
 // transmitter defined in the video devices. This ensures the list of
 // receivers always covers all available transmitters without having to

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -52,7 +52,7 @@ describe('script.js functions', () => {
         }
       },
       lenses: {
-        LensA: { brand: 'TestBrand', tStop: 2.0 }
+        LensA: { brand: 'TestBrand', tStop: 2.0, lensSupport: { rodType: '19mm', rodLengthCm: 20, required: true } }
       },
       fiz: {
         motors: {
@@ -70,7 +70,7 @@ describe('script.js functions', () => {
       },
       accessories: {
         powerPlates: { 'Generic V-Mount Plate': { mount: 'V-Mount' } },
-        cages: { 'Universal Cage': { compatible: ['CamA'] } },
+        cages: { 'Universal Cage': { compatible: ['CamA'], rodStandard: '15mm' } },
         chargers: {
           'Single V-Mount Charger': { mount: 'V-Mount', slots: 1, chargingSpeedAmps: 3 },
           'Dual V-Mount Charger': { mount: 'V-Mount', slots: 2, chargingSpeedAmps: 2 },
@@ -216,6 +216,25 @@ describe('script.js functions', () => {
     cageSelect.dispatchEvent(new Event('change', { bubbles: true }));
     cageSelEl = gearList.querySelector('#gearListCage');
     expect(cageSelEl.value).toBe('Cage2');
+  });
+
+  test('lens selection adds rods, support and cage compatibility warning', () => {
+    const addOpt = (id, value) => {
+      const sel = document.getElementById(id);
+      sel.innerHTML = `<option value="${value}">${value}</option>`;
+      sel.value = value;
+    };
+    addOpt('cameraSelect', 'CamA');
+    addOpt('batterySelect', 'BattA');
+    addOpt('cageSelect', 'Universal Cage');
+    const lensSel = document.getElementById('lenses');
+    lensSel.innerHTML = '<option value="LensA">LensA</option>';
+    lensSel.options[0].selected = true;
+    const html = script.generateGearListHtml({ lenses: 'LensA' });
+    const section = html.slice(html.indexOf('Lens Support'), html.indexOf('Matte box'));
+    expect(section).toContain('1x 19mm rods 20 cm');
+    expect(section).toContain('1x 19mm lens support');
+    expect(section).toContain('1x Cage incompatible with 19mm rods');
   });
 
   test('gear list cage selection is stored with selected attribute', () => {


### PR DESCRIPTION
## Summary
- add default lens support metadata to lens entries
- generate gear list rows for required rods and lens supports with cage compatibility check
- test lens rod and support handling

## Testing
- `npm test 2>&1 | tail -n 20`

------
https://chatgpt.com/codex/tasks/task_e_68b6d9fa1bcc8320b8bb3a9110b67f70