### PR TITLE
Stop listing filters in gear list summary

### DIFF
--- a/script.js
+++ b/script.js
@@ -7050,6 +7050,9 @@ function generateGearListHtml(info = {}) {
     const monitorEquipOptions = ['Directors Monitor 7" handheld', 'Directors Monitor 15-19 inch', 'Combo Monitor 15-19 inch'];
     const monitoringEquipmentPrefs = monitoringPrefs.filter(p => monitorEquipOptions.includes(p));
     const monitoringSupportPrefs = monitoringPrefs.filter(p => !monitorEquipOptions.includes(p));
+    const filterSelections = info.filter
+        ? info.filter.split(',').map(s => s.trim()).filter(Boolean)
+        : [];
     const receiverCount = (monitoringPrefs.includes('Directors Monitor 7" handheld') ? 1 : 0) + (hasMotor ? 1 : 0);
     if (selectedNames.video) {
         monitoringSupportAcc.push('Antenna 5,8GHz 5dBi Long (spare)');
@@ -7097,6 +7100,7 @@ function generateGearListHtml(info = {}) {
     }
     const projectInfo = { ...info };
     delete projectInfo.lenses;
+    delete projectInfo.filter;
     if (monitoringSupportPrefs.length) {
         projectInfo.monitoringSupport = monitoringSupportPrefs.join(', ');
     }
@@ -7120,8 +7124,7 @@ function generateGearListHtml(info = {}) {
         requiredScenarios: 'Required Scenarios',
         rigging: 'Rigging',
         monitoringSupport: 'Monitoring support',
-        monitoring: 'Monitoring',
-        filter: 'Filter'
+        monitoring: 'Monitoring'
     };
     const boxFields = ['deliveryResolution', 'recordingResolution', 'aspectRatio', 'codec', 'baseFrameRate', 'sensorMode'];
     const fieldIcons = {
@@ -7228,7 +7231,7 @@ function generateGearListHtml(info = {}) {
         }
     });
     addRow('Lens Support', formatItems(lensSupportItems));
-    addRow('Matte box + filter', '');
+    addRow('Matte box + filter', formatItems(filterSelections));
     addRow('LDS (FIZ)', formatItems([...selectedNames.motors, ...selectedNames.controllers, selectedNames.distance, ...fizCableAcc]));
     let batteryItems = '';
     if (selectedNames.battery) {

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -1008,7 +1008,9 @@ describe('script.js functions', () => {
       expect(html).toContain('<h3>Project Requirements</h3>');
       expect(html).toContain('DoP: DopName');
       expect(html).toContain('Required Scenarios: Handheld, Slider');
-      expect(html).toContain('Filter: IRND');
+      expect(html).not.toContain('Filter: IRND');
+      expect(html).toContain('Matte box + filter');
+      expect(html).toContain('1x IRND');
       expect(html).toContain('<table class="gear-table">');
       expect(html).toContain('Camera');
       expect(html).toContain('1x CamA');


### PR DESCRIPTION
## Summary
- Exclude selected filters from the gear list summary while still collecting them
- Show chosen filters only within the gear list table under "Matte box + filter"
- Update tests to validate new filter placement

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b753fb349c83208982a56df0caf696