### PR TITLE
Add camera power supply for studio scenario

### DIFF
--- a/script.js
+++ b/script.js
@@ -8294,6 +8294,9 @@ function generateGearListHtml(info = {}) {
         ...Array(3).fill('PRCD-S (Portable Residual Current Device-Safety)'),
         ...Array(3).fill('Power Three Way Splitter')
     ];
+    if (scenarios.includes('Studio')) {
+        powerItems.push('Camera Power Supply');
+    }
     addRow('Power', formatItems(powerItems));
     addRow('Grip', [sliderSelectHtml, formatItems(gripItems), easyrigSelectHtml].filter(Boolean).join('<br>'));
     addRow('Carts and Transportation', formatItems(cartsTransportationItems));

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -2032,6 +2032,18 @@ describe('script.js functions', () => {
     expect(itemsRow.textContent).toContain('1x Spare Disc (1x Schulz Sprayoff Micro)');
   });
 
+  test('Studio scenario adds Camera Power Supply to power section', () => {
+    const { generateGearListHtml } = script;
+    const html = generateGearListHtml({ requiredScenarios: 'Studio' });
+    const wrap = document.createElement('div');
+    wrap.innerHTML = html;
+    const rows = Array.from(wrap.querySelectorAll('.gear-table tr'));
+    const powerIdx = rows.findIndex(r => r.textContent === 'Power');
+    expect(powerIdx).toBeGreaterThanOrEqual(0);
+    const itemsRow = rows[powerIdx + 1];
+    expect(itemsRow.textContent).toContain('1x Camera Power Supply');
+  });
+
   test('Swing Away mattebox adds LMB 4x5 Pro Set and accessories to gear list', () => {
     const { generateGearListHtml } = script;
     const html = generateGearListHtml({ mattebox: 'Swing Away' });


### PR DESCRIPTION
## Summary
- Add Camera Power Supply to power items when Studio scenario selected
- Test ensures Studio scenario adds Camera Power Supply to power list

## Testing
- `npm run lint`
- `npm run check-consistency`
- `npx jest tests/script.test.js -t "Studio scenario adds Camera Power Supply to power section" --runInBand`


------
https://chatgpt.com/codex/tasks/task_e_68bc98ea5fe48320a2cea179f278faf8