### PR TITLE
Improve theme handling and header button styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,6 +16,7 @@
   <meta name="apple-mobile-web-app-title" content="Cine List" />
   <!-- Enables features that rely on eval(); revisit if security requirements change -->
   <meta http-equiv="Content-Security-Policy" content="script-src 'self' 'unsafe-eval' 'unsafe-inline';" />
+  <meta name="color-scheme" content="light dark" />
   <title>Cine List</title>
   <link href="https://fonts.googleapis.com/css2?family=Ubuntu:wght@300;700&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="style.css" />

--- a/style.css
+++ b/style.css
@@ -1,5 +1,6 @@
 /* General styles */
 :root {
+  color-scheme: light dark;
   --accent-color: #001589;
   --background-color: #f9f9f9;
   --surface-color: #ffffff;
@@ -687,20 +688,11 @@ button:disabled {
   border-radius: 50%;
 }
 
-#topBar button:hover {
-  background-color: var(--control-hover-bg);
-  color: var(--control-text);
-  border-color: var(--control-border);
-  box-shadow: none;
-  transform: none;
-}
-
+#topBar button:hover,
 #topBar button:active {
-  background-color: var(--control-active-bg);
-  color: var(--control-text);
-  border-color: var(--control-border);
-  box-shadow: none;
-  transform: none;
+  background-color: var(--accent-color);
+  color: var(--inverse-text-color);
+  border-color: var(--accent-color);
 }
 
 #helpButton {
@@ -1212,6 +1204,7 @@ body.pink-mode #userFeedbackTable th {
 
 html.dark-mode,
 .dark-mode {
+  color-scheme: dark light;
   --background-color: #1c1c1e;
   --surface-color: #1c1c1e;
   --text-color: #f0f0f0;


### PR DESCRIPTION
## Summary
- Declare support for light and dark themes and set color-scheme hints
- Let header controls use the accent color on hover/active for a consistent look

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd5d239d008320a0fc1bcc78f1a669