### PR TITLE
Include gear list in overview and print styles

### DIFF
--- a/overview-print.css
+++ b/overview-print.css
@@ -49,7 +49,7 @@ p {
   display: none;
 }
 
-h2, h3, table, .device-block, .device-category {
+h2, h3, table, .device-block, .device-category, .requirement-box {
   page-break-inside: avoid;
   break-inside: avoid;
 }
@@ -75,6 +75,23 @@ table, th, td {
 }
 th { background-color: #e0e0e0; font-weight: 700; }
 tr:nth-child(even) { background-color: #f9f9f9; }
+
+.requirement-box {
+  background: #fff;
+  border: 1px solid #000;
+  box-shadow: none;
+}
+
+.gear-table td {
+  border: 1px solid #000;
+  background: #fff;
+}
+
+.gear-table .category-row td {
+  background: #e0e0e0;
+  font-weight: 700;
+  color: #000;
+}
 
 
 .device-block,

--- a/script.js
+++ b/script.js
@@ -6816,6 +6816,12 @@ function generatePrintableOverview() {
     const diagramSectionHtmlWithBreak = diagramSectionHtml ? `<div class="page-break"></div>${diagramSectionHtml}` : '';
     const batteryTableHtmlWithBreak = batteryTableHtml ? `<div class="page-break"></div>${batteryTableHtml}` : '';
 
+    let gearListHtml = getCurrentGearListHtml();
+    if (!gearListHtml && currentProjectInfo) {
+        gearListHtml = generateGearListHtml(currentProjectInfo);
+    }
+    const gearListHtmlWithBreak = gearListHtml ? `<div class="page-break"></div>${gearListHtml}` : '';
+
     const overviewHtml = `
         <div id="overviewDialogContent">
             <button id="closeOverviewBtn" class="back-btn">${t.backToAppBtn}</button>
@@ -6832,6 +6838,8 @@ function generatePrintableOverview() {
             <h2>${t.resultsHeading}</h2>
             ${resultsHtml}
             ${warningHtml}
+
+            ${gearListHtmlWithBreak}
 
             ${diagramSectionHtmlWithBreak}
             ${batteryTableHtmlWithBreak}

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -1016,6 +1016,31 @@ describe('script.js functions', () => {
     expect(document.body.classList.contains('dark-mode')).toBe(false);
   });
 
+  test('generatePrintableOverview includes project requirements and gear list', () => {
+    const { generatePrintableOverview } = script;
+    document.getElementById('setupName').value = 'Test';
+    const addOpt = (id, value) => {
+      const sel = document.getElementById(id);
+      sel.innerHTML = `<option value="${value}">${value}</option>`;
+      sel.value = value;
+    };
+    addOpt('cameraSelect', 'CamA');
+    script.updateCalculations();
+
+    const projOut = document.getElementById('projectRequirementsOutput');
+    projOut.innerHTML = '<h2>Proj</h2><h3>Project Requirements</h3>';
+    projOut.classList.remove('hidden');
+    const gearOut = document.getElementById('gearListOutput');
+    gearOut.innerHTML = '<h3>Gear List</h3><table class="gear-table"><tr class="category-row"><td>Camera</td></tr><tr><td>CamA</td></tr></table>';
+    gearOut.classList.remove('hidden');
+
+    generatePrintableOverview();
+    const html = document.getElementById('overviewDialog').innerHTML;
+    expect(html).toContain('Project Requirements');
+    expect(html).toContain('Gear List');
+    expect(html).toContain('CamA');
+  });
+
   test('generateGearListHtml returns table with categories and accessories', () => {
       const { generateGearListHtml } = script;
       const addOpt = (id, value) => {


### PR DESCRIPTION
## Summary
- embed project requirements and gear list into printable overview
- style requirement boxes and gear table for print output
- test overview generation includes gear list

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b778a4304483209b1253be8289c4ac