### PR TITLE
Split user buttons into separate fields

### DIFF
--- a/index.html
+++ b/index.html
@@ -1017,7 +1017,9 @@
           <option value="IOS Video (Teradek Serv + Link)">IOS Video (Teradek Serv + Link)</option>
         </select>
       </label></div>
-      <div class="form-row"><label for="userButtons">User Buttons:<input type="text" id="userButtons" name="userButtons"></label></div>
+      <div class="form-row"><label for="onboardMonitorUserButtons">Onboard Monitor User Buttons:<input type="text" id="onboardMonitorUserButtons" name="onboardMonitorUserButtons"></label></div>
+      <div class="form-row"><label for="cameraUserButtons">Camera User Buttons:<input type="text" id="cameraUserButtons" name="cameraUserButtons"></label></div>
+      <div class="form-row"><label for="viewfinderUserButtons">Viewfinder User Buttons:<input type="text" id="viewfinderUserButtons" name="viewfinderUserButtons"></label></div>
       <div class="form-row hidden" id="tripodPreferencesRow"><label for="tripodPreferences">Tripod Preferences:
         <select id="tripodPreferences" name="tripodPreferences" multiple size="13">
           <option value="O'Connor">O'Connor</option>

--- a/script.js
+++ b/script.js
@@ -7219,7 +7219,9 @@ function collectProjectFormData() {
         monitoringSettings: multi('monitoringSettings'),
         videoDistribution: multi('videoDistribution'),
         monitoringConfiguration: val('monitoringConfiguration'),
-        userButtons: val('userButtons'),
+        onboardMonitorUserButtons: val('onboardMonitorUserButtons'),
+        cameraUserButtons: val('cameraUserButtons'),
+        viewfinderUserButtons: val('viewfinderUserButtons'),
         tripodPreferences: multi('tripodPreferences'),
         sliderBowl: getSliderBowlValue(),
         filter: multi('filter')
@@ -7367,7 +7369,9 @@ function generateGearListHtml(info = {}) {
         monitoringSupport: 'Monitoring support',
         monitoring: 'Monitoring',
         monitoringConfiguration: 'Monitoring configuration',
-        userButtons: 'User Buttons'
+        onboardMonitorUserButtons: 'Onboard Monitor User Buttons',
+        cameraUserButtons: 'Camera User Buttons',
+        viewfinderUserButtons: 'Viewfinder User Buttons'
     };
     const fieldIcons = {
         dop: '👤',
@@ -7385,7 +7389,9 @@ function generateGearListHtml(info = {}) {
         monitoringSupport: '🧰',
         monitoring: '📡',
         monitoringConfiguration: '🎛️',
-        userButtons: '🔘'
+        onboardMonitorUserButtons: '🔘',
+        cameraUserButtons: '🔘',
+        viewfinderUserButtons: '🔘'
     };
     const infoEntries = Object.entries(projectInfo)
         .filter(([k, v]) => v && k !== 'projectName' && k !== 'sliderBowl');

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -296,9 +296,10 @@ describe('script.js functions', () => {
     expect(copyBtn.nextElementSibling).toBe(generateBtn);
   });
 
-  test('project form includes user buttons input', () => {
-    const input = document.getElementById('userButtons');
-    expect(input).not.toBeNull();
+  test('project form includes user buttons inputs', () => {
+    ['onboardMonitorUserButtons', 'cameraUserButtons', 'viewfinderUserButtons'].forEach(id => {
+      expect(document.getElementById(id)).not.toBeNull();
+    });
   });
 
   test('new device form includes cable category option', () => {
@@ -1875,7 +1876,9 @@ describe('script.js functions', () => {
     const html = generateGearListHtml({
       rigging: 'Shoulder rig, Hand Grips',
       monitoringSettings: 'VF Clean Feed, Onboard Clean Feed',
-      userButtons: 'Toggle LUT, False Color'
+      onboardMonitorUserButtons: 'Toggle LUT',
+      cameraUserButtons: 'False Color',
+      viewfinderUserButtons: 'Peaking'
     });
     expect(html).toContain('<span class="req-label">Rigging</span>');
     expect(html).toContain('<span class="req-value">Shoulder rig, Hand Grips</span>');
@@ -1886,9 +1889,15 @@ describe('script.js functions', () => {
     const msSection = html.slice(html.indexOf('<td>Monitoring support</td>'), html.indexOf('Power'));
     expect(msSection).not.toContain('VF Clean Feed');
     expect(msSection).not.toContain('Onboard Clean Feed');
-    expect(msSection).not.toContain('User Buttons');
-    expect(html).toContain('<span class="req-label">User Buttons</span>');
-    expect(html).toContain('<span class="req-value">Toggle LUT, False Color</span>');
+    expect(msSection).not.toContain('Onboard Monitor User Buttons');
+    expect(msSection).not.toContain('Camera User Buttons');
+    expect(msSection).not.toContain('Viewfinder User Buttons');
+    expect(html).toContain('<span class="req-label">Onboard Monitor User Buttons</span>');
+    expect(html).toContain('<span class="req-value">Toggle LUT</span>');
+    expect(html).toContain('<span class="req-label">Camera User Buttons</span>');
+    expect(html).toContain('<span class="req-value">False Color</span>');
+    expect(html).toContain('<span class="req-label">Viewfinder User Buttons</span>');
+    expect(html).toContain('<span class="req-value">Peaking</span>');
   });
 
   test('Directors handheld monitor appears under monitoring in project requirements', () => {


### PR DESCRIPTION
## Summary
- Separate user button input into Onboard Monitor, Camera, and Viewfinder fields
- Capture new fields in project info with matching labels and icons
- Adjust tests for the new inputs and project requirements

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bb570add708320b0a837bab419e478