### PR TITLE
Ensure scenario icon boxes appear below selector

### DIFF
--- a/style.css
+++ b/style.css
@@ -755,9 +755,10 @@ button:disabled {
 }
 
 .scenario-summary {
-  margin-top: 4px;
-  display: flex;
-  flex-wrap: wrap;
+    margin-top: 4px;
+    display: flex;
+    flex-wrap: wrap;
+    width: 100%;
 }
 
 .connector-block,


### PR DESCRIPTION
## Summary
- Make shooting scenario icons flow under the scenario selector

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb61ac52cc8320bfe75df0da605053