### PR TITLE
Add icon summary for required scenarios

### DIFF
--- a/index.html
+++ b/index.html
@@ -916,7 +916,9 @@
           <option value="Zoom Remote handle">Zoom Remote handle</option>
           <option value="Dolly Remote handle">Dolly Remote handle</option>
         </select>
-      </label></div>
+      </label>
+      <div id="requiredScenariosSummary" class="scenario-summary" aria-live="polite"></div>
+      </div>
       <div class="form-row"><label for="rigging">How would you like to have your camera rigged?
         <select id="rigging" name="rigging" multiple size="15">
           <option value="Shoulder rig">Shoulder rig</option>

--- a/script.js
+++ b/script.js
@@ -1467,6 +1467,8 @@ const controllerSelects = [
 const distanceSelect = document.getElementById("distanceSelect");
 const batterySelect  = document.getElementById("batterySelect");
 const lensSelect     = document.getElementById("lenses");
+const requiredScenariosSelect = document.getElementById("requiredScenarios");
+const requiredScenariosSummary = document.getElementById("requiredScenariosSummary");
 
 const totalPowerElem      = document.getElementById("totalPower");
 const totalCurrent144Elem = document.getElementById("totalCurrent144");
@@ -8185,6 +8187,50 @@ function isRunningPWA() {
   );
 }
 
+const scenarioIcons = {
+  Indoor: '🏠',
+  Outdoor: '🌳',
+  Studio: '🎬',
+  Tripod: '🎥',
+  Handheld: '✋',
+  Easyrig: '🎒',
+  'Cine Saddle': '💺',
+  Steadybag: '👜',
+  Dolly: '🛞',
+  Slider: '📏',
+  Steadicam: '🏃',
+  Gimbal: '🌀',
+  Trinity: '♾️',
+  Rollcage: '🛡️',
+  'Car Mount': '🚗',
+  Jib: '🪝',
+  'Undersling mode': '⬇️',
+  Crane: '🏗️',
+  'Remote Head': '🎮',
+  'Extreme weather conditions (like snow, rain, heat)': '🌧️',
+  'Rain Machine': '🌧️',
+  'Slow Motion': '🐌',
+  'Viewfinder Extension': '🔭',
+  'Zoom Remote handle': '🔍',
+  'Dolly Remote handle': '🎛️'
+};
+
+function updateRequiredScenariosSummary() {
+  if (!requiredScenariosSelect || !requiredScenariosSummary) return;
+  requiredScenariosSummary.innerHTML = '';
+  const selected = Array.from(requiredScenariosSelect.selectedOptions).map(o => o.value);
+  selected.forEach(val => {
+    const box = document.createElement('span');
+    box.className = 'scenario-box';
+    const iconSpan = document.createElement('span');
+    iconSpan.className = 'scenario-icon';
+    iconSpan.textContent = scenarioIcons[val] || '📌';
+    box.appendChild(iconSpan);
+    box.appendChild(document.createTextNode(val));
+    requiredScenariosSummary.appendChild(box);
+  });
+}
+
 function initApp() {
   if (sharedLinkRow) {
     if (isRunningPWA()) {
@@ -8201,6 +8247,10 @@ function initApp() {
   resetDeviceForm();
   restoreSessionState();
   applySharedSetupFromUrl();
+  if (requiredScenariosSelect) {
+    requiredScenariosSelect.addEventListener('change', updateRequiredScenariosSummary);
+    updateRequiredScenariosSummary();
+  }
   updateCalculations();
   applyFilters();
 }
@@ -8358,5 +8408,6 @@ if (typeof module !== "undefined" && module.exports) {
     populateLensDropdown,
     populateSensorModeDropdown,
     populateCodecDropdown,
+    updateRequiredScenariosSummary,
   };
 }

--- a/style.css
+++ b/style.css
@@ -736,6 +736,12 @@ button:disabled {
   flex-wrap: wrap;
 }
 
+.scenario-summary {
+  margin-top: 4px;
+  display: flex;
+  flex-wrap: wrap;
+}
+
 .connector-block,
 .info-box {
   display: inline-block;
@@ -745,6 +751,21 @@ button:disabled {
   border: 1px solid;
   background-color: rgba(0,0,0,0.03);
   font-size: 0.75em;
+}
+
+.scenario-box {
+  display: flex;
+  align-items: center;
+  padding: 2px 6px;
+  margin: 2px;
+  border-radius: 3px;
+  border: 1px solid;
+  background-color: rgba(0,0,0,0.03);
+  font-size: 0.75em;
+}
+
+.scenario-box .scenario-icon {
+  margin-right: 4px;
 }
 
 .tray-box {
@@ -1077,6 +1098,7 @@ body.dark-mode.pink-mode h2 {
 }
 .dark-mode .connector-block,
 .dark-mode .info-box { background-color: rgba(255,255,255,0.1); }
+.dark-mode .scenario-box { background-color: rgba(255,255,255,0.1); }
 .dark-mode .power-conn { background-color: rgba(244, 67, 54, 0.3); }
 .dark-mode .fiz-conn { background-color: rgba(76, 175, 80, 0.3); }
 .dark-mode .video-conn { background-color: rgba(33, 150, 243, 0.3); }
@@ -1150,6 +1172,7 @@ body.dark-mode.pink-mode .help-content { border-color: var(--accent-color); }
   }
   body:not(.light-mode) .connector-block,
   body:not(.light-mode) .info-box { background-color: rgba(255,255,255,0.1); }
+  body:not(.light-mode) .scenario-box { background-color: rgba(255,255,255,0.1); }
   body:not(.light-mode) .power-conn { background-color: rgba(244, 67, 54, 0.3); }
   body:not(.light-mode) .fiz-conn { background-color: rgba(76, 175, 80, 0.3); }
   body:not(.light-mode) .video-conn { background-color: rgba(33, 150, 243, 0.3); }

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -1229,6 +1229,17 @@ describe('script.js functions', () => {
     expect(itemsRow.textContent).toContain('1x SHAPE Telescopic Handle ARRI Rosette Kit 12"');
   });
 
+  test('updateRequiredScenariosSummary creates a box for each selection', () => {
+    const select = document.getElementById('requiredScenarios');
+    select.querySelector('option[value="Indoor"]').selected = true;
+    select.querySelector('option[value="Gimbal"]').selected = true;
+    script.updateRequiredScenariosSummary();
+    const boxes = document.querySelectorAll('#requiredScenariosSummary .scenario-box');
+    expect(boxes).toHaveLength(2);
+    expect(boxes[0].textContent).toContain('Indoor');
+    expect(boxes[1].textContent).toContain('Gimbal');
+  });
+
   test('Hand Grips rigging adds telescopic handle', () => {
     const { generateGearListHtml } = script;
     const html = generateGearListHtml({ rigging: 'Hand Grips' });


### PR DESCRIPTION
## Summary
- Display selected required scenarios as individual boxes with emoji icons
- Style scenario summary boxes and support dark mode
- Test scenario summary rendering

## Testing
- `npm test >/tmp/test.log 2>&1 && tail -n 20 /tmp/test.log`

------
https://chatgpt.com/codex/tasks/task_e_68b75029f4e483208b6326931b396be9