### PR TITLE
feat: add customizable focus monitor

### DIFF
--- a/devices/monitors.js
+++ b/devices/monitors.js
@@ -1001,6 +1001,26 @@ const monitorData = {
       }
     ]
   },
+  "TV Logic F7HS": {
+    "screenSizeInches": 7,
+    "brightnessNits": 1800,
+    "powerDrawWatts": 24,
+    "power": {
+      "input": {
+        "voltageRange": "12-24",
+        "type": "Mini XLR 3-pin"
+      },
+      "output": null
+    },
+    "wirelessTx": false,
+    "videoInputs": [
+      { "type": "HDMI" },
+      { "type": "3G-SDI" }
+    ],
+    "videoOutputs": [
+      { "type": "3G-SDI" }
+    ]
+  },
   "TVLogic F-7H mkII": {
     "screenSizeInches": 7,
     "brightnessNits": 3600,

--- a/script.js
+++ b/script.js
@@ -8132,8 +8132,18 @@ function generateGearListHtml(info = {}) {
         if (size) monitorSizes.push(size);
     });
     if (hasMotor) {
-        monitoringItems += (monitoringItems ? '<br>' : '') + '1x <strong>Focus Monitor</strong> - 7&quot; - TV Logic F7HS incl Directors cage, shoulder strap, sunhood, rigging for teradeks';
-        monitorSizes.push(7);
+        const monitorsDb = devices && devices.monitors ? devices.monitors : {};
+        const names = Object.keys(monitorsDb)
+            .filter(n => (!monitorsDb[n].wirelessTx || monitorsDb[n].wirelessRX))
+            .sort(localeSort);
+        const defaultName = names.includes('TV Logic F7HS') ? 'TV Logic F7HS' : names[0];
+        const opts = names
+            .map(n => `<option value="${escapeHtml(n)}"${n === defaultName ? ' selected' : ''}>${escapeHtml(addArriKNumber(n))}</option>`)
+            .join('');
+        const selectedSize = monitorsDb[defaultName]?.screenSizeInches || '';
+        monitoringItems += (monitoringItems ? '<br>' : '') +
+            `1x <strong>Focus Monitor</strong> - <span id="monitorSizeFocus">${selectedSize}&quot;</span> - <select id="gearListFocusMonitor">${opts}</select> incl Directors cage, shoulder strap, sunhood, rigging for teradeks`;
+        if (selectedSize) monitorSizes.push(selectedSize);
     }
     const monitoringGear = [];
     const wirelessSize = monitorSizes.includes(5) ? 5 : 7;
@@ -8430,6 +8440,20 @@ function getCurrentGearListHtml() {
         if (editBtn) editBtn.remove();
         const t = clone.querySelector('h2');
         if (t) t.remove();
+        ['Directors', 'Dop', 'Gaffers', 'Focus'].forEach(role => {
+            const sel = clone.querySelector(`#gearList${role}Monitor`);
+            if (sel) {
+                const originalSel = gearListOutput.querySelector(`#gearList${role}Monitor`);
+                const val = originalSel ? originalSel.value : sel.value;
+                Array.from(sel.options).forEach(opt => {
+                    if (opt.value === val) {
+                        opt.setAttribute('selected', '');
+                    } else {
+                        opt.removeAttribute('selected');
+                    }
+                });
+            }
+        });
         const cageSel = clone.querySelector('#gearListCage');
         if (cageSel) {
             const originalSel = gearListOutput.querySelector('#gearListCage');
@@ -8646,7 +8670,7 @@ function bindGearListSliderBowlListener() {
 
 function bindGearListDirectorsMonitorListener() {
     if (!gearListOutput) return;
-    ['Directors', 'Dop', 'Gaffers'].forEach(role => {
+    ['Directors', 'Dop', 'Gaffers', 'Focus'].forEach(role => {
         const sel = gearListOutput.querySelector(`#gearList${role}Monitor`);
         if (sel) {
             sel.addEventListener('change', () => {

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -1844,7 +1844,8 @@ describe('script.js functions', () => {
     addOpt('motor1Select', 'MotorA');
     addOpt('videoSelect', 'VidA TX');
     const html = generateGearListHtml();
-    expect(html).toContain('Focus Monitor</strong> - 7&quot; - TV Logic F7HS incl Directors cage, shoulder strap, sunhood, rigging for teradeks');
+    expect(html).toContain('<strong>Focus Monitor</strong> - <span id="monitorSizeFocus">7&quot;</span> - <select id="gearListFocusMonitor">');
+    expect(html).toContain('incl Directors cage, shoulder strap, sunhood, rigging for teradeks');
     expect(html).toContain('3x Bebob V150micro');
     const msSection = html.slice(html.indexOf('<td>Monitoring support</td>'), html.indexOf('Power'));
     expect(msSection).toContain('2x Ultraslim BNC Cable 0.3 m (1x Focus, 1x Spare)');


### PR DESCRIPTION
## Summary
- allow selecting a custom focus monitor in gear list (TV Logic F7HS by default)
- preserve and edit focus monitor selections in saved gear lists

## Testing
- `npm run lint`
- `npm run check-consistency`
- `node --max-old-space-size=4096 node_modules/.bin/jest --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_68bc95a6a0bc8320ba05aaacf633a5f0