### PR TITLE
Include gear list in exported project data

### DIFF
--- a/storage.js
+++ b/storage.js
@@ -341,6 +341,7 @@ function exportAllData() {
     setups: loadSetups(),
     session: loadSessionState(),
     feedback: loadFeedback(),
+    gearList: loadGearList(),
   };
 }
 
@@ -357,6 +358,9 @@ function importAllData(allData) {
     }
     if (allData.feedback) {
       saveFeedback(allData.feedback);
+    }
+    if (typeof allData.gearList === "string") {
+      saveGearList(allData.gearList);
     }
   }
 }

--- a/tests/storage.test.js
+++ b/tests/storage.test.js
@@ -12,6 +12,7 @@ const {
     loadFeedback,
     saveFeedback,
     saveGearList,
+    loadGearList,
     clearAllData,
     exportAllData,
     importAllData,
@@ -278,11 +279,13 @@ describe('export/import all data', () => {
     saveSetups({ A: { foo: 1 } });
     saveSessionState({ camera: 'CamA' });
     saveFeedback({ note: 'hi' });
+    saveGearList('<ul></ul>');
     expect(exportAllData()).toEqual({
       devices: validDeviceData,
       setups: { A: { foo: 1 } },
       session: { camera: 'CamA' },
-      feedback: { note: 'hi' }
+      feedback: { note: 'hi' },
+      gearList: '<ul></ul>'
     });
   });
 
@@ -291,13 +294,15 @@ describe('export/import all data', () => {
       devices: validDeviceData,
       setups: { A: { foo: 1 } },
       session: { camera: 'CamA' },
-      feedback: { note: 'hi' }
+      feedback: { note: 'hi' },
+      gearList: '<ol></ol>'
     };
     importAllData(data);
     expect(loadDeviceData()).toEqual(validDeviceData);
     expect(loadSetups()).toEqual({ A: { foo: 1 } });
     expect(loadSessionState()).toEqual({ camera: 'CamA' });
     expect(loadFeedback()).toEqual({ note: 'hi' });
+    expect(loadGearList()).toBe('<ol></ol>');
   });
 });
 


### PR DESCRIPTION
## Summary
- Include gear list when exporting/importing full project data
- Test export/import helpers with gear list persistence

## Testing
- `NODE_OPTIONS=--max_old_space_size=4096 npm test` *(fails: script.js functions › gear list separates multiple items with line breaks)*

------
https://chatgpt.com/codex/tasks/task_e_68bc73056bc483209b2c8b4e9460341e