### PR TITLE
feat: add TVLogic VFM-058W monitor

### DIFF
--- a/devices/monitors.js
+++ b/devices/monitors.js
@@ -975,6 +975,27 @@ const monitorData = {
       { "type": "3G-SDI" }
     ]
   },
+  "TVLogic VFM-058W": {
+    "screenSizeInches": 5.5,
+    "brightnessNits": 450,
+    "powerDrawWatts": 9,
+    "power": {
+      "input": {
+        "voltageRange": "6.8-12",
+        "type": "DC Barrel / D-Tap"
+      },
+      "output": null
+    },
+    "wirelessTx": false,
+    "videoInputs": [
+      { "type": "HDMI" },
+      { "type": "3G-SDI" }
+    ],
+    "videoOutputs": [
+      { "type": "HDMI" },
+      { "type": "3G-SDI" }
+    ]
+  },
   "SmallHD 703 UltraBright": {
     "screenSizeInches": 7,
     "brightnessNits": 2200,


### PR DESCRIPTION
## Summary
- add TVLogic VFM-058W monitor with HDMI and 3G-SDI I/O

## Testing
- `npm run check-consistency`
- `CI=true npx jest tests/utils.test.js --runInBand`
- `CI=true npm test` *(fails: command terminated after several minutes without completing)*

------
https://chatgpt.com/codex/tasks/task_e_68bcabf498c883209a046e2e5de5cad9