### PR TITLE
Increase auto backup frequency

### DIFF
--- a/script.js
+++ b/script.js
@@ -5808,7 +5808,7 @@ function populateSetupSelect() {
 populateSetupSelect(); // Initial populate of setups
 checkSetupChanged();
 
-// Auto-save a backup project after 10 minutes if none selected. The timer is
+// Auto-save a backup project after 5 minutes if none selected. The timer is
 // long-lived and would keep Node's event loop active in tests or server-side
 // rendering scenarios. Calling `unref()` (when available) allows the process to
 // exit naturally without waiting for the timeout to fire.
@@ -5826,7 +5826,7 @@ const backupTimer = setTimeout(() => {
   if (setupNameInput) setupNameInput.value = backupName;
   loadedSetupState = getCurrentSetupState();
   checkSetupChanged();
-}, 10 * 60 * 1000);
+}, 5 * 60 * 1000);
 if (typeof backupTimer.unref === 'function') {
   backupTimer.unref();
 }

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -200,7 +200,7 @@ test('restores project requirements from legacy object storage', () => {
 });
 
 describe('auto backup', () => {
-  test('creates backup after 10 minutes when no project selected', () => {
+  test('creates backup after 5 minutes when no project selected', () => {
     setupDom(false);
     const stored = {};
     global.loadSetups = jest.fn(() => stored);
@@ -209,7 +209,7 @@ describe('auto backup', () => {
     require('../translations.js');
     const script = require('../script.js');
     script.setLanguage('en');
-    jest.advanceTimersByTime(10 * 60 * 1000);
+    jest.advanceTimersByTime(5 * 60 * 1000);
     expect(global.saveSetups).toHaveBeenCalled();
     const names = Object.keys(stored);
     expect(names.length).toBe(1);


### PR DESCRIPTION
## Summary
- autosave backup setups every 5 minutes instead of 10 when no project is loaded
- adjust backup timing test to match 5-minute interval

## Testing
- `NODE_OPTIONS=--max_old_space_size=4096 npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bc3cbe504483208cce2c498236d406