### PR TITLE
Include project requirements in saved setups

### DIFF
--- a/script.js
+++ b/script.js
@@ -7494,48 +7494,67 @@ function generateGearListHtml(info = {}) {
 
 
 function getCurrentGearListHtml() {
-    if (!gearListOutput) return '';
-    const clone = gearListOutput.cloneNode(true);
-    const actions = clone.querySelector('#gearListActions');
-    if (actions) actions.remove();
-    const cageSel = clone.querySelector('#gearListCage');
-    if (cageSel) {
-        const originalSel = gearListOutput.querySelector('#gearListCage');
-        const val = originalSel ? originalSel.value : cageSel.value;
-        Array.from(cageSel.options).forEach(opt => {
-            if (opt.value === val) {
-                opt.setAttribute('selected', '');
-            } else {
-                opt.removeAttribute('selected');
-            }
-        });
-    }
-    const easyrigSel = clone.querySelector('#gearListEasyrig');
-    if (easyrigSel) {
-        const originalSel = gearListOutput.querySelector('#gearListEasyrig');
-        const val = originalSel ? originalSel.value : easyrigSel.value;
-        Array.from(easyrigSel.options).forEach(opt => {
-            if (opt.value === val) {
-                opt.setAttribute('selected', '');
-            } else {
-                opt.removeAttribute('selected');
-            }
-        });
-    }
-    const sliderSel = clone.querySelector('#gearListSliderBowl');
-    if (sliderSel) {
-        const originalSel = gearListOutput.querySelector('#gearListSliderBowl');
-        const val = originalSel ? originalSel.value : sliderSel.value;
-        Array.from(sliderSel.options).forEach(opt => {
-            if (opt.value === val) {
-                opt.setAttribute('selected', '');
-            } else {
-                opt.removeAttribute('selected');
-            }
-        });
+    if (!gearListOutput && !projectRequirementsOutput) return '';
+
+    const titleElem = (projectRequirementsOutput && projectRequirementsOutput.querySelector('h2'))
+        || (gearListOutput && gearListOutput.querySelector('h2'));
+    const titleHtml = titleElem ? titleElem.outerHTML : '';
+
+    let projHtml = '';
+    if (projectRequirementsOutput) {
+        const projClone = projectRequirementsOutput.cloneNode(true);
+        const t = projClone.querySelector('h2');
+        if (t) t.remove();
+        projHtml = projClone.innerHTML.trim();
     }
 
-    return clone.innerHTML.trim();
+    let gearHtml = '';
+    if (gearListOutput) {
+        const clone = gearListOutput.cloneNode(true);
+        const actions = clone.querySelector('#gearListActions');
+        if (actions) actions.remove();
+        const t = clone.querySelector('h2');
+        if (t) t.remove();
+        const cageSel = clone.querySelector('#gearListCage');
+        if (cageSel) {
+            const originalSel = gearListOutput.querySelector('#gearListCage');
+            const val = originalSel ? originalSel.value : cageSel.value;
+            Array.from(cageSel.options).forEach(opt => {
+                if (opt.value === val) {
+                    opt.setAttribute('selected', '');
+                } else {
+                    opt.removeAttribute('selected');
+                }
+            });
+        }
+        const easyrigSel = clone.querySelector('#gearListEasyrig');
+        if (easyrigSel) {
+            const originalSel = gearListOutput.querySelector('#gearListEasyrig');
+            const val = originalSel ? originalSel.value : easyrigSel.value;
+            Array.from(easyrigSel.options).forEach(opt => {
+                if (opt.value === val) {
+                    opt.setAttribute('selected', '');
+                } else {
+                    opt.removeAttribute('selected');
+                }
+            });
+        }
+        const sliderSel = clone.querySelector('#gearListSliderBowl');
+        if (sliderSel) {
+            const originalSel = gearListOutput.querySelector('#gearListSliderBowl');
+            const val = originalSel ? originalSel.value : sliderSel.value;
+            Array.from(sliderSel.options).forEach(opt => {
+                if (opt.value === val) {
+                    opt.setAttribute('selected', '');
+                } else {
+                    opt.removeAttribute('selected');
+                }
+            });
+        }
+        gearHtml = clone.innerHTML.trim();
+    }
+
+    return `${titleHtml}${projHtml}${gearHtml}`.trim();
 }
 
 function saveCurrentGearList() {

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -294,6 +294,20 @@ describe('script.js functions', () => {
     expect(savedHtml).toContain('<option value="Cage2" selected');
   });
 
+  test('project requirements are saved with gear list', () => {
+    global.saveGearList = jest.fn();
+    const proj = document.getElementById('projectRequirementsOutput');
+    proj.innerHTML = '<h2>Proj</h2><h3>Project Requirements</h3><div class="requirements-grid"><div class="requirement-box"><span class="req-label">Codec</span><span class="req-value">ProRes</span></div></div>';
+    proj.classList.remove('hidden');
+    const gear = document.getElementById('gearListOutput');
+    gear.innerHTML = '<h2>Proj</h2><h3>Gear List</h3><table class="gear-table"></table>';
+    gear.classList.remove('hidden');
+    script.saveCurrentGearList();
+    const savedHtml = global.saveGearList.mock.calls[0][0];
+    expect(savedHtml).toContain('<div class="requirements-grid">');
+    expect(savedHtml).toContain('<table class="gear-table">');
+  });
+
   test('suggests chargers based on total batteries', () => {
     const addOpt = (id, value) => {
       const sel = document.getElementById(id);


### PR DESCRIPTION
## Summary
- Ensure gear list HTML includes project requirements when saving setups
- Add test to confirm project requirements are persisted

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b769eacca88320ab0fdab69fd1d765