### PR TITLE
Add viewfinder extension rigging selector

### DIFF
--- a/index.html
+++ b/index.html
@@ -994,7 +994,6 @@
           <option value="Extreme heat">Extreme heat</option>
           <option value="Rain Machine">Rain Machine</option>
           <option value="Slow Motion">Slow Motion</option>
-          <option value="Viewfinder Extension">Viewfinder Extension</option>
           <option value="Battery Belt">Battery Belt</option>
         </select>
         <div id="requiredScenariosSummary" class="scenario-summary" aria-live="polite"></div>
@@ -1005,6 +1004,16 @@
           <option value="Handle Extension">Handle Extension</option>
           <option value="L-Handle">L-Handle</option>
           <option value="Hand Grips">Hand Grips</option>
+        </select>
+      </div>
+      <div class="form-row hidden" id="viewfinderExtensionRow">
+        <label for="viewfinderExtension">Viewfinder Extension:</label>
+        <select id="viewfinderExtension" name="viewfinderExtension" multiple size="5">
+          <option value="ARRI VEB-3 Viewfinder Extension Bracket">ARRI VEB-3 Viewfinder Extension Bracket</option>
+          <option value="ARRI Viewfinder Bracket (FS7II/FX9)">ARRI Viewfinder Bracket (FS7II/FX9)</option>
+          <option value="ARRI Viewfinder Adapter VFA-3">ARRI Viewfinder Adapter VFA-3</option>
+          <option value="ARRI Viewfinder Adapter VFA-4">ARRI Viewfinder Adapter VFA-4</option>
+          <option value="ARRI Viewfinder Adapter VFA-2">ARRI Viewfinder Adapter VFA-2</option>
         </select>
       </div>
       <div class="form-row">

--- a/script.js
+++ b/script.js
@@ -675,6 +675,7 @@ function updateBatteryPlateVisibility() {
     else batteryPlateSelect.value = '';
   }
   updateViewfinderSettingsVisibility();
