### PR TITLE
Fix hotswap placement in gear list

### DIFF
--- a/script.js
+++ b/script.js
@@ -7134,12 +7134,6 @@ function generateGearListHtml(info = {}) {
     };
     addRow('Camera', formatItems([selectedNames.camera]));
     const cameraSupportItems = [selectedNames.batteryPlate, ...supportAccNoCages];
-    if (selectedNames.battery && batterySelect && batterySelect.value) {
-        const mount = devices.batteries?.[batterySelect.value]?.mount_type;
-        if (mount === 'V-Mount' || mount === 'B-Mount') {
-            cameraSupportItems.push(`Hotswap Plate ${mount}`);
-        }
-    }
     const cameraSupportText = formatItems(cameraSupportItems);
     let cageSelectHtml = '';
     if (compatibleCages.length) {
@@ -7213,6 +7207,10 @@ function generateGearListHtml(info = {}) {
         if (!count || isNaN(count)) count = 1;
         const safeBatt = escapeHtml(selectedNames.battery);
         batteryItems = `${count}x ${safeBatt}`;
+        const mount = devices.batteries?.[batterySelect && batterySelect.value]?.mount_type;
+        if (mount === 'V-Mount' || mount === 'B-Mount') {
+            batteryItems += `<br>1x Hotswap Plate ${mount}`;
+        }
     }
     addRow('Camera Batteries', batteryItems);
     let monitoringBatteryItems = [];

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -1157,7 +1157,7 @@ describe('script.js functions', () => {
     expect(html).toContain('6x BattA');
   });
 
-  test('gear list adds hotswap plate matching battery mount', () => {
+  test('gear list adds hotswap plate only in battery section', () => {
     const { generateGearListHtml } = script;
     const addOpt = (id, value) => {
       const sel = document.getElementById(id);
@@ -1167,12 +1167,18 @@ describe('script.js functions', () => {
     // V-Mount battery
     addOpt('batterySelect', 'BattA');
     let html = generateGearListHtml();
-    expect(html).toContain('1x Hotswap Plate V-Mount');
+    let csSection = html.slice(html.indexOf('Camera Support'), html.indexOf('Lens Support'));
+    let battSection = html.slice(html.indexOf('Camera Batteries'), html.indexOf('Monitoring Batteries'));
+    expect(csSection).not.toContain('Hotswap Plate');
+    expect(battSection).toContain('1x Hotswap Plate V-Mount');
     // B-Mount battery
     devices.batteries.BattB = { capacity: 100, pinA: 10, dtapA: 5, mount_type: 'B-Mount' };
     addOpt('batterySelect', 'BattB');
     html = generateGearListHtml();
-    expect(html).toContain('1x Hotswap Plate B-Mount');
+    csSection = html.slice(html.indexOf('Camera Support'), html.indexOf('Lens Support'));
+    battSection = html.slice(html.indexOf('Camera Batteries'), html.indexOf('Monitoring Batteries'));
+    expect(csSection).not.toContain('Hotswap Plate');
+    expect(battSection).toContain('1x Hotswap Plate B-Mount');
   });
 
   test('gear list lists 4x media cards with usable size', () => {


### PR DESCRIPTION
## Summary
- restrict camera support to battery plate and accessories
- add hotswap plate entry to camera batteries when using V- or B-mount
- adjust tests to verify hotswap plate only appears in battery section

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b7040e19988320838b8a593137dd34