### PR TITLE
Ensure gear list and project requirements update on device changes

### DIFF
--- a/script.js
+++ b/script.js
@@ -7837,9 +7837,22 @@ function bindGearListSliderBowlListener() {
 
 
 function refreshGearListIfVisible() {
-    if (!gearListOutput || gearListOutput.classList.contains('hidden') || !currentProjectInfo) return;
-    const html = generateGearListHtml(currentProjectInfo);
-    displayGearAndRequirements(html);
+    if (!gearListOutput || gearListOutput.classList.contains('hidden')) return;
+
+    if (projectForm) {
+        populateSensorModeDropdown(currentProjectInfo && currentProjectInfo.sensorMode);
+        populateCodecDropdown(currentProjectInfo && currentProjectInfo.codec);
+        const info = collectProjectFormData();
+        currentProjectInfo = Object.values(info).some(v => v) ? info : null;
+    }
+
+    const html = generateGearListHtml(currentProjectInfo || {});
+    if (currentProjectInfo) {
+        displayGearAndRequirements(html);
+    } else {
+        const { gearHtml } = splitGearListHtml(html);
+        gearListOutput.innerHTML = gearHtml;
+    }
     ensureGearListActions();
     bindGearListCageListener();
     bindGearListEasyrigListener();


### PR DESCRIPTION
## Summary
- Refresh gear list when device selections change even if project info is missing
- Run project requirement form logic during device changes to adjust dependent options
- Add unit test verifying project form dropdowns repopulate on camera change

## Testing
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9ee0d9d28832085f719ef7b821fc1