### PR TITLE
Hide viewfinder-only option when monitor selected

### DIFF
--- a/script.js
+++ b/script.js
@@ -676,6 +676,7 @@ function updateBatteryPlateVisibility() {
   }
   updateViewfinderSettingsVisibility();
   updateViewfinderExtensionVisibility();
+  updateMonitoringConfigurationOptions();
 }
 
 function updateViewfinderSettingsVisibility() {
@@ -694,6 +695,22 @@ function updateViewfinderSettingsVisibility() {
       }
     }
   }
+}
+
+function updateMonitoringConfigurationOptions() {
+  if (!monitoringConfigurationSelect) return;
+  const cam = devices?.cameras?.[cameraSelect?.value];
+  const hasViewfinder = Array.isArray(cam?.viewfinder) && cam.viewfinder.length > 0;
+  const monitorSelected = monitorSelect && monitorSelect.value && monitorSelect.value !== 'None';
+  const vfOnlyOption = Array.from(monitoringConfigurationSelect.options || [])
+    .find(o => o.value === 'Viewfinder only');
+  if (!vfOnlyOption) return;
+  const show = hasViewfinder && !monitorSelected;
+  vfOnlyOption.hidden = !show;
+  if (!show && monitoringConfigurationSelect.value === 'Viewfinder only') {
+    monitoringConfigurationSelect.value = hasViewfinder ? 'Viewfinder and Onboard' : 'Onboard Only';
+  }
+  updateViewfinderSettingsVisibility();
 }
 
 function updateViewfinderExtensionVisibility() {
@@ -8341,6 +8358,9 @@ if (cameraSelect) {
 if (monitoringConfigurationSelect) {
   monitoringConfigurationSelect.addEventListener('change', updateViewfinderSettingsVisibility);
 }
+if (monitorSelect) {
+  monitorSelect.addEventListener('change', updateMonitoringConfigurationOptions);
+}
 if (batteryPlateSelect) batteryPlateSelect.addEventListener('change', updateBatteryOptions);
 
 motorSelects.forEach(sel => { if (sel) sel.addEventListener("change", updateCalculations); });
@@ -9128,6 +9148,7 @@ if (typeof module !== "undefined" && module.exports) {
     populateSensorModeDropdown,
     populateCodecDropdown,
     updateRequiredScenariosSummary,
+    updateMonitoringConfigurationOptions,
     updateViewfinderExtensionVisibility,
   };
 }

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -2258,6 +2258,40 @@ describe('script.js functions', () => {
     expect(row.classList.contains('hidden')).toBe(false);
   });
 
+  test('viewfinder only option visible only with viewfinder and no monitor', () => {
+    const { updateMonitoringConfigurationOptions } = script;
+    const camSel = document.getElementById('cameraSelect');
+    const monitorSel = document.getElementById('monitorSelect');
+    const configSel = document.getElementById('monitoringConfiguration');
+    camSel.innerHTML = '<option value="NoVF">NoVF</option><option value="WithVF">WithVF</option>';
+    monitorSel.innerHTML = '<option value=""></option><option value="MonA">MonA</option>';
+    devices.cameras.NoVF = { powerDrawWatts: 10 };
+    devices.cameras.WithVF = { powerDrawWatts: 10, viewfinder: [{ type: 'EVF' }] };
+    devices.monitors.MonA = { powerDrawWatts: 5 };
+
+    camSel.value = 'WithVF';
+    monitorSel.value = '';
+    configSel.value = 'Viewfinder only';
+    updateMonitoringConfigurationOptions();
+    let opt = Array.from(configSel.options).find(o => o.value === 'Viewfinder only');
+    expect(opt.hidden).toBe(false);
+    expect(configSel.value).toBe('Viewfinder only');
+
+    monitorSel.value = 'MonA';
+    updateMonitoringConfigurationOptions();
+    opt = Array.from(configSel.options).find(o => o.value === 'Viewfinder only');
+    expect(opt.hidden).toBe(true);
+    expect(configSel.value).toBe('Viewfinder and Onboard');
+
+    camSel.value = 'NoVF';
+    monitorSel.value = '';
+    configSel.value = 'Viewfinder only';
+    updateMonitoringConfigurationOptions();
+    opt = Array.from(configSel.options).find(o => o.value === 'Viewfinder only');
+    expect(opt.hidden).toBe(true);
+    expect(configSel.value).toBe('Onboard Only');
+  });
+
   test('Directors handheld monitor appears under monitoring in project requirements', () => {
     const { generateGearListHtml } = script;
     const html = generateGearListHtml({ videoDistribution: 'Directors Monitor 7" handheld' });


### PR DESCRIPTION
## Summary
- Dynamically hide the “Viewfinder only” monitoring option unless the chosen camera includes a viewfinder and no monitor is selected
- Added tests ensuring visibility logic for the viewfinder-only option

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bbed2c4b78832085f92a67cded0db3