### PR TITLE
Assign Bebob V290 batteries to large monitors

### DIFF
--- a/script.js
+++ b/script.js
@@ -8085,6 +8085,10 @@ function generateGearListHtml(info = {}) {
         const bebob150 = Object.keys(devices.batteries || {}).find(n => /V150micro/i.test(n)) || 'Bebob V150micro';
         monitoringBatteryItems.push(bebob150, bebob150, bebob150);
     }
+    const bebob290 = Object.keys(devices.batteries || {}).find(n => /V290RM-Cine/i.test(n)) || 'Bebob V290RM-Cine';
+    largeMonitorPrefs.forEach(() => {
+        monitoringBatteryItems.push(bebob290, bebob290);
+    });
     addRow('Monitoring Batteries', formatItems(monitoringBatteryItems));
     addRow('Chargers', formatItems(chargersAcc));
     let monitoringItems = '';

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -1965,6 +1965,19 @@ describe('script.js functions', () => {
     expect(battSection).toContain('1x Hotswap Plate B-Mount');
   });
 
+  test('gear list adds 2x Bebob V290RM-Cine for each large monitor', () => {
+    devices.batteries['Bebob V290RM-Cine'] = {
+      capacity: 285,
+      pinA: 20,
+      dtapA: 5,
+      mount_type: 'V-Mount'
+    };
+    const { generateGearListHtml } = script;
+    const html = generateGearListHtml({ videoDistribution: 'Directors Monitor 15-21"' });
+    const battSection = html.slice(html.indexOf('Monitoring Batteries'), html.indexOf('Chargers'));
+    expect(battSection).toContain('2x Bebob V290RM-Cine');
+  });
+
   test('gear list lists media cards and USB-C readers', () => {
     const { generateGearListHtml } = script;
     devices.cameras.CamA.recordingMedia = [{ type: 'CFast 2.0' }];


### PR DESCRIPTION
## Summary
- Add logic to include two Bebob V290RM-Cine batteries for every large (15–21") monitor in gear list generation
- Test that gear list correctly lists two Bebob V290RM-Cine batteries for large monitors

## Testing
- `npm run lint`
- `npm run check-consistency`
- `npx jest tests/script.test.js -t "Bebob V290RM-Cine" --runInBand`


------
https://chatgpt.com/codex/tasks/task_e_68bc9864756c8320adc598e6f88ab440