### PR TITLE
chore: silence missing lens warning

### DIFF
--- a/script.js
+++ b/script.js
@@ -9497,7 +9497,6 @@ function populateLensDropdown() {
   const lensData = devices && devices.lenses;
 
   if (!lensData || Object.keys(lensData).length === 0) {
-    console.warn('No lens data available to populate dropdown');
     return;
   }
 


### PR DESCRIPTION
## Summary
- suppress lens dropdown warning when no lens data exists to avoid noisy logs

## Testing
- `CI=true npx jest tests/script.test.js --runInBand --forceExit --testNamePattern='unifyDevices normalizes videoOutputs' --verbose`
- `CI=true npx jest tests/script.test.js --runInBand --forceExit` *(fails: command produced no output after extended wait)*

------
https://chatgpt.com/codex/tasks/task_e_68bc82bf693883208d273f2e0a1eb2bb