### PR TITLE
Expose grid snap toggle state

### DIFF
--- a/index.html
+++ b/index.html
@@ -207,7 +207,7 @@
       <button id="zoomIn" type="button" title="Zoom in" aria-label="Zoom in">+</button>
       <button id="resetView" type="button">Reset View</button>
       <button id="downloadDiagram" type="button">Download Diagram</button>
-      <button id="gridSnapToggle" type="button">Snap to Grid</button>
+      <button id="gridSnapToggle" type="button" aria-pressed="false">Snap to Grid</button>
     </div>
     <p id="diagramHint" class="diagram-hint"></p>
   </section>

--- a/script.js
+++ b/script.js
@@ -1413,6 +1413,7 @@ function setLanguage(lang) {
     gridSnapToggleBtn.setAttribute("title", texts[lang].gridSnapToggle);
     gridSnapToggleBtn.setAttribute("aria-label", texts[lang].gridSnapToggle);
     gridSnapToggleBtn.setAttribute("data-help", texts[lang].gridSnapToggleHelp);
+    gridSnapToggleBtn.setAttribute("aria-pressed", gridSnap);
   }
   if (resetViewBtn) {
     resetViewBtn.textContent = texts[lang].resetViewBtn;
@@ -8041,6 +8042,7 @@ if (gridSnapToggleBtn) {
   gridSnapToggleBtn.addEventListener('click', () => {
     gridSnap = !gridSnap;
     gridSnapToggleBtn.classList.toggle('active', gridSnap);
+    gridSnapToggleBtn.setAttribute('aria-pressed', gridSnap);
     if (setupDiagramContainer) {
       setupDiagramContainer.classList.toggle('grid-snap', gridSnap);
     }

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -755,7 +755,7 @@ describe('script.js functions', () => {
     script.setLanguage('de');
     expect(document.documentElement.lang).toBe('de');
     expect(localStorage.getItem('language')).toBe('de');
-    expect(document.getElementById('mainTitle').textContent).toBe('Kamera-Stromverbrauchs-App');
+    expect(document.getElementById('mainTitle').textContent).toBe(texts.de.appHeading);
     expect(document.getElementById('offlineIndicator').textContent).toBe(texts.de.offlineIndicator);
   });
 
@@ -763,7 +763,7 @@ describe('script.js functions', () => {
     script.setLanguage('es');
     expect(document.documentElement.lang).toBe('es');
     expect(localStorage.getItem('language')).toBe('es');
-    expect(document.getElementById('mainTitle').textContent).toBe('Aplicación de Consumo de Energía para Cámaras');
+    expect(document.getElementById('mainTitle').textContent).toBe(texts.es.appHeading);
     expect(document.getElementById('offlineIndicator').textContent).toBe(texts.es.offlineIndicator);
   });
 
@@ -2438,7 +2438,9 @@ describe('script.js functions', () => {
     script.renderSetupDiagram();
 
     const gridBtn = document.getElementById('gridSnapToggle');
+    expect(gridBtn.getAttribute('aria-pressed')).toBe('false');
     gridBtn.click();
+    expect(gridBtn.getAttribute('aria-pressed')).toBe('true');
 
     const area = document.getElementById('diagramArea');
     expect(gridBtn.classList.contains('active')).toBe(true);
@@ -2496,7 +2498,9 @@ describe('script.js functions', () => {
 
     const gridBtn = document.getElementById('gridSnapToggle');
     const zoomBtn = document.getElementById('zoomIn');
+    expect(gridBtn.getAttribute('aria-pressed')).toBe('false');
     gridBtn.click();
+    expect(gridBtn.getAttribute('aria-pressed')).toBe('true');
     zoomBtn.click();
 
     const node = document.querySelector('#diagramArea .diagram-node[data-node="battery"]');


### PR DESCRIPTION
## Summary
- convey grid snap activation state via `aria-pressed` on the toggle
- verify pressed state and translation-driven headings in tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b7703fa1148320afaaf6c72274448a