### PR TITLE
Add filter for lens selector

### DIFF
--- a/index.html
+++ b/index.html
@@ -881,7 +881,13 @@
           <option value="59.94">59.94</option>
           <option value="60">60</option>
         </select></label></div>
-      <div class="form-row"><label for="lenses">Lenses:<select id="lenses" name="lenses" multiple size="10"></select></label></div>
+      <div class="form-row">
+        <label for="lenses" id="lensesLabel">Lenses:</label>
+        <div class="select-wrapper">
+          <input type="search" id="lensFilter" class="filter-input" placeholder="Filter..." aria-label="Filter" inputmode="search" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" />
+          <select id="lenses" name="lenses" multiple size="10" aria-labelledby="lensesLabel"></select>
+        </div>
+      </div>
       <div class="form-row"><label for="requiredScenarios">What required scenarios do we have for this shoot?
         <select id="requiredScenarios" name="requiredScenarios" multiple size="25">
           <option value="Indoor">Indoor</option>

--- a/script.js
+++ b/script.js
@@ -1256,6 +1256,7 @@ function setLanguage(lang) {
     {input: controllerFilterInput, label: texts[lang].fizControllersLabel},
     {input: distanceFilterInput, label: texts[lang].distanceLabel},
     {input: batteryFilterInput, label: texts[lang].batteryLabel},
+    {input: lensFilterInput, label: texts[lang].lensesLabel},
     {input: cameraListFilterInput, label: texts[lang].category_cameras},
     {input: viewfinderListFilterInput, label: texts[lang].category_viewfinders},
     {input: monitorListFilterInput, label: texts[lang].category_monitors},
@@ -1465,6 +1466,7 @@ const controllerSelects = [
 ];
 const distanceSelect = document.getElementById("distanceSelect");
 const batterySelect  = document.getElementById("batterySelect");
+const lensSelect     = document.getElementById("lenses");
 
 const totalPowerElem      = document.getElementById("totalPower");
 const totalCurrent144Elem = document.getElementById("totalCurrent144");
@@ -1760,6 +1762,7 @@ const motorFilterInput = document.getElementById("motorFilter");
 const controllerFilterInput = document.getElementById("controllerFilter");
 const distanceFilterInput = document.getElementById("distanceFilter");
 const batteryFilterInput = document.getElementById("batteryFilter");
+const lensFilterInput = document.getElementById("lensFilter");
 
 // List filters for existing device categories
 const cameraListFilterInput = document.getElementById("cameraListFilter");
@@ -3365,7 +3368,7 @@ function clearFilterOnSelect(selectElem, filterInput, resetCallback) {
 
 function clearAllFilters() {
   [cameraFilterInput, monitorFilterInput, videoFilterInput, cageFilterInput, motorFilterInput,
-   controllerFilterInput, distanceFilterInput, batteryFilterInput].forEach(input => {
+   controllerFilterInput, distanceFilterInput, batteryFilterInput, lensFilterInput].forEach(input => {
     if (input) input.value = "";
   });
   filterSelect(cameraSelect, "");
@@ -3376,6 +3379,7 @@ function clearAllFilters() {
   controllerSelects.forEach(sel => filterSelect(sel, ""));
   filterSelect(distanceSelect, "");
   filterSelect(batterySelect, "");
+  filterSelect(lensSelect, "");
 }
 
 function applyFilters() {
@@ -3387,6 +3391,7 @@ function applyFilters() {
   controllerSelects.forEach(sel => filterSelect(sel, controllerFilterInput.value));
   filterSelect(distanceSelect, distanceFilterInput.value);
   filterSelect(batterySelect, batteryFilterInput.value);
+  filterSelect(lensSelect, lensFilterInput.value);
 
   filterDeviceList(cameraListElem, cameraListFilterInput.value);
   filterDeviceList(viewfinderListElem, viewfinderListFilterInput.value);
@@ -5154,6 +5159,7 @@ bindFilterInput(motorFilterInput, () => motorSelects.forEach(sel => filterSelect
 bindFilterInput(controllerFilterInput, () => controllerSelects.forEach(sel => filterSelect(sel, controllerFilterInput.value)));
 bindFilterInput(distanceFilterInput, () => filterSelect(distanceSelect, distanceFilterInput.value));
 bindFilterInput(batteryFilterInput, () => filterSelect(batterySelect, batteryFilterInput.value));
+bindFilterInput(lensFilterInput, () => filterSelect(lensSelect, lensFilterInput.value));
 
 clearFilterOnSelect(cameraSelect, cameraFilterInput);
 clearFilterOnSelect(monitorSelect, monitorFilterInput);
@@ -5163,6 +5169,7 @@ motorSelects.forEach(sel => clearFilterOnSelect(sel, motorFilterInput, () => mot
 controllerSelects.forEach(sel => clearFilterOnSelect(sel, controllerFilterInput, () => controllerSelects.forEach(s => filterSelect(s, ""))));
 clearFilterOnSelect(distanceSelect, distanceFilterInput);
 clearFilterOnSelect(batterySelect, batteryFilterInput);
+clearFilterOnSelect(lensSelect, lensFilterInput);
 
 clearFiltersBtn.addEventListener("click", clearAllFilters);
 
@@ -8188,12 +8195,14 @@ function initApp() {
   }
   populateEnvironmentDropdowns();
   populateLensDropdown();
+  attachSelectSearch(lensSelect);
   populateFilterDropdown();
   setLanguage(currentLang);
   resetDeviceForm();
   restoreSessionState();
   applySharedSetupFromUrl();
   updateCalculations();
+  applyFilters();
 }
 
 function populateEnvironmentDropdowns() {
@@ -8213,7 +8222,6 @@ function populateEnvironmentDropdowns() {
 }
 
 function populateLensDropdown() {
-  const lensSelect = document.getElementById('lenses');
   if (!lensSelect) return;
 
   lensSelect.innerHTML = '';

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -174,6 +174,16 @@ describe('script.js functions', () => {
     expect(Array.from(sel.options).map(o => o.value)).toEqual(['LensA']);
   });
 
+  test('lens filter narrows lens options', () => {
+    const sel = document.getElementById('lenses');
+    sel.innerHTML = '<option value="LensA">LensA</option><option value="LensB">LensB</option>';
+    const input = document.getElementById('lensFilter');
+    input.value = 'b';
+    input.dispatchEvent(new Event('input'));
+    expect(sel.options[0].hidden).toBe(true);
+    expect(sel.options[1].hidden).toBe(false);
+  });
+
   test('selected cage appears in camera support category of gear list', () => {
     const addOpt = (id, value) => {
       const sel = document.getElementById(id);

--- a/translations.js
+++ b/translations.js
@@ -67,6 +67,7 @@ const texts = {
     batteryLabel: "V-Mount Battery:",
     batteryBMountLabel: "B-Mount Battery:",
     batteryPlateLabel: "Battery Plate:",
+    lensesLabel: "Lenses:",
 
     fizLegend: "FIZ (Follow Focus) Systems",
     fizMotorsLabel: "FIZ Motors:",
@@ -420,6 +421,7 @@ const texts = {
     batteryLabel: "Batteria a V-Mount:",
     batteryBMountLabel: "Batteria B-Mount:",
     batteryPlateLabel: "Piastra batteria:",
+    lensesLabel: "Obiettivi:",
     fizLegend: "Sistemi FIZ (Follow Focus)",
     fizMotorsLabel: "Motori FIZ:",
     fizControllersLabel: "Controller FIZ:",
@@ -752,6 +754,7 @@ const texts = {
     batteryLabel: "Batería V-Mount:",
     batteryBMountLabel: "Batería B-Mount:",
     batteryPlateLabel: "Placa de Batería:",
+    lensesLabel: "Lentes:",
 
     fizLegend: "Sistemas FIZ (Follow Focus)",
     fizMotorsLabel: "Motores FIZ:",
@@ -1098,6 +1101,7 @@ const texts = {
     batteryLabel: "Batterie V-Mount:",
     batteryBMountLabel: "Batterie B-Mount:",
     batteryPlateLabel: "Plaque Batterie:",
+    lensesLabel: "Objectifs:",
 
     fizLegend: "Systèmes FIZ",
     fizMotorsLabel: "Moteurs FIZ:",
@@ -1446,6 +1450,7 @@ const texts = {
     batteryLabel: "V-Mount Akku:",
     batteryBMountLabel: "B-Mount Akku:",
     batteryPlateLabel: "Akkuschacht:",
+    lensesLabel: "Objektive:",
 
     fizLegend: "FIZ (Follow Focus) Systeme",
     fizMotorsLabel: "FIZ Motoren:",


### PR DESCRIPTION
## Summary
- Add search input to the lens selector so users can filter available lenses
- Integrate lens filter with existing filter utilities and translations
- Test lens filtering behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b74066719c8320a915a94da2e8dd58