### PR TITLE
Align app heading with title across translations

### DIFF
--- a/translations.js
+++ b/translations.js
@@ -3,7 +3,7 @@
 const texts = {
   en: {
     appTitle: "Camera Power Planner",
-    appHeading: "Camera Power Consumption App",
+    appHeading: "Camera Power Planner",
     tagline: "Plan your film rig and calculate power consumption & battery life.",
     skipToContent: "Skip to content",
     offlineIndicator: "Offline",
@@ -361,7 +361,7 @@ const texts = {
   },
   it: {
     appTitle: "Pianificatore di alimentazione della fotocamera",
-    appHeading: "App per consumo di energia della fotocamera",
+    appHeading: "Pianificatore di alimentazione della fotocamera",
     tagline: "Pianifica la tua attrezzatura da set e calcola il consumo di energia e l'autonomia delle batterie.",
     skipToContent: "Vai al contenuto",
     offlineIndicator: "Offline",
@@ -692,7 +692,7 @@ const texts = {
   },
   es: {
     appTitle: "Planificador de Consumo de Energía de Cámaras",
-    appHeading: "Aplicación de Consumo de Energía para Cámaras",
+    appHeading: "Planificador de Consumo de Energía de Cámaras",
     tagline: "Planifica tu equipo de rodaje y calcula el consumo de energía y la autonomía de las baterías.",
     skipToContent: "Saltar al contenido",
     offlineIndicator: "Sin conexión",
@@ -1039,7 +1039,7 @@ const texts = {
   },
   fr: {
     appTitle: "Planificateur de Consommation Caméra",
-    appHeading: "Application de Consommation Caméra",
+    appHeading: "Planificateur de Consommation Caméra",
     tagline: "Planifiez votre équipement de tournage et calculez la consommation et l'autonomie des batteries.",
     skipToContent: "Aller au contenu",
     offlineIndicator: "Hors ligne",
@@ -1388,7 +1388,7 @@ const texts = {
   },
   de: {
     appTitle: "Kamera Stromverbrauchs Planer",
-    appHeading: "Kamera-Stromverbrauchs-App",
+    appHeading: "Kamera Stromverbrauchs Planer",
     tagline: "Plane dein Dreh-Setup und berechne Stromverbrauch und Akkulaufzeit.",
     skipToContent: "Zum Inhalt springen",
     offlineIndicator: "Offline",


### PR DESCRIPTION
## Summary
- Ensure the app heading matches the app title in English, Italian, Spanish, French, and German translations for consistent branding.

## Testing
- `npm test` *(fails: script test hung; other suites passed)*


------
https://chatgpt.com/codex/tasks/task_e_68b76d512f688320a481017bc46345ff