### PR TITLE
Fix FIZ fieldset overflow on mobile

### DIFF
--- a/style.css
+++ b/style.css
@@ -200,6 +200,10 @@ p {
     min-width: unset;
     margin-bottom: 5px;
   }
+  .form-row select,
+  .form-row input {
+    margin: 5px 0 0 0;
+  }
 }
 
 @supports (-webkit-touch-callout: none) {
@@ -1223,6 +1227,10 @@ body.dark-mode.pink-mode .help-content { border-color: var(--accent-color); }
     width: auto;
     min-width: auto;
     margin-bottom: 4px;
+  }
+  .form-row select,
+  .form-row input {
+    margin: 5px 0 0 0;
   }
 
   .form-row > button {


### PR DESCRIPTION
## Summary
- Prevent FIZ fieldset border from exceeding viewport width on mobile by removing right margin from form controls in narrow layouts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b74f6618348320b2a9db61c50304e0