### PR TITLE
Fix early escapeHtml usage causing ReferenceError

### DIFF
--- a/script.js
+++ b/script.js
@@ -43,6 +43,14 @@ if (typeof window !== 'undefined') {
   setupOfflineIndicator();
 }
 
+// Simple HTML escaping helper available early for bootstrap code
+const escapeDiv = typeof document !== 'undefined' ? document.createElement('div') : null;
+function escapeHtml(str) {
+  if (!escapeDiv) return String(str);
+  escapeDiv.textContent = str;
+  return escapeDiv.innerHTML;
+}
+
 // Use a Set for O(1) lookups when validating video output types
 const VIDEO_OUTPUT_TYPES = new Set([
   '3G-SDI',
@@ -5444,13 +5452,6 @@ function createDeviceDetailsList(deviceData) {
 
   return list;
 }
-
-const escapeDiv = document.createElement('div');
-function escapeHtml(str) {
-  escapeDiv.textContent = str;
-  return escapeDiv.innerHTML;
-}
-
 function formatDateString(val) {
   if (!val) return '';
   const d = new Date(val);


### PR DESCRIPTION
## Summary
- Initialize escapeHtml helper at top of script to ensure it's available before bootstrap code runs
- Safely create escapeDiv only when `document` is present to support non-browser environments

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc0a5e9fb0832094c8fad068202807