### PR TITLE
Show popup when storage fails

### DIFF
--- a/storage.js
+++ b/storage.js
@@ -1,4 +1,5 @@
 // storage.js - Handles reading from and writing to localStorage.
+/* global texts, currentLang */
 
 const DEVICE_STORAGE_KEY = 'cameraPowerPlanner_devices';
 const SETUP_STORAGE_KEY = 'cameraPowerPlanner_setups';
@@ -18,6 +19,7 @@ const SAFE_LOCAL_STORAGE = (() => {
     }
   } catch (e) {
     console.warn('localStorage is unavailable:', e);
+    alertStorageError();
   }
   return null;
 })();
@@ -25,6 +27,23 @@ const SAFE_LOCAL_STORAGE = (() => {
 // Helper to check for plain objects
 function isPlainObject(val) {
   return val !== null && typeof val === 'object' && !Array.isArray(val);
+}
+
+function alertStorageError() {
+  if (typeof window === 'undefined' || typeof window.alert !== 'function') return;
+  let msg = 'Storage error: Unable to access local data. Changes may not be saved.';
+  try {
+    if (typeof texts !== 'undefined') {
+      const lang = typeof currentLang !== 'undefined' && texts[currentLang]
+        ? currentLang
+        : 'en';
+      msg = texts[lang]?.alertStorageError || msg;
+    }
+  } catch (err) {
+    void err;
+    // ignore and fall back to default
+  }
+  window.alert(msg);
 }
 
 // Generic helpers for storage access
@@ -35,6 +54,7 @@ function loadJSONFromStorage(storage, key, errorMessage, defaultValue = null) {
     return raw ? JSON.parse(raw) : defaultValue;
   } catch (e) {
     console.error(errorMessage, e);
+    alertStorageError();
     return defaultValue;
   }
 }
@@ -48,6 +68,7 @@ function saveJSONToStorage(storage, key, value, errorMessage, successMessage) {
     }
   } catch (e) {
     console.error(errorMessage, e);
+    alertStorageError();
   }
 }
 
@@ -236,6 +257,7 @@ function deleteGearList() {
     SAFE_LOCAL_STORAGE.removeItem(GEARLIST_STORAGE_KEY);
   } catch (e) {
     console.error("Error deleting gear list from localStorage:", e);
+    alertStorageError();
   }
 }
 
@@ -278,6 +300,7 @@ function clearAllData() {
     console.log("All planner data cleared from storage.");
   } catch (e) {
     console.error("Error clearing storage:", e);
+    alertStorageError();
   }
 }
 

--- a/translations.js
+++ b/translations.js
@@ -236,6 +236,7 @@ const texts = {
     alertImportError: "Failed to import database. Invalid file or data format.",
     confirmExportAndRevert: "Are you sure you want to export the current database AND then revert to the default database? This will overwrite your current saved data with the original defaults.",
     alertExportAndRevertSuccess: "Database exported and reverted to defaults successfully.",
+    alertStorageError: "Storage error: Unable to access local data. Changes may not be saved.",
 
     placeholder_deviceName: "Device name",
     placeholder_watt: "e.g. 12.5",
@@ -596,6 +597,7 @@ const texts = {
     alertImportError: "Impossibile importare il database. File o formato dati non valido.",
     confirmExportAndRevert: "Sei sicuro di voler esportare il database corrente e quindi tornare al database predefinito? Ciò sovrascriverà i tuoi dati salvati attuali con le impostazioni predefinite originali.",
     alertExportAndRevertSuccess: "Database esportato e ripristinato in predefiniti.",
+    alertStorageError: "Errore di archiviazione: impossibile accedere ai dati locali. Le modifiche potrebbero non essere salvate.",
     placeholder_deviceName: "Nome del dispositivo",
     placeholder_watt: "es. 12.5",
     placeholder_capacity: "es. 98",
@@ -948,6 +950,7 @@ const texts = {
     alertImportError: "Error al importar la base de datos.",
     confirmExportAndRevert: "¿Seguro que deseas exportar y restaurar la base de datos por defecto?",
     alertExportAndRevertSuccess: "Base de datos exportada y restablecida.",
+    alertStorageError: "Error de almacenamiento: no se pudo acceder a los datos locales. Es posible que los cambios no se guarden.",
 
     placeholder_deviceName: "Nombre del dispositivo",
     placeholder_watt: "ej. 12.5",
@@ -1308,6 +1311,7 @@ const texts = {
     alertImportError: "Échec de l'importation de la base.",
     confirmExportAndRevert: "Exporter puis rétablir la base par défaut ?",
     alertExportAndRevertSuccess: "Base exportée et réinitialisée.",
+    alertStorageError: "Erreur de stockage : accès aux données locales impossible. Les modifications peuvent ne pas être enregistrées.",
 
     placeholder_deviceName: "Nom de l'appareil",
     placeholder_watt: "ex. 12.5",
@@ -1670,6 +1674,7 @@ const texts = {
     alertImportError: "Fehler beim Import der Datenbank. Ungültige Datei oder Datenformat.",
     confirmExportAndRevert: "Möchten Sie die aktuelle Datenbank exportieren UND dann auf die Standarddatenbank zurücksetzen? Dies wird Ihre aktuell gespeicherten Daten mit den ursprünglichen Standardwerten überschreiben.",
     alertExportAndRevertSuccess: "Datenbank exportiert und erfolgreich auf Standardwerte zurückgesetzt.",
+    alertStorageError: "Speicherfehler: Auf lokale Daten konnte nicht zugegriffen werden. Änderungen werden möglicherweise nicht gespeichert.",
 
     placeholder_deviceName: "Gerätename",
     placeholder_watt: "z.B. 12.5",


### PR DESCRIPTION
## Summary
- alert the user when browser storage isn't available or throws an error
- localize storage error message for multiple languages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bbd17f989c83209884eaa38726c7d3