### PR TITLE
Add umbrella support for extreme heat

### DIFF
--- a/script.js
+++ b/script.js
@@ -7868,10 +7868,15 @@ function generateGearListHtml(info = {}) {
         for (let i = 0; i < count; i++) consumables.push(item.name);
     }
     const needsRainProtection = ['Outdoor', 'Extreme rain', 'Rain Machine'].some(s => scenarios.includes(s));
-    if (needsRainProtection) {
-        if (selectedNames.camera) miscItems.push(`Rain Cover "${selectedNames.camera}"`);
+    if (needsRainProtection && selectedNames.camera) {
+        miscItems.push(`Rain Cover "${selectedNames.camera}"`);
+    }
+    const needsUmbrellas = needsRainProtection || scenarios.includes('Extreme heat');
+    if (needsUmbrellas) {
         if (!miscItems.includes('Umbrella for Focus Monitor')) miscItems.push('Umbrella for Focus Monitor');
         if (!miscItems.includes('Umbrella Magliner incl Mounting to Magliner')) miscItems.push('Umbrella Magliner incl Mounting to Magliner');
+    }
+    if (needsRainProtection) {
         const monitorSizes = [];
         if (monitorSelect && monitorSelect.value) {
             const m = devices.monitors[monitorSelect.value];

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -1984,6 +1984,26 @@ describe('script.js functions', () => {
     expect(miscText).not.toContain('2x Umbrella Magliner incl Mounting to Magliner');
   });
 
+  test('Extreme heat scenario adds umbrellas to miscellaneous', () => {
+    const { generateGearListHtml } = script;
+    const addOpt = (id, value) => {
+      const sel = document.getElementById(id);
+      sel.innerHTML = `<option value="${value}">${value}</option>`;
+      sel.value = value;
+    };
+    addOpt('cameraSelect', 'CamA');
+    addOpt('monitorSelect', 'MonA');
+    const html = generateGearListHtml({ requiredScenarios: 'Extreme heat' });
+    const wrap = document.createElement('div');
+    wrap.innerHTML = html;
+    const rows = Array.from(wrap.querySelectorAll('.gear-table tr'));
+    const miscIdx = rows.findIndex(r => r.textContent === 'Miscellaneous');
+    const miscText = rows[miscIdx + 1].textContent;
+    expect(miscText).toContain('1x Umbrella for Focus Monitor');
+    expect(miscText).toContain('1x Umbrella Magliner incl Mounting to Magliner');
+    expect(miscText).not.toContain('Rain Cover');
+  });
+
   test('Extreme cold scenario adds hair dryer to miscellaneous', () => {
     const { generateGearListHtml } = script;
     const html = generateGearListHtml({ requiredScenarios: 'Extreme cold (snow)' });


### PR DESCRIPTION
## Summary
- add umbrella handling for "Extreme heat" scenario to gear list logic
- cover new scenario with unit test

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb706965208320893535fad71f872e