### PR TITLE
feat: add icon to reset view button

### DIFF
--- a/index.html
+++ b/index.html
@@ -197,7 +197,7 @@
     <div class="diagram-controls">
       <button id="zoomOut" type="button" title="Zoom out" aria-label="Zoom out">-</button>
       <button id="zoomIn" type="button" title="Zoom in" aria-label="Zoom in">+</button>
-      <button id="resetView" type="button">Reset View</button>
+      <button id="resetView" type="button"><span class="btn-icon" aria-hidden="true">🔄</span>Reset View</button>
       <button id="downloadDiagram" type="button">Download Diagram</button>
       <button id="gridSnapToggle" type="button">Snap to Grid</button>
     </div>

--- a/script.js
+++ b/script.js
@@ -1525,7 +1525,7 @@ function setLanguage(lang) {
     gridSnapToggleBtn.setAttribute("data-help", texts[lang].gridSnapToggleHelp);
   }
   if (resetViewBtn) {
-    resetViewBtn.textContent = texts[lang].resetViewBtn;
+    resetViewBtn.innerHTML = `<span class="btn-icon" aria-hidden="true">🔄</span>${texts[lang].resetViewBtn}`;
     resetViewBtn.setAttribute("title", texts[lang].resetViewBtn);
     resetViewBtn.setAttribute("aria-label", texts[lang].resetViewBtn);
     resetViewBtn.setAttribute("data-help", texts[lang].resetViewHelp);

--- a/style.css
+++ b/style.css
@@ -354,6 +354,10 @@ a:focus {
   margin-right: 0.3em;
 }
 
+.btn-icon {
+  margin-right: 0.3em;
+}
+
 #hoverHelpTooltip {
   position: absolute;
   z-index: 1000;


### PR DESCRIPTION
## Summary
- add reset icon to diagram's reset view button
- style button icon spacing
- update reset view button to include icon when translating

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc9b14d6f4832090cddcafd7df54bc