### PR TITLE
Filter out underpowered hotswap options

### DIFF
--- a/script.js
+++ b/script.js
@@ -811,6 +811,15 @@ function updateBatteryOptions() {
       Object.entries(swaps).filter(([name]) => name !== 'FX-Lion NANO Dual V-Mount Hot-Swap Plate')
     );
   }
+
+  // Filter out hotswaps that cannot supply the required current
+  const totalCurrentLow = parseFloat(totalCurrent12Elem.textContent);
+  if (isFinite(totalCurrentLow) && totalCurrentLow > 0) {
+    swaps = Object.fromEntries(
+      Object.entries(swaps).filter(([, info]) => typeof info.pinA !== 'number' || info.pinA >= totalCurrentLow)
+    );
+  }
+
   populateSelect(hotswapSelect, swaps, true);
   if (Array.from(batterySelect.options).some(o => o.value === current)) {
     batterySelect.value = current;
@@ -4024,7 +4033,7 @@ function updateCalculations() {
   const motors      = motorSelects.map(sel => sel.value);
   const controllers = controllerSelects.map(sel => sel.value);
   const distance    = distanceSelect.value;
-  const battery     = batterySelect.value;
+  let battery       = batterySelect.value;
 
   // Calculate total power consumption (W)
   let cameraW = 0;
@@ -4139,6 +4148,10 @@ function updateCalculations() {
   );
   totalCurrent144Elem.textContent = totalCurrentHigh.toFixed(2);
   totalCurrent12Elem.textContent = totalCurrentLow.toFixed(2);
+
+  // Update battery and hotswap options based on current draw
+  updateBatteryOptions();
+  battery = batterySelect.value;
 
 // Wenn kein Akku oder "None" ausgewählt ist: Laufzeit = nicht berechenbar, keine Warnungen
 let hours = null;

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -1116,6 +1116,31 @@ describe('script.js functions', () => {
     expect(options).toContain('FX-Lion NANO Dual V-Mount Hot-Swap Plate');
   });
 
+  test('hotswap dropdown hides swaps below current draw', () => {
+    const camSel = document.getElementById('cameraSelect');
+    const battSel = document.getElementById('batterySelect');
+    const swapSel = document.getElementById('batteryHotswapSelect');
+
+    // Ensure battery can handle high current
+    devices.batteries.BattA.pinA = 50;
+    devices.batteries.BattA.dtapA = 50;
+
+    camSel.value = 'CamA';
+    battSel.value = 'BattA';
+
+    // High power draw removes low-amp hotswap
+    devices.cameras.CamA.powerDrawWatts = 150;
+    script.updateCalculations();
+    let options = Array.from(swapSel.options).map(o => o.value);
+    expect(options).not.toContain('SwapLo');
+
+    // Lower power draw brings it back
+    devices.cameras.CamA.powerDrawWatts = 10;
+    script.updateCalculations();
+    options = Array.from(swapSel.options).map(o => o.value);
+    expect(options).toContain('SwapLo');
+  });
+
   test('filter inputs disable autocomplete and spellcheck', () => {
     const ids = [
       'cameraListFilter', 'viewfinderListFilter', 'monitorListFilter', 'videoListFilter',


### PR DESCRIPTION
## Summary
- hide battery hotswap models that cannot supply the required current draw
- update calculations to refresh the hotswap list whenever power usage changes
- add regression test covering current-based hotswap filtering

## Testing
- `npm run lint`
- `npm run check-consistency`
- `node --max-old-space-size=4096 node_modules/.bin/jest --runInBand` *(fails: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_68bcc37f824c83208092b265db6b20ec