### PR TITLE
Increase help dialog line spacing

### DIFF
--- a/style.css
+++ b/style.css
@@ -318,6 +318,11 @@ a:focus {
   color: var(--text-color);
 }
 
+.help-content p,
+.help-content li {
+  line-height: 1.6;
+}
+
 
 #helpSearchContainer {
   position: relative;


### PR DESCRIPTION
## Summary
- Add explicit line height for help dialog body text to improve readability

## Testing
- `npm run lint`
- `npm run check-consistency`
- `node --max-old-space-size=8192 node_modules/.bin/jest --runInBand tests/cliHelp.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68bd5affdf10832087fc202493c05619