### PR TITLE
Move hotswap plate to battery list

### DIFF
--- a/script.js
+++ b/script.js
@@ -7134,12 +7134,6 @@ function generateGearListHtml(info = {}) {
     };
     addRow('Camera', formatItems([selectedNames.camera]));
     const cameraSupportItems = [selectedNames.batteryPlate, ...supportAccNoCages];
-    if (selectedNames.battery && batterySelect && batterySelect.value) {
-        const mount = devices.batteries?.[batterySelect.value]?.mount_type;
-        if (mount === 'V-Mount' || mount === 'B-Mount') {
-            cameraSupportItems.push(`Hotswap Plate ${mount}`);
-        }
-    }
     const cameraSupportText = formatItems(cameraSupportItems);
     let cageSelectHtml = '';
     if (compatibleCages.length) {
@@ -7207,14 +7201,20 @@ function generateGearListHtml(info = {}) {
     addRow('Lens Support', formatItems(lensSupportItems));
     addRow('Matte box + filter', '');
     addRow('LDS (FIZ)', formatItems([...selectedNames.motors, ...selectedNames.controllers, selectedNames.distance, ...fizCableAcc]));
-    let batteryItems = '';
+    const batteryItems = [];
     if (selectedNames.battery) {
         let count = batteryCountElem ? parseInt(batteryCountElem.textContent, 10) : NaN;
         if (!count || isNaN(count)) count = 1;
         const safeBatt = escapeHtml(selectedNames.battery);
-        batteryItems = `${count}x ${safeBatt}`;
+        batteryItems.push(`${count}x ${safeBatt}`);
+        if (batterySelect && batterySelect.value) {
+            const mount = devices.batteries?.[batterySelect.value]?.mount_type;
+            if (mount === 'V-Mount' || mount === 'B-Mount') {
+                batteryItems.push(`Hotswap Plate ${escapeHtml(mount)}`);
+            }
+        }
     }
-    addRow('Camera Batteries', batteryItems);
+    addRow('Camera Batteries', batteryItems.join('<br>'));
     let monitoringBatteryItems = [];
     if (monitoringPrefs.includes('Directors Monitor 7" handheld')) {
         monitoringBatteryItems.push('3x Bebob 98 Micros');

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -1118,8 +1118,8 @@ describe('script.js functions', () => {
     expect(html).toContain('Avenger C-Stand Sliding Leg 20"');
     expect(html).toContain('Lite-Tite Swivel Aluminium Umbrella Adapter');
     expect(html).toContain('3x Tennisball');
-    const msSection = html.slice(html.indexOf('Monitoring support'), html.indexOf('Power'));
-    expect(msSection).toContain('2x Antenna 5,8GHz 5dBi Long (spare)');
+    const msSection2 = html.slice(html.indexOf('Monitoring support'), html.indexOf('Power'));
+    expect(msSection2).toContain('2x Antenna 5,8GHz 5dBi Long (spare)');
   });
 
   test('director handheld and focus monitor each get wireless receiver', () => {
@@ -1158,7 +1158,7 @@ describe('script.js functions', () => {
     expect(html).toContain('6x BattA');
   });
 
-  test('gear list adds hotswap plate matching battery mount', () => {
+  test('gear list adds hotswap plate matching battery mount in batteries row', () => {
     const { generateGearListHtml } = script;
     const addOpt = (id, value) => {
       const sel = document.getElementById(id);
@@ -1168,12 +1168,16 @@ describe('script.js functions', () => {
     // V-Mount battery
     addOpt('batterySelect', 'BattA');
     let html = generateGearListHtml();
-    expect(html).toContain('1x Hotswap Plate V-Mount');
+    let camSupportSection = html.slice(html.indexOf('Camera Support'), html.indexOf('Lens Support'));
+    expect(camSupportSection).not.toContain('Hotswap Plate');
+    let batterySection = html.slice(html.indexOf('Camera Batteries'), html.indexOf('Monitoring Batteries'));
+    expect(batterySection).toContain('Hotswap Plate V-Mount');
     // B-Mount battery
     devices.batteries.BattB = { capacity: 100, pinA: 10, dtapA: 5, mount_type: 'B-Mount' };
     addOpt('batterySelect', 'BattB');
     html = generateGearListHtml();
-    expect(html).toContain('1x Hotswap Plate B-Mount');
+    batterySection = html.slice(html.indexOf('Camera Batteries'), html.indexOf('Monitoring Batteries'));
+    expect(batterySection).toContain('Hotswap Plate B-Mount');
   });
 
   test('gear list lists 4x media cards with usable size', () => {


### PR DESCRIPTION
## Summary
- show hotswap plate under Camera Batteries instead of Camera Support
- adjust tests for new hotswap placement

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6e07daf2c8320a2b1ad3ad6bbd07e