### PR TITLE
Enable saving shared setups without renaming

### DIFF
--- a/script.js
+++ b/script.js
@@ -8561,7 +8561,10 @@ function saveCurrentSession() {
 function restoreSessionState() {
   const state = loadSession();
   if (!state) return;
-  if (setupNameInput) setupNameInput.value = state.setupName || '';
+  if (setupNameInput) {
+    setupNameInput.value = state.setupName || '';
+    setupNameInput.dispatchEvent(new Event('input'));
+  }
   if (cameraSelect && state.camera) cameraSelect.value = state.camera;
   updateBatteryPlateVisibility();
   if (batteryPlateSelect && state.batteryPlate) batteryPlateSelect.value = state.batteryPlate;
@@ -8587,7 +8590,10 @@ function applySharedSetup(shared) {
     if (decoded.changedDevices) {
       applyDeviceChanges(decoded.changedDevices);
     }
-    if (setupNameInput && decoded.setupName) setupNameInput.value = decoded.setupName;
+    if (setupNameInput && decoded.setupName) {
+      setupNameInput.value = decoded.setupName;
+      setupNameInput.dispatchEvent(new Event('input'));
+    }
     if (cameraSelect && decoded.camera) cameraSelect.value = decoded.camera;
     updateBatteryPlateVisibility();
     if (batteryPlateSelect && decoded.batteryPlate) batteryPlateSelect.value = decoded.batteryPlate;

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -4287,6 +4287,16 @@ describe('script.js functions', () => {
     expect(nameInput.value).toBe('Shared Setup');
   });
 
+  test('Save button enables after applying shared setup', () => {
+    const data = { setupName: 'Shared Setup' };
+    const encoded = LZString.compressToEncodedURIComponent(JSON.stringify(data));
+    window.history.pushState({}, '', `/?shared=${encoded}`);
+    const saveBtn = document.getElementById('saveSetupBtn');
+    expect(saveBtn.disabled).toBe(true);
+    script.applySharedSetupFromUrl();
+    expect(saveBtn.disabled).toBe(false);
+  });
+
   test('applySharedSetupFromUrl applies device changes and feedback', () => {
     const payload = {
       camera: 'CamB',


### PR DESCRIPTION
## Summary
- Dispatch input event after programmatically setting project name so Save button activates automatically
- Cover shared setup save behavior with a test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bc3689b81c83208497545d10a2117f