### PR TITLE
Increase Jest worker memory limit

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -3,5 +3,6 @@ module.exports = {
   setupFiles: ['jest-localstorage-mock'],
   moduleNameMapper: {
     '^lz-string$': '<rootDir>/tests/__mocks__/lz-string.js'
-  }
+  },
+  workerIdleMemoryLimit: '1GB'
 };

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "lint": "eslint .",
     "check-consistency": "node checkConsistency.js",
     "normalize": "node normalizeData.js",
-    "test": "npm run lint && npm run check-consistency && jest"
+    "test": "npm run lint && npm run check-consistency && node --max-old-space-size=4096 node_modules/.bin/jest"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- allow Jest workers to use up to 1GB before recycling
- expand Node heap to 4GB when running tests

## Testing
- `npm test` *(hangs after script.test.js; 9/10 suites passed)*

------
https://chatgpt.com/codex/tasks/task_e_68bc7b043bf88320846ca6b633f60daf