### PR TITLE
Preserve FIZ devices when loading stored data

### DIFF
--- a/script.js
+++ b/script.js
@@ -546,7 +546,25 @@ if (window.defaultDevices === undefined) {
 // Load any saved device data from localStorage
 let storedDevices = loadDeviceData();
 if (storedDevices) {
-  devices = storedDevices;
+  // Merge stored devices with the defaults so that categories missing
+  // from saved data (e.g. FIZ) fall back to the built-in definitions.
+  const merged = JSON.parse(JSON.stringify(window.defaultDevices));
+  for (const [key, value] of Object.entries(storedDevices)) {
+    if (key === 'fiz' && value && typeof value === 'object') {
+      merged.fiz = merged.fiz || {};
+      for (const [sub, subVal] of Object.entries(value)) {
+        merged.fiz[sub] = {
+          ...(merged.fiz[sub] || {}),
+          ...(subVal || {}),
+        };
+      }
+    } else if (merged[key] && typeof merged[key] === 'object') {
+      merged[key] = { ...merged[key], ...(value || {}) };
+    } else {
+      merged[key] = value;
+    }
+  }
+  devices = merged;
 }
 unifyDevices(devices);
 

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -158,6 +158,21 @@ test('Easyrig stabiliser data exposes attachments', () => {
   ]);
 });
 
+test('default FIZ devices remain when stored data lacks them', () => {
+  setupDom(false);
+  const defaultMotors = Object.keys(devices.fiz.motors);
+  // Stored data missing FIZ entries
+  global.loadDeviceData = jest.fn(() => ({
+    cameras: {},
+    monitors: {},
+    video: {},
+    batteries: {},
+    fiz: { motors: {}, controllers: {}, distance: {} }
+  }));
+  require('../script.js');
+  expect(Object.keys(devices.fiz.motors)).toEqual(defaultMotors);
+});
+
 test('filter options include diopter', () => {
   const gear = require('../devices/gearList.js');
   expect(gear.filterOptions).toContain('Diopter');


### PR DESCRIPTION
## Summary
- merge saved device data with defaults so missing categories like FIZ still include built-in entries
- add regression test ensuring default FIZ devices remain when storage lacks them

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd6b5983cc832087e3aeab0ffbad12