### PR TITLE
Ensure only one spigot per handheld monitor

### DIFF
--- a/script.js
+++ b/script.js
@@ -8092,7 +8092,6 @@ function generateGearListHtml(info = {}) {
         gripItems.push(`Steelfingers Wheel C-Stand 3er Set (${p.role} handheld)`);
         gripItems.push(`Lite-Tite Swivel Aluminium Umbrella Adapter (${p.role} handheld)`);
         riggingAcc.push(`spigot with male 3/8" and 1/4" (${p.role} handheld)`);
-        riggingAcc.push(`spigot with male 3/8" and 1/4" (${p.role} handheld)`);
     });
     largeMonitorPrefs.forEach(p => {
         gripItems.push(`Matthews Monitor Stand II (249562) (${p.role} 15-21")`);

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -1514,7 +1514,7 @@ describe('script.js functions', () => {
     expect(html).toContain('Steelfingers Wheel C-Stand 3er Set (1x Directors handheld)');
     expect(html).toContain('Lite-Tite Swivel Aluminium Umbrella Adapter (1x Directors handheld)');
     const rigSection = html.slice(html.indexOf('Rigging'), html.indexOf('Power'));
-    expect(rigSection).toContain('5x spigot with male 3/8" and 1/4" (1x Directors handheld, 4x Spare)');
+    expect(rigSection).toContain('4x spigot with male 3/8" and 1/4" (1x Directors handheld, 3x Spare)');
     const gripSection = html.slice(html.indexOf('Grip'), html.indexOf('Carts and Transportation'));
     expect(gripSection).not.toContain('spigot with male 3/8" and 1/4"');
     expect(html).toContain('3x Tennisball');
@@ -1542,7 +1542,7 @@ describe('script.js functions', () => {
     expect(html).toContain('Steelfingers Wheel C-Stand 3er Set (1x Gaffers handheld)');
     expect(html).toContain('Lite-Tite Swivel Aluminium Umbrella Adapter (1x Gaffers handheld)');
     const rigSection = html.slice(html.indexOf('Rigging'), html.indexOf('Power'));
-    expect(rigSection).toContain('5x spigot with male 3/8" and 1/4" (1x Gaffers handheld, 4x Spare)');
+    expect(rigSection).toContain('4x spigot with male 3/8" and 1/4" (1x Gaffers handheld, 3x Spare)');
     const msSection = html.slice(html.indexOf('<td>Monitoring support</td>'), html.indexOf('Power'));
     expect(msSection).toContain('2x Ultraslim BNC 0.3 m (1x Gaffers handheld, 1x Spare)');
     expect(msSection).toContain('2x D-Tap to Lemo-2-pin Cable 0,3m (1x Gaffers handheld, 1x Spare)');
@@ -1562,7 +1562,7 @@ describe('script.js functions', () => {
     expect(html).toContain('Steelfingers Wheel C-Stand 3er Set (1x DoP handheld)');
     expect(html).toContain('Lite-Tite Swivel Aluminium Umbrella Adapter (1x DoP handheld)');
     const rigSection = html.slice(html.indexOf('Rigging'), html.indexOf('Power'));
-    expect(rigSection).toContain('5x spigot with male 3/8" and 1/4" (1x DoP handheld, 4x Spare)');
+    expect(rigSection).toContain('4x spigot with male 3/8" and 1/4" (1x DoP handheld, 3x Spare)');
     const msSection = html.slice(html.indexOf('<td>Monitoring support</td>'), html.indexOf('Power'));
     expect(msSection).toContain('2x Ultraslim BNC 0.3 m (1x DoP handheld, 1x Spare)');
     expect(msSection).toContain('2x D-Tap to Lemo-2-pin Cable 0,3m (1x DoP handheld, 1x Spare)');


### PR DESCRIPTION
## Summary
- Remove duplicate spigot entries for handheld monitors
- Update tests to expect a single spigot per monitor and adjusted spare counts

## Testing
- `NODE_OPTIONS=--max-old-space-size=4096 npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc725202c483208705049255b94027