### PR TITLE
fix: persist saved gear list after reload

### DIFF
--- a/script.js
+++ b/script.js
@@ -1762,6 +1762,7 @@ const runtimeFeedbackBtn = document.getElementById("runtimeFeedbackBtn");
 const generateGearListBtn = document.getElementById("generateGearListBtn");
 const gearListOutput = document.getElementById("gearListOutput");
 const projectRequirementsOutput = document.getElementById("projectRequirementsOutput");
+let skipNextGearListRefresh = false;
 
 function setEditProjectBtnText() {
   const btn = document.getElementById('editProjectBtn');
@@ -1911,6 +1912,7 @@ if (gearListOutput || projectRequirementsOutput) {
   const storedGearList = typeof loadGearList === 'function' ? loadGearList() : '';
   if (storedGearList) {
     displayGearAndRequirements(storedGearList);
+    skipNextGearListRefresh = true;
     if (gearListOutput) {
       ensureGearListActions();
       bindGearListCageListener();
@@ -5773,6 +5775,7 @@ setupSelect.addEventListener("change", (event) => {
       updateBatteryOptions();
       if (gearListOutput) {
         displayGearAndRequirements(setup.gearList || '');
+        skipNextGearListRefresh = true;
         if (setup.gearList) {
           ensureGearListActions();
       bindGearListCageListener();
@@ -8403,6 +8406,7 @@ function handleImportGearList(e) {
             const obj = JSON.parse(ev.target.result);
             if (obj && obj.gearList) {
             displayGearAndRequirements(obj.gearList);
+            skipNextGearListRefresh = true;
             ensureGearListActions();
             bindGearListCageListener();
             bindGearListEasyrigListener();
@@ -8544,6 +8548,10 @@ function bindGearListDirectorsMonitorListener() {
 
 function refreshGearListIfVisible() {
     if (!gearListOutput || gearListOutput.classList.contains('hidden')) return;
+    if (skipNextGearListRefresh) {
+        skipNextGearListRefresh = false;
+        return;
+    }
 
     if (projectForm) {
         populateRecordingResolutionDropdown(currentProjectInfo && currentProjectInfo.recordingResolution);
@@ -9490,6 +9498,7 @@ if (typeof module !== "undefined" && module.exports) {
     autoSaveCurrentSetup,
     displayGearAndRequirements,
     ensureGearListActions,
+    refreshGearListIfVisible,
     populateLensDropdown,
     populateCameraPropertyDropdown,
     populateRecordingResolutionDropdown,

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -612,6 +612,20 @@ describe('script.js functions', () => {
     expect(global.saveGearList).toHaveBeenCalled();
   });
 
+  test('restored gear list persists through initial refresh', () => {
+    const savedHtml = '<h3>Gear List</h3><table class="gear-table"><tr><td>SavedCam</td></tr></table>';
+    require('../translations.js');
+    global.loadGearList = jest.fn(() => savedHtml);
+    global.saveGearList = jest.fn();
+    const script = require('../script.js');
+    const gear = document.getElementById('gearListOutput');
+    expect(gear.innerHTML).toContain('SavedCam');
+    expect(global.saveGearList).not.toHaveBeenCalled();
+    script.refreshGearListIfVisible();
+    expect(global.saveGearList).toHaveBeenCalled();
+    expect(gear.innerHTML).not.toContain('SavedCam');
+  });
+
   test('generate gear list hides button until deleted', () => {
     const addOpt = (id, value) => {
       const sel = document.getElementById(id);


### PR DESCRIPTION
## Summary
- prevent initial refresh from overwriting saved gear list
- test that saved gear list survives initial render

## Testing
- `npm run lint`
- `NODE_OPTIONS=--max_old_space_size=4096 npm test` *(fails: Expected substring "Wireless Receiver</strong> - 7" - VidA RX (1x Directors handheld, 1x Focus)")*

------
https://chatgpt.com/codex/tasks/task_e_68bc4d64351483209365a74ed2e075bb