### PR TITLE
Add labeled handheld monitors and accessories

### DIFF
--- a/script.js
+++ b/script.js
@@ -7499,7 +7499,12 @@ function generateGearListHtml(info = {}) {
         filterSelections.push('Fischer RS to D-Tap cable 0,5m');
         filterSelections.push('Spare Disc (Schulz Sprayoff Micro)');
     }
-    const receiverCount = (videoDistPrefs.includes('Directors Monitor 7" handheld') ? 1 : 0) + (hasMotor ? 1 : 0);
+    const receiverLabels = [];
+    if (videoDistPrefs.includes('Directors Monitor 7" handheld')) receiverLabels.push('Directors handheld');
+    if (videoDistPrefs.includes('Gaffers Monitor 7" handheld')) receiverLabels.push('Gaffers handheld');
+    if (videoDistPrefs.includes('DoP Monitor 7" handheld')) receiverLabels.push('DoP handheld');
+    if (hasMotor) receiverLabels.push('Focus');
+    const receiverCount = receiverLabels.length;
     if (selectedNames.video) {
         monitoringSupportAcc.push('Antenna 5,8GHz 5dBi Long (spare)');
         const rxName = selectedNames.video.replace(/ TX\b/, ' RX');
@@ -7510,20 +7515,23 @@ function generateGearListHtml(info = {}) {
             }
         }
     }
-    if (videoDistPrefs.includes('Directors Monitor 7" handheld')) {
+    const addMonitorCables = label => {
         monitoringSupportAcc.push(
-            'D-Tap to Lemo-2-pin Cable 0,3m',
-            'D-Tap to Lemo-2-pin Cable 0,3m',
-            'Ultraslim BNC 0.3 m',
-            'Ultraslim BNC 0.3 m'
+            `D-Tap to Lemo-2-pin Cable 0,3m (${label})`,
+            `D-Tap to Lemo-2-pin Cable 0,3m (${label})`,
+            `Ultraslim BNC 0.3 m (${label})`,
+            `Ultraslim BNC 0.3 m (${label})`
         );
-    }
+    };
+    if (videoDistPrefs.includes('Directors Monitor 7" handheld')) addMonitorCables('Directors handheld');
+    if (videoDistPrefs.includes('Gaffers Monitor 7" handheld')) addMonitorCables('Gaffers handheld');
+    if (videoDistPrefs.includes('DoP Monitor 7" handheld')) addMonitorCables('DoP handheld');
     if (hasMotor) {
         monitoringSupportAcc.push(
-            'D-Tap to Mini XLR 3-pin Cable 0,3m',
-            'D-Tap to Mini XLR 3-pin Cable 0,3m',
-            'Ultraslim BNC 0.3 m',
-            'Ultraslim BNC 0.3 m'
+            'D-Tap to Mini XLR 3-pin Cable 0,3m (Focus)',
+            'D-Tap to Mini XLR 3-pin Cable 0,3m (Focus)',
+            'Ultraslim BNC 0.3 m (Focus)',
+            'Ultraslim BNC 0.3 m (Focus)'
         );
     }
     const handleName = 'SHAPE Telescopic Handle ARRI Rosette Kit 12"';
@@ -7701,10 +7709,13 @@ function generateGearListHtml(info = {}) {
     }
     addRow('Camera Batteries', batteryItems);
     let monitoringBatteryItems = [];
