### PR TITLE
Translate Bodenmatte to cable matt

### DIFF
--- a/script.js
+++ b/script.js
@@ -8224,9 +8224,9 @@ function generateGearListHtml(info = {}) {
         gripItems.push('Satz Paganinis');
         gripItems.push('sand bag');
         gripItems.push('sand bag');
-        gripItems.push('Bodenmatte');
-        gripItems.push('Bodenmatte');
-        gripItems.push('Bodenmatte');
+        gripItems.push('cable matt');
+        gripItems.push('cable matt');
+        gripItems.push('cable matt');
     }
     if (scenarios.includes('Slider') && scenarios.includes('Undersling mode')) {
         gripItems.push('Tango Beam');

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -2286,7 +2286,7 @@ describe('script.js functions', () => {
     expect(text).toContain('2x Apple Box Set / Bühnenkisten Set');
     expect(text).toContain('1x Satz Paganinis');
     expect(text).toContain('2x sand bag');
-    expect(text).toContain('3x Bodenmatte');
+    expect(text).toContain('3x cable matt');
     expect(text).toContain('12x Tennisball');
   });
 


### PR DESCRIPTION
## Summary
- replace German term "Bodenmatte" with English "cable matt"
- update associated test expectation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc9cc0e3f88320842a3a1323a630a6