### PR TITLE
Include USB-C media readers in gear list

### DIFF
--- a/script.js
+++ b/script.js
@@ -7865,7 +7865,7 @@ function generateGearListHtml(info = {}) {
                     if (match) size = match[1].toUpperCase();
                 }
                 if (!size) size = sizeMap[type] || '512GB';
-                return `4x ${escapeHtml(size)} ${escapeHtml(type)}`;
+                return `4x ${escapeHtml(size)} ${escapeHtml(type)}<br>2x ${escapeHtml(type)} reader with USB-C`;
             })
             .filter(Boolean)
             .join('<br>');

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -1697,7 +1697,7 @@ describe('script.js functions', () => {
     expect(battSection).toContain('1x Hotswap Plate B-Mount');
   });
 
-  test('gear list lists 4x media cards with usable size', () => {
+  test('gear list lists media cards and USB-C readers', () => {
     const { generateGearListHtml } = script;
     devices.cameras.CamA.recordingMedia = [{ type: 'CFast 2.0' }];
     const addOpt = (id, value) => {
@@ -1708,6 +1708,7 @@ describe('script.js functions', () => {
     addOpt('cameraSelect', 'CamA');
     const html = generateGearListHtml();
     expect(html).toContain('4x 512GB CFast 2.0');
+    expect(html).toContain('2x CFast 2.0 reader with USB-C');
   });
 
   test('gear list uses first recording media when multiple types', () => {


### PR DESCRIPTION
## Summary
- append a USB-C card reader line for selected media type in gear list generation
- test gear list output to ensure reader line is present

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc266a499083208b3b547138aa2e80