### PR TITLE
Split monitoring support into dedicated selectors

### DIFF
--- a/index.html
+++ b/index.html
@@ -980,17 +980,22 @@
           <option value="Teradek and Battery belt">Teradek and Battery belt</option>
           <option value="Top handle extension">Top handle extension</option>
           <option value="Rear Handle">Rear Handle</option>
-          <option value="Viewfinder + Onboard">Viewfinder + Onboard</option>
-          <option value="VF only">VF only</option>
-          <option value="Onboard only">Onboard only</option>
           <option value="Clamp-On Mattebox">Clamp-On Mattebox</option>
           <option value="Swingaway Mattebox">Swingaway Mattebox</option>
           <option value="Rod based Mattebox">Rod based Mattebox</option>
           <option value="Film magazines">Film magazines</option>
         </select>
       </label></div>
-      <div class="form-row"><label for="monitoringPreferences">Monitoring support:
-        <select id="monitoringPreferences" name="monitoringPreferences" multiple size="18">
+      <h3 id="monitoringHeading">Monitoring</h3>
+      <div class="form-row"><label for="monitoringConfiguration">Camera Monitoring Configuration:
+        <select id="monitoringConfiguration" name="monitoringConfiguration">
+          <option value="Viewfinder only">Viewfinder only</option>
+          <option value="Viewfinder and Onboard">Viewfinder and Onboard</option>
+          <option value="Onboard Only">Onboard Only</option>
+        </select>
+      </label></div>
+      <div class="form-row"><label for="monitoringSettings">Camera Monitoring Settings:
+        <select id="monitoringSettings" name="monitoringSettings" multiple size="13">
           <option value="VF Clean Feed">VF Clean Feed</option>
           <option value="Onboard Clean Feed">Onboard Clean Feed</option>
           <option value="Surroundview (if available)">Surroundview (if available)</option>
@@ -1004,6 +1009,10 @@
           <option value="AM Opacity 50%">AM Opacity 50%</option>
           <option value="AM Opacity 25%">AM Opacity 25%</option>
           <option value="AM Opacity 0%">AM Opacity 0%</option>
+        </select>
+      </label></div>
+      <div class="form-row"><label for="videoDistribution">Video distribution:
+        <select id="videoDistribution" name="videoDistribution" multiple size="3">
           <option value="Directors Monitor 7&quot; handheld">Directors Monitor 7&quot; handheld</option>
           <option value="Directors Monitor 15-19 inch">Directors Monitor 15-19 inch</option>
           <option value="Combo Monitor 15-19 inch">Combo Monitor 15-19 inch</option>

