### PR TITLE
Remove monitoring project requirement box

### DIFF
--- a/script.js
+++ b/script.js
@@ -1645,7 +1645,6 @@ const projectFieldIcons = {
   viewfinderExtension: '🔭',
   gimbal: '🌀',
   monitoringSupport: '🧰',
-  monitoring: '🖥️',
   monitoringConfiguration: '🎛️',
   monitorUserButtons: '🔘',
   cameraUserButtons: '🔘',
@@ -8061,13 +8060,11 @@ function generateGearListHtml(info = {}) {
     if (monitoringSettings.length) {
         projectInfo.monitoringSupport = monitoringSettings.join(', ');
     }
-    if (videoDistPrefs.length) {
-        projectInfo.monitoring = videoDistPrefs.join(', ');
-    }
     if (!info.monitoringConfiguration || info.monitoringConfiguration === 'Viewfinder and Onboard') {
         delete projectInfo.monitoringConfiguration;
     }
     delete projectInfo.monitoringSettings;
+    delete projectInfo.monitoring;
     delete projectInfo.videoDistribution;
     delete projectInfo.tripodHeadBrand;
     delete projectInfo.tripodBowl;
@@ -8088,7 +8085,6 @@ function generateGearListHtml(info = {}) {
         requiredScenarios: 'Required Scenarios',
         gimbal: 'Gimbal',
         monitoringSupport: 'Monitoring support',
-        monitoring: 'Monitoring',
         monitoringConfiguration: 'Monitoring configuration',
         monitorUserButtons: 'Onboard Monitor User Buttons',
         cameraUserButtons: 'Camera User Buttons',

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -2951,11 +2951,11 @@ describe('script.js functions', () => {
     expect(customHtml).toContain('<span class="req-value">Onboard Only</span>');
   });
 
-  test('iOS video option appears under monitoring in project requirements', () => {
+  test('iOS video option is not included in project requirements', () => {
     const { generateGearListHtml } = script;
     const html = generateGearListHtml({ videoDistribution: 'IOS Video (Teradek Serv + Link)' });
-    expect(html).toContain('<span class="req-label">Monitoring</span>');
-    expect(html).toContain('<span class="req-value">IOS Video (Teradek Serv + Link)</span>');
+    expect(html).not.toContain('<span class="req-label">Monitoring</span>');
+    expect(html).not.toContain('<span class="req-value">IOS Video (Teradek Serv + Link)</span>');
     expect(html).not.toContain('<span class="req-label">Monitoring support</span><span class="req-value">IOS Video (Teradek Serv + Link)</span>');
   });
 


### PR DESCRIPTION
## Summary
- omit Monitoring box from project requirements by removing video distribution data
- update icons and labels to match
- adjust tests for monitoring removal

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bcad1349888320937f34c1a79083b3