### PR TITLE
Persist setup across sessions

### DIFF
--- a/script.js
+++ b/script.js
@@ -5298,6 +5298,9 @@ clearSetupBtn.addEventListener("click", () => {
     confirm(texts[currentLang].confirmClearSetup) &&
     confirm(texts[currentLang].confirmClearSetupAgain)
   ) {
+    if (typeof localStorage !== 'undefined') {
+      localStorage.removeItem('cameraPowerPlanner_session');
+    }
     if (typeof sessionStorage !== 'undefined') {
       sessionStorage.removeItem('cameraPowerPlanner_session');
     }

--- a/storage.js
+++ b/storage.js
@@ -50,20 +50,22 @@ function generateUniqueName(base, usedNames) {
 }
 
 // --- Session State Storage ---
+// Store the current session (unsaved setup) in localStorage so it survives
+// full app reloads.
 function loadSessionState() {
   return loadJSONFromStorage(
-    sessionStorage,
+    localStorage,
     SESSION_STATE_KEY,
-    "Error loading session state from sessionStorage:"
+    "Error loading session state from localStorage:"
   );
 }
 
 function saveSessionState(state) {
   saveJSONToStorage(
-    sessionStorage,
+    localStorage,
     SESSION_STATE_KEY,
     state,
-    "Error saving session state to sessionStorage:"
+    "Error saving session state to localStorage:"
   );
 }
 
@@ -240,7 +242,10 @@ function clearAllData() {
     localStorage.removeItem(SETUP_STORAGE_KEY);
     localStorage.removeItem(FEEDBACK_STORAGE_KEY);
     localStorage.removeItem(GEARLIST_STORAGE_KEY);
-    sessionStorage.removeItem(SESSION_STATE_KEY);
+    localStorage.removeItem(SESSION_STATE_KEY);
+    if (typeof sessionStorage !== 'undefined') {
+      sessionStorage.removeItem(SESSION_STATE_KEY);
+    }
     console.log("All planner data cleared from storage.");
   } catch (e) {
     console.error("Error clearing storage:", e);

--- a/tests/storage.test.js
+++ b/tests/storage.test.js
@@ -184,18 +184,18 @@ describe('setup storage', () => {
 
 describe('session state storage', () => {
   beforeEach(() => {
-    sessionStorage.clear();
+    localStorage.clear();
   });
 
-  test('saveSessionState stores JSON in sessionStorage', () => {
+  test('saveSessionState stores JSON in localStorage', () => {
     const state = { camera: 'CamA' };
     saveSessionState(state);
-    expect(sessionStorage.getItem(SESSION_KEY)).toBe(JSON.stringify(state));
+    expect(localStorage.getItem(SESSION_KEY)).toBe(JSON.stringify(state));
   });
 
   test('loadSessionState returns parsed object when present', () => {
     const state = { camera: 'CamA' };
-    sessionStorage.setItem(SESSION_KEY, JSON.stringify(state));
+    localStorage.setItem(SESSION_KEY, JSON.stringify(state));
     expect(loadSessionState()).toEqual(state);
   });
 
@@ -246,7 +246,7 @@ describe('clearAllData', () => {
     expect(localStorage.getItem(SETUP_KEY)).toBeNull();
     expect(localStorage.getItem(FEEDBACK_KEY)).toBeNull();
     expect(localStorage.getItem(GEARLIST_KEY)).toBeNull();
-    expect(sessionStorage.getItem(SESSION_KEY)).toBeNull();
+    expect(localStorage.getItem(SESSION_KEY)).toBeNull();
   });
 });
 


### PR DESCRIPTION
## Summary
- Store session state in localStorage so unsaved setups survive full reloads
- Clear setup data from both localStorage and sessionStorage for a full reset
- Update storage tests for new persistence logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b7cb77d3d48320bebb847529da7e08