### PR TITLE
Exclude matte box from project requirements

### DIFF
--- a/script.js
+++ b/script.js
@@ -1549,7 +1549,6 @@ const projectFieldIcons = {
   lenses: '💎',
   cameraHandle: '🛠️',
   viewfinderExtension: '🔭',
-  mattebox: '🎬',
   gimbal: '🌀',
   monitoringSupport: '🧰',
   monitoring: '🖥️',
@@ -7691,6 +7690,7 @@ function generateGearListHtml(info = {}) {
     const projectInfo = { ...info };
     delete projectInfo.lenses;
     delete projectInfo.filter;
+    delete projectInfo.mattebox;
     if (monitoringSettings.length) {
         projectInfo.monitoringSupport = monitoringSettings.join(', ');
     }
@@ -7719,7 +7719,6 @@ function generateGearListHtml(info = {}) {
         requiredScenarios: 'Required Scenarios',
         cameraHandle: 'Camera Handle',
         viewfinderExtension: 'Viewfinder Extension',
-        mattebox: 'Mattebox',
         gimbal: 'Gimbal',
         monitoringSupport: 'Monitoring support',
         monitoring: 'Monitoring',

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -2441,7 +2441,7 @@ describe('script.js functions', () => {
     });
   });
 
-  test('camera handle and mattebox appear in project requirements', () => {
+  test('camera handle appears but mattebox excluded from project requirements', () => {
     const { generateGearListHtml } = script;
     const html = generateGearListHtml({
       cameraHandle: 'Hand Grips, L-Handle',
@@ -2454,8 +2454,8 @@ describe('script.js functions', () => {
     });
     expect(html).toContain('<span class="req-label">Camera Handle</span>');
     expect(html).toContain('<span class="req-value">Hand Grips, L-Handle</span>');
-    expect(html).toContain('<span class="req-label">Mattebox</span>');
-    expect(html).toContain('<span class="req-value">Rod based</span>');
+    expect(html).not.toContain('<span class="req-label">Mattebox</span>');
+    expect(html).not.toContain('<span class="req-value">Rod based</span>');
     expect(html).toContain('<span class="req-label">Viewfinder Extension</span>');
     expect(html).toContain('<span class="req-value">ARRI VEB-3 Viewfinder Extension Bracket</span>');
     expect(html).toContain('<span class="req-label">Monitoring support</span>');
@@ -2479,6 +2479,9 @@ describe('script.js functions', () => {
     const csIndex = rows.findIndex(r => r.textContent === 'Camera Support');
     const csRow = rows[csIndex + 1];
     expect(csRow.textContent).toContain('ARRI VEB-3 Viewfinder Extension Bracket');
+    const mbIndex = rows.findIndex(r => r.textContent === 'Matte box + filter');
+    const mbRow = rows[mbIndex + 1];
+    expect(mbRow.textContent).toContain('ARRI LMB 4x5 15mm LWS Set 3-Stage');
   });
 
   test('viewfinder extension selector visible only when camera has viewfinder', () => {


### PR DESCRIPTION
## Summary
- omit matte box selection from project requirements and keep it only in the gear list
- add tests confirming matte boxes only affect the gear list

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bc04ff5b2c8320b2eb4bf4dc5b3f40