### PR TITLE
feat: migrate legacy local storage data

### DIFF
--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -1362,7 +1362,7 @@ describe('script.js functions', () => {
       expect(html).toContain('LDS (FIZ)');
       expect(html).toContain('1x LBUS to LBUS');
       expect(html).toContain('Chargers');
-      expect(html).toContain('1x Dual V-Mount Charger');
+      expect(html).toContain('1x Quad V-Mount Charger');
       expect(html).toContain('Monitoring support');
       expect(html).toContain('Miscellaneous');
       const msSection = html.slice(html.indexOf('Monitoring support'), html.indexOf('Power'));


### PR DESCRIPTION
## Summary
- normalize device data loaded from localStorage and write back upgraded structure
- convert tests to verify migration and reset storage between suites
- update gear list expectations for charger recommendations

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc2b8eaf84832092444ab88b72551b