### PR TITLE
feat: add help option to schema generator

### DIFF
--- a/generateSchema.js
+++ b/generateSchema.js
@@ -46,7 +46,23 @@ function buildSchema(node) {
   return typeof node;
 }
 
-const schema = buildSchema(devices);
-fs.writeFileSync('schema.json', JSON.stringify(schema, null, 2));
-console.log('schema.json generated');
-
+if (require.main === module) {
+  const args = process.argv.slice(2);
+  if (args.includes('--help') || args.includes('-h')) {
+    console.log(
+      'Usage: node generateSchema.js [--help]\n' +
+        '\nGenerates schema.json from data.js.\n' +
+        '\nExamples:\n' +
+        '  node generateSchema.js\n' +
+        '  node generateSchema.js --help\n' +
+        '\nOptions:\n' +
+        '  -h, --help  Show this help message and exit.'
+    );
+    process.exit(0);
+  }
+  const schema = buildSchema(devices);
+  fs.writeFileSync('schema.json', JSON.stringify(schema, null, 2));
+  console.log('schema.json generated');
+} else {
+  module.exports = { buildSchema, isDeviceObject, isDeviceMap };
+}


### PR DESCRIPTION
## Summary
- add `--help` flag with usage guidance to `generateSchema.js`
- export schema helper functions to avoid side effects when required

## Testing
- `npm run lint`
- `npm run check-consistency`
- `npx jest checkConsistency.test.js --runInBand`
- `npm test` *(fails: process took too long and was terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68bcc3d70c588320adb618efec5f3515