### PR TITLE
Rename app to Cine List

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -1,4 +1,4 @@
-# 🎥 Kamera-Stromverbrauchs-Planer
+# 🎥 Cine List
 
 Dieses browserbasierte Tool hilft beim Planen professioneller Kamera-Setups mit V‑Mount-Akkus. Es berechnet **Stromverbrauch**, **Stromstärke** (bei 14,4 V und 12 V) sowie die **geschätzte Akkulaufzeit** und prüft, ob der Akku genügend Leistung liefert.
 

--- a/README.en.md
+++ b/README.en.md
@@ -1,4 +1,4 @@
-# 🎥 Camera Power Consumption Planner
+# 🎥 Cine List
 
 This browser based tool helps plan professional camera projects powered by V‑Mount batteries. It calculates **total power consumption**, **current draw** (at 14.4 V and 12 V) and **estimated battery runtime** while checking that the battery can safely supply the required power.
 

--- a/README.es.md
+++ b/README.es.md
@@ -1,4 +1,4 @@
-# 🎥 Planificador de Consumo de Energía de Cámaras
+# 🎥 Cine List
 
 Esta herramienta en el navegador ayuda a planificar configuraciones profesionales con baterías V‑Mount. Calcula **el consumo total**, **la corriente** (a 14,4 V y 12 V) y **la autonomía estimada**, comprobando que la batería pueda entregar la potencia necesaria.
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -1,4 +1,4 @@
-# 🎥 Planificateur de Consommation Caméra
+# 🎥 Cine List
 
 Cet outil fonctionnant dans le navigateur aide à planifier des configurations professionnelles alimentées par des batteries V‑Mount. Il calcule la **consommation totale**, le **courant** (à 14,4 V et 12 V) et l'**autonomie estimée**, tout en vérifiant que la batterie peut fournir la puissance requise.
 

--- a/README.it.md
+++ b/README.it.md
@@ -1,4 +1,4 @@
-# 🎥 Pianificatore del Consumo della Fotocamera
+# 🎥 Cine List
 
 Questo strumento basato sul browser aiuta a pianificare configurazioni professionali alimentate da batterie V‑Mount. Calcola **consumo totale**, **corrente** (a 14,4 V e 12 V) e **durata stimata della batteria**, verificando che la batteria possa fornire in sicurezza la potenza richiesta.
 ---

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Camera Power Planner
+# Cine List
 
-![Camera Power Planner icon](icon.svg)
+![Cine List icon](icon.svg)
 
-Camera Power Planner is a standalone web app for planning professional camera
+Cine List is a standalone web app for planning professional camera
 rigs powered by V‑Mount or B‑Mount batteries. It calculates total power draw,
 checks that batteries can safely deliver the required output, and estimates how
 long your project will run. The tool runs entirely in the browser and even works
@@ -118,7 +118,7 @@ Set up a development environment:
 
 ## Install as an App
 
-Camera Power Planner is a Progressive Web App and can be installed for quick
+Cine List is a Progressive Web App and can be installed for quick
 access:
 
 1. Open `index.html` in a supported browser.
@@ -131,7 +131,7 @@ access:
 
 ## Browser Support
 
-Camera Power Planner relies on modern web APIs and is tested in current versions of Chrome, Firefox, Edge and Safari. Older browsers may lack support for features like installation or offline caching. For the best experience, use a browser with up-to-date Progressive Web App (PWA) capabilities.
+Cine List relies on modern web APIs and is tested in current versions of Chrome, Firefox, Edge and Safari. Older browsers may lack support for features like installation or offline caching. For the best experience, use a browser with up-to-date Progressive Web App (PWA) capabilities.
 
 ## Development
 

--- a/index.html
+++ b/index.html
@@ -7,16 +7,16 @@
   <meta name="mobile-web-app-capable" content="yes" />
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
   <meta name="description" content="Plan your camera project and calculate power consumption &amp; battery life." />
-  <meta property="og:title" content="Camera Power Planner" />
+  <meta property="og:title" content="Cine List" />
   <meta property="og:description" content="Plan your camera project and calculate power consumption &amp; battery life." />
   <meta property="og:type" content="website" />
   <meta property="og:image" content="icon.png" />
   <meta name="theme-color" content="#f9f9f9" />
