### PR TITLE
Ensure monitor cable inclusion

### DIFF
--- a/devices/gearList.js
+++ b/devices/gearList.js
@@ -535,6 +535,10 @@ const gear = {
           "type": "3G-SDI",
           "lengthM": 0.5
         },
+        "Ultraslim HDMI 0.5 m": {
+          "type": "HDMI",
+          "lengthM": 0.5
+        },
         "BNC Cable 0.5 m": {
           "type": "3G-SDI",
           "lengthM": 0.5
@@ -605,6 +609,17 @@ const gear = {
         },
         "D-Tap to Lemo-2-pin Cable 0,3m": {
           "lengthM": 0.3,
+          "connectors": [
+            "D-Tap",
+            "LEMO 2-pin"
+          ],
+          "orientation": "straight",
+          "useCase": [
+            "Power"
+          ]
+        },
+        "D-Tap to Lemo-2-pin Cable 0,5m": {
+          "lengthM": 0.5,
           "connectors": [
             "D-Tap",
             "LEMO 2-pin"

--- a/script.js
+++ b/script.js
@@ -7472,8 +7472,34 @@ function collectAccessories({ hasMotor = false, videoDistPrefs = [] } = {}) {
         });
     };
     gatherPower(devices.cameras[cameraSelect.value]);
-    gatherPower(devices.monitors[monitorSelect.value], monitoringSupport, true);
     gatherPower(devices.video[videoSelect.value]);
+    const onboardMonitor = devices.monitors[monitorSelect.value];
+    if (onboardMonitor) {
+        const monitorLabel = 'Onboard monitor';
+        const powerType = onboardMonitor?.power?.input?.type;
+        if (powerType === 'LEMO 2-pin') {
+            monitoringSupport.push(
+                `D-Tap to Lemo-2-pin Cable 0,5m (${monitorLabel})`,
+                `D-Tap to Lemo-2-pin Cable 0,5m (${monitorLabel})`
+            );
+        }
+        const cameraData = devices.cameras[cameraSelect.value];
+        const camVideo = (cameraData?.videoOutputs || []).map(v => v.type?.toUpperCase());
+        const monVideo = (onboardMonitor.videoInputs || []).map(v => v.type?.toUpperCase());
+        const hasSDI = camVideo.some(t => t && t.includes('SDI')) && monVideo.some(t => t && t.includes('SDI'));
+        const hasHDMI = camVideo.includes('HDMI') && monVideo.includes('HDMI');
+        if (hasSDI) {
+            monitoringSupport.push(
+                `Ultraslim BNC 0.5 m (${monitorLabel})`,
+                `Ultraslim BNC 0.5 m (${monitorLabel})`
+            );
+        } else if (hasHDMI) {
+            monitoringSupport.push(
+                `Ultraslim HDMI 0.5 m (${monitorLabel})`,
+                `Ultraslim HDMI 0.5 m (${monitorLabel})`
+            );
+        }
+    }
     if (videoSelect.value) {
         const rxName = videoSelect.value.replace(/ TX\b/, ' RX');
         if (devices.wirelessReceivers && devices.wirelessReceivers[rxName]) {

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -1472,9 +1472,15 @@ describe('script.js functions', () => {
     addOpt('monitorSelect', 'MonA');
     const html = generateGearListHtml();
     const msSection = html.slice(html.indexOf('<td>Monitoring support</td>'), html.indexOf('Power'));
-    expect(msSection).toContain('1x D-Tap to LEMO 2-pin');
+    expect(msSection).toContain(
+      '2x D-Tap to Lemo-2-pin Cable 0,5m (1x Onboard monitor, 1x Spare)'
+    );
+    expect(msSection).toContain(
+      '2x Ultraslim BNC 0.5 m (1x Onboard monitor, 1x Spare)'
+    );
     const miscSection = html.slice(html.indexOf('Miscellaneous'), html.indexOf('Consumables'));
-    expect(miscSection).not.toContain('D-Tap to LEMO 2-pin');
+    expect(miscSection).not.toContain('D-Tap to Lemo-2-pin Cable 0,5m');
+    expect(miscSection).not.toContain('Ultraslim BNC 0.5 m');
   });
 
   test('Directors handheld monitor adds dropdown, batteries and grip items', () => {


### PR DESCRIPTION
## Summary
- add 0.5 m ultraslim HDMI and D-Tap-to-Lemo-2-pin power cables to gear list
- supply onboard monitors with two 0.5 m power cables and matching video cables based on available ports
- update tests for new monitor cabling behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bc3daa7270832086322c63e2b18f53