### PR TITLE
feat: add CLI help for unifyPorts script

### DIFF
--- a/tests/cliHelp.test.js
+++ b/tests/cliHelp.test.js
@@ -17,3 +17,10 @@ test('normalizeData CLI --help', () => {
   expect(stdout).toMatch(/-h, --help\s+Show this help message/);
   expect(status).toBe(0);
 });
+
+test('unifyPorts CLI --help', () => {
+  const { stdout, status } = run('unifyPorts.js');
+  expect(stdout).toMatch(/Usage: node unifyPorts\.js \[--help\]/);
+  expect(stdout).toMatch(/-h, --help\s+Show this help message/);
+  expect(status).toBe(0);
+});

--- a/unifyPorts.js
+++ b/unifyPorts.js
@@ -301,6 +301,19 @@ function normalizeCollection(collection, fn) {
 }
 
 if (require.main === module) {
+  const args = process.argv.slice(2);
+  if (args.includes('--help') || args.includes('-h')) {
+    console.log(
+      'Usage: node unifyPorts.js [--help]\n' +
+        '\nNormalizes connector and port definitions in data.js and overwrites the file.\n' +
+        '\nExamples:\n' +
+        '  node unifyPorts.js\n' +
+        '  node unifyPorts.js --help\n' +
+        '\nOptions:\n' +
+        '  -h, --help  Show this help message.'
+    );
+    process.exit(0);
+  }
   normalizeCollection(devices.cameras, normalizeCamera);
   normalizeCollection(devices.monitors, normalizeMonitor);
   normalizeCollection(devices.video, normalizeVideoDevice);


### PR DESCRIPTION
## Summary
- add --help usage info to unifyPorts data normalization script
- cover unifyPorts CLI help with tests

## Testing
- `npm test 2>&1 | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68bbcd66fcc08320a9c4eb0f319f1944