### PR TITLE
Show all video distribution options without scrolling

### DIFF
--- a/index.html
+++ b/index.html
@@ -1061,7 +1061,7 @@
       </div>
       <div class="form-row">
         <label for="videoDistribution">Video distribution:</label>
-        <select id="videoDistribution" name="videoDistribution" multiple size="4">
+        <select id="videoDistribution" name="videoDistribution" multiple size="5">
           <option value="Directors Monitor 7&quot; handheld">Directors Monitor 7&quot; handheld</option>
           <option value="Gaffers Monitor 7&quot; handheld">Gaffers Monitor 7&quot; handheld</option>
           <option value="Directors Monitor 15-21 inch">Directors Monitor 15-21 inch</option>


### PR DESCRIPTION
## Summary
- Prevent video distribution selector from scrolling by displaying all options

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bbf509a920832096b2fccc1553cc3e