### PR TITLE
Load wireless receiver data for gear list

### DIFF
--- a/index.html
+++ b/index.html
@@ -1240,6 +1240,7 @@
   <script src="devices/batteries.js"></script>
   <script src="devices/cages.js"></script>
   <script src="devices/gearList.js"></script>
+  <script src="devices/wirelessReceivers.js"></script>
   <script src="storage.js"></script>
   <script src="translations.js"></script>
   <script src="lz-string.min.js"></script>

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -1,0 +1,7 @@
+const fs = require('fs');
+const path = require('path');
+
+test('index.html loads wireless receiver definitions', () => {
+  const html = fs.readFileSync(path.join(__dirname, '../index.html'), 'utf8');
+  expect(html).toContain('<script src="devices/wirelessReceivers.js"></script>');
+});


### PR DESCRIPTION
## Summary
- Load wireless receiver definitions in the web app by including devices/wirelessReceivers.js
- Add regression test to ensure index.html references wirelessReceivers.js

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bb6dbdfe808320a73f1a622f396c59