### PR TITLE
Move remote handles to tripod selector

### DIFF
--- a/index.html
+++ b/index.html
@@ -968,8 +968,6 @@
           <option value="Rain Machine">Rain Machine</option>
           <option value="Slow Motion">Slow Motion</option>
           <option value="Viewfinder Extension">Viewfinder Extension</option>
-          <option value="Zoom Remote handle">Zoom Remote handle</option>
-          <option value="Dolly Remote handle">Dolly Remote handle</option>
         </select>
       </label>
       <div id="requiredScenariosSummary" class="scenario-summary" aria-live="polite"></div>
@@ -1028,7 +1026,7 @@
       </label></div>
       <div class="form-row"><label for="userButtons">User Buttons:<input type="text" id="userButtons" name="userButtons"></label></div>
       <div class="form-row hidden" id="tripodPreferencesRow"><label for="tripodPreferences">Tripod Preferences:
-        <select id="tripodPreferences" name="tripodPreferences" multiple size="13">
+        <select id="tripodPreferences" name="tripodPreferences" multiple size="15">
           <option value="O'Connor">O'Connor</option>
           <option value="Sachtler">Sachtler</option>
           <option value="Other Head Brand">Other Head Brand</option>
@@ -1042,6 +1040,8 @@
           <option value="Normal">Normal</option>
           <option value="Bodenspinne">Bodenspinne</option>
           <option value="Mittelspinne">Mittelspinne</option>
+          <option value="Zoom Remote handle">Zoom Remote handle</option>
+          <option value="Dolly Remote handle">Dolly Remote handle</option>
         </select>
       </label></div>
       <div class="form-row"><label for="filter">Filter:

--- a/script.js
+++ b/script.js
@@ -8579,9 +8579,7 @@ const scenarioIcons = {
   'Extreme heat': '🔥',
   'Rain Machine': '🌧️',
   'Slow Motion': '🐌',
-  'Viewfinder Extension': '🔭',
-  'Zoom Remote handle': '🔍',
-  'Dolly Remote handle': '🎛️'
+  'Viewfinder Extension': '🔭'
 };
 
 function updateRequiredScenariosSummary() {


### PR DESCRIPTION
## Summary
- Move Dolly Remote handle and Zoom Remote handle options from required scenarios to tripod preferences
- Drop related scenario icons from script.js

## Testing
- `npm run lint`
- `npm run check-consistency`
- `npx jest` *(fails to exit, all tests reported as passing before termination)*

------
https://chatgpt.com/codex/tasks/task_e_68bb58bc51748320ad8693e66918825b