### PR TITLE
Refactor tripod preferences workflow

### DIFF
--- a/index.html
+++ b/index.html
@@ -1027,25 +1027,41 @@
       <div class="form-row"><label for="monitorUserButtons">Onboard Monitor User Buttons:<input type="text" id="monitorUserButtons" name="monitorUserButtons"></label></div>
       <div class="form-row"><label for="cameraUserButtons">Camera User Buttons:<input type="text" id="cameraUserButtons" name="cameraUserButtons"></label></div>
       <div class="form-row"><label for="viewfinderUserButtons">Viewfinder User Buttons:<input type="text" id="viewfinderUserButtons" name="viewfinderUserButtons"></label></div>
-      <div class="form-row hidden" id="tripodPreferencesRow"><label for="tripodPreferences">Tripod Preferences:
-        <select id="tripodPreferences" name="tripodPreferences" multiple size="15">
-          <option value="O'Connor">O'Connor</option>
-          <option value="Sachtler">Sachtler</option>
-          <option value="Other Head Brand">Other Head Brand</option>
-          <option value="75er bowl">75er bowl</option>
-          <option value="100er bowl">100er bowl</option>
-          <option value="150 bowl">150 bowl</option>
-          <option value="Mitchell Mount">Mitchell Mount</option>
-          <option value="Bodenstern">Bodenstern</option>
-          <option value="Frosch">Frosch</option>
-          <option value="Baby">Baby</option>
-          <option value="Normal">Normal</option>
-          <option value="Bodenspinne">Bodenspinne</option>
-          <option value="Mittelspinne">Mittelspinne</option>
-          <option value="Zoom Remote handle">Zoom Remote handle</option>
-          <option value="Dolly Remote handle">Dolly Remote handle</option>
-        </select>
-      </label></div>
+      <div class="form-row hidden" id="tripodPreferencesRow">
+        <strong>Tripod Preferences:</strong>
+        <label for="tripodHeadBrand">Head Brand:
+          <select id="tripodHeadBrand" name="tripodHeadBrand">
+            <option value=""></option>
+            <option value="OConnor">O'Connor</option>
+            <option value="Sachtler">Sachtler</option>
+            <option value="other">other</option>
+          </select>
+        </label>
+        <label for="tripodBowl">Bowl type:
+          <select id="tripodBowl" name="tripodBowl">
+            <option value=""></option>
+            <option value="75mm bowl">75mm bowl</option>
+            <option value="100mm bowl">100mm bowl</option>
+            <option value="150mm bowl">150mm bowl</option>
+            <option value="Mitchell Mount">Mitchell Mount</option>
+          </select>
+        </label>
+        <label for="tripodTypes">Tripod types:
+          <select id="tripodTypes" name="tripodTypes" multiple size="4">
+            <option value="Standard Tripod">Standard Tripod</option>
+            <option value="Baby Tripod">Baby Tripod</option>
+            <option value="Frog Tripod">Frog Tripod</option>
+            <option value="Hi-Head">Hi-Head</option>
+          </select>
+        </label>
+        <label for="tripodSpreader">Spreader Preference:
+          <select id="tripodSpreader" name="tripodSpreader">
+            <option value=""></option>
+            <option value="Mid-Level Spreader">Mid-Level Spreader</option>
+            <option value="Ground Spreader">Ground Spreader</option>
+          </select>
+        </label>
+      </div>
       <div class="form-row"><label for="filter">Filter:
         <select id="filter" name="filter" multiple size="10"></select>
       </label></div>

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -1568,22 +1568,28 @@ describe('script.js functions', () => {
   test('tripod preferences selector is shown only when Tripod scenario is selected', () => {
     const select = document.getElementById('requiredScenarios');
     const tripodRow = document.getElementById('tripodPreferencesRow');
-    const tripodSelect = document.getElementById('tripodPreferences');
+    const headSel = document.getElementById('tripodHeadBrand');
+    const bowlSel = document.getElementById('tripodBowl');
+    const typesSel = document.getElementById('tripodTypes');
+    const spreaderSel = document.getElementById('tripodSpreader');
 
-    // Initially hidden
     expect(tripodRow.classList.contains('hidden')).toBe(true);
 
-    // Select Tripod scenario
     select.querySelector('option[value="Tripod"]').selected = true;
     script.updateRequiredScenariosSummary();
     expect(tripodRow.classList.contains('hidden')).toBe(false);
 
-    // Choose a tripod preference and then deselect Tripod scenario
-    tripodSelect.querySelector('option').selected = true;
+    headSel.value = 'OConnor';
+    bowlSel.value = '100mm bowl';
+    typesSel.querySelector('option').selected = true;
+    spreaderSel.value = 'Mid-Level Spreader';
     select.querySelector('option[value="Tripod"]').selected = false;
     script.updateRequiredScenariosSummary();
     expect(tripodRow.classList.contains('hidden')).toBe(true);
-    expect(Array.from(tripodSelect.selectedOptions)).toHaveLength(0);
+    expect(headSel.value).toBe('');
+    expect(bowlSel.value).toBe('');
+    expect(Array.from(typesSel.selectedOptions)).toHaveLength(0);
+    expect(spreaderSel.value).toBe('');
   });
 
   test('Hand Grips rigging adds telescopic handle', () => {
@@ -1678,54 +1684,28 @@ describe('script.js functions', () => {
     });
   });
 
-  test('Tripod scenario adds tripod legs', () => {
+
+  test('Tripod preferences add selected head and tripods', () => {
     const { generateGearListHtml } = script;
-    const html = generateGearListHtml({ requiredScenarios: 'Tripod' });
+    const html = generateGearListHtml({
+      requiredScenarios: 'Tripod',
+      tripodHeadBrand: 'OConnor',
+      tripodBowl: '100mm bowl',
+      tripodTypes: 'Standard Tripod, Frog Tripod, Hi-Head',
+      tripodSpreader: 'Mid-Level Spreader'
+    });
     const wrap = document.createElement('div');
     wrap.innerHTML = html;
     const rows = Array.from(wrap.querySelectorAll('.gear-table tr'));
     const gripIdx = rows.findIndex(r => r.textContent === 'Grip');
     const itemsRow = rows[gripIdx + 1];
     const text = itemsRow.textContent;
-    expect(text).toContain('1x Legs Large');
-    expect(text).toContain('1x Legs Medium');
-    expect(text).toContain('1x Legs Short');
-  });
-
-  test('Tripod scenario adds OConnor head for heavy camera', () => {
-    const { generateGearListHtml } = script;
-    global.devices.cameras['Arri Alexa Mini LF'] = { weight_g: 2600 };
-    const addOpt = (id, value) => {
-      const sel = document.getElementById(id);
-      sel.innerHTML = `<option value="${value}">${value}</option>`;
-      sel.value = value;
-    };
-    addOpt('cameraSelect', 'Arri Alexa Mini LF');
-    const html = generateGearListHtml({ requiredScenarios: 'Tripod' });
-    const wrap = document.createElement('div');
-    wrap.innerHTML = html;
-    const rows = Array.from(wrap.querySelectorAll('.gear-table tr'));
-    const gripIdx = rows.findIndex(r => r.textContent === 'Grip');
-    const itemsRow = rows[gripIdx + 1];
-    expect(itemsRow.textContent).toContain('OConnor 2560 Head');
-  });
-
-  test('Tripod scenario adds 75mm head for light camera', () => {
-    const { generateGearListHtml } = script;
-    global.devices.cameras['Blackmagic BMPCC 4K'] = { weight_g: 680 };
-    const addOpt = (id, value) => {
-      const sel = document.getElementById(id);
-      sel.innerHTML = `<option value="${value}">${value}</option>`;
-      sel.value = value;
-    };
-    addOpt('cameraSelect', 'Blackmagic BMPCC 4K');
-    const html = generateGearListHtml({ requiredScenarios: 'Tripod' });
-    const wrap = document.createElement('div');
-    wrap.innerHTML = html;
-    const rows = Array.from(wrap.querySelectorAll('.gear-table tr'));
-    const gripIdx = rows.findIndex(r => r.textContent === 'Grip');
-    const itemsRow = rows[gripIdx + 1];
-    expect(itemsRow.textContent).toContain('Sachtler FSB 8 Head');
+    expect(text).toContain("1x O'Connor Ultimate 1040 Fluid-Head 100mm bowl");
+    expect(text).toContain('1x 100mm bowl Standard Tripod + Mid-Level Spreader');
+    expect(text).toContain('1x 100mm bowl Frog Tripod + Mid-Level Spreader');
+    expect(text).toContain('1x 100mm bowl Hi-Head');
+    expect(text).toContain('1x Sandsack (for Frog Tripod)');
+    expect(text).toContain('1x Sandsack (for Hi-Head)');
   });
 
   test('Easyrig scenario adds stabiliser with dropdown options', () => {
@@ -1951,7 +1931,7 @@ describe('script.js functions', () => {
 
   test('tripod preferences are excluded from project requirements', () => {
     const { generateGearListHtml } = script;
-    const html = generateGearListHtml({ tripodPreferences: 'OConnor 2560 Head' });
+    const html = generateGearListHtml({ tripodHeadBrand: 'OConnor' });
     expect(html).not.toContain('Tripod Preferences');
   });
 


### PR DESCRIPTION
## Summary
- Replace single tripod preferences select with structured head brand, bowl, type, and spreader selectors
- Prevent incompatible tripod option combinations and generate gear list entries for selected heads and tripods
- Reset and hide tripod settings when Tripod scenario is deselected

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bb682f6c808320ad4fa6fbf447939f