### PR TITLE
Refine rigging options into dedicated handle and mattebox selectors

### DIFF
--- a/index.html
+++ b/index.html
@@ -1013,20 +1013,25 @@
           <option value="Rain Machine">Rain Machine</option>
           <option value="Slow Motion">Slow Motion</option>
           <option value="Viewfinder Extension">Viewfinder Extension</option>
+          <option value="Battery Belt">Battery Belt</option>
         </select>
         <div id="requiredScenariosSummary" class="scenario-summary" aria-live="polite"></div>
       </div>
       <div class="form-row">
-        <label for="rigging">How would you like to have your camera rigged?</label>
-        <select id="rigging" name="rigging" multiple size="15">
-          <option value="Shoulder rig">Shoulder rig</option>
+        <label for="cameraHandle">Camera Handle:</label>
+        <select id="cameraHandle" name="cameraHandle" multiple size="3">
+          <option value="Handle Extension">Handle Extension</option>
+          <option value="L-Handle">L-Handle</option>
           <option value="Hand Grips">Hand Grips</option>
-          <option value="Teradek and Battery belt">Teradek and Battery belt</option>
-          <option value="Top handle extension">Top handle extension</option>
-          <option value="Rear Handle">Rear Handle</option>
-          <option value="Clamp-On Mattebox">Clamp-On Mattebox</option>
-          <option value="Swingaway Mattebox">Swingaway Mattebox</option>
-          <option value="Rod based Mattebox">Rod based Mattebox</option>
+        </select>
+      </div>
+      <div class="form-row">
+        <label for="mattebox">Mattebox:</label>
+        <select id="mattebox" name="mattebox">
+          <option value="">-- Select --</option>
+          <option value="Rod based">Rod based</option>
+          <option value="Clamp On">Clamp On</option>
+          <option value="Swing Away">Swing Away</option>
         </select>
       </div>
       <h3 id="monitoringHeading">Monitoring</h3>

--- a/script.js
+++ b/script.js
@@ -7295,7 +7295,8 @@ function collectProjectFormData() {
         sensorMode: val('sensorMode'),
         lenses: multi('lenses'),
         requiredScenarios: multi('requiredScenarios'),
-        rigging: multi('rigging'),
+        cameraHandle: multi('cameraHandle'),
+        mattebox: val('mattebox'),
         gimbal: multi('gimbal'),
         monitoringSettings: monitoringSelections,
         videoDistribution: multi('videoDistribution'),
@@ -7400,8 +7401,8 @@ function generateGearListHtml(info = {}) {
             riggingAcc.push('D-Tap Extension 50 cm');
         }
     }
-    const rigging = info.rigging
-        ? info.rigging.split(',').map(r => r.trim()).filter(Boolean)
+    const handleSelections = info.cameraHandle
+        ? info.cameraHandle.split(',').map(r => r.trim()).filter(Boolean)
         : [];
     const monitoringSettings = info.monitoringSettings
         ? info.monitoringSettings.split(',').map(s => s.trim()).filter(Boolean)
