### PR TITLE
Add DoP monitor options for rigging scenarios

### DIFF
--- a/script.js
+++ b/script.js
@@ -1474,6 +1474,7 @@ function setLanguage(lang) {
 const cameraSelect    = document.getElementById("cameraSelect");
 const monitorSelect   = document.getElementById("monitorSelect");
 const videoSelect     = document.getElementById("videoSelect");
+const videoDistributionSelect = document.getElementById("videoDistribution");
 const cageSelect      = document.getElementById("cageSelect");
 const motorSelects    = [
   document.getElementById("motor1Select"),
@@ -8771,6 +8772,26 @@ function updateRequiredScenariosSummary() {
       monitorSelect.value = defaultMonitor;
       monitorSelect.dispatchEvent(new Event('change'));
     }
+  }
+  if (videoDistributionSelect) {
+    const dopScenarios = ['Trinity', 'Gimbal', 'Car Mount', 'Remote Head', 'Crane'];
+    const needsDop = selected.some(s => dopScenarios.includes(s));
+    const ensureOption = val => {
+      let opt = Array.from(videoDistributionSelect.options).find(o => o.value === val);
+      if (needsDop) {
+        if (!opt) {
+          opt = document.createElement('option');
+          opt.value = val;
+          opt.textContent = val;
+          videoDistributionSelect.appendChild(opt);
+        }
+      } else if (opt) {
+        if (opt.selected) opt.selected = false;
+        opt.remove();
+      }
+    };
+    ensureOption('DoP Handheld 7" Monitor');
+    ensureOption('DoP 15-21" Monitor');
   }
   selected.forEach(val => {
     const box = document.createElement('span');

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -1685,6 +1685,26 @@ describe('script.js functions', () => {
     expect(remoteOpt.selected).toBe(false);
   });
 
+  test('DoP monitor options appear for specific scenarios', () => {
+    const select = document.getElementById('requiredScenarios');
+    const videoSel = document.getElementById('videoDistribution');
+
+    const values = () => Array.from(videoSel.options).map(o => o.value);
+
+    expect(values()).not.toContain('DoP Handheld 7" Monitor');
+    expect(values()).not.toContain('DoP 15-21" Monitor');
+
+    select.querySelector('option[value="Trinity"]').selected = true;
+    script.updateRequiredScenariosSummary();
+    expect(values()).toContain('DoP Handheld 7" Monitor');
+    expect(values()).toContain('DoP 15-21" Monitor');
+
+    select.querySelector('option[value="Trinity"]').selected = false;
+    script.updateRequiredScenariosSummary();
+    expect(values()).not.toContain('DoP Handheld 7" Monitor');
+    expect(values()).not.toContain('DoP 15-21" Monitor');
+  });
+
   test('selecting Dolly adds SmallHD Ultra 7 monitor when none selected', () => {
     const select = document.getElementById('requiredScenarios');
     const monitorSel = document.getElementById('monitorSelect');


### PR DESCRIPTION
## Summary
- Dynamically add DoP Handheld 7" and DoP 15-21" monitor options when selecting Trinity, Gimbal, Car Mount, Remote Head, or Crane scenarios
- Test ensures DoP monitor options appear and disappear based on scenario selection

## Testing
- `npm run lint`
- `npm run check-consistency`
- `CI=true npx jest tests/script.test.js -t "DoP monitor options appear for specific scenarios"`

------
https://chatgpt.com/codex/tasks/task_e_68bb730916588320bf221f95469cffa3