### PR TITLE
Allow opening help dialog while typing

### DIFF
--- a/script.js
+++ b/script.js
@@ -8226,7 +8226,8 @@ if (helpButton && helpDialog) {
     ) {
       e.preventDefault();
       toggleHelp();
-    } else if ((e.key === '?' || e.key.toLowerCase() === 'h') && !isTextField) {
+    } else if (e.key === '?' || e.key.toLowerCase() === 'h') {
+      e.preventDefault();
       toggleHelp();
     } else if (
       !helpDialog.hasAttribute('hidden') &&

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -2568,6 +2568,17 @@ describe('script.js functions', () => {
     expect(helpDialog.hasAttribute('hidden')).toBe(false);
     document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
     expect(helpDialog.hasAttribute('hidden')).toBe(true);
+
+    // open with question mark while typing
+    const input = document.createElement('input');
+    document.body.appendChild(input);
+    input.focus();
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: '?' }));
+    expect(helpDialog.hasAttribute('hidden')).toBe(false);
+    expect(input.value).toBe('');
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    expect(helpDialog.hasAttribute('hidden')).toBe(true);
+    document.body.removeChild(input);
   });
 
   test('slash or Ctrl+F focuses help search', () => {


### PR DESCRIPTION
## Summary
- Allow '?' and 'H' shortcuts to open the help dialog even when focus is in an input, preventing the character from being inserted.
- Add regression test covering help dialog toggling while typing in a field.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b7724936208320907c86ae0829a34e