### PR TITLE
Enable search in lens selector

### DIFF
--- a/script.js
+++ b/script.js
@@ -3735,7 +3735,7 @@ updateBatteryPlateVisibility();
 updateBatteryOptions();
 
 // Enable search inside dropdowns
-[cameraSelect, monitorSelect, videoSelect, distanceSelect, batterySelect]
+[cameraSelect, monitorSelect, videoSelect, distanceSelect, batterySelect, lensSelect]
   .forEach(sel => attachSelectSearch(sel));
 motorSelects.forEach(sel => attachSelectSearch(sel));
 controllerSelects.forEach(sel => attachSelectSearch(sel));

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -352,6 +352,16 @@ describe('script.js functions', () => {
     expect(Array.from(sel.options).map(o => o.value)).toEqual(['LensA']);
   });
 
+  test('lens selector supports in-select search', () => {
+    const sel = document.getElementById('lenses');
+    sel.innerHTML = '<option value="Alpha">Alpha</option><option value="Beta">Beta</option>';
+    sel.focus();
+    sel.dispatchEvent(new KeyboardEvent('keydown', { key: 'b' }));
+    const [alpha, beta] = sel.options;
+    expect(alpha.hidden).toBe(true);
+    expect(beta.hidden).toBe(false);
+  });
+
   test('selected cage appears in camera support category of gear list', () => {
     const addOpt = (id, value) => {
       const sel = document.getElementById(id);


### PR DESCRIPTION
## Summary
- include lens dropdown in search-enabled selects
- add unit test verifying lens selector filtering

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bbeae3c1448320863786200153031f