### PR TITLE
feat: strip connector/port suffixes

### DIFF
--- a/tests/unifyPorts.test.js
+++ b/tests/unifyPorts.test.js
@@ -27,6 +27,10 @@ describe('cleanTypeName', () => {
     expect(cleanTypeName('HDMI Input OUTPUT')).toBe('HDMI');
     expect(cleanTypeName('SDI IN/OUT')).toBe('SDI IN/OUT');
   });
+  it('removes trailing connector and port descriptors', () => {
+    expect(cleanTypeName('USB-C connector')).toBe('USB-C');
+    expect(cleanTypeName('HDMI port')).toBe('HDMI');
+  });
 });
 
 describe('normalizeMonitor', () => {

--- a/unifyPorts.js
+++ b/unifyPorts.js
@@ -12,6 +12,7 @@ const IO_WORDS_REGEX = /\b(?:INPUT|OUTPUT)\b/gi;
 const LEMO_2PIN_REGEX = /lemo\s*2\s*-?\s*pin/i;
 const DTAP_REGEX = /d[\s-]?tap/i;
 const USB_TYPEC_REGEX = /usb\s*type[-\s]?c/i;
+const CONNECTOR_PORT_REGEX = /\b(?:connector|port)\b/gi;
 const MULTISPACE_REGEX = /\s+/g;
 
 const VOLTAGE_DC_REGEX = /DC/gi;
@@ -40,6 +41,7 @@ function cleanTypeName(name) {
   if (LEMO_2PIN_REGEX.test(t)) t = "LEMO 2-pin";
   else if (DTAP_REGEX.test(t)) t = "D-Tap";
   else if (USB_TYPEC_REGEX.test(t)) t = "USB-C";
+  t = t.replace(CONNECTOR_PORT_REGEX, "").trim();
   t = t.replace(MULTISPACE_REGEX, " ");
   typeNameCache.set(key, t);
   return t;


### PR DESCRIPTION
## Summary
- avoid caching generic connector/port words in connector names
- test cleanTypeName to remove trailing connector/port descriptors

## Testing
- `npm test >/tmp/unit.log 2>&1 && tail -n 20 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_68bbcdd54b14832087c98ada7107d873