+  updateViewfinderExtensionVisibility();
 }
 
 function updateViewfinderSettingsVisibility() {
@@ -690,6 +691,22 @@ function updateViewfinderSettingsVisibility() {
       const vfSelect = document.getElementById('viewfinderSettings');
       if (vfSelect) {
         Array.from(vfSelect.options).forEach(o => { o.selected = false; });
+      }
+    }
+  }
+}
+
+function updateViewfinderExtensionVisibility() {
+  const cam = devices?.cameras?.[cameraSelect?.value];
+  const hasViewfinder = Array.isArray(cam?.viewfinder) && cam.viewfinder.length > 0;
+  if (viewfinderExtensionRow) {
+    if (hasViewfinder) {
+      viewfinderExtensionRow.classList.remove('hidden');
+    } else {
+      viewfinderExtensionRow.classList.add('hidden');
+      const vfExtSel = document.getElementById('viewfinderExtension');
+      if (vfExtSel) {
+        Array.from(vfExtSel.options).forEach(o => { o.selected = false; });
       }
     }
   }
@@ -1499,6 +1516,7 @@ const tripodTypesSelect = document.getElementById("tripodTypes");
 const tripodSpreaderSelect = document.getElementById("tripodSpreader");
 const monitoringConfigurationSelect = document.getElementById("monitoringConfiguration");
 const viewfinderSettingsRow = document.getElementById("viewfinderSettingsRow");
+const viewfinderExtensionRow = document.getElementById("viewfinderExtensionRow");
 
 const projectFieldIcons = {
   dop: '👤',
@@ -1512,6 +1530,7 @@ const projectFieldIcons = {
   sensorMode: '🔍',
   requiredScenarios: '🌄',
   cameraHandle: '🛠️',
+  viewfinderExtension: '🔭',
   mattebox: '🎬',
   gimbal: '🌀',
   monitoringSupport: '🧰',
@@ -7324,6 +7343,7 @@ function collectProjectFormData() {
         lenses: multi('lenses'),
         requiredScenarios: multi('requiredScenarios'),
         cameraHandle: multi('cameraHandle'),
+        viewfinderExtension: multi('viewfinderExtension'),
         mattebox: val('mattebox'),
         gimbal: multi('gimbal'),
         monitoringSettings: monitoringSelections,
@@ -7432,6 +7452,9 @@ function generateGearListHtml(info = {}) {
     const handleSelections = info.cameraHandle
         ? info.cameraHandle.split(',').map(r => r.trim()).filter(Boolean)
         : [];
+    const viewfinderExtSelections = info.viewfinderExtension
+        ? info.viewfinderExtension.split(',').map(r => r.trim()).filter(Boolean)
+        : [];
     const monitoringSettings = info.monitoringSettings
         ? info.monitoringSettings.split(',').map(s => s.trim()).filter(Boolean)
         : [];
@@ -7441,6 +7464,7 @@ function generateGearListHtml(info = {}) {
     const filterSelections = info.filter
         ? info.filter.split(',').map(s => s.trim()).filter(Boolean)
         : [];
+    viewfinderExtSelections.forEach(vf => supportAccNoCages.push(vf));
     if (scenarios.includes('Rain Machine') || scenarios.includes('Extreme rain')) {
         filterSelections.push('Schulz Sprayoff Micro');
         filterSelections.push('Fischer RS to D-Tap cable 0,5m');
@@ -7519,6 +7543,7 @@ function generateGearListHtml(info = {}) {
         lenses: 'Lenses',
         requiredScenarios: 'Required Scenarios',
         cameraHandle: 'Camera Handle',
+        viewfinderExtension: 'Viewfinder Extension',
         mattebox: 'Mattebox',
         gimbal: 'Gimbal',
         monitoringSupport: 'Monitoring support',
@@ -8755,8 +8780,7 @@ const scenarioIcons = {
   'Extreme rain': '🌧️',
   'Extreme heat': '🔥',
   'Rain Machine': '🌧️',
-  'Slow Motion': '🐌',
-  'Viewfinder Extension': '🔭'
+  'Slow Motion': '🐌'
 };
 
 function updateSelectIconBoxes(sel) {
@@ -8887,6 +8911,7 @@ function initApp() {
     tripodBowlSelect.addEventListener('change', updateTripodOptions);
   }
   updateTripodOptions();
+  updateViewfinderExtensionVisibility();
   updateCalculations();
   applyFilters();
 }
@@ -9064,5 +9089,6 @@ if (typeof module !== "undefined" && module.exports) {
     populateSensorModeDropdown,
     populateCodecDropdown,
     updateRequiredScenariosSummary,
+    updateViewfinderExtensionVisibility,
   };
 }

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -2148,6 +2148,7 @@ describe('script.js functions', () => {
     const { generateGearListHtml } = script;
     const html = generateGearListHtml({
       cameraHandle: 'Hand Grips, L-Handle',
+      viewfinderExtension: 'ARRI VEB-3 Viewfinder Extension Bracket',
       mattebox: 'Rod based',
       monitoringSettings: 'Viewfinder Clean Feed, Surround View',
       monitorUserButtons: 'Toggle LUT',
@@ -2158,6 +2159,8 @@ describe('script.js functions', () => {
     expect(html).toContain('<span class="req-value">Hand Grips, L-Handle</span>');
     expect(html).toContain('<span class="req-label">Mattebox</span>');
     expect(html).toContain('<span class="req-value">Rod based</span>');
+    expect(html).toContain('<span class="req-label">Viewfinder Extension</span>');
+    expect(html).toContain('<span class="req-value">ARRI VEB-3 Viewfinder Extension Bracket</span>');
     expect(html).toContain('<span class="req-label">Monitoring support</span>');
     expect(html).toContain('<span class="req-value">Viewfinder Clean Feed, Surround View</span>');
     const msSection = html.slice(html.indexOf('<td>Monitoring support</td>'), html.indexOf('Power'));
@@ -2173,6 +2176,27 @@ describe('script.js functions', () => {
     expect(html).toContain('<span class="req-label">Viewfinder User Buttons</span>');
     expect(html).toContain('<span class="req-value">Peaking</span>');
     expect(html).toContain('<td>Rigging</td>');
+    const wrap = document.createElement('div');
+    wrap.innerHTML = html;
+    const rows = Array.from(wrap.querySelectorAll('.gear-table tr'));
+    const csIndex = rows.findIndex(r => r.textContent === 'Camera Support');
+    const csRow = rows[csIndex + 1];
+    expect(csRow.textContent).toContain('ARRI VEB-3 Viewfinder Extension Bracket');
+  });
+
+  test('viewfinder extension selector visible only when camera has viewfinder', () => {
+    const { updateViewfinderExtensionVisibility } = script;
+    const camSel = document.getElementById('cameraSelect');
+    const row = document.getElementById('viewfinderExtensionRow');
+    camSel.innerHTML = '<option value="NoVF">NoVF</option><option value="WithVF">WithVF</option>';
+    devices.cameras.NoVF = { powerDrawWatts: 10 };
+    devices.cameras.WithVF = { powerDrawWatts: 10, viewfinder: [{ type: 'EVF' }] };
+    camSel.value = 'NoVF';
+    updateViewfinderExtensionVisibility();
+    expect(row.classList.contains('hidden')).toBe(true);
+    camSel.value = 'WithVF';
+    updateViewfinderExtensionVisibility();
+    expect(row.classList.contains('hidden')).toBe(false);
   });
 
   test('Directors handheld monitor appears under monitoring in project requirements', () => {


### PR DESCRIPTION
## Summary
- add viewfinder extension selector under rigging and hide if camera lacks a viewfinder
- record selected extensions in project requirements and camera support gear
- cover new selector with tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bbcf7fc90c8320b55d09cb80304d8e