### PR TITLE
Deduplicate rod lengths per lens

### DIFF
--- a/script.js
+++ b/script.js
@@ -7213,12 +7213,17 @@ function generateGearListHtml(info = {}) {
     addRow('Lens', formatItems(selectedLensNames));
     const lensSupportItems = [];
     const requiredRodTypes = new Set();
+    const addedRodPairs = new Set();
     selectedLensNames.forEach(name => {
         const lens = devices.lenses && devices.lenses[name];
         if (!lens) return;
         const rodType = lens.rodStandard || '15mm';
         const rodLength = lens.rodLengthCm || (rodType === '19mm' ? 45 : 30);
-        lensSupportItems.push(`${rodType} rods ${rodLength}cm`);
+        const rodKey = `${rodType}-${rodLength}`;
+        if (!addedRodPairs.has(rodKey)) {
+            lensSupportItems.push(`${rodType} rods ${rodLength}cm`);
+            addedRodPairs.add(rodKey);
+        }
         requiredRodTypes.add(rodType);
         if (lens.needsLensSupport) {
             lensSupportItems.push(`${rodType} lens support`);

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -229,6 +229,26 @@ describe('script.js functions', () => {
     expect(supportRow.textContent).toContain('15mm lens support');
   });
 
+  test('multiple lenses with same rod length only add one pair of rods', () => {
+    const addOpt = (id, value) => {
+      const sel = document.getElementById(id);
+      sel.innerHTML = `<option value="${value}">${value}</option>`;
+      sel.value = value;
+    };
+    addOpt('cameraSelect', 'CamA');
+    addOpt('batterySelect', 'BattA');
+    addOpt('cageSelect', 'Universal Cage');
+    devices.lenses.LensB = { brand: 'TestBrand', rodStandard: '15mm', rodLengthCm: 30 };
+    const html = script.generateGearListHtml({ lenses: 'LensA, LensB' });
+    const wrap = document.createElement('div');
+    wrap.innerHTML = html;
+    const rows = Array.from(wrap.querySelectorAll('.gear-table tr'));
+    const supportIndex = rows.findIndex(r => r.textContent === 'Lens Support');
+    const supportRow = rows[supportIndex + 1];
+    expect(supportRow.textContent).toContain('1x 15mm rods 30cm');
+    expect(supportRow.textContent).not.toContain('2x 15mm rods 30cm');
+  });
+
   test('selected lens does not appear in project requirements list', () => {
     const html = script.generateGearListHtml({ lenses: 'LensA' });
     expect(html).not.toContain('Lenses: LensA');


### PR DESCRIPTION
## Summary
- ensure only one rod pair is listed per unique rod type and length across selected lenses
- add regression test for duplicate rod handling

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b758f9d0848320ba6bcefa3c1f3266