### PR TITLE
feat: add RX monitor variants and filter selections

### DIFF
--- a/devices/monitors.js
+++ b/devices/monitors.js
@@ -60,6 +60,37 @@ const monitorData = {
       }
     ]
   },
+  "SmallHD Ultra 7 Bolt 6 RX": {
+    "screenSizeInches": 7,
+    "brightnessNits": 2300,
+    "powerDrawWatts": 55,
+    "power": {
+      "input": {
+        "voltageRange": "10-34",
+        "type": "LEMO 2-pin"
+      },
+      "output": null
+    },
+    "wirelessTx": false,
+    "wirelessRX": true,
+    "latencyMs": "< 1ms",
+    "videoInputs": [
+      {
+        "type": "HDMI"
+      },
+      {
+        "type": "12G-SDI"
+      }
+    ],
+    "videoOutputs": [
+      {
+        "type": "HDMI"
+      },
+      {
+        "type": "12G-SDI"
+      }
+    ]
+  },
   "SmallHD Cine 7": {
     "screenSizeInches": 7,
     "brightnessNits": 1800,
@@ -119,6 +150,37 @@ const monitorData = {
       }
     ]
   },
+  "SmallHD Cine 7 Bolt 4K RX": {
+    "screenSizeInches": 7,
+    "brightnessNits": 1800,
+    "powerDrawWatts": 50,
+    "power": {
+      "input": {
+        "voltageRange": "10-34",
+        "type": "LEMO 2-pin"
+      },
+      "output": null
+    },
+    "wirelessTx": false,
+    "wirelessRX": true,
+    "latencyMs": "< 1ms",
+    "videoInputs": [
+      {
+        "type": "HDMI"
+      },
+      {
+        "type": "3G-SDI"
+      }
+    ],
+    "videoOutputs": [
+      {
+        "type": "HDMI"
+      },
+      {
+        "type": "3G-SDI"
+      }
+    ]
+  },
   "SmallHD Indie 7": {
     "screenSizeInches": 7,
     "brightnessNits": 1000,
@@ -160,6 +222,37 @@ const monitorData = {
       "output": null
     },
     "wirelessTx": true,
+    "latencyMs": "< 1ms",
+    "videoInputs": [
+      {
+        "type": "HDMI"
+      },
+      {
+        "type": "3G-SDI"
+      }
+    ],
+    "videoOutputs": [
+      {
+        "type": "HDMI"
+      },
+      {
+        "type": "3G-SDI"
+      }
+    ]
+  },
+  "SmallHD Indie 7 Bolt 4K RX": {
+    "screenSizeInches": 7,
+    "brightnessNits": 1000,
+    "powerDrawWatts": 37.3,
+    "power": {
+      "input": {
+        "voltageRange": "10-34",
+        "type": "LEMO 2-pin"
+      },
+      "output": null
+    },
+    "wirelessTx": false,
+    "wirelessRX": true,
     "latencyMs": "< 1ms",
     "videoInputs": [
       {
@@ -259,6 +352,37 @@ const monitorData = {
       }
     ]
   },
+  "SmallHD Ultra 5 Bolt 6 RX": {
+    "screenSizeInches": 5,
+    "brightnessNits": 3000,
+    "powerDrawWatts": 50,
+    "power": {
+      "input": {
+        "voltageRange": "10-34",
+        "type": "LEMO 2-pin"
+      },
+      "output": null
+    },
+    "wirelessTx": false,
+    "wirelessRX": true,
+    "latencyMs": "< 1ms",
+    "videoInputs": [
+      {
+        "type": "HDMI"
+      },
+      {
+        "type": "3G-SDI"
+      }
+    ],
+    "videoOutputs": [
+      {
+        "type": "HDMI"
+      },
+      {
+        "type": "3G-SDI"
+      }
+    ]
+  },
   "SmallHD Cine 5": {
     "screenSizeInches": 5,
     "brightnessNits": 2000,
@@ -300,6 +424,37 @@ const monitorData = {
       "output": null
     },
     "wirelessTx": true,
+    "latencyMs": "< 1ms",
+    "videoInputs": [
+      {
+        "type": "HDMI"
+      },
+      {
+        "type": "3G-SDI"
+      }
+    ],
+    "videoOutputs": [
+      {
+        "type": "HDMI"
+      },
+      {
+        "type": "3G-SDI"
+      }
+    ]
+  },
+  "SmallHD Cine 5 Bolt 6 RX": {
+    "screenSizeInches": 5,
+    "brightnessNits": 2000,
+    "powerDrawWatts": 44,
+    "power": {
+      "input": {
+        "voltageRange": "10-34",
+        "type": "LEMO 2-pin"
+      },
+      "output": null
+    },
+    "wirelessTx": false,
+    "wirelessRX": true,
     "latencyMs": "< 1ms",
     "videoInputs": [
       {
@@ -381,6 +536,7 @@ const monitorData = {
       "output": null
     },
     "wirelessTx": true,
+    "wirelessRX": true,
     "latencyMs": "50ms",
     "videoInputs": [
       {
@@ -411,6 +567,7 @@ const monitorData = {
       "output": null
     },
     "wirelessTx": true,
+    "wirelessRX": true,
     "latencyMs": "50ms",
     "videoInputs": [
       {
@@ -438,6 +595,7 @@ const monitorData = {
       "output": null
     },
     "wirelessTx": true,
+    "wirelessRX": true,
     "latencyMs": "< 80ms",
     "audioOutput": {
       "portType": "3.5mm Headphone Jack"

--- a/script.js
+++ b/script.js
@@ -3668,6 +3668,14 @@ function populateSelect(selectElem, optionsObj = {}, includeNone = true) {
     });
 }
 
+function populateMonitorSelect() {
+  const filtered = Object.fromEntries(
+    Object.entries(devices.monitors || {})
+      .filter(([, data]) => !(data.wirelessRX && !data.wirelessTx))
+  );
+  populateSelect(monitorSelect, filtered, true);
+}
+
 function filterSelect(selectElem, filterValue) {
   const text = filterValue.toLowerCase();
   Array.from(selectElem.options).forEach(opt => {
@@ -3781,7 +3789,7 @@ function applyFilters() {
 
 // Initialize device selection dropdowns
 populateSelect(cameraSelect, devices.cameras, true);
-populateSelect(monitorSelect, devices.monitors, true);
+populateMonitorSelect();
 populateSelect(videoSelect, devices.video, true);
 if (cageSelect) populateSelect(cageSelect, devices.accessories?.cages || {}, true);
 motorSelects.forEach(sel => populateSelect(sel, devices.fiz.motors, true));
@@ -4569,7 +4577,7 @@ function applyDeviceChanges(changes) {
 
   // Re-populate dropdowns to include any newly added devices
   populateSelect(cameraSelect, devices.cameras, true);
-  populateSelect(monitorSelect, devices.monitors, true);
+  populateMonitorSelect();
   populateSelect(videoSelect, devices.video, true);
   motorSelects.forEach(sel => populateSelect(sel, devices.fiz.motors, true));
   controllerSelects.forEach(sel => populateSelect(sel, devices.fiz.controllers, true));
@@ -5996,7 +6004,7 @@ deviceManagerSection.addEventListener("click", (event) => {
       refreshDeviceLists();
       // Re-populate all dropdowns and update calculations
       populateSelect(cameraSelect, devices.cameras, true);
-      populateSelect(monitorSelect, devices.monitors, true);
+      populateMonitorSelect();
       populateSelect(videoSelect, devices.video, true);
       motorSelects.forEach(sel => populateSelect(sel, devices.fiz.motors, true));
       controllerSelects.forEach(sel => populateSelect(sel, devices.fiz.controllers, true));
@@ -6433,7 +6441,7 @@ addDeviceBtn.addEventListener("click", () => {
   refreshDeviceLists();
   // Re-populate all dropdowns to include the new/updated device
   populateSelect(cameraSelect, devices.cameras, true);
-  populateSelect(monitorSelect, devices.monitors, true);
+  populateMonitorSelect();
   populateSelect(videoSelect, devices.video, true);
   motorSelects.forEach(sel => populateSelect(sel, devices.fiz.motors, true));
   controllerSelects.forEach(sel => populateSelect(sel, devices.fiz.controllers, true));
@@ -6533,7 +6541,7 @@ importFileInput.addEventListener("change", (event) => {
         refreshDeviceLists(); // Update device manager lists
         // Re-populate all dropdowns and update calculations
         populateSelect(cameraSelect, devices.cameras, true);
-        populateSelect(monitorSelect, devices.monitors, true);
+        populateMonitorSelect();
         populateSelect(videoSelect, devices.video, true);
         motorSelects.forEach(sel => populateSelect(sel, devices.fiz.motors, true));
         controllerSelects.forEach(sel => populateSelect(sel, devices.fiz.controllers, true));
@@ -7944,7 +7952,7 @@ function generateGearListHtml(info = {}) {
     if (videoDistPrefs.includes('Directors Monitor 7" handheld')) {
         const monitorsDb = devices && devices.monitors ? devices.monitors : {};
         const sevenInchNames = Object.keys(monitorsDb)
-            .filter(n => monitorsDb[n].screenSizeInches === 7)
+            .filter(n => monitorsDb[n].screenSizeInches === 7 && (!monitorsDb[n].wirelessTx || monitorsDb[n].wirelessRX))
             .sort(localeSort);
         const opts = sevenInchNames
             .map(n => `<option value="${escapeHtml(n)}"${n === 'SmallHD Ultra 7' ? ' selected' : ''}>${escapeHtml(n)}</option>`)
@@ -7954,7 +7962,7 @@ function generateGearListHtml(info = {}) {
     if (videoDistPrefs.includes('DoP Monitor 7" handheld')) {
         const monitorsDb = devices && devices.monitors ? devices.monitors : {};
         const sevenInchNames = Object.keys(monitorsDb)
-            .filter(n => monitorsDb[n].screenSizeInches === 7)
+            .filter(n => monitorsDb[n].screenSizeInches === 7 && (!monitorsDb[n].wirelessTx || monitorsDb[n].wirelessRX))
             .sort(localeSort);
         const opts = sevenInchNames
             .map(n => `<option value="${escapeHtml(n)}"${n === 'SmallHD Ultra 7' ? ' selected' : ''}>${escapeHtml(n)}</option>`)
@@ -7964,7 +7972,7 @@ function generateGearListHtml(info = {}) {
     if (videoDistPrefs.includes('Gaffers Monitor 7" handheld')) {
         const monitorsDb = devices && devices.monitors ? devices.monitors : {};
         const sevenInchNames = Object.keys(monitorsDb)
-            .filter(n => monitorsDb[n].screenSizeInches === 7)
+            .filter(n => monitorsDb[n].screenSizeInches === 7 && (!monitorsDb[n].wirelessTx || monitorsDb[n].wirelessRX))
             .sort(localeSort);
         const opts = sevenInchNames
             .map(n => `<option value="${escapeHtml(n)}"${n === 'SmallHD Ultra 7' ? ' selected' : ''}>${escapeHtml(n)}</option>`)

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -1559,6 +1559,31 @@ describe('script.js functions', () => {
     expect(msSection).toContain('2x D-Tap to Mini XLR 3-pin Cable 0,3m (Focus)');
   });
 
+  test('RX-only monitors hidden from monitor select and TX-only monitors excluded from gear list', () => {
+    setupDom();
+    global.devices.monitors = {
+      'Mon TX': { screenSizeInches: 7, wirelessTx: true },
+      'Mon RX': { screenSizeInches: 7, wirelessRX: true },
+      'Mon RXTX': { screenSizeInches: 7, wirelessTx: true, wirelessRX: true },
+      'Mon Plain': { screenSizeInches: 7 }
+    };
+    const script = require('../script.js');
+    const options = Array.from(document.getElementById('monitorSelect').options).map(o => o.value);
+    expect(options).toContain('Mon TX');
+    expect(options).toContain('Mon RXTX');
+    expect(options).toContain('Mon Plain');
+    expect(options).not.toContain('Mon RX');
+    const html = script.generateGearListHtml({ videoDistribution: 'Directors Monitor 7" handheld' });
+    const selectHtml = html.slice(
+      html.indexOf('<select id="gearListDirectorsMonitor7"'),
+      html.indexOf('</select>', html.indexOf('<select id="gearListDirectorsMonitor7"'))
+    );
+    expect(selectHtml).toContain('Mon RX');
+    expect(selectHtml).toContain('Mon RXTX');
+    expect(selectHtml).toContain('Mon Plain');
+    expect(selectHtml).not.toContain('Mon TX');
+  });
+
   test('motor adds focus monitor and related accessories to gear list', () => {
     const { generateGearListHtml } = script;
     global.devices.video = {


### PR DESCRIPTION
## Summary
- add RX counterparts for TX-only monitors with wirelessRX flag
- hide RX-only monitors from monitor selector and show them in gear list instead
- skip TX-only monitors in gear list dropdowns and cover with tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bc2856047c83209e2be5f5749ef20a