### PR TITLE
Handle non-string input in parsePowerInput

### DIFF
--- a/tests/parsePowerInputCache.test.js
+++ b/tests/parsePowerInputCache.test.js
@@ -7,4 +7,10 @@ describe('parsePowerInput cache', () => {
     const second = parsePowerInput('D-Tap');
     expect(second[0].extra).toBeUndefined();
   });
+
+  test('returns null for non-string input', () => {
+    // Previously a non-string would throw when parsePowerInput attempted to
+    // call string methods on the value. It should now safely return null.
+    expect(parsePowerInput(123)).toBeNull();
+  });
 });

--- a/unifyPorts.js
+++ b/unifyPorts.js
@@ -246,7 +246,11 @@ function extractTypeAndNotes(segment) {
  * @returns {Array<{type: string, notes?: string}>|null} Parsed representation.
  */
 function parsePowerInput(str) {
-  if (!str) return null;
+  // Gracefully handle non-string inputs. Consumers may accidentally pass
+  // numbers or other types, which previously caused a runtime error when the
+  // value was fed into string helpers like `trim`. Treat such inputs as
+  // unparsable instead of throwing.
+  if (typeof str !== "string" || !str) return null;
   if (powerInputCache.has(str)) {
     // Return a fresh copy of the cached array so callers can mutate the
     // result without affecting subsequent lookups.


### PR DESCRIPTION
## Summary
- Avoid TypeError when parsePowerInput receives non-string values by returning null early
- Add regression test covering non-string input

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bbd0179488832089d093f4c5630d28