### PR TITLE
Move power accessories to power category

### DIFF
--- a/script.js
+++ b/script.js
@@ -7376,7 +7376,10 @@ function generateGearListHtml(info = {}) {
     const powerItems = [
         'Power Cable Drum 25-50 m',
         ...Array(2).fill('Power Cable 10 m'),
-        ...Array(2).fill('Power Cable 5 m')
+        ...Array(2).fill('Power Cable 5 m'),
+        ...Array(3).fill('Power Strip'),
+        ...Array(3).fill('PRCD-S (Portable Residual Current Device-Safety)'),
+        ...Array(3).fill('Power Three Way Splitter')
     ];
     addRow('Power', formatItems(powerItems));
     addRow('Grip', [sliderSelectHtml, formatItems(gripItems), easyrigSelectHtml].filter(Boolean).join('<br>'));
@@ -7394,11 +7397,6 @@ function generateGearListHtml(info = {}) {
         'Ultraslim BNC 0.5 m'
     ]);
     const miscItems = [...miscAcc].filter(item => !miscExcluded.has(item));
-    miscItems.push(
-        ...Array(3).fill('Power Strip'),
-        ...Array(3).fill('PRCD-S (Portable Residual Current Device-Safety)'),
-        ...Array(3).fill('Power Three Way Splitter')
-    );
     const consumables = [];
     const baseConsumables = [
         { name: 'Kimtech Wipes', count: 1 },

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -1035,6 +1035,9 @@ describe('script.js functions', () => {
       expect(powerSection).toContain('1x Power Cable Drum 25-50 m');
       expect(powerSection).toContain('2x Power Cable 10 m');
       expect(powerSection).toContain('2x Power Cable 5 m');
+      expect(powerSection).toContain('3x Power Strip');
+      expect(powerSection).toContain('3x PRCD-S (Portable Residual Current Device-Safety)');
+      expect(powerSection).toContain('3x Power Three Way Splitter');
       const miscSection = html.slice(html.indexOf('Miscellaneous'), html.indexOf('Consumables'));
       expect(miscSection).not.toContain('BNC Cable 0.5 m');
       expect(miscSection).not.toContain('BNC Cable 1 m');
@@ -1045,9 +1048,9 @@ describe('script.js functions', () => {
       expect(miscSection).not.toContain('Power Cable Drum 25-50 m');
       expect(miscSection).not.toContain('Power Cable 10 m');
       expect(miscSection).not.toContain('Power Cable 5 m');
-      expect(miscSection).toContain('3x Power Strip');
-      expect(miscSection).toContain('3x PRCD-S (Portable Residual Current Device-Safety)');
-      expect(miscSection).toContain('3x Power Three Way Splitter');
+      expect(miscSection).not.toContain('Power Strip');
+      expect(miscSection).not.toContain('PRCD-S (Portable Residual Current Device-Safety)');
+      expect(miscSection).not.toContain('Power Three Way Splitter');
       expect(html).not.toContain('BNC SDI Cable');
       expect(msSection).toContain('2x Ultraslim BNC 0.3 m');
       expect(msSection).toContain('2x D-Tap to Mini XLR 3-pin Cable 0,3m');


### PR DESCRIPTION
## Summary
- classify Power Strip, PRCD-S and Power Three Way Splitter under Power
- adjust tests to expect these accessories in Power instead of Miscellaneous

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b75889692c8320ad1375619cc5fbec