### PR TITLE
Avoid empty setup entries when persisting gear list

### DIFF
--- a/script.js
+++ b/script.js
@@ -8686,20 +8686,25 @@ function getCurrentGearListHtml() {
 
 function saveCurrentGearList() {
     const html = getCurrentGearListHtml();
-    if (!html) return;
     const info = projectForm ? collectProjectFormData() : {};
     currentProjectInfo = Object.values(info).some(v => v) ? info : null;
+
     if (typeof saveProject === 'function') {
         saveProject({ projectInfo: currentProjectInfo, gearList: html });
     }
-    const setupName = (setupSelect && setupSelect.value) || (setupNameInput && setupNameInput.value.trim());
+
+    const setupName = (setupSelect && setupSelect.value) ||
+        (setupNameInput && setupNameInput.value.trim());
     if (setupName) {
         const setups = getSetups();
-        const setup = setups[setupName] || {};
-        setup.gearList = html;
-        setup.projectInfo = currentProjectInfo;
-        setups[setupName] = setup;
-        storeSetups(setups);
+        const existing = setups[setupName];
+        if (html || existing) {
+            const setup = existing || {};
+            if (html) setup.gearList = html;
+            setup.projectInfo = currentProjectInfo;
+            setups[setupName] = setup;
+            storeSetups(setups);
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- Avoid creating setup entries when the gear list is empty
- Still persist project requirements to local storage

## Testing
- `npm run lint`
- `npm run check-consistency`
- `node --max-old-space-size=4096 node_modules/.bin/jest --runInBand tests/script.test.js -t "restoring session state preserves selections|auto backup"`
- `node --max-old-space-size=4096 node_modules/.bin/jest --runInBand tests/script.test.js -t "battery plate selection is saved and loaded with setups"`


------
https://chatgpt.com/codex/tasks/task_e_68bcaf6a69b483208f3eba59c7ec706a