### PR TITLE
Translate Bodenmatte gear item to English

### DIFF
--- a/script.js
+++ b/script.js
@@ -8323,9 +8323,9 @@ function generateGearListHtml(info = {}) {
         gripItems.push('Paganini set');
         gripItems.push('sand bag');
         gripItems.push('sand bag');
-        gripItems.push('Bodenmatte');
-        gripItems.push('Bodenmatte');
-        gripItems.push('Bodenmatte');
+        gripItems.push('cable mat');
+        gripItems.push('cable mat');
+        gripItems.push('cable mat');
     }
     if (scenarios.includes('Slider') && scenarios.includes('Undersling mode')) {
         gripItems.push('Tango Beam');

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -2338,7 +2338,7 @@ describe('script.js functions', () => {
     expect(text).toContain('2x Apple Box Set / Bühnenkisten Set');
     expect(text).toContain('1x Paganini set');
     expect(text).toContain('2x sand bag');
-    expect(text).toContain('3x Bodenmatte');
+    expect(text).toContain('3x cable mat');
     expect(text).toContain('12x tennis ball');
   });
 


### PR DESCRIPTION
## Summary
- Replace German "Bodenmatte" with English "cable mat" in slider grip accessories
- Update corresponding test to expect the new phrasing

## Testing
- `npm run lint`
- `npm run check-consistency`
- `npx jest tests/script.test.js -t 'Slider scenario adds Tango Roller and accessories' --runInBand`


------
https://chatgpt.com/codex/tasks/task_e_68bca1d68bec83208ad68f8684eaad6a