### PR TITLE
Show tripod preferences only when Tripod scenario selected

### DIFF
--- a/index.html
+++ b/index.html
@@ -1010,7 +1010,7 @@
         </select>
       </label></div>
       <div class="form-row"><label for="userButtons">User Buttons:<input type="text" id="userButtons" name="userButtons"></label></div>
-      <div class="form-row"><label for="tripodPreferences">Tripod Preferences:
+      <div class="form-row hidden" id="tripodPreferencesRow"><label for="tripodPreferences">Tripod Preferences:
         <select id="tripodPreferences" name="tripodPreferences" multiple size="13">
           <option value="O'Connor">O'Connor</option>
           <option value="Sachtler">Sachtler</option>

--- a/script.js
+++ b/script.js
@@ -1466,6 +1466,8 @@ const batterySelect  = document.getElementById("batterySelect");
 const lensSelect     = document.getElementById("lenses");
 const requiredScenariosSelect = document.getElementById("requiredScenarios");
 const requiredScenariosSummary = document.getElementById("requiredScenariosSummary");
+const tripodPreferencesRow = document.getElementById("tripodPreferencesRow");
+const tripodPreferencesSelect = document.getElementById("tripodPreferences");
 
 const totalPowerElem      = document.getElementById("totalPower");
 const totalCurrent144Elem = document.getElementById("totalCurrent144");
@@ -8453,6 +8455,16 @@ function updateRequiredScenariosSummary() {
     box.appendChild(document.createTextNode(val));
     requiredScenariosSummary.appendChild(box);
   });
+  if (tripodPreferencesRow) {
+    if (selected.includes('Tripod')) {
+      tripodPreferencesRow.classList.remove('hidden');
+    } else {
+      tripodPreferencesRow.classList.add('hidden');
+      if (tripodPreferencesSelect) {
+        Array.from(tripodPreferencesSelect.options).forEach(o => { o.selected = false; });
+      }
+    }
+  }
 }
 
 function initApp() {

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -1489,6 +1489,27 @@ describe('script.js functions', () => {
     expect(boxes[1].textContent).toContain('Gimbal');
   });
 
+  test('tripod preferences selector is shown only when Tripod scenario is selected', () => {
+    const select = document.getElementById('requiredScenarios');
+    const tripodRow = document.getElementById('tripodPreferencesRow');
+    const tripodSelect = document.getElementById('tripodPreferences');
+
+    // Initially hidden
+    expect(tripodRow.classList.contains('hidden')).toBe(true);
+
+    // Select Tripod scenario
+    select.querySelector('option[value="Tripod"]').selected = true;
+    script.updateRequiredScenariosSummary();
+    expect(tripodRow.classList.contains('hidden')).toBe(false);
+
+    // Choose a tripod preference and then deselect Tripod scenario
+    tripodSelect.querySelector('option').selected = true;
+    select.querySelector('option[value="Tripod"]').selected = false;
+    script.updateRequiredScenariosSummary();
+    expect(tripodRow.classList.contains('hidden')).toBe(true);
+    expect(Array.from(tripodSelect.selectedOptions)).toHaveLength(0);
+  });
+
   test('Hand Grips rigging adds telescopic handle', () => {
     const { generateGearListHtml } = script;
     const html = generateGearListHtml({ rigging: 'Hand Grips' });


### PR DESCRIPTION
## Summary
- Hide tripod preferences by default and toggle visibility when the Tripod scenario is selected
- Clear tripod preference selections when the Tripod scenario is unselected
- Test that tripod preferences only appear with Tripod scenario and are cleared otherwise

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb4ba732588320ad13abb4a17c8f2f