### PR TITLE
Expand video distribution dropdown size

### DIFF
--- a/index.html
+++ b/index.html
@@ -1078,7 +1078,7 @@
       </div>
       <div class="form-row">
         <label for="videoDistribution">Video distribution:</label>
-        <select id="videoDistribution" name="videoDistribution" multiple size="5">
+        <select id="videoDistribution" name="videoDistribution" multiple size="10">
           <option value="Directors Monitor 7&quot; handheld">Directors Monitor 7&quot; handheld</option>
           <option value="Gaffers Monitor 7&quot; handheld">Gaffers Monitor 7&quot; handheld</option>
           <option value="Directors Monitor 15-21 inch">Directors Monitor 15-21 inch</option>


### PR DESCRIPTION
## Summary
- increase visible options in video distribution dropdown to avoid scrolling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bc2c1cf8b4832093af50a6c5e9cbe0