### PR TITLE
Rename setup to project

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -1,6 +1,6 @@
 # 🎥 Camera Power Consumption Planner
 
-This browser based tool helps plan professional camera setups powered by V‑Mount batteries. It calculates **total power consumption**, **current draw** (at 14.4 V and 12 V) and **estimated battery runtime** while checking that the battery can safely supply the required power.
+This browser based tool helps plan professional camera projects powered by V‑Mount batteries. It calculates **total power consumption**, **current draw** (at 14.4 V and 12 V) and **estimated battery runtime** while checking that the battery can safely supply the required power.
 
 ---
 
@@ -16,7 +16,7 @@ The app automatically uses your browser language on first load, and you can swit
 ---
 
 ## 🆕 Recent Features
-- Interactive setup diagram that lets you drag devices, zoom, snap nodes to a grid and export the layout as SVG or JPG.
+- Interactive project diagram that lets you drag devices, zoom, snap nodes to a grid and export the layout as SVG or JPG.
 - Playful pink accent theme that persists between visits.
 - Searchable help dialog with step-by-step sections and a FAQ; open with ?, H, F1 or Ctrl+/.
 - Contextual hover help for buttons, fields, dropdowns and headers.
@@ -24,26 +24,26 @@ The app automatically uses your browser language on first load, and you can swit
 - Submit user runtime feedback with temperature for better estimates.
 - Visual runtime weighting dashboard to inspect how settings influence each report, now sorted by weight and showing exact share percentages.
 - Generate gear lists to compile selected gear and project requirements.
-- Save project requirements with each setup so gear lists retain full context.
+- Save project requirements with each project so gear lists retain full context.
 - Duplicate user entries in gear list forms using fork buttons to copy fields instantly.
 
 ---
 
 ## 🔧 Features
 
-### ✅ Setup Management
-- Save, load and delete multiple camera setups (press Enter or Ctrl+S to save quickly; the Save button stays disabled until a name is entered)
-- Share a setup via link or clear the current configuration
+-### ✅ Project Management
+- Save, load and delete multiple camera projects (press Enter or Ctrl+S to save quickly; the Save button stays disabled until a name is entered)
+- Share a project via link or clear the current configuration
 - Data is stored locally via `localStorage`
-- Import and export setups as JSON
-- Generate a printable overview for any saved setup
-- Save project requirements along with each setup
-- Works fully offline – language, dark mode, setups and device data persist
+- Import and export projects as JSON
+- Generate a printable overview for any saved project
+- Save project requirements along with each project
+- Works fully offline – language, dark mode, projects and device data persist
 - Choose a **B‑Mount** or **V‑Mount** plate on supported cameras; the battery list adapts automatically
 
 ### 📋 Gear List
 - Click **Generate Gear List** to compile selected gear and project requirements.
-- **Save Gear List** stores the current list with the setup.
+- **Save Gear List** stores the current list with the project.
 - **Export Gear List** downloads a JSON file; **Import Gear List** restores it.
 - **Delete Gear List** removes the saved list and hides the output.
 
@@ -72,7 +72,7 @@ The app automatically uses your browser language on first load, and you can swit
 - Compare runtime estimates across all batteries
 - Visual bar graph for quick reference
 
-### 🖼 Setup Diagram
+### 🖼 Project Diagram
 - Visualize power and video connections for the selected devices
 - Warns when FIZ brands are incompatible
 - Drag nodes to rearrange the layout, zoom with the buttons and download the diagram as SVG or JPG
@@ -93,7 +93,7 @@ The app automatically uses your browser language on first load, and you can swit
   - Wi‑Fi enabled adds 10 %
   - Codec factors: RAW/BRAW/ARRIRAW/R3D/CinemaDNG/Canon RAW/X‑OCN ×1; ProRes ×1.1; DNx/AVID ×1.2; All‑Intra ×1.3; H.264/AVC ×1.5; H.265/HEVC ×1.7
   - Monitor entries below the specified brightness are weighted by their brightness ratio
