### PR TITLE
Refactor translation handling to remove duplicate appHeading

### DIFF
--- a/script.js
+++ b/script.js
@@ -920,9 +920,9 @@ function setLanguage(lang) {
   }
   // update html lang attribute for better persistence
   document.documentElement.lang = lang;
-  // Document title and main heading
+  // Document title and main heading share the same text
   document.title = texts[lang].appTitle;
-  document.getElementById("mainTitle").textContent = texts[lang].appHeading;
+  document.getElementById("mainTitle").textContent = texts[lang].appTitle;
   document.getElementById("tagline").textContent = texts[lang].tagline;
   if (skipLink) skipLink.textContent = texts[lang].skipToContent;
   const offlineElem = document.getElementById("offlineIndicator");

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -755,7 +755,7 @@ describe('script.js functions', () => {
     script.setLanguage('de');
     expect(document.documentElement.lang).toBe('de');
     expect(localStorage.getItem('language')).toBe('de');
-    expect(document.getElementById('mainTitle').textContent).toBe('Kamera-Stromverbrauchs-App');
+    expect(document.getElementById('mainTitle').textContent).toBe(texts.de.appTitle);
     expect(document.getElementById('offlineIndicator').textContent).toBe(texts.de.offlineIndicator);
   });
 
@@ -763,7 +763,7 @@ describe('script.js functions', () => {
     script.setLanguage('es');
     expect(document.documentElement.lang).toBe('es');
     expect(localStorage.getItem('language')).toBe('es');
-    expect(document.getElementById('mainTitle').textContent).toBe('Aplicación de Consumo de Energía para Cámaras');
+    expect(document.getElementById('mainTitle').textContent).toBe(texts.es.appTitle);
     expect(document.getElementById('offlineIndicator').textContent).toBe(texts.es.offlineIndicator);
   });
 

--- a/translations.js
+++ b/translations.js
@@ -3,7 +3,6 @@
 const texts = {
   en: {
     appTitle: "Camera Power Planner",
-    appHeading: "Camera Power Planner",
     tagline: "Plan your film rig and calculate power consumption & battery life.",
     skipToContent: "Skip to content",
     offlineIndicator: "Offline",
@@ -362,7 +361,6 @@ const texts = {
   },
   it: {
     appTitle: "Pianificatore di alimentazione della fotocamera",
-    appHeading: "Pianificatore di alimentazione della fotocamera",
     tagline: "Pianifica la tua attrezzatura da set e calcola il consumo di energia e l'autonomia delle batterie.",
     skipToContent: "Vai al contenuto",
     offlineIndicator: "Offline",
@@ -694,7 +692,6 @@ const texts = {
   },
   es: {
     appTitle: "Planificador de Consumo de Energía de Cámaras",
-    appHeading: "Planificador de Consumo de Energía de Cámaras",
     tagline: "Planifica tu equipo de rodaje y calcula el consumo de energía y la autonomía de las baterías.",
     skipToContent: "Saltar al contenido",
     offlineIndicator: "Sin conexión",
@@ -1042,7 +1039,6 @@ const texts = {
   },
   fr: {
     appTitle: "Planificateur de Consommation Caméra",
-    appHeading: "Planificateur de Consommation Caméra",
     tagline: "Planifiez votre équipement de tournage et calculez la consommation et l'autonomie des batteries.",
     skipToContent: "Aller au contenu",
     offlineIndicator: "Hors ligne",
@@ -1392,7 +1388,6 @@ const texts = {
   },
   de: {
     appTitle: "Kamera Stromverbrauchs Planer",
-    appHeading: "Kamera Stromverbrauchs Planer",
     tagline: "Plane dein Dreh-Setup und berechne Stromverbrauch und Akkulaufzeit.",
     skipToContent: "Zum Inhalt springen",
     offlineIndicator: "Offline",


### PR DESCRIPTION
## Summary
- simplify translation data by removing redundant `appHeading` key
- use `appTitle` for both document title and main heading
- adjust tests to reference translation data directly

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b77029d21083209a904d4858883614