### PR TITLE
Hide Dolly remote handle until dolly scenario selected

### DIFF
--- a/index.html
+++ b/index.html
@@ -1053,7 +1053,7 @@
           <option value="Bodenspinne">Bodenspinne</option>
           <option value="Mittelspinne">Mittelspinne</option>
           <option value="Zoom Remote handle">Zoom Remote handle</option>
-          <option value="Dolly Remote handle">Dolly Remote handle</option>
+          <option value="Dolly Remote handle" hidden>Dolly Remote handle</option>
         </select>
       </label></div>
       <div class="form-row"><label for="filter">Filter:

--- a/script.js
+++ b/script.js
@@ -8627,6 +8627,14 @@ function updateRequiredScenariosSummary() {
       }
     }
   }
+  if (tripodPreferencesSelect) {
+    const dollyOption = Array.from(tripodPreferencesSelect.options).find(o => o.value === 'Dolly Remote handle');
+    if (dollyOption) {
+      const show = selected.includes('Dolly');
+      dollyOption.hidden = !show;
+      if (!show) dollyOption.selected = false;
+    }
+  }
 }
 
 function initApp() {


### PR DESCRIPTION
## Summary
- Hide Dolly Remote handle option by default
- Show Dolly Remote handle only when Dolly scenario is chosen

## Testing
- `CI=1 npm test -- --runInBand`


------
https://chatgpt.com/codex/tasks/task_e_68bb69776a0483208de238613d507b5d