### PR TITLE
Add Bebob V290RM-Cine batteries for large monitors

### DIFF
--- a/script.js
+++ b/script.js
@@ -8172,8 +8172,6 @@ function generateGearListHtml(info = {}) {
         const bebob150 = Object.keys(devices.batteries || {}).find(n => /V150micro/i.test(n)) || 'Bebob V150micro';
         monitoringBatteryItems.push(bebob150, bebob150, bebob150);
     }
-    addRow('Monitoring Batteries', formatItems(monitoringBatteryItems));
-    addRow('Chargers', formatItems(chargersAcc));
     let monitoringItems = '';
     const monitorSizes = [];
     if (selectedNames.viewfinder) {
@@ -8232,6 +8230,13 @@ function generateGearListHtml(info = {}) {
             `1x <strong>Focus Monitor</strong> - <span id="monitorSizeFocus">${selectedSize}&quot;</span> - <select id="gearListFocusMonitor">${opts}</select> incl Directors cage, shoulder strap, sunhood, rigging for teradeks`;
         if (selectedSize) monitorSizes.push(selectedSize);
     }
+    const monitorsAbove10 = monitorSizes.filter(s => s > 10).length;
+    if (monitorsAbove10) {
+        const bebob290 = Object.keys(devices.batteries || {}).find(n => /V290RM-Cine/i.test(n)) || 'Bebob V290RM-Cine';
+        for (let i = 0; i < monitorsAbove10; i++) monitoringBatteryItems.push(bebob290, bebob290);
+    }
+    addRow('Monitoring Batteries', formatItems(monitoringBatteryItems));
+    addRow('Chargers', formatItems(chargersAcc));
     const monitoringGear = [];
     const wirelessSize = monitorSizes.includes(5) ? 5 : 7;
     if (selectedNames.video) {

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -1734,6 +1734,7 @@ describe('script.js functions', () => {
     const html = generateGearListHtml({ videoDistribution: 'Directors Monitor 15-21"' });
     expect(html).toContain('<select id="gearListDirectorsMonitor15"');
     expect(html).toContain('Directors Monitor');
+    expect(html).toContain('2x Bebob V290RM-Cine');
     const msSection = html.slice(html.indexOf('<td>Monitoring support</td>'), html.indexOf('Power'));
     expect(msSection).toContain('4x D-Tap to Lemo-2-pin Cable 0,5m (1x Onboard monitor, 1x Directors 15-21", 2x Spare)');
     expect(msSection).toContain('4x Ultraslim BNC 0.5 m (1x Onboard monitor, 1x Directors 15-21", 2x Spare)');
@@ -1769,10 +1770,21 @@ describe('script.js functions', () => {
     const html = generateGearListHtml({ videoDistribution: 'DoP Monitor 15-21"' });
     expect(html).toContain('<select id="gearListDopMonitor15"');
     expect(html).toContain('DoP Monitor');
+    expect(html).toContain('2x Bebob V290RM-Cine');
     const msSection = html.slice(html.indexOf('<td>Monitoring support</td>'), html.indexOf('Power'));
     expect(msSection).toContain('4x D-Tap to Lemo-2-pin Cable 0,5m (1x Onboard monitor, 1x DoP 15-21", 2x Spare)');
     const gripSection = html.slice(html.indexOf('Grip'), html.indexOf('Carts and Transportation'));
     expect(gripSection).toContain('Matthews Monitor Stand II (249562) (1x DoP 15-21")');
+  });
+
+  test('adds 2x Bebob V290RM-Cine per monitor above 10"', () => {
+    const { generateGearListHtml } = script;
+    global.devices.directorMonitors = {
+      'SmallHD Cine 24" 4K High-Bright Monitor': { screenSizeInches: 24 },
+      Other: { screenSizeInches: 17 }
+    };
+    const html = generateGearListHtml({ videoDistribution: 'Directors Monitor 15-21", DoP Monitor 15-21"' });
+    expect(html).toContain('4x Bebob V290RM-Cine');
   });
 
   test('multiple handheld monitors merge grip items', () => {


### PR DESCRIPTION
## Summary
- Add logic to include two Bebob V290RM-Cine batteries for every monitor larger than 10"
- Extend tests to cover large monitor battery requirements, including multi-monitor scenarios

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bca035b0d88320939f1c954b8627e4