### PR TITLE
refactor: extract helper for power input parsing

### DIFF
--- a/unifyPorts.js
+++ b/unifyPorts.js
@@ -203,6 +203,31 @@ function splitOutside(str, delimiter = '/') {
 }
 
 /**
+ * Extracts a connector type and optional notes from a segment.
+ *
+ * @param {string} segment - Raw segment containing type and optional notes.
+ * @returns {{type: string, notes: string}} Parsed type and notes.
+ */
+function extractTypeAndNotes(segment) {
+  let type = segment;
+  let notes = '';
+
+  let m = type.match(PAREN_NOTES_REGEX);
+  if (m) {
+    type = m[1].trim();
+    notes = m[2].trim();
+  } else {
+    m = type.match(QUOTE_NOTES_REGEX);
+    if (m) {
+      type = m[1].trim();
+      notes = m[2].trim();
+    }
+  }
+
+  return { type, notes };
+}
+
+/**
  * Parses a power input description into structured objects.
  *
  * Each segment is separated by `/` unless the slash appears inside parentheses
@@ -217,22 +242,9 @@ function parsePowerInput(str) {
   if (powerInputCache.has(str)) return powerInputCache.get(str);
   const arr = splitOutside(str)
     .map(p => p.trim())
-    .filter(p => p.length > 0)
-    .map(p => {
-      let type = p;
-      let notes = '';
-
-      let m = type.match(PAREN_NOTES_REGEX);
-      if (m) {
-        type = m[1].trim();
-        notes = m[2].trim();
-      } else {
-        m = type.match(QUOTE_NOTES_REGEX);
-        if (m) {
-          type = m[1].trim();
-          notes = m[2].trim();
-        }
-      }
+    .filter(Boolean)
+    .map(segment => {
+      const { type, notes } = extractTypeAndNotes(segment);
       const obj = { type: cleanTypeName(type) };
       if (notes) obj.notes = notes;
       return obj;


### PR DESCRIPTION
## Summary
- simplify power input parsing with reusable helper
- streamline parsePowerInput logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b774bd22d08320916670a06bc15cda