### PR TITLE
feat: add viewfinder extension selector

### DIFF
--- a/index.html
+++ b/index.html
@@ -1012,7 +1012,6 @@
           <option value="Extreme heat">Extreme heat</option>
           <option value="Rain Machine">Rain Machine</option>
           <option value="Slow Motion">Slow Motion</option>
-          <option value="Viewfinder Extension">Viewfinder Extension</option>
           <option value="Battery Belt">Battery Belt</option>
         </select>
         <div id="requiredScenariosSummary" class="scenario-summary" aria-live="polite"></div>
@@ -1032,6 +1031,13 @@
           <option value="Rod based">Rod based</option>
           <option value="Clamp On">Clamp On</option>
           <option value="Swing Away">Swing Away</option>
+        </select>
+      </div>
+      <div class="form-row hidden" id="viewfinderExtensionRow">
+        <label for="viewfinderExtension">Viewfinder Extension:</label>
+        <select id="viewfinderExtension" name="viewfinderExtension">
+          <option value=""></option>
+          <option value="ARRI VEB-3 Viewfinder Extension Bracket">ARRI VEB-3 Viewfinder Extension Bracket</option>
         </select>
       </div>
       <h3 id="monitoringHeading">Monitoring</h3>

--- a/script.js
+++ b/script.js
@@ -696,6 +696,15 @@ function updateViewfinderSettingsVisibility() {
       }
     }
   }
+  if (viewfinderExtensionRow) {
+    const extSelect = document.getElementById('viewfinderExtension');
+    if (hasViewfinder) {
+      viewfinderExtensionRow.classList.remove('hidden');
+    } else {
+      viewfinderExtensionRow.classList.add('hidden');
+      if (extSelect) extSelect.value = '';
+    }
+  }
 }
 
 
@@ -1502,6 +1511,7 @@ const tripodTypesSelect = document.getElementById("tripodTypes");
 const tripodSpreaderSelect = document.getElementById("tripodSpreader");
 const monitoringConfigurationSelect = document.getElementById("monitoringConfiguration");
 const viewfinderSettingsRow = document.getElementById("viewfinderSettingsRow");
+const viewfinderExtensionRow = document.getElementById("viewfinderExtensionRow");
 
 function updateTripodOptions() {
   const headBrand = tripodHeadBrandSelect ? tripodHeadBrandSelect.value : '';
@@ -7298,6 +7308,7 @@ function collectProjectFormData() {
         requiredScenarios: multi('requiredScenarios'),
         cameraHandle: multi('cameraHandle'),
         mattebox: val('mattebox'),
+        viewfinderExtension: val('viewfinderExtension'),
         gimbal: multi('gimbal'),
         monitoringSettings: monitoringSelections,
         videoDistribution: multi('videoDistribution'),
@@ -7405,6 +7416,9 @@ function generateGearListHtml(info = {}) {
     const handleSelections = info.cameraHandle
         ? info.cameraHandle.split(',').map(r => r.trim()).filter(Boolean)
         : [];
+    if (info.viewfinderExtension) {
+        supportAccNoCages.push(info.viewfinderExtension);
+    }
     const monitoringSettings = info.monitoringSettings
         ? info.monitoringSettings.split(',').map(s => s.trim()).filter(Boolean)
         : [];
@@ -7493,6 +7507,7 @@ function generateGearListHtml(info = {}) {
         requiredScenarios: 'Required Scenarios',
         cameraHandle: 'Camera Handle',
         mattebox: 'Mattebox',
+        viewfinderExtension: 'Viewfinder Extension',
         gimbal: 'Gimbal',
         monitoringSupport: 'Monitoring support',
         monitoring: 'Monitoring',
@@ -7514,6 +7529,7 @@ function generateGearListHtml(info = {}) {
         requiredScenarios: '🌄',
         cameraHandle: '🛠️',
         mattebox: '🎬',
+        viewfinderExtension: '🔭',
         gimbal: '🌀',
         monitoringSupport: '🧰',
         monitoring: '📡',
@@ -8742,8 +8758,7 @@ const scenarioIcons = {
   'Extreme rain': '🌧️',
   'Extreme heat': '🔥',
   'Rain Machine': '🌧️',
-  'Slow Motion': '🐌',
-  'Viewfinder Extension': '🔭'
+  'Slow Motion': '🐌'
 };
 
 function updateRequiredScenariosSummary() {

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -1788,6 +1788,41 @@ describe('script.js functions', () => {
     });
   });
 
+  test('viewfinder extension selector visibility toggles with camera viewfinder', () => {
+    const camSel = document.getElementById('cameraSelect');
+    const row = document.getElementById('viewfinderExtensionRow');
+    const extSel = document.getElementById('viewfinderExtension');
+
+    devices.cameras.CamWithVF = { viewfinder: [{}] };
+    devices.cameras.CamNoVF = { viewfinder: [] };
+    const optWith = new Option('CamWithVF', 'CamWithVF');
+    const optWithout = new Option('CamNoVF', 'CamNoVF');
+    camSel.appendChild(optWith);
+    camSel.appendChild(optWithout);
+
+    camSel.value = 'CamWithVF';
+    script.updateBatteryPlateVisibility();
+    expect(row.classList.contains('hidden')).toBe(false);
+
+    extSel.value = 'ARRI VEB-3 Viewfinder Extension Bracket';
+    camSel.value = 'CamNoVF';
+    script.updateBatteryPlateVisibility();
+    expect(row.classList.contains('hidden')).toBe(true);
+    expect(extSel.value).toBe('');
+  });
+
+  test('selecting viewfinder extension adds bracket to camera support', () => {
+    const { generateGearListHtml } = script;
+    const html = generateGearListHtml({ viewfinderExtension: 'ARRI VEB-3 Viewfinder Extension Bracket' });
+    const wrap = document.createElement('div');
+    wrap.innerHTML = html;
+    const rows = Array.from(wrap.querySelectorAll('.gear-table tr'));
+    const cameraSupportIndex = rows.findIndex(r => r.textContent === 'Camera Support');
+    expect(cameraSupportIndex).toBeGreaterThanOrEqual(0);
+    const itemsRow = rows[cameraSupportIndex + 1];
+    expect(itemsRow.textContent).toContain('ARRI VEB-3 Viewfinder Extension Bracket');
+  });
+
   test('Carts and Transportation category includes default items', () => {
     const { generateGearListHtml } = script;
     const html = generateGearListHtml();


### PR DESCRIPTION
## Summary
- add dedicated viewfinder extension selector in rigging
- hide viewfinder extension when selected camera has no viewfinder
- include viewfinder extension in gear list and project summary

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bbccb326e0832087b15ca804882994