### PR TITLE
Wrap diagram controls on small screens

### DIFF
--- a/overview.css
+++ b/overview.css
@@ -95,7 +95,23 @@ th { background-color: var(--control-bg); font-weight: 700; }
 .video-conn { background-color: rgba(33,150,243,0.15); }
 .neutral-conn { background-color: rgba(158,158,158,0.15); }
 .diagram-section { margin-top: 20px; }
-.diagram-controls { margin-bottom: 10px; }
+.diagram-controls {
+  margin-bottom: 10px;
+  display: flex;
+  justify-content: center;
+  gap: 0.5em;
+  flex-wrap: wrap;
+}
+
+.diagram-controls button {
+  min-width: 32px;
+}
+
+@media (max-width: 600px) {
+  .diagram-controls button {
+    flex: 1 0 calc(50% - 0.5em);
+  }
+}
 #diagramArea { border: 1px solid var(--panel-border); padding: 10px; margin-top: 10px; border-radius: 4px; }
 .no-break { break-inside: avoid; page-break-inside: avoid; }
 

--- a/style.css
+++ b/style.css
@@ -723,6 +723,7 @@ button:disabled {
   display: flex;
   justify-content: center;
   gap: 0.5em;
+  flex-wrap: wrap;
 }
 
 .diagram-controls button {
@@ -731,6 +732,12 @@ button:disabled {
 
 .diagram-controls button.active {
   background: #ddd;
+}
+
+@media (max-width: 600px) {
+  .diagram-controls button {
+    flex: 1 0 calc(50% - 0.5em);
+  }
 }
 
 #diagramHint {


### PR DESCRIPTION
## Summary
- allow diagram controls to wrap onto multiple lines
- make diagram controls display two buttons per row on narrow viewports

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bbcf3e4ed48320bdf1a4e1099dba4e