### PR TITLE
Add ULCS arm for onboard monitors

### DIFF
--- a/script.js
+++ b/script.js
@@ -7511,6 +7511,7 @@ function collectAccessories({ hasMotor = false, videoDistPrefs = [] } = {}) {
                 `Ultraslim HDMI 0.5 m (${monitorLabel})`
             );
         }
+        rigging.push(`ULCS Arm mit 3/8" und 1/4" double (${monitorLabel})`);
     }
     if (videoSelect.value) {
         const rxName = videoSelect.value.replace(/ TX\b/, ' RX');

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -1586,6 +1586,20 @@ describe('script.js functions', () => {
     expect(miscSection).not.toContain('Ultraslim BNC 0.5 m');
   });
 
+  test('onboard monitor adds ULCS arm to rigging', () => {
+    const { generateGearListHtml } = script;
+    const addOpt = (id, value) => {
+      const sel = document.getElementById(id);
+      sel.innerHTML = `<option value="${value}">${value}</option>`;
+      sel.value = value;
+    };
+    addOpt('cameraSelect', 'CamA');
+    addOpt('monitorSelect', 'MonA');
+    const html = generateGearListHtml();
+    const rigSection = html.slice(html.indexOf('Rigging'), html.indexOf('Power'));
+    expect(rigSection).toContain('1x ULCS Arm mit 3/8" und 1/4" double (1x Onboard monitor)');
+  });
+
   test('Directors 7" handheld monitor adds dropdown, batteries and grip items', () => {
     const { generateGearListHtml } = script;
     global.devices.monitors = {


### PR DESCRIPTION
## Summary
- Include ULCS Arm mit 3/8" und 1/4" double with every onboard monitor
- Test ULCS arm presence in rigging section

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bc88a10c048320a077e9cc9db705fc