### PR TITLE
Add swing-away matte box option

### DIFF
--- a/devices/gearList.js
+++ b/devices/gearList.js
@@ -373,7 +373,17 @@ const gear = {
         "stages": 3,
         "type": "Clamp-On"
       },
-      "ARRI Tray Catcher": {
+      "ARRI LMB 4x5 Pro Set": {
+        "brand": "ARRI",
+        "kNumber": "KK.0015177",
+        "stages": 3,
+        "type": "Swing Away"
+      },
+      "ARRI LMB 19mm Studio Rod Adapter": {
+        "brand": "ARRI",
+        "kNumber": "K2.0013432"
+      },
+      "ARRI LMB 4x5 / LMB-6 Tray Catcher": {
         "brand": "ARRI",
         "kNumber": "K2.66202.0",
         "compatible": [

--- a/script.js
+++ b/script.js
@@ -7492,6 +7492,19 @@ function generateGearListHtml(info = {}) {
     const filterSelections = info.filter
         ? info.filter.split(',').map(s => s.trim()).filter(Boolean)
         : [];
+    if (info.mattebox) {
+        const matteboxes = devices.accessories?.matteboxes || {};
+        for (const [name, mb] of Object.entries(matteboxes)) {
+            if (mb.type && mb.type.toLowerCase() === info.mattebox.toLowerCase()) {
+                filterSelections.unshift(name);
+                if (name === 'ARRI LMB 4x5 Pro Set') {
+                    filterSelections.push('ARRI LMB 19mm Studio Rod Adapter');
+                    filterSelections.push('ARRI LMB 4x5 / LMB-6 Tray Catcher');
+                }
+                break;
+            }
+        }
+    }
     viewfinderExtSelections.forEach(vf => supportAccNoCages.push(vf));
     if (scenarios.includes('Rain Machine') || scenarios.includes('Extreme rain')) {
         filterSelections.push('Schulz Sprayoff Micro');

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -60,6 +60,10 @@ function setupDom(removeGear) {
     accessories: {
       powerPlates: { 'Generic V-Mount Plate': { mount: 'V-Mount' } },
       cages: { 'Universal Cage': { compatible: ['CamA'], rodStandard: '15mm' } },
+      matteboxes: {
+        'ARRI LMB 4x5 Pro Set': { type: 'Swing Away' },
+        'ARRI LMB 4x5 Clamp-On (3-Stage)': { type: 'Clamp-On' }
+      },
       chargers: {
         'Single V-Mount Charger': { mount: 'V-Mount', slots: 1, chargingSpeedAmps: 3 },
         'Dual V-Mount Charger': { mount: 'V-Mount', slots: 2, chargingSpeedAmps: 2 },
@@ -241,6 +245,10 @@ describe('script.js functions', () => {
       accessories: {
         powerPlates: { 'Generic V-Mount Plate': { mount: 'V-Mount' } },
         cages: { 'Universal Cage': { compatible: ['CamA'], rodStandard: '15mm' } },
+        matteboxes: {
+          'ARRI LMB 4x5 Pro Set': { type: 'Swing Away' },
+          'ARRI LMB 4x5 Clamp-On (3-Stage)': { type: 'Clamp-On' }
+        },
         chargers: {
           'Single V-Mount Charger': { mount: 'V-Mount', slots: 1, chargingSpeedAmps: 3 },
           'Dual V-Mount Charger': { mount: 'V-Mount', slots: 2, chargingSpeedAmps: 2 },
@@ -1647,6 +1655,20 @@ describe('script.js functions', () => {
     expect(itemsRow.textContent).toContain('1x Schulz Sprayoff Micro');
     expect(itemsRow.textContent).toContain('2x Fischer RS to D-Tap cable 0,5m');
     expect(itemsRow.textContent).toContain('1x Spare Disc (Schulz Sprayoff Micro)');
+  });
+
+  test('Swing Away mattebox adds LMB 4x5 Pro Set and accessories to gear list', () => {
+    const { generateGearListHtml } = script;
+    const html = generateGearListHtml({ mattebox: 'Swing Away' });
+    const wrap = document.createElement('div');
+    wrap.innerHTML = html;
+    const rows = Array.from(wrap.querySelectorAll('.gear-table tr'));
+    const matteIdx = rows.findIndex(r => r.textContent === 'Matte box + filter');
+    expect(matteIdx).toBeGreaterThanOrEqual(0);
+    const itemsRow = rows[matteIdx + 1];
+    expect(itemsRow.textContent).toContain('1x ARRI LMB 4x5 Pro Set');
+    expect(itemsRow.textContent).toContain('1x ARRI LMB 19mm Studio Rod Adapter');
+    expect(itemsRow.textContent).toContain('1x ARRI LMB 4x5 / LMB-6 Tray Catcher');
   });
 
   test('updateRequiredScenariosSummary creates a box for each selection', () => {


### PR DESCRIPTION
## Summary
- include ARRI LMB 19mm Studio Rod Adapter and ARRI LMB 4x5 / LMB-6 Tray Catcher with swing-away matte box
- auto-add rod adapter and tray catcher when ARRI LMB 4x5 Pro Set is selected
- test swing-away matte box accessories inclusion

## Testing
- `CI=true npx jest tests/script.test.js -t "Swing Away mattebox adds LMB 4x5 Pro Set and accessories to gear list"`
- `CI=true npm test` *(fails: process hung after running several suites)*

------
https://chatgpt.com/codex/tasks/task_e_68bbec7e64988320a0d9cce4ad719539