### PR TITLE
Add rain-specific mattebox accessories

### DIFF
--- a/script.js
+++ b/script.js
@@ -7374,6 +7374,12 @@ function generateGearListHtml(info = {}) {
     const filterSelections = info.filter
         ? info.filter.split(',').map(s => s.trim()).filter(Boolean)
         : [];
+    if (scenarios.includes('Rain Machine') || scenarios.includes('Extreme rain')) {
+        filterSelections.push('Schulz Sprayoff Micro');
+        filterSelections.push('Fischer RS to D-Tap cable 0,5m');
+        filterSelections.push('Fischer RS to D-Tap cable 0,5m');
+        filterSelections.push('Spare Disc (Schulz Sprayoff Micro)');
+    }
     const receiverCount = (videoDistPrefs.includes('Directors Monitor 7" handheld') ? 1 : 0) + (hasMotor ? 1 : 0);
     if (selectedNames.video) {
         monitoringSupportAcc.push('Antenna 5,8GHz 5dBi Long (spare)');

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -1552,6 +1552,20 @@ describe('script.js functions', () => {
     expect(itemsRow.textContent).toContain('1x SHAPE Telescopic Handle ARRI Rosette Kit 12"');
   });
 
+  test('Rain Machine scenario adds Sprayoff and cables to Matte box section', () => {
+    const { generateGearListHtml } = script;
+    const html = generateGearListHtml({ requiredScenarios: 'Rain Machine' });
+    const wrap = document.createElement('div');
+    wrap.innerHTML = html;
+    const rows = Array.from(wrap.querySelectorAll('.gear-table tr'));
+    const matteIdx = rows.findIndex(r => r.textContent === 'Matte box + filter');
+    expect(matteIdx).toBeGreaterThanOrEqual(0);
+    const itemsRow = rows[matteIdx + 1];
+    expect(itemsRow.textContent).toContain('1x Schulz Sprayoff Micro');
+    expect(itemsRow.textContent).toContain('2x Fischer RS to D-Tap cable 0,5m');
+    expect(itemsRow.textContent).toContain('1x Spare Disc (Schulz Sprayoff Micro)');
+  });
+
   test('updateRequiredScenariosSummary creates a box for each selection', () => {
     const select = document.getElementById('requiredScenarios');
     select.querySelector('option[value="Indoor"]').selected = true;


### PR DESCRIPTION
## Summary
- Include Sprayoff and Fischer RS to D-Tap cables in Matte box section for Rain Machine or Extreme rain scenarios
- Test Rain Machine scenario populates Matte box section with rain gear

## Testing
- `CI=true npm test -- --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_68bb6c135bdc8320a8293c93a32260c8