### PR TITLE
Document offline data handling in README files

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -102,6 +102,15 @@ Die Sprache kann oben rechts umgeschaltet werden und wird für den nächsten Bes
 5. **Setups speichern & laden:** Setups benennen, exportieren/importieren und eine druckbare Übersicht erzeugen
 6. **Geräteliste verwalten:** „Gerätedaten bearbeiten…“ öffnet den Editor zum Anpassen oder Zurücksetzen
 
+## 📡 Offline-Nutzung & Datenspeicherung
+
+Wird die App über HTTP(S) bereitgestellt, installiert sie einen Service Worker,
+der alle Dateien für die Offline-Nutzung zwischenspeichert und im Hintergrund
+aktualisiert. Projekte, Laufzeitmeldungen und Einstellungen (Sprache, Theme,
+Pinkmodus und gespeicherte Listen) werden im `localStorage` deines Browsers
+gespeichert. Über die Seiteneinstellungen des Browsers lassen sich alle
+gespeicherten Daten löschen.
+
 ---
 
 ## 🗂️ Dateistruktur

--- a/README.en.md
+++ b/README.en.md
@@ -154,6 +154,14 @@ The planner is a Progressive Web App and can be installed directly from your bro
 
 Once installed, the app launches from your home screen, works offline and updates itself automatically.
 
+## 📡 Offline Use & Data Storage
+
+Serving the app over HTTP(S) installs a service worker that caches every file
+so Cine List works fully offline and updates in the background. Projects,
+runtime submissions and preferences (language, theme, pink mode and saved gear
+lists) live in your browser's `localStorage`. Clearing the site's data in the
+browser removes all stored information.
+
 ---
 
 ## 🗂️ File Structure

--- a/README.es.md
+++ b/README.es.md
@@ -102,6 +102,15 @@ El idioma puede cambiarse en la esquina superior derecha y se recuerda para la p
 5. **Guardar y cargar configuraciones:** nombrar y exportar/importar configuraciones, además de generar un resumen imprimible
 6. **Gestionar lista de dispositivos:** “Editar datos de dispositivos…” abre el editor para modificarlos o restablecer la base
 
+## 📡 Uso sin conexión y almacenamiento de datos
+
+Al servirse mediante HTTP(S), la aplicación instala un service worker que
+almacena en caché todos los archivos para que funcione sin conexión y se
+actualice en segundo plano. Los proyectos, las autonomías enviadas y las
+preferencias (idioma, tema, modo rosa y listas guardadas) se guardan en el
+`localStorage` del navegador. Al borrar los datos del sitio en el navegador se
+elimina toda la información almacenada.
+
 ---
 
 ## 🗂️ Estructura de Archivos

--- a/README.fr.md
+++ b/README.fr.md
@@ -102,6 +102,15 @@ La langue se change en haut à droite et est mémorisée pour la prochaine visit
 5. **Enregistrer et charger des configurations :** nommer et exporter/importer les configurations et générer un aperçu imprimable
 6. **Gérer la liste des appareils :** « Éditer les données… » ouvre l'éditeur pour modifier ou réinitialiser
 
+## 📡 Utilisation hors ligne et stockage des données
+
+Servie via HTTP(S), l'application installe un service worker qui met en cache
+tous les fichiers afin que Cine List fonctionne hors ligne et se mette à jour en
+arrière-plan. Les projets, rapports d'autonomie et préférences (langue, thème,
+mode rose et listes enregistrées) sont stockés dans le `localStorage` du
+navigateur. Effacer les données du site dans le navigateur supprime toutes les
+informations sauvegardées.
+
 ---
 
 ## 🗂️ Arborescence

--- a/README.it.md
+++ b/README.it.md
@@ -101,6 +101,15 @@ Puoi cambiare lingua nell'angolo in alto a destra. La scelta viene memorizzata p
 5. **Salva e carica le configurazioni:** dai un nome alla configurazione, salvala, esportala/importala e genera una panoramica stampabile
 6. **Gestisci la lista dei dispositivi:** clicca su “Modifica dati dispositivi…” per aprire l'editor, modificare i dispositivi o ripristinare i valori predefiniti
 
+## 📡 Uso offline e conservazione dei dati
+
+Quando viene servita via HTTP(S), l'app installa un service worker che memorizza
+in cache tutti i file affinché Cine List funzioni senza connessione e si
+aggiorni in background. I progetti, i report di autonomia e le preferenze
+(lingua, tema, modalità rosa e liste salvate) vengono salvati nel `localStorage`
+del browser. Cancellando i dati del sito nel browser si rimuovono tutte le
+informazioni memorizzate.
+
 ---
 
 ## 🗂️ Struttura dei file

--- a/README.md
+++ b/README.md
@@ -131,6 +131,15 @@ access:
 3. Launch the app from your applications list. The installed version works
    offline and updates automatically.
 
+## Offline Use and Data Storage
+
+When served over HTTP(S), Cine List installs a service worker that caches all
+files so the planner runs entirely offline and pulls updates in the
+background. Projects, runtime submissions and preferences (language, theme,
+pink mode and saved gear lists) are stored locally via `localStorage` in your
+browser. Clearing the site's data in your browser removes all saved
+information.
+
 ## Browser Support
 
 Cine List relies on modern web APIs and is tested in current versions of Chrome, Firefox, Edge and Safari. Older browsers may lack support for features like installation or offline caching. For the best experience, use a browser with up-to-date Progressive Web App (PWA) capabilities.


### PR DESCRIPTION
## Summary
- add detailed offline usage and data storage section to README
- mirror offline details across localized README files

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bd5df136d883208d96f4480292c6d8