### PR TITLE
Reduce test memory usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "normalize": "node normalizeData.js",
     "test": "npm run lint && npm run check-consistency && npm run test:jest",
     "test:jest": "npm run test:unit && npm run test:script",
-    "test:unit": "node --max-old-space-size=8192 node_modules/.bin/jest --runInBand --testPathIgnorePatterns=tests/script.test.js",
-    "test:script": "node --max-old-space-size=8192 node_modules/.bin/jest --runInBand tests/script.test.js"
+    "test:unit": "jest --runInBand --testPathIgnorePatterns=tests/script.test.js",
+    "test:script": "jest --runInBand tests/script.test.js"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- run Jest directly without forcing an 8GB heap for tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd5ff1b9648320a70ffb4abd8143e0