### PR TITLE
Improve parsing helper tests

### DIFF
--- a/tests/unifyPorts.test.js
+++ b/tests/unifyPorts.test.js
@@ -6,7 +6,8 @@ const {
   cleanVoltageRange,
   normalizeFiz,
   cleanTypeName,
-  cleanPort
+  cleanPort,
+  splitOutside
 } = require('../unifyPorts.js');
 
 describe('cleanVoltageRange', () => {
@@ -98,6 +99,38 @@ describe('parsePowerInput', () => {
     expect(parsePowerInput(input)).toEqual([
       { type: 'LEMO' }
     ]);
+  });
+
+  it('returns null for non-string input', () => {
+    expect(parsePowerInput(123)).toBeNull();
+  });
+
+  it('returns a fresh copy on repeated calls', () => {
+    const first = parsePowerInput('D-Tap');
+    first[0].type = 'Changed';
+    const second = parsePowerInput('D-Tap');
+    expect(second).toEqual([{ type: 'D-Tap' }]);
+  });
+});
+
+describe('splitOutside', () => {
+  it('ignores delimiters inside parentheses', () => {
+    const input = 'A (B/C) / D';
+    expect(splitOutside(input)).toEqual(['A (B/C) ', ' D']);
+  });
+
+  it('ignores delimiters inside quotes', () => {
+    const input = 'A "B/C" / D';
+    expect(splitOutside(input)).toEqual(['A "B/C" ', ' D']);
+  });
+
+  it('handles nested parentheses', () => {
+    const input = 'A (B (C/D)) / E';
+    expect(splitOutside(input)).toEqual(['A (B (C/D)) ', ' E']);
+  });
+
+  it('returns original string when delimiter is absent', () => {
+    expect(splitOutside('LEMO')).toEqual(['LEMO']);
   });
 });
 


### PR DESCRIPTION
## Summary
- test parsePowerInput for invalid input and defensive copy behavior
- add splitOutside tests for parentheses, quotes, and missing delimiters

## Testing
- `npm run lint`
- `npm run check-consistency`
- `node --max-old-space-size=4096 node_modules/.bin/jest --runInBand tests/unifyPorts.test.js`
- `npm test` *(fails: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_68bcc3ddb9bc8320b6cb37a99a7d3231