### PR TITLE
Clarify CLI help messaging

### DIFF
--- a/checkConsistency.js
+++ b/checkConsistency.js
@@ -38,7 +38,7 @@ if (require.main === module) {
         '  npm run check-consistency\n' +
         '  node checkConsistency.js --help\n' +
         '\nOptions:\n' +
-        '  -h, --help  Show this help message.'
+        '  -h, --help  Show this help message and exit.'
     );
     process.exit(0);
   }

--- a/normalizeData.js
+++ b/normalizeData.js
@@ -393,7 +393,7 @@ if (require.main === module) {
         '  npm run normalize\n' +
         '  node normalizeData.js --help\n' +
         '\nOptions:\n' +
-        '  -h, --help  Show this help message.'
+        '  -h, --help  Show this help message and exit.'
     );
     process.exit(0);
   }

--- a/tests/cliHelp.test.js
+++ b/tests/cliHelp.test.js
@@ -7,20 +7,20 @@ function run(script) {
 test('checkConsistency CLI --help', () => {
   const { stdout, status } = run('checkConsistency.js');
   expect(stdout).toMatch(/Usage: node checkConsistency\.js \[--help\]/);
-  expect(stdout).toMatch(/-h, --help\s+Show this help message/);
+  expect(stdout).toMatch(/-h, --help\s+Show this help message and exit/);
   expect(status).toBe(0);
 });
 
 test('normalizeData CLI --help', () => {
   const { stdout, status } = run('normalizeData.js');
   expect(stdout).toMatch(/Usage: node normalizeData\.js \[--help\]/);
-  expect(stdout).toMatch(/-h, --help\s+Show this help message/);
+  expect(stdout).toMatch(/-h, --help\s+Show this help message and exit/);
   expect(status).toBe(0);
 });
 
 test('unifyPorts CLI --help', () => {
   const { stdout, status } = run('unifyPorts.js');
   expect(stdout).toMatch(/Usage: node unifyPorts\.js \[--help\]/);
-  expect(stdout).toMatch(/-h, --help\s+Show this help message/);
+  expect(stdout).toMatch(/-h, --help\s+Show this help message and exit/);
   expect(status).toBe(0);
 });

--- a/unifyPorts.js
+++ b/unifyPorts.js
@@ -316,7 +316,7 @@ if (require.main === module) {
         '  node unifyPorts.js\n' +
         '  node unifyPorts.js --help\n' +
         '\nOptions:\n' +
-        '  -h, --help  Show this help message.'
+        '  -h, --help  Show this help message and exit.'
     );
     process.exit(0);
   }


### PR DESCRIPTION
## Summary
- Clarify that `-h, --help` exits after showing help for all CLI tools
- Update CLI tests to match improved help text

## Testing
- `npx jest tests/cliHelp.test.js tests/checkConsistency.test.js tests/unifyPorts.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68bbff1f39b88320bfb62f77a03b3f08