### PR TITLE
Aggregate repeated grip items

### DIFF
--- a/script.js
+++ b/script.js
@@ -7734,12 +7734,24 @@ function generateGearListHtml(info = {}) {
     const infoHtml = infoEntries.length ? `<h3>Project Requirements</h3>${boxesHtml}` : '';
     const formatItems = arr => {
         const counts = {};
-        arr.filter(Boolean).forEach(n => {
-            const key = n.trim();
-            counts[key] = (counts[key] || 0) + 1;
+        arr.filter(Boolean).forEach(item => {
+            const match = item.trim().match(/^(.*?)(?: \(([^()]+)\))?$/);
+            const base = match ? match[1].trim() : item.trim();
+            const ctx = match && match[2] ? match[2].trim() : '';
+            if (!counts[base]) {
+                counts[base] = { count: 0, ctxs: [] };
+            }
+            counts[base].count++;
+            if (ctx && !counts[base].ctxs.includes(ctx)) {
+                counts[base].ctxs.push(ctx);
+            }
         });
         return Object.entries(counts)
-            .map(([n, c]) => `<span class="gear-item" data-gear-name="${escapeHtml(n)}">${c}x ${escapeHtml(n)}</span>`)
+            .map(([base, { count, ctxs }]) => {
+                const ctxStr = ctxs.length ? ` (${ctxs.join(', ')})` : '';
+                const name = `${base}${ctxStr}`;
+                return `<span class="gear-item" data-gear-name="${escapeHtml(name)}">${count}x ${escapeHtml(name)}</span>`;
+            })
             .join('<br>');
     };
     const rows = [];
@@ -7920,19 +7932,19 @@ function generateGearListHtml(info = {}) {
     let sliderSelectHtml = '';
     let easyrigSelectHtml = '';
     if (videoDistPrefs.includes('Directors Monitor 7" handheld')) {
-        gripItems.push('C-Stand 20" (Directors handheld)');
+        gripItems.push('Avenger C-Stand Sliding Leg 20" (Directors handheld)');
         gripItems.push('Lite-Tite Swivel Aluminium Umbrella Adapter (Directors handheld)');
         riggingAcc.push('Spigot (Directors handheld)');
         riggingAcc.push('Spigot (Directors handheld)');
     }
     if (videoDistPrefs.includes('Gaffers Monitor 7" handheld')) {
-        gripItems.push('C-Stand 20" (Gaffers handheld)');
+        gripItems.push('Avenger C-Stand Sliding Leg 20" (Gaffers handheld)');
         gripItems.push('Lite-Tite Swivel Aluminium Umbrella Adapter (Gaffers handheld)');
         riggingAcc.push('Spigot (Gaffers handheld)');
         riggingAcc.push('Spigot (Gaffers handheld)');
     }
     if (videoDistPrefs.includes('DoP Monitor 7" handheld')) {
-        gripItems.push('C-Stand 20" (DoP handheld)');
+        gripItems.push('Avenger C-Stand Sliding Leg 20" (DoP handheld)');
         gripItems.push('Lite-Tite Swivel Aluminium Umbrella Adapter (DoP handheld)');
         riggingAcc.push('Spigot (DoP handheld)');
         riggingAcc.push('Spigot (DoP handheld)');

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -1452,7 +1452,7 @@ describe('script.js functions', () => {
     expect(html).toContain('SmallHD Ultra 7');
     expect(html).toContain('Directors cage, shoulder strap, sunhood, rigging for teradeks');
     expect(html).toContain('3x Bebob V98micro');
-    expect(html).toContain('C-Stand 20" (Directors handheld)');
+    expect(html).toContain('Avenger C-Stand Sliding Leg 20" (Directors handheld)');
     expect(html).toContain('Lite-Tite Swivel Aluminium Umbrella Adapter (Directors handheld)');
     const rigSection = html.slice(html.indexOf('Rigging'), html.indexOf('Power'));
     expect(rigSection).toContain('2x Spigot (Directors handheld)');
@@ -1479,7 +1479,7 @@ describe('script.js functions', () => {
     expect(html).toContain('<select id="gearListGaffersMonitor7"');
     expect(html).toContain('Gaffer Handheld Monitor');
     expect(html).toContain('3x Bebob V98micro');
-    expect(html).toContain('C-Stand 20" (Gaffers handheld)');
+    expect(html).toContain('Avenger C-Stand Sliding Leg 20" (Gaffers handheld)');
     expect(html).toContain('Lite-Tite Swivel Aluminium Umbrella Adapter (Gaffers handheld)');
     const rigSection = html.slice(html.indexOf('Rigging'), html.indexOf('Power'));
     expect(rigSection).toContain('2x Spigot (Gaffers handheld)');
@@ -1498,13 +1498,28 @@ describe('script.js functions', () => {
     expect(html).toContain('<select id="gearListDopMonitor7"');
     expect(html).toContain('DoP Handheld Monitor');
     expect(html).toContain('3x Bebob V98micro');
-    expect(html).toContain('C-Stand 20" (DoP handheld)');
+    expect(html).toContain('Avenger C-Stand Sliding Leg 20" (DoP handheld)');
     expect(html).toContain('Lite-Tite Swivel Aluminium Umbrella Adapter (DoP handheld)');
     const rigSection = html.slice(html.indexOf('Rigging'), html.indexOf('Power'));
     expect(rigSection).toContain('2x Spigot (DoP handheld)');
     const msSection = html.slice(html.indexOf('<td>Monitoring support</td>'), html.indexOf('Power'));
     expect(msSection).toContain('2x Ultraslim BNC 0.3 m (DoP handheld)');
     expect(msSection).toContain('2x D-Tap to Lemo-2-pin Cable 0,3m (DoP handheld)');
+  });
+
+  test('multiple handheld monitors merge grip items', () => {
+    const { generateGearListHtml } = script;
+    global.devices.monitors = { 'SmallHD Ultra 7': { screenSizeInches: 7 } };
+    const html = generateGearListHtml({
+      videoDistribution: 'Directors Monitor 7" handheld, Gaffers Monitor 7" handheld, DoP Monitor 7" handheld'
+    });
+    const gripSection = html.slice(html.indexOf('Grip'), html.indexOf('Carts and Transportation'));
+    expect(gripSection).toContain(
+      '3x Avenger C-Stand Sliding Leg 20" (Directors handheld, Gaffers handheld, DoP handheld)'
+    );
+    expect(gripSection).toContain(
+      '3x Lite-Tite Swivel Aluminium Umbrella Adapter (Directors handheld, Gaffers handheld, DoP handheld)'
+    );
   });
 
   test('motor adds focus monitor and related accessories to gear list', () => {
@@ -2025,8 +2040,7 @@ describe('script.js functions', () => {
     expect(text).toContain('1x 100mm bowl Standard Tripod + Mid-Level Spreader');
     expect(text).toContain('1x 100mm bowl Frog Tripod + Mid-Level Spreader');
     expect(text).toContain('1x 100mm bowl Hi-Head');
-    expect(text).toContain('1x Sandsack (for Frog Tripod)');
-    expect(text).toContain('1x Sandsack (for Hi-Head)');
+    expect(text).toContain('2x Sandsack (for Frog Tripod, for Hi-Head)');
   });
 
   test('Easyrig scenario adds stabiliser with dropdown options', () => {


### PR DESCRIPTION
## Summary
- Rename C-Stand 20" entries to Avenger C-Stand Sliding Leg 20"
- Collapse duplicate gear entries by merging contexts and counts
- Cover new grouping logic with tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bbffee88148320b17911d657d55ed8