### PR TITLE
Exclude monitoring selections from project requirements

### DIFF
--- a/script.js
+++ b/script.js
@@ -7707,6 +7707,7 @@ function collectProjectFormData() {
         ...multiVals('frameGuides'),
         ...multiVals('aspectMaskOpacity')
     ].join(', ');
+    const videoDist = multi('videoDistribution');
     return {
         projectName: val('projectName'),
         dop: val('dop'),
@@ -7726,7 +7727,8 @@ function collectProjectFormData() {
         mattebox: val('mattebox'),
         gimbal: multi('gimbal'),
         monitoringSettings: monitoringSelections,
-        videoDistribution: multi('videoDistribution'),
+        videoDistribution: videoDist,
+        monitoring: videoDist,
         monitoringConfiguration: val('monitoringConfiguration'),
         monitorUserButtons: multi('monitorUserButtons'),
         cameraUserButtons: multi('cameraUserButtons'),
@@ -8049,11 +8051,9 @@ function generateGearListHtml(info = {}) {
     if (monitoringSettings.length) {
         projectInfo.monitoringSupport = monitoringSettings.join(', ');
     }
-    if (videoDistPrefs.length) {
-        projectInfo.monitoring = videoDistPrefs.join(', ');
-    }
     if (!info.monitoringConfiguration) delete projectInfo.monitoringConfiguration;
     delete projectInfo.monitoringSettings;
+    delete projectInfo.monitoring;
     delete projectInfo.videoDistribution;
     delete projectInfo.tripodHeadBrand;
     delete projectInfo.tripodBowl;

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -673,11 +673,16 @@ describe('script.js functions', () => {
     const codecSel = document.getElementById('codec');
     codecSel.innerHTML = '<option value="ProRes">ProRes</option>';
     codecSel.value = 'ProRes';
+    const videoSel = document.getElementById('videoDistribution');
+    videoSel.innerHTML = '<option value="IOS Video (Teradek Serv + Link)">IOS Video (Teradek Serv + Link)</option>';
+    videoSel.value = 'IOS Video (Teradek Serv + Link)';
     const form = document.getElementById('projectForm');
     form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
     const saved = global.saveProject.mock.calls[0][0];
     expect(saved.projectInfo.projectName).toBe('Proj');
     expect(saved.projectInfo.codec).toBe('ProRes');
+    expect(saved.projectInfo.videoDistribution).toBe('IOS Video (Teradek Serv + Link)');
+    expect(saved.projectInfo.monitoring).toBe('IOS Video (Teradek Serv + Link)');
   });
 
   test('project requirements form saved with project', () => {
@@ -2928,12 +2933,11 @@ describe('script.js functions', () => {
     expect(configSel.value).toBe('Onboard Only');
   });
 
-  test('iOS video option appears under monitoring in project requirements', () => {
+  test('iOS video option excluded from project requirements', () => {
     const { generateGearListHtml } = script;
     const html = generateGearListHtml({ videoDistribution: 'IOS Video (Teradek Serv + Link)' });
-    expect(html).toContain('<span class="req-label">Monitoring</span>');
-    expect(html).toContain('<span class="req-value">IOS Video (Teradek Serv + Link)</span>');
-    expect(html).not.toContain('<span class="req-label">Monitoring support</span><span class="req-value">IOS Video (Teradek Serv + Link)</span>');
+    expect(html).not.toContain('<span class="req-label">Monitoring</span>');
+    expect(html).not.toContain('<span class="req-value">IOS Video (Teradek Serv + Link)</span>');
   });
 
   test('project requirements form includes handheld monitor size options', () => {


### PR DESCRIPTION
## Summary
- Preserve video distribution selections in saved project data while omitting them from visible project requirements
- Verify gear list saves monitoring selections through an extended unit test

## Testing
- `npm run lint`
- `npm run check-consistency`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bca515af7083209e8e871faec1d05d