### PR TITLE
Fix diagram popup positioning near right edge

### DIFF
--- a/script.js
+++ b/script.js
@@ -5178,9 +5178,21 @@ function attachDiagramPopups(map) {
       const pointer = e.touches && e.touches[0] ? e.touches[0] : e;
       popup.innerHTML = html;
       popup.style.display = 'block';
+
       const rect = setupDiagramContainer.getBoundingClientRect();
-      popup.style.left = `${pointer.clientX - rect.left + 10}px`;
-      popup.style.top = `${pointer.clientY - rect.top + 10}px`;
+      const relX = pointer.clientX - rect.left;
+      const relY = pointer.clientY - rect.top;
+      const offset = 10;
+      const popupWidth = popup.offsetWidth;
+
+      // Open the popup to the left if it would otherwise overflow the container
+      let left = relX + offset;
+      if (relX + popupWidth + offset > rect.width) {
+        left = Math.max(0, relX - popupWidth - offset);
+      }
+
+      popup.style.left = `${left}px`;
+      popup.style.top = `${relY + offset}px`;
     };
     const hide = () => { popup.style.display = 'none'; };
     node.addEventListener('mousemove', show);

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -3408,6 +3408,35 @@ describe('script.js functions', () => {
     expect(popup.innerHTML).toContain('FIZ Port: LBUS');
   });
 
+  test('diagram popup opens to the left near right edge', () => {
+    global.devices.fiz.controllers.ControllerA.fizConnectors = [{ type: 'LBUS' }];
+
+    const addOpt = (id, value) => {
+      const sel = document.getElementById(id);
+      sel.innerHTML = `<option value="${value}">${value}</option>`;
+      sel.value = value;
+    };
+    addOpt('cameraSelect', 'CamA');
+    addOpt('controller1Select', 'ControllerA');
+    addOpt('batterySelect', 'BattA');
+
+    script.renderSetupDiagram();
+
+    const container = document.getElementById('diagramArea');
+    const originalRect = container.getBoundingClientRect;
+    container.getBoundingClientRect = () => ({ left: 0, top: 0, width: 200, height: 200 });
+    const popup = document.getElementById('diagramPopup');
+    Object.defineProperty(popup, 'offsetWidth', { configurable: true, get: () => 100 });
+
+    const node = container.querySelector('.diagram-node[data-node="controller0"]');
+    node.dispatchEvent(new MouseEvent('mousemove', { clientX: 190, clientY: 10 }));
+
+    expect(popup.style.left).toBe('80px');
+
+    container.getBoundingClientRect = originalRect;
+    delete popup.offsetWidth;
+  });
+
   test('grid snap toggle snaps nodes to grid', () => {
     const addOpt = (id, value) => {
       const sel = document.getElementById(id);


### PR DESCRIPTION
## Summary
- Prevent diagram tooltips from overflowing by flipping to the left when hovered near the right edge
- Add regression test to ensure right-edge nodes open tooltips on the left side

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc038b31d08320b3492462ab1f9698