### PR TITLE
fix: prevent blank setup names

### DIFF
--- a/storage.js
+++ b/storage.js
@@ -172,6 +172,12 @@ function renameSetup(oldName, newName) {
     return null;
   }
   const sanitized = newName.trim();
+  // Guard against empty or whitespace-only names. Renaming to such a value
+  // would create an empty key in the setups object. In that case simply keep
+  // the original name.
+  if (!sanitized) {
+    return oldName;
+  }
   if (oldName.trim().toLowerCase() === sanitized.toLowerCase()) {
     return oldName;
   }

--- a/tests/storage.test.js
+++ b/tests/storage.test.js
@@ -180,6 +180,14 @@ describe('setup storage', () => {
       expect(result).toBeNull();
       expect(JSON.parse(localStorage.getItem(SETUP_KEY))).toEqual({A:{foo:1}});
     });
+
+    test('renameSetup ignores empty new name', () => {
+      const setups = {A:{foo:1}};
+      localStorage.setItem(SETUP_KEY, JSON.stringify(setups));
+      const newName = renameSetup('A', '   ');
+      expect(newName).toBe('A');
+      expect(JSON.parse(localStorage.getItem(SETUP_KEY))).toEqual({A:{foo:1}});
+    });
   });
 
 describe('session state storage', () => {


### PR DESCRIPTION
## Summary
- avoid creating empty keys when renaming setups with whitespace-only names
- cover renaming edge case with new test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bb735218908320885bba0c97843e08