### PR TITLE
Replace Sandsack with sand bag

### DIFF
--- a/script.js
+++ b/script.js
@@ -8096,8 +8096,8 @@ function generateGearListHtml(info = {}) {
         gripItems.push('Apple Box Set / Bühnenkisten Set');
         gripItems.push('Apple Box Set / Bühnenkisten Set');
         gripItems.push('Satz Paganinis');
-        gripItems.push('Sandsack');
-        gripItems.push('Sandsack');
+        gripItems.push('sand bag');
+        gripItems.push('sand bag');
         gripItems.push('Bodenmatte');
         gripItems.push('Bodenmatte');
         gripItems.push('Bodenmatte');
@@ -8144,10 +8144,10 @@ function generateGearListHtml(info = {}) {
             gripItems.push(base);
         }
         if (t === 'Frog Tripod') {
-            gripItems.push('Sandsack (for Frog Tripod)');
+            gripItems.push('sand bag (for Frog Tripod)');
         }
         if (t === 'Hi-Head') {
-            gripItems.push('Sandsack (for Hi-Head)');
+            gripItems.push('sand bag (for Hi-Head)');
         }
     });
     const standCount = gripItems.filter(item => /\bstand\b/i.test(item)).length;

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -2115,7 +2115,7 @@ describe('script.js functions', () => {
     expect(text).toContain('2x Avenger Combo Stand 20 A1020B 110-198 cm black');
     expect(text).toContain('2x Apple Box Set / Bühnenkisten Set');
     expect(text).toContain('1x Satz Paganinis');
-    expect(text).toContain('2x Sandsack');
+    expect(text).toContain('2x sand bag');
     expect(text).toContain('3x Bodenmatte');
     expect(text).toContain('12x Tennisball');
   });
@@ -2165,7 +2165,7 @@ describe('script.js functions', () => {
     expect(text).toContain('1x 100mm bowl Standard Tripod + Mid-Level Spreader');
     expect(text).toContain('1x 100mm bowl Frog Tripod + Mid-Level Spreader');
     expect(text).toContain('1x 100mm bowl Hi-Head');
-    expect(text).toContain('2x Sandsack (1x for Frog Tripod, 1x for Hi-Head)');
+    expect(text).toContain('2x sand bag (1x for Frog Tripod, 1x for Hi-Head)');
   });
 
   test('Easyrig scenario adds stabiliser with dropdown options', () => {


### PR DESCRIPTION
## Summary
- replace German term "Sandsack" with "sand bag" in generated grip items
- update tests to expect "sand bag"

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bc72a936188320ac09aea5f6342c47