### PR TITLE
Split camera monitoring options into dedicated selectors

### DIFF
--- a/index.html
+++ b/index.html
@@ -993,16 +993,23 @@
           <option value="Onboard Only">Onboard Only</option>
         </select>
       </label></div>
-      <div class="form-row"><label for="monitoringSettings">Camera Monitoring Settings:
-        <select id="monitoringSettings" name="monitoringSettings" multiple size="13">
-          <option value="VF Clean Feed">VF Clean Feed</option>
-          <option value="Onboard Clean Feed">Onboard Clean Feed</option>
-          <option value="Surroundview (if available)">Surroundview (if available)</option>
+      <div class="form-row hidden" id="viewfinderSettingsRow"><label for="viewfinderSettings">Viewfinder Settings:
+        <select id="viewfinderSettings" name="viewfinderSettings" multiple size="2">
+          <option value="Viewfinder Clean Feed">Viewfinder Clean Feed</option>
+          <option value="Surround View">Surround View</option>
+        </select>
+      </label></div>
+      <div class="form-row"><label for="frameGuides">Frameguides:
+        <select id="frameGuides" name="frameGuides" multiple size="5">
           <option value="Frame Guide: Center Dot">Frame Guide: Center Dot</option>
           <option value="Frame Guides: Center Cross">Frame Guides: Center Cross</option>
           <option value="Frame Guide: Rule of Thirds">Frame Guide: Rule of Thirds</option>
           <option value="Frame Guide: User Box">Frame Guide: User Box</option>
           <option value="Frame Guide: 90% marker">Frame Guide: 90% marker</option>
+        </select>
+      </label></div>
+      <div class="form-row"><label for="aspectMaskOpacity">Aspect Mask Opacity:
+        <select id="aspectMaskOpacity" name="aspectMaskOpacity" multiple size="5">
           <option value="Aspect Mask Opacity 100%">Aspect Mask Opacity 100%</option>
           <option value="AM Opacity 75%">AM Opacity 75%</option>
           <option value="AM Opacity 50%">AM Opacity 50%</option>

--- a/script.js
+++ b/script.js
@@ -677,6 +677,25 @@ function updateBatteryPlateVisibility() {
     else if (hasV) batteryPlateSelect.value = 'V-Mount';
     else batteryPlateSelect.value = '';
   }
+  updateViewfinderSettingsVisibility();
+}
+
+function updateViewfinderSettingsVisibility() {
+  const cam = devices?.cameras?.[cameraSelect?.value];
+  const hasViewfinder = Array.isArray(cam?.viewfinder) && cam.viewfinder.length > 0;
+  const config = monitoringConfigurationSelect?.value;
+  const show = hasViewfinder && (config === 'Viewfinder only' || config === 'Viewfinder and Onboard');
+  if (viewfinderSettingsRow) {
+    if (show) {
+      viewfinderSettingsRow.classList.remove('hidden');
+    } else {
+      viewfinderSettingsRow.classList.add('hidden');
+      const vfSelect = document.getElementById('viewfinderSettings');
+      if (vfSelect) {
+        Array.from(vfSelect.options).forEach(o => { o.selected = false; });
+      }
+    }
+  }
 }
 
 
@@ -1475,6 +1494,8 @@ const requiredScenariosSelect = document.getElementById("requiredScenarios");
 const requiredScenariosSummary = document.getElementById("requiredScenariosSummary");
 const tripodPreferencesRow = document.getElementById("tripodPreferencesRow");
 const tripodPreferencesSelect = document.getElementById("tripodPreferences");
+const monitoringConfigurationSelect = document.getElementById("monitoringConfiguration");
+const viewfinderSettingsRow = document.getElementById("viewfinderSettingsRow");
 
 const totalPowerElem      = document.getElementById("totalPower");
 const totalCurrent144Elem = document.getElementById("totalCurrent144");
@@ -7200,7 +7221,14 @@ function collectProjectFormData() {
     const val = name => (projectForm.querySelector(`[name="${name}"]`)?.value || '').trim();
     const multi = name => Array.from(projectForm.querySelector(`[name="${name}"]`)?.selectedOptions || [])
         .map(o => o.value).join(', ');
+    const multiVals = name => Array.from(projectForm.querySelector(`[name="${name}"]`)?.selectedOptions || [])
+        .map(o => o.value);
     const range = (start, end) => [val(start), val(end)].filter(Boolean).join(' to ');
+    const monitoringSelections = [
+        ...multiVals('viewfinderSettings'),
+        ...multiVals('frameGuides'),
+        ...multiVals('aspectMaskOpacity')
+    ].join(', ');
     return {
         projectName: val('projectName'),
         dop: val('dop'),
@@ -7216,7 +7244,7 @@ function collectProjectFormData() {
         requiredScenarios: multi('requiredScenarios'),
         rigging: multi('rigging'),
         gimbal: multi('gimbal'),
-        monitoringSettings: multi('monitoringSettings'),
+        monitoringSettings: monitoringSelections,
         videoDistribution: multi('videoDistribution'),
         monitoringConfiguration: val('monitoringConfiguration'),
         userButtons: val('userButtons'),
@@ -8068,6 +8096,9 @@ if (cameraSelect) {
     updateBatteryPlateVisibility();
     updateBatteryOptions();
   });
+}
+if (monitoringConfigurationSelect) {
+  monitoringConfigurationSelect.addEventListener('change', updateViewfinderSettingsVisibility);
 }
 if (batteryPlateSelect) batteryPlateSelect.addEventListener('change', updateBatteryOptions);
 

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -1874,18 +1874,18 @@ describe('script.js functions', () => {
     const { generateGearListHtml } = script;
     const html = generateGearListHtml({
       rigging: 'Shoulder rig, Hand Grips',
-      monitoringSettings: 'VF Clean Feed, Onboard Clean Feed',
+      monitoringSettings: 'Viewfinder Clean Feed, Surround View',
       userButtons: 'Toggle LUT, False Color'
     });
     expect(html).toContain('<span class="req-label">Rigging</span>');
     expect(html).toContain('<span class="req-value">Shoulder rig, Hand Grips</span>');
     expect(html).toContain('<td>Rigging</td>');
     expect(html).toContain('<span class="req-label">Monitoring support</span>');
-    expect(html).toContain('<span class="req-value">VF Clean Feed, Onboard Clean Feed</span>');
+    expect(html).toContain('<span class="req-value">Viewfinder Clean Feed, Surround View</span>');
     expect(html).toContain('<td>Monitoring support</td>');
     const msSection = html.slice(html.indexOf('<td>Monitoring support</td>'), html.indexOf('Power'));
-    expect(msSection).not.toContain('VF Clean Feed');
-    expect(msSection).not.toContain('Onboard Clean Feed');
+    expect(msSection).not.toContain('Viewfinder Clean Feed');
+    expect(msSection).not.toContain('Surround View');
     expect(msSection).not.toContain('User Buttons');
     expect(html).toContain('<span class="req-label">User Buttons</span>');
     expect(html).toContain('<span class="req-value">Toggle LUT, False Color</span>');


### PR DESCRIPTION
## Summary
- Separate monitoring settings into Viewfinder, Frameguides, and Aspect Mask opacity selectors
- Show Viewfinder settings only for cameras with a viewfinder and matching monitoring configuration
- Aggregate new monitoring selections when building project info

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb5502d30483209fa1d9b77915a892