### PR TITLE
Increase Jest memory limit for tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "lint": "eslint .",
     "check-consistency": "node checkConsistency.js",
     "normalize": "node normalizeData.js",
-    "test": "npm run lint && npm run check-consistency && jest"
+    "test": "npm run lint && npm run check-consistency && node --max-old-space-size=4096 node_modules/.bin/jest"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- raise Node memory limit in npm test script to prevent Jest OOM crashes

## Testing
- `npm run lint`
- `npm run check-consistency`
- `node --max-old-space-size=4096 node_modules/.bin/jest`


------
https://chatgpt.com/codex/tasks/task_e_68bc7b8d7e2c8320b60f447bdbae8fb7