-  <meta name="application-name" content="Camera Power Planner" />
-  <meta name="apple-mobile-web-app-title" content="Camera Power Planner" />
+  <meta name="application-name" content="Cine List" />
+  <meta name="apple-mobile-web-app-title" content="Cine List" />
   <!-- Enables features that rely on eval(); revisit if security requirements change -->
   <meta http-equiv="Content-Security-Policy" content="script-src 'self' 'unsafe-eval' 'unsafe-inline';" />
-  <title>Camera Power Planner</title>
+  <title>Cine List</title>
   <link href="https://fonts.googleapis.com/css2?family=Ubuntu:wght@300;700&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="style.css" />
   <link rel="stylesheet" href="overview-print.css" media="print" />
@@ -29,7 +29,7 @@
   <a href="#mainContent" class="skip-link" id="skipLink">Skip to content</a>
   <div id="offlineIndicator" role="status" aria-live="polite">Offline</div>
   <header id="topBar">
-    <h1 id="mainTitle">Camera Power Consumption App</h1>
+    <h1 id="mainTitle">Cine List</h1>
     <div class="controls">
       <select id="languageSelect" aria-label="Select language">
         <option value="en">English</option>

--- a/manifest.webmanifest
+++ b/manifest.webmanifest
@@ -1,6 +1,6 @@
 {
-  "name": "Camera Power Planner",
-  "short_name": "Power Planner",
+  "name": "Cine List",
+  "short_name": "Cine List",
   "start_url": ".",
   "display": "standalone",
   "background_color": "#1a1a1a",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "camera-power-planner",
+  "name": "cine-list",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "camera-power-planner",
+      "name": "cine-list",
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "camera-power-planner",
+  "name": "cine-list",
   "version": "1.0.0",
   "description": "Browser-based tool for planning professional camera setups powered by V-Mount or B-Mount batteries. It calculates total power consumption, current draw at 14.4 V and 12 V, and estimated battery runtime while checking that the battery can safely deliver the required power.",
   "main": "data.js",

--- a/script.js
+++ b/script.js
@@ -1,4 +1,4 @@
-// script.js – Main logic for the Camera Power Planner app
+// script.js – Main logic for the Cine List app
 /* global texts, categoryNames, loadSessionState, saveSessionState, loadProject, saveProject, deleteProject */
 
 // Use `var` here instead of `let` because `index.html` loads the lz-string
@@ -5698,10 +5698,10 @@ clearSetupBtn.addEventListener("click", () => {
     confirm(texts[currentLang].confirmClearSetupAgain)
   ) {
     if (typeof localStorage !== 'undefined') {
-      localStorage.removeItem('cameraPowerPlanner_session');
+        localStorage.removeItem('cineList_session');
     }
     if (typeof sessionStorage !== 'undefined') {
-      sessionStorage.removeItem('cameraPowerPlanner_session');
+        sessionStorage.removeItem('cineList_session');
     }
     setupSelect.value = "";
     setupNameInput.value = "";
@@ -6550,7 +6550,7 @@ if (exportAndRevertBtn) {
       // Give a small delay to ensure download prompt appears before next step
       const revertTimer = setTimeout(() => {
         // Step 2: Remove saved database and reload page so device files are re-read
-        localStorage.removeItem('cameraPowerPlanner_devices');
+        localStorage.removeItem('cineList_devices');
         alert(texts[currentLang].alertExportAndRevertSuccess);
         location.reload();
       }, 500); // 500ms delay
@@ -6935,7 +6935,7 @@ if (runtimeFeedbackBtn && feedbackDialog && feedbackForm) {
     Object.entries(entry).forEach(([k, v]) => {
       lines.push(`${k}: ${v}`);
     });
-    const subject = encodeURIComponent('Camera Power Planner Runtime Feedback');
+    const subject = encodeURIComponent('Cine List Runtime Feedback');
     const body = encodeURIComponent(lines.join('\n'));
     window.location.href = `mailto:info@lucazanner.de?subject=${subject}&body=${body}`;
     closeDialog(feedbackDialog);

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,5 +1,5 @@
 /* eslint-env serviceworker */
-const CACHE_NAME = 'camera-power-planner-v11';
+const CACHE_NAME = 'cine-list-v11';
 const ASSETS = [
   './',
   './index.html',

--- a/storage.js
+++ b/storage.js
@@ -1,11 +1,11 @@
 // storage.js - Handles reading from and writing to localStorage.
 /* global texts, currentLang */
 
-const DEVICE_STORAGE_KEY = 'cameraPowerPlanner_devices';
-const SETUP_STORAGE_KEY = 'cameraPowerPlanner_setups';
-const SESSION_STATE_KEY = 'cameraPowerPlanner_session';
-const FEEDBACK_STORAGE_KEY = 'cameraPowerPlanner_feedback';
-const PROJECT_STORAGE_KEY = 'cameraPowerPlanner_project';
+const DEVICE_STORAGE_KEY = 'cineList_devices';
+const SETUP_STORAGE_KEY = 'cineList_setups';
+const SESSION_STATE_KEY = 'cineList_session';
+const FEEDBACK_STORAGE_KEY = 'cineList_feedback';
+const PROJECT_STORAGE_KEY = 'cineList_project';
 
 // Safely detect usable localStorage. Some environments (like private browsing)
 // may block access and throw errors. If unavailable, this returns null.

--- a/tests/storage.test.js
+++ b/tests/storage.test.js
@@ -18,11 +18,11 @@ const {
     importAllData,
 } = require('../storage');
 
-const DEVICE_KEY = 'cameraPowerPlanner_devices';
-const SETUP_KEY = 'cameraPowerPlanner_setups';
-const SESSION_KEY = 'cameraPowerPlanner_session';
-const FEEDBACK_KEY = 'cameraPowerPlanner_feedback';
-const PROJECT_KEY = 'cameraPowerPlanner_project';
+const DEVICE_KEY = 'cineList_devices';
+const SETUP_KEY = 'cineList_setups';
+const SESSION_KEY = 'cineList_session';
+const FEEDBACK_KEY = 'cineList_feedback';
+const PROJECT_KEY = 'cineList_project';
 
 const validDeviceData = {
   cameras: {},

--- a/translations.js
+++ b/translations.js
@@ -2,7 +2,7 @@
 // Translation text for English, Italian, Spanish, French and German
 const texts = {
   en: {
-    appTitle: "Camera Power Planner",
+    appTitle: "Cine List",
     tagline: "Plan your film rig and calculate power consumption & battery life.",
     skipToContent: "Skip to content",
     offlineIndicator: "Offline",
@@ -382,7 +382,7 @@ const texts = {
     // NEW TEXTS FOR SETUP MANAGEMENT END HERE
   },
   it: {
-    appTitle: "Pianificatore di alimentazione della fotocamera",
+    appTitle: "Cine List",
     tagline: "Pianifica la tua configurazione cinematografica e calcola il consumo energetico e l'autonomia delle batterie.",
     skipToContent: "Vai al contenuto",
     offlineIndicator: "Offline",
@@ -734,7 +734,7 @@ const texts = {
     diagramMoveHint: "Trascina i nodi per spostarli. Trascina uno spazio vuoto per spostare il diagramma.",
   },
   es: {
-    appTitle: "Planificador de Consumo de Energía de Cámaras",
+    appTitle: "Cine List",
     tagline: "Planifica tu equipo de rodaje y calcula el consumo de energía y la autonomía de las baterías.",
     skipToContent: "Saltar al contenido",
     offlineIndicator: "Sin conexión",
@@ -1102,7 +1102,7 @@ const texts = {
     // NEW TEXTS FOR SETUP MANAGEMENT END HERE
   },
   fr: {
-    appTitle: "Planificateur de Consommation Caméra",
+    appTitle: "Cine List",
     tagline: "Planifiez votre équipement de tournage et calculez la consommation énergétique et l'autonomie des batteries.",
     skipToContent: "Aller au contenu",
     offlineIndicator: "Hors ligne",
@@ -1472,7 +1472,7 @@ const texts = {
     // NEW TEXTS FOR SETUP MANAGEMENT END HERE
   },
   de: {
-    appTitle: "Kamera Stromverbrauchs Planer",
+    appTitle: "Cine List",
     tagline: "Plane dein Film-Setup und berechne Stromverbrauch und Akkulaufzeit.",
     skipToContent: "Zum Inhalt springen",
     offlineIndicator: "Offline",


### PR DESCRIPTION
## Summary
- rename app references and metadata from "Camera Power Planner" to **Cine List**
- update translations and storage keys to new app name
- adjust service worker cache and package metadata

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bc9c4533ec8320acfcbcab1f65926e