### PR TITLE
Hide default monitoring configuration in requirements

### DIFF
--- a/script.js
+++ b/script.js
@@ -8030,7 +8030,9 @@ function generateGearListHtml(info = {}) {
     if (videoDistPrefs.length) {
         projectInfo.monitoring = videoDistPrefs.join(', ');
     }
-    if (!info.monitoringConfiguration) delete projectInfo.monitoringConfiguration;
+    if (!info.monitoringConfiguration || info.monitoringConfiguration === 'Viewfinder and Onboard') {
+        delete projectInfo.monitoringConfiguration;
+    }
     delete projectInfo.monitoringSettings;
     delete projectInfo.videoDistribution;
     delete projectInfo.tripodHeadBrand;

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -2928,6 +2928,17 @@ describe('script.js functions', () => {
     expect(configSel.value).toBe('Onboard Only');
   });
 
+  test('default monitoring configuration omitted from project requirements', () => {
+    const { generateGearListHtml } = script;
+    const defaultHtml = generateGearListHtml({ monitoringConfiguration: 'Viewfinder and Onboard' });
+    expect(defaultHtml).not.toContain('<span class="req-label">Monitoring configuration</span>');
+    expect(defaultHtml).not.toContain('<span class="req-value">Viewfinder and Onboard</span>');
+
+    const customHtml = generateGearListHtml({ monitoringConfiguration: 'Onboard Only' });
+    expect(customHtml).toContain('<span class="req-label">Monitoring configuration</span>');
+    expect(customHtml).toContain('<span class="req-value">Onboard Only</span>');
+  });
+
   test('iOS video option appears under monitoring in project requirements', () => {
     const { generateGearListHtml } = script;
     const html = generateGearListHtml({ videoDistribution: 'IOS Video (Teradek Serv + Link)' });


### PR DESCRIPTION
## Summary
- omit `Monitoring configuration` from project requirements when set to default 'Viewfinder and Onboard'
- test that non-default monitoring configurations still appear

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bca4a6446883208a715564f86b98c3