### PR TITLE
Simplify viewfinder extension selection

### DIFF
--- a/index.html
+++ b/index.html
@@ -1009,12 +1009,9 @@
       </div>
       <div class="form-row hidden" id="viewfinderExtensionRow">
         <label for="viewfinderExtension">Viewfinder Extension:</label>
-        <select id="viewfinderExtension" name="viewfinderExtension" multiple size="5">
-          <option value="ARRI VEB-3 Viewfinder Extension Bracket">ARRI VEB-3 Viewfinder Extension Bracket</option>
-          <option value="ARRI Viewfinder Bracket (FS7II/FX9)">ARRI Viewfinder Bracket (FS7II/FX9)</option>
-          <option value="ARRI Viewfinder Adapter VFA-3">ARRI Viewfinder Adapter VFA-3</option>
-          <option value="ARRI Viewfinder Adapter VFA-4">ARRI Viewfinder Adapter VFA-4</option>
-          <option value="ARRI Viewfinder Adapter VFA-2">ARRI Viewfinder Adapter VFA-2</option>
+        <select id="viewfinderExtension" name="viewfinderExtension">
+          <option value="" selected>No</option>
+          <option value="ARRI VEB-3 Viewfinder Extension Bracket">Yes</option>
         </select>
       </div>
       <div class="form-row">

--- a/script.js
+++ b/script.js
@@ -706,7 +706,7 @@ function updateViewfinderExtensionVisibility() {
       viewfinderExtensionRow.classList.add('hidden');
       const vfExtSel = document.getElementById('viewfinderExtension');
       if (vfExtSel) {
-        Array.from(vfExtSel.options).forEach(o => { o.selected = false; });
+        vfExtSel.value = '';
       }
     }
   }
@@ -7371,7 +7371,7 @@ function collectProjectFormData() {
         lenses: multi('lenses'),
         requiredScenarios: multi('requiredScenarios'),
         cameraHandle: multi('cameraHandle'),
-        viewfinderExtension: multi('viewfinderExtension'),
+        viewfinderExtension: val('viewfinderExtension'),
         mattebox: val('mattebox'),
         gimbal: multi('gimbal'),
         monitoringSettings: monitoringSelections,


### PR DESCRIPTION
## Summary
- Simplify viewfinder extension selection to a yes/no choice
- Reset extension selection when camera lacks a viewfinder
- Capture single viewfinder extension value in project data

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bbed49357c8320a06faa331e322ed4