### PR TITLE
Add viewfinder heaters for cold weather

### DIFF
--- a/script.js
+++ b/script.js
@@ -8039,10 +8039,17 @@ function generateGearListHtml(info = {}) {
         for (let i = 0; i < 10; i++) consumables.push('Duschhaube');
         consumables.push('Magliner Rain Cover Transparent');
     }
-    const needsHairDryer = isWinterShoot || scenarios.includes('Extreme cold (snow)');
+    const needsHairDryer =
+        (isWinterShoot && scenarios.includes('Outdoor')) ||
+        scenarios.includes('Extreme cold (snow)');
     const needsHandAndFeetWarmers = scenarios.includes('Extreme cold (snow)');
     if (needsHairDryer) {
         miscItems.push('Hair Dryer');
+        if (["Sony Venice 2", "Sony Venice"].includes(selectedNames.camera)) {
+            miscItems.push('Denz C0100072 Shut-Eye Heater für Sony');
+        } else if (["Arri Alexa Mini", "Arri Amira"].includes(selectedNames.camera)) {
+            miscItems.push('Arri K2.0003898 Heated Eyecup HE-7 for the MVF-1');
+        }
     }
     if (needsHandAndFeetWarmers) {
         const warmersCount = Math.max(shootDays, 1) * 2;

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -2202,15 +2202,80 @@ describe('script.js functions', () => {
     expect(miscText).toContain('10x Feet Warmers');
   });
 
-  test('Winter shooting days add hair dryer to miscellaneous', () => {
+  test('Winter outdoor shooting adds hair dryer and heater for Venice', () => {
     const { generateGearListHtml } = script;
-    const html = generateGearListHtml({ shootingDays: '2024-01-10 to 2024-01-12' });
+    const addOpt = (id, value) => {
+      const sel = document.getElementById(id);
+      sel.innerHTML = `<option value="${value}">${value}</option>`;
+      sel.value = value;
+    };
+    devices.cameras['Sony Venice 2'] = { powerDrawWatts: 10, power: { input: { type: 'LEMO 2-pin' } }, videoOutputs: [] };
+    addOpt('cameraSelect', 'Sony Venice 2');
+    const html = generateGearListHtml({ shootingDays: '2024-01-10 to 2024-01-12', requiredScenarios: 'Outdoor' });
     const wrap = document.createElement('div');
     wrap.innerHTML = html;
     const rows = Array.from(wrap.querySelectorAll('.gear-table tr'));
     const miscIdx = rows.findIndex(r => r.textContent === 'Miscellaneous');
     const miscText = rows[miscIdx + 1].textContent;
     expect(miscText).toContain('1x Hair Dryer');
+    expect(miscText).toContain('1x Denz C0100072 Shut-Eye Heater für Sony');
+  });
+
+  test('Winter indoor shooting does not add hair dryer or heater', () => {
+    const { generateGearListHtml } = script;
+    const addOpt = (id, value) => {
+      const sel = document.getElementById(id);
+      sel.innerHTML = `<option value="${value}">${value}</option>`;
+      sel.value = value;
+    };
+    devices.cameras['Sony Venice 2'] = { powerDrawWatts: 10, power: { input: { type: 'LEMO 2-pin' } }, videoOutputs: [] };
+    addOpt('cameraSelect', 'Sony Venice 2');
+    const html = generateGearListHtml({ shootingDays: '2024-01-10 to 2024-01-12' });
+    const wrap = document.createElement('div');
+    wrap.innerHTML = html;
+    const rows = Array.from(wrap.querySelectorAll('.gear-table tr'));
+    const miscIdx = rows.findIndex(r => r.textContent === 'Miscellaneous');
+    const miscText = rows[miscIdx + 1] ? rows[miscIdx + 1].textContent : '';
+    expect(miscText).not.toContain('Hair Dryer');
+    expect(miscText).not.toContain('Denz C0100072 Shut-Eye Heater für Sony');
+  });
+
+  test('Cold weather adds viewfinder heater for Venice cameras', () => {
+    const { generateGearListHtml } = script;
+    const addOpt = (id, value) => {
+      const sel = document.getElementById(id);
+      sel.innerHTML = `<option value="${value}">${value}</option>`;
+      sel.value = value;
+    };
+    devices.cameras['Sony Venice 2'] = { powerDrawWatts: 10, power: { input: { type: 'LEMO 2-pin' } }, videoOutputs: [] };
+    addOpt('cameraSelect', 'Sony Venice 2');
+    const html = generateGearListHtml({ requiredScenarios: 'Extreme cold (snow)' });
+    const wrap = document.createElement('div');
+    wrap.innerHTML = html;
+    const rows = Array.from(wrap.querySelectorAll('.gear-table tr'));
+    const miscIdx = rows.findIndex(r => r.textContent === 'Miscellaneous');
+    const miscText = rows[miscIdx + 1].textContent;
+    expect(miscText).toContain('1x Hair Dryer');
+    expect(miscText).toContain('1x Denz C0100072 Shut-Eye Heater für Sony');
+  });
+
+  test('Cold weather adds viewfinder heater for Alexa Mini', () => {
+    const { generateGearListHtml } = script;
+    const addOpt = (id, value) => {
+      const sel = document.getElementById(id);
+      sel.innerHTML = `<option value="${value}">${value}</option>`;
+      sel.value = value;
+    };
+    devices.cameras['Arri Alexa Mini'] = { powerDrawWatts: 10, power: { input: { type: 'LEMO 2-pin' } }, videoOutputs: [] };
+    addOpt('cameraSelect', 'Arri Alexa Mini');
+    const html = generateGearListHtml({ requiredScenarios: 'Extreme cold (snow)' });
+    const wrap = document.createElement('div');
+    wrap.innerHTML = html;
+    const rows = Array.from(wrap.querySelectorAll('.gear-table tr'));
+    const miscIdx = rows.findIndex(r => r.textContent === 'Miscellaneous');
+    const miscText = rows[miscIdx + 1].textContent;
+    expect(miscText).toContain('1x Hair Dryer');
+    expect(miscText).toContain('1x Arri K2.0003898 Heated Eyecup HE-7 for the MVF-1');
   });
 
   test('Outdoor scenario calculates CapIt sizes for large monitors', () => {


### PR DESCRIPTION
## Summary
- Add automatic viewfinder heater selection for Sony Venice and Arri Alexa Mini/Amira cameras when winter or extreme cold is detected, requiring the Outdoor scenario for winter shoots
- Extend tests to verify viewfinder heaters appear only for Venice in winter outdoor shoots and not for indoor winter shoots

## Testing
- `npm test` *(fails: hangs after running most suites)*
- `CI=true npx jest tests/script.test.js --runInBand -t "Winter outdoor shooting adds hair dryer and heater for Venice"`

------
https://chatgpt.com/codex/tasks/task_e_68bbf853f2408320b682417bf98c70a6