### PR TITLE
Rename Gaffers monitor option

### DIFF
--- a/index.html
+++ b/index.html
@@ -1066,7 +1066,7 @@
         <label for="videoDistribution">Video distribution:</label>
         <select id="videoDistribution" name="videoDistribution" multiple size="4">
           <option value="Directors Monitor 7&quot; handheld">Directors Monitor 7&quot; handheld</option>
-          <option value="Gaffers 7&quot; Monitor">Gaffers 7&quot; Monitor</option>
+          <option value="Gaffers Monitor 7&quot; handheld">Gaffers Monitor 7&quot; handheld</option>
           <option value="Directors Monitor 15-21 inch">Directors Monitor 15-21 inch</option>
           <option value="Combo Monitor 15-21 inch">Combo Monitor 15-21 inch</option>
           <option value="IOS Video (Teradek Serv + Link)">IOS Video (Teradek Serv + Link)</option>

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -2233,11 +2233,11 @@ describe('script.js functions', () => {
     expect(html).not.toContain('<span class="req-label">Monitoring support</span><span class="req-value">IOS Video (Teradek Serv + Link)</span>');
   });
 
-  test('project requirements form includes Gaffers 7" Monitor option', () => {
+  test('project requirements form includes Gaffers Monitor 7" handheld option', () => {
     setupDom(true);
     const sel = document.getElementById('videoDistribution');
     const values = Array.from(sel.options).map(o => o.value);
-    expect(values).toContain('Gaffers 7" Monitor');
+    expect(values).toContain('Gaffers Monitor 7" handheld');
   });
 
   test('sensor mode appears in project requirements when provided', () => {


### PR DESCRIPTION
## Summary
- rename Gaffers 7" Monitor to "Gaffers Monitor 7" handheld"
- update related test

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bbe859274c8320b3ae56abfe3cf298