### PR TITLE
Respect dark mode in generated overview

### DIFF
--- a/script.js
+++ b/script.js
@@ -6842,24 +6842,16 @@ function generatePrintableOverview() {
     overviewDialog.innerHTML = overviewHtml;
     const content = overviewDialog.querySelector('#overviewDialogContent');
 
-    const darkModeActive = document.body.classList.contains('dark-mode');
-    if (darkModeActive) {
-        document.body.classList.remove('dark-mode');
+    if (document.body.classList.contains('dark-mode')) {
+        content.classList.add('dark-mode');
     }
     if (document.body.classList.contains('pink-mode')) {
         content.classList.add('pink-mode');
     }
 
-    const restoreTheme = () => {
-        if (darkModeActive) {
-            document.body.classList.add('dark-mode');
-        }
-    };
-
     const closeBtn = overviewDialog.querySelector('#closeOverviewBtn');
     if (closeBtn) {
         closeBtn.addEventListener('click', () => {
-            restoreTheme();
             overviewDialog.close();
         });
     }
@@ -6870,7 +6862,6 @@ function generatePrintableOverview() {
     }
 
     const closeAfterPrint = () => {
-        restoreTheme();
         overviewDialog.close();
     };
     if (typeof window.matchMedia === 'function') {

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -999,7 +999,7 @@ describe('script.js functions', () => {
     expect(html).toContain(`<strong>${texts.en.cameraLabel}</strong>`);
   });
 
-  test('generatePrintableOverview removes dark mode styling when active', () => {
+  test('generatePrintableOverview keeps dark mode styling when active', () => {
     const { generatePrintableOverview } = script;
     document.body.classList.add('dark-mode');
     document.getElementById('setupName').value = 'Test';
@@ -1012,8 +1012,8 @@ describe('script.js functions', () => {
     script.updateCalculations();
     generatePrintableOverview();
     const content = document.querySelector('#overviewDialogContent');
-    expect(content.classList.contains('dark-mode')).toBe(false);
-    expect(document.body.classList.contains('dark-mode')).toBe(false);
+    expect(content.classList.contains('dark-mode')).toBe(true);
+    expect(document.body.classList.contains('dark-mode')).toBe(true);
   });
 
   test('generateGearListHtml returns table with categories and accessories', () => {


### PR DESCRIPTION
## Summary
- Preserve dark mode styling when generating printable overview dialogs
- Update tests to ensure overview retains dark mode

## Testing
- `npm run lint && npm run check-consistency && npx jest --runInBand --forceExit`


------
https://chatgpt.com/codex/tasks/task_e_68b777fcc2308320ae0032c8ca759e70