### PR TITLE
Expand hover help descriptions

### DIFF
--- a/script.js
+++ b/script.js
@@ -8958,7 +8958,8 @@ if (helpButton && helpDialog) {
       hoverHelpTooltip.setAttribute('hidden', '');
       return;
     }
-    hoverHelpTooltip.textContent = text.slice(0, 200);
+    // Show the full help text instead of truncating at 200 characters
+    hoverHelpTooltip.textContent = text;
     const rect = el.getBoundingClientRect();
     hoverHelpTooltip.style.top = `${rect.bottom + window.scrollY + 10}px`;
     hoverHelpTooltip.style.left = `${rect.left + window.scrollX}px`;

--- a/style.css
+++ b/style.css
@@ -363,7 +363,8 @@ a:focus {
   border-radius: 4px;
   font-size: 0.8rem;
   pointer-events: none;
-  max-width: 200px;
+  /* Allow longer hover help descriptions */
+  max-width: 320px;
   white-space: normal;
 }
 

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -3928,6 +3928,22 @@ describe('script.js functions', () => {
     document.dispatchEvent(new MouseEvent('click', { bubbles: true }));
   });
 
+  test('hover help displays long descriptions without truncation', () => {
+    const hoverHelpButton = document.getElementById('hoverHelpButton');
+    hoverHelpButton.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+    const longText = 'x'.repeat(500);
+    const dummy = document.createElement('button');
+    dummy.setAttribute('data-help', longText);
+    document.body.appendChild(dummy);
+
+    dummy.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
+    const tooltip = document.getElementById('hoverHelpTooltip');
+    expect(tooltip.textContent).toBe(longText);
+
+    document.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+  });
+
   test('saved setups label has descriptive hover help', () => {
     const label = document.getElementById('savedSetupsLabel');
     expect(label.getAttribute('data-help')).toBe(texts.en.setupSelectHelp);


### PR DESCRIPTION
## Summary
- Remove truncation for hover help tooltip text
- Increase tooltip width for longer descriptions
- Test coverage for displaying full-length hover help

## Testing
- `npm test 2>&1 | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68bc0ad2aacc83208aa2e958efc9cd2e