### PR TITLE
Use primary recording media type for gear list

### DIFF
--- a/script.js
+++ b/script.js
@@ -7354,17 +7354,21 @@ function generateGearListHtml(info = {}) {
             'USB-C 3.1 Gen 2 expansion port for external media': '1TB',
             'USB-C to external SSD/HDD': '1TB'
         };
-        mediaItems = cam.recordingMedia.map(m => {
-            const type = m && m.type ? m.type : '';
-            if (!type) return '';
-            let size = '';
-            if (m.notes) {
-                const match = m.notes.match(/(\d+(?:\.\d+)?\s*(?:TB|GB))/i);
-                if (match) size = match[1].toUpperCase();
-            }
-            if (!size) size = sizeMap[type] || '512GB';
-            return `4x ${escapeHtml(size)} ${escapeHtml(type)}`;
-        }).filter(Boolean).join('<br>');
+        mediaItems = cam.recordingMedia
+            .slice(0, 1)
+            .map(m => {
+                const type = m && m.type ? m.type : '';
+                if (!type) return '';
+                let size = '';
+                if (m.notes) {
+                    const match = m.notes.match(/(\d+(?:\.\d+)?\s*(?:TB|GB))/i);
+                    if (match) size = match[1].toUpperCase();
+                }
+                if (!size) size = sizeMap[type] || '512GB';
+                return `4x ${escapeHtml(size)} ${escapeHtml(type)}`;
+            })
+            .filter(Boolean)
+            .join('<br>');
     }
     addRow('Media', mediaItems);
     const selectedLensNames = info.lenses

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -1439,6 +1439,20 @@ describe('script.js functions', () => {
     expect(html).toContain('4x 512GB CFast 2.0');
   });
 
+  test('gear list uses first recording media when multiple types', () => {
+    const { generateGearListHtml } = script;
+    devices.cameras.CamA.recordingMedia = [{ type: 'CFast 2.0' }, { type: 'SD' }];
+    const addOpt = (id, value) => {
+      const sel = document.getElementById(id);
+      sel.innerHTML = `<option value="${value}">${value}</option>`;
+      sel.value = value;
+    };
+    addOpt('cameraSelect', 'CamA');
+    const html = generateGearListHtml();
+    expect(html).toContain('4x 512GB CFast 2.0');
+    expect(html).not.toContain('SD');
+  });
+
   test('Cine Saddle and Steadybag scenarios populate grip section', () => {
     const { generateGearListHtml } = script;
     const html = generateGearListHtml({ requiredScenarios: 'Cine Saddle, Steadybag' });


### PR DESCRIPTION
## Summary
- Limit media items in gear list to the first supported recording media for a camera
- Add test to verify only the primary media type appears when multiple are available

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bb497361988320a8b58c6008e8ea08