### PR TITLE
Add lens rod support metadata and gear list handling

### DIFF
--- a/devices/gearList.js
+++ b/devices/gearList.js
@@ -1612,6 +1612,30 @@ const gear = {
   ]
 };
 
+// Annotate lenses with support requirements and rod details.
+const lensSupportDefaults = {
+  "Angenieux Optimo 25-250mm T3.5 (PL)": { rodStandard: "19mm", rodLengthCm: 45, needsLensSupport: true },
+  "LOMO Anamorphic RF 35mm T2.5": { rodStandard: "19mm", rodLengthCm: 45, needsLensSupport: true },
+  "LOMO Anamorphic RF 50mm T2.4": { rodStandard: "15mm", rodLengthCm: 30, needsLensSupport: true },
+  "LOMO Anamorphic RF 75mm T2.4": { rodStandard: "15mm", rodLengthCm: 30, needsLensSupport: true },
+  "LOMO Anamorphic RF 100mm T3.2": { rodStandard: "15mm", rodLengthCm: 30, needsLensSupport: true },
+  "Canon CN7x17 17-120mm T3.0-3.9": { rodStandard: "15mm", rodLengthCm: 45, needsLensSupport: true },
+  "Angénieux Ultra Compact FF 37-102mm T2.9": { rodStandard: "15mm", rodLengthCm: 45, needsLensSupport: true },
+  "Angénieux Ultra Compact FF 21-56mm T2.9": { rodStandard: "15mm", rodLengthCm: 45, needsLensSupport: true },
+  "Angénieux Optimo Ultra 12x 36-435mm T4.2 (FF/VV)": { rodStandard: "19mm", rodLengthCm: 60, needsLensSupport: true },
+  "ZEISS Compact Zoom CZ.2 28-80mm T2.9": { rodStandard: "15mm", rodLengthCm: 45, needsLensSupport: true },
+  "ZEISS Compact Zoom CZ.2 70-200mm T2.9": { rodStandard: "15mm", rodLengthCm: 45, needsLensSupport: true },
+  "Laowa 24mm T8 2× Pro2be (3-lens set: Direct / 35° / Periscope)": { rodStandard: "15mm", rodLengthCm: 45, needsLensSupport: true },
+  "Sony FE 70–200mm f/2.8 G Master II": { rodStandard: "15mm", rodLengthCm: 45, needsLensSupport: true }
+};
+
+for (const [name, lens] of Object.entries(gear.accessories.lenses)) {
+  const cfg = lensSupportDefaults[name] || {};
+  lens.rodStandard = cfg.rodStandard || "15mm";
+  lens.rodLengthCm = cfg.rodLengthCm || 30;
+  lens.needsLensSupport = cfg.needsLensSupport || false;
+}
+
 // Expose lenses at the top level for easier access
 gear.lenses = gear.accessories.lenses;
 

--- a/script.js
+++ b/script.js
@@ -7170,8 +7170,30 @@ function generateGearListHtml(info = {}) {
         }).filter(Boolean).join('<br>');
     }
     addRow('Media', mediaItems);
-    addRow('Lens', '');
-    addRow('Lens Support', '');
+    const selectedLensNames = info.lenses
+        ? info.lenses.split(',').map(s => s.trim()).filter(Boolean)
+        : [];
+    addRow('Lens', formatItems(selectedLensNames));
+    const lensSupportItems = [];
+    const requiredRodTypes = new Set();
+    selectedLensNames.forEach(name => {
+        const lens = devices.lenses && devices.lenses[name];
+        if (!lens) return;
+        const rodType = lens.rodStandard || '15mm';
+        const rodLength = lens.rodLengthCm || (rodType === '19mm' ? 45 : 30);
+        lensSupportItems.push(`${rodType} rods ${rodLength}cm`);
+        requiredRodTypes.add(rodType);
+        if (lens.needsLensSupport) {
+            lensSupportItems.push(`${rodType} lens support`);
+        }
+    });
+    const cageRodType = devices.accessories?.cages?.[selectedNames.cage]?.rodStandard;
+    requiredRodTypes.forEach(rt => {
+        if (cageRodType && cageRodType !== rt) {
+            lensSupportItems.push(`⚠️ cage incompatible with ${rt} rods`);
+        }
+    });
+    addRow('Lens Support', formatItems(lensSupportItems));
     addRow('Matte box + filter', '');
     addRow('LDS (FIZ)', formatItems([...selectedNames.motors, ...selectedNames.controllers, selectedNames.distance, ...fizCableAcc]));
     let batteryItems = '';

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -52,7 +52,7 @@ describe('script.js functions', () => {
         }
       },
       lenses: {
-        LensA: { brand: 'TestBrand', tStop: 2.0 }
+        LensA: { brand: 'TestBrand', tStop: 2.0, rodStandard: '15mm', rodLengthCm: 30, needsLensSupport: true }
       },
       fiz: {
         motors: {
@@ -70,7 +70,7 @@ describe('script.js functions', () => {
       },
       accessories: {
         powerPlates: { 'Generic V-Mount Plate': { mount: 'V-Mount' } },
-        cages: { 'Universal Cage': { compatible: ['CamA'] } },
+        cages: { 'Universal Cage': { compatible: ['CamA'], rodStandard: '15mm' } },
         chargers: {
           'Single V-Mount Charger': { mount: 'V-Mount', slots: 1, chargingSpeedAmps: 3 },
           'Dual V-Mount Charger': { mount: 'V-Mount', slots: 2, chargingSpeedAmps: 2 },
@@ -194,6 +194,29 @@ describe('script.js functions', () => {
     const cageSel = itemsRow.querySelector('#gearListCage');
     expect(cageSel).not.toBeNull();
     expect(cageSel.value).toBe('Universal Cage');
+  });
+
+  test('selected lens adds rods and support to lens support category of gear list', () => {
+    const addOpt = (id, value) => {
+      const sel = document.getElementById(id);
+      sel.innerHTML = `<option value="${value}">${value}</option>`;
+      sel.value = value;
+    };
+    addOpt('cameraSelect', 'CamA');
+    addOpt('batterySelect', 'BattA');
+    addOpt('cageSelect', 'Universal Cage');
+    const html = script.generateGearListHtml({ lenses: 'LensA' });
+    const wrap = document.createElement('div');
+    wrap.innerHTML = html;
+    const rows = Array.from(wrap.querySelectorAll('.gear-table tr'));
+    const lensIndex = rows.findIndex(r => r.textContent === 'Lens');
+    expect(lensIndex).toBeGreaterThanOrEqual(0);
+    const lensRow = rows[lensIndex + 1];
+    expect(lensRow.textContent).toContain('LensA');
+    const supportIndex = rows.findIndex(r => r.textContent === 'Lens Support');
+    const supportRow = rows[supportIndex + 1];
+    expect(supportRow.textContent).toContain('15mm rods 30cm');
+    expect(supportRow.textContent).toContain('15mm lens support');
   });
 
   test('gear list updates when device selection changes', () => {


### PR DESCRIPTION
## Summary
- annotate lenses with default rod type, length, and support requirements
- include lens selections in gear list with rods, lens supports, and cage compatibility checks
- test lens support gear list integration

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6df91efe883208a126c270dd76e13