### PR TITLE
Handle rain scenarios with additional gear

### DIFF
--- a/script.js
+++ b/script.js
@@ -7803,10 +7803,11 @@ function generateGearListHtml(info = {}) {
         }
         for (let i = 0; i < count; i++) consumables.push(item.name);
     }
-    if (scenarios.includes('Outdoor')) {
+    const needsRainProtection = ['Outdoor', 'Extreme rain', 'Rain Machine'].some(s => scenarios.includes(s));
+    if (needsRainProtection) {
         if (selectedNames.camera) miscItems.push(`Rain Cover "${selectedNames.camera}"`);
-        miscItems.push('Umbrella for Focus Monitor');
-        miscItems.push('Umbrella Magliner incl Mounting to Magliner');
+        if (!miscItems.includes('Umbrella for Focus Monitor')) miscItems.push('Umbrella for Focus Monitor');
+        if (!miscItems.includes('Umbrella Magliner incl Mounting to Magliner')) miscItems.push('Umbrella Magliner incl Mounting to Magliner');
         const monitorSizes = [];
         if (monitorSelect && monitorSelect.value) {
             const m = devices.monitors[monitorSelect.value];

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -1843,6 +1843,54 @@ describe('script.js functions', () => {
     expect(consumText).toContain('1x Magliner Rain Cover Transparent');
   });
 
+  test('Extreme rain scenario adds weather protection gear and consumables for small monitor', () => {
+    const { generateGearListHtml } = script;
+    const addOpt = (id, value) => {
+      const sel = document.getElementById(id);
+      sel.innerHTML = `<option value="${value}">${value}</option>`;
+      sel.value = value;
+    };
+    addOpt('cameraSelect', 'CamA');
+    addOpt('monitorSelect', 'MonA');
+    const html = generateGearListHtml({ requiredScenarios: 'Extreme rain' });
+    const wrap = document.createElement('div');
+    wrap.innerHTML = html;
+    const rows = Array.from(wrap.querySelectorAll('.gear-table tr'));
+    const miscIdx = rows.findIndex(r => r.textContent === 'Miscellaneous');
+    const miscText = rows[miscIdx + 1].textContent;
+    expect(miscText).toContain('Rain Cover "CamA"');
+    expect(miscText).toContain('1x Umbrella for Focus Monitor');
+    expect(miscText).toContain('1x Umbrella Magliner incl Mounting to Magliner');
+    const consumIdx = rows.findIndex(r => r.textContent === 'Consumables');
+    const consumText = rows[consumIdx + 1].textContent;
+    expect(consumText).toContain('2x CapIt Large');
+    expect(consumText).toContain('4x CapIt Medium');
+    expect(consumText).toContain('3x CapIt Small');
+    expect(consumText).toContain('10x Duschhaube');
+    expect(consumText).toContain('1x Magliner Rain Cover Transparent');
+  });
+
+  test('Rain Machine scenario does not duplicate umbrellas when combined with Outdoor', () => {
+    const { generateGearListHtml } = script;
+    const addOpt = (id, value) => {
+      const sel = document.getElementById(id);
+      sel.innerHTML = `<option value="${value}">${value}</option>`;
+      sel.value = value;
+    };
+    addOpt('cameraSelect', 'CamA');
+    addOpt('monitorSelect', 'MonA');
+    const html = generateGearListHtml({ requiredScenarios: 'Outdoor, Rain Machine' });
+    const wrap = document.createElement('div');
+    wrap.innerHTML = html;
+    const rows = Array.from(wrap.querySelectorAll('.gear-table tr'));
+    const miscIdx = rows.findIndex(r => r.textContent === 'Miscellaneous');
+    const miscText = rows[miscIdx + 1].textContent;
+    expect(miscText).toContain('1x Umbrella for Focus Monitor');
+    expect(miscText).toContain('1x Umbrella Magliner incl Mounting to Magliner');
+    expect(miscText).not.toContain('2x Umbrella for Focus Monitor');
+    expect(miscText).not.toContain('2x Umbrella Magliner incl Mounting to Magliner');
+  });
+
   test('Outdoor scenario calculates CapIt sizes for large monitors', () => {
     const { generateGearListHtml } = script;
     devices.monitors.MonB = {


### PR DESCRIPTION
## Summary
- Add rain protection gear when Extreme rain or Rain Machine scenarios are selected
- Prevent duplicate umbrellas across rain-related scenarios
- Cover new scenarios with tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bb6c57604083208c82524f602c1b3e