### PR TITLE
Replace power diagram labels with color legend

### DIFF
--- a/index.html
+++ b/index.html
@@ -173,6 +173,7 @@
     </ul>
     <div id="powerDiagram" class="hidden">
       <div id="powerDiagramBar" class="power-bar" role="img" aria-label="Power usage diagram"></div>
+      <div id="powerDiagramLegend"></div>
       <p id="maxPowerText"></p>
     </div>
     <p><strong><span id="totalPowerLabel">Total Consumption:</span></strong> <span id="totalPower">0.0</span> W</p>

--- a/script.js
+++ b/script.js
@@ -1695,17 +1695,20 @@ const hotswapWarnElem     = document.getElementById("hotswapWarning");
 const powerDiagramElem    = document.getElementById("powerDiagram");
 const powerDiagramBarElem = document.getElementById("powerDiagramBar");
 const maxPowerTextElem    = document.getElementById("maxPowerText");
+const powerDiagramLegendElem = document.getElementById("powerDiagramLegend");
 
 function drawPowerDiagram(availableWatt, segments) {
-  if (!powerDiagramElem || !powerDiagramBarElem || !maxPowerTextElem) return;
+  if (!powerDiagramElem || !powerDiagramBarElem || !maxPowerTextElem || !powerDiagramLegendElem) return;
   if (!availableWatt || availableWatt <= 0) {
     powerDiagramElem.classList.add("hidden");
     powerDiagramBarElem.innerHTML = "";
+    powerDiagramLegendElem.innerHTML = "";
     maxPowerTextElem.textContent = "";
     return;
   }
   powerDiagramElem.classList.remove("hidden");
   powerDiagramBarElem.innerHTML = "";
+  powerDiagramLegendElem.innerHTML = "";
   const MAX_WIDTH = 300;
   const total = segments.reduce((sum, s) => sum + s.power, 0);
   const scale = MAX_WIDTH / Math.max(availableWatt, total);
@@ -1718,10 +1721,14 @@ function drawPowerDiagram(availableWatt, segments) {
     div.className = `segment ${seg.className}`;
     div.style.width = `${width}px`;
     div.setAttribute("title", `${seg.label} ${seg.power.toFixed(1)} W`);
-    const span = document.createElement("span");
-    span.textContent = seg.label.replace(/:$/, "");
-    div.appendChild(span);
     powerDiagramBarElem.appendChild(div);
+
+    const legendItem = document.createElement("span");
+    const swatch = document.createElement("span");
+    swatch.className = `swatch ${seg.className}`;
+    legendItem.appendChild(swatch);
+    legendItem.appendChild(document.createTextNode(seg.label.replace(/:$/, "")));
+    powerDiagramLegendElem.appendChild(legendItem);
   });
 
   if (total > availableWatt) {

--- a/style.css
+++ b/style.css
@@ -811,6 +811,29 @@ button:disabled {
 #diagramLegend .video { background: #369; }
 #diagramLegend .fiz { background: #090; }
 
+#powerDiagramLegend {
+  margin-top: 0.25em;
+  font-size: 12px;
+}
+#powerDiagramLegend span {
+  margin: 0 6px;
+  display: inline-flex;
+  align-items: center;
+}
+#powerDiagramLegend .swatch {
+  width: 12px;
+  height: 12px;
+  border-radius: 2px;
+  margin-right: 4px;
+  display: inline-block;
+}
+#powerDiagramLegend .camera { background-color: #4caf50; }
+#powerDiagramLegend .monitor { background-color: #2196f3; }
+#powerDiagramLegend .video { background-color: #ffc107; }
+#powerDiagramLegend .motors { background-color: #9c27b0; }
+#powerDiagramLegend .controllers { background-color: #ff5722; }
+#powerDiagramLegend .distance { background-color: #795548; }
+
 .diagram-controls {
   margin-top: 0.5em;
   display: flex;


### PR DESCRIPTION
## Summary
- render power usage bar without inline labels
- add color legend explaining bar segments
- build legend dynamically from segment data and style it accordingly

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bca9e2cffc83208ba92a7a75c296eb