### PR TITLE
Show setup diagram tooltips on tap

### DIFF
--- a/script.js
+++ b/script.js
@@ -5154,6 +5154,7 @@ function attachDiagramPopups(map) {
     node.addEventListener('mousemove', show);
     node.addEventListener('mouseout', hide);
     node.addEventListener('touchstart', show);
+    node.addEventListener('click', show);
   });
 
   if (!setupDiagramContainer.dataset.popupOutsideListeners) {

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -3388,6 +3388,26 @@ describe('script.js functions', () => {
     expect(popup.innerHTML).toContain('Power: 2 W');
   });
 
+  test('diagram popup appears on click events', () => {
+    global.devices.fiz.controllers.ControllerA.fizConnectors = [{ type: 'LBUS' }];
+
+    const addOpt = (id, value) => {
+      const sel = document.getElementById(id);
+      sel.innerHTML = `<option value="${value}">${value}</option>`;
+      sel.value = value;
+    };
+    addOpt('cameraSelect', 'CamA');
+    addOpt('controller1Select', 'ControllerA');
+    addOpt('batterySelect', 'BattA');
+
+    script.renderSetupDiagram();
+
+    const node = document.querySelector('#diagramArea .diagram-node[data-node="controller0"]');
+    node.dispatchEvent(new MouseEvent('click', { clientX: 0, clientY: 0 }));
+    const popup = document.getElementById('diagramPopup');
+    expect(popup.innerHTML).toContain('FIZ Port: LBUS');
+  });
+
   test('grid snap toggle snaps nodes to grid', () => {
     const addOpt = (id, value) => {
       const sel = document.getElementById(id);


### PR DESCRIPTION
## Summary
- Show setup-diagram node info popup when users tap a node
- Test that clicking a node displays its popup

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bc01187e7c83208a8ddcdef94bb9c1