### PR TITLE
Add DoP monitor options for special rigging scenarios

### DIFF
--- a/script.js
+++ b/script.js
@@ -1501,6 +1501,7 @@ const tripodTypesSelect = document.getElementById("tripodTypes");
 const tripodSpreaderSelect = document.getElementById("tripodSpreader");
 const monitoringConfigurationSelect = document.getElementById("monitoringConfiguration");
 const viewfinderSettingsRow = document.getElementById("viewfinderSettingsRow");
+const videoDistributionSelect = document.getElementById("videoDistribution");
 
 function updateTripodOptions() {
   const headBrand = tripodHeadBrandSelect ? tripodHeadBrandSelect.value : '';
@@ -8759,6 +8760,37 @@ function updateRequiredScenariosSummary() {
   }
 }
 
+function updateVideoDistributionOptions() {
+  if (!requiredScenariosSelect || !videoDistributionSelect) return;
+  const selected = Array.from(requiredScenariosSelect.selectedOptions).map(o => o.value);
+  const needsDopMonitor = selected.some(s => [
+    'Trinity',
+    'Gimbal',
+    'Car Mount',
+    'Remote Head',
+    'Crane',
+    'Steadicam'
+  ].includes(s));
+  const dopOptions = ['DoP Handheld 7" Monitor', 'DoP 15-21" Monitor'];
+  if (needsDopMonitor) {
+    dopOptions.forEach(val => {
+      const exists = Array.from(videoDistributionSelect.options).some(o => o.value === val);
+      if (!exists) {
+        const opt = new Option(val, val);
+        videoDistributionSelect.add(opt);
+      }
+    });
+  } else {
+    dopOptions.forEach(val => {
+      const opt = Array.from(videoDistributionSelect.options).find(o => o.value === val);
+      if (opt) {
+        opt.selected = false;
+        opt.remove();
+      }
+    });
+  }
+}
+
 function initApp() {
   if (sharedLinkRow) {
     if (isRunningPWA()) {
@@ -8778,7 +8810,9 @@ function initApp() {
   applySharedSetupFromUrl();
   if (requiredScenariosSelect) {
     requiredScenariosSelect.addEventListener('change', updateRequiredScenariosSummary);
+    requiredScenariosSelect.addEventListener('change', updateVideoDistributionOptions);
     updateRequiredScenariosSummary();
+    updateVideoDistributionOptions();
   }
   if (tripodHeadBrandSelect) {
     tripodHeadBrandSelect.addEventListener('change', updateTripodOptions);
@@ -8950,5 +8984,6 @@ if (typeof module !== "undefined" && module.exports) {
     populateSensorModeDropdown,
     populateCodecDropdown,
     updateRequiredScenariosSummary,
+    updateVideoDistributionOptions,
   };
 }

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -1685,6 +1685,32 @@ describe('script.js functions', () => {
     expect(remoteOpt.selected).toBe(false);
   });
 
+  test.each([
+    'Trinity',
+    'Gimbal',
+    'Car Mount',
+    'Remote Head',
+    'Crane',
+    'Steadicam'
+  ])('DoP monitor options toggle when %s is selected', scenario => {
+    const reqSel = document.getElementById('requiredScenarios');
+    const videoSel = document.getElementById('videoDistribution');
+    const getVals = () => Array.from(videoSel.options).map(o => o.value);
+
+    expect(getVals()).not.toContain('DoP Handheld 7" Monitor');
+    expect(getVals()).not.toContain('DoP 15-21" Monitor');
+
+    reqSel.querySelector(`option[value="${scenario}"]`).selected = true;
+    script.updateVideoDistributionOptions();
+    expect(getVals()).toContain('DoP Handheld 7" Monitor');
+    expect(getVals()).toContain('DoP 15-21" Monitor');
+
+    reqSel.querySelector(`option[value="${scenario}"]`).selected = false;
+    script.updateVideoDistributionOptions();
+    expect(getVals()).not.toContain('DoP Handheld 7" Monitor');
+    expect(getVals()).not.toContain('DoP 15-21" Monitor');
+  });
+
   test('double-clicking an option only deselects that option', () => {
     const selects = document.querySelectorAll('#projectForm select[multiple]');
     selects.forEach(sel => {


### PR DESCRIPTION
## Summary
- Dynamically add DoP Handheld 7" and 15-21" monitor options to video distribution when using Trinity, Gimbal, Car Mount, Remote Head, Crane, or Steadicam
- Hook new logic into app initialization and provide tests

## Testing
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb6fc7277c8320af6e5e8925956689