### PR TITLE
feat: add viewfinder extension selector

### DIFF
--- a/index.html
+++ b/index.html
@@ -1012,10 +1012,16 @@
           <option value="Extreme heat">Extreme heat</option>
           <option value="Rain Machine">Rain Machine</option>
           <option value="Slow Motion">Slow Motion</option>
-          <option value="Viewfinder Extension">Viewfinder Extension</option>
           <option value="Battery Belt">Battery Belt</option>
         </select>
         <div id="requiredScenariosSummary" class="scenario-summary" aria-live="polite"></div>
+      </div>
+      <div class="form-row hidden" id="viewfinderExtensionRow">
+        <label for="viewfinderExtension">Viewfinder Extension:</label>
+        <select id="viewfinderExtension" name="viewfinderExtension">
+          <option value=""></option>
+          <option value="ARRI VEB-3 Viewfinder Extension Bracket">ARRI VEB-3 Viewfinder Extension Bracket</option>
+        </select>
       </div>
       <div class="form-row">
         <label for="cameraHandle">Camera Handle:</label>

--- a/script.js
+++ b/script.js
@@ -678,6 +678,7 @@ function updateBatteryPlateVisibility() {
     else batteryPlateSelect.value = '';
   }
   updateViewfinderSettingsVisibility();
+  updateViewfinderExtensionVisibility();
 }
 
 function updateViewfinderSettingsVisibility() {
@@ -698,6 +699,19 @@ function updateViewfinderSettingsVisibility() {
   }
 }
 
+
+function updateViewfinderExtensionVisibility() {
+  const cam = devices?.cameras?.[cameraSelect?.value];
+  const hasViewfinder = Array.isArray(cam?.viewfinder) && cam.viewfinder.length > 0;
+  if (viewfinderExtensionRow) {
+    if (hasViewfinder) {
+      viewfinderExtensionRow.classList.remove('hidden');
+    } else {
+      viewfinderExtensionRow.classList.add('hidden');
+      if (viewfinderExtensionSelect) viewfinderExtensionSelect.value = '';
+    }
+  }
+}
 
 function updateBatteryLabel() {
   const label = document.getElementById('batteryLabel');
@@ -1501,6 +1515,8 @@ const tripodTypesSelect = document.getElementById("tripodTypes");
 const tripodSpreaderSelect = document.getElementById("tripodSpreader");
 const monitoringConfigurationSelect = document.getElementById("monitoringConfiguration");
 const viewfinderSettingsRow = document.getElementById("viewfinderSettingsRow");
+const viewfinderExtensionRow = document.getElementById("viewfinderExtensionRow");
+const viewfinderExtensionSelect = document.getElementById("viewfinderExtension");
 
 function updateTripodOptions() {
   const headBrand = tripodHeadBrandSelect ? tripodHeadBrandSelect.value : '';
@@ -7296,6 +7312,7 @@ function collectProjectFormData() {
         lenses: multi('lenses'),
         requiredScenarios: multi('requiredScenarios'),
         cameraHandle: multi('cameraHandle'),
+        viewfinderExtension: val('viewfinderExtension'),
         mattebox: val('mattebox'),
         gimbal: multi('gimbal'),
         monitoringSettings: monitoringSelections,
@@ -7382,6 +7399,9 @@ function generateGearListHtml(info = {}) {
     riggingAcc.push('SmallRig - Super lightweight 15mm RailBlock');
     for (let i = 0; i < 3; i++) riggingAcc.push('stud 5/8" with male 3/8" and 1/4"');
     for (let i = 0; i < 2; i++) riggingAcc.push('D-Tap Splitter');
+    if (info.viewfinderExtension) {
+        riggingAcc.push(info.viewfinderExtension);
+    }
     const cagesDb = devices.accessories?.cages || {};
     const compatibleCages = [];
     if (cameraSelect && cameraSelect.value && cameraSelect.value !== 'None') {
@@ -8741,8 +8761,7 @@ const scenarioIcons = {
   'Extreme rain': '🌧️',
   'Extreme heat': '🔥',
   'Rain Machine': '🌧️',
-  'Slow Motion': '🐌',
-  'Viewfinder Extension': '🔭'
+  'Slow Motion': '🐌'
 };
 
 function updateRequiredScenariosSummary() {

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -1369,6 +1369,13 @@ describe('script.js functions', () => {
     expect(rigSection).toContain('2x D-Tap Splitter');
   });
 
+  test('viewfinder extension adds bracket to rigging list', () => {
+    const { generateGearListHtml } = script;
+    const html = generateGearListHtml({ viewfinderExtension: 'ARRI VEB-3 Viewfinder Extension Bracket' });
+    const rigSection = html.slice(html.indexOf('Rigging'), html.indexOf('Power'));
+    expect(rigSection).toContain('ARRI VEB-3 Viewfinder Extension Bracket');
+  });
+
   test.each(['Trinity', 'Steadicam'])(
     '%s scenario adds D-Tap rigging accessories',
     (scenario) => {
@@ -1683,6 +1690,24 @@ describe('script.js functions', () => {
     script.updateRequiredScenariosSummary();
     expect(remoteOpt.hidden).toBe(true);
     expect(remoteOpt.selected).toBe(false);
+  });
+
+  test('viewfinder extension selector is shown only for cameras with a viewfinder', () => {
+    devices.cameras = {
+      CamWithVF: { viewfinder: [{}] },
+      CamNoVF: { viewfinder: [] }
+    };
+    const camSel = document.getElementById('cameraSelect');
+    camSel.innerHTML = '<option value="CamWithVF">CamWithVF</option><option value="CamNoVF">CamNoVF</option>';
+    const row = document.getElementById('viewfinderExtensionRow');
+
+    camSel.value = 'CamNoVF';
+    script.updateBatteryPlateVisibility();
+    expect(row.classList.contains('hidden')).toBe(true);
+
+    camSel.value = 'CamWithVF';
+    script.updateBatteryPlateVisibility();
+    expect(row.classList.contains('hidden')).toBe(false);
   });
 
   test('selecting Dolly adds SmallHD Ultra 7 monitor when none selected', () => {


### PR DESCRIPTION
## Summary
- add dedicated viewfinder extension selector under rigging
- toggle selector visibility based on camera's viewfinder
- include selected extension in gear list and tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bb74a556b08320b609a0ee2dffa6ea