### PR TITLE
Expand help with project requirements and hover mode details

### DIFF
--- a/index.html
+++ b/index.html
@@ -651,11 +651,19 @@
             <li><strong>Generate Overview</strong> produces a printable summary of any saved project.</li>
             </ul>
           </section>
-          <section data-help-section id="gearListHelp">
-            <h3><span class="help-icon" aria-hidden="true">📋</span>Gear List</h3>
-            <ul>
-              <li>The <strong>Generate Gear List</strong> button compiles selected gear and project requirements.</li>
-              <li>The <strong>Save Gear List</strong> button stores the current list with the project.</li>
+        <section data-help-section id="projectRequirementsHelp">
+          <h3><span class="help-icon" aria-hidden="true">🗒️</span>Project Requirements</h3>
+          <ul>
+            <li>Capture details like DoP, shooting dates, resolutions, codecs and more for each project.</li>
+            <li>Multi-select lists let you specify multiple scenarios, accessories or monitoring setups.</li>
+            <li>The information is saved with the project and included in printed overviews and gear lists.</li>
+          </ul>
+        </section>
+        <section data-help-section id="gearListHelp">
+          <h3><span class="help-icon" aria-hidden="true">📋</span>Gear List</h3>
+          <ul>
+            <li>The <strong>Generate Gear List</strong> button compiles selected gear and project requirements.</li>
+            <li>The <strong>Save Gear List</strong> button stores the current list with the project.</li>
               <li>The <strong>Export Gear List</strong> button downloads a JSON file, and <strong>Import Gear List</strong> restores it.</li>
               <li>The <strong>Delete Gear List</strong> button removes the saved list and hides the output.</li>
               <li>Gear list forms use fork buttons to duplicate your entries instantly.</li>
@@ -749,7 +757,16 @@
           <ul>
             <li>Open with the <strong>?</strong> button or press <kbd>?</kbd>, <kbd>H</kbd> or <kbd>F1</kbd>.</li>
             <li>Use the search field to filter topics; the query resets when closed.</li>
+            <li>Press <kbd>/</kbd> or <kbd>Ctrl</kbd>+<kbd>F</kbd> (<kbd>⌘</kbd>+<kbd>F</kbd> on macOS) to jump to the search box.</li>
             <li>Close the dialog with <kbd>Escape</kbd> or by clicking outside.</li>
+          </ul>
+        </section>
+        <section data-help-section id="hoverHelp">
+          <h3><span class="help-icon" aria-hidden="true">🖱️</span>Hover Help</h3>
+          <ul>
+            <li>Activate tooltip mode with <strong>Hover for help</strong> in the help dialog.</li>
+            <li>Move the cursor over buttons, fields, dropdowns or headers to see brief explanations.</li>
+            <li>Click anywhere or press <kbd>Escape</kbd> to exit.</li>
           </ul>
         </section>
         <section data-help-section id="languageHelp">


### PR DESCRIPTION
## Summary
- Document project requirements dialog and its multi-select inputs in the help overlay
- Add hover help section and mention shortcut to focus help search

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bc0ac499b08320a32f0c4b19e3023e