### PR TITLE
Assign sand bags to slider context

### DIFF
--- a/script.js
+++ b/script.js
@@ -8112,10 +8112,20 @@ function generateGearListHtml(info = {}) {
                 const hasContext = ctxKeys.some(c => c);
                 let ctxParts = [];
                 if (hasContext) {
-                    const realContexts = ctxKeys.filter(c => c && c.toLowerCase() !== 'spare');
-                    const spareCount = total - realContexts.length;
-                    ctxParts = realContexts.map(c => `1x ${c}`);
-                    if (spareCount > 0) ctxParts.push(`${spareCount}x Spare`);
+                    if (base === 'sand bag') {
+                        const realEntries = Object.entries(ctxCounts)
+                            .filter(([c]) => c && c.toLowerCase() !== 'spare')
+                            .sort(([a], [b]) => a.localeCompare(b, undefined, { sensitivity: 'base' }));
+                        const usedCount = realEntries.reduce((sum, [, count]) => sum + count, 0);
+                        const spareCount = total - usedCount;
+                        ctxParts = realEntries.map(([c, count]) => `${count}x ${c}`);
+                        if (spareCount > 0) ctxParts.push(`${spareCount}x Spare`);
+                    } else {
+                        const realContexts = ctxKeys.filter(c => c && c.toLowerCase() !== 'spare');
+                        const spareCount = total - realContexts.length;
+                        ctxParts = realContexts.map(c => `1x ${c}`);
+                        if (spareCount > 0) ctxParts.push(`${spareCount}x Spare`);
+                    }
                 }
                 const ctxStr = ctxParts.length ? ` (${ctxParts.join(', ')})` : '';
                 const translatedBase = gearItemTranslations[currentLang]?.[base] || base;
@@ -8392,8 +8402,8 @@ function generateGearListHtml(info = {}) {
         gripItems.push('Apple Box Set / Bühnenkisten Set');
         gripItems.push('Apple Box Set / Bühnenkisten Set');
         gripItems.push('Paganini set');
-        gripItems.push('sand bag');
-        gripItems.push('sand bag');
+        gripItems.push('sand bag (for Slider)');
+        gripItems.push('sand bag (for Slider)');
         gripItems.push('cable mat');
         gripItems.push('cable mat');
         gripItems.push('cable mat');

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -2349,7 +2349,7 @@ describe('script.js functions', () => {
     expect(text).toContain('2x Avenger Combo Stand 20 A1020B 110-198 cm black');
     expect(text).toContain('2x Apple Box Set / Bühnenkisten Set');
     expect(text).toContain('1x Paganini set');
-    expect(text).toContain('2x sand bag');
+    expect(text).toContain('2x sand bag (2x for Slider)');
     expect(text).toContain('3x cable mat');
     expect(text).toContain('12x tennis ball');
   });
@@ -2365,6 +2365,17 @@ describe('script.js functions', () => {
       const itemsRow = rows[gripIdx + 1];
       expect(itemsRow.textContent).toContain('Tango Beam');
     });
+  });
+
+  test('Slider with Frog Tripod and Hi-Head counts sand bags per context', () => {
+    const { generateGearListHtml } = script;
+    const html = generateGearListHtml({ requiredScenarios: 'Slider', tripodTypes: 'Frog Tripod, Hi-Head' });
+    const wrap = document.createElement('div');
+    wrap.innerHTML = html;
+    const rows = Array.from(wrap.querySelectorAll('.gear-table tr'));
+    const gripIdx = rows.findIndex(r => r.textContent === 'Grip');
+    const text = rows[gripIdx + 1].textContent;
+    expect(text).toContain('4x sand bag (1x for Frog Tripod, 1x for Hi-Head, 2x for Slider)');
   });
 
   test('Jib scenario adds EJib Arm, counter weights, and tripod legs', () => {


### PR DESCRIPTION
## Summary
- Track contexts by count for sand bags so repeated contexts don't appear as spares
- Mark slider sand bags with a slider-specific context
- Add tests ensuring slider and tripod sand bags show accurate counts

## Testing
- `npm test` *(failed: process did not complete in container)*

------
https://chatgpt.com/codex/tasks/task_e_68bca722f5848320a3ef58d2d0763bf0