### PR TITLE
Enable project update when no name change

### DIFF
--- a/script.js
+++ b/script.js
@@ -5769,6 +5769,9 @@ setupSelect.addEventListener("change", (event) => {
     }
     loadedSetupState = getCurrentSetupState();
   }
+  if (saveSetupBtn) {
+    saveSetupBtn.disabled = !setupNameInput.value.trim();
+  }
   updateCalculations();
   checkSetupChanged();
 });


### PR DESCRIPTION
## Summary
- Ensure save/update button enables when loading a setup with existing name

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bc36473d8c83209fe1f3a924b5720f