### PR TITLE
feat: add batteries for large monitors

### DIFF
--- a/script.js
+++ b/script.js
@@ -7554,6 +7554,11 @@ function collectAccessories({ hasMotor = false, videoDistPrefs = [] } = {}) {
             if (Array.isArray(videoDistPrefs)) {
                 const handheldCount = videoDistPrefs.filter(v => /Monitor(?: \d+")? handheld$/.test(v)).length;
                 monCount += handheldCount * 3;
+                const largeCount = videoDistPrefs.filter(v => {
+                    const m = v.match(/Monitor (\d+(?:\.\d+)?)/);
+                    return m && parseFloat(m[1]) > 10 && !/handheld$/.test(v);
+                }).length;
+                monCount += largeCount * 2;
             }
             if (hasMotor) monCount += 3;
             const total = camCount + monCount;
@@ -8201,17 +8206,6 @@ function generateGearListHtml(info = {}) {
         }
     }
     addRow('Camera Batteries', batteryItems);
-    let monitoringBatteryItems = [];
-    const bebob98 = Object.keys(devices.batteries || {}).find(n => /V98micro/i.test(n)) || 'Bebob V98micro';
-    handheldPrefs.forEach(() => {
-        monitoringBatteryItems.push(bebob98, bebob98, bebob98);
-    });
-    if (hasMotor) {
-        const bebob150 = Object.keys(devices.batteries || {}).find(n => /V150micro/i.test(n)) || 'Bebob V150micro';
-        monitoringBatteryItems.push(bebob150, bebob150, bebob150);
-    }
-    addRow('Monitoring Batteries', formatItems(monitoringBatteryItems));
-    addRow('Chargers', formatItems(chargersAcc));
     let monitoringItems = '';
     const monitorSizes = [];
     if (selectedNames.viewfinder) {
@@ -8288,6 +8282,22 @@ function generateGearListHtml(info = {}) {
             .replace(/&amp;quot;/g, '&quot;');
         monitoringItems += (monitoringItems ? '<br>' : '') + gearHtml;
     }
+    let monitoringBatteryItems = [];
+    const bebob98 = Object.keys(devices.batteries || {}).find(n => /V98micro/i.test(n)) || 'Bebob V98micro';
+    handheldPrefs.forEach(() => {
+        monitoringBatteryItems.push(bebob98, bebob98, bebob98);
+    });
+    if (hasMotor) {
+        const bebob150 = Object.keys(devices.batteries || {}).find(n => /V150micro/i.test(n)) || 'Bebob V150micro';
+        monitoringBatteryItems.push(bebob150, bebob150, bebob150);
+    }
+    const bebob290 = Object.keys(devices.batteries || {}).find(n => /V290RM-Cine/i.test(n)) || 'Bebob V290RM-Cine';
+    const monitorsAbove10 = monitorSizes.filter(s => s > 10).length;
+    for (let i = 0; i < monitorsAbove10; i++) {
+        monitoringBatteryItems.push(bebob290, bebob290);
+    }
+    addRow('Monitoring Batteries', formatItems(monitoringBatteryItems));
+    addRow('Chargers', formatItems(chargersAcc));
     addRow('Monitoring', monitoringItems);
     const monitoringSupportHardware = formatItems(monitoringSupportAcc);
     const monitoringSupportItems = monitoringSupportHardware;

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -1734,6 +1734,7 @@ describe('script.js functions', () => {
     const html = generateGearListHtml({ videoDistribution: 'Directors Monitor 15-21"' });
     expect(html).toContain('<select id="gearListDirectorsMonitor15"');
     expect(html).toContain('Directors Monitor');
+    expect(html).toContain('2x Bebob V290RM-Cine');
     const msSection = html.slice(html.indexOf('<td>Monitoring support</td>'), html.indexOf('Power'));
     expect(msSection).toContain('4x D-Tap to Lemo-2-pin Cable 0,5m (1x Onboard monitor, 1x Directors 15-21", 2x Spare)');
     expect(msSection).toContain('4x Ultraslim BNC 0.5 m (1x Onboard monitor, 1x Directors 15-21", 2x Spare)');


### PR DESCRIPTION
## Summary
- allocate two Bebob V290RM-Cine batteries per monitor above 10"
- include large monitors in charger estimation
- test coverage for large monitor battery allocation

## Testing
- `npm test` *(timed out after >8min; process terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68bca322b9208320a291d1e8fba9151a