### PR TITLE
Ensure gear list saves with project

### DIFF
--- a/script.js
+++ b/script.js
@@ -5651,6 +5651,9 @@ saveSetupBtn.addEventListener("click", () => {
   setupSelect.value = setupName; // Select the newly saved setup
   loadedSetupState = getCurrentSetupState();
   checkSetupChanged();
+  // Ensure the current gear list is persisted with the project so it can be
+  // restored even without a manual "Save Gear List" action.
+  saveCurrentGearList();
   alert(texts[currentLang].alertSetupSaved.replace("{name}", setupName));
 });
 

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -2842,6 +2842,18 @@ describe('script.js functions', () => {
     expect(saved.WithGear.gearList).toContain('<table>');
   });
 
+  test('saving setup triggers gear list save', () => {
+    global.saveGearList = jest.fn();
+    const gear = document.getElementById('gearListOutput');
+    gear.innerHTML = '<table></table>';
+    gear.classList.remove('hidden');
+    const nameInput = document.getElementById('setupName');
+    nameInput.value = 'WithGear';
+    nameInput.dispatchEvent(new Event('input', { bubbles: true }));
+    document.getElementById('saveSetupBtn').click();
+    expect(global.saveGearList).toHaveBeenCalled();
+  });
+
   test('Save button enables on input and Enter key saves setup', () => {
     const saveSpy = global.saveSetups;
     const nameInput = document.getElementById('setupName');


### PR DESCRIPTION
## Summary
- Persist gear list data when saving a project, without requiring a separate save
- Add test verifying setup saving triggers gear list storage

## Testing
- `npm run lint`
- `npm run check-consistency`
- `npx jest tests/unifyPorts.test.js tests/cliHelp.test.js tests/checkConsistency.test.js tests/parsePowerInputCache.test.js tests/service-worker.test.js tests/cages.test.js tests/index.test.js tests/utils.test.js`
- `npx jest tests/script.test.js -t 'saving setup triggers gear list save'`

------
https://chatgpt.com/codex/tasks/task_e_68bc40b3356083208f75505b2ec3a272