### PR TITLE
fix cleanPort handling for primitive values

### DIFF
--- a/tests/unifyPorts.test.js
+++ b/tests/unifyPorts.test.js
@@ -4,7 +4,8 @@ const {
   normalizeVideoDevice,
   cleanVoltageRange,
   normalizeFiz,
-  cleanTypeName
+  cleanTypeName,
+  cleanPort
 } = require('../unifyPorts.js');
 
 describe('cleanVoltageRange', () => {
@@ -128,5 +129,11 @@ describe('normalizeFiz', () => {
     normalizeFiz(dev);
     expect(dev.power.input[0].voltageRange).toBe('5-16');
     expect(dev.power.input[1].voltageRange).toBe('11-17');
+  });
+});
+
+describe('cleanPort', () => {
+  it('handles primitive values without throwing', () => {
+    expect(() => cleanPort('USB-C')).not.toThrow();
   });
 });

--- a/unifyPorts.js
+++ b/unifyPorts.js
@@ -82,6 +82,11 @@ function cleanPort(port) {
     port.forEach(cleanPort);
     return;
   }
+  // Guard against primitive values (e.g. strings) which would cause the
+  // `in` operator to throw a TypeError. Such values can't be normalized in
+  // place, so we simply ignore them.
+  if (typeof port !== 'object') return;
+
   if ('portType' in port) {
     if (!('type' in port)) port.type = port.portType;
     delete port.portType;


### PR DESCRIPTION
## Summary
- avoid TypeError in `cleanPort` when given primitive values
- test that `cleanPort` safely ignores primitive inputs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b76d17a76483208706471e128001b8