### PR TITLE
Ensure project requirements persist with saved gear list

### DIFF
--- a/script.js
+++ b/script.js
@@ -8587,30 +8587,29 @@ function autoSaveCurrentSetup() {
 
 function restoreSessionState() {
   const state = loadSession();
-  if (!state) {
-    return;
+  if (state) {
+    if (setupNameInput) {
+      setupNameInput.value = state.setupName || '';
+      setupNameInput.dispatchEvent(new Event('input'));
+    }
+    if (cameraSelect && state.camera) cameraSelect.value = state.camera;
+    updateBatteryPlateVisibility();
+    if (batteryPlateSelect && state.batteryPlate) batteryPlateSelect.value = state.batteryPlate;
+    updateBatteryOptions();
+    if (monitorSelect && state.monitor) monitorSelect.value = state.monitor;
+    if (videoSelect && state.video) videoSelect.value = state.video;
+    if (cageSelect && state.cage) cageSelect.value = state.cage;
+    if (distanceSelect && state.distance) distanceSelect.value = state.distance;
+    if (Array.isArray(state.motors)) {
+      state.motors.forEach((val, i) => { if (motorSelects[i]) motorSelects[i].value = val; });
+    }
+    if (Array.isArray(state.controllers)) {
+      state.controllers.forEach((val, i) => { if (controllerSelects[i]) controllerSelects[i].value = val; });
+    }
+    if (batterySelect && state.battery) batterySelect.value = state.battery;
+    setSliderBowlValue(state.sliderBowl);
+    if (setupSelect && state.setupSelect) setupSelect.value = state.setupSelect;
   }
-  if (setupNameInput) {
-    setupNameInput.value = state.setupName || '';
-    setupNameInput.dispatchEvent(new Event('input'));
-  }
-  if (cameraSelect && state.camera) cameraSelect.value = state.camera;
-  updateBatteryPlateVisibility();
-  if (batteryPlateSelect && state.batteryPlate) batteryPlateSelect.value = state.batteryPlate;
-  updateBatteryOptions();
-  if (monitorSelect && state.monitor) monitorSelect.value = state.monitor;
-  if (videoSelect && state.video) videoSelect.value = state.video;
-  if (cageSelect && state.cage) cageSelect.value = state.cage;
-  if (distanceSelect && state.distance) distanceSelect.value = state.distance;
-  if (Array.isArray(state.motors)) {
-    state.motors.forEach((val, i) => { if (motorSelects[i]) motorSelects[i].value = val; });
-  }
-  if (Array.isArray(state.controllers)) {
-    state.controllers.forEach((val, i) => { if (controllerSelects[i]) controllerSelects[i].value = val; });
-  }
-  if (batterySelect && state.battery) batterySelect.value = state.battery;
-  setSliderBowlValue(state.sliderBowl);
-  if (setupSelect && state.setupSelect) setupSelect.value = state.setupSelect;
   if (gearListOutput || projectRequirementsOutput) {
     const storedGearList = typeof loadGearList === 'function' ? loadGearList() : '';
     if (storedGearList) {

--- a/script.js
+++ b/script.js
@@ -1829,15 +1829,17 @@ function splitGearListHtml(html) {
     html = html.gearList || '';
   }
   const doc = new DOMParser().parseFromString(html, 'text/html');
-  const title = doc.querySelector('h2');
-  const h3s = doc.querySelectorAll('h3');
-  const reqHeading = h3s[0];
-  const gearHeading = h3s.length > 1 ? h3s[1] : h3s[0];
+  const titleHtml = doc.querySelector('h2')?.outerHTML || '';
   const reqGrid = doc.querySelector('.requirements-grid');
+  const projectHeading = reqGrid ? reqGrid.previousElementSibling : doc.querySelector('h3');
+  const projectHtml = reqGrid
+    ? titleHtml + (projectHeading ? projectHeading.outerHTML : '') + reqGrid.outerHTML
+    : '';
   const table = doc.querySelector('.gear-table');
-  const titleHtml = title ? title.outerHTML : '';
-  const projectHtml = reqHeading && reqGrid ? titleHtml + reqHeading.outerHTML + reqGrid.outerHTML : '';
-  const gearHtml = table ? titleHtml + (gearHeading ? gearHeading.outerHTML : '') + table.outerHTML : '';
+  const gearHeading = table ? table.previousElementSibling : null;
+  const gearHtml = table
+    ? titleHtml + (gearHeading ? gearHeading.outerHTML : '') + table.outerHTML
+    : '';
   return { projectHtml, gearHtml };
 }
 
@@ -8586,17 +8588,6 @@ function autoSaveCurrentSetup() {
 function restoreSessionState() {
   const state = loadSession();
   if (!state) {
-    if (gearListOutput) {
-      gearListOutput.innerHTML = '';
-      gearListOutput.classList.add('hidden');
-    }
-    if (projectRequirementsOutput) {
-      projectRequirementsOutput.innerHTML = '';
-      projectRequirementsOutput.classList.add('hidden');
-    }
-    if (typeof deleteGearList === 'function') {
-      deleteGearList();
-    }
     return;
   }
   if (setupNameInput) {


### PR DESCRIPTION
## Summary
- Improve HTML parsing when splitting saved gear list content to reliably extract project requirements and gear data
- Avoid clearing stored gear list and project requirements when no session state exists

## Testing
- `NODE_OPTIONS=--max-old-space-size=4096 npm test 2>&1 | tail -n 50 | grep -v 'Received string' | tail -n 20`
- `NODE_OPTIONS=--max-old-space-size=4096 npx jest tests/script.test.js -t 'restores project requirements' 2>&1 | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68bc5053b0b483208f8f5de9299a43bb