-- The final weight reflects each device's share of the total power draw, so matching setups count more.
+- The final weight reflects each device's share of the total power draw, so matching projects count more.
 - The weighted average is used once at least three entries are available.
 - A dashboard orders entries by weight and displays each one's share percentage for quick comparison.
 
@@ -139,7 +139,7 @@ The app automatically uses your browser language on first load, and you can swit
 2. **Select Devices:** Choose devices from each category using the dropdowns
 3. **View Calculations:** See total draw, current and runtime when a battery is selected
 4. **Check Output Limits:** Status indicators show if the battery output is exceeded
-5. **Save & Load Setups:** Name and save your setup, export/import them and generate a printable overview
+5. **Save & Load Projects:** Name and save your project, export/import them and generate a printable overview
 6. **Manage Device List:** Click “Edit Device Data…” to open the editor, modify devices or revert to the defaults
 7. **Submit Runtime Data (optional):** Use “Submit User Runtime Feedback” to share your results and improve estimates
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 Camera Power Planner is a standalone web app for planning professional camera
 rigs powered by V‑Mount or B‑Mount batteries. It calculates total power draw,
 checks that batteries can safely deliver the required output and estimates how
-long your setup will run. The tool runs entirely in the browser and even works
+ long your project will run. The tool runs entirely in the browser and even works
 offline.
 
 No build step is required—open `index.html` in your browser and start planning
@@ -42,7 +42,7 @@ Choose your preferred language above.
 
 Recent updates include:
 
-- **Interactive setup diagram** – drag devices, zoom, snap nodes to a grid, and export layouts as SVG or JPG.
+- **Interactive project diagram** – drag devices, zoom, snap nodes to a grid, and export layouts as SVG or JPG.
 - **Pink accent theme** – toggle a playful pink highlight that persists between visits or press **P** to switch quickly.
 - **Searchable help dialog and hover hints** – open with ?, H, F1 or Ctrl+/ (even while typing), filter topics instantly, press / or Ctrl+F to jump to the search box, browse the built-in FAQ, and hover over any button, field, dropdown or header for a quick explanation.
 - **Type-to-search dropdowns** – quickly narrow device lists by typing directly into any selector.
@@ -50,8 +50,8 @@ Recent updates include:
 - **User runtime feedback** – submit real-world runtimes with environment details to refine estimates.
 - **Visual runtime weighting dashboard** – see how temperature, resolution, frame rate and codec affect each runtime report, now sorted by weight with exact share percentages.
 - **Gear list generator** – compile selected gear and project requirements with one click.
-- **Quick setup saving** – press Enter or Ctrl+S (⌘S on macOS) to save a setup and the Save button stays disabled until a name is entered.
-- **Project requirement saving** – store project requirements with each setup so gear lists retain full context.
+- **Quick project saving** – press Enter or Ctrl+S (⌘S on macOS) to save a project and the Save button stays disabled until a name is entered.
+- **Project requirement saving** – store project requirements with each project so gear lists retain full context.
 - **User entry duplication** – gear list forms use fork buttons to copy user fields instantly.
 
 See the language-specific README files for full details.
@@ -63,7 +63,7 @@ See the language-specific README files for full details.
 - Check that selected batteries can supply the required output.
 - See required battery counts for a 10 h shoot and adjust runtimes for temperature.
 - Compare runtimes across all batteries with an optional battery comparison panel.
-- Save, load, share and clear setups (project requirements included); import/export them as JSON, and generate gear lists and printable overviews.
+- Save, load, share and clear projects (project requirements included); import/export them as JSON, and generate gear lists and printable overviews.
 - Visualize power and video connections with an interactive diagram.
 - Customize the device database with your own gear.
 - Automatically selects your browser language on first load, lets you switch languages, toggle dark or playful pink themes, and swap between V‑ and B‑Mount plates on supported cameras.
@@ -71,7 +71,7 @@ See the language-specific README files for full details.
 
 ## Runtime Data Weighting
 
-User-submitted battery runtimes are combined using a weighted average to better match your setup:
+User-submitted battery runtimes are combined using a weighted average to better match your project:
 
 - Entries are adjusted for temperature, scaling from ×1 at 25 °C to ×1.25 at 0 °C, ×1.6 at −10 °C and ×2 at −20 °C.
 - Resolution multipliers: ≥12K ×3, ≥8K ×2, ≥4K ×1.5, ≥1080p ×1, lower scaled relative to 1080p.
