### PR TITLE
Use icon-based requirement boxes in gear list overview

### DIFF
--- a/script.js
+++ b/script.js
@@ -7126,29 +7126,26 @@ function generateGearListHtml(info = {}) {
         monitoringSupport: 'Monitoring support',
         monitoring: 'Monitoring'
     };
-    const boxFields = ['deliveryResolution', 'recordingResolution', 'aspectRatio', 'codec', 'baseFrameRate', 'sensorMode'];
     const fieldIcons = {
+        dop: '👤',
+        prepDays: '📅',
+        shootingDays: '🎬',
         deliveryResolution: '📺',
-        recordingResolution: '🎥',
+        recordingResolution: '📹',
         aspectRatio: '🖼️',
         codec: '💾',
         baseFrameRate: '⏱️',
-        sensorMode: '🔍'
+        sensorMode: '🔍',
+        requiredScenarios: '🌄',
+        rigging: '🛠️',
+        monitoringSupport: '🧰',
+        monitoring: '📡'
     };
-    const boxInfoPairs = [];
-    boxFields.forEach(f => {
-        if (projectInfo[f]) {
-            boxInfoPairs.push([f, projectInfo[f]]);
-            delete projectInfo[f];
-        }
-    });
-    const infoPairs = Object.entries(projectInfo)
+    const infoEntries = Object.entries(projectInfo)
         .filter(([k, v]) => v && k !== 'projectName' && k !== 'sliderBowl');
-    const boxesHtml = boxInfoPairs.length ? '<div class="requirements-grid">' +
-        boxInfoPairs.map(([k, v]) => `<div class="requirement-box"><span class="req-icon">${fieldIcons[k]}</span><span class="req-label">${escapeHtml(labels[k] || k)}</span><span class="req-value">${escapeHtml(v)}</span></div>`).join('') + '</div>' : '';
-    const listHtml = infoPairs.length ? '<ul>' +
-        infoPairs.map(([k, v]) => `<li>${escapeHtml(labels[k] || k)}: ${escapeHtml(v)}</li>`).join('') + '</ul>' : '';
-    const infoHtml = (boxInfoPairs.length || infoPairs.length) ? `<h3>Project Requirements</h3>${boxesHtml}${listHtml}` : '';
+    const boxesHtml = infoEntries.length ? '<div class="requirements-grid">' +
+        infoEntries.map(([k, v]) => `<div class="requirement-box"><span class="req-icon">${fieldIcons[k] || ''}</span><span class="req-label">${escapeHtml(labels[k] || k)}</span><span class="req-value">${escapeHtml(v)}</span></div>`).join('') + '</div>' : '';
+    const infoHtml = infoEntries.length ? `<h3>Project Requirements</h3>${boxesHtml}` : '';
     const formatItems = arr => {
         const counts = {};
         arr.filter(Boolean).forEach(n => {

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -1006,8 +1006,10 @@ describe('script.js functions', () => {
       });
       expect(html).toContain('<h2>Proj</h2>');
       expect(html).toContain('<h3>Project Requirements</h3>');
-      expect(html).toContain('DoP: DopName');
-      expect(html).toContain('Required Scenarios: Handheld, Slider');
+      expect(html).toContain('<span class="req-label">DoP</span>');
+      expect(html).toContain('<span class="req-value">DopName</span>');
+      expect(html).toContain('<span class="req-label">Required Scenarios</span>');
+      expect(html).toContain('<span class="req-value">Handheld, Slider</span>');
       expect(html).not.toContain('Filter: IRND');
       expect(html).toContain('Matte box + filter');
       expect(html).toContain('1x IRND');
@@ -1552,17 +1554,20 @@ describe('script.js functions', () => {
       rigging: 'Shoulder rig, Hand Grips',
       monitoringPreferences: 'VF Clean Feed, Onboard Clean Feed, User Buttons'
     });
-    expect(html).toContain('Rigging: Shoulder rig, Hand Grips');
+    expect(html).toContain('<span class="req-label">Rigging</span>');
+    expect(html).toContain('<span class="req-value">Shoulder rig, Hand Grips</span>');
     expect(html).toContain('<td>Rigging</td>');
-    expect(html).toContain('Monitoring support: VF Clean Feed, Onboard Clean Feed, User Buttons');
+    expect(html).toContain('<span class="req-label">Monitoring support</span>');
+    expect(html).toContain('<span class="req-value">VF Clean Feed, Onboard Clean Feed, User Buttons</span>');
     expect(html).toContain('<td>Monitoring support</td>');
   });
 
   test('Directors handheld monitor appears under monitoring in project requirements', () => {
     const { generateGearListHtml } = script;
     const html = generateGearListHtml({ monitoringPreferences: 'Directors Monitor 7" handheld' });
-    expect(html).toContain('Monitoring: Directors Monitor 7" handheld');
-    expect(html).not.toContain('Monitoring support: Directors Monitor 7" handheld');
+    expect(html).toContain('<span class="req-label">Monitoring</span>');
+    expect(html).toContain('<span class="req-value">Directors Monitor 7" handheld</span>');
+    expect(html).not.toContain('<span class="req-label">Monitoring support</span><span class="req-value">Directors Monitor 7" handheld</span>');
   });
 
   test('sensor mode appears in project requirements when provided', () => {


### PR DESCRIPTION
## Summary
- Replace project requirement list items with grid of icon boxes
- Add icons for all fields such as rigging and monitoring
- Update tests for new requirement box structure

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b757652d248320b4ce0c964345c6f5