### PR TITLE
Handle double-clicks in multiselects without clearing selection

### DIFF
--- a/script.js
+++ b/script.js
@@ -1826,6 +1826,9 @@ if (projectForm) {
             sel.focus();
             sel.scrollTop = scrollTop;
         });
+        sel.addEventListener('dblclick', e => {
+            e.preventDefault();
+        });
     });
 }
 

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -1565,6 +1565,23 @@ describe('script.js functions', () => {
     expect(Array.from(tripodSelect.selectedOptions)).toHaveLength(0);
   });
 
+  test('double-clicking an option only deselects that option', () => {
+    const selects = document.querySelectorAll('#projectForm select[multiple]');
+    selects.forEach(sel => {
+      const [first, second] = sel.options;
+      if (!first) return;
+      Array.from(sel.options).forEach(o => { o.selected = false; });
+      if (second) second.selected = true;
+      first.dispatchEvent(new MouseEvent('mousedown', { bubbles: true, detail: 1 }));
+      first.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }));
+      first.dispatchEvent(new MouseEvent('mousedown', { bubbles: true, detail: 2 }));
+      first.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }));
+      first.dispatchEvent(new MouseEvent('dblclick', { bubbles: true }));
+      expect(first.selected).toBe(false);
+      if (second) expect(second.selected).toBe(true);
+    });
+  });
+
   test('Hand Grips rigging adds telescopic handle', () => {
     const { generateGearListHtml } = script;
     const html = generateGearListHtml({ rigging: 'Hand Grips' });


### PR DESCRIPTION
## Summary
- prevent double-click default behavior from clearing existing selections in multi-select inputs
- test that double-clicking only deselects the clicked option

## Testing
- `npm run lint`
- `npm run check-consistency`
- `CI=true npx jest --runInBand --forceExit --verbose`


------
https://chatgpt.com/codex/tasks/task_e_68bb6189b374832085639638f95ba21c