### PR TITLE
Add Bluestar eye leather color selection for viewfinder setups

### DIFF
--- a/index.html
+++ b/index.html
@@ -1034,6 +1034,23 @@
           <option value="ARRI VEB-3 Viewfinder Extension Bracket">Yes</option>
         </select>
       </div>
+      <div class="form-row hidden" id="eyeLeatherColorRow">
+        <label for="viewfinderEyeLeatherColor">Bluestar eye leather color:</label>
+        <select id="viewfinderEyeLeatherColor" name="viewfinderEyeLeatherColor">
+          <option value="rot">Rot</option>
+          <option value="blau">Blau</option>
+          <option value="natur">Natur</option>
+          <option value="grün">Grün</option>
+          <option value="lila">Lila</option>
+          <option value="orange">Orange</option>
+          <option value="grau">Grau</option>
+          <option value="gelb">Gelb</option>
+          <option value="jaguar">Jaguar</option>
+          <option value="killer bee">Killer Bee</option>
+          <option value="green rabbit">Green Rabbit</option>
+          <option value="schwarz">Schwarz</option>
+        </select>
+      </div>
 
       <h3 id="matteboxFilterHeading">Mattebox and Filter</h3>
       <div class="form-row">

--- a/script.js
+++ b/script.js
@@ -710,6 +710,7 @@ function updateBatteryPlateVisibility() {
   }
   updateViewfinderSettingsVisibility();
   updateViewfinderExtensionVisibility();
+  updateEyeLeatherColorVisibility();
   updateMonitoringConfigurationOptions();
 }
 
@@ -759,6 +760,18 @@ function updateViewfinderExtensionVisibility() {
       if (vfExtSel) {
         vfExtSel.value = '';
       }
+    }
+  }
+}
+
+function updateEyeLeatherColorVisibility() {
+  const cam = devices?.cameras?.[cameraSelect?.value];
+  const hasViewfinder = Array.isArray(cam?.viewfinder) && cam.viewfinder.length > 0;
+  if (eyeLeatherColorRow) {
+    if (hasViewfinder) {
+      eyeLeatherColorRow.classList.remove('hidden');
+    } else {
+      eyeLeatherColorRow.classList.add('hidden');
     }
   }
 }
@@ -1581,6 +1594,7 @@ const tripodSpreaderSelect = document.getElementById("tripodSpreader");
 const monitoringConfigurationSelect = document.getElementById("monitoringConfiguration");
 const viewfinderSettingsRow = document.getElementById("viewfinderSettingsRow");
 const viewfinderExtensionRow = document.getElementById("viewfinderExtensionRow");
