### PR TITLE
Standardize battery mount naming

### DIFF
--- a/devices/cages.js
+++ b/devices/cages.js
@@ -759,7 +759,7 @@ const cageData = {
     ],
     "top_handle_included": true,
     "side_plates": true,
-    "notes": "Complete rig with shoulder support, EVF bracket, power module (Gold mount or V-mount), 15 mm rod support and modular plates.",
+    "notes": "Complete rig with shoulder support, EVF bracket, power module (Gold-Mount or V-Mount), 15 mm rod support and modular plates.",
     "verified_source": "https://www.adorama.com/iaest65.html",
     "handle_extension_compatible": true
   },
@@ -777,7 +777,7 @@ const cageData = {
       "ARRI rosette",
       "shoulder pad",
       "VCT-14 dovetail",
-      "Gold mount battery plate",
+      "Gold-Mount battery plate",
       "power outputs",
       "EVF support",
       "quick-release top handle",
@@ -1174,7 +1174,7 @@ const cageData = {
       "3/8\"-16",
       "15 mm LWS rods",
       "lens support",
-      "V-mount/Gold Mount interfaces"
+      "V-Mount/Gold-Mount interfaces"
     ],
     "top_handle_included": false,
     "side_plates": true,

--- a/devices/gearList.js
+++ b/devices/gearList.js
@@ -176,7 +176,7 @@ const gear = {
         "input": [
           { "type": "XLR 4-pin" },
           { "type": "V-Mount" },
-          { "type": "Gold Mount" }
+          { "type": "Gold-Mount" }
         ],
         "output": null
       },
@@ -249,7 +249,7 @@ const gear = {
         "input": [
           { "type": "XLR 4-pin" },
           { "type": "V-Mount" },
-          { "type": "Gold Mount" }
+          { "type": "Gold-Mount" }
         ],
         "output": null
       },

--- a/devices/video.js
+++ b/devices/video.js
@@ -52,10 +52,10 @@ const videoData = {
           "notes": "6-28V"
         },
         {
-          "type": "Gold-mount"
+          "type": "Gold-Mount"
         },
         {
-          "type": "V-mount"
+          "type": "V-Mount"
         }
       ]
     }
@@ -87,10 +87,10 @@ const videoData = {
           "notes": "6-28V"
         },
         {
-          "type": "Gold-mount"
+          "type": "Gold-Mount"
         },
         {
-          "type": "V-mount"
+          "type": "V-Mount"
         }
       ]
     }
@@ -146,10 +146,10 @@ const videoData = {
           "notes": "6-28V"
         },
         {
-          "type": "Gold-mount"
+          "type": "Gold-Mount"
         },
         {
-          "type": "V-mount"
+          "type": "V-Mount"
         }
       ]
     }

--- a/devices/wirelessReceivers.js
+++ b/devices/wirelessReceivers.js
@@ -21,10 +21,10 @@ const wirelessReceiversData = {
           "notes": "6-28V"
         },
         {
-          "type": "Gold-mount"
+          "type": "Gold-Mount"
         },
         {
-          "type": "V-mount"
+          "type": "V-Mount"
         }
       ]
     }
@@ -49,10 +49,10 @@ const wirelessReceiversData = {
           "notes": "6-28V"
         },
         {
-          "type": "Gold-mount"
+          "type": "Gold-Mount"
         },
         {
-          "type": "V-mount"
+          "type": "V-Mount"
         }
       ]
     }
@@ -77,10 +77,10 @@ const wirelessReceiversData = {
           "notes": "6-28V"
         },
         {
-          "type": "Gold-mount"
+          "type": "Gold-Mount"
         },
         {
-          "type": "V-mount"
+          "type": "V-Mount"
         }
       ]
     }
@@ -105,10 +105,10 @@ const wirelessReceiversData = {
           "notes": "7-17V"
         },
         {
-          "type": "Gold-mount"
+          "type": "Gold-Mount"
         },
         {
-          "type": "V-mount"
+          "type": "V-Mount"
         }
       ]
     }
@@ -163,10 +163,10 @@ const wirelessReceiversData = {
           "notes": "6-28V"
         },
         {
-          "type": "Gold-mount"
+          "type": "Gold-Mount"
         },
         {
-          "type": "V-mount"
+          "type": "V-Mount"
         }
       ]
     }
@@ -208,10 +208,10 @@ const wirelessReceiversData = {
           "notes": "6-28V"
         },
         {
-          "type": "Gold-mount"
+          "type": "Gold-Mount"
         },
         {
-          "type": "V-mount"
+          "type": "V-Mount"
         }
       ]
     }


### PR DESCRIPTION
## Summary
- Standardize battery plate type strings to `V-Mount` and `Gold-Mount`
- Update notes referencing battery plates to use consistent casing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd5d3acee48320b53655dd7798a367