### PR TITLE
Load battery hotswap device data

### DIFF
--- a/index.html
+++ b/index.html
@@ -1283,6 +1283,7 @@
   <script src="devices/video.js"></script>
   <script src="devices/fiz.js"></script>
   <script src="devices/batteries.js"></script>
+  <script src="devices/batteryHotswaps.js"></script>
   <script src="devices/cages.js"></script>
   <script src="devices/gearList.js"></script>
   <script src="devices/wirelessReceivers.js"></script>


### PR DESCRIPTION
## Summary
- Fix empty battery hotswap selector by including `devices/batteryHotswaps.js` in `index.html`

## Testing
- `npm test` *(fails: script.js functions – viewfinder field mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_68bcbbbe5d148320884e0d6b97d7439b