### PR TITLE
Label power diagram and highlight battery overdraw

### DIFF
--- a/script.js
+++ b/script.js
@@ -1707,16 +1707,38 @@ function drawPowerDiagram(availableWatt, segments) {
   powerDiagramElem.classList.remove("hidden");
   powerDiagramBarElem.innerHTML = "";
   const MAX_WIDTH = 300;
+  const total = segments.reduce((sum, s) => sum + s.power, 0);
+  const scale = MAX_WIDTH / Math.max(availableWatt, total);
+  const limitPos = availableWatt * scale;
+
   segments.forEach(seg => {
-    const width = (seg.power / availableWatt) * MAX_WIDTH;
+    const width = seg.power * scale;
     if (width <= 0) return;
     const div = document.createElement("div");
     div.className = `segment ${seg.className}`;
     div.style.width = `${width}px`;
     div.setAttribute("title", `${seg.label} ${seg.power.toFixed(1)} W`);
+    const span = document.createElement("span");
+    span.textContent = seg.label.replace(/:$/, "");
+    div.appendChild(span);
     powerDiagramBarElem.appendChild(div);
   });
+
+  if (total > availableWatt) {
+    const over = document.createElement("div");
+    over.className = "over-usage";
+    over.style.left = `${limitPos}px`;
+    powerDiagramBarElem.appendChild(over);
+  }
+
+  const limit = document.createElement("div");
+  limit.className = "limit-line";
+  limit.style.left = `${limitPos}px`;
+  powerDiagramBarElem.appendChild(limit);
+
+  powerDiagramElem.classList.toggle("over", total > availableWatt);
   maxPowerTextElem.textContent = `${texts[currentLang].availablePowerLabel} ${availableWatt.toFixed(0)} W`;
+  maxPowerTextElem.style.color = total > availableWatt ? "red" : "";
 }
 
 const setupSelect     = document.getElementById("setupSelect");

--- a/style.css
+++ b/style.css
@@ -716,8 +716,22 @@ button:disabled {
 }
 
 .power-bar .segment {
+  position: relative;
+  z-index: 1;
   height: 100%;
   flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #fff;
+  font-size: 0.75em;
+  overflow: hidden;
+}
+
+.power-bar .segment span {
+  position: relative;
+  z-index: 3;
+  padding: 0 2px;
 }
 
 .power-bar .camera { background-color: #4caf50; }
@@ -726,6 +740,33 @@ button:disabled {
 .power-bar .motors { background-color: #9c27b0; }
 .power-bar .controllers { background-color: #ff5722; }
 .power-bar .distance { background-color: #795548; }
+
+.power-bar .over-usage {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  right: 0;
+  background: rgba(244, 67, 54, 0.4);
+  z-index: 2;
+  pointer-events: none;
+}
+
+.power-bar .limit-line {
+  position: absolute;
+  top: -4px;
+  bottom: -4px;
+  width: 2px;
+  background: #000;
+  z-index: 4;
+}
+
+#powerDiagram.over .power-bar {
+  border-color: red;
+}
+
+#powerDiagram.over .limit-line {
+  background: red;
+}
 
 #maxPowerText {
   margin-top: 4px;


### PR DESCRIPTION
## Summary
- Display descriptive labels within each power usage segment
- Scale and shade the power bar when draw exceeds battery output
- Style power diagram segments, limit marker, and overdraw overlay

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bca2f4904c8320bb45eaaa1b2220a9