### PR TITLE
Merge duplicate monitoring batteries

### DIFF
--- a/script.js
+++ b/script.js
@@ -7999,16 +7999,15 @@ function generateGearListHtml(info = {}) {
     }
     addRow('Camera Batteries', batteryItems);
     let monitoringBatteryItems = [];
-    const addV98 = () => {
-        const bebob98 = Object.keys(devices.batteries || {}).find(n => /V98micro/i.test(n)) || 'Bebob V98micro';
-        monitoringBatteryItems.push(`3x ${escapeHtml(bebob98)}`);
-    };
-    handheldPrefs.forEach(() => addV98());
+    const bebob98 = Object.keys(devices.batteries || {}).find(n => /V98micro/i.test(n)) || 'Bebob V98micro';
+    handheldPrefs.forEach(() => {
+        monitoringBatteryItems.push(bebob98, bebob98, bebob98);
+    });
     if (hasMotor) {
         const bebob150 = Object.keys(devices.batteries || {}).find(n => /V150micro/i.test(n)) || 'Bebob V150micro';
-        monitoringBatteryItems.push(`3x ${escapeHtml(bebob150)}`);
+        monitoringBatteryItems.push(bebob150, bebob150, bebob150);
     }
-    addRow('Monitoring Batteries', monitoringBatteryItems.join('<br>'));
+    addRow('Monitoring Batteries', formatItems(monitoringBatteryItems));
     addRow('Chargers', formatItems(chargersAcc));
     let monitoringItems = '';
     const monitorSizes = [];

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -1568,6 +1568,21 @@ describe('script.js functions', () => {
     expect(msSection).toContain('2x D-Tap to Lemo-2-pin Cable 0,3m (1x DoP handheld, 1x Spare)');
   });
 
+  test('merges monitoring batteries across multiple handheld monitors', () => {
+    setupDom();
+    script = require('../script.js');
+    const { generateGearListHtml } = script;
+    const videoDistribution = [
+      'Directors Monitor handheld',
+      'Gaffers Monitor handheld',
+      'DoP Monitor handheld',
+      'Directors Monitor handheld'
+    ].join(', ');
+    const html = generateGearListHtml({ videoDistribution });
+    expect(html).toContain('12x Bebob V98micro');
+    expect(html).not.toContain('3x Bebob V98micro');
+  });
+
   test('Directors 15-21" monitor adds dropdown and accessories', () => {
     const { generateGearListHtml } = script;
     global.devices.directorMonitors = {


### PR DESCRIPTION
## Summary
- aggregate monitoring batteries to combine counts like other accessories
- add regression test for merging battery entries across multiple handheld monitors

## Testing
- `npm run lint`
- `npm run check-consistency`
- `npx jest tests/script.test.js -t 'merges monitoring batteries'`
- `npm test` *(fails: Jest worker ran out of memory and crashed)*

------
https://chatgpt.com/codex/tasks/task_e_68bc7910c9f88320b33f61a7613956cb