### PR TITLE
feat: expand lens database with additional lenses

### DIFF
--- a/devices/gearList.js
+++ b/devices/gearList.js
@@ -1347,6 +1347,13 @@ const gear = {
         "tStop": 4.2,
         "mount": "PL"
       },
+      "ARRI Signature Prime 12mm T1.8": {
+        "brand": "ARRI",
+        "frontDiameterMm": 134,
+        "clampOn": true,
+        "tStop": 1.8,
+        "mount": "LPL"
+      },
       "ARRI Signature Prime 15mm T1.8": {
         "brand": "ARRI",
         "frontDiameterMm": 114,
@@ -1370,6 +1377,111 @@ const gear = {
         "frontDiameterMm": 114,
         "clampOn": true,
         "tStop": 1.8
+      },
+      "ARRI Signature Prime 29mm T1.8": {
+        "brand": "ARRI",
+        "frontDiameterMm": 114,
+        "clampOn": true,
+        "tStop": 1.8,
+        "mount": "LPL"
+      },
+      "ARRI Signature Prime 35mm T1.8": {
+        "brand": "ARRI",
+        "frontDiameterMm": 114,
+        "clampOn": true,
+        "tStop": 1.8,
+        "mount": "LPL"
+      },
+      "ARRI Signature Prime 40mm T1.8": {
+        "brand": "ARRI",
+        "frontDiameterMm": 114,
+        "clampOn": true,
+        "tStop": 1.8,
+        "mount": "LPL"
+      },
+      "ARRI Signature Prime 47mm T1.8": {
+        "brand": "ARRI",
+        "frontDiameterMm": 114,
+        "clampOn": true,
+        "tStop": 1.8,
+        "mount": "LPL"
+      },
+      "ARRI Signature Prime 58mm T1.8": {
+        "brand": "ARRI",
+        "frontDiameterMm": 114,
+        "clampOn": true,
+        "tStop": 1.8,
+        "mount": "LPL"
+      },
+      "ARRI Signature Prime 75mm T1.8": {
+        "brand": "ARRI",
+        "frontDiameterMm": 114,
+        "clampOn": true,
+        "tStop": 1.8,
+        "mount": "LPL"
+      },
+      "ARRI Signature Prime 95mm T1.8": {
+        "brand": "ARRI",
+        "frontDiameterMm": 114,
+        "clampOn": true,
+        "tStop": 1.8,
+        "mount": "LPL"
+      },
+      "ARRI Signature Prime 125mm T1.8": {
+        "brand": "ARRI",
+        "frontDiameterMm": 114,
+        "clampOn": true,
+        "tStop": 1.8,
+        "mount": "LPL"
+      },
+      "ARRI Signature Prime 150mm T1.8": {
+        "brand": "ARRI",
+        "frontDiameterMm": 114,
+        "clampOn": true,
+        "tStop": 1.8,
+        "mount": "LPL"
+      },
+      "ARRI Signature Prime 200mm T2.5": {
+        "brand": "ARRI",
+        "frontDiameterMm": 114,
+        "clampOn": true,
+        "tStop": 2.5,
+        "mount": "LPL"
+      },
+      "ARRI Signature Prime 280mm T2.8": {
+        "brand": "ARRI",
+        "frontDiameterMm": 134,
+        "clampOn": true,
+        "tStop": 2.8,
+        "mount": "LPL"
+      },
+      "ARRI Signature Zoom 16-32mm T2.8": {
+        "brand": "ARRI",
+        "frontDiameterMm": 156,
+        "clampOn": true,
+        "tStop": 2.8,
+        "mount": "LPL"
+      },
+      "ARRI Signature Zoom 24-75mm T2.8": {
+        "brand": "ARRI",
+        "frontDiameterMm": 114,
+        "clampOn": true,
+        "tStop": 2.8,
+        "mount": "LPL"
+      },
+      "ARRI Signature Zoom 45-135mm T2.8": {
+        "brand": "ARRI",
+        "frontDiameterMm": 114,
+        "clampOn": true,
+        "tStop": 2.8,
+        "mount": "LPL"
+      },
+      "ARRI Signature Zoom 65-300mm T2.8": {
+        "brand": "ARRI",
+        "frontDiameterMm": 156,
+        "clampOn": true,
+        "tStop": 2.8,
+        "mount": "LPL"
       },
       "ARRI/ZEISS Ultra Prime 16mm T1.9": {
         "brand": "ARRI/ZEISS",
@@ -1425,6 +1537,48 @@ const gear = {
         "clampOn": true,
         "tStop": 1.9
       },
+      "ZEISS Master Prime 14mm T1.3": {
+        "brand": "ZEISS/ARRI",
+        "frontDiameterMm": 114,
+        "clampOn": true,
+        "tStop": 1.3,
+        "mount": "PL"
+      },
+      "ZEISS Master Prime 27mm T1.3": {
+        "brand": "ZEISS/ARRI",
+        "frontDiameterMm": 114,
+        "clampOn": true,
+        "tStop": 1.3,
+        "mount": "PL"
+      },
+      "ZEISS Master Prime 40mm T1.3": {
+        "brand": "ZEISS/ARRI",
+        "frontDiameterMm": 114,
+        "clampOn": true,
+        "tStop": 1.3,
+        "mount": "PL"
+      },
+      "ZEISS Master Prime 65mm T1.3": {
+        "brand": "ZEISS/ARRI",
+        "frontDiameterMm": 114,
+        "clampOn": true,
+        "tStop": 1.3,
+        "mount": "PL"
+      },
+      "ZEISS Master Prime 100mm T1.3": {
+        "brand": "ZEISS/ARRI",
+        "frontDiameterMm": 114,
+        "clampOn": true,
+        "tStop": 1.3,
+        "mount": "PL"
+      },
+      "ZEISS Master Prime 135mm T1.3": {
+        "brand": "ZEISS/ARRI",
+        "frontDiameterMm": 114,
+        "clampOn": true,
+        "tStop": 1.3,
+        "mount": "PL"
+      },
       "ZEISS Compact Zoom CZ.2 28-80mm T2.9": {
         "brand": "ZEISS",
         "frontDiameterMm": 95,
@@ -1448,6 +1602,146 @@ const gear = {
         "frontDiameterMm": 95,
         "clampOn": true,
         "tStop": 1.5
+      },
+      "Leitz Summicron-C 18mm T2.0": {
+        "brand": "Leitz",
+        "frontDiameterMm": 95,
+        "clampOn": true,
+        "tStop": 2.0,
+        "mount": "PL"
+      },
+      "Leitz Summicron-C 25mm T2.0": {
+        "brand": "Leitz",
+        "frontDiameterMm": 95,
+        "clampOn": true,
+        "tStop": 2.0,
+        "mount": "PL"
+      },
+      "Leitz Summicron-C 35mm T2.0": {
+        "brand": "Leitz",
+        "frontDiameterMm": 95,
+        "clampOn": true,
+        "tStop": 2.0,
+        "mount": "PL"
+      },
+      "Leitz Summicron-C 50mm T2.0": {
+        "brand": "Leitz",
+        "frontDiameterMm": 95,
+        "clampOn": true,
+        "tStop": 2.0,
+        "mount": "PL"
+      },
+      "Leitz Summicron-C 75mm T2.0": {
+        "brand": "Leitz",
+        "frontDiameterMm": 95,
+        "clampOn": true,
+        "tStop": 2.0,
+        "mount": "PL"
+      },
+      "Leitz Summicron-C 100mm T2.0": {
+        "brand": "Leitz",
+        "frontDiameterMm": 95,
+        "clampOn": true,
+        "tStop": 2.0,
+        "mount": "PL"
+      },
+      "Cooke S7/i FF 25mm T2.0": {
+        "brand": "Cooke",
+        "frontDiameterMm": 110,
+        "clampOn": true,
+        "tStop": 2.0,
+        "mount": "PL"
+      },
+      "Cooke S7/i FF 32mm T2.0": {
+        "brand": "Cooke",
+        "frontDiameterMm": 110,
+        "clampOn": true,
+        "tStop": 2.0,
+        "mount": "PL"
+      },
+      "Cooke S7/i FF 40mm T2.0": {
+        "brand": "Cooke",
+        "frontDiameterMm": 110,
+        "clampOn": true,
+        "tStop": 2.0,
+        "mount": "PL"
+      },
+      "Cooke S7/i FF 50mm T2.0": {
+        "brand": "Cooke",
+        "frontDiameterMm": 110,
+        "clampOn": true,
+        "tStop": 2.0,
+        "mount": "PL"
+      },
+      "Cooke S7/i FF 75mm T2.0": {
+        "brand": "Cooke",
+        "frontDiameterMm": 110,
+        "clampOn": true,
+        "tStop": 2.0,
+        "mount": "PL"
+      },
+      "Cooke S7/i FF 100mm T2.0": {
+        "brand": "Cooke",
+        "frontDiameterMm": 110,
+        "clampOn": true,
+        "tStop": 2.0,
+        "mount": "PL"
+      },
+      "Fujinon Premista 19-45mm T2.9": {
+        "brand": "Fujinon",
+        "frontDiameterMm": 114,
+        "clampOn": true,
+        "tStop": 2.9,
+        "mount": "PL"
+      },
+      "Fujinon Premista 28-100mm T2.9": {
+        "brand": "Fujinon",
+        "frontDiameterMm": 114,
+        "clampOn": true,
+        "tStop": 2.9,
+        "mount": "PL"
+      },
+      "Fujinon Premista 80-250mm T2.9-3.5": {
+        "brand": "Fujinon",
+        "frontDiameterMm": 114,
+        "clampOn": true,
+        "tStop": 2.9,
+        "mount": "PL"
+      },
+      "DZOFilm Vespid 35mm T2.1": {
+        "brand": "DZOFilm",
+        "frontDiameterMm": 80,
+        "clampOn": true,
+        "tStop": 2.1,
+        "mount": "PL"
+      },
+      "DZOFilm Vespid 50mm T2.1": {
+        "brand": "DZOFilm",
+        "frontDiameterMm": 80,
+        "clampOn": true,
+        "tStop": 2.1,
+        "mount": "PL"
+      },
+      "DZOFilm Vespid 75mm T2.1": {
+        "brand": "DZOFilm",
+        "frontDiameterMm": 80,
+        "clampOn": true,
+        "tStop": 2.1,
+        "mount": "PL"
+      },
+      "Meike FF Prime 24mm T2.1": {
+        "brand": "Meike",
+        "frontDiameterMm": 85,
+        "clampOn": true,
+        "tStop": 2.1,
+        "mount": "PL"
+      },
+      "Meike FF Prime 35mm T2.1": {
+        "brand": "Meike",
+        "frontDiameterMm": 85,
+        "clampOn": true,
+        "tStop": 2.1,
+        "mount": "PL"
       },
       "Cooke Speed Panchro 18mm (P+S rehousing)": {
         "brand": "Cooke (P+S rehoused)",
@@ -1625,6 +1919,13 @@ const lensSupportDefaults = {
   "Angénieux Optimo Ultra 12x 36-435mm T4.2 (FF/VV)": { rodStandard: "19mm", rodLengthCm: 60, needsLensSupport: true },
   "ZEISS Compact Zoom CZ.2 28-80mm T2.9": { rodStandard: "15mm", rodLengthCm: 45, needsLensSupport: true },
   "ZEISS Compact Zoom CZ.2 70-200mm T2.9": { rodStandard: "15mm", rodLengthCm: 45, needsLensSupport: true },
+  "ARRI Signature Zoom 16-32mm T2.8": { rodStandard: "19mm", rodLengthCm: 45, needsLensSupport: true },
+  "ARRI Signature Zoom 24-75mm T2.8": { rodStandard: "15mm", rodLengthCm: 45, needsLensSupport: true },
+  "ARRI Signature Zoom 45-135mm T2.8": { rodStandard: "15mm", rodLengthCm: 45, needsLensSupport: true },
+  "ARRI Signature Zoom 65-300mm T2.8": { rodStandard: "19mm", rodLengthCm: 45, needsLensSupport: true },
+  "Fujinon Premista 19-45mm T2.9": { rodStandard: "15mm", rodLengthCm: 45, needsLensSupport: true },
+  "Fujinon Premista 28-100mm T2.9": { rodStandard: "15mm", rodLengthCm: 45, needsLensSupport: true },
+  "Fujinon Premista 80-250mm T2.9-3.5": { rodStandard: "19mm", rodLengthCm: 45, needsLensSupport: true },
   "Laowa 24mm T8 2× Pro2be (3-lens set: Direct / 35° / Periscope)": { rodStandard: "15mm", rodLengthCm: 45, needsLensSupport: true },
   "Sony FE 70–200mm f/2.8 G Master II": { rodStandard: "15mm", rodLengthCm: 45, needsLensSupport: true }
 };


### PR DESCRIPTION
## Summary
- add ARRI Signature Prime and Zoom lenses
- include ZEISS Master Prime, Leitz Summicron-C, Cooke S7/i FF, Fujinon Premista, DZOFilm Vespid, and Meike FF Prime lenses
- define lens support defaults for new zooms

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b7061429a08320bda449285265f2f8