### PR TITLE
Show filter inputs for device dropdowns

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Recent updates include:
 - **Interactive setup diagram** – drag devices, zoom, snap nodes to a grid, and export layouts as SVG or JPG.
 - **Pink accent theme** – toggle a playful pink highlight that persists between visits or press **P** to switch quickly.
 - **Searchable help dialog and hover hints** – open with ?, H, F1 or Ctrl+/ (even while typing), filter topics instantly, press / or Ctrl+F to jump to the search box, browse the built-in FAQ, and hover over any button, field, dropdown or header for a quick explanation.
+- **Inline dropdown filters with clear buttons** – quickly narrow device lists using search boxes above each selector and reset them with a single click.
 - **Dual V‑/B‑Mount support** – choose between plate types on supported cameras and the battery list updates automatically.
 - **User runtime feedback** – submit real-world runtimes with environment details to refine estimates.
 - **Visual runtime weighting dashboard** – see how temperature, resolution, frame rate and codec affect each runtime report, now sorted by weight with exact share percentages.

--- a/style.css
+++ b/style.css
@@ -378,10 +378,23 @@ body.hover-help-active * {
   flex-direction: column;
   flex: 1;
   min-width: 0; /* allow wrapper to shrink on narrow screens */
+  position: relative;
 }
 
 .select-wrapper .filter-input {
-  display: none;
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
+  margin-bottom: 4px;
+  padding-right: 1.5em; /* space for clear button */
+}
+
+.select-wrapper .filter-input + .clear-input-btn {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  margin: 0;
+  line-height: 1;
 }
 
 /* Prevent long option text from widening selects on mobile */


### PR DESCRIPTION
## Summary
- Display dropdown filter inputs with inline clear buttons to allow quick device list searching.
- Document the new inline filters in the README.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b774d9c8288320895c4fd8c63917cd