### PR TITLE
Show selected filters only in gear list table

### DIFF
--- a/script.js
+++ b/script.js
@@ -7045,6 +7045,9 @@ function generateGearListHtml(info = {}) {
     const monitoringPrefs = info.monitoringPreferences
         ? info.monitoringPreferences.split(',').map(s => s.trim()).filter(Boolean)
         : [];
+    const selectedFilters = info.filter
+        ? info.filter.split(',').map(s => s.trim()).filter(Boolean)
+        : [];
     const monitorEquipOptions = ['Directors Monitor 7" handheld', 'Directors Monitor 15-19 inch', 'Combo Monitor 15-19 inch'];
     const monitoringEquipmentPrefs = monitoringPrefs.filter(p => monitorEquipOptions.includes(p));
     const monitoringSupportPrefs = monitoringPrefs.filter(p => !monitorEquipOptions.includes(p));
@@ -7101,6 +7104,7 @@ function generateGearListHtml(info = {}) {
         projectInfo.monitoring = monitoringEquipmentPrefs.join(', ');
     }
     delete projectInfo.monitoringPreferences;
+    delete projectInfo.filter;
     const projectTitle = escapeHtml(info.projectName || setupNameInput.value);
     const labels = {
         dop: 'DoP',
@@ -7206,7 +7210,7 @@ function generateGearListHtml(info = {}) {
         }
     });
     addRow('Lens Support', formatItems(lensSupportItems));
-    addRow('Matte box + filter', '');
+    addRow('Matte box + filter', formatItems(selectedFilters));
     addRow('LDS (FIZ)', formatItems([...selectedNames.motors, ...selectedNames.controllers, selectedNames.distance, ...fizCableAcc]));
     let batteryItems = '';
     if (selectedNames.battery) {

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -996,7 +996,7 @@ describe('script.js functions', () => {
       expect(html).toContain('<h3>Project Requirements</h3>');
       expect(html).toContain('DoP: DopName');
       expect(html).toContain('Required Scenarios: Handheld, Slider');
-      expect(html).toContain('Filter: IRND');
+      expect(html).not.toContain('Filter: IRND');
       expect(html).toContain('<table class="gear-table">');
       expect(html).toContain('Camera');
       expect(html).toContain('1x CamA');
@@ -1041,6 +1041,8 @@ describe('script.js functions', () => {
       expect(miscSection).not.toContain('D-Tap to Mini XLR 3-pin Cable 0,3m');
       expect(html).not.toContain('Ultraslim BNC 0.5 m');
       expect(html).not.toContain('HDMI Cable');
+      const filterSection = html.slice(html.indexOf('Matte box + filter'), html.indexOf('LDS (FIZ)'));
+      expect(filterSection).toContain('1x IRND');
     });
 
   test('standard rigging accessories are always included', () => {


### PR DESCRIPTION
## Summary
- Include selected filters only within the "Matte box + filter" table row
- Remove filter selections from the Project Requirements summary
- Update tests to cover new filter placement

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b750982a108320a2c744b4e67b0cfd