### PR TITLE
Exclude lenses from project requirements list

### DIFF
--- a/script.js
+++ b/script.js
@@ -7094,6 +7094,7 @@ function generateGearListHtml(info = {}) {
         supportAccNoCages.push('ARRI KK.0037820 Handle Extension Set');
     }
     const projectInfo = { ...info };
+    delete projectInfo.lenses;
     if (monitoringSupportPrefs.length) {
         projectInfo.monitoringSupport = monitoringSupportPrefs.join(', ');
     }

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -229,6 +229,18 @@ describe('script.js functions', () => {
     expect(supportRow.textContent).toContain('15mm lens support');
   });
 
+  test('selected lens does not appear in project requirements list', () => {
+    const html = script.generateGearListHtml({ lenses: 'LensA' });
+    expect(html).not.toContain('Lenses: LensA');
+    const wrap = document.createElement('div');
+    wrap.innerHTML = html;
+    const rows = Array.from(wrap.querySelectorAll('.gear-table tr'));
+    const lensIndex = rows.findIndex(r => r.textContent === 'Lens');
+    expect(lensIndex).toBeGreaterThanOrEqual(0);
+    const lensRow = rows[lensIndex + 1];
+    expect(lensRow.textContent).toContain('LensA');
+  });
+
   test('gear list updates when device selection changes', () => {
     const projectDialog = document.getElementById('projectDialog');
     projectDialog.close = jest.fn();


### PR DESCRIPTION
## Summary
- Skip adding selected lenses to the Project Requirements section
- Test that lenses only appear in the gear table

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b74fc0ddf88320995bd44aa61b7d6f