@@ -97,7 +97,7 @@ User-submitted battery runtimes are combined using a weighted average to better 
 ## Gear List
 
 - Click **Generate Gear List** to compile selected gear and project requirements.
-- **Save Gear List** stores the current list with the setup.
+- **Save Gear List** stores the current list with the project.
 - **Export Gear List** downloads a JSON file; **Import Gear List** restores it.
 - **Delete Gear List** removes the saved list and hides the output.
 
@@ -177,7 +177,7 @@ Contributions are welcome! Please open an issue or submit a pull request on GitH
 
 ## Acknowledgements
 
-The planner uses the [OpenMoji](https://openmoji.org/) icon set when a network connection is available and relies on [lz-string](https://pieroxy.net/blog/pages/lz-string/index.html) to compactly store setups in URLs.
+ The planner uses the [OpenMoji](https://openmoji.org/) icon set when a network connection is available and relies on [lz-string](https://pieroxy.net/blog/pages/lz-string/index.html) to compactly store projects in URLs.
 
 ## License
 

--- a/index.html
+++ b/index.html
@@ -6,9 +6,9 @@
   <meta name="apple-mobile-web-app-capable" content="yes" />
   <meta name="mobile-web-app-capable" content="yes" />
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
-  <meta name="description" content="Plan your camera setup and calculate power consumption &amp; battery life." />
+  <meta name="description" content="Plan your camera project and calculate power consumption &amp; battery life." />
   <meta property="og:title" content="Camera Power Planner" />
-  <meta property="og:description" content="Plan your camera setup and calculate power consumption &amp; battery life." />
+  <meta property="og:description" content="Plan your camera project and calculate power consumption &amp; battery life." />
   <meta property="og:type" content="website" />
   <meta property="og:image" content="icon.png" />
   <meta name="theme-color" content="#f9f9f9" />
@@ -47,35 +47,35 @@
 
   <main id="mainContent" tabindex="-1">
 
-  <p id="tagline">Plan your camera setup and calculate power consumption &amp; battery life.</p>
+  <p id="tagline">Plan your camera project and calculate power consumption &amp; battery life.</p>
 
   <section id="setup-manager">
-    <h2 id="setupManageHeading">Manage Setup</h2>
+    <h2 id="setupManageHeading">Manage Project</h2>
     <div class="form-row">
-      <label for="setupSelect" id="savedSetupsLabel">Saved Setups:</label>
+      <label for="setupSelect" id="savedSetupsLabel">Saved Projects:</label>
       <select id="setupSelect" aria-labelledby="savedSetupsLabel">
-        <option value="">-- New Setup --</option>
+        <option value="">-- New Project --</option>
       </select>
-      <button id="deleteSetupBtn" title="Delete selected setup">Delete</button>
+      <button id="deleteSetupBtn" title="Delete selected project">Delete</button>
     </div>
     <div class="form-row">
-      <label for="setupName" id="setupNameLabel">Setup Name:</label>
-      <input type="text" id="setupName" placeholder="Setup name" aria-labelledby="setupNameLabel" />
+      <label for="setupName" id="setupNameLabel">Project Name:</label>
+      <input type="text" id="setupName" placeholder="Project name" aria-labelledby="setupNameLabel" />
       <button id="saveSetupBtn">Save</button>
     </div>
-    <!-- Moved Setup Actions here -->
-    <h3 id="setupActionsHeading">Setup Actions</h3>
-    <button id="exportSetupsBtn">Export All Setups</button>
-    <button id="importSetupsBtn">Import Setups</button>
+    <!-- Moved Project Actions here -->
+    <h3 id="setupActionsHeading">Project Actions</h3>
+    <button id="exportSetupsBtn">Export All Projects</button>
+    <button id="importSetupsBtn">Import Projects</button>
     <input type="file" id="importSetupsInput" accept=".json" class="hidden" />
     <button id="generateOverviewBtn">Generate Overview</button>
-    <button id="shareSetupBtn">Share Setup Link</button>
+      <button id="shareSetupBtn">Share Project Link</button>
     <div class="form-row hidden" id="sharedLinkRow">
       <label for="sharedLinkInput" id="sharedLinkLabel">Shared Link:</label>
       <input type="url" id="sharedLinkInput" placeholder="Paste shared link" aria-labelledby="sharedLinkLabel" />
       <button id="applySharedLinkBtn">Load</button>
     </div>
-    <button id="clearSetupBtn">Clear Current Setup</button>
+    <button id="clearSetupBtn">Clear Current Project</button>
   </section>
 
   <section id="setup-config">
@@ -187,10 +187,10 @@
   <section id="gearListOutput" class="hidden"></section>
 
   <section id="setupDiagram">
-    <h2 id="setupDiagramHeading">Setup Diagram</h2>
+    <h2 id="setupDiagramHeading">Project Diagram</h2>
     <p id="compatWarning" role="status" aria-live="polite"></p>
     <p id="diagramDesc" class="visually-hidden">Visual representation of connected devices.</p>
-    <div id="diagramArea" role="img" aria-label="Setup diagram" aria-describedby="diagramDesc">
+    <div id="diagramArea" role="img" aria-label="Project diagram" aria-describedby="diagramDesc">
       <div id="diagramPopup" class="diagram-popup"></div>
     </div>
     <div id="diagramLegend" class="diagram-legend"></div>
@@ -624,7 +624,7 @@
           <h3><span class="help-icon" aria-hidden="true">✨</span>Features at a Glance</h3>
           <ul>
             <li>Plan complete camera rigs and compute power draw and battery life.</li>
-            <li>Save multiple setups, export or import them and print overviews.</li>
+            <li>Save multiple projects, export or import them and print overviews.</li>
             <li>Visualize power and video connections with an interactive diagram—drag to rearrange, pan, snap to grid, reset the view, zoom and download the layout.</li>
             <li>Compare battery runtimes and check against safe output limits.</li>
             <li>Customize the device database with your own gear.</li>
@@ -642,20 +642,20 @@
           </ol>
         </section>
         <section data-help-section id="managingSetups">
-          <h3><span class="help-icon" aria-hidden="true">🗂️</span>Managing Setups</h3>
+          <h3><span class="help-icon" aria-hidden="true">🗂️</span>Managing Projects</h3>
           <ul>
             <li>Use <strong>Save</strong> to store the current configuration in your browser. Press Enter or Ctrl+S (⌘S on macOS) to save quickly; the Save button stays disabled until a name is entered.</li>
-            <li>Import, export or delete setups via the <em>Setup Actions</em> section.</li>
-            <li><strong>Share Setup Link</strong> copies a URL for the current configuration.</li>
-            <li><strong>Clear Current Setup</strong> removes all selected devices.</li>
-            <li><strong>Generate Overview</strong> produces a printable summary of any saved setup.</li>
+            <li>Import, export or delete projects via the <em>Project Actions</em> section.</li>
+            <li><strong>Share Project Link</strong> copies a URL for the current configuration.</li>
+            <li><strong>Clear Current Project</strong> removes all selected devices.</li>
+            <li><strong>Generate Overview</strong> produces a printable summary of any saved project.</li>
             </ul>
           </section>
           <section data-help-section id="gearListHelp">
             <h3><span class="help-icon" aria-hidden="true">📋</span>Gear List</h3>
             <ul>
               <li>The <strong>Generate Gear List</strong> button compiles selected gear and project requirements.</li>
-              <li>The <strong>Save Gear List</strong> button stores the current list with the setup.</li>
+              <li>The <strong>Save Gear List</strong> button stores the current list with the project.</li>
               <li>The <strong>Export Gear List</strong> button downloads a JSON file, and <strong>Import Gear List</strong> restores it.</li>
               <li>The <strong>Delete Gear List</strong> button removes the saved list and hides the output.</li>
             </ul>
@@ -702,7 +702,7 @@
           </ul>
         </section>
         <section data-help-section id="setupDiagramHelp">
-          <h3><span class="help-icon" aria-hidden="true">🗺️</span>Setup Diagram</h3>
+          <h3><span class="help-icon" aria-hidden="true">🗺️</span>Project Diagram</h3>
           <ul>
             <li>Visualizes power and video connections between selected devices.</li>
             <li>Drag nodes to rearrange the layout; use +/– buttons to zoom.</li>
@@ -780,19 +780,19 @@
             <li><kbd>Escape</kbd> – close dialogs</li>
             <li><kbd>D</kbd> – toggle dark mode</li>
             <li><kbd>P</kbd> – toggle pink mode</li>
-            <li><kbd>Enter</kbd> or <kbd>Ctrl</kbd>+<kbd>S</kbd> (<kbd>⌘</kbd>+<kbd>S</kbd> on macOS) – save setup</li>
+            <li><kbd>Enter</kbd> or <kbd>Ctrl</kbd>+<kbd>S</kbd> (<kbd>⌘</kbd>+<kbd>S</kbd> on macOS) – save project</li>
             <li>Type in dropdowns to filter options</li>
           </ul>
         </section>
         <section data-help-section id="faq">
           <h3><span class="help-icon" aria-hidden="true">❓</span>FAQ</h3>
           <details class="faq-item">
-            <summary>How do I save a setup?</summary>
-            <p>Enter a name in the Setup Name field and click Save. It will then appear in the Saved Setups list.</p>
+            <summary>How do I save a project?</summary>
+            <p>Enter a name in the Project Name field and click Save. It will then appear in the Saved Projects list.</p>
           </details>
           <details class="faq-item">
-            <summary>Can I export my setups?</summary>
-            <p>Yes. Use the Export All Setups button to download a JSON file containing every saved setup.</p>
+            <summary>Can I export my projects?</summary>
+            <p>Yes. Use the Export All Projects button to download a JSON file containing every saved project.</p>
           </details>
           <details class="faq-item">
             <summary>How do I edit device data?</summary>
@@ -800,15 +800,15 @@
           </details>
           <details class="faq-item">
             <summary>How is battery runtime calculated?</summary>
-            <p>The app divides the selected battery's capacity (in watt-hours) by the total power consumption of your devices. For example, a 98&nbsp;Wh battery powering a 24&nbsp;W setup is estimated to run for about 4&nbsp;hours.</p>
+            <p>The app divides the selected battery's capacity (in watt-hours) by the total power consumption of your devices. For example, a 98&nbsp;Wh battery powering a 24&nbsp;W project is estimated to run for about 4&nbsp;hours.</p>
           </details>
           <details class="faq-item">
             <summary>What do the warning colors mean?</summary>
-            <p>Orange messages indicate the setup is nearing the battery's output limit. Red warnings mean the estimated current exceeds the safe rating and could damage the battery.</p>
+            <p>Orange messages indicate the project is nearing the battery's output limit. Red warnings mean the estimated current exceeds the safe rating and could damage the battery.</p>
           </details>
           <details class="faq-item">
-            <summary>Where are my setups saved?</summary>
-            <p>Setups and device edits are stored in your browser's <code>localStorage</code>. Use Export/Import to back them up or share them.</p>
+            <summary>Where are my projects saved?</summary>
+            <p>Projects and device edits are stored in your browser's <code>localStorage</code>. Use Export/Import to back them up or share them.</p>
           </details>
           <details class="faq-item">
             <summary>Does the planner work offline?</summary>
@@ -826,15 +826,15 @@
           </details>
           <details class="faq-item">
             <summary>How do I reset everything to the defaults?</summary>
-            <p>Open the device editor and choose <em>Export and Revert</em> to restore the default database. Delete setups individually using the Delete button.</p>
+            <p>Open the device editor and choose <em>Export and Revert</em> to restore the default database. Delete projects individually using the Delete button.</p>
           </details>
           <details class="faq-item">
             <summary>How do I change the language?</summary>
             <p>Use the dropdown in the top right to pick a language. The planner remembers your choice for the next visit.</p>
           </details>
           <details class="faq-item">
-            <summary>How can I print a setup overview?</summary>
-            <p>Save the setup, then click <em>Generate Overview</em> in Setup Actions and print from the dialog.</p>
+            <summary>How can I print a project overview?</summary>
+            <p>Save the project, then click <em>Generate Overview</em> in Project Actions and print from the dialog.</p>
           </details>
           <details class="faq-item">
             <summary>How do I compare different batteries?</summary>
@@ -849,7 +849,7 @@
             <p>Yes. In the Device Database Editor you can create new devices, change existing ones or delete entries. The changes appear immediately in the dropdown menus.</p>
           </details>
           <details class="faq-item">
-            <summary>What does the Setup Diagram show?</summary>
+            <summary>What does the Project Diagram show?</summary>
             <p>The diagram illustrates how power and video cables connect between your chosen devices. Drag the nodes to arrange them and use the buttons to zoom or download an image.</p>
           </details>
           <details class="faq-item">
@@ -1071,7 +1071,7 @@
       </fieldset>
 
       <fieldset>
-        <legend>🎥 Camera Setup</legend>
+        <legend>🎥 Camera Project</legend>
         <div class="form-row"><label>Camera:<input type="text" id="fbCamera" name="fbCamera" readonly></label></div>
         <div class="form-row"><label>Battery Plate:<input type="text" id="fbBatteryPlate" name="fbBatteryPlate" readonly></label></div>
         <div class="form-row"><label>Lens Mount:<input list="mountOptions" id="fbLensMount" name="fbLensMount"></label></div>

--- a/style.css
+++ b/style.css
@@ -671,7 +671,7 @@ button:disabled {
   margin: 3px 0;
 }
 
-/* Setup diagram */
+/* Project diagram */
 #setupDiagram {
   text-align: center;
   min-height: 440px;

--- a/translations.js
+++ b/translations.js
@@ -7,14 +7,14 @@ const texts = {
     skipToContent: "Skip to content",
     offlineIndicator: "Offline",
 
-    setupManageHeading: "Manage Setup",
+    setupManageHeading: "Manage Project",
     deviceSelectionHeading: "Device Selection",
     resultsHeading: "Results",
     deviceManagerHeading: "Manage Device Database",
     batteryComparisonHeading: "Battery Comparison",
-    setupDiagramHeading: "Setup Diagram",
+    setupDiagramHeading: "Project Diagram",
     setupManageHeadingHelp:
-      "Manage saved setups: save, load, or clear configurations.",
+      "Manage saved projects: save, load, or clear configurations.",
     deviceSelectionHeadingHelp:
       "Choose cameras, monitors, and accessories for your rig.",
     resultsHeadingHelp:
@@ -25,7 +25,7 @@ const texts = {
       "Compare runtimes for all compatible batteries.",
     setupDiagramHeadingHelp:
       "View a visual diagram of how selected devices connect.",
-    setupDiagramPlaceholder: "Select devices to visualize the setup.",
+    setupDiagramPlaceholder: "Select devices to visualize the project.",
     diagramLegendPower: "Power",
     diagramLegendVideo: "Video",
     diagramLegendFIZ: "FIZ",
@@ -42,16 +42,16 @@ const texts = {
     reloadAppLabel: "Force reload",
     reloadAppHelp: "Clear cached files and reload to apply updates.",
 
-    savedSetupsLabel: "Saved Setups:",
-    newSetupOption: "-- New Setup --",
-    setupNameLabel: "Setup Name:",
+    savedSetupsLabel: "Saved Projects:",
+    newSetupOption: "-- New Project --",
+    setupNameLabel: "Project Name:",
     deleteSetupBtn: "Delete",
     saveSetupBtn: "Save",
     updateSetupBtn: "Update",
-    clearSetupBtn: "Clear Current Setup",
+    clearSetupBtn: "Clear Current Project",
     clearFilter: "Clear filter",
-    shareSetupBtn: "Share Setup Link",
-    shareSetupPrompt: "Copy this link to share your setup:",
+    shareSetupBtn: "Share Project Link",
+    shareSetupPrompt: "Copy this link to share your project:",
     shareLinkCopied: "Link copied to clipboard.",
     sharedLinkLabel: "Shared Link:",
     sharedLinkPlaceholder: "Paste shared link",
@@ -124,7 +124,7 @@ const texts = {
     missingFIZControllerWarning: "ERROR: FIZ motors require a controller with LBUS/CAM connection.",
     arriUMC4Warning: "WARNING: UMC-4 only works with LCS (LEMO 7-pin) to LBUS cable with LBUS devices.",
     arriRIA1Warning: "WARNING: RIA-1 or cforce RF controllers are not compatible with CLM-4/5.",
-    arriCLMNoUMC4Warning: "WARNING: No FIZ controller present. Select a UMC-4 for a complete setup. CLM-4/5 are not compatible with RIA-1, cforce RF or Master Grips.",
+    arriCLMNoUMC4Warning: "WARNING: No FIZ controller present. Select a UMC-4 for a complete project. CLM-4/5 are not compatible with RIA-1, cforce RF or Master Grips.",
     distanceControllerWarning: "WARNING: Distance units require UMC-4, RIA-1 or cforce RF.",
     masterGripWirelessWarning: "WARNING: Master Grip has no wireless capability. Use RIA-1, UMC-4 or cforce RF for wireless control.",
 
@@ -261,7 +261,7 @@ const texts = {
     runtimeLabel: "Estimated Runtime (h)",
     batteryLifeUnit: "hrs",
     runtimeAverageNote: "Note: runtime estimate uses a weighted average of user-submitted runtimes adjusted for resolution, codec, frame rate, brightness and temperature.",
-    runtimeUserCountNote: "Based on {count} user reports for this setup.",
+    runtimeUserCountNote: "Based on {count} user reports for this project.",
     temperatureNoteHeading: "Temperature impact on runtime:",
     temperatureNoteHelp: "Shows how different temperatures affect battery runtime.",
     temperatureLabel: "Temperature (°C)",
@@ -269,12 +269,12 @@ const texts = {
 
     noBatterySupports: "No battery can supply this load.",
 
-    alertSetupName: "Please enter a name for the setup.",
-    alertSetupSaved: "Setup \"{name}\" saved.",
-    alertNoSetupSelected: "Please select a saved setup to delete.",
-    confirmClearSetup: "Clear current setup?",
+    alertSetupName: "Please enter a name for the project.",
+    alertSetupSaved: "Project \"{name}\" saved.",
+    alertNoSetupSelected: "Please select a saved project to delete.",
+    confirmClearSetup: "Clear current project?",
     confirmClearSetupAgain: "This will remove all selections. Are you sure?",
-    confirmDeleteSetup: "Really delete setup \"{name}\"?",
+    confirmDeleteSetup: "Really delete project \"{name}\"?",
     // alertSetupDeleted not used
     confirmDeleteDevice: "Really delete device \"{name}\"?",
     alertDeviceExists: "A device with this name already exists in this category.",
@@ -286,11 +286,11 @@ const texts = {
     alertInvalidCameraJSON: "Invalid JSON for camera details",
 
     // NEW TEXTS FOR SETUP MANAGEMENT START HERE
-    setupActionsHeading: "Setup Actions",
+    setupActionsHeading: "Project Actions",
     setupActionsHeadingHelp:
-      "Export, import or share saved setups.",
-    exportSetupsBtn: "Export All Setups",
-    importSetupsBtn: "Import Setups",
+      "Export, import or share saved projects.",
+    exportSetupsBtn: "Export All Projects",
+    importSetupsBtn: "Import Projects",
     generateOverviewBtn: "Generate Overview",
     generateGearListBtn: "Generate Gear List and Project Requirements",
     editProjectBtn: "Edit Project requirements",
@@ -298,11 +298,11 @@ const texts = {
     exportGearListBtn: "Export Gear List",
     importGearListBtn: "Import Gear List",
     deleteGearListBtn: "Delete Gear List",
-    alertNoSetupsToExport: "There are no saved setups to export.",
-    alertImportSetupsSuccess: "Successfully imported {num_setups} setups.",
-    alertImportSetupsError: "Error: Could not import setups. The file may be invalid or corrupted.",
-    alertSelectSetupForOverview: "Please select a saved setup to generate an overview.",
-    overviewTitle: "Setup Overview",
+    alertNoSetupsToExport: "There are no saved projects to export.",
+    alertImportSetupsSuccess: "Successfully imported {num_setups} projects.",
+    alertImportSetupsError: "Error: Could not import projects. The file may be invalid or corrupted.",
+    alertSelectSetupForOverview: "Please select a saved project to generate an overview.",
+    overviewTitle: "Project Overview",
     backToAppBtn: "Back to App",
     exportAndRevertBtn: "Export and Revert to default Database",
     exportAndRevertBtnHelp: "Export your database and restore default entries.",
@@ -324,27 +324,27 @@ const texts = {
     hoverHelpButtonHelp:
       "Activate hover help so moving the cursor over buttons, fields, dropdowns or headers reveals brief explanations.",
     setupSelectHelp:
-      "Pick a previously saved configuration or select '-- New Setup --' to start from scratch.",
+      "Pick a previously saved configuration or select '-- New Project --' to start from scratch.",
     setupNameHelp:
-      "Enter a descriptive name for the current setup so you can recognize it later.",
+      "Enter a descriptive name for the current project so you can recognize it later.",
     deleteSetupHelp:
-      "Remove the highlighted saved setup permanently from your browser.",
+      "Remove the highlighted saved project permanently from your browser.",
     saveSetupHelp:
-      "Store the devices and battery you have selected so the setup can be recalled later. Press Enter or Ctrl+S (Cmd+S on Mac) to save quickly; the Save button stays disabled until a name is entered.",
+      "Store the devices and battery you have selected so the project can be recalled later. Press Enter or Ctrl+S (Cmd+S on Mac) to save quickly; the Save button stays disabled until a name is entered.",
     exportSetupsHelp:
       "Download every saved configuration as a JSON file for backup or sharing.",
     importSetupsHelp:
-      "Load setups from a previously exported JSON file, replacing the current list.",
+      "Load projects from a previously exported JSON file, replacing the current list.",
     generateOverviewHelp:
-      "Generate a print-ready summary of any saved setup, including power and connection details.",
+      "Generate a print-ready summary of any saved project, including power and connection details.",
     generateGearListHelp:
       "Show selected gear and project requirements in a list.",
     shareSetupHelp:
-      "Copy a unique link representing the current setup that others can open to load the same configuration.",
+      "Copy a unique link representing the current project that others can open to load the same configuration.",
     applySharedLinkHelp:
       "Load the configuration described by the shared link entered above.",
     sharedLinkHelp:
-      "Paste a previously generated share link in this field to load that setup.",
+      "Paste a previously generated share link in this field to load that project.",
     cameraSelectHelp: "Choose the camera body that anchors your rig.",
     monitorSelectHelp: "Choose an on-board or wireless monitor to include.",
     videoSelectHelp: "Choose a transmitter/receiver pair or other wireless video link.",
@@ -354,10 +354,10 @@ const texts = {
     batteryPlateSelectHelp: "Choose the battery plate or adapter that connects the battery to the camera.",
     clearSetupHelp: "Reset the planner by removing every selected device.",    runtimeFeedbackBtnHelp:
       "Open a form where you can submit real-world runtime data for this configuration.",
-    zoomOutHelp: "Zoom out of the setup diagram to view more of the layout.",
-    zoomInHelp: "Zoom in on the setup diagram for a closer look at connections.",
+    zoomOutHelp: "Zoom out of the project diagram to view more of the layout.",
+    zoomInHelp: "Zoom in on the project diagram for a closer look at connections.",
     downloadDiagramHelp:
-      "Download the current setup diagram as an SVG or JPG image.",
+      "Download the current project diagram as an SVG or JPG image.",
     gridSnapToggleHelp:
       "Turn grid snapping on or off to help align items in the diagram.",
     resetViewBtn: "Reset View",


### PR DESCRIPTION
## Summary
- Rename setup references to project across UI and docs
- Update English translation strings and documentation to use project terminology
- Adjust project diagram comment in CSS

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bb5c678c6083209fe5aba2de0bf361