### PR TITLE
Use database battery names for monitoring

### DIFF
--- a/script.js
+++ b/script.js
@@ -7183,11 +7183,14 @@ function generateGearListHtml(info = {}) {
     }
     addRow('Camera Batteries', batteryItems);
     let monitoringBatteryItems = [];
+    const batteryNames = devices && devices.batteries ? Object.keys(devices.batteries) : [];
     if (monitoringPrefs.includes('Directors Monitor 7" handheld')) {
-        monitoringBatteryItems.push('3x Bebob 98 Micros');
+        const bebob98 = batteryNames.find(name => /\bV98micro\b/.test(name));
+        if (bebob98) monitoringBatteryItems.push(`3x ${escapeHtml(bebob98)}`);
     }
     if (hasMotor) {
-        monitoringBatteryItems.push('3x Bebob 150micro');
+        const bebob150 = batteryNames.find(name => /\bV150micro\b/.test(name));
+        if (bebob150) monitoringBatteryItems.push(`3x ${escapeHtml(bebob150)}`);
     }
     addRow('Monitoring Batteries', monitoringBatteryItems.join('<br>'));
     addRow('Chargers', formatItems(chargersAcc));

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -1040,11 +1040,12 @@ describe('script.js functions', () => {
       'SmallHD Ultra 7': { screenSizeInches: 7 },
       MonA: { screenSizeInches: 7 }
     };
+    global.devices.batteries['Bebob V98micro'] = {};
     const html = generateGearListHtml({ monitoringPreferences: 'Directors Monitor 7" handheld' });
     expect(html).toContain('<select id="gearListDirectorsMonitor7"');
     expect(html).toContain('SmallHD Ultra 7');
     expect(html).toContain('Directors cage, shoulder strap, sunhood, rigging for teradeks');
-    expect(html).toContain('3x Bebob 98 Micros');
+    expect(html).toContain('3x Bebob V98micro');
     expect(html).toContain('C-Stand 20"');
     expect(html).toContain('Lite-Tite Swivel Aluminium Umbrella Adapter');
     expect(html).toContain('2x spigot');
@@ -1074,9 +1075,10 @@ describe('script.js functions', () => {
     };
     addOpt('motor1Select', 'MotorA');
     addOpt('videoSelect', 'VidA TX');
+    global.devices.batteries['Bebob V150micro'] = {};
     const html = generateGearListHtml();
     expect(html).toContain('Focus Monitor</strong> - 7&quot; - TV Logic F7HS incl Directors cage, shoulder strap, sunhood, rigging for teradeks');
-    expect(html).toContain('3x Bebob 150micro');
+    expect(html).toContain('3x Bebob V150micro');
     expect(html).toContain('2x Ultraslim BNC 0.3 m');
     expect(html).toContain('2x D-Tap to Mini XLR 3-pin Cable 0,3m');
     expect(html).toContain('1x <strong>Wireless Receiver</strong> - VidA RX');


### PR DESCRIPTION
## Summary
- Derive monitoring battery names from the device database
- Update gear list tests to use database-driven Bebob battery names

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6e02506b48320a5ec35ad1e9d2274