### PR TITLE
Ensure project requirements persist across reloads

### DIFF
--- a/script.js
+++ b/script.js
@@ -1977,6 +1977,10 @@ if (projectForm) {
         sel.addEventListener('change', () => updateSelectIconBoxes(sel));
         updateSelectIconBoxes(sel);
     });
+
+    projectForm.querySelectorAll('input, textarea, select').forEach(el => {
+        el.addEventListener('change', saveCurrentSession);
+    });
 }
 
 let manualPositions = {};

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -214,6 +214,21 @@ test('restores project requirements form from saved gear list', () => {
   expect(projName.value).toBe('Proj');
 });
 
+test('project requirements changes persist via session save', () => {
+  setupDom(false);
+  global.loadSessionState = jest.fn(() => null);
+  const savedState = {};
+  global.saveSessionState = jest.fn(state => Object.assign(savedState, state));
+  global.saveGearList = jest.fn();
+  require('../translations.js');
+  const script = require('../script.js');
+  script.setLanguage('en');
+  const nameInput = document.getElementById('projectName');
+  nameInput.value = 'Proj';
+  nameInput.dispatchEvent(new Event('change', { bubbles: true }));
+  expect(savedState.projectInfo.projectName).toBe('Proj');
+});
+
 describe('auto backup', () => {
   test('creates backup after 5 minutes when no project selected', () => {
     setupDom(false);


### PR DESCRIPTION
## Summary
- auto-save project requirement form changes into session state
- cover auto-save with new test

## Testing
- `npx jest tests/script.test.js -t "project requirements changes persist via session save" --runInBand`
- `npm test` *(fails: Jest worker ran out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_68bc7b35dfd08320bcc727c5ae3a7ea2