### PR TITLE
Include monitoring batteries in charger calculation

### DIFF
--- a/script.js
+++ b/script.js
@@ -7349,7 +7349,7 @@ function addArriKNumber(name) {
     return name;
 }
 
-function collectAccessories() {
+function collectAccessories({ hasMotor = false, videoDistPrefs = [] } = {}) {
     const cameraSupport = [];
     const misc = [];
     const monitoringSupport = [
@@ -7377,9 +7377,12 @@ function collectAccessories() {
         if (acc.chargers) {
             let camCount = parseInt(batteryCountElem?.textContent || '', 10);
             if (!Number.isFinite(camCount)) camCount = batterySelect.value ? 1 : 0;
-            const monitorElem = document.getElementById('monitoringBatteryCount');
-            let monCount = monitorElem ? parseInt(monitorElem.textContent, 10) : 0;
-            if (!Number.isFinite(monCount)) monCount = 0;
+            let monCount = 0;
+            if (Array.isArray(videoDistPrefs)) {
+                const handheldCount = videoDistPrefs.filter(v => v.endsWith('Monitor 7" handheld')).length;
+                monCount += handheldCount * 3;
+            }
+            if (hasMotor) monCount += 3;
             const total = camCount + monCount;
             if (total > 0) {
                 const counts = suggestChargerCounts(total);
@@ -7566,12 +7569,15 @@ function generateGearListHtml(info = {}) {
         battery: batterySelect && batterySelect.value && batterySelect.value !== 'None' ? getText(batterySelect) : ''
     };
     const hasMotor = selectedNames.motors.length > 0;
+    const videoDistPrefs = info.videoDistribution
+        ? info.videoDistribution.split(',').map(s => s.trim()).filter(Boolean)
+        : [];
     if (["Arri Alexa Mini", "Arri Amira"].includes(selectedNames.camera)) {
         selectedNames.viewfinder = "ARRI K2.75004.0 MVF-1 Viewfinder";
     } else {
         selectedNames.viewfinder = "";
     }
-    const { cameraSupport: cameraSupportAcc, chargers: chargersAcc, fizCables: fizCableAcc, misc: miscAcc, monitoringSupport: monitoringSupportAcc, rigging: riggingAcc } = collectAccessories();
+    const { cameraSupport: cameraSupportAcc, chargers: chargersAcc, fizCables: fizCableAcc, misc: miscAcc, monitoringSupport: monitoringSupportAcc, rigging: riggingAcc } = collectAccessories({ hasMotor, videoDistPrefs });
     for (const key of Object.keys(selectedNames)) {
         if (Array.isArray(selectedNames[key])) {
             selectedNames[key] = selectedNames[key].map(addArriKNumber);
@@ -7615,9 +7621,6 @@ function generateGearListHtml(info = {}) {
         : [];
     const monitoringSettings = info.monitoringSettings
         ? info.monitoringSettings.split(',').map(s => s.trim()).filter(Boolean)
-        : [];
-    const videoDistPrefs = info.videoDistribution
-        ? info.videoDistribution.split(',').map(s => s.trim()).filter(Boolean)
         : [];
     const selectedLensNames = info.lenses
         ? info.lenses.split(',').map(s => addArriKNumber(s.trim())).filter(Boolean)

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -632,10 +632,6 @@ describe('script.js functions', () => {
     addOpt('batterySelect', 'BattA');
 
     document.getElementById('batteryCount').textContent = '9';
-    const monElem = document.createElement('span');
-    monElem.id = 'monitoringBatteryCount';
-    monElem.textContent = '0';
-    document.body.appendChild(monElem);
 
     const html = script.generateGearListHtml();
     const wrap = document.createElement('div');
@@ -646,6 +642,26 @@ describe('script.js functions', () => {
     const itemsRow = rows[chargersIndex + 1];
     expect(itemsRow.textContent).toContain('2x Quad V-Mount Charger');
     expect(itemsRow.textContent).toContain('1x Dual V-Mount Charger');
+  });
+
+  test('adds monitoring batteries to charger calculation', () => {
+    const addOpt = (id, value) => {
+      const sel = document.getElementById(id);
+      sel.innerHTML = `<option value="${value}">${value}</option>`;
+      sel.value = value;
+    };
+    addOpt('cameraSelect', 'CamA');
+    addOpt('batterySelect', 'BattA');
+    document.getElementById('batteryCount').textContent = '9';
+    const html = script.generateGearListHtml({ videoDistribution: 'Directors Monitor 7" handheld' });
+    const wrap = document.createElement('div');
+    wrap.innerHTML = html;
+    const rows = Array.from(wrap.querySelectorAll('.gear-table tr'));
+    const chargersIndex = rows.findIndex(r => r.textContent === 'Chargers');
+    expect(chargersIndex).toBeGreaterThanOrEqual(0);
+    const itemsRow = rows[chargersIndex + 1];
+    expect(itemsRow.textContent).toContain('3x Quad V-Mount Charger');
+    expect(itemsRow.textContent).not.toContain('Dual V-Mount Charger');
   });
 
   test('shows runtime average note when more than four user entries', () => {


### PR DESCRIPTION
## Summary
- account for monitoring batteries when recommending chargers
- forward monitoring selections to accessory collection
- test charger suggestion with monitoring batteries

## Testing
- `CI=true npx jest tests/script.test.js --runInBand --testNamePattern "adds monitoring batteries"`


------
https://chatgpt.com/codex/tasks/task_e_68bc270910fc8320aa73497046191e0e