### PR TITLE
Add standard tripod legs for Jib scenario

### DIFF
--- a/script.js
+++ b/script.js
@@ -8164,6 +8164,7 @@ function generateGearListHtml(info = {}) {
         ...Array(20).fill('Airliner Ösen')
     ];
     const gripItems = [];
+    let needsStandardTripod = false;
     let sliderSelectHtml = '';
     let easyrigSelectHtml = '';
     handheldPrefs.forEach(p => {
@@ -8211,6 +8212,7 @@ function generateGearListHtml(info = {}) {
     if (scenarios.includes('Jib')) {
         gripItems.push('Pro Sup EJIb-Arm');
         gripItems.push('jib counter weights');
+        needsStandardTripod = true;
     }
     if (scenarios.includes('Slider')) {
         const options = ['', '75er bowl', '100er bowl', '150er bowl', 'Mitchell Mount'].map(o => `<option value="${escapeHtml(o)}"${o === info.sliderBowl ? ' selected' : ''}>${escapeHtml(addArriKNumber(o))}</option>`).join('');
@@ -8276,6 +8278,9 @@ function generateGearListHtml(info = {}) {
             gripItems.push('sand bag (for Hi-Head)');
         }
     });
+    if (needsStandardTripod && !gripItems.some(item => /Standard Tripod/.test(item))) {
+        gripItems.push('Standard Tripod');
+    }
     const standCount = gripItems.filter(item => /\bstand\b/i.test(item) && !/wheel/i.test(item)).length;
     if (standCount) {
         gripItems.push(...Array(standCount * 3).fill('Tennisball'));

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -2303,7 +2303,7 @@ describe('script.js functions', () => {
     });
   });
 
-  test('Jib scenario adds EJib Arm and counter weights', () => {
+  test('Jib scenario adds EJib Arm, counter weights, and tripod legs', () => {
     const { generateGearListHtml } = script;
     const html = generateGearListHtml({ requiredScenarios: 'Jib' });
     const wrap = document.createElement('div');
@@ -2313,6 +2313,22 @@ describe('script.js functions', () => {
     const text = rows[gripIdx + 1].textContent;
     expect(text).toContain('1x Pro Sup EJIb-Arm');
     expect(text).toContain('1x jib counter weights');
+    expect(text).toContain('1x Standard Tripod');
+  });
+
+  test('Tripod legs for Jib are not duplicated when Tripod selected', () => {
+    const { generateGearListHtml } = script;
+    const html = generateGearListHtml({
+      requiredScenarios: 'Jib, Tripod',
+      tripodTypes: 'Standard Tripod'
+    });
+    const wrap = document.createElement('div');
+    wrap.innerHTML = html;
+    const rows = Array.from(wrap.querySelectorAll('.gear-table tr'));
+    const gripIdx = rows.findIndex(r => r.textContent === 'Grip');
+    const text = rows[gripIdx + 1].textContent;
+    const matches = text.match(/Standard Tripod/g) || [];
+    expect(matches.length).toBe(1);
   });
 
 


### PR DESCRIPTION
## Summary
- Add automatic inclusion of standard tripod legs when the Jib scenario is selected
- Avoid duplicate tripod legs if a standard tripod is already chosen via tripod preferences
- Test coverage for new Jib tripod behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc94df2fe88320b0616921dc217a39