### PR TITLE
Rename Airliner Oesen to Ring Fitting for Airline Rails

### DIFF
--- a/script.js
+++ b/script.js
@@ -8161,7 +8161,7 @@ function generateGearListHtml(info = {}) {
         'Magliner Senior - with quick release mount + tripod holder + utility tray + O‘Connor-Aufhängung',
         ...Array(10).fill('Securing Straps (25mm wide)'),
         'Loading Ramp (pair, 420kg)',
-        ...Array(20).fill('Airliner Ösen')
+        ...Array(20).fill('Ring Fitting for Airline Rails')
     ];
     const gripItems = [];
     let sliderSelectHtml = '';

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -2253,7 +2253,7 @@ describe('script.js functions', () => {
     expect(itemsText).toContain('1x Magliner Senior - with quick release mount + tripod holder + utility tray + O‘Connor-Aufhängung');
     expect(itemsText).toContain('10x Securing Straps (1x 25mm wide, 9x Spare)');
     expect(itemsText).toContain('1x Loading Ramp (1x pair, 420kg)');
-    expect(itemsText).toContain('20x Airliner Ösen');
+    expect(itemsText).toContain('20x Ring Fitting for Airline Rails');
   });
 
   test('Magliner adds wooden wedges to grip section', () => {


### PR DESCRIPTION
## Summary
- Replace outdated "Airliner Ösen" terminology with "Ring Fitting for Airline Rails" in gear list
- Align related unit test with new label

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc96fbb158832094b6f3660b998527