### PR TITLE
Prevent parsePowerInput cache mutation

### DIFF
--- a/tests/parsePowerInputCache.test.js
+++ b/tests/parsePowerInputCache.test.js
@@ -1,0 +1,10 @@
+const { parsePowerInput } = require('../unifyPorts.js');
+
+describe('parsePowerInput cache', () => {
+  test('modifying returned array does not pollute cache', () => {
+    const first = parsePowerInput('D-Tap');
+    first[0].extra = 'modified';
+    const second = parsePowerInput('D-Tap');
+    expect(second[0].extra).toBeUndefined();
+  });
+});

--- a/unifyPorts.js
+++ b/unifyPorts.js
@@ -214,7 +214,13 @@ function splitOutside(str, delimiter = '/') {
  */
 function parsePowerInput(str) {
   if (!str) return null;
-  if (powerInputCache.has(str)) return powerInputCache.get(str);
+  if (powerInputCache.has(str)) {
+    // Return a fresh copy of the cached array so callers can mutate the
+    // result without affecting subsequent lookups.
+    const cached = powerInputCache.get(str);
+    return cached.map(obj => ({ ...obj }));
+  }
+
   const arr = splitOutside(str)
     .map(p => p.trim())
     .filter(p => p.length > 0)
@@ -237,7 +243,12 @@ function parsePowerInput(str) {
       if (notes) obj.notes = notes;
       return obj;
     });
-  powerInputCache.set(str, arr);
+
+  // Store a defensive copy to keep the cached data immutable.
+  powerInputCache.set(
+    str,
+    arr.map(obj => ({ ...obj }))
+  );
   return arr;
 }
 


### PR DESCRIPTION
## Summary
- avoid returning cached power input objects directly by returning fresh copies
- add regression test for parsePowerInput cache pollution

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b774b0ab7c8320b2d721762482a5f3