### PR TITLE
test: split heavy script tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,10 @@
     "lint": "eslint .",
     "check-consistency": "node checkConsistency.js",
     "normalize": "node normalizeData.js",
-    "test": "npm run lint && npm run check-consistency && node --max-old-space-size=8192 node_modules/.bin/jest --runInBand"
+    "test": "npm run lint && npm run check-consistency && npm run test:jest",
+    "test:jest": "npm run test:unit && npm run test:script",
+    "test:unit": "node --max-old-space-size=8192 node_modules/.bin/jest --runInBand --testPathIgnorePatterns=tests/script.test.js",
+    "test:script": "node --max-old-space-size=8192 node_modules/.bin/jest --runInBand tests/script.test.js"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- split heavy `script.test.js` into a dedicated Jest run to avoid hitting Node's heap limit

## Testing
- `npm test` *(hangs on long-running script tests)*

------
https://chatgpt.com/codex/tasks/task_e_68bd58413c308320abd45617f87c5665