### PR TITLE
Remove dropdown filter fields

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -70,7 +70,7 @@ Die Sprache kann oben rechts umgeschaltet werden und wird für den nächsten Bes
   🎮 Controller, 📐 Distanz, 🎮 Griff und 🔌 Akkuschacht
 
 ### 🔍 Suche & Filter
-- Alle Dropdowns und Listen lassen sich über ein Suchfeld filtern
+- Listen lassen sich über ein Suchfeld filtern
 - Durch Tippen im Dropdown schnell Einträge finden
 
 ### 🛠 Geräte-Datenbank

--- a/README.en.md
+++ b/README.en.md
@@ -98,8 +98,8 @@ The app automatically uses your browser language on first load, and you can swit
 - A dashboard orders entries by weight and displays each one's share percentage for quick comparison.
 
 ### 🔍 Search & Filtering
-- Filter every dropdown and device list with a search box
 - Type inside dropdowns to quickly find entries
+- Filter device lists with a search box
 
 ### 🛠 Device Database Editor
 - Add, edit or delete devices in all categories

--- a/README.es.md
+++ b/README.es.md
@@ -70,8 +70,8 @@ El idioma puede cambiarse en la esquina superior derecha y se recuerda para la p
   🎮 controlador, 📐 distancia, 🎮 empuñadura y 🔌 placa de batería
 
 ### 🔍 Búsqueda y Filtros
-- Filtrar cualquier lista o menú desplegable con un campo de búsqueda
 - Escribir dentro de los desplegables para encontrar rápido
+- Filtrar las listas con un campo de búsqueda
 
 ### 🛠 Base de Datos de Dispositivos
 - Añadir, editar o eliminar dispositivos de todas las categorías

--- a/README.fr.md
+++ b/README.fr.md
@@ -70,8 +70,8 @@ La langue se change en haut à droite et est mémorisée pour la prochaine visit
   🎮 contrôleur, 📐 distance, 🎮 poignée et 🔌 plaque batterie
 
 ### 🔍 Recherche et Filtres
-- Champ de recherche pour filtrer toutes les listes et menus déroulants
 - Taper dans les menus pour trouver rapidement
+- Champ de recherche pour filtrer les listes
 
 ### 🛠 Base de Données des Appareils
 - Ajouter, modifier ou supprimer des appareils de chaque catégorie

--- a/README.it.md
+++ b/README.it.md
@@ -69,8 +69,8 @@ Puoi cambiare lingua nell'angolo in alto a destra. La scelta viene memorizzata p
   🎮 controller, 📐 distanza, 🎮 impugnatura e 🔌 piastra batteria
 
 ### 🔍 Ricerca e filtri
-- Filtra ogni menu a discesa e lista dispositivi con un campo di ricerca
 - Digita nei menu a discesa per trovare rapidamente le voci
+- Filtra le liste dispositivi con un campo di ricerca
 
 ### 🛠 Editor del database dei dispositivi
 - Aggiungi, modifica o elimina dispositivi in tutte le categorie

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Recent updates include:
 - **Interactive setup diagram** – drag devices, zoom, snap nodes to a grid, and export layouts as SVG or JPG.
 - **Pink accent theme** – toggle a playful pink highlight that persists between visits or press **P** to switch quickly.
 - **Searchable help dialog and hover hints** – open with ?, H, F1 or Ctrl+/ (even while typing), filter topics instantly, press / or Ctrl+F to jump to the search box, browse the built-in FAQ, and hover over any button, field, dropdown or header for a quick explanation.
-- **Inline dropdown filters with clear buttons** – quickly narrow device lists using search boxes above each selector and reset them with a single click.
+- **Type-to-search dropdowns** – quickly narrow device lists by typing directly into any selector.
 - **Dual V‑/B‑Mount support** – choose between plate types on supported cameras and the battery list updates automatically.
 - **User runtime feedback** – submit real-world runtimes with environment details to refine estimates.
 - **Visual runtime weighting dashboard** – see how temperature, resolution, frame rate and codec affect each runtime report, now sorted by weight with exact share percentages.

