### PR TITLE
Reduce mobile margins

### DIFF
--- a/overview.css
+++ b/overview.css
@@ -1,6 +1,9 @@
 @import url('https://fonts.googleapis.com/css2?family=Ubuntu:wght@300;700&display=swap');
 
 body { font-family: 'Ubuntu', sans-serif; font-weight: 300; margin: 25px; color: var(--control-text); font-size: 0.9em; -webkit-print-color-adjust: exact; print-color-adjust: exact; }
+@media (max-width: 600px) {
+  body { margin: 10px; }
+}
 h1, h2, h3 { font-family: 'Ubuntu', sans-serif; font-weight: 700; color: var(--accent-color); }
 h1 { font-size: 1.8em; margin-bottom: 0.2em; }
 h2 { font-size: 1.4em; margin-top: 1.3em; border-bottom: 2px solid var(--accent-color); padding-bottom: 5px; }

--- a/style.css
+++ b/style.css
@@ -18,7 +18,7 @@
 }
 @media (max-width: 600px) {
   :root {
-    --page-padding: 10px;
+    --page-padding: 5px;
   }
 }
 body.pink-mode {


### PR DESCRIPTION
## Summary
- Tighten `--page-padding` for mobile screens to shrink overall page margins
- Decrease body margins on overview pages for small devices

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b75b294bbc8320b09266a99db170ad