### PR TITLE
Filter out underpowered hotswaps

### DIFF
--- a/script.js
+++ b/script.js
@@ -489,6 +489,29 @@ function getHotswapsByMount(mountType) {
   return out;
 }
 
+function filterHotswapsByCurrent(requiredCurrent) {
+  if (!hotswapSelect) return;
+  const currentValue = hotswapSelect.value;
+  let hasValid = false;
+  Array.from(hotswapSelect.options).forEach(opt => {
+    if (opt.value === "None") {
+      opt.hidden = false;
+      opt.disabled = false;
+      if (currentValue === opt.value) hasValid = true;
+      return;
+    }
+    const info = devices.batteryHotswaps && devices.batteryHotswaps[opt.value];
+    const ok = info && typeof info.pinA === "number" && info.pinA >= requiredCurrent;
+    opt.hidden = !ok;
+    opt.disabled = !ok;
+    if (ok && currentValue === opt.value) hasValid = true;
+  });
+  if (!hasValid) {
+    const first = Array.from(hotswapSelect.options).find(o => !o.hidden);
+    if (first) hotswapSelect.value = first.value;
+  }
+}
+
 function getSelectedPlate() {
   const camName = cameraSelect.value;
   const hasB = isNativeBMountCamera(camName);
@@ -4133,6 +4156,7 @@ function updateCalculations() {
   );
   totalCurrent144Elem.textContent = totalCurrentHigh.toFixed(2);
   totalCurrent12Elem.textContent = totalCurrentLow.toFixed(2);
+  filterHotswapsByCurrent(totalCurrentLow);
 
 // Wenn kein Akku oder "None" ausgewählt ist: Laufzeit = nicht berechenbar, keine Warnungen
 let hours = null;

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -1085,6 +1085,28 @@ describe('script.js functions', () => {
     expect(optionsB).not.toContain('VBatt');
   });
 
+  test('hotswap dropdown hides options below required current', () => {
+    global.devices.batteryHotswaps = {
+      SwapHi: { capacity: 50, pinA: 20, mount_type: 'V-Mount' },
+      SwapLo: { capacity: 20, pinA: 5, mount_type: 'V-Mount' }
+    };
+    global.devices.cameras.CamA.powerDrawWatts = 120;
+    const addOpt = (id, value) => {
+      const sel = document.getElementById(id);
+      sel.innerHTML = `<option value="${value}">${value}</option>`;
+      sel.value = value;
+    };
+    addOpt('cameraSelect', 'CamA');
+    addOpt('monitorSelect', 'MonA');
+    addOpt('videoSelect', 'VidA');
+    script.updateBatteryOptions();
+    script.updateCalculations();
+    const hsSel = document.getElementById('batteryHotswapSelect');
+    const visible = Array.from(hsSel.options).filter(o => !o.hidden).map(o => o.value);
+    expect(visible).toContain('SwapHi');
+    expect(visible).not.toContain('SwapLo');
+  });
+
   test('filter inputs disable autocomplete and spellcheck', () => {
     const ids = [
       'cameraListFilter', 'viewfinderListFilter', 'monitorListFilter', 'videoListFilter',


### PR DESCRIPTION
## Summary
- hide hotswap plates that cannot supply required current by checking pin amp rating
- add unit test to ensure low-current hotswaps are omitted from dropdown

## Testing
- `npx jest tests/script.test.js -t "hotswap dropdown hides options below required current"`

------
https://chatgpt.com/codex/tasks/task_e_68bcbfe335808320b42e429cb888625d