### PR TITLE
feat: split user buttons by device

### DIFF
--- a/index.html
+++ b/index.html
@@ -1026,7 +1026,9 @@
           <option value="IOS Video (Teradek Serv + Link)">IOS Video (Teradek Serv + Link)</option>
         </select>
       </label></div>
-      <div class="form-row"><label for="userButtons">User Buttons:<input type="text" id="userButtons" name="userButtons"></label></div>
+      <div class="form-row"><label for="monitorUserButtons">Onboard Monitor User Buttons:<input type="text" id="monitorUserButtons" name="monitorUserButtons"></label></div>
+      <div class="form-row"><label for="cameraUserButtons">Camera User Buttons:<input type="text" id="cameraUserButtons" name="cameraUserButtons"></label></div>
+      <div class="form-row"><label for="viewfinderUserButtons">Viewfinder User Buttons:<input type="text" id="viewfinderUserButtons" name="viewfinderUserButtons"></label></div>
       <div class="form-row hidden" id="tripodPreferencesRow"><label for="tripodPreferences">Tripod Preferences:
         <select id="tripodPreferences" name="tripodPreferences" multiple size="13">
           <option value="O'Connor">O'Connor</option>

--- a/script.js
+++ b/script.js
@@ -7247,7 +7247,9 @@ function collectProjectFormData() {
         monitoringSettings: monitoringSelections,
         videoDistribution: multi('videoDistribution'),
         monitoringConfiguration: val('monitoringConfiguration'),
-        userButtons: val('userButtons'),
+        monitorUserButtons: val('monitorUserButtons'),
+        cameraUserButtons: val('cameraUserButtons'),
+        viewfinderUserButtons: val('viewfinderUserButtons'),
         tripodPreferences: multi('tripodPreferences'),
         sliderBowl: getSliderBowlValue(),
         filter: multi('filter')
@@ -7395,7 +7397,9 @@ function generateGearListHtml(info = {}) {
         monitoringSupport: 'Monitoring support',
         monitoring: 'Monitoring',
         monitoringConfiguration: 'Monitoring configuration',
-        userButtons: 'User Buttons'
+        monitorUserButtons: 'Onboard Monitor User Buttons',
+        cameraUserButtons: 'Camera User Buttons',
+        viewfinderUserButtons: 'Viewfinder User Buttons'
     };
     const fieldIcons = {
         dop: '👤',
@@ -7413,7 +7417,9 @@ function generateGearListHtml(info = {}) {
         monitoringSupport: '🧰',
         monitoring: '📡',
         monitoringConfiguration: '🎛️',
-        userButtons: '🔘'
+        monitorUserButtons: '🔘',
+        cameraUserButtons: '🔘',
+        viewfinderUserButtons: '🔘'
     };
     const infoEntries = Object.entries(projectInfo)
         .filter(([k, v]) => v && k !== 'projectName' && k !== 'sliderBowl');

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -296,9 +296,13 @@ describe('script.js functions', () => {
     expect(copyBtn.nextElementSibling).toBe(generateBtn);
   });
 
-  test('project form includes user buttons input', () => {
-    const input = document.getElementById('userButtons');
-    expect(input).not.toBeNull();
+  test('project form includes user buttons inputs', () => {
+    const monitorInput = document.getElementById('monitorUserButtons');
+    const cameraInput = document.getElementById('cameraUserButtons');
+    const viewfinderInput = document.getElementById('viewfinderUserButtons');
+    expect(monitorInput).not.toBeNull();
+    expect(cameraInput).not.toBeNull();
+    expect(viewfinderInput).not.toBeNull();
   });
 
   test('new device form includes cable category option', () => {
@@ -1877,7 +1881,9 @@ describe('script.js functions', () => {
     const html = generateGearListHtml({
       rigging: 'Shoulder rig, Hand Grips',
       monitoringSettings: 'Viewfinder Clean Feed, Surround View',
-      userButtons: 'Toggle LUT, False Color'
+      monitorUserButtons: 'Toggle LUT',
+      cameraUserButtons: 'False Color',
+      viewfinderUserButtons: 'Peaking'
     });
     expect(html).toContain('<span class="req-label">Rigging</span>');
     expect(html).toContain('<span class="req-value">Shoulder rig, Hand Grips</span>');
@@ -1888,9 +1894,15 @@ describe('script.js functions', () => {
     const msSection = html.slice(html.indexOf('<td>Monitoring support</td>'), html.indexOf('Power'));
     expect(msSection).not.toContain('Viewfinder Clean Feed');
     expect(msSection).not.toContain('Surround View');
-    expect(msSection).not.toContain('User Buttons');
-    expect(html).toContain('<span class="req-label">User Buttons</span>');
-    expect(html).toContain('<span class="req-value">Toggle LUT, False Color</span>');
+    expect(msSection).not.toContain('Onboard Monitor User Buttons');
+    expect(msSection).not.toContain('Camera User Buttons');
+    expect(msSection).not.toContain('Viewfinder User Buttons');
+    expect(html).toContain('<span class="req-label">Onboard Monitor User Buttons</span>');
+    expect(html).toContain('<span class="req-value">Toggle LUT</span>');
+    expect(html).toContain('<span class="req-label">Camera User Buttons</span>');
+    expect(html).toContain('<span class="req-value">False Color</span>');
+    expect(html).toContain('<span class="req-label">Viewfinder User Buttons</span>');
+    expect(html).toContain('<span class="req-value">Peaking</span>');
   });
 
   test('Directors handheld monitor appears under monitoring in project requirements', () => {


### PR DESCRIPTION
## Summary
- separate user button entries for onboard monitor, camera, and viewfinder
- display new user button fields in project requirements
- test coverage for new inputs and gear list output

## Testing
- `npx jest tests/script.test.js --runInBand`
- `npx jest tests/unifyPorts.test.js --runInBand`
- `npx jest tests/storage.test.js tests/checkConsistency.test.js tests/service-worker.test.js tests/cliHelp.test.js tests/parsePowerInputCache.test.js tests/utils.test.js --runInBand`


------
https://chatgpt.com/codex/tasks/task_e_68bb59e6f844832082eb5b9561ba0dc5