### PR TITLE
Add Clamp-On matte box accessories and adapters

### DIFF
--- a/devices/gearList.js
+++ b/devices/gearList.js
@@ -395,14 +395,34 @@ const gear = {
           "LMB-6"
         ]
       },
-      "ARRI Diopter Frame 138mm": {
+      "ARRI LMB 4x5 Side Flags": {
         "brand": "ARRI",
-        "kNumber": "K2.0013740",
-        "diameterMm": 138
+        "kNumber": "K2.0013750"
+      },
+      "ARRI LMB Flag Holders": {
+        "brand": "ARRI",
+        "kNumber": "K2.0013825"
+      },
+      "ARRI LMB 4x5 Set of Mattes spherical": {
+        "brand": "ARRI",
+        "kNumber": "K2.0000069"
       },
       "ARRI LMB Accessory Adapter": {
         "brand": "ARRI",
         "kNumber": "K2.0013014"
+      },
+      "ARRI LMB 4x5 Clamp Adapter Set Pro": {
+        "brand": "ARRI",
+        "kNumber": "KK.0015133"
+      },
+      "ARRI Anti-Reflection Frame 4x5.65": {
+        "brand": "ARRI",
+        "kNumber": "K2.0008133"
+      },
+      "ARRI Diopter Frame 138mm": {
+        "brand": "ARRI",
+        "kNumber": "K2.0013740",
+        "diameterMm": 138
       }
     },
     "filters": {

--- a/script.js
+++ b/script.js
@@ -7512,11 +7512,27 @@ function generateGearListHtml(info = {}) {
     if (info.mattebox) {
         const matteboxes = devices.accessories?.matteboxes || {};
         for (const [name, mb] of Object.entries(matteboxes)) {
-            if (mb.type && mb.type.toLowerCase() === info.mattebox.toLowerCase()) {
+            const normalize = s => s.replace(/[-\s]/g, '').toLowerCase();
+            if (mb.type && normalize(mb.type) === normalize(info.mattebox)) {
                 filterSelections.unshift(name);
                 if (name === 'ARRI LMB 4x5 Pro Set') {
                     filterSelections.push('ARRI LMB 19mm Studio Rod Adapter');
                     filterSelections.push('ARRI LMB 4x5 / LMB-6 Tray Catcher');
+                } else if (name === 'ARRI LMB 4x5 Clamp-On (3-Stage)') {
+                    filterSelections.push('ARRI LMB 4x5 / LMB-6 Tray Catcher');
+                    filterSelections.push('ARRI LMB 4x5 Side Flags');
+                    filterSelections.push('ARRI LMB Flag Holders');
+                    filterSelections.push('ARRI LMB 4x5 Set of Mattes spherical');
+                    filterSelections.push('ARRI LMB Accessory Adapter');
+                    filterSelections.push('ARRI Anti-Reflection Frame 4x5.65');
+                    filterSelections.push('ARRI LMB 4x5 Clamp Adapter Set Pro');
+                    const lensNames = info.lenses
+                        ? info.lenses.split(',').map(s => s.trim()).filter(Boolean)
+                        : [];
+                    const diameters = [...new Set(lensNames
+                        .map(n => devices.lenses && devices.lenses[n] && devices.lenses[n].frontDiameterMm)
+                        .filter(Boolean))];
+                    diameters.forEach(d => filterSelections.push(`ARRI LMB 4x5 Clamp Adapter ${d}mm`));
                 }
                 break;
             }

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -1721,6 +1721,28 @@ describe('script.js functions', () => {
     expect(itemsRow.textContent).toContain('1x ARRI LMB 4x5 / LMB-6 Tray Catcher');
   });
 
+  test('Clamp On mattebox adds LMB 4x5 Clamp-On set and accessories to gear list', () => {
+    const { generateGearListHtml } = script;
+    devices.lenses.LensB = { brand: 'TestBrand', frontDiameterMm: 95 };
+    const html = generateGearListHtml({ mattebox: 'Clamp On', lenses: 'LensA, LensB' });
+    const wrap = document.createElement('div');
+    wrap.innerHTML = html;
+    const rows = Array.from(wrap.querySelectorAll('.gear-table tr'));
+    const matteIdx = rows.findIndex(r => r.textContent === 'Matte box + filter');
+    expect(matteIdx).toBeGreaterThanOrEqual(0);
+    const itemsRow = rows[matteIdx + 1];
+    expect(itemsRow.textContent).toContain('1x ARRI LMB 4x5 Clamp-On (3-Stage)');
+    expect(itemsRow.textContent).toContain('1x ARRI LMB 4x5 / LMB-6 Tray Catcher');
+    expect(itemsRow.textContent).toContain('1x ARRI LMB 4x5 Side Flags');
+    expect(itemsRow.textContent).toContain('1x ARRI LMB Flag Holders');
+    expect(itemsRow.textContent).toContain('1x ARRI LMB 4x5 Set of Mattes spherical');
+    expect(itemsRow.textContent).toContain('1x ARRI LMB Accessory Adapter');
+    expect(itemsRow.textContent).toContain('1x ARRI Anti-Reflection Frame 4x5.65');
+    expect(itemsRow.textContent).toContain('1x ARRI LMB 4x5 Clamp Adapter Set Pro');
+    expect(itemsRow.textContent).toContain('1x ARRI LMB 4x5 Clamp Adapter 80mm');
+    expect(itemsRow.textContent).toContain('1x ARRI LMB 4x5 Clamp Adapter 95mm');
+  });
+
   test('updateRequiredScenariosSummary creates a box for each selection', () => {
     const select = document.getElementById('requiredScenarios');
     select.querySelector('option[value="Indoor"]').selected = true;


### PR DESCRIPTION
## Summary
- extend mattebox gear database with ARRI LMB 4x5 Clamp-On accessories and adapter set
- auto-include accessories, anti-reflection frame, and lens diameter clamp adapters when Clamp On mattebox is selected
- test Clamp On mattebox gear list generation

## Testing
- `npm run lint`
- `npm run check-consistency`
- `CI=true npx jest --testPathIgnorePatterns script.test.js`
- `CI=true npx jest tests/script.test.js -t "Clamp On mattebox adds LMB 4x5 Clamp-On set and accessories to gear list"`


------
https://chatgpt.com/codex/tasks/task_e_68bbf621766083209bbd28f01782d4cc