### PR TITLE
Fix dark backgrounds in printed gear list and diagram

### DIFF
--- a/overview-print.css
+++ b/overview-print.css
@@ -109,6 +109,12 @@ table, th, td {
   word-break: break-word;
   hyphens: auto;
 }
+#overviewDialogContent section,
+#overviewDialogContent #diagramArea {
+  background: #fff !important;
+  border-color: #000;
+  box-shadow: none;
+}
 #overviewDialogContent th {
   background-color: #e0e0e0 !important;
   font-weight: 700;
@@ -125,14 +131,13 @@ table, th, td {
   border: 1px solid #000;
   box-shadow: none;
 }
-
-.gear-table td {
+#overviewDialogContent .gear-table td {
   border: 1px solid #000;
-  background: #fff;
+  background: #fff !important;
 }
 
-.gear-table .category-row td {
-  background: #e0e0e0;
+#overviewDialogContent .gear-table .category-row td {
+  background: #e0e0e0 !important;
   font-weight: 700;
   color: #000;
 }


### PR DESCRIPTION
## Summary
- Force white backgrounds on all sections and the setup diagram when printing
- Override dark-mode colors for gear list table rows during print

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb4a99bf148320a2135eee86a7541f