### PR TITLE
Clear gear list when purging planner data

### DIFF
--- a/storage.js
+++ b/storage.js
@@ -239,6 +239,7 @@ function clearAllData() {
     localStorage.removeItem(DEVICE_STORAGE_KEY);
     localStorage.removeItem(SETUP_STORAGE_KEY);
     localStorage.removeItem(FEEDBACK_STORAGE_KEY);
+    localStorage.removeItem(GEARLIST_STORAGE_KEY);
     sessionStorage.removeItem(SESSION_STATE_KEY);
     console.log("All planner data cleared from storage.");
   } catch (e) {

--- a/tests/storage.test.js
+++ b/tests/storage.test.js
@@ -11,6 +11,7 @@ const {
     saveSessionState,
     loadFeedback,
     saveFeedback,
+    saveGearList,
     clearAllData,
     exportAllData,
     importAllData,
@@ -20,6 +21,7 @@ const DEVICE_KEY = 'cameraPowerPlanner_devices';
 const SETUP_KEY = 'cameraPowerPlanner_setups';
 const SESSION_KEY = 'cameraPowerPlanner_session';
 const FEEDBACK_KEY = 'cameraPowerPlanner_feedback';
+const GEARLIST_KEY = 'cameraPowerPlanner_gearList';
 
 const validDeviceData = {
   cameras: {},
@@ -237,11 +239,13 @@ describe('clearAllData', () => {
     saveDeviceData(validDeviceData);
     saveSetups({ A: { foo: 1 } });
     saveFeedback({ note: 'hi' });
+    saveGearList('<ul></ul>');
     saveSessionState({ camera: 'CamA' });
     clearAllData();
     expect(localStorage.getItem(DEVICE_KEY)).toBeNull();
     expect(localStorage.getItem(SETUP_KEY)).toBeNull();
     expect(localStorage.getItem(FEEDBACK_KEY)).toBeNull();
+    expect(localStorage.getItem(GEARLIST_KEY)).toBeNull();
     expect(sessionStorage.getItem(SESSION_KEY)).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- Ensure `clearAllData` also removes the cached gear list
- Test that clearing data removes all associated storage entries

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b76d7d67588320b4ad6e05e54cb67e