### PR TITLE
Add friction arm and gimbal accessories to grip list

### DIFF
--- a/script.js
+++ b/script.js
@@ -7230,6 +7230,7 @@ function generateGearListHtml(info = {}) {
     const gripItems = [];
     let sliderSelectHtml = '';
     let easyrigSelectHtml = '';
+    const hasGimbal = scenarios.includes('Gimbal');
     if (monitoringPrefs.includes('Directors Monitor 7" handheld')) {
         gripItems.push('C-Stand 20"');
         gripItems.push('Lite-Tite Swivel Aluminium Umbrella Adapter');
@@ -7253,11 +7254,18 @@ function generateGearListHtml(info = {}) {
         const optsHtml = options.map(o => `<option value="${escapeHtml(o)}">${escapeHtml(o)}</option>`).join('');
         easyrigSelectHtml = `1x Easyrig 5 Vario <select id="gearListEasyrig">${optsHtml}</select>`;
     }
-    if (scenarios.includes('Gimbal')) {
+    if (hasGimbal) {
         const cam = devices && devices.cameras && devices.cameras[selectedNames.camera];
         const weight = cam && cam.weight_g;
         const isSmall = weight != null ? weight < 2000 : /(FX3|FX6|R5)/i.test(selectedNames.camera);
         gripItems.push(isSmall ? 'DJI Ronin RS4 Pro Combo' : 'DJI Ronin 2');
+    }
+    const frictionArmCount = hasGimbal ? 2 : 1;
+    gripItems.push(...Array(frictionArmCount).fill('Manfrotto 244N Friktion Arm'));
+    if (hasGimbal) {
+        gripItems.push('Super Clamp');
+        gripItems.push('Gobo Head');
+        gripItems.push('spigot');
     }
     if (scenarios.includes('Cine Saddle')) gripItems.push('Cinekinetic Cinesaddle');
     if (scenarios.includes('Steadybag')) gripItems.push('Steadybag');

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -1332,6 +1332,44 @@ describe('script.js functions', () => {
     ]);
   });
 
+  test('Grip section always includes a friction arm', () => {
+    const { generateGearListHtml } = script;
+    const addOpt = (id, value) => {
+      const sel = document.getElementById(id);
+      sel.innerHTML = `<option value="${value}">${value}</option>`;
+      sel.value = value;
+    };
+    addOpt('cameraSelect', 'CamA');
+    const html = generateGearListHtml();
+    const wrap = document.createElement('div');
+    wrap.innerHTML = html;
+    const rows = Array.from(wrap.querySelectorAll('.gear-table tr'));
+    const gripIdx = rows.findIndex(r => r.textContent === 'Grip');
+    const itemsRow = rows[gripIdx + 1];
+    expect(itemsRow.textContent).toContain('1x Manfrotto 244N Friktion Arm');
+  });
+
+  test('Gimbal scenario adds extra grip accessories', () => {
+    const { generateGearListHtml } = script;
+    const addOpt = (id, value) => {
+      const sel = document.getElementById(id);
+      sel.innerHTML = `<option value="${value}">${value}</option>`;
+      sel.value = value;
+    };
+    addOpt('cameraSelect', 'CamA');
+    const html = generateGearListHtml({ requiredScenarios: 'Gimbal' });
+    const wrap = document.createElement('div');
+    wrap.innerHTML = html;
+    const rows = Array.from(wrap.querySelectorAll('.gear-table tr'));
+    const gripIdx = rows.findIndex(r => r.textContent === 'Grip');
+    const itemsRow = rows[gripIdx + 1];
+    const text = itemsRow.textContent;
+    expect(text).toContain('2x Manfrotto 244N Friktion Arm');
+    expect(text).toContain('1x Super Clamp');
+    expect(text).toContain('1x Gobo Head');
+    expect(text).toContain('1x spigot');
+  });
+
   test('Outdoor scenario adds weather protection gear and consumables for small monitor', () => {
     const { generateGearListHtml } = script;
     const addOpt = (id, value) => {


### PR DESCRIPTION
## Summary
- Always include a Manfrotto 244N Friktion Arm in grip gear
- When a gimbal is selected, add a second arm plus Super Clamp, Gobo Head, and spigot
- Test coverage for new grip defaults and gimbal-specific accessories

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b6df5ddc508320974f6f35ec581630