### PR TITLE
feat: add spare antennas for wireless video

### DIFF
--- a/script.js
+++ b/script.js
@@ -7041,6 +7041,17 @@ function generateGearListHtml(info = {}) {
     const monitorEquipOptions = ['Directors Monitor 7" handheld', 'Directors Monitor 15-19 inch', 'Combo Monitor 15-19 inch'];
     const monitoringEquipmentPrefs = monitoringPrefs.filter(p => monitorEquipOptions.includes(p));
     const monitoringSupportPrefs = monitoringPrefs.filter(p => !monitorEquipOptions.includes(p));
+    const receiverCount = (monitoringPrefs.includes('Directors Monitor 7" handheld') ? 1 : 0) + (hasMotor ? 1 : 0);
+    if (selectedNames.video) {
+        monitoringSupportAcc.push('Antenna 5,8GHz 5dBi Long (spare)');
+        const rxName = selectedNames.video.replace(/ TX\b/, ' RX');
+        if (devices && devices.wirelessReceivers && devices.wirelessReceivers[rxName]) {
+            const receivers = receiverCount || 1;
+            for (let i = 0; i < receivers; i++) {
+                monitoringSupportAcc.push('Antenna 5,8GHz 5dBi Long (spare)');
+            }
+        }
+    }
     if (monitoringPrefs.includes('Directors Monitor 7" handheld')) {
         monitoringSupportAcc.push(
             'D-Tap to Lemo-2-pin Cable 0,3m',
@@ -7211,8 +7222,8 @@ function generateGearListHtml(info = {}) {
         monitoringItems += (monitoringItems ? '<br>' : '') + `1x <strong>Wireless Transmitter</strong> - ${escapeHtml(selectedNames.video)}`;
         const rxName = selectedNames.video.replace(/ TX\b/, ' RX');
         if (devices && devices.wirelessReceivers && devices.wirelessReceivers[rxName]) {
-            const receiverCount = (monitoringPrefs.includes('Directors Monitor 7" handheld') ? 1 : 0) + (hasMotor ? 1 : 0);
-            monitoringItems += `<br>${receiverCount || 1}x <strong>Wireless Receiver</strong> - ${escapeHtml(rxName)}`;
+            const receivers = receiverCount || 1;
+            monitoringItems += `<br>${receivers}x <strong>Wireless Receiver</strong> - ${escapeHtml(rxName)}`;
         }
     }
     addRow('Monitoring', monitoringItems);

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -983,6 +983,7 @@ describe('script.js functions', () => {
       expect(msSection).toContain('1x BNC Cable 10 m');
       expect(msSection).toContain('1x BNC Drum 25 m');
       expect(msSection).toContain('4x BNC Connector');
+      expect(msSection).toContain('1x Antenna 5,8GHz 5dBi Long (spare)');
       const powerSection = html.slice(html.indexOf('Power'), html.indexOf('Grip'));
       expect(powerSection).toContain('1x Power Cable Drum 25-50 m');
       expect(powerSection).toContain('2x Power Cable 10 m');
@@ -1083,6 +1084,8 @@ describe('script.js functions', () => {
     expect(html).toContain('Avenger C-Stand Sliding Leg 20"');
     expect(html).toContain('Lite-Tite Swivel Aluminium Umbrella Adapter');
     expect(html).toContain('3x Tennisball');
+    const msSection = html.slice(html.indexOf('Monitoring support'), html.indexOf('Power'));
+    expect(msSection).toContain('2x Antenna 5,8GHz 5dBi Long (spare)');
   });
 
   test('director handheld and focus monitor each get wireless receiver', () => {
@@ -1104,6 +1107,8 @@ describe('script.js functions', () => {
     addOpt('videoSelect', 'VidA TX');
     const html = generateGearListHtml({ monitoringPreferences: 'Directors Monitor 7" handheld' });
     expect(html).toContain('2x <strong>Wireless Receiver</strong> - VidA RX');
+    const msSection = html.slice(html.indexOf('Monitoring support'), html.indexOf('Power'));
+    expect(msSection).toContain('3x Antenna 5,8GHz 5dBi Long (spare)');
   });
 
   test('gear list includes battery count in camera batteries row', () => {


### PR DESCRIPTION
## Summary
- include a spare 5.8 GHz antenna for each wireless video transmitter and receiver in monitoring support
- cover antenna counts in gear list tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b6df7de6288320b5f81d7d333e073e