### PR TITLE
fix: keep diagram popups open on touch

### DIFF
--- a/script.js
+++ b/script.js
@@ -5149,6 +5149,7 @@ function attachDiagramPopups(map) {
   const popup = document.getElementById('diagramPopup');
   if (!popup) return;
   popup.style.display = 'none';
+  const isTouchDevice = (navigator.maxTouchPoints || 0) > 0;
 
   setupDiagramContainer.querySelectorAll('.diagram-node').forEach(node => {
     const id = node.getAttribute('data-node');
@@ -5174,6 +5175,7 @@ function attachDiagramPopups(map) {
       connectors + infoHtml;
 
     const show = e => {
+      e.stopPropagation();
       const pointer = e.touches && e.touches[0] ? e.touches[0] : e;
       popup.innerHTML = html;
       popup.style.display = 'block';
@@ -5194,7 +5196,6 @@ function attachDiagramPopups(map) {
       popup.style.top = `${relY + offset}px`;
     };
     const hide = () => { popup.style.display = 'none'; };
-    const isTouchDevice = (navigator.maxTouchPoints || 0) > 0;
     if (isTouchDevice) {
       node.addEventListener('touchstart', show);
       node.addEventListener('click', show);
@@ -5209,8 +5210,11 @@ function attachDiagramPopups(map) {
     const hideOnOutside = e => {
       if (!e.target.closest('.diagram-node')) popup.style.display = 'none';
     };
-    setupDiagramContainer.addEventListener('click', hideOnOutside);
-    setupDiagramContainer.addEventListener('touchstart', hideOnOutside);
+    if (isTouchDevice) {
+      setupDiagramContainer.addEventListener('touchstart', hideOnOutside);
+    } else {
+      setupDiagramContainer.addEventListener('click', hideOnOutside);
+    }
     setupDiagramContainer.dataset.popupOutsideListeners = 'true';
   }
 }

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -3450,11 +3450,14 @@ describe('script.js functions', () => {
     const popup = document.getElementById('diagramPopup');
     expect(popup.style.display).toBe('block');
 
-    // Clicking outside hides the popup
-    document.getElementById('diagramArea').dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    // Tapping outside hides the popup
+    document.getElementById('diagramArea').dispatchEvent(new Event('touchstart', { bubbles: true }));
     expect(popup.style.display).toBe('none');
 
-    delete navigator.maxTouchPoints;
+    Object.defineProperty(navigator, 'maxTouchPoints', {
+      value: 0,
+      configurable: true
+    });
   });
 
   test('diagram popup opens to the left near right edge', () => {


### PR DESCRIPTION
## Summary
- prevent diagram popups from immediately hiding on touch devices by ignoring synthetic click events
- adjust outside tap handler to use `touchstart` on touch screens
- update tests for touch behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bc09abbbb4832083e3e0949273e2b2