### PR TITLE
feat: show lens details in selections and gear list

### DIFF
--- a/script.js
+++ b/script.js
@@ -7544,7 +7544,16 @@ function generateGearListHtml(info = {}) {
     const selectedLensNames = info.lenses
         ? info.lenses.split(',').map(s => s.trim()).filter(Boolean)
         : [];
-    addRow('Lens', formatItems(selectedLensNames));
+    const lensDisplayNames = selectedLensNames.map(name => {
+        const lens = devices.lenses && devices.lenses[name];
+        if (!lens) return name;
+        const attrs = [];
+        if (lens.weight_g) attrs.push(`${lens.weight_g}g`);
+        if (lens.frontDiameterMm) attrs.push(`${lens.frontDiameterMm}mm front`);
+        if (lens.tStop) attrs.push(`T${lens.tStop}`);
+        return attrs.length ? `${name} (${attrs.join(', ')})` : name;
+    });
+    addRow('Lens', formatItems(lensDisplayNames));
     const lensSupportItems = [];
     const requiredRodTypes = new Set();
     const addedRodPairs = new Set();
@@ -8759,7 +8768,12 @@ function populateLensDropdown() {
   Object.keys(lensData).sort(localeSort).forEach(name => {
     const opt = document.createElement('option');
     opt.value = name;
-    opt.textContent = name;
+    const lens = lensData[name] || {};
+    const attrs = [];
+    if (lens.weight_g) attrs.push(`${lens.weight_g}g`);
+    if (lens.frontDiameterMm) attrs.push(`${lens.frontDiameterMm}mm front`);
+    if (lens.tStop) attrs.push(`T${lens.tStop}`);
+    opt.textContent = attrs.length ? `${name} (${attrs.join(', ')})` : name;
     lensSelect.appendChild(opt);
   });
 }

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -41,7 +41,7 @@ function setupDom(removeGear) {
       }
     },
     lenses: {
-      LensA: { brand: 'TestBrand', tStop: 2.0, rodStandard: '15mm', rodLengthCm: 30, needsLensSupport: true }
+      LensA: { brand: 'TestBrand', tStop: 2.0, rodStandard: '15mm', rodLengthCm: 30, needsLensSupport: true, frontDiameterMm: 80, weight_g: 110 }
     },
     fiz: {
       motors: {
@@ -217,7 +217,7 @@ describe('script.js functions', () => {
         }
       },
       lenses: {
-        LensA: { brand: 'TestBrand', tStop: 2.0, rodStandard: '15mm', rodLengthCm: 30, needsLensSupport: true }
+        LensA: { brand: 'TestBrand', tStop: 2.0, rodStandard: '15mm', rodLengthCm: 30, needsLensSupport: true, frontDiameterMm: 80, weight_g: 110 }
       },
       fiz: {
         motors: {
@@ -332,11 +332,14 @@ describe('script.js functions', () => {
     expect(hasCable).toBe(true);
   });
 
-  test('populateLensDropdown fills lens list without duplicates', () => {
+  test('populateLensDropdown fills lens list without duplicates and adds attributes', () => {
     const sel = document.getElementById('lenses');
     sel.innerHTML = '<option value="Existing">Existing</option>';
     script.populateLensDropdown();
     expect(Array.from(sel.options).map(o => o.value)).toEqual(['LensA']);
+    expect(sel.options[0].textContent).toContain('LensA');
+    expect(sel.options[0].textContent).toContain('110g');
+    expect(sel.options[0].textContent).toContain('80mm front');
     // Call again to ensure no duplication occurs
     script.populateLensDropdown();
     expect(Array.from(sel.options).map(o => o.value)).toEqual(['LensA']);
@@ -385,6 +388,18 @@ describe('script.js functions', () => {
     const supportRow = rows[supportIndex + 1];
     expect(supportRow.textContent).toContain('15mm rods 30cm');
     expect(supportRow.textContent).toContain('15mm lens support');
+  });
+
+  test('gear list lens row includes lens attributes', () => {
+    const html = script.generateGearListHtml({ lenses: 'LensA' });
+    const wrap = document.createElement('div');
+    wrap.innerHTML = html;
+    const rows = Array.from(wrap.querySelectorAll('.gear-table tr'));
+    const lensIndex = rows.findIndex(r => r.textContent === 'Lens');
+    const lensRow = rows[lensIndex + 1];
+    expect(lensRow.textContent).toContain('LensA');
+    expect(lensRow.textContent).toContain('110g');
+    expect(lensRow.textContent).toContain('80mm front');
   });
 
   test('multiple lenses with same rod length only add one pair of rods', () => {


### PR DESCRIPTION
## Summary
- display lens attributes like weight and front diameter after the lens name
- ensure lens dropdown includes these attributes for quick reference
- test lens attribute display

## Testing
- `npm run lint`
- `npm run check-consistency`
- `npx jest --runInBand --forceExit --silent`


------
https://chatgpt.com/codex/tasks/task_e_68bb6afd75508320979dee920d6f4123