### PR TITLE
Show filters only in gear list table

### DIFF
--- a/script.js
+++ b/script.js
@@ -7105,6 +7105,8 @@ function generateGearListHtml(info = {}) {
     }
     delete projectInfo.monitoringPreferences;
     delete projectInfo.tripodPreferences;
+    // Filters should only appear in the gear list table, not in the summary
+    delete projectInfo.filter;
     const projectTitle = escapeHtml(info.projectName || setupNameInput.value);
     const labels = {
         dop: 'DoP',
@@ -7120,11 +7122,10 @@ function generateGearListHtml(info = {}) {
         requiredScenarios: 'Required Scenarios',
         rigging: 'Rigging',
         monitoringSupport: 'Monitoring support',
-        monitoring: 'Monitoring',
-        filter: 'Filter'
+        monitoring: 'Monitoring'
     };
     const infoPairs = Object.entries(projectInfo)
-        .filter(([k, v]) => v && k !== 'projectName' && k !== 'sliderBowl');
+        .filter(([k, v]) => v && k !== 'projectName' && k !== 'sliderBowl' && k !== 'filter');
     const infoHtml = infoPairs.length ? '<h3>Project Requirements</h3><ul>' +
         infoPairs.map(([k, v]) => `<li>${escapeHtml(labels[k] || k)}: ${escapeHtml(v)}</li>`).join('') + '</ul>' : '';
     const formatItems = arr => {
@@ -7209,7 +7210,10 @@ function generateGearListHtml(info = {}) {
         }
     });
     addRow('Lens Support', formatItems(lensSupportItems));
-    addRow('Matte box + filter', '');
+    const filterItems = info.filter
+        ? info.filter.split(',').map(s => s.trim()).filter(Boolean)
+        : [];
+    addRow('Matte box + filter', formatItems(filterItems));
     addRow('LDS (FIZ)', formatItems([...selectedNames.motors, ...selectedNames.controllers, selectedNames.distance, ...fizCableAcc]));
     let batteryItems = '';
     if (selectedNames.battery) {

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -1008,7 +1008,10 @@ describe('script.js functions', () => {
       expect(html).toContain('<h3>Project Requirements</h3>');
       expect(html).toContain('DoP: DopName');
       expect(html).toContain('Required Scenarios: Handheld, Slider');
-      expect(html).toContain('Filter: IRND');
+      // Filters should appear only in the gear list table, not in the summary
+      expect(html).not.toContain('Filter: IRND');
+      expect(html).toContain('Matte box + filter');
+      expect(html).toContain('1x IRND');
       expect(html).toContain('<table class="gear-table">');
       expect(html).toContain('Camera');
       expect(html).toContain('1x CamA');


### PR DESCRIPTION
## Summary
- exclude selected filters from project summary and display them only in gear list table
- update tests to expect filters in table only

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b752d17eac8320bb870a9a4a4d23cc