### PR TITLE
Ensure setup diagram prints in light mode

### DIFF
--- a/overview-print.css
+++ b/overview-print.css
@@ -26,6 +26,42 @@ body.dark-mode {
   background: #fff !important;
 }
 
+/* Ensure setup diagram uses light theme when printing */
+#overviewDialogContent #setupDiagram .node-box,
+#overviewDialogContent #setupDiagram .node-box.first-fiz {
+  fill: #e8f0fe;
+  stroke: none;
+}
+#overviewDialogContent #setupDiagram text {
+  fill: #000;
+  font-family: 'Ubuntu', sans-serif;
+}
+#overviewDialogContent #setupDiagram line,
+#overviewDialogContent #setupDiagram path.edge-path {
+  stroke: #333;
+}
+#overviewDialogContent #setupDiagram path.power {
+  stroke: #d33;
+}
+#overviewDialogContent #setupDiagram path.video {
+  stroke: #369;
+}
+#overviewDialogContent #setupDiagram path.fiz {
+  stroke: #090;
+}
+#overviewDialogContent #setupDiagram .conn.red {
+  fill: #d33;
+}
+#overviewDialogContent #setupDiagram .conn.blue {
+  fill: #369;
+}
+#overviewDialogContent #setupDiagram .conn.green {
+  fill: #090;
+}
+#overviewDialogContent #setupDiagram marker polygon {
+  fill: #333;
+}
+
 #overviewDialogContent h1,
 #overviewDialogContent h2,
 #overviewDialogContent h3 {

--- a/script.js
+++ b/script.js
@@ -6850,9 +6850,7 @@ function generatePrintableOverview() {
     overviewDialog.innerHTML = overviewHtml;
     const content = overviewDialog.querySelector('#overviewDialogContent');
 
-    if (document.body.classList.contains('dark-mode')) {
-        content.classList.add('dark-mode');
-    }
+    // Always use light mode for printed overview regardless of current theme
     if (document.body.classList.contains('pink-mode')) {
         content.classList.add('pink-mode');
     }

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -999,7 +999,7 @@ describe('script.js functions', () => {
     expect(html).toContain(`<strong>${texts.en.cameraLabel}</strong>`);
   });
 
-  test('generatePrintableOverview keeps dark mode styling when active', () => {
+  test('generatePrintableOverview uses light mode styling even when dark mode active', () => {
     const { generatePrintableOverview } = script;
     document.body.classList.add('dark-mode');
     document.getElementById('setupName').value = 'Test';
@@ -1012,7 +1012,7 @@ describe('script.js functions', () => {
     script.updateCalculations();
     generatePrintableOverview();
     const content = document.querySelector('#overviewDialogContent');
-    expect(content.classList.contains('dark-mode')).toBe(true);
+    expect(content.classList.contains('dark-mode')).toBe(false);
     expect(document.body.classList.contains('dark-mode')).toBe(true);
   });
 


### PR DESCRIPTION
## Summary
- Prevent dark-mode class from being applied to printable overview so exports use light theme
- Add print-specific styles to force light colors for setup diagram
- Update tests to expect light-mode styling when dark mode is active

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b77865a9508320b4deec8a7b748771