### PR TITLE
Add icon box summaries for project form selectors

### DIFF
--- a/script.js
+++ b/script.js
@@ -1503,6 +1503,28 @@ const tripodSpreaderSelect = document.getElementById("tripodSpreader");
 const monitoringConfigurationSelect = document.getElementById("monitoringConfiguration");
 const viewfinderSettingsRow = document.getElementById("viewfinderSettingsRow");
 
+const projectFieldIcons = {
+  dop: '👤',
+  prepDays: '📅',
+  shootingDays: '🎬',
+  deliveryResolution: '📺',
+  recordingResolution: '📹',
+  aspectRatio: '🖼️',
+  codec: '💾',
+  baseFrameRate: '⏱️',
+  sensorMode: '🔍',
+  requiredScenarios: '🌄',
+  cameraHandle: '🛠️',
+  mattebox: '🎬',
+  gimbal: '🌀',
+  monitoringSupport: '🧰',
+  monitoring: '📡',
+  monitoringConfiguration: '🎛️',
+  monitorUserButtons: '🔘',
+  cameraUserButtons: '🔘',
+  viewfinderUserButtons: '🔘'
+};
+
 function updateTripodOptions() {
   const headBrand = tripodHeadBrandSelect ? tripodHeadBrandSelect.value : '';
   const bowl = tripodBowlSelect ? tripodBowlSelect.value : '';
@@ -1864,6 +1886,12 @@ if (projectForm) {
         sel.addEventListener('dblclick', e => {
             e.preventDefault();
         });
+    });
+
+    projectForm.querySelectorAll('select').forEach(sel => {
+        if (sel.id === 'requiredScenarios') return;
+        sel.addEventListener('change', () => updateSelectIconBoxes(sel));
+        updateSelectIconBoxes(sel);
     });
 }
 
@@ -7501,31 +7529,10 @@ function generateGearListHtml(info = {}) {
         cameraUserButtons: 'Camera User Buttons',
         viewfinderUserButtons: 'Viewfinder User Buttons'
     };
-    const fieldIcons = {
-        dop: '👤',
-        prepDays: '📅',
-        shootingDays: '🎬',
-        deliveryResolution: '📺',
-        recordingResolution: '📹',
-        aspectRatio: '🖼️',
-        codec: '💾',
-        baseFrameRate: '⏱️',
-        sensorMode: '🔍',
-        requiredScenarios: '🌄',
-        cameraHandle: '🛠️',
-        mattebox: '🎬',
-        gimbal: '🌀',
-        monitoringSupport: '🧰',
-        monitoring: '📡',
-        monitoringConfiguration: '🎛️',
-        monitorUserButtons: '🔘',
-        cameraUserButtons: '🔘',
-        viewfinderUserButtons: '🔘'
-    };
     const infoEntries = Object.entries(projectInfo)
         .filter(([k, v]) => v && k !== 'projectName' && k !== 'sliderBowl');
     const boxesHtml = infoEntries.length ? '<div class="requirements-grid">' +
-        infoEntries.map(([k, v]) => `<div class="requirement-box"><span class="req-icon">${fieldIcons[k] || ''}</span><span class="req-label">${escapeHtml(labels[k] || k)}</span><span class="req-value">${escapeHtml(v)}</span></div>`).join('') + '</div>' : '';
+        infoEntries.map(([k, v]) => `<div class="requirement-box"><span class="req-icon">${projectFieldIcons[k] || ''}</span><span class="req-label">${escapeHtml(labels[k] || k)}</span><span class="req-value">${escapeHtml(v)}</span></div>`).join('') + '</div>' : '';
     const infoHtml = infoEntries.length ? `<h3>Project Requirements</h3>${boxesHtml}` : '';
     const formatItems = arr => {
         const counts = {};
@@ -8745,6 +8752,30 @@ const scenarioIcons = {
   'Slow Motion': '🐌',
   'Viewfinder Extension': '🔭'
 };
+
+function updateSelectIconBoxes(sel) {
+  if (!sel) return;
+  let container = sel.parentNode.querySelector('.icon-box-summary');
+  if (!container) {
+    container = document.createElement('div');
+    container.className = 'icon-box-summary';
+    sel.parentNode.insertBefore(container, sel.nextSibling);
+  }
+  container.innerHTML = '';
+  const opts = sel.multiple
+    ? Array.from(sel.selectedOptions)
+    : (sel.value ? [sel.options[sel.selectedIndex]] : []);
+  opts.forEach(opt => {
+    const box = document.createElement('span');
+    box.className = 'icon-box';
+    const iconSpan = document.createElement('span');
+    iconSpan.className = 'icon';
+    iconSpan.textContent = opt.dataset.icon || projectFieldIcons[sel.name] || '📌';
+    box.appendChild(iconSpan);
+    box.appendChild(document.createTextNode(opt.value));
+    container.appendChild(box);
+  });
+}
 
 function updateRequiredScenariosSummary() {
   if (!requiredScenariosSelect || !requiredScenariosSummary) return;

--- a/style.css
+++ b/style.css
@@ -754,7 +754,8 @@ button:disabled {
   flex-wrap: wrap;
 }
 
-.scenario-summary {
+.scenario-summary,
+.icon-box-summary {
     margin-top: 4px;
     display: flex;
     flex-wrap: wrap;
@@ -772,7 +773,8 @@ button:disabled {
   font-size: 0.75em;
 }
 
-.scenario-box {
+.scenario-box,
+.icon-box {
   display: flex;
   align-items: center;
   padding: 2px 6px;
@@ -783,7 +785,8 @@ button:disabled {
   font-size: 0.75em;
 }
 
-.scenario-box .scenario-icon {
+.scenario-box .scenario-icon,
+.icon-box .icon {
   margin-right: 4px;
 }
 


### PR DESCRIPTION
## Summary
- Render selected options from project requirements selectors as icon boxes
- Share icon mappings through new `projectFieldIcons` constant
- Style icon box summaries with reusable CSS classes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb76644c6c83209777b57215cad4ff