+const eyeLeatherColorRow = document.getElementById("eyeLeatherColorRow");
 
 const projectFieldIcons = {
   dop: '👤',
@@ -7584,6 +7598,7 @@ function collectProjectFormData() {
         requiredScenarios: multi('requiredScenarios'),
         cameraHandle: multi('cameraHandle'),
         viewfinderExtension: val('viewfinderExtension'),
+        viewfinderEyeLeatherColor: val('viewfinderEyeLeatherColor'),
         mattebox: val('mattebox'),
         gimbal: multi('gimbal'),
         monitoringSettings: monitoringSelections,
@@ -7636,6 +7651,7 @@ function populateProjectForm(info) {
     setMulti('requiredScenarios', info.requiredScenarios);
     setMulti('cameraHandle', info.cameraHandle);
     setVal('viewfinderExtension', info.viewfinderExtension);
+    setVal('viewfinderEyeLeatherColor', info.viewfinderEyeLeatherColor);
     setVal('mattebox', info.mattebox);
     setMulti('gimbal', info.gimbal);
     setMulti('videoDistribution', info.videoDistribution);
@@ -8305,14 +8321,18 @@ function generateGearListHtml(info = {}) {
     ]);
     const miscItems = [...miscAcc].filter(item => !miscExcluded.has(item));
     const consumables = [];
+    const hasViewfinder = Array.isArray(cam?.viewfinder) && cam.viewfinder.length > 0;
+    const eyeLeatherColor = info.viewfinderEyeLeatherColor || 'rot';
     const baseConsumables = [
         { name: 'Kimtech Wipes', count: 1 },
         { name: 'Lasso Rot 24mm', count: 1 },
         { name: 'Lasso Blau 24mm', count: 1 },
         { name: 'Sprigs rot 1/4“', count: 1, noScale: true },
-        { name: 'Augenleder Large Oval Farbe rot', count: 2 },
         { name: 'Klappenstift', count: 2, klappen: true }
     ];
+    if (hasViewfinder) {
+        baseConsumables.splice(baseConsumables.length - 1, 0, { name: `Bluestar eye leather made of microfiber oval, large ${eyeLeatherColor}`, count: 2 });
+    }
     let shootDays = 0;
     let isWinterShoot = false;
     if (info.shootingDays) {
@@ -9471,6 +9491,7 @@ function initApp() {
   }
   updateTripodOptions();
   updateViewfinderExtensionVisibility();
+  updateEyeLeatherColorVisibility();
   updateCalculations();
   applyFilters();
 }

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -2701,6 +2701,10 @@ describe('script.js functions', () => {
 
   test('base consumables added with correct counts for short shoot', () => {
     const { generateGearListHtml } = script;
+    const camSel = document.getElementById('cameraSelect');
+    camSel.innerHTML = '<option value="CamA">CamA</option>';
+    camSel.value = 'CamA';
+    devices.cameras.CamA.viewfinder = ['VF'];
     const html = generateGearListHtml({ shootingDays: '2024-05-01 to 2024-05-05' });
     const wrap = document.createElement('div');
     wrap.innerHTML = html;
@@ -2711,18 +2715,22 @@ describe('script.js functions', () => {
     expect(consumText).toContain('1x Lasso Rot 24mm');
     expect(consumText).toContain('1x Lasso Blau 24mm');
     expect(consumText).toContain('1x Sprigs rot 1/4“');
-    expect(consumText).toContain('2x Augenleder Large Oval Farbe rot');
+    expect(consumText).toContain('2x Bluestar eye leather made of microfiber oval, large rot');
     expect(consumText).toContain('2x Klappenstift');
   });
 
   test('consumables scale with shooting days and special rules', () => {
     const { generateGearListHtml } = script;
+    const camSel = document.getElementById('cameraSelect');
+    camSel.innerHTML = '<option value="CamA">CamA</option>';
+    camSel.value = 'CamA';
+    devices.cameras.CamA.viewfinder = ['VF'];
     const scenarios = [
-      ['2024-05-01 to 2024-05-10', '2x Kimtech Wipes', '4x Klappenstift', '4x Augenleder Large Oval Farbe rot'],
-      ['2024-05-01 to 2024-05-16', '3x Kimtech Wipes', '4x Klappenstift', '6x Augenleder Large Oval Farbe rot'],
-      ['2024-05-01 to 2024-05-22', '4x Kimtech Wipes', '8x Klappenstift', '8x Augenleder Large Oval Farbe rot']
+      ['2024-05-01 to 2024-05-10', '2x Kimtech Wipes', '4x Klappenstift', '4x Bluestar eye leather made of microfiber oval, large rot'],
+      ['2024-05-01 to 2024-05-16', '3x Kimtech Wipes', '4x Klappenstift', '6x Bluestar eye leather made of microfiber oval, large rot'],
+      ['2024-05-01 to 2024-05-22', '4x Kimtech Wipes', '8x Klappenstift', '8x Bluestar eye leather made of microfiber oval, large rot']
     ];
-    scenarios.forEach(([range, wipes, klappen, augen]) => {
+    scenarios.forEach(([range, wipes, klappen, eye]) => {
       const html = generateGearListHtml({ shootingDays: range });
       const wrap = document.createElement('div');
       wrap.innerHTML = html;
@@ -2732,8 +2740,23 @@ describe('script.js functions', () => {
       expect(consumText).toContain(wipes);
       expect(consumText).toContain('1x Sprigs rot 1/4“');
       expect(consumText).toContain(klappen);
-      expect(consumText).toContain(augen);
+      expect(consumText).toContain(eye);
     });
+  });
+
+  test('eye leather excluded when camera has no viewfinder', () => {
+    const { generateGearListHtml } = script;
+    const camSel = document.getElementById('cameraSelect');
+    camSel.innerHTML = '<option value="CamA">CamA</option>';
+    camSel.value = 'CamA';
+    delete devices.cameras.CamA.viewfinder;
+    const html = generateGearListHtml({});
+    const wrap = document.createElement('div');
+    wrap.innerHTML = html;
+    const rows = Array.from(wrap.querySelectorAll('.gear-table tr'));
+    const consumIdx = rows.findIndex(r => r.textContent === 'Consumables');
+    const consumText = rows[consumIdx + 1].textContent;
+    expect(consumText).not.toContain('Bluestar eye leather made of microfiber oval, large');
   });
 
   test('camera handle and viewfinder extension excluded from project requirements', () => {


### PR DESCRIPTION
## Summary
- add Bluestar eye leather color selector shown only when camera has a viewfinder
- generate consumables entry using chosen color and include only for viewfinder setups
- cover new behavior with tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc96886c10832084bcead8a6f05689