### PR TITLE
Optimize tests to avoid loading full dataset

### DIFF
--- a/tests/cages.test.js
+++ b/tests/cages.test.js
@@ -1,8 +1,7 @@
-const devices = require('../data.js');
+const cages = require('../devices/cages.js');
 
 describe('cages data', () => {
   test('every cage specifies handle_extension_compatible', () => {
-    const cages = devices.accessories.cages;
     Object.values(cages).forEach(cage => {
       expect(typeof cage.handle_extension_compatible).toBe('boolean');
     });

--- a/tests/checkConsistency.test.js
+++ b/tests/checkConsistency.test.js
@@ -1,7 +1,23 @@
 const checkConsistency = require('../checkConsistency');
 
 test('camera data includes required fields', () => {
-  const result = checkConsistency();
+  const validData = {
+    cameras: {
+      CamA: {
+        powerDrawWatts: 1,
+        power: {},
+        videoOutputs: [],
+        fizConnectors: [],
+        recordingMedia: [],
+        viewfinder: [],
+        lensMount: [],
+        timecode: []
+      }
+    },
+    monitors: { MonA: { power: {}, videoInputs: [], videoOutputs: [] } },
+    video: { VidA: { power: {}, videoInputs: [], videoOutputs: [] } }
+  };
+  const result = checkConsistency(validData);
   expect(result).toEqual([]);
 });
 

--- a/tests/parsePowerInputCache.test.js
+++ b/tests/parsePowerInputCache.test.js
@@ -1,3 +1,4 @@
+jest.mock('../data.js', () => ({}));
 const { parsePowerInput } = require('../unifyPorts.js');
 
 describe('parsePowerInput cache', () => {

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -6,27 +6,13 @@ global.TextEncoder = global.TextEncoder || UtilTextEncoder;
 global.TextDecoder = global.TextDecoder || UtilTextDecoder;
 const { JSDOM } = require('jsdom');
 const LZString = require('lz-string');
-const cagesData = require('../devices/cages.js');
-let cageCamera = '';
-let cageNames = [];
-for (const [, cage] of Object.entries(cagesData)) {
-  if (Array.isArray(cage.compatible) && cage.compatible.length) {
-    const cam = cage.compatible[0];
-    const matches = Object.entries(cagesData)
-      .filter(([, c]) => Array.isArray(c.compatible) && c.compatible.includes(cam))
-      .map(([n]) => n);
-    if (matches.length >= 2) {
-      cageCamera = cam;
-      cageNames = matches;
-      break;
-    }
-  }
-}
-if (!cageCamera) {
-  const [firstName, firstCage] = Object.entries(cagesData)[0];
-  cageCamera = Array.isArray(firstCage.compatible) && firstCage.compatible.length ? firstCage.compatible[0] : 'CamA';
-  cageNames = [firstName];
-}
+// Use a small, purpose-built cage dataset to keep memory usage low during tests
+const cagesData = {
+  CageA: { brand: 'TestBrand', compatible: ['CamA'] },
+  CageB: { brand: 'TestBrand', compatible: ['CamA'] }
+};
+const cageCamera = 'CamA';
+const cageNames = Object.keys(cagesData);
 
 function setupDom(removeGear) {
   jest.resetModules();
@@ -4836,12 +4822,12 @@ describe('script.js functions', () => {
 
 describe('monitor wireless metadata', () => {
   test('SmallHD Ultra 7 has wirelessTx set to false', () => {
-    const devices = require('../data.js');
-    expect(devices.monitors['SmallHD Ultra 7'].wirelessTx).toBe(false);
+    const monitors = require('../devices/monitors.js');
+    expect(monitors['SmallHD Ultra 7'].wirelessTx).toBe(false);
   });
 
   test('wirelessTx monitors include latency information', () => {
-    const monitors = require('../data.js').monitors;
+    const monitors = require('../devices/monitors.js');
     Object.values(monitors).forEach((monitor) => {
       if (monitor.wirelessTx) {
         expect(monitor.latencyMs).toBeDefined();
@@ -4850,7 +4836,7 @@ describe('monitor wireless metadata', () => {
   });
 
   test('latency values are set for key wireless monitors', () => {
-    const monitors = require('../data.js').monitors;
+    const monitors = require('../devices/monitors.js');
     expect(monitors['SmallHD Cine 7 Bolt 4K TX'].latencyMs).toBe('< 1ms');
     expect(monitors['Hollyland Pyro 7 (RX/TX)'].latencyMs).toBe('50ms');
     expect(monitors['Hollyland Mars M1 Enhanced (RX/TX)'].wirelessTx).toBe(true);

--- a/tests/unifyPorts.test.js
+++ b/tests/unifyPorts.test.js
@@ -1,3 +1,4 @@
+jest.mock('../data.js', () => ({}));
 const {
   normalizeMonitor,
   normalizeVideoPorts,


### PR DESCRIPTION
## Summary
- Use lightweight cage fixture in script tests to avoid loading the full accessories dataset.
- Limit monitor checks to monitors module and mock data.js in various tests to prevent heavy imports.
- Provide explicit sample data to consistency tests so they don't require the full device catalog.

## Testing
- `npm run lint`
- `npm run check-consistency`
- `node node_modules/.bin/jest tests/unifyPorts.test.js tests/parsePowerInputCache.test.js tests/checkConsistency.test.js tests/cages.test.js tests/utils.test.js tests/index.test.js tests/service-worker.test.js --runInBand`
- ⚠️ `node --max-old-space-size=8192 node_modules/.bin/jest --runInBand` *(timeout)*

------
https://chatgpt.com/codex/tasks/task_e_68bcc44cd8088320abb492920091ff1e