### PR TITLE
Include D-Tap accessories for Trinity and Steadicam

### DIFF
--- a/script.js
+++ b/script.js
@@ -7254,6 +7254,7 @@ function generateGearListHtml(info = {}) {
     for (let i = 0; i < 4; i++) riggingAcc.push('Cine Quick Release');
     riggingAcc.push('SmallRig - Super lightweight 15mm RailBlock');
     for (let i = 0; i < 3; i++) riggingAcc.push('stud 5/8" with male 3/8" and 1/4"');
+    for (let i = 0; i < 2; i++) riggingAcc.push('D-Tap Splitter');
     const cagesDb = devices.accessories?.cages || {};
     const compatibleCages = [];
     if (cameraSelect && cameraSelect.value && cameraSelect.value !== 'None') {
@@ -7267,6 +7268,12 @@ function generateGearListHtml(info = {}) {
     const scenarios = info.requiredScenarios
         ? info.requiredScenarios.split(',').map(s => s.trim()).filter(Boolean)
         : [];
+    if (scenarios.includes('Trinity') || scenarios.includes('Steadicam')) {
+        for (let i = 0; i < 2; i++) {
+            riggingAcc.push('D-Tap Splitter');
+            riggingAcc.push('D-Tap Extension 50 cm');
+        }
+    }
     const rigging = info.rigging
         ? info.rigging.split(',').map(r => r.trim()).filter(Boolean)
         : [];

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -1316,7 +1316,19 @@ describe('script.js functions', () => {
     expect(rigSection).toContain('4x Cine Quick Release');
     expect(rigSection).toContain('1x SmallRig - Super lightweight 15mm RailBlock');
     expect(rigSection).toContain('3x stud 5/8" with male 3/8" and 1/4"');
+    expect(rigSection).toContain('2x D-Tap Splitter');
   });
+
+  test.each(['Trinity', 'Steadicam'])(
+    '%s scenario adds D-Tap rigging accessories',
+    (scenario) => {
+      const { generateGearListHtml } = script;
+      const html = generateGearListHtml({ requiredScenarios: scenario });
+      const rigSection = html.slice(html.indexOf('Rigging'), html.indexOf('Power'));
+      expect(rigSection).toContain('4x D-Tap Splitter');
+      expect(rigSection).toContain('2x D-Tap Extension 50 cm');
+    }
+  );
 
   test('gear list separates multiple items with line breaks', () => {
     const { generateGearListHtml } = script;


### PR DESCRIPTION
## Summary
- Always include 2x D-Tap Splitter in rigging accessories
- Add extra D-Tap Splitters and D-Tap Extension 50 cm when using Trinity or Steadicam
- Test updates for new rigging accessories

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb4f12ebac832091c77a4af2f4b09e