### PR TITLE
Clarify purpose of D-Tap extension cables

### DIFF
--- a/script.js
+++ b/script.js
@@ -7751,7 +7751,7 @@ function generateGearListHtml(info = {}) {
     if (scenarios.includes('Trinity') || scenarios.includes('Steadicam')) {
         for (let i = 0; i < 2; i++) {
             riggingAcc.push('D-Tap Splitter');
-            riggingAcc.push('D-Tap Extension 50 cm');
+            riggingAcc.push('D-Tap Extension 50 cm (to reach power on Steadicam/Trinity rigs)');
         }
     }
     const handleSelections = info.cameraHandle

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -1530,7 +1530,7 @@ describe('script.js functions', () => {
       const html = generateGearListHtml({ requiredScenarios: scenario });
       const rigSection = html.slice(html.indexOf('Rigging'), html.indexOf('Power'));
       expect(rigSection).toContain('4x D-Tap Splitter');
-      expect(rigSection).toContain('2x D-Tap Extension 50 cm');
+      expect(rigSection).toContain('2x D-Tap Extension 50 cm (1x to reach power on Steadicam/Trinity rigs, 1x Spare)');
     }
   );
 


### PR DESCRIPTION
## Summary
- Explain that D-Tap extension cables extend power on Steadicam/Trinity rigs
- Update tests to match new gear list description

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc9d48144c8320a59514f7f5d4f31e