### PR TITLE
Auto-select SmallHD Ultra 7 when Dolly scenario chosen

### DIFF
--- a/script.js
+++ b/script.js
@@ -8735,6 +8735,23 @@ function updateRequiredScenariosSummary() {
       remoteHeadOption.hidden = false;
     }
   }
+  if (
+    hasDolly &&
+    monitorSelect &&
+    (!monitorSelect.value || monitorSelect.value === 'None')
+  ) {
+    const defaultMonitor = 'SmallHD Ultra 7';
+    if (devices?.monitors?.[defaultMonitor]) {
+      if (!Array.from(monitorSelect.options).some(o => o.value === defaultMonitor)) {
+        const opt = document.createElement('option');
+        opt.value = defaultMonitor;
+        opt.textContent = defaultMonitor;
+        monitorSelect.appendChild(opt);
+      }
+      monitorSelect.value = defaultMonitor;
+      monitorSelect.dispatchEvent(new Event('change'));
+    }
+  }
   selected.forEach(val => {
     const box = document.createElement('span');
     box.className = 'scenario-box';

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -1685,6 +1685,23 @@ describe('script.js functions', () => {
     expect(remoteOpt.selected).toBe(false);
   });
 
+  test('selecting Dolly adds SmallHD Ultra 7 monitor when none selected', () => {
+    const select = document.getElementById('requiredScenarios');
+    const monitorSel = document.getElementById('monitorSelect');
+
+    devices.monitors['SmallHD Ultra 7'] = { powerDrawWatts: 5 };
+    const opt = document.createElement('option');
+    opt.value = 'SmallHD Ultra 7';
+    opt.textContent = 'SmallHD Ultra 7';
+    monitorSel.appendChild(opt);
+    monitorSel.value = 'None';
+
+    select.querySelector('option[value="Dolly"]').selected = true;
+    script.updateRequiredScenariosSummary();
+
+    expect(monitorSel.value).toBe('SmallHD Ultra 7');
+  });
+
   test('double-clicking an option only deselects that option', () => {
     const selects = document.querySelectorAll('#projectForm select[multiple]');
     selects.forEach(sel => {


### PR DESCRIPTION
## Summary
- Auto-select SmallHD Ultra 7 monitor if Dolly scenario is chosen and no monitor is picked.
- Add regression test verifying monitor auto-selection.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb6ff101688320973eee551f6e90a5