@@ -7454,13 +7455,10 @@ function generateGearListHtml(info = {}) {
     if (scenarios.includes('Handheld') && scenarios.includes('Easyrig')) {
         addHandle();
     }
-    if (rigging.some(r => r === 'Shoulder rig' || r === 'Hand Grips')) {
+    if (handleSelections.includes('Hand Grips')) {
         addHandle();
     }
-    const riggingSelections = info.rigging
-        ? info.rigging.split(',').map(s => s.trim())
-        : [];
-    if (riggingSelections.includes('Top handle extension') || riggingSelections.includes('Rear Handle')) {
+    if (handleSelections.includes('Handle Extension') || handleSelections.includes('L-Handle')) {
         supportAccNoCages.push('ARRI KK.0037820 Handle Extension Set');
     }
     const projectInfo = { ...info };
@@ -7492,7 +7490,8 @@ function generateGearListHtml(info = {}) {
         sensorMode: 'Sensor Mode',
         lenses: 'Lenses',
         requiredScenarios: 'Required Scenarios',
-        rigging: 'Rigging',
+        cameraHandle: 'Camera Handle',
+        mattebox: 'Mattebox',
         gimbal: 'Gimbal',
         monitoringSupport: 'Monitoring support',
         monitoring: 'Monitoring',
@@ -7512,7 +7511,8 @@ function generateGearListHtml(info = {}) {
         baseFrameRate: '⏱️',
         sensorMode: '🔍',
         requiredScenarios: '🌄',
-        rigging: '🛠️',
+        cameraHandle: '🛠️',
+        mattebox: '🎬',
         gimbal: '🌀',
         monitoringSupport: '🧰',
         monitoring: '📡',

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -1702,9 +1702,9 @@ describe('script.js functions', () => {
     });
   });
 
-  test('Hand Grips rigging adds telescopic handle', () => {
+  test('Hand Grips handle adds telescopic handle', () => {
     const { generateGearListHtml } = script;
-    const html = generateGearListHtml({ rigging: 'Hand Grips' });
+    const html = generateGearListHtml({ cameraHandle: 'Hand Grips' });
     const wrap = document.createElement('div');
     wrap.innerHTML = html;
     const rows = Array.from(wrap.querySelectorAll('.gear-table tr'));
@@ -1716,9 +1716,9 @@ describe('script.js functions', () => {
     expect(text).not.toContain('2x SHAPE Telescopic Handle ARRI Rosette Kit 12"');
   });
 
-  test('Rigging options add telescopic handle without duplication', () => {
+  test('Handle and scenario combo adds telescopic handle only once', () => {
     const { generateGearListHtml } = script;
-    const html = generateGearListHtml({ rigging: 'Shoulder rig, Hand Grips' });
+    const html = generateGearListHtml({ cameraHandle: 'Hand Grips', requiredScenarios: 'Handheld, Easyrig' });
     const wrap = document.createElement('div');
     wrap.innerHTML = html;
     const rows = Array.from(wrap.querySelectorAll('.gear-table tr'));
@@ -1730,10 +1730,10 @@ describe('script.js functions', () => {
     expect(text).not.toContain('2x SHAPE Telescopic Handle ARRI Rosette Kit 12"');
   });
 
-  test('Top handle extension or Rear Handle rigging adds handle extension set', () => {
+  test('Handle extension or L-Handle adds handle extension set', () => {
     const { generateGearListHtml } = script;
-    ['Top handle extension', 'Rear Handle'].forEach(rig => {
-      const html = generateGearListHtml({ rigging: rig });
+    ['Handle Extension', 'L-Handle'].forEach(rig => {
+      const html = generateGearListHtml({ cameraHandle: rig });
       const wrap = document.createElement('div');
       wrap.innerHTML = html;
       const rows = Array.from(wrap.querySelectorAll('.gear-table tr'));
@@ -2068,21 +2068,22 @@ describe('script.js functions', () => {
     });
   });
 
-  test('rigging appears in project requirements and gear table', () => {
+  test('camera handle and mattebox appear in project requirements', () => {
     const { generateGearListHtml } = script;
     const html = generateGearListHtml({
-      rigging: 'Shoulder rig, Hand Grips',
+      cameraHandle: 'Hand Grips, L-Handle',
+      mattebox: 'Rod based',
       monitoringSettings: 'Viewfinder Clean Feed, Surround View',
       monitorUserButtons: 'Toggle LUT',
       cameraUserButtons: 'False Color',
       viewfinderUserButtons: 'Peaking'
     });
-    expect(html).toContain('<span class="req-label">Rigging</span>');
-    expect(html).toContain('<span class="req-value">Shoulder rig, Hand Grips</span>');
-    expect(html).toContain('<td>Rigging</td>');
+    expect(html).toContain('<span class="req-label">Camera Handle</span>');
+    expect(html).toContain('<span class="req-value">Hand Grips, L-Handle</span>');
+    expect(html).toContain('<span class="req-label">Mattebox</span>');
+    expect(html).toContain('<span class="req-value">Rod based</span>');
     expect(html).toContain('<span class="req-label">Monitoring support</span>');
     expect(html).toContain('<span class="req-value">Viewfinder Clean Feed, Surround View</span>');
-    expect(html).toContain('<td>Monitoring support</td>');
     const msSection = html.slice(html.indexOf('<td>Monitoring support</td>'), html.indexOf('Power'));
     expect(msSection).not.toContain('Viewfinder Clean Feed');
     expect(msSection).not.toContain('Surround View');
@@ -2095,6 +2096,7 @@ describe('script.js functions', () => {
     expect(html).toContain('<span class="req-value">False Color</span>');
     expect(html).toContain('<span class="req-label">Viewfinder User Buttons</span>');
     expect(html).toContain('<span class="req-value">Peaking</span>');
+    expect(html).toContain('<td>Rigging</td>');
   });
 
   test('Directors handheld monitor appears under monitoring in project requirements', () => {


### PR DESCRIPTION
## Summary
- Add **Battery Belt** to shooting scenarios and replace the single Rigging selector with separate Camera Handle and Mattebox selectors
- Track Camera Handle and Mattebox choices in project data and gear list generation
- Update tests for new selectors and handle logic

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68bb71429f288320b656d9134e2b1e89