### PR TITLE
Add user buttons field to gear list form

### DIFF
--- a/index.html
+++ b/index.html
@@ -950,12 +950,12 @@
           <option value="AM Opacity 50%">AM Opacity 50%</option>
           <option value="AM Opacity 25%">AM Opacity 25%</option>
           <option value="AM Opacity 0%">AM Opacity 0%</option>
-          <option value="User Buttons">User Buttons</option>
           <option value="Directors Monitor 7&quot; handheld">Directors Monitor 7&quot; handheld</option>
           <option value="Directors Monitor 15-19 inch">Directors Monitor 15-19 inch</option>
           <option value="Combo Monitor 15-19 inch">Combo Monitor 15-19 inch</option>
         </select>
       </label></div>
+      <div class="form-row"><label for="userButtons">User Buttons:<input type="text" id="userButtons" name="userButtons"></label></div>
       <div class="form-row"><label for="tripodPreferences">Tripod Preferences:
         <select id="tripodPreferences" name="tripodPreferences" multiple size="13">
           <option value="O'Connor">O'Connor</option>

--- a/script.js
+++ b/script.js
@@ -6989,6 +6989,7 @@ function collectProjectFormData() {
         requiredScenarios: multi('requiredScenarios'),
         rigging: multi('rigging'),
         monitoringPreferences: multi('monitoringPreferences'),
+        userButtons: val('userButtons'),
         tripodPreferences: multi('tripodPreferences'),
         sliderBowl: getSliderBowlValue(),
         filter: multi('filter')
@@ -7124,7 +7125,8 @@ function generateGearListHtml(info = {}) {
         requiredScenarios: 'Required Scenarios',
         rigging: 'Rigging',
         monitoringSupport: 'Monitoring support',
-        monitoring: 'Monitoring'
+        monitoring: 'Monitoring',
+        userButtons: 'User Buttons'
     };
     const fieldIcons = {
         dop: '👤',
@@ -7139,7 +7141,8 @@ function generateGearListHtml(info = {}) {
         requiredScenarios: '🌄',
         rigging: '🛠️',
         monitoringSupport: '🧰',
-        monitoring: '📡'
+        monitoring: '📡',
+        userButtons: '🔘'
     };
     const infoEntries = Object.entries(projectInfo)
         .filter(([k, v]) => v && k !== 'projectName' && k !== 'sliderBowl');

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -152,10 +152,9 @@ describe('script.js functions', () => {
     expect(copyBtn.nextElementSibling).toBe(generateBtn);
   });
 
-  test('project form includes User Buttons monitoring option', () => {
-    const select = document.getElementById('monitoringPreferences');
-    const hasOption = Array.from(select.options).some(o => o.value === 'User Buttons');
-    expect(hasOption).toBe(true);
+  test('project form includes user buttons input', () => {
+    const input = document.getElementById('userButtons');
+    expect(input).not.toBeNull();
   });
 
   test('new device form includes cable category option', () => {
@@ -1575,18 +1574,21 @@ describe('script.js functions', () => {
     const { generateGearListHtml } = script;
     const html = generateGearListHtml({
       rigging: 'Shoulder rig, Hand Grips',
-      monitoringPreferences: 'VF Clean Feed, Onboard Clean Feed, User Buttons'
+      monitoringPreferences: 'VF Clean Feed, Onboard Clean Feed',
+      userButtons: 'Toggle LUT, False Color'
     });
     expect(html).toContain('<span class="req-label">Rigging</span>');
     expect(html).toContain('<span class="req-value">Shoulder rig, Hand Grips</span>');
     expect(html).toContain('<td>Rigging</td>');
     expect(html).toContain('<span class="req-label">Monitoring support</span>');
-    expect(html).toContain('<span class="req-value">VF Clean Feed, Onboard Clean Feed, User Buttons</span>');
+    expect(html).toContain('<span class="req-value">VF Clean Feed, Onboard Clean Feed</span>');
     expect(html).toContain('<td>Monitoring support</td>');
     const msSection = html.slice(html.indexOf('<td>Monitoring support</td>'), html.indexOf('Power'));
     expect(msSection).not.toContain('VF Clean Feed');
     expect(msSection).not.toContain('Onboard Clean Feed');
     expect(msSection).not.toContain('User Buttons');
+    expect(html).toContain('<span class="req-label">User Buttons</span>');
+    expect(html).toContain('<span class="req-value">Toggle LUT, False Color</span>');
   });
 
   test('Directors handheld monitor appears under monitoring in project requirements', () => {


### PR DESCRIPTION
## Summary
- add dedicated User Buttons text field to project requirements dialog
- capture and display user button preferences in generated gear list
- update tests for new field

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b75e67037883209d2d1d8cd65b110b