### PR TITLE
Include monitor power cable in gear list

### DIFF
--- a/script.js
+++ b/script.js
@@ -7269,17 +7269,18 @@ function collectAccessories() {
     }
 
     const powerCableDb = acc.cables?.power || {};
-    const gatherPower = (data, target = misc) => {
+    const gatherPower = (data, target = misc, includeExcluded = false) => {
         const input = data?.power?.input?.type;
         const types = Array.isArray(input) ? input : input ? [input] : [];
         types.forEach(t => {
             for (const [name, cable] of Object.entries(powerCableDb)) {
-                if (cable.to === t && !excludedCables.has(name)) target.push(name);
+                const isExcluded = excludedCables.has(name);
+                if (cable.to === t && (!isExcluded || includeExcluded)) target.push(name);
             }
         });
     };
     gatherPower(devices.cameras[cameraSelect.value]);
-    gatherPower(devices.monitors[monitorSelect.value], monitoringSupport);
+    gatherPower(devices.monitors[monitorSelect.value], monitoringSupport, true);
     gatherPower(devices.video[videoSelect.value]);
     if (videoSelect.value) {
         const rxName = videoSelect.value.replace(/ TX\b/, ' RX');

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -1401,6 +1401,22 @@ describe('script.js functions', () => {
     expect(html).not.toContain('MonA, VidA');
   });
 
+  test('onboard monitor adds power cable to monitoring support', () => {
+    const { generateGearListHtml } = script;
+    const addOpt = (id, value) => {
+      const sel = document.getElementById(id);
+      sel.innerHTML = `<option value="${value}">${value}</option>`;
+      sel.value = value;
+    };
+    addOpt('cameraSelect', 'CamA');
+    addOpt('monitorSelect', 'MonA');
+    const html = generateGearListHtml();
+    const msSection = html.slice(html.indexOf('<td>Monitoring support</td>'), html.indexOf('Power'));
+    expect(msSection).toContain('1x D-Tap to LEMO 2-pin');
+    const miscSection = html.slice(html.indexOf('Miscellaneous'), html.indexOf('Consumables'));
+    expect(miscSection).not.toContain('D-Tap to LEMO 2-pin');
+  });
+
   test('Directors handheld monitor adds dropdown, batteries and grip items', () => {
     const { generateGearListHtml } = script;
     global.devices.monitors = {


### PR DESCRIPTION
## Summary
- show necessary power cable for onboard monitor in Monitoring support
- test that D-Tap to LEMO 2-pin appears for selected monitor

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bbd1fb47208320911ab2859e2b66a5