### PR TITLE
Show remote head option only when Dolly scenario is selected

### DIFF
--- a/script.js
+++ b/script.js
@@ -1492,6 +1492,8 @@ const batterySelect  = document.getElementById("batterySelect");
 const lensSelect     = document.getElementById("lenses");
 const requiredScenariosSelect = document.getElementById("requiredScenarios");
 const requiredScenariosSummary = document.getElementById("requiredScenariosSummary");
+const remoteHeadOption = requiredScenariosSelect ?
+  requiredScenariosSelect.querySelector('option[value="Remote Head"]') : null;
 const tripodPreferencesRow = document.getElementById("tripodPreferencesRow");
 const tripodHeadBrandSelect = document.getElementById("tripodHeadBrand");
 const tripodBowlSelect = document.getElementById("tripodBowl");
@@ -8670,7 +8672,17 @@ const scenarioIcons = {
 function updateRequiredScenariosSummary() {
   if (!requiredScenariosSelect || !requiredScenariosSummary) return;
   requiredScenariosSummary.innerHTML = '';
-  const selected = Array.from(requiredScenariosSelect.selectedOptions).map(o => o.value);
+  let selected = Array.from(requiredScenariosSelect.selectedOptions).map(o => o.value);
+  const hasDolly = selected.includes('Dolly');
+  if (remoteHeadOption) {
+    if (!hasDolly) {
+      remoteHeadOption.hidden = true;
+      remoteHeadOption.selected = false;
+      selected = selected.filter(v => v !== 'Remote Head');
+    } else {
+      remoteHeadOption.hidden = false;
+    }
+  }
   selected.forEach(val => {
     const box = document.createElement('span');
     box.className = 'scenario-box';

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -1592,6 +1592,27 @@ describe('script.js functions', () => {
     expect(spreaderSel.value).toBe('');
   });
 
+  test('remote head option is only visible when Dolly is selected', () => {
+    const select = document.getElementById('requiredScenarios');
+    const remoteOpt = select.querySelector('option[value="Remote Head"]');
+
+    script.updateRequiredScenariosSummary();
+    expect(remoteOpt.hidden).toBe(true);
+
+    select.querySelector('option[value="Dolly"]').selected = true;
+    script.updateRequiredScenariosSummary();
+    expect(remoteOpt.hidden).toBe(false);
+
+    remoteOpt.selected = true;
+    script.updateRequiredScenariosSummary();
+    expect(remoteOpt.hidden).toBe(false);
+
+    select.querySelector('option[value="Dolly"]').selected = false;
+    script.updateRequiredScenariosSummary();
+    expect(remoteOpt.hidden).toBe(true);
+    expect(remoteOpt.selected).toBe(false);
+  });
+
   test('double-clicking an option only deselects that option', () => {
     const selects = document.querySelectorAll('#projectForm select[multiple]');
     selects.forEach(sel => {


### PR DESCRIPTION
## Summary
- Hide the "Remote Head" scenario option unless the "Dolly" scenario is selected
- Update scenario summary logic to clear and hide the remote option when Dolly is deselected
- Add tests covering the conditional visibility of the Remote Head option

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb6b5a0e5c8320850a6cd00004974a