### PR TITLE
Reduce mobile page padding

### DIFF
--- a/style.css
+++ b/style.css
@@ -14,6 +14,12 @@
   --panel-bg: #f9f9f9;
   --panel-border: #ddd;
   --panel-shadow: 0 2px 6px rgba(0, 0, 0, 0.05);
+  --page-padding: 20px;
+}
+@media (max-width: 600px) {
+  :root {
+    --page-padding: 10px;
+  }
 }
 body.pink-mode {
   --accent-color: #ff69b4;
@@ -44,7 +50,7 @@ body {
 main {
   max-width: 1200px;
   margin: 0 auto;
-  padding: 20px;
+  padding: var(--page-padding);
 }
 
 section,
@@ -58,10 +64,10 @@ textarea {
 @supports (padding: env(safe-area-inset-top)) {
   main {
     padding:
-      calc(env(safe-area-inset-top) + 20px)
-      calc(env(safe-area-inset-right) + 20px)
-      calc(env(safe-area-inset-bottom) + 20px)
-      calc(env(safe-area-inset-left) + 20px);
+      calc(env(safe-area-inset-top) + var(--page-padding))
+      calc(env(safe-area-inset-right) + var(--page-padding))
+      calc(env(safe-area-inset-bottom) + var(--page-padding))
+      calc(env(safe-area-inset-left) + var(--page-padding));
   }
 }
 


### PR DESCRIPTION
## Summary
- Use --page-padding variable to control overall page padding
- Decrease padding on small screens for better use of space

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b754265a5483208e3b938473eadeec