### PR TITLE
Add clamp-on matte box accessories

### DIFF
--- a/devices/gearList.js
+++ b/devices/gearList.js
@@ -373,13 +373,29 @@ const gear = {
         "stages": 3,
         "type": "Clamp-On"
       },
-      "ARRI Tray Catcher": {
+      "ARRI LMB 4x5 / LMB-6 Tray Catcher": {
         "brand": "ARRI",
         "kNumber": "K2.66202.0",
         "compatible": [
           "LMB 4x5",
           "LMB-6"
         ]
+      },
+      "ARRI LMB 4x5 Side Flags": {
+        "brand": "ARRI",
+        "kNumber": "K2.0013750"
+      },
+      "ARRI LMB Flag Holders": {
+        "brand": "ARRI",
+        "kNumber": "K2.0013825"
+      },
+      "ARRI LMB 4x5 Set of Mattes spherical": {
+        "brand": "ARRI",
+        "kNumber": "K2.0000069"
+      },
+      "ARRI LMB 4x5 Clamp Adapter Set Pro": {
+        "brand": "ARRI",
+        "kNumber": "KK.0015133"
       },
       "ARRI Diopter Frame 138mm": {
         "brand": "ARRI",

--- a/script.js
+++ b/script.js
@@ -7672,6 +7672,7 @@ function generateGearListHtml(info = {}) {
     const lensSupportItems = [];
     const requiredRodTypes = new Set();
     const addedRodPairs = new Set();
+    const uniqueFrontDiameters = new Set();
     selectedLensNames.forEach(name => {
         const lens = devices.lenses && devices.lenses[name];
         if (!lens) return;
@@ -7686,6 +7687,7 @@ function generateGearListHtml(info = {}) {
         if (lens.needsLensSupport) {
             lensSupportItems.push(`${rodType} lens support`);
         }
+        if (lens.frontDiameterMm) uniqueFrontDiameters.add(lens.frontDiameterMm);
     });
     const cageRodType = devices.accessories?.cages?.[selectedNames.cage]?.rodStandard;
     requiredRodTypes.forEach(rt => {
@@ -7694,6 +7696,18 @@ function generateGearListHtml(info = {}) {
         }
     });
     addRow('Lens Support', formatItems(lensSupportItems));
+    if (info.mattebox === 'Clamp On') {
+        filterSelections.push('ARRI LMB 4x5 Clamp-On (3-Stage)');
+        filterSelections.push('ARRI LMB 4x5 / LMB-6 Tray Catcher');
+        filterSelections.push('ARRI LMB 4x5 Side Flags');
+        filterSelections.push('ARRI LMB Flag Holders');
+        filterSelections.push('ARRI LMB 4x5 Set of Mattes spherical');
+        filterSelections.push('ARRI LMB Accessory Adapter');
+        filterSelections.push('ARRI LMB 4x5 Clamp Adapter Set Pro');
+        uniqueFrontDiameters.forEach(d => {
+            filterSelections.push(`ARRI LMB 4x5 Clamp Adapter ${d}mm`);
+        });
+    }
     addRow('Matte box + filter', formatItems(filterSelections));
     addRow('LDS (FIZ)', formatItems([...selectedNames.motors, ...selectedNames.controllers, selectedNames.distance, ...fizCableAcc]));
     let batteryItems = '';

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -1699,6 +1699,30 @@ describe('script.js functions', () => {
     expect(itemsRow.textContent).toContain('1x Spare Disc (Schulz Sprayoff Micro)');
   });
 
+  test('Clamp On mattebox adds LMB 4x5 accessories and adapters', () => {
+    const { generateGearListHtml } = script;
+    devices.lenses['ZEISS High Speed MK III 18mm T1.3'] = { frontDiameterMm: 80 };
+    devices.lenses['ARRI/ZEISS Ultra Prime 16mm T1.9'] = { frontDiameterMm: 95 };
+    const lenses = 'ZEISS High Speed MK III 18mm T1.3, ARRI/ZEISS Ultra Prime 16mm T1.9';
+    const html = generateGearListHtml({ mattebox: 'Clamp On', lenses });
+    const wrap = document.createElement('div');
+    wrap.innerHTML = html;
+    const rows = Array.from(wrap.querySelectorAll('.gear-table tr'));
+    const matteIdx = rows.findIndex(r => r.textContent === 'Matte box + filter');
+    expect(matteIdx).toBeGreaterThanOrEqual(0);
+    const itemsRow = rows[matteIdx + 1];
+    const text = itemsRow.textContent;
+    expect(text).toContain('1x ARRI LMB 4x5 Clamp-On (3-Stage)');
+    expect(text).toContain('1x ARRI LMB 4x5 / LMB-6 Tray Catcher');
+    expect(text).toContain('1x ARRI LMB 4x5 Side Flags');
+    expect(text).toContain('1x ARRI LMB Flag Holders');
+    expect(text).toContain('1x ARRI LMB 4x5 Set of Mattes spherical');
+    expect(text).toContain('1x ARRI LMB Accessory Adapter');
+    expect(text).toContain('1x ARRI LMB 4x5 Clamp Adapter Set Pro');
+    expect(text).toContain('1x ARRI LMB 4x5 Clamp Adapter 80mm');
+    expect(text).toContain('1x ARRI LMB 4x5 Clamp Adapter 95mm');
+  });
+
   test('updateRequiredScenariosSummary creates a box for each selection', () => {
     const select = document.getElementById('requiredScenarios');
     select.querySelector('option[value="Indoor"]').selected = true;


### PR DESCRIPTION
## Summary
- add ARRI LMB 4x5 accessories to gear database
- automatically include clamp-on matte box kit with lens-specific adapters
- test clamp-on matte box accessory selection

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bbf2bbccac8320b786f3cf0d240412