--- a/index.html
+++ b/index.html
@@ -80,25 +80,21 @@
 
   <section id="setup-config">
     <h2 id="deviceSelectionHeading">Device Selection</h2>
-    <button id="clearFiltersBtn" aria-label="Clear All Filters" title="Clear All Filters">&times;</button>
       <div class="form-row">
         <label for="cameraSelect" id="cameraLabel">Camera:</label>
         <div class="select-wrapper">
-          <input type="search" id="cameraFilter" class="filter-input" placeholder="Filter..." aria-label="Filter" inputmode="search" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" />
           <select id="cameraSelect" aria-labelledby="cameraLabel"></select>
         </div>
       </div>
       <div class="form-row">
         <label for="monitorSelect" id="monitorLabel">Monitor:</label>
         <div class="select-wrapper">
-          <input type="search" id="monitorFilter" class="filter-input" placeholder="Filter..." aria-label="Filter" inputmode="search" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" />
           <select id="monitorSelect" aria-labelledby="monitorLabel"></select>
         </div>
       </div>
       <div class="form-row">
         <label for="videoSelect" id="videoLabel">Wireless Video:</label>
       <div class="select-wrapper">
-          <input type="search" id="videoFilter" class="filter-input" placeholder="Filter..." aria-label="Filter" inputmode="search" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" />
           <select id="videoSelect" aria-labelledby="videoLabel"></select>
         </div>
       </div>
@@ -111,7 +107,6 @@
       <div class="form-row">
         <label for="motor1Select" id="fizMotorsLabel">FIZ Motors:</label>
         <div class="select-wrapper">
-          <input type="search" id="motorFilter" class="filter-input" placeholder="Filter..." aria-label="Filter" inputmode="search" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" />
           <select id="motor1Select" aria-labelledby="fizMotorsLabel"></select>
         </div>
       </div>
@@ -130,7 +125,6 @@
       <div class="form-row">
         <label for="controller1Select" id="fizControllersLabel">FIZ Controllers:</label>
         <div class="select-wrapper">
-          <input type="search" id="controllerFilter" class="filter-input" placeholder="Filter..." aria-label="Filter" inputmode="search" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" />
           <select id="controller1Select" aria-labelledby="fizControllersLabel"></select>
         </div>
       </div>
@@ -149,7 +143,6 @@
     <div class="form-row">
       <label for="distanceSelect" id="distanceLabel">Distance Sensor:</label>
       <div class="select-wrapper">
-        <input type="search" id="distanceFilter" class="filter-input" placeholder="Filter..." aria-label="Filter" inputmode="search" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" />
         <select id="distanceSelect" aria-labelledby="distanceLabel"></select>
       </div>
     </div>
@@ -162,7 +155,6 @@
     <div class="form-row">
       <label for="batterySelect" id="batteryLabel">V-Mount Battery:</label>
       <div class="select-wrapper">
-        <input type="search" id="batteryFilter" class="filter-input" placeholder="Filter..." aria-label="Filter" inputmode="search" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" />
         <select id="batterySelect" aria-labelledby="batteryLabel"></select>
       </div>
     </div>
@@ -897,7 +889,6 @@
       <div class="form-row">
         <label for="lenses" id="lensesLabel">Lenses:</label>
         <div class="select-wrapper">
-          <input type="search" id="lensFilter" class="filter-input" placeholder="Filter..." aria-label="Filter" inputmode="search" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" />
           <select id="lenses" name="lenses" multiple size="10" aria-labelledby="lensesLabel"></select>
         </div>
       </div>

--- a/script.js
+++ b/script.js
@@ -710,7 +710,6 @@ function updateBatteryOptions() {
   if (Array.from(batterySelect.options).some(o => o.value === current)) {
     batterySelect.value = current;
   }
-  filterSelect(batterySelect, batteryFilterInput.value);
   updateBatteryLabel();
 }
 
