### PR TITLE
Aggregate wireless receiver entries for handheld monitors

### DIFF
--- a/script.js
+++ b/script.js
@@ -7923,14 +7923,21 @@ function generateGearListHtml(info = {}) {
     if (hasMotor) {
         monitoringItems += (monitoringItems ? '<br>' : '') + '1x <strong>Focus Monitor</strong> - 7&quot; - TV Logic F7HS incl Directors cage, shoulder strap, sunhood, rigging for teradeks';
     }
+    const monitoringGear = [];
     if (selectedNames.video) {
-        monitoringItems += (monitoringItems ? '<br>' : '') + `1x <strong>Wireless Transmitter</strong> - ${escapeHtml(selectedNames.video)}`;
+        monitoringGear.push(`Wireless Transmitter - ${selectedNames.video}`);
         const rxName = selectedNames.video.replace(/ TX\b/, ' RX');
         if (devices && devices.wirelessReceivers && devices.wirelessReceivers[rxName]) {
             receiverLabels.forEach(label => {
-                monitoringItems += `<br>1x <strong>Wireless Receiver</strong> - ${escapeHtml(rxName)} (${label})`;
+                monitoringGear.push(`Wireless Receiver - ${rxName} (${label})`);
             });
         }
+    }
+    if (monitoringGear.length) {
+        const gearHtml = formatItems(monitoringGear)
+            .replace(/>(\d+x )Wireless Transmitter/g, '>$1<strong>Wireless Transmitter</strong>')
+            .replace(/>(\d+x )Wireless Receiver/g, '>$1<strong>Wireless Receiver</strong>');
+        monitoringItems += (monitoringItems ? '<br>' : '') + gearHtml;
     }
     addRow('Monitoring', monitoringItems);
     const monitoringSupportHardware = formatItems(monitoringSupportAcc);

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -1421,7 +1421,9 @@ describe('script.js functions', () => {
     addOpt('monitorSelect', 'MonA');
     addOpt('videoSelect', 'VidA');
     const html = generateGearListHtml({ projectName: 'Proj' });
-    expect(html).toContain('1x <strong>Onboard Monitor</strong> - MonA - incl. Sunhood<br>1x <strong>Wireless Transmitter</strong> - VidA');
+    expect(html).toContain(
+      '1x <strong>Onboard Monitor</strong> - MonA - incl. Sunhood<br><span class="gear-item" data-gear-name="Wireless Transmitter - VidA">1x <strong>Wireless Transmitter</strong> - VidA</span>'
+    );
     expect(html).not.toContain('MonA, VidA');
   });
 
@@ -1522,6 +1524,41 @@ describe('script.js functions', () => {
     );
   });
 
+  test('multiple handheld monitors merge wireless receivers and cables', () => {
+    const { generateGearListHtml } = script;
+    global.devices.video = {
+      'VidA TX': {
+        powerDrawWatts: 3,
+        power: { input: { type: 'LEMO 2-pin' } },
+        videoInputs: [{ type: '3G-SDI' }]
+      }
+    };
+    global.devices.wirelessReceivers = { 'VidA RX': {} };
+    global.devices.monitors = { 'SmallHD Ultra 7': { screenSizeInches: 7 } };
+    const addOpt = (id, value) => {
+      const sel = document.getElementById(id);
+      sel.innerHTML = `<option value="${value}">${value}</option>`;
+      sel.value = value;
+    };
+    addOpt('motor1Select', 'MotorA');
+    addOpt('videoSelect', 'VidA TX');
+    const html = generateGearListHtml({
+      videoDistribution:
+        'Directors Monitor 7" handheld, Gaffers Monitor 7" handheld, DoP Monitor 7" handheld'
+    });
+    expect(html).toContain(
+      '4x <strong>Wireless Receiver</strong> - VidA RX (Directors handheld, Gaffers handheld, DoP handheld, Focus)'
+    );
+    const msSection = html.slice(html.indexOf('<td>Monitoring support</td>'), html.indexOf('Power'));
+    expect(msSection).toContain(
+      '6x D-Tap to Lemo-2-pin Cable 0,3m (Directors handheld, Gaffers handheld, DoP handheld)'
+    );
+    expect(msSection).toContain(
+      '8x Ultraslim BNC 0.3 m (Directors handheld, Gaffers handheld, DoP handheld, Focus)'
+    );
+    expect(msSection).toContain('2x D-Tap to Mini XLR 3-pin Cable 0,3m (Focus)');
+  });
+
   test('motor adds focus monitor and related accessories to gear list', () => {
     const { generateGearListHtml } = script;
     global.devices.video = {
@@ -1616,8 +1653,9 @@ describe('script.js functions', () => {
     addOpt('motor1Select', 'MotorA');
     addOpt('videoSelect', 'VidA TX');
     const html = generateGearListHtml({ videoDistribution: 'Directors Monitor 7" handheld' });
-    expect(html).toContain('1x <strong>Wireless Receiver</strong> - VidA RX (Focus)');
-    expect(html).toContain('1x <strong>Wireless Receiver</strong> - VidA RX (Directors handheld)');
+    expect(html).toContain(
+      '2x <strong>Wireless Receiver</strong> - VidA RX (Directors handheld, Focus)'
+    );
     const msSection = html.slice(html.indexOf('Monitoring support'), html.indexOf('Power'));
     expect(msSection).toContain('3x Antenna 5,8GHz 5dBi Long (spare)');
   });


### PR DESCRIPTION
## Summary
- Consolidate wireless receiver entries into a single aggregated line in gear list
- Ensure handheld monitor cable counts merge across recipients
- Add comprehensive tests covering receiver and cable aggregation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc071ff79483208049552f940f53f5