### PR TITLE
Translate consumable color names to English

### DIFF
--- a/script.js
+++ b/script.js
@@ -8411,9 +8411,9 @@ function generateGearListHtml(info = {}) {
     const eyeLeatherColor = info.viewfinderEyeLeatherColor || 'rot';
     const baseConsumables = [
         { name: 'Kimtech Wipes', count: 1 },
-        { name: 'Lasso Rot 24mm', count: 1 },
-        { name: 'Lasso Blau 24mm', count: 1 },
-        { name: 'Sprigs rot 1/4“', count: 1, noScale: true },
+        { name: 'Lasso Red 24mm', count: 1 },
+        { name: 'Lasso Blue 24mm', count: 1 },
+        { name: 'Sprigs Red 1/4"', count: 1, noScale: true },
         { name: 'Klappenstift', count: 2, klappen: true }
     ];
     if (hasViewfinder) {

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -2768,9 +2768,9 @@ describe('script.js functions', () => {
     const consumIdx = rows.findIndex(r => r.textContent === 'Consumables');
     const consumText = rows[consumIdx + 1].textContent;
     expect(consumText).toContain('1x Kimtech Wipes');
-    expect(consumText).toContain('1x Lasso Rot 24mm');
-    expect(consumText).toContain('1x Lasso Blau 24mm');
-    expect(consumText).toContain('1x Sprigs rot 1/4“');
+    expect(consumText).toContain('1x Lasso Red 24mm');
+    expect(consumText).toContain('1x Lasso Blue 24mm');
+    expect(consumText).toContain('1x Sprigs Red 1/4"');
     expect(consumText).toContain('2x Bluestar eye leather made of microfiber oval, large rot');
     expect(consumText).toContain('2x Klappenstift');
   });
@@ -2794,7 +2794,7 @@ describe('script.js functions', () => {
       const consumIdx = rows.findIndex(r => r.textContent === 'Consumables');
       const consumText = rows[consumIdx + 1].textContent;
       expect(consumText).toContain(wipes);
-      expect(consumText).toContain('1x Sprigs rot 1/4“');
+      expect(consumText).toContain('1x Sprigs Red 1/4"');
       expect(consumText).toContain(klappen);
       expect(consumText).toContain(eye);
     });


### PR DESCRIPTION
## Summary
- translate German color descriptors in base consumables to English
- update tests to expect new English names

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bc97a258e0832086dac7692e6a94cf