--- a/script.js
+++ b/script.js
@@ -7213,7 +7213,9 @@ function collectProjectFormData() {
         requiredScenarios: multi('requiredScenarios'),
         rigging: multi('rigging'),
         gimbal: multi('gimbal'),
-        monitoringPreferences: multi('monitoringPreferences'),
+        monitoringSettings: multi('monitoringSettings'),
+        videoDistribution: multi('videoDistribution'),
+        monitoringConfiguration: val('monitoringConfiguration'),
         userButtons: val('userButtons'),
         tripodPreferences: multi('tripodPreferences'),
         sliderBowl: getSliderBowlValue(),
@@ -7270,16 +7272,16 @@ function generateGearListHtml(info = {}) {
     const rigging = info.rigging
         ? info.rigging.split(',').map(r => r.trim()).filter(Boolean)
         : [];
-    const monitoringPrefs = info.monitoringPreferences
-        ? info.monitoringPreferences.split(',').map(s => s.trim()).filter(Boolean)
+    const monitoringSettings = info.monitoringSettings
+        ? info.monitoringSettings.split(',').map(s => s.trim()).filter(Boolean)
         : [];
-    const monitorEquipOptions = ['Directors Monitor 7" handheld', 'Directors Monitor 15-19 inch', 'Combo Monitor 15-19 inch'];
-    const monitoringEquipmentPrefs = monitoringPrefs.filter(p => monitorEquipOptions.includes(p));
-    const monitoringSupportPrefs = monitoringPrefs.filter(p => !monitorEquipOptions.includes(p));
+    const videoDistPrefs = info.videoDistribution
+        ? info.videoDistribution.split(',').map(s => s.trim()).filter(Boolean)
+        : [];
     const filterSelections = info.filter
         ? info.filter.split(',').map(s => s.trim()).filter(Boolean)
         : [];
-    const receiverCount = (monitoringPrefs.includes('Directors Monitor 7" handheld') ? 1 : 0) + (hasMotor ? 1 : 0);
+    const receiverCount = (videoDistPrefs.includes('Directors Monitor 7" handheld') ? 1 : 0) + (hasMotor ? 1 : 0);
     if (selectedNames.video) {
         monitoringSupportAcc.push('Antenna 5,8GHz 5dBi Long (spare)');
         const rxName = selectedNames.video.replace(/ TX\b/, ' RX');
@@ -7290,7 +7292,7 @@ function generateGearListHtml(info = {}) {
             }
         }
     }
-    if (monitoringPrefs.includes('Directors Monitor 7" handheld')) {
+    if (videoDistPrefs.includes('Directors Monitor 7" handheld')) {
         monitoringSupportAcc.push(
             'D-Tap to Lemo-2-pin Cable 0,3m',
             'D-Tap to Lemo-2-pin Cable 0,3m',
@@ -7327,13 +7329,15 @@ function generateGearListHtml(info = {}) {
     const projectInfo = { ...info };
     delete projectInfo.lenses;
     delete projectInfo.filter;
-    if (monitoringSupportPrefs.length) {
-        projectInfo.monitoringSupport = monitoringSupportPrefs.join(', ');
+    if (monitoringSettings.length) {
+        projectInfo.monitoringSupport = monitoringSettings.join(', ');
     }
-    if (monitoringEquipmentPrefs.length) {
-        projectInfo.monitoring = monitoringEquipmentPrefs.join(', ');
+    if (videoDistPrefs.length) {
+        projectInfo.monitoring = videoDistPrefs.join(', ');
     }
-    delete projectInfo.monitoringPreferences;
+    if (!info.monitoringConfiguration) delete projectInfo.monitoringConfiguration;
+    delete projectInfo.monitoringSettings;
+    delete projectInfo.videoDistribution;
     delete projectInfo.tripodPreferences;
     const projectTitle = escapeHtml(info.projectName || setupNameInput.value);
     const labels = {
@@ -7352,6 +7356,7 @@ function generateGearListHtml(info = {}) {
         gimbal: 'Gimbal',
         monitoringSupport: 'Monitoring support',
         monitoring: 'Monitoring',
+        monitoringConfiguration: 'Monitoring configuration',
         userButtons: 'User Buttons'
     };
     const fieldIcons = {
@@ -7369,6 +7374,7 @@ function generateGearListHtml(info = {}) {
         gimbal: '🌀',
         monitoringSupport: '🧰',
         monitoring: '📡',
+        monitoringConfiguration: '🎛️',
         userButtons: '🔘'
     };
     const infoEntries = Object.entries(projectInfo)
@@ -7482,7 +7488,7 @@ function generateGearListHtml(info = {}) {
     }
     addRow('Camera Batteries', batteryItems);
     let monitoringBatteryItems = [];
-    if (monitoringPrefs.includes('Directors Monitor 7" handheld')) {
+    if (videoDistPrefs.includes('Directors Monitor 7" handheld')) {
         const bebob98 = Object.keys(devices.batteries || {}).find(n => /V98micro/i.test(n)) || 'Bebob V98micro';
         monitoringBatteryItems.push(`3x ${escapeHtml(bebob98)}`);
     }
@@ -7499,7 +7505,7 @@ function generateGearListHtml(info = {}) {
     if (selectedNames.monitor) {
         monitoringItems += (monitoringItems ? '<br>' : '') + `1x <strong>Onboard Monitor</strong> - ${escapeHtml(selectedNames.monitor)} - incl. Sunhood`;
     }
-    if (monitoringPrefs.includes('Directors Monitor 7" handheld')) {
+    if (videoDistPrefs.includes('Directors Monitor 7" handheld')) {
         const monitorsDb = devices && devices.monitors ? devices.monitors : {};
         const sevenInchNames = Object.keys(monitorsDb).filter(n => monitorsDb[n].screenSizeInches === 7).sort(localeSort);
         const opts = sevenInchNames.map(n => `<option value="${escapeHtml(n)}"${n === 'SmallHD Ultra 7' ? ' selected' : ''}>${escapeHtml(n)}</option>`).join('');
@@ -7524,7 +7530,7 @@ function generateGearListHtml(info = {}) {
     let sliderSelectHtml = '';
     let easyrigSelectHtml = '';
     const hasGimbal = scenarios.includes('Gimbal');
-    if (monitoringPrefs.includes('Directors Monitor 7" handheld')) {
+    if (videoDistPrefs.includes('Directors Monitor 7" handheld')) {
         gripItems.push('C-Stand 20"');
         gripItems.push('Lite-Tite Swivel Aluminium Umbrella Adapter');
         riggingAcc.push('Spigot');

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -1338,7 +1338,7 @@ describe('script.js functions', () => {
       'SmallHD Ultra 7': { screenSizeInches: 7 },
       MonA: { screenSizeInches: 7 }
     };
-    const html = generateGearListHtml({ monitoringPreferences: 'Directors Monitor 7" handheld' });
+    const html = generateGearListHtml({ videoDistribution: 'Directors Monitor 7" handheld' });
     expect(html).toContain('<select id="gearListDirectorsMonitor7"');
     expect(html).toContain('SmallHD Ultra 7');
     expect(html).toContain('Directors cage, shoulder strap, sunhood, rigging for teradeks');
@@ -1410,7 +1410,7 @@ describe('script.js functions', () => {
     };
     addOpt('motor1Select', 'MotorA');
     addOpt('videoSelect', 'VidA TX');
-    const html = generateGearListHtml({ monitoringPreferences: 'Directors Monitor 7" handheld' });
+    const html = generateGearListHtml({ videoDistribution: 'Directors Monitor 7" handheld' });
     expect(html).toContain('2x <strong>Wireless Receiver</strong> - VidA RX');
     const msSection = html.slice(html.indexOf('Monitoring support'), html.indexOf('Power'));
     expect(msSection).toContain('3x Antenna 5,8GHz 5dBi Long (spare)');
@@ -1852,7 +1852,7 @@ describe('script.js functions', () => {
     const { generateGearListHtml } = script;
     const html = generateGearListHtml({
       rigging: 'Shoulder rig, Hand Grips',
-      monitoringPreferences: 'VF Clean Feed, Onboard Clean Feed',
+      monitoringSettings: 'VF Clean Feed, Onboard Clean Feed',
       userButtons: 'Toggle LUT, False Color'
     });
     expect(html).toContain('<span class="req-label">Rigging</span>');
@@ -1871,7 +1871,7 @@ describe('script.js functions', () => {
 
   test('Directors handheld monitor appears under monitoring in project requirements', () => {
     const { generateGearListHtml } = script;
-    const html = generateGearListHtml({ monitoringPreferences: 'Directors Monitor 7" handheld' });
+    const html = generateGearListHtml({ videoDistribution: 'Directors Monitor 7" handheld' });
     expect(html).toContain('<span class="req-label">Monitoring</span>');
     expect(html).toContain('<span class="req-value">Directors Monitor 7" handheld</span>');
     expect(html).not.toContain('<span class="req-label">Monitoring support</span><span class="req-value">Directors Monitor 7" handheld</span>');


### PR DESCRIPTION
## Summary
- restructure monitoring options into configuration, settings, and video distribution selectors
- handle new monitoring fields in form collection, project info, and labels
- update tests for new monitoring selectors

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bb4f443a1c83208f481c75a702a091