### PR TITLE
Populate recording options from camera data

### DIFF
--- a/index.html
+++ b/index.html
@@ -912,25 +912,7 @@
       </div>
       <div class="form-row">
         <label for="recordingResolution">Recording Resolution:</label>
-        <select id="recordingResolution" name="recordingResolution">
-          <option value=""></option>
-          <option value="720p">720p</option>
-          <option value="1080p">1080p</option>
-          <option value="1440p">1440p</option>
-          <option value="2K">2K</option>
-          <option value="2.7K">2.7K</option>
-          <option value="3.2K UHD">3.2K UHD</option>
-          <option value="4K">4K</option>
-          <option value="4.5K">4.5K</option>
-          <option value="5K">5K</option>
-          <option value="5.7K">5.7K</option>
-          <option value="6K">6K</option>
-          <option value="7K">7K</option>
-          <option value="8K">8K</option>
-          <option value="9K">9K</option>
-          <option value="12K">12K</option>
-          <option value="16K">16K</option>
-        </select>
+        <select id="recordingResolution" name="recordingResolution"></select>
       </div>
       <div class="form-row">
         <label for="sensorMode">Sensor Mode:</label>

--- a/script.js
+++ b/script.js
@@ -1696,6 +1696,7 @@ function ensureEditProjectButton() {
     btn = document.createElement('button');
     btn.id = 'editProjectBtn';
     btn.addEventListener('click', () => {
+      populateRecordingResolutionDropdown(currentProjectInfo && currentProjectInfo.recordingResolution);
       populateSensorModeDropdown(currentProjectInfo && currentProjectInfo.sensorMode);
       populateCodecDropdown(currentProjectInfo && currentProjectInfo.codec);
       projectDialog.showModal();
@@ -6514,6 +6515,7 @@ generateGearListBtn.addEventListener('click', () => {
         alertPinExceeded();
         return;
     }
+    populateRecordingResolutionDropdown(currentProjectInfo && currentProjectInfo.recordingResolution);
     populateSensorModeDropdown(currentProjectInfo && currentProjectInfo.sensorMode);
     populateCodecDropdown(currentProjectInfo && currentProjectInfo.codec);
     projectDialog.showModal();
@@ -8142,6 +8144,7 @@ function refreshGearListIfVisible() {
     if (!gearListOutput || gearListOutput.classList.contains('hidden')) return;
 
     if (projectForm) {
+        populateRecordingResolutionDropdown(currentProjectInfo && currentProjectInfo.recordingResolution);
         populateSensorModeDropdown(currentProjectInfo && currentProjectInfo.sensorMode);
         populateCodecDropdown(currentProjectInfo && currentProjectInfo.codec);
         const info = collectProjectFormData();
@@ -8259,6 +8262,8 @@ if (cameraSelect) {
   cameraSelect.addEventListener('change', () => {
     updateBatteryPlateVisibility();
     updateBatteryOptions();
+    populateRecordingResolutionDropdown(currentProjectInfo && currentProjectInfo.recordingResolution);
+    populateSensorModeDropdown(currentProjectInfo && currentProjectInfo.sensorMode);
   });
 }
 if (monitoringConfigurationSelect) {
@@ -8923,6 +8928,10 @@ function populateCameraPropertyDropdown(selectId, property, selected = '') {
   }
 }
 
+function populateRecordingResolutionDropdown(selected = '') {
+  populateCameraPropertyDropdown('recordingResolution', 'resolutions', selected);
+}
+
 function populateSensorModeDropdown(selected = '') {
   populateCameraPropertyDropdown('sensorMode', 'sensorModes', selected);
 }
@@ -8993,6 +9002,7 @@ if (typeof module !== "undefined" && module.exports) {
     saveCurrentGearList,
     populateLensDropdown,
     populateCameraPropertyDropdown,
+    populateRecordingResolutionDropdown,
     populateSensorModeDropdown,
     populateCodecDropdown,
     updateRequiredScenariosSummary,

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -2218,6 +2218,38 @@ describe('script.js functions', () => {
     expect(opts).toEqual(['', 'CodecA', 'CodecB']);
   });
 
+  test('recording resolution dropdown populates from camera resolutions', () => {
+    devices.cameras.CamA.resolutions = ['4K', '6K'];
+    const camSel = document.getElementById('cameraSelect');
+    camSel.innerHTML = '<option value="CamA">CamA</option>';
+    camSel.value = 'CamA';
+    const setupSelectElem = document.getElementById('setupSelect');
+    setupSelectElem.innerHTML = '<option value="Test">Test</option>';
+    setupSelectElem.value = 'Test';
+    const projectDialog = document.getElementById('projectDialog');
+    projectDialog.showModal = jest.fn();
+    document.getElementById('generateGearListBtn').click();
+    const resSelect = document.getElementById('recordingResolution');
+    const opts = Array.from(resSelect.options).map(o => o.value);
+    expect(opts).toEqual(['', '4K', '6K']);
+  });
+
+  test('sensor mode dropdown populates from camera sensor modes', () => {
+    devices.cameras.CamA.sensorModes = ['ModeA', 'ModeB'];
+    const camSel = document.getElementById('cameraSelect');
+    camSel.innerHTML = '<option value="CamA">CamA</option>';
+    camSel.value = 'CamA';
+    const setupSelectElem = document.getElementById('setupSelect');
+    setupSelectElem.innerHTML = '<option value="Test">Test</option>';
+    setupSelectElem.value = 'Test';
+    const projectDialog = document.getElementById('projectDialog');
+    projectDialog.showModal = jest.fn();
+    document.getElementById('generateGearListBtn').click();
+    const modeSelect = document.getElementById('sensorMode');
+    const opts = Array.from(modeSelect.options).map(o => o.value);
+    expect(opts).toEqual(['', 'ModeA', 'ModeB']);
+  });
+
   test('duplicate motors are aggregated with count in gear list', () => {
     const { generateGearListHtml } = script;
     const addOpt = (id, value) => {


### PR DESCRIPTION
## Summary
- Populate recording resolution dropdown from the selected camera's supported resolutions
- Refresh resolution and sensor mode selections whenever the camera changes or project dialog opens
- Add tests for camera-specific recording resolution and sensor mode dropdowns

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb760d13cc83209d63cb8b6b350bdb