-    if (videoDistPrefs.includes('Directors Monitor 7" handheld')) {
+    const addV98 = () => {
         const bebob98 = Object.keys(devices.batteries || {}).find(n => /V98micro/i.test(n)) || 'Bebob V98micro';
         monitoringBatteryItems.push(`3x ${escapeHtml(bebob98)}`);
-    }
+    };
+    if (videoDistPrefs.includes('Directors Monitor 7" handheld')) addV98();
+    if (videoDistPrefs.includes('Gaffers Monitor 7" handheld')) addV98();
+    if (videoDistPrefs.includes('DoP Monitor 7" handheld')) addV98();
     if (hasMotor) {
         const bebob150 = Object.keys(devices.batteries || {}).find(n => /V150micro/i.test(n)) || 'Bebob V150micro';
         monitoringBatteryItems.push(`3x ${escapeHtml(bebob150)}`);
@@ -7728,6 +7739,26 @@ function generateGearListHtml(info = {}) {
             .join('');
         monitoringItems += (monitoringItems ? '<br>' : '') + `1x <strong>Directors Handheld Monitor</strong> - <select id="gearListDirectorsMonitor7">${opts}</select> incl. Directors cage, shoulder strap, sunhood, rigging for teradeks`;
     }
+    if (videoDistPrefs.includes('DoP Monitor 7" handheld')) {
+        const monitorsDb = devices && devices.monitors ? devices.monitors : {};
+        const sevenInchNames = Object.keys(monitorsDb)
+            .filter(n => monitorsDb[n].screenSizeInches === 7)
+            .sort(localeSort);
+        const opts = sevenInchNames
+            .map(n => `<option value="${escapeHtml(n)}"${n === 'SmallHD Ultra 7' ? ' selected' : ''}>${escapeHtml(n)}</option>`)
+            .join('');
+        monitoringItems += (monitoringItems ? '<br>' : '') + `1x <strong>DoP Handheld Monitor</strong> - <select id="gearListDopMonitor7">${opts}</select> incl. Directors cage, shoulder strap, sunhood, rigging for teradeks`;
+    }
+    if (videoDistPrefs.includes('Gaffers Monitor 7" handheld')) {
+        const monitorsDb = devices && devices.monitors ? devices.monitors : {};
+        const sevenInchNames = Object.keys(monitorsDb)
+            .filter(n => monitorsDb[n].screenSizeInches === 7)
+            .sort(localeSort);
+        const opts = sevenInchNames
+            .map(n => `<option value="${escapeHtml(n)}"${n === 'SmallHD Ultra 7' ? ' selected' : ''}>${escapeHtml(n)}</option>`)
+            .join('');
+        monitoringItems += (monitoringItems ? '<br>' : '') + `1x <strong>Gaffer Handheld Monitor</strong> - <select id="gearListGaffersMonitor7">${opts}</select> incl. Directors cage, shoulder strap, sunhood, rigging for teradeks`;
+    }
     if (hasMotor) {
         monitoringItems += (monitoringItems ? '<br>' : '') + '1x <strong>Focus Monitor</strong> - 7&quot; - TV Logic F7HS incl Directors cage, shoulder strap, sunhood, rigging for teradeks';
     }
@@ -7735,8 +7766,9 @@ function generateGearListHtml(info = {}) {
         monitoringItems += (monitoringItems ? '<br>' : '') + `1x <strong>Wireless Transmitter</strong> - ${escapeHtml(selectedNames.video)}`;
         const rxName = selectedNames.video.replace(/ TX\b/, ' RX');
         if (devices && devices.wirelessReceivers && devices.wirelessReceivers[rxName]) {
-            const receivers = receiverCount || 1;
-            monitoringItems += `<br>${receivers}x <strong>Wireless Receiver</strong> - ${escapeHtml(rxName)}`;
+            receiverLabels.forEach(label => {
+                monitoringItems += `<br>1x <strong>Wireless Receiver</strong> - ${escapeHtml(rxName)} (${label})`;
+            });
         }
     }
     addRow('Monitoring', monitoringItems);
@@ -7754,14 +7786,26 @@ function generateGearListHtml(info = {}) {
     let easyrigSelectHtml = '';
     const hasGimbal = scenarios.includes('Gimbal');
     if (videoDistPrefs.includes('Directors Monitor 7" handheld')) {
-        gripItems.push('C-Stand 20"');
-        gripItems.push('Lite-Tite Swivel Aluminium Umbrella Adapter');
-        riggingAcc.push('Spigot');
-        riggingAcc.push('Spigot');
+        gripItems.push('C-Stand 20" (Directors handheld)');
+        gripItems.push('Lite-Tite Swivel Aluminium Umbrella Adapter (Directors handheld)');
+        riggingAcc.push('Spigot (Directors handheld)');
+        riggingAcc.push('Spigot (Directors handheld)');
+    }
+    if (videoDistPrefs.includes('Gaffers Monitor 7" handheld')) {
+        gripItems.push('C-Stand 20" (Gaffers handheld)');
+        gripItems.push('Lite-Tite Swivel Aluminium Umbrella Adapter (Gaffers handheld)');
+        riggingAcc.push('Spigot (Gaffers handheld)');
+        riggingAcc.push('Spigot (Gaffers handheld)');
+    }
+    if (videoDistPrefs.includes('DoP Monitor 7" handheld')) {
+        gripItems.push('C-Stand 20" (DoP handheld)');
+        gripItems.push('Lite-Tite Swivel Aluminium Umbrella Adapter (DoP handheld)');
+        riggingAcc.push('Spigot (DoP handheld)');
+        riggingAcc.push('Spigot (DoP handheld)');
     }
     if (hasMotor) {
-        gripItems.push('Avenger C-Stand Sliding Leg 20"');
-        gripItems.push('Lite-Tite Swivel Aluminium Umbrella Adapter');
+        gripItems.push('Avenger C-Stand Sliding Leg 20" (Focus)');
+        gripItems.push('Lite-Tite Swivel Aluminium Umbrella Adapter (Focus)');
     }
     if (scenarios.includes('Easyrig')) {
         const stabiliser = devices && devices.accessories && devices.accessories.cameraStabiliser && devices.accessories.cameraStabiliser['Easyrig 5 Vario'];
@@ -8203,12 +8247,14 @@ function bindGearListSliderBowlListener() {
 
 function bindGearListDirectorsMonitorListener() {
     if (!gearListOutput) return;
-    const sel = gearListOutput.querySelector('#gearListDirectorsMonitor7');
-    if (sel) {
-        sel.addEventListener('change', () => {
-            saveCurrentGearList();
-        });
-    }
+    ['#gearListDirectorsMonitor7', '#gearListDopMonitor7', '#gearListGaffersMonitor7'].forEach(id => {
+        const sel = gearListOutput.querySelector(id);
+        if (sel) {
+            sel.addEventListener('change', () => {
+                saveCurrentGearList();
+            });
+        }
+    });
 }
 
 

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -1356,10 +1356,10 @@ describe('script.js functions', () => {
       expect(miscSection).not.toContain('PRCD-S (Portable Residual Current Device-Safety)');
       expect(miscSection).not.toContain('Power Three Way Splitter');
       expect(html).not.toContain('BNC SDI Cable');
-      expect(msSection).toContain('2x Ultraslim BNC 0.3 m');
-      expect(msSection).toContain('2x D-Tap to Mini XLR 3-pin Cable 0,3m');
-      expect(miscSection).not.toContain('Ultraslim BNC 0.3 m');
-      expect(miscSection).not.toContain('D-Tap to Mini XLR 3-pin Cable 0,3m');
+        expect(msSection).toContain('2x Ultraslim BNC 0.3 m (Focus)');
+        expect(msSection).toContain('2x D-Tap to Mini XLR 3-pin Cable 0,3m (Focus)');
+        expect(miscSection).not.toContain('Ultraslim BNC 0.3 m (Focus)');
+        expect(miscSection).not.toContain('D-Tap to Mini XLR 3-pin Cable 0,3m (Focus)');
       expect(html).not.toContain('Ultraslim BNC 0.5 m');
       expect(html).not.toContain('HDMI Cable');
     });
@@ -1430,21 +1430,59 @@ describe('script.js functions', () => {
     expect(html).toContain('SmallHD Ultra 7');
     expect(html).toContain('Directors cage, shoulder strap, sunhood, rigging for teradeks');
     expect(html).toContain('3x Bebob V98micro');
-    expect(html).toContain('C-Stand 20"');
-    expect(html).toContain('Lite-Tite Swivel Aluminium Umbrella Adapter');
+    expect(html).toContain('C-Stand 20" (Directors handheld)');
+    expect(html).toContain('Lite-Tite Swivel Aluminium Umbrella Adapter (Directors handheld)');
     const rigSection = html.slice(html.indexOf('Rigging'), html.indexOf('Power'));
-    expect(rigSection).toContain('2x Spigot');
+    expect(rigSection).toContain('2x Spigot (Directors handheld)');
     const gripSection = html.slice(html.indexOf('Grip'), html.indexOf('Carts and Transportation'));
     expect(gripSection).not.toContain('Spigot');
     expect(html).toContain('3x Tennisball');
-    expect(html).toContain('2x Ultraslim BNC 0.3 m');
-    expect(html).toContain('2x D-Tap to Lemo-2-pin Cable 0,3m');
+    expect(html).toContain('2x Ultraslim BNC 0.3 m (Directors handheld)');
+    expect(html).toContain('2x D-Tap to Lemo-2-pin Cable 0,3m (Directors handheld)');
     const msSection = html.slice(html.indexOf('<td>Monitoring support</td>'), html.indexOf('Power'));
-    expect(msSection).toContain('2x Ultraslim BNC 0.3 m');
-    expect(msSection).toContain('2x D-Tap to Lemo-2-pin Cable 0,3m');
+    expect(msSection).toContain('2x Ultraslim BNC 0.3 m (Directors handheld)');
+    expect(msSection).toContain('2x D-Tap to Lemo-2-pin Cable 0,3m (Directors handheld)');
     const miscSection = html.slice(html.indexOf('Miscellaneous'), html.indexOf('Consumables'));
-    expect(miscSection).not.toContain('Ultraslim BNC 0.3 m');
-    expect(miscSection).not.toContain('D-Tap to Lemo-2-pin Cable 0,3m');
+    expect(miscSection).not.toContain('Ultraslim BNC 0.3 m (Directors handheld)');
+  expect(miscSection).not.toContain('D-Tap to Lemo-2-pin Cable 0,3m (Directors handheld)');
+  });
+
+  test('Gaffers handheld monitor adds dropdown, batteries and grip items', () => {
+    const { generateGearListHtml } = script;
+    global.devices.monitors = {
+      'SmallHD Ultra 7': { screenSizeInches: 7 },
+      MonA: { screenSizeInches: 7 }
+    };
+    const html = generateGearListHtml({ videoDistribution: 'Gaffers Monitor 7" handheld' });
+    expect(html).toContain('<select id="gearListGaffersMonitor7"');
+    expect(html).toContain('Gaffer Handheld Monitor');
+    expect(html).toContain('3x Bebob V98micro');
+    expect(html).toContain('C-Stand 20" (Gaffers handheld)');
+    expect(html).toContain('Lite-Tite Swivel Aluminium Umbrella Adapter (Gaffers handheld)');
+    const rigSection = html.slice(html.indexOf('Rigging'), html.indexOf('Power'));
+    expect(rigSection).toContain('2x Spigot (Gaffers handheld)');
+    const msSection = html.slice(html.indexOf('<td>Monitoring support</td>'), html.indexOf('Power'));
+    expect(msSection).toContain('2x Ultraslim BNC 0.3 m (Gaffers handheld)');
+    expect(msSection).toContain('2x D-Tap to Lemo-2-pin Cable 0,3m (Gaffers handheld)');
+  });
+
+  test('DoP handheld monitor adds dropdown, batteries and grip items', () => {
+    const { generateGearListHtml } = script;
+    global.devices.monitors = {
+      'SmallHD Ultra 7': { screenSizeInches: 7 },
+      MonA: { screenSizeInches: 7 }
+    };
+    const html = generateGearListHtml({ videoDistribution: 'DoP Monitor 7" handheld' });
+    expect(html).toContain('<select id="gearListDopMonitor7"');
+    expect(html).toContain('DoP Handheld Monitor');
+    expect(html).toContain('3x Bebob V98micro');
+    expect(html).toContain('C-Stand 20" (DoP handheld)');
+    expect(html).toContain('Lite-Tite Swivel Aluminium Umbrella Adapter (DoP handheld)');
+    const rigSection = html.slice(html.indexOf('Rigging'), html.indexOf('Power'));
+    expect(rigSection).toContain('2x Spigot (DoP handheld)');
+    const msSection = html.slice(html.indexOf('<td>Monitoring support</td>'), html.indexOf('Power'));
+    expect(msSection).toContain('2x Ultraslim BNC 0.3 m (DoP handheld)');
+    expect(msSection).toContain('2x D-Tap to Lemo-2-pin Cable 0,3m (DoP handheld)');
   });
 
   test('motor adds focus monitor and related accessories to gear list', () => {
@@ -1468,14 +1506,14 @@ describe('script.js functions', () => {
     expect(html).toContain('Focus Monitor</strong> - 7&quot; - TV Logic F7HS incl Directors cage, shoulder strap, sunhood, rigging for teradeks');
     expect(html).toContain('3x Bebob V150micro');
     const msSection = html.slice(html.indexOf('<td>Monitoring support</td>'), html.indexOf('Power'));
-    expect(msSection).toContain('2x Ultraslim BNC 0.3 m');
-    expect(msSection).toContain('2x D-Tap to Mini XLR 3-pin Cable 0,3m');
+    expect(msSection).toContain('2x Ultraslim BNC 0.3 m (Focus)');
+    expect(msSection).toContain('2x D-Tap to Mini XLR 3-pin Cable 0,3m (Focus)');
       const miscSection = html.slice(html.indexOf('Miscellaneous'), html.indexOf('Consumables'));
-      expect(miscSection).not.toContain('Ultraslim BNC 0.3 m');
-      expect(miscSection).not.toContain('D-Tap to Mini XLR 3-pin Cable 0,3m');
-      expect(html).toContain('1x <strong>Wireless Receiver</strong> - VidA RX');
-      expect(html).toContain('Avenger C-Stand Sliding Leg 20"');
-      expect(html).toContain('Lite-Tite Swivel Aluminium Umbrella Adapter');
+      expect(miscSection).not.toContain('Ultraslim BNC 0.3 m (Focus)');
+      expect(miscSection).not.toContain('D-Tap to Mini XLR 3-pin Cable 0,3m (Focus)');
+      expect(html).toContain('1x <strong>Wireless Receiver</strong> - VidA RX (Focus)');
+      expect(html).toContain('Avenger C-Stand Sliding Leg 20" (Focus)');
+      expect(html).toContain('Lite-Tite Swivel Aluminium Umbrella Adapter (Focus)');
       expect(html).toContain('3x Tennisball');
     expect(msSection).toContain('2x Antenna 5,8GHz 5dBi Long (spare)');
   });
@@ -1541,7 +1579,8 @@ describe('script.js functions', () => {
     addOpt('motor1Select', 'MotorA');
     addOpt('videoSelect', 'VidA TX');
     const html = generateGearListHtml({ videoDistribution: 'Directors Monitor 7" handheld' });
-    expect(html).toContain('2x <strong>Wireless Receiver</strong> - VidA RX');
+    expect(html).toContain('1x <strong>Wireless Receiver</strong> - VidA RX (Focus)');
+    expect(html).toContain('1x <strong>Wireless Receiver</strong> - VidA RX (Directors handheld)');
     const msSection = html.slice(html.indexOf('Monitoring support'), html.indexOf('Power'));
     expect(msSection).toContain('3x Antenna 5,8GHz 5dBi Long (spare)');
   });


### PR DESCRIPTION
## Summary
- Support DoP and Gaffer handheld monitor options alongside existing Director monitor
- Tag wireless receivers, cables, and stands with their associated monitor names
- Expand tests for new monitor options and updated accessory labeling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bbec08567c83209f855625065127fc