### PR TITLE
Fix mobile battery selector width

### DIFF
--- a/style.css
+++ b/style.css
@@ -375,10 +375,17 @@ body.hover-help-active * {
   display: flex;
   flex-direction: column;
   flex: 1;
+  min-width: 0; /* allow wrapper to shrink on narrow screens */
 }
 
 .select-wrapper .filter-input {
   display: none;
+}
+
+/* Prevent long option text from widening selects on mobile */
+.select-wrapper select {
+  width: 100%;
+  max-width: 100%;
 }
 
 .device-category .list-filter {


### PR DESCRIPTION
## Summary
- prevent long option names from widening select controls on small screens

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b75aa7596c83209649440463387baa