### PR TITLE
Handle empty power port segments

### DIFF
--- a/script.js
+++ b/script.js
@@ -214,7 +214,8 @@ function normalizePowerPortType(type) {
   const toArray = val =>
     mapPowerPortOne(val)
       .split('/')
-      .map(p => mapPowerPortOne(p));
+      .map(p => mapPowerPortOne(p))
+      .filter(Boolean);
   return Array.isArray(type) ? type.flatMap(toArray) : toArray(type);
 }
 

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -102,6 +102,12 @@ describe('utility function tests', () => {
     expect(normalizePowerPortType('battery slot / usb type-c®')).toEqual(['Battery Slot', 'USB-C']);
   });
 
+  test('normalizePowerPortType filters empty segments', () => {
+    const { normalizePowerPortType } = utils;
+    expect(normalizePowerPortType('dc input /')).toEqual(['DC IN']);
+    expect(normalizePowerPortType('/ LEMO 8-PIN (BAT)')).toEqual(['Bat LEMO 8-pin']);
+  });
+
   test('normalizeVideoType recognizes DisplayPort variants', () => {
     const { normalizeVideoType } = utils;
     expect(normalizeVideoType('DisplayPort')).toBe('DisplayPort');


### PR DESCRIPTION
## Summary
- ignore empty segments when normalizing power port types
- test normalization of trailing and leading slash scenarios

## Testing
- `npm run lint`
- `npm run check-consistency`
- `npx jest tests/utils.test.js tests/unifyPorts.test.js tests/cliHelp.test.js tests/service-worker.test.js tests/storage.test.js tests/checkConsistency.test.js --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_68b7729c4a988320996a726633a583cf