### PR TITLE
Fix dark rows in battery comparison when printing

### DIFF
--- a/overview-print.css
+++ b/overview-print.css
@@ -73,8 +73,16 @@ table, th, td {
   word-break: break-word;
   hyphens: auto;
 }
-th { background-color: #e0e0e0; font-weight: 700; }
-tr:nth-child(even) { background-color: #f9f9f9; }
+#overviewDialogContent th {
+  background-color: #e0e0e0 !important;
+  font-weight: 700;
+}
+#overviewDialogContent tr {
+  background-color: #fff !important;
+}
+#overviewDialogContent tr:nth-child(even) {
+  background-color: #f9f9f9 !important;
+}
 
 
 .device-block,


### PR DESCRIPTION
## Summary
- Override dark-mode row styling in `overview-print.css` so all rows print with light backgrounds

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b77845662c8320b250ef710c8253e0