### PR TITLE
Populate recording resolution selector from camera data

### DIFF
--- a/script.js
+++ b/script.js
@@ -1696,6 +1696,9 @@ function ensureEditProjectButton() {
     btn.id = 'editProjectBtn';
     btn.addEventListener('click', () => {
       populateSensorModeDropdown(currentProjectInfo && currentProjectInfo.sensorMode);
+      populateRecordingResolutionDropdown(
+        currentProjectInfo && currentProjectInfo.recordingResolution
+      );
       populateCodecDropdown(currentProjectInfo && currentProjectInfo.codec);
       projectDialog.showModal();
     });
@@ -6514,6 +6517,9 @@ generateGearListBtn.addEventListener('click', () => {
         return;
     }
     populateSensorModeDropdown(currentProjectInfo && currentProjectInfo.sensorMode);
+    populateRecordingResolutionDropdown(
+        currentProjectInfo && currentProjectInfo.recordingResolution
+    );
     populateCodecDropdown(currentProjectInfo && currentProjectInfo.codec);
     projectDialog.showModal();
 });
@@ -8142,6 +8148,9 @@ function refreshGearListIfVisible() {
 
     if (projectForm) {
         populateSensorModeDropdown(currentProjectInfo && currentProjectInfo.sensorMode);
+        populateRecordingResolutionDropdown(
+            currentProjectInfo && currentProjectInfo.recordingResolution
+        );
         populateCodecDropdown(currentProjectInfo && currentProjectInfo.codec);
         const info = collectProjectFormData();
         currentProjectInfo = Object.values(info).some(v => v) ? info : null;
@@ -8902,6 +8911,31 @@ function populateSensorModeDropdown(selected = '') {
   }
 }
 
+function populateRecordingResolutionDropdown(selected = '') {
+  const resSelect = document.getElementById('recordingResolution');
+  if (!resSelect) return;
+
+  resSelect.innerHTML = '';
+  const emptyOpt = document.createElement('option');
+  emptyOpt.value = '';
+  resSelect.appendChild(emptyOpt);
+
+  const camKey = cameraSelect && cameraSelect.value;
+  const resolutions =
+    camKey && devices && devices.cameras && devices.cameras[camKey]
+      ? devices.cameras[camKey].resolutions
+      : null;
+  if (Array.isArray(resolutions)) {
+    resolutions.forEach(r => {
+      const opt = document.createElement('option');
+      opt.value = r;
+      opt.textContent = r;
+      if (r === selected) opt.selected = true;
+      resSelect.appendChild(opt);
+    });
+  }
+}
+
 function populateCodecDropdown(selected = '') {
   const codecSelect = document.getElementById('codec');
   if (!codecSelect) return;
@@ -8989,6 +9023,7 @@ if (typeof module !== "undefined" && module.exports) {
     saveCurrentGearList,
     populateLensDropdown,
     populateSensorModeDropdown,
+    populateRecordingResolutionDropdown,
     populateCodecDropdown,
     updateRequiredScenariosSummary,
   };

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -2177,6 +2177,26 @@ describe('script.js functions', () => {
     expect(html).not.toContain('Tripod Preferences');
   });
 
+  test('recording resolution and sensor mode dropdowns populate from camera data', () => {
+    devices.cameras.CamA.resolutions = ['720p', '1080p'];
+    devices.cameras.CamA.sensorModes = ['ModeA', 'ModeB'];
+    const camSel = document.getElementById('cameraSelect');
+    camSel.innerHTML = '<option value="CamA">CamA</option>';
+    camSel.value = 'CamA';
+    const setupSelectElem = document.getElementById('setupSelect');
+    setupSelectElem.innerHTML = '<option value="Test">Test</option>';
+    setupSelectElem.value = 'Test';
+    const projectDialog = document.getElementById('projectDialog');
+    projectDialog.showModal = jest.fn();
+    document.getElementById('generateGearListBtn').click();
+    const resSelect = document.getElementById('recordingResolution');
+    const resOpts = Array.from(resSelect.options).map(o => o.value);
+    expect(resOpts).toEqual(['', '720p', '1080p']);
+    const sensorSelect = document.getElementById('sensorMode');
+    const sensorOpts = Array.from(sensorSelect.options).map(o => o.value);
+    expect(sensorOpts).toEqual(['', 'ModeA', 'ModeB']);
+  });
+
   test('codec dropdown populates from camera recording codecs', () => {
     devices.cameras.CamA.recordingCodecs = ['CodecA', 'CodecB'];
     const camSel = document.getElementById('cameraSelect');


### PR DESCRIPTION
## Summary
- Populate recording resolution dropdown using selected camera's defined resolutions
- Refresh resolution and sensor mode options when project dialog opens
- Test resolution and sensor mode dropdown population

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb74154d648320a77568077c82fda2