### PR TITLE
feat: add user button multiselects

### DIFF
--- a/index.html
+++ b/index.html
@@ -1081,15 +1081,15 @@
       </div>
       <div class="form-row">
         <label for="monitorUserButtons">Onboard Monitor User Buttons:</label>
-        <input type="text" id="monitorUserButtons" name="monitorUserButtons" />
+        <select id="monitorUserButtons" name="monitorUserButtons" multiple size="5"></select>
       </div>
       <div class="form-row">
         <label for="cameraUserButtons">Camera User Buttons:</label>
-        <input type="text" id="cameraUserButtons" name="cameraUserButtons" />
+        <select id="cameraUserButtons" name="cameraUserButtons" multiple size="5"></select>
       </div>
       <div class="form-row">
         <label for="viewfinderUserButtons">Viewfinder User Buttons:</label>
-        <input type="text" id="viewfinderUserButtons" name="viewfinderUserButtons" />
+        <select id="viewfinderUserButtons" name="viewfinderUserButtons" multiple size="5"></select>
       </div>
       <div class="form-row hidden" id="tripodPreferencesRow">
         <strong>Tripod Preferences:</strong>

--- a/script.js
+++ b/script.js
@@ -7301,9 +7301,9 @@ function collectProjectFormData() {
         monitoringSettings: monitoringSelections,
         videoDistribution: multi('videoDistribution'),
         monitoringConfiguration: val('monitoringConfiguration'),
-        monitorUserButtons: val('monitorUserButtons'),
-        cameraUserButtons: val('cameraUserButtons'),
-        viewfinderUserButtons: val('viewfinderUserButtons'),
+        monitorUserButtons: multi('monitorUserButtons'),
+        cameraUserButtons: multi('cameraUserButtons'),
+        viewfinderUserButtons: multi('viewfinderUserButtons'),
         tripodHeadBrand: val('tripodHeadBrand'),
         tripodBowl: val('tripodBowl'),
         tripodTypes: multi('tripodTypes'),
@@ -8811,6 +8811,7 @@ function initApp() {
   populateEnvironmentDropdowns();
   populateLensDropdown();
   populateFilterDropdown();
+  populateUserButtonDropdowns();
   document.querySelectorAll('#projectForm select')
     .forEach(sel => attachSelectSearch(sel));
   setLanguage(currentLang);
@@ -8942,6 +8943,31 @@ function populateFilterDropdown() {
       filterSelect.appendChild(opt);
     });
   }
+}
+
+function populateUserButtonDropdowns() {
+  const functions = [
+    'Toggle LUT',
+    'False Color',
+    'Peaking',
+    'Anamorphic Desqueeze',
+    'Surround View',
+    '1:1 Zoom',
+    'Playback',
+    'Record',
+    'Zoom',
+    'Frame Lines'
+  ];
+  ['monitorUserButtons', 'cameraUserButtons', 'viewfinderUserButtons'].forEach(id => {
+    const sel = document.getElementById(id);
+    if (!sel) return;
+    functions.forEach(fn => {
+      const opt = document.createElement('option');
+      opt.value = fn;
+      opt.textContent = fn;
+      sel.appendChild(opt);
+    });
+  });
 }
 
 if (document.readyState === "loading") {

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -317,13 +317,15 @@ describe('script.js functions', () => {
     expect(copyBtn.nextElementSibling).toBe(generateBtn);
   });
 
-  test('project form includes user buttons inputs', () => {
-    const monitorInput = document.getElementById('monitorUserButtons');
-    const cameraInput = document.getElementById('cameraUserButtons');
-    const viewfinderInput = document.getElementById('viewfinderUserButtons');
-    expect(monitorInput).not.toBeNull();
-    expect(cameraInput).not.toBeNull();
-    expect(viewfinderInput).not.toBeNull();
+  test('project form includes user buttons multiselects', () => {
+    ['monitorUserButtons', 'cameraUserButtons', 'viewfinderUserButtons'].forEach(id => {
+      const sel = document.getElementById(id);
+      expect(sel).not.toBeNull();
+      expect(sel.tagName).toBe('SELECT');
+      expect(sel.multiple).toBe(true);
+      const values = Array.from(sel.options).map(o => o.value);
+      expect(values).toEqual(expect.arrayContaining(['Toggle LUT', 'False Color', 'Peaking']));
+    });
   });
 
   test('new device form includes cable category option', () => {


### PR DESCRIPTION
## Summary
- replace user button text fields with multi-selects populated with common functions
- collect selected user button functions and expose them in project data
- test for user button multiselects and options

## Testing
- `npm run lint`
- `npm run check-consistency`
- `./node_modules/.bin/jest tests/script.test.js` *(fails to exit cleanly, but tests pass)*

------
https://chatgpt.com/codex/tasks/task_e_68bb748402e083208a9db47cbfb938aa