### PR TITLE
Add wooden wedges per Magliner cart

### DIFF
--- a/script.js
+++ b/script.js
@@ -7585,6 +7585,12 @@ function generateGearListHtml(info = {}) {
     const monitoringSupportHardware = formatItems(monitoringSupportAcc);
     const monitoringSupportItems = monitoringSupportHardware;
     addRow('Monitoring support', monitoringSupportItems);
+    const cartsTransportationItems = [
+        'Magliner Senior - with quick release mount + tripod holder + utility tray + O‘Connor-Aufhängung',
+        ...Array(10).fill('Securing Straps (25mm wide)'),
+        'Loading Ramp (pair, 420kg)',
+        ...Array(20).fill('Airliner Ösen')
+    ];
     const gripItems = [];
     let sliderSelectHtml = '';
     let easyrigSelectHtml = '';
@@ -7673,6 +7679,10 @@ function generateGearListHtml(info = {}) {
     if (standCount) {
         gripItems.push(...Array(standCount * 3).fill('Tennisball'));
     }
+    const maglinerCount = cartsTransportationItems.filter(item => /Magliner/i.test(item)).length;
+    if (maglinerCount) {
+        gripItems.push(...Array(maglinerCount * 2).fill('Wooden wedge'));
+    }
     const riggingItems = formatItems(riggingAcc);
     addRow('Rigging', riggingItems);
     const powerItems = [
@@ -7685,12 +7695,6 @@ function generateGearListHtml(info = {}) {
     ];
     addRow('Power', formatItems(powerItems));
     addRow('Grip', [sliderSelectHtml, formatItems(gripItems), easyrigSelectHtml].filter(Boolean).join('<br>'));
-    const cartsTransportationItems = [
-        'Magliner Senior - with quick release mount + tripod holder + utility tray + O‘Connor-Aufhängung',
-        ...Array(10).fill('Securing Straps (25mm wide)'),
-        'Loading Ramp (pair, 420kg)',
-        ...Array(20).fill('Airliner Ösen')
-    ];
     addRow('Carts and Transportation', formatItems(cartsTransportationItems));
     const miscExcluded = new Set([
         'D-Tap to LEMO 2-pin',

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -1642,6 +1642,17 @@ describe('script.js functions', () => {
     expect(itemsText).toContain('20x Airliner Ösen');
   });
 
+  test('Magliner adds wooden wedges to grip section', () => {
+    const { generateGearListHtml } = script;
+    const html = generateGearListHtml();
+    const wrap = document.createElement('div');
+    wrap.innerHTML = html;
+    const rows = Array.from(wrap.querySelectorAll('.gear-table tr'));
+    const gripIdx = rows.findIndex(r => r.textContent === 'Grip');
+    const gripText = rows[gripIdx + 1].textContent;
+    expect(gripText).toContain('2x Wooden wedge');
+  });
+
   test('Slider scenario adds Tango Roller and accessories', () => {
     const { generateGearListHtml } = script;
     const html = generateGearListHtml({ requiredScenarios: 'Slider', sliderBowl: '75er bowl' });


### PR DESCRIPTION
## Summary
- Add Magliner cart inventory to grip gear calculation
- Automatically append two wooden wedges per Magliner to grip section
- Test wooden wedge inclusion in grip list

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bb6860b0008320821bfd71c71053ad