### PR TITLE
Fix gear list table overflow on mobile

### DIFF
--- a/style.css
+++ b/style.css
@@ -1541,7 +1541,11 @@ body.dark-mode.pink-mode .help-content { border-color: var(--accent-color); }
   }
   #gearListOutput table,
   #gearListOutput select {
+    width: 100%;
     max-width: 100%;
+  }
+  #gearListOutput select {
+    box-sizing: border-box;
   }
   #gearListOutput td {
     white-space: normal;


### PR DESCRIPTION
## Summary
- Ensure gear list table and dropdowns scale to the viewport on small screens

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b758c81dd0832084c2d93f9003e3b4