### PR TITLE
fix: preserve metadata when normalizing ports

### DIFF
--- a/tests/unifyPorts.test.js
+++ b/tests/unifyPorts.test.js
@@ -1,5 +1,6 @@
 const {
   normalizeMonitor,
+  normalizeVideoPorts,
   parsePowerInput,
   normalizeVideoDevice,
   cleanVoltageRange,
@@ -143,5 +144,27 @@ describe('normalizeFiz', () => {
 describe('cleanPort', () => {
   it('handles primitive values without throwing', () => {
     expect(() => cleanPort('USB-C')).not.toThrow();
+  });
+});
+
+describe('normalizeVideoPorts', () => {
+  it('preserves additional port properties', () => {
+    const device = {
+      videoInputs: [
+        { portType: 'HDMI', notes: '1.4', extra: 'keep' },
+        'SDI'
+      ],
+      videoOutputs: [
+        { type: 'USB-C', notes: 'Alt mode' }
+      ]
+    };
+    normalizeVideoPorts(device);
+    expect(device.videoInputs).toEqual([
+      { type: 'HDMI', notes: '1.4', extra: 'keep' },
+      { type: 'SDI' }
+    ]);
+    expect(device.videoOutputs).toEqual([
+      { type: 'USB-C', notes: 'Alt mode' }
+    ]);
   });
 });

--- a/unifyPorts.js
+++ b/unifyPorts.js
@@ -126,7 +126,11 @@ function cleanPorts(...ports) {
 
 function normalizePortList(list) {
   return list.map(p => {
-    const portObj = { type: p.portType || p.type || p };
+    // Preserve all existing properties on the port definition instead of
+    // throwing them away. The previous implementation only kept the type and
+    // silently discarded fields like `notes` or custom metadata which are used
+    // elsewhere in the application.
+    const portObj = (p && typeof p === 'object') ? { ...p } : { type: p };
     cleanPort(portObj);
     return portObj;
   });


### PR DESCRIPTION
## Summary
- keep extra properties when normalizing port lists
- add regression test for normalizeVideoPorts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bbfe3e5154832095079f64fde68a74