### PR TITLE
Match overview theme to main page

### DIFF
--- a/script.js
+++ b/script.js
@@ -6956,7 +6956,10 @@ function generatePrintableOverview() {
     overviewDialog.innerHTML = overviewHtml;
     const content = overviewDialog.querySelector('#overviewDialogContent');
 
-    // Always use light mode for printed overview regardless of current theme
+    // Match current theme for on-screen overview; print stylesheet will override
+    if (document.body.classList.contains('dark-mode')) {
+        content.classList.add('dark-mode');
+    }
     if (document.body.classList.contains('pink-mode')) {
         content.classList.add('pink-mode');
     }

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -1157,9 +1157,10 @@ describe('script.js functions', () => {
     expect(html).toContain(`<strong>${texts.en.cameraLabel}</strong>`);
   });
 
-  test('generatePrintableOverview uses light mode styling even when dark mode active', () => {
+  test('generatePrintableOverview inherits current theme classes', () => {
     const { generatePrintableOverview } = script;
     document.body.classList.add('dark-mode');
+    document.body.classList.add('pink-mode');
     document.getElementById('setupName').value = 'Test';
     const addOpt = (id, value) => {
       const sel = document.getElementById(id);
@@ -1170,8 +1171,8 @@ describe('script.js functions', () => {
     script.updateCalculations();
     generatePrintableOverview();
     const content = document.querySelector('#overviewDialogContent');
-    expect(content.classList.contains('dark-mode')).toBe(false);
-    expect(document.body.classList.contains('dark-mode')).toBe(true);
+    expect(content.classList.contains('dark-mode')).toBe(true);
+    expect(content.classList.contains('pink-mode')).toBe(true);
   });
 
   test('generatePrintableOverview includes project requirements and gear list', () => {


### PR DESCRIPTION
## Summary
- Apply active theme classes to generated overview so it mirrors main page styling
- Update overview generation test to expect theme inheritance

## Testing
- `npm run lint`
- `npm run check-consistency`
- `CI=true npx jest --runInBand --forceExit`

------
https://chatgpt.com/codex/tasks/task_e_68bb4aca9ca88320af6df65a5fb81f17