### PR TITLE
Enable diagram popups on touch devices

### DIFF
--- a/script.js
+++ b/script.js
@@ -5143,16 +5143,27 @@ function attachDiagramPopups(map) {
       connectors + infoHtml;
 
     const show = e => {
+      const pointer = e.touches && e.touches[0] ? e.touches[0] : e;
       popup.innerHTML = html;
       popup.style.display = 'block';
       const rect = setupDiagramContainer.getBoundingClientRect();
-      popup.style.left = `${e.clientX - rect.left + 10}px`;
-      popup.style.top = `${e.clientY - rect.top + 10}px`;
+      popup.style.left = `${pointer.clientX - rect.left + 10}px`;
+      popup.style.top = `${pointer.clientY - rect.top + 10}px`;
     };
     const hide = () => { popup.style.display = 'none'; };
     node.addEventListener('mousemove', show);
     node.addEventListener('mouseout', hide);
+    node.addEventListener('touchstart', show);
   });
+
+  if (!setupDiagramContainer.dataset.popupOutsideListeners) {
+    const hideOnOutside = e => {
+      if (!e.target.closest('.diagram-node')) popup.style.display = 'none';
+    };
+    setupDiagramContainer.addEventListener('click', hideOnOutside);
+    setupDiagramContainer.addEventListener('touchstart', hideOnOutside);
+    setupDiagramContainer.dataset.popupOutsideListeners = 'true';
+  }
 }
 
 function enableDiagramInteractions() {


### PR DESCRIPTION
## Summary
- Show device info popup when tapping diagram nodes
- Hide popup when tapping outside the nodes
- Support both mouse and touch coordinates

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bbfee0160c8320b237216e33c6ad23