### PR TITLE
Clarify scenario accessory additions in gear list help

### DIFF
--- a/index.html
+++ b/index.html
@@ -681,7 +681,13 @@
               <li>Once generated, the list refreshes automatically when device selections or project requirements change.</li>
               <li>Items are grouped by category (camera, lens, power, monitoring, accessories) with duplicates merged and counted.</li>
               <li>The generator auto-adds required cables, rigging and accessories for monitors, motors, gimbals and weather scenarios.</li>
-              <li>Scenario selections (e.g. Handheld, Gimbal, Outdoor) inject related gear such as Easyrig parts, gimbal filters or rain protection.</li>
+              <li>Scenario selections inject related gear:
+                <ul>
+                  <li><strong>Handheld + Easyrig</strong> adds a telescopic handle for stable support.</li>
+                  <li><strong>Gimbal</strong> supplies the chosen gimbal and required filters or sunshades.</li>
+                  <li><strong>Outdoor</strong> adds spigots, umbrellas and CapIt rain covers for monitor protection.</li>
+                </ul>
+              </li>
               <li>Lens choices append front diameter, weight and rod requirements, add lens supports and matte box components, and warn about incompatible rod standards.</li>
               <li>Battery entries reflect counts from the power calculator and include hotswap plates or selected hotswap devices when needed.</li>
               <li>Monitoring preferences provide default monitors for each role (Director, DoP, etc.) and include cable sets for every screen.</li>


### PR DESCRIPTION
## Summary
- detail automatic accessory additions for Handheld + Easyrig, Gimbal and Outdoor scenarios in gear list help

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd6ab8da3883209eefa4840165bc4d