### PR TITLE
Improve connector type normalization

### DIFF
--- a/tests/unifyPorts.test.js
+++ b/tests/unifyPorts.test.js
@@ -23,6 +23,10 @@ describe('cleanTypeName', () => {
     expect(cleanTypeName('dtap')).toBe('D-Tap');
     expect(cleanTypeName('USB Type C')).toBe('USB-C');
   });
+  it('strips multiple generic input/output words', () => {
+    expect(cleanTypeName('HDMI Input OUTPUT')).toBe('HDMI');
+    expect(cleanTypeName('SDI IN/OUT')).toBe('SDI IN/OUT');
+  });
 });
 
 describe('normalizeMonitor', () => {

--- a/unifyPorts.js
+++ b/unifyPorts.js
@@ -18,7 +18,8 @@ function cleanTypeName(name) {
   if (typeNameCache.has(key)) return typeNameCache.get(key);
   let t = key.trim();
   // Preserve explicit IN/OUT labels; only remove generic INPUT/OUTPUT words.
-  t = t.replace(/\b(INPUT|OUTPUT)\b/i, "").trim();
+  // The regex is global to ensure multiple occurrences are stripped.
+  t = t.replace(/\b(?:INPUT|OUTPUT)\b/gi, "").trim();
   if (/lemo\s*2\s*-?\s*pin/i.test(t)) t = "LEMO 2-pin";
   if (/d[\s-]?tap/i.test(t)) t = "D-Tap";
   if (/usb\s*type[-\s]?c/i.test(t)) t = "USB-C";


### PR DESCRIPTION
## Summary
- handle multiple INPUT/OUTPUT occurrences when normalizing connector names
- test connector name cleanup with repeated input/output labels

## Testing
- `npm run lint`
- `npm run check-consistency`
- `CI=true npx jest tests/storage.test.js tests/unifyPorts.test.js tests/utils.test.js tests/checkConsistency.test.js tests/service-worker.test.js tests/cliHelp.test.js --runInBand`


------
https://chatgpt.com/codex/tasks/task_e_68b77035b8b083209c58f9e83922a6b5