@@ -1070,10 +1069,6 @@ function setLanguage(lang) {
   batteryPlateLabelElem.setAttribute("data-help", texts[lang].batteryPlateSelectHelp);
 
   updateBatteryLabel();
-  clearFiltersBtn.textContent = "\u00d7";
-  clearFiltersBtn.setAttribute("aria-label", texts[lang].clearFiltersBtn);
-  clearFiltersBtn.setAttribute("title", texts[lang].clearFiltersBtn);
-  clearFiltersBtn.setAttribute("data-help", texts[lang].clearFiltersHelp);
   // FIZ legend and labels
   const fizLegendElem = document.getElementById("fizLegend");
   if (fizLegendElem) {
@@ -1247,15 +1242,6 @@ function setLanguage(lang) {
   cameraVoltageInput.placeholder = texts[lang].placeholder_voltage;
   monitorVoltageInput.placeholder = texts[lang].placeholder_voltage;
   const filterMappings = [
-    {input: cameraFilterInput, label: texts[lang].cameraLabel},
-    {input: monitorFilterInput, label: texts[lang].monitorLabel},
-    {input: videoFilterInput, label: texts[lang].videoLabel},
-    {input: cageFilterInput, label: texts[lang].cageLabel},
-    {input: motorFilterInput, label: texts[lang].fizMotorsLabel},
-    {input: controllerFilterInput, label: texts[lang].fizControllersLabel},
-    {input: distanceFilterInput, label: texts[lang].distanceLabel},
-    {input: batteryFilterInput, label: texts[lang].batteryLabel},
-    {input: lensFilterInput, label: texts[lang].lensesLabel},
     {input: cameraListFilterInput, label: texts[lang].category_cameras},
     {input: viewfinderListFilterInput, label: texts[lang].category_viewfinders},
     {input: monitorListFilterInput, label: texts[lang].category_monitors},
@@ -1485,7 +1471,6 @@ const setupNameInput  = document.getElementById("setupName");
 const saveSetupBtn    = document.getElementById("saveSetupBtn");
 const deleteSetupBtn  = document.getElementById("deleteSetupBtn");
 const clearSetupBtn   = document.getElementById("clearSetupBtn");
-const clearFiltersBtn = document.getElementById("clearFiltersBtn");
 const shareSetupBtn   = document.getElementById("shareSetupBtn");
 const sharedLinkRow   = document.getElementById("sharedLinkRow");
 const sharedLinkInput = document.getElementById("sharedLinkInput");
@@ -1786,17 +1771,6 @@ const overviewSectionIcons = {
 };
 
 // Load an image and optionally strip a solid background using Canvas
-// Filter inputs
-const cameraFilterInput = document.getElementById("cameraFilter");
-const monitorFilterInput = document.getElementById("monitorFilter");
-const videoFilterInput = document.getElementById("videoFilter");
-const cageFilterInput = document.getElementById("cageFilter");
-const motorFilterInput = document.getElementById("motorFilter");
-const controllerFilterInput = document.getElementById("controllerFilter");
-const distanceFilterInput = document.getElementById("distanceFilter");
-const batteryFilterInput = document.getElementById("batteryFilter");
-const lensFilterInput = document.getElementById("lensFilter");
-
 // List filters for existing device categories
 const cameraListFilterInput = document.getElementById("cameraListFilter");
 const viewfinderListFilterInput = document.getElementById("viewfinderListFilter");
@@ -3406,49 +3380,7 @@ function addInputClearButton(inputElem, callback) {
   toggle();
 }
 
-function clearFilterOnSelect(selectElem, filterInput, resetCallback) {
-  if (!selectElem || !filterInput) {
-    return;
-  }
-  selectElem.addEventListener("change", () => {
-    if (filterInput.value !== "") {
-      filterInput.value = "";
-      if (typeof resetCallback === "function") {
-        resetCallback();
-      } else {
-        filterSelect(selectElem, "");
-      }
-    }
-  });
-}
-
-function clearAllFilters() {
-  [cameraFilterInput, monitorFilterInput, videoFilterInput, cageFilterInput, motorFilterInput,
-   controllerFilterInput, distanceFilterInput, batteryFilterInput, lensFilterInput].forEach(input => {
-    if (input) input.value = "";
-  });
-  filterSelect(cameraSelect, "");
-  filterSelect(monitorSelect, "");
-  filterSelect(videoSelect, "");
-  if (cageSelect) filterSelect(cageSelect, "");
-  motorSelects.forEach(sel => filterSelect(sel, ""));
-  controllerSelects.forEach(sel => filterSelect(sel, ""));
-  filterSelect(distanceSelect, "");
-  filterSelect(batterySelect, "");
-  filterSelect(lensSelect, "");
-}
-
 function applyFilters() {
-  filterSelect(cameraSelect, cameraFilterInput.value);
-  filterSelect(monitorSelect, monitorFilterInput.value);
-  filterSelect(videoSelect, videoFilterInput.value);
-  if (cageSelect) filterSelect(cageSelect, cageFilterInput ? cageFilterInput.value : "");
-  motorSelects.forEach(sel => filterSelect(sel, motorFilterInput.value));
-  controllerSelects.forEach(sel => filterSelect(sel, controllerFilterInput.value));
-  filterSelect(distanceSelect, distanceFilterInput.value);
-  filterSelect(batterySelect, batteryFilterInput.value);
-  filterSelect(lensSelect, lensFilterInput.value);
-
   filterDeviceList(cameraListElem, cameraListFilterInput.value);
   filterDeviceList(viewfinderListElem, viewfinderListFilterInput.value);
   filterDeviceList(monitorListElem, monitorListFilterInput.value);
@@ -5207,27 +5139,8 @@ if (skipLink) {
 }
 
 // Filtering inputs
-bindFilterInput(cameraFilterInput, () => filterSelect(cameraSelect, cameraFilterInput.value));
-bindFilterInput(monitorFilterInput, () => filterSelect(monitorSelect, monitorFilterInput.value));
-bindFilterInput(videoFilterInput, () => filterSelect(videoSelect, videoFilterInput.value));
-if (cageFilterInput && cageSelect) bindFilterInput(cageFilterInput, () => filterSelect(cageSelect, cageFilterInput.value));
-bindFilterInput(motorFilterInput, () => motorSelects.forEach(sel => filterSelect(sel, motorFilterInput.value)));
-bindFilterInput(controllerFilterInput, () => controllerSelects.forEach(sel => filterSelect(sel, controllerFilterInput.value)));
-bindFilterInput(distanceFilterInput, () => filterSelect(distanceSelect, distanceFilterInput.value));
-bindFilterInput(batteryFilterInput, () => filterSelect(batterySelect, batteryFilterInput.value));
-bindFilterInput(lensFilterInput, () => filterSelect(lensSelect, lensFilterInput.value));
 
-clearFilterOnSelect(cameraSelect, cameraFilterInput);
-clearFilterOnSelect(monitorSelect, monitorFilterInput);
-clearFilterOnSelect(videoSelect, videoFilterInput);
-if (cageSelect && cageFilterInput) clearFilterOnSelect(cageSelect, cageFilterInput);
-motorSelects.forEach(sel => clearFilterOnSelect(sel, motorFilterInput, () => motorSelects.forEach(s => filterSelect(s, ""))));
-controllerSelects.forEach(sel => clearFilterOnSelect(sel, controllerFilterInput, () => controllerSelects.forEach(s => filterSelect(s, ""))));
-clearFilterOnSelect(distanceSelect, distanceFilterInput);
-clearFilterOnSelect(batterySelect, batteryFilterInput);
-clearFilterOnSelect(lensSelect, lensFilterInput);
 
-clearFiltersBtn.addEventListener("click", clearAllFilters);
 
 bindFilterInput(cameraListFilterInput, () => filterDeviceList(cameraListElem, cameraListFilterInput.value));
 bindFilterInput(viewfinderListFilterInput, () => filterDeviceList(viewfinderListElem, viewfinderListFilterInput.value));
@@ -8501,7 +8414,6 @@ if (typeof module !== "undefined" && module.exports) {
     normalizePowerPortType,
     getCurrentSetupKey,
     renderFeedbackTable,
-    clearAllFilters,
     saveCurrentGearList,
     populateLensDropdown,
     populateSensorModeDropdown,

--- a/style.css
+++ b/style.css
@@ -368,33 +368,13 @@ body.hover-help-active * {
   margin: 5px 5px 0 0;
 }
 
-/* smaller width for search inputs */
-.form-row .filter-input {
-  flex: 0 0 120px;
-}
-
+/* Wrapper for selects to allow flexible layout */
 .select-wrapper {
   display: flex;
   flex-direction: column;
   flex: 1;
   min-width: 0; /* allow wrapper to shrink on narrow screens */
   position: relative;
-}
-
-.select-wrapper .filter-input {
-  display: block;
-  width: 100%;
-  box-sizing: border-box;
-  margin-bottom: 4px;
-  padding-right: 1.5em; /* space for clear button */
-}
-
-.select-wrapper .filter-input + .clear-input-btn {
-  position: absolute;
-  top: 6px;
-  right: 6px;
-  margin: 0;
-  line-height: 1;
 }
 
 /* Prevent long option text from widening selects on mobile */
@@ -425,14 +405,6 @@ select {
   background-image: none;
   -webkit-appearance: none;
   appearance: none;
-}
-
-#clearFiltersBtn {
-  float: right;
-  background: transparent;
-  border: none;
-  font-size: 1.2em;
-  cursor: pointer;
 }
 
 .clear-input-btn {

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -173,16 +173,6 @@ describe('script.js functions', () => {
     expect(Array.from(sel.options).map(o => o.value)).toEqual(['LensA']);
   });
 
-  test('lens filter narrows lens options', () => {
-    const sel = document.getElementById('lenses');
-    sel.innerHTML = '<option value="LensA">LensA</option><option value="LensB">LensB</option>';
-    const input = document.getElementById('lensFilter');
-    input.value = 'b';
-    input.dispatchEvent(new Event('input'));
-    expect(sel.options[0].hidden).toBe(true);
-    expect(sel.options[1].hidden).toBe(false);
-  });
-
   test('selected cage appears in camera support category of gear list', () => {
     const addOpt = (id, value) => {
       const sel = document.getElementById(id);
@@ -619,61 +609,12 @@ describe('script.js functions', () => {
     expect(optionsB).not.toContain('VBatt');
   });
 
-  test('filter input clears on Escape key press', () => {
-    const camSel = document.getElementById('cameraSelect');
-    camSel.innerHTML = '<option value="CamA">CamA</option><option value="CamB">CamB</option>';
-
-    const filterInput = document.getElementById('cameraFilter');
-    filterInput.value = 'CamA';
-    filterInput.dispatchEvent(new Event('input'));
-    expect(camSel.options[1].hidden).toBe(true);
-
-    filterInput.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
-    expect(filterInput.value).toBe('');
-    expect(camSel.options[1].hidden).toBe(false);
-  });
-
-  test('filter input clears after selecting an option', () => {
-    const camSel = document.getElementById('cameraSelect');
-    camSel.innerHTML = '<option value="CamA">CamA</option><option value="CamB">CamB</option>';
-
-    const filterInput = document.getElementById('cameraFilter');
-    filterInput.value = 'CamA';
-    filterInput.dispatchEvent(new Event('input'));
-    expect(camSel.options[1].hidden).toBe(true);
-
-    camSel.value = 'CamA';
-    camSel.dispatchEvent(new Event('change'));
-    expect(filterInput.value).toBe('');
-    expect(camSel.options[1].hidden).toBe(false);
-  });
-
-  test('clear filters button resets all filter fields', () => {
-    const camSel = document.getElementById('cameraSelect');
-    camSel.innerHTML = '<option value="CamA">CamA</option><option value="CamB">CamB</option>';
-
-    const ids = ['cameraFilter','monitorFilter','videoFilter','motorFilter','controllerFilter','distanceFilter','batteryFilter'];
-    ids.forEach(id => {
-      const inp = document.getElementById(id);
-      inp.value = 'x';
-      inp.dispatchEvent(new Event('input'));
-    });
-
-    document.getElementById('clearFiltersBtn').click();
-
-    ids.forEach(id => {
-      expect(document.getElementById(id).value).toBe('');
-    });
-    expect(camSel.options[1].hidden).toBe(false);
-  });
-
   test('filter inputs disable autocomplete and spellcheck', () => {
     const ids = [
-      'cameraFilter', 'monitorFilter', 'videoFilter', 'motorFilter',
-      'controllerFilter', 'distanceFilter', 'batteryFilter',
-      'cameraListFilter', 'monitorListFilter', 'videoListFilter',
+      'cameraListFilter', 'viewfinderListFilter', 'monitorListFilter', 'videoListFilter',
       'motorListFilter', 'controllerListFilter', 'distanceListFilter',
-      'batteryListFilter'
+      'batteryListFilter', 'accessoryBatteryListFilter', 'cableListFilter',
+      'fizCableListFilter', 'cameraSupportListFilter', 'chargerListFilter'
     ];
     ids.forEach(id => {
       const inp = document.getElementById(id);

--- a/translations.js
+++ b/translations.js
@@ -49,7 +49,6 @@ const texts = {
     saveSetupBtn: "Save",
     updateSetupBtn: "Update",
     clearSetupBtn: "Clear Current Setup",
-    clearFiltersBtn: "Clear All Filters",
     clearFilter: "Clear filter",
     shareSetupBtn: "Share Setup Link",
     shareSetupPrompt: "Copy this link to share your setup:",
@@ -339,9 +338,7 @@ const texts = {
     distanceSelectHelp: "Choose an optional distance or range-finder sensor.",
     batterySelectHelp: "Choose the battery model that will power the entire rig.",
     batteryPlateSelectHelp: "Choose the battery plate or adapter that connects the battery to the camera.",
-    clearSetupHelp: "Reset the planner by removing every selected device.",
-    clearFiltersHelp: "Remove text from all filter fields to show all options.",
-    runtimeFeedbackBtnHelp:
+    clearSetupHelp: "Reset the planner by removing every selected device.",    runtimeFeedbackBtnHelp:
       "Open a form where you can submit real-world runtime data for this configuration.",
     zoomOutHelp: "Zoom out of the setup diagram to view more of the layout.",
     zoomInHelp: "Zoom in on the setup diagram for a closer look at connections.",
@@ -405,7 +402,6 @@ const texts = {
     saveSetupBtn: "Salva",
     updateSetupBtn: "Aggiorna",
     clearSetupBtn: "Cancella configurazione corrente",
-    clearFiltersBtn: "Cancella tutti i filtri",
     clearFilter: "Cancella filtro",
     shareSetupBtn: "Condividi link della configurazione",
     shareSetupPrompt: "Copia questo link per condividere la configurazione:",
@@ -673,10 +669,7 @@ const texts = {
     batterySelectHelp: "Seleziona la batteria che alimenta la configurazione.",
     batteryPlateSelectHelp: "Seleziona la piastra o l'adattatore della batteria.",
     clearSetupHelp:
-      "Rimuove tutti i dispositivi dalla configurazione corrente.",
-    clearFiltersHelp:
-      "Rimuove il testo da tutti i campi filtro per mostrare tutte le opzioni.",
-    runtimeFeedbackBtnHelp:
+      "Rimuove tutti i dispositivi dalla configurazione corrente.",    runtimeFeedbackBtnHelp:
       "Invia il runtime misurato per questa configurazione.",
     zoomOutHelp: "Allontana il diagramma di configurazione.",
     zoomInHelp: "Avvicina il diagramma di configurazione.",
@@ -738,7 +731,6 @@ const texts = {
     saveSetupBtn: "Guardar",
     updateSetupBtn: "Actualizar",
     clearSetupBtn: "Borrar configuración actual",
-    clearFiltersBtn: "Limpiar todos los filtros",
     clearFilter: "Limpiar filtro",
     shareSetupBtn: "Compartir enlace de configuración",
     shareSetupPrompt: "Copia este enlace para compartir tu configuración:",
@@ -1020,10 +1012,7 @@ const texts = {
     batterySelectHelp: "Selecciona la batería que alimenta la configuración.",
     batteryPlateSelectHelp: "Selecciona la placa o adaptador de batería.",
     clearSetupHelp:
-      "Borra todos los dispositivos de la configuración actual.",
-    clearFiltersHelp:
-      "Borra el texto de todos los campos de filtro para mostrar todas las opciones.",
-    runtimeFeedbackBtnHelp:
+      "Borra todos los dispositivos de la configuración actual.",    runtimeFeedbackBtnHelp:
       "Envía tu tiempo de funcionamiento medido para esta configuración.",
     zoomOutHelp: "Alejar el diagrama de configuración.",
     zoomInHelp: "Acercar el diagrama de configuración.",
@@ -1086,7 +1075,6 @@ const texts = {
     saveSetupBtn: "Enregistrer",
     updateSetupBtn: "Mettre à jour",
     clearSetupBtn: "Effacer la configuration actuelle",
-    clearFiltersBtn: "Effacer tous les filtres",
     clearFilter: "Effacer le filtre",
     shareSetupBtn: "Partager le lien de configuration",
     shareSetupPrompt: "Copiez ce lien pour partager votre configuration :",
@@ -1370,10 +1358,7 @@ const texts = {
     batteryPlateSelectHelp:
       "Sélectionnez la plaque ou l'adaptateur de batterie utilisé.",
     clearSetupHelp:
-      "Efface tous les appareils de la configuration actuelle.",
-    clearFiltersHelp:
-      "Supprime le texte de tous les champs de filtre pour afficher toutes les options.",
-    runtimeFeedbackBtnHelp:
+      "Efface tous les appareils de la configuration actuelle.",    runtimeFeedbackBtnHelp:
       "Soumettez votre durée mesurée pour cette configuration.",
     zoomOutHelp: "Réduit le diagramme de configuration.",
     zoomInHelp: "Agrandit le diagramme de configuration.",
@@ -1436,7 +1421,6 @@ const texts = {
     saveSetupBtn: "Speichern",
     updateSetupBtn: "Aktualisieren",
     clearSetupBtn: "Aktuelles Setup zurücksetzen",
-    clearFiltersBtn: "Alle Filter zurücksetzen",
     clearFilter: "Filter löschen",
     shareSetupBtn: "Link zum Setup teilen",
     shareSetupPrompt: "Diesen Link kopieren, um das Setup zu teilen:",
@@ -1717,10 +1701,7 @@ const texts = {
     batterySelectHelp: "Wähle den Akku, der das Setup versorgt.",
     batteryPlateSelectHelp: "Wähle die Batterieplatte oder den Adapter aus.",
     clearSetupHelp:
-      "Entfernt alle Geräte aus der aktuellen Konfiguration.",
-    clearFiltersHelp:
-      "Entfernt den Text aus allen Filterfeldern, um wieder alle Optionen anzuzeigen.",
-    runtimeFeedbackBtnHelp:
+      "Entfernt alle Geräte aus der aktuellen Konfiguration.",    runtimeFeedbackBtnHelp:
       "Sende deine gemessene Laufzeit für diese Konfiguration.",
     zoomOutHelp: "Verkleinert das Setup-Diagramm.",
     zoomInHelp: "Vergrößert das Setup-Diagramm.",


### PR DESCRIPTION
## Summary
- drop filter text boxes from device selection and rely on type-to-search in the native dropdowns
- simplify style and script logic for removed filters
- update documentation to mention type-to-search dropdowns

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b7ccc45bd08320a36a7b580eda9dbe