### PR TITLE
docs: document project requirement features

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -24,6 +24,8 @@ The app automatically uses your browser language on first load, and you can swit
 - Submit user runtime feedback with temperature for better estimates.
 - Visual runtime weighting dashboard to inspect how settings influence each report, now sorted by weight and showing exact share percentages.
 - Generate gear lists to compile selected gear and project requirements.
+- Save project requirements with each setup so gear lists keep context.
+- Duplicate user entries in gear list forms with new fork buttons.
 
 ---
 
@@ -35,6 +37,7 @@ The app automatically uses your browser language on first load, and you can swit
 - Data is stored locally via `localStorage`
 - Import and export setups as JSON
 - Generate a printable overview for any saved setup
+- Save project requirements along with each setup
 - Generate gear lists for selected equipment and project requirements
 - Works fully offline – language, dark mode, setups and device data persist
 - Choose a **B‑Mount** or **V‑Mount** plate on supported cameras; the battery list adapts automatically

--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ Recent updates include:
 - **Visual runtime weighting dashboard** – see how temperature, resolution, frame rate and codec affect each runtime report, now sorted by weight with exact share percentages.
 - **Gear list generator** – compile selected gear and project requirements with one click.
 - **Quick setup saving** – press Enter or Ctrl+S (⌘S on macOS) to save a setup and the Save button stays disabled until a name is entered.
+- **Project requirement saving** – store project requirements with each setup so gear lists restore full context.
+- **User entry duplication** – gear list forms include fork buttons to copy user fields instantly.
 
 See the language-specific README files for full details.
 
@@ -59,7 +61,7 @@ See the language-specific README files for full details.
 - Check that selected batteries can supply the required output.
 - See required battery counts for a 10 h shoot and adjust runtimes for temperature.
 - Compare runtimes across all batteries with an optional battery comparison panel.
-- Save, load, share and clear setups; import/export them as JSON, and generate gear lists and printable overviews.
+- Save, load, share and clear setups (project requirements included); import/export them as JSON, and generate gear lists and printable overviews.
 - Visualize power and video connections with an interactive diagram.
 - Customize the device database with your own gear.
 - Automatically selects your browser language on first load, lets you switch languages, toggle dark or playful pink themes, and swap between V‑ and B‑Mount plates on supported cameras.


### PR DESCRIPTION
## Summary
- mention that project requirements now save with setups
- note new fork buttons for quickly duplicating user entries in gear list forms
- clarify features overview that project requirements are stored

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b76e19e7008320b89cca3bfc588ba4