### PR TITLE
Fix camera support mount output

### DIFF
--- a/script.js
+++ b/script.js
@@ -7643,7 +7643,6 @@ function generateGearListHtml(info = {}) {
             .filter(Boolean),
         distance: distanceSelect && distanceSelect.value && distanceSelect.value !== 'None' ? getText(distanceSelect) : '',
         cage: cageSelect && cageSelect.value && cageSelect.value !== 'None' ? getText(cageSelect) : '',
-        batteryPlate: batteryPlateSelect && batteryPlateSelect.value && batteryPlateSelect.value !== 'None' ? getText(batteryPlateSelect) : '',
         battery: batterySelect && batterySelect.value && batterySelect.value !== 'None' ? getText(batterySelect) : ''
     };
     const hasMotor = selectedNames.motors.length > 0;
@@ -7907,8 +7906,7 @@ function generateGearListHtml(info = {}) {
         rows.push(`<tr><td>${items}</td></tr>`);
     };
     addRow('Camera', formatItems([selectedNames.camera]));
-    const cameraSupportItems = [selectedNames.batteryPlate, ...supportAccNoCages];
-    const cameraSupportText = formatItems(cameraSupportItems);
+    const cameraSupportText = formatItems(supportAccNoCages);
     let cageSelectHtml = '';
     if (compatibleCages.length) {
         const options = compatibleCages.map(c => `<option value="${escapeHtml(c)}"${c === selectedNames.cage ? ' selected' : ''}>${escapeHtml(addArriKNumber(c))}</option>`).join('');

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -1763,6 +1763,7 @@ describe('script.js functions', () => {
     let csSection = html.slice(html.indexOf('Camera Support'), html.indexOf('Lens Support'));
     let battSection = html.slice(html.indexOf('Camera Batteries'), html.indexOf('Monitoring Batteries'));
     expect(csSection).not.toContain('Hotswap Plate');
+    expect(csSection).not.toContain('data-gear-name="V-Mount"');
     expect(battSection).toContain('1x Hotswap Plate V-Mount');
     // B-Mount battery
     devices.batteries.BattB = { capacity: 100, pinA: 10, dtapA: 5, mount_type: 'B-Mount' };
@@ -1771,6 +1772,7 @@ describe('script.js functions', () => {
     csSection = html.slice(html.indexOf('Camera Support'), html.indexOf('Lens Support'));
     battSection = html.slice(html.indexOf('Camera Batteries'), html.indexOf('Monitoring Batteries'));
     expect(csSection).not.toContain('Hotswap Plate');
+    expect(csSection).not.toContain('data-gear-name="B-Mount"');
     expect(battSection).toContain('1x Hotswap Plate B-Mount');
   });
 


### PR DESCRIPTION
## Summary
- avoid listing raw battery mount types as camera support items
- update tests to ensure battery mounts stay in battery section

## Testing
- `npx jest tests/script.test.js -t "gear list adds hotswap plate only in battery section"`

------
https://chatgpt.com/codex/tasks/task_e_68bc4b53df988320bc2a24a027910232