### PR TITLE
Add warmers for extreme cold scenario

### DIFF
--- a/script.js
+++ b/script.js
@@ -7959,8 +7959,14 @@ function generateGearListHtml(info = {}) {
         consumables.push('Magliner Rain Cover Transparent');
     }
     const needsHairDryer = isWinterShoot || scenarios.includes('Extreme cold (snow)');
+    const needsHandAndFeetWarmers = scenarios.includes('Extreme cold (snow)');
     if (needsHairDryer) {
         miscItems.push('Hair Dryer');
+    }
+    if (needsHandAndFeetWarmers) {
+        const warmersCount = Math.max(shootDays, 1) * 2;
+        for (let i = 0; i < warmersCount; i++) miscItems.push('Hand Warmers');
+        for (let i = 0; i < warmersCount; i++) miscItems.push('Feet Warmers');
     }
     addRow('Miscellaneous', formatItems(miscItems));
     addRow('Consumables', formatItems(consumables));

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -2078,7 +2078,7 @@ describe('script.js functions', () => {
     expect(miscText).not.toContain('Rain Cover');
   });
 
-  test('Extreme cold scenario adds hair dryer to miscellaneous', () => {
+  test('Extreme cold scenario adds cold weather gear to miscellaneous', () => {
     const { generateGearListHtml } = script;
     const html = generateGearListHtml({ requiredScenarios: 'Extreme cold (snow)' });
     const wrap = document.createElement('div');
@@ -2087,6 +2087,21 @@ describe('script.js functions', () => {
     const miscIdx = rows.findIndex(r => r.textContent === 'Miscellaneous');
     const miscText = rows[miscIdx + 1].textContent;
     expect(miscText).toContain('1x Hair Dryer');
+    expect(miscText).toContain('2x Hand Warmers');
+    expect(miscText).toContain('2x Feet Warmers');
+  });
+
+  test('Warmers scale with shooting days in extreme cold scenario', () => {
+    const { generateGearListHtml } = script;
+    const html = generateGearListHtml({ requiredScenarios: 'Extreme cold (snow)', shootingDays: '2024-05-01 to 2024-05-05' });
+    const wrap = document.createElement('div');
+    wrap.innerHTML = html;
+    const rows = Array.from(wrap.querySelectorAll('.gear-table tr'));
+    const miscIdx = rows.findIndex(r => r.textContent === 'Miscellaneous');
+    const miscText = rows[miscIdx + 1].textContent;
+    expect(miscText).toContain('1x Hair Dryer');
+    expect(miscText).toContain('10x Hand Warmers');
+    expect(miscText).toContain('10x Feet Warmers');
   });
 
   test('Winter shooting days add hair dryer to miscellaneous', () => {


### PR DESCRIPTION
## Summary
- Add hand and feet warmers at 2 per shooting day when extreme cold scenario is selected
- Extend tests to cover scaling of warmers with shooting days

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bbe27f32e88320b07741e2c200d1e8