### PR TITLE
Move remote handles to tripod preferences

### DIFF
--- a/index.html
+++ b/index.html
@@ -966,8 +966,6 @@
           <option value="Rain Machine">Rain Machine</option>
           <option value="Slow Motion">Slow Motion</option>
           <option value="Viewfinder Extension">Viewfinder Extension</option>
-          <option value="Zoom Remote handle">Zoom Remote handle</option>
-          <option value="Dolly Remote handle">Dolly Remote handle</option>
         </select>
       </label>
       <div id="requiredScenariosSummary" class="scenario-summary" aria-live="polite"></div>
@@ -1019,7 +1017,7 @@
       </label></div>
       <div class="form-row"><label for="userButtons">User Buttons:<input type="text" id="userButtons" name="userButtons"></label></div>
       <div class="form-row hidden" id="tripodPreferencesRow"><label for="tripodPreferences">Tripod Preferences:
-        <select id="tripodPreferences" name="tripodPreferences" multiple size="13">
+        <select id="tripodPreferences" name="tripodPreferences" multiple size="15">
           <option value="O'Connor">O'Connor</option>
           <option value="Sachtler">Sachtler</option>
           <option value="Other Head Brand">Other Head Brand</option>
@@ -1033,6 +1031,8 @@
           <option value="Normal">Normal</option>
           <option value="Bodenspinne">Bodenspinne</option>
           <option value="Mittelspinne">Mittelspinne</option>
+          <option value="Zoom Remote handle">Zoom Remote handle</option>
+          <option value="Dolly Remote handle">Dolly Remote handle</option>
         </select>
       </label></div>
       <div class="form-row"><label for="filter">Filter:

--- a/script.js
+++ b/script.js
@@ -8538,18 +8538,16 @@ const scenarioIcons = {
   Gimbal: '🌀',
   Trinity: '♾️',
   Rollcage: '🛡️',
-  'Car Mount': '🚗',
-  Jib: '🪝',
-  'Undersling mode': '⬇️',
-  Crane: '🏗️',
-  'Remote Head': '🎮',
-  'Extreme weather conditions (like snow, rain, heat)': '🌧️',
-  'Rain Machine': '🌧️',
-  'Slow Motion': '🐌',
-  'Viewfinder Extension': '🔭',
-  'Zoom Remote handle': '🔍',
-  'Dolly Remote handle': '🎛️'
-};
+    'Car Mount': '🚗',
+    Jib: '🪝',
+    'Undersling mode': '⬇️',
+    Crane: '🏗️',
+    'Remote Head': '🎮',
+    'Extreme weather conditions (like snow, rain, heat)': '🌧️',
+    'Rain Machine': '🌧️',
+    'Slow Motion': '🐌',
+    'Viewfinder Extension': '🔭'
+  };
 
 function updateRequiredScenariosSummary() {
   if (!requiredScenariosSelect || !requiredScenariosSummary) return;

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -1559,6 +1559,15 @@ describe('script.js functions', () => {
     expect(Array.from(tripodSelect.selectedOptions)).toHaveLength(0);
   });
 
+  test('tripod preferences include remote handles', () => {
+    const requiredSelect = document.getElementById('requiredScenarios');
+    const tripodSelect = document.getElementById('tripodPreferences');
+    expect(requiredSelect.querySelector('option[value="Zoom Remote handle"]')).toBeNull();
+    expect(requiredSelect.querySelector('option[value="Dolly Remote handle"]')).toBeNull();
+    expect(tripodSelect.querySelector('option[value="Zoom Remote handle"]')).not.toBeNull();
+    expect(tripodSelect.querySelector('option[value="Dolly Remote handle"]')).not.toBeNull();
+  });
+
   test('Hand Grips rigging adds telescopic handle', () => {
     const { generateGearListHtml } = script;
     const html = generateGearListHtml({ rigging: 'Hand Grips' });


### PR DESCRIPTION
## Summary
- Move Dolly Remote handle and Zoom Remote handle from required scenarios to tripod preferences
- Drop remote handle icons from scenario list
- Test remote handles are now part of tripod preferences

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb56a7083883209cc7666f9f40be96