### PR TITLE
Standardize spigot naming across rigging accessories

### DIFF
--- a/script.js
+++ b/script.js
@@ -7585,7 +7585,7 @@ function generateGearListHtml(info = {}) {
     for (let i = 0; i < 2; i++) riggingAcc.push('Mini Magic Arm');
     for (let i = 0; i < 4; i++) riggingAcc.push('Cine Quick Release');
     riggingAcc.push('SmallRig - Super lightweight 15mm RailBlock');
-    for (let i = 0; i < 3; i++) riggingAcc.push('stud 5/8" with male 3/8" and 1/4"');
+    for (let i = 0; i < 3; i++) riggingAcc.push('spigot with male 3/8" and 1/4"');
     for (let i = 0; i < 2; i++) riggingAcc.push('D-Tap Splitter');
     const cagesDb = devices.accessories?.cages || {};
     const compatibleCages = [];
@@ -8006,20 +8006,20 @@ function generateGearListHtml(info = {}) {
     if (videoDistPrefs.includes('Directors Monitor 7" handheld')) {
         gripItems.push('Avenger C-Stand Sliding Leg 20" (Directors handheld)');
         gripItems.push('Lite-Tite Swivel Aluminium Umbrella Adapter (Directors handheld)');
-        riggingAcc.push('Spigot (Directors handheld)');
-        riggingAcc.push('Spigot (Directors handheld)');
+        riggingAcc.push('spigot with male 3/8" and 1/4" (Directors handheld)');
+        riggingAcc.push('spigot with male 3/8" and 1/4" (Directors handheld)');
     }
     if (videoDistPrefs.includes('Gaffers Monitor 7" handheld')) {
         gripItems.push('Avenger C-Stand Sliding Leg 20" (Gaffers handheld)');
         gripItems.push('Lite-Tite Swivel Aluminium Umbrella Adapter (Gaffers handheld)');
-        riggingAcc.push('Spigot (Gaffers handheld)');
-        riggingAcc.push('Spigot (Gaffers handheld)');
+        riggingAcc.push('spigot with male 3/8" and 1/4" (Gaffers handheld)');
+        riggingAcc.push('spigot with male 3/8" and 1/4" (Gaffers handheld)');
     }
     if (videoDistPrefs.includes('DoP Monitor 7" handheld')) {
         gripItems.push('Avenger C-Stand Sliding Leg 20" (DoP handheld)');
         gripItems.push('Lite-Tite Swivel Aluminium Umbrella Adapter (DoP handheld)');
-        riggingAcc.push('Spigot (DoP handheld)');
-        riggingAcc.push('Spigot (DoP handheld)');
+        riggingAcc.push('spigot with male 3/8" and 1/4" (DoP handheld)');
+        riggingAcc.push('spigot with male 3/8" and 1/4" (DoP handheld)');
     }
     if (hasMotor) {
         gripItems.push('Avenger C-Stand Sliding Leg 20" (Focus)');
@@ -8040,7 +8040,7 @@ function generateGearListHtml(info = {}) {
     if (hasGimbal) {
         gripItems.push('Super Clamp');
         gripItems.push('Gobo Head');
-        gripItems.push('spigot');
+        gripItems.push('spigot with male 3/8" and 1/4"');
     }
     if (scenarios.includes('Cine Saddle')) gripItems.push('Cinekinetic Cinesaddle');
     if (scenarios.includes('Steadybag')) gripItems.push('Steadybag');
@@ -8070,7 +8070,7 @@ function generateGearListHtml(info = {}) {
     if (scenarios.includes('Outdoor')) {
         gripItems.push('Super Clamp');
         gripItems.push('Super Clamp');
-        riggingAcc.push('Spigot');
+        riggingAcc.push('spigot with male 3/8" and 1/4"');
     }
     if (['Extreme heat', 'Extreme rain', 'Rain Machine'].some(s => scenarios.includes(s))) {
         gripItems.push('Large Umbrella');

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -1396,7 +1396,7 @@ describe('script.js functions', () => {
     expect(rigSection).toContain('2x Mini Magic Arm');
     expect(rigSection).toContain('4x Cine Quick Release');
     expect(rigSection).toContain('1x SmallRig - Super lightweight 15mm RailBlock');
-    expect(rigSection).toContain('3x stud 5/8" with male 3/8" and 1/4"');
+    expect(rigSection).toContain('3x spigot with male 3/8" and 1/4"');
     expect(rigSection).toContain('2x D-Tap Splitter');
   });
 
@@ -1457,9 +1457,9 @@ describe('script.js functions', () => {
     expect(html).toContain('Avenger C-Stand Sliding Leg 20" (Directors handheld)');
     expect(html).toContain('Lite-Tite Swivel Aluminium Umbrella Adapter (Directors handheld)');
     const rigSection = html.slice(html.indexOf('Rigging'), html.indexOf('Power'));
-    expect(rigSection).toContain('2x Spigot (Directors handheld)');
+    expect(rigSection).toContain('5x spigot with male 3/8" and 1/4" (Directors handheld)');
     const gripSection = html.slice(html.indexOf('Grip'), html.indexOf('Carts and Transportation'));
-    expect(gripSection).not.toContain('Spigot');
+    expect(gripSection).not.toContain('spigot with male 3/8" and 1/4"');
     expect(html).toContain('3x Tennisball');
     expect(html).toContain('2x Ultraslim BNC 0.3 m (Directors handheld)');
     expect(html).toContain('2x D-Tap to Lemo-2-pin Cable 0,3m (Directors handheld)');
@@ -1484,7 +1484,7 @@ describe('script.js functions', () => {
     expect(html).toContain('Avenger C-Stand Sliding Leg 20" (Gaffers handheld)');
     expect(html).toContain('Lite-Tite Swivel Aluminium Umbrella Adapter (Gaffers handheld)');
     const rigSection = html.slice(html.indexOf('Rigging'), html.indexOf('Power'));
-    expect(rigSection).toContain('2x Spigot (Gaffers handheld)');
+    expect(rigSection).toContain('5x spigot with male 3/8" and 1/4" (Gaffers handheld)');
     const msSection = html.slice(html.indexOf('<td>Monitoring support</td>'), html.indexOf('Power'));
     expect(msSection).toContain('2x Ultraslim BNC 0.3 m (Gaffers handheld)');
     expect(msSection).toContain('2x D-Tap to Lemo-2-pin Cable 0,3m (Gaffers handheld)');
@@ -1503,7 +1503,7 @@ describe('script.js functions', () => {
     expect(html).toContain('Avenger C-Stand Sliding Leg 20" (DoP handheld)');
     expect(html).toContain('Lite-Tite Swivel Aluminium Umbrella Adapter (DoP handheld)');
     const rigSection = html.slice(html.indexOf('Rigging'), html.indexOf('Power'));
-    expect(rigSection).toContain('2x Spigot (DoP handheld)');
+    expect(rigSection).toContain('5x spigot with male 3/8" and 1/4" (DoP handheld)');
     const msSection = html.slice(html.indexOf('<td>Monitoring support</td>'), html.indexOf('Power'));
     expect(msSection).toContain('2x Ultraslim BNC 0.3 m (DoP handheld)');
     expect(msSection).toContain('2x D-Tap to Lemo-2-pin Cable 0,3m (DoP handheld)');
@@ -2131,7 +2131,7 @@ describe('script.js functions', () => {
     expect(text).toContain('2x Manfrotto 244N Friktion Arm');
     expect(text).toContain('1x Super Clamp');
     expect(text).toContain('1x Gobo Head');
-    expect(text).toContain('1x spigot');
+    expect(text).toContain('1x spigot with male 3/8" and 1/4"');
   });
 
   test('Gimbal selector adds specified devices', () => {
@@ -2219,11 +2219,11 @@ describe('script.js functions', () => {
     expect(miscText).toContain('1x Umbrella for Focus Monitor');
     expect(miscText).toContain('1x Umbrella Magliner incl Mounting to Magliner');
     expect(gripText).toContain('2x Super Clamp');
-    expect(rigText).toContain('1x Spigot');
+    expect(rigText).toContain('4x spigot with male 3/8" and 1/4"');
     expect(gripText).not.toContain('Large Umbrella');
     expect(gripText).not.toContain('Avenger A5036CS Roller 36 Low Base with Umbrella Mounting');
     expect(miscText).not.toContain('Super Clamp');
-    expect(miscText).not.toContain('Spigot');
+    expect(miscText).not.toContain('spigot with male 3/8" and 1/4"');
     const consumIdx = rows.findIndex(r => r.textContent === 'Consumables');
     const consumText = rows[consumIdx + 1].textContent;
     expect(consumText).toContain('2x CapIt Large');


### PR DESCRIPTION
## Summary
- replace stud/spigot entries with unified "spigot with male 3/8" and 1/4"" wording and preserve context (Directors, Gaffers, DoP, etc.)
- adjust tests to expect new spigot wording and counts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bc27df598083209add9acf0c111b6a