### PR TITLE
Fix lens selector scaling and selection

### DIFF
--- a/script.js
+++ b/script.js
@@ -1718,7 +1718,12 @@ if (projectForm) {
         sel.addEventListener('mousedown', e => {
             if (e.target.tagName !== 'OPTION') return;
             e.preventDefault();
-            e.target.selected = !e.target.selected;
+            const option = e.target;
+            const scrollTop = sel.scrollTop;
+            option.selected = !option.selected;
+            sel.dispatchEvent(new Event('change'));
+            sel.focus();
+            sel.scrollTop = scrollTop;
         });
     });
 }

--- a/style.css
+++ b/style.css
@@ -1334,6 +1334,11 @@ body.dark-mode.pink-mode .help-content { border-color: var(--accent-color); }
   height: auto;
 }
 
+#projectDialog #lenses {
+  height: 15rem;
+  overflow-y: auto;
+}
+
 /* Project requirement boxes */
 .requirements-grid {
   display: flex;


### PR DESCRIPTION
## Summary
- limit lens list height with scrolling to avoid oversized dropdown
- keep existing selections when clicking items in multi-selects

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b802defa1483208dcf8963c14e8bc6