### PR TITLE
Expand monitor size options and add iOS video option

### DIFF
--- a/index.html
+++ b/index.html
@@ -1011,10 +1011,11 @@
         </select>
       </label></div>
       <div class="form-row"><label for="videoDistribution">Video distribution:
-        <select id="videoDistribution" name="videoDistribution" multiple size="3">
+        <select id="videoDistribution" name="videoDistribution" multiple size="4">
           <option value="Directors Monitor 7&quot; handheld">Directors Monitor 7&quot; handheld</option>
-          <option value="Directors Monitor 15-19 inch">Directors Monitor 15-19 inch</option>
-          <option value="Combo Monitor 15-19 inch">Combo Monitor 15-19 inch</option>
+          <option value="Directors Monitor 15-21 inch">Directors Monitor 15-21 inch</option>
+          <option value="Combo Monitor 15-21 inch">Combo Monitor 15-21 inch</option>
+          <option value="IOS Video (Teradek Serv + Link)">IOS Video (Teradek Serv + Link)</option>
         </select>
       </label></div>
       <div class="form-row"><label for="userButtons">User Buttons:<input type="text" id="userButtons" name="userButtons"></label></div>

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -1899,6 +1899,14 @@ describe('script.js functions', () => {
     expect(html).not.toContain('<span class="req-label">Monitoring support</span><span class="req-value">Directors Monitor 7" handheld</span>');
   });
 
+  test('iOS video option appears under monitoring in project requirements', () => {
+    const { generateGearListHtml } = script;
+    const html = generateGearListHtml({ videoDistribution: 'IOS Video (Teradek Serv + Link)' });
+    expect(html).toContain('<span class="req-label">Monitoring</span>');
+    expect(html).toContain('<span class="req-value">IOS Video (Teradek Serv + Link)</span>');
+    expect(html).not.toContain('<span class="req-label">Monitoring support</span><span class="req-value">IOS Video (Teradek Serv + Link)</span>');
+  });
+
   test('sensor mode appears in project requirements when provided', () => {
     const { generateGearListHtml } = script;
     const html = generateGearListHtml({ sensorMode: 'S35 3:2' });


### PR DESCRIPTION
## Summary
- widen Directors and Combo monitor choices to 15–21"
- add IOS Video (Teradek Serv + Link) as a video distribution option
- test that IOS video selection appears in project requirements

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bb5399dbfc8320be85dd950e0fe38e