### PR TITLE
fix: add camera support device category

### DIFF
--- a/index.html
+++ b/index.html
@@ -247,6 +247,7 @@
         <option value="accessories.batteries">Accessory Battery</option>
         <option value="accessories.cables">Cable</option>
         <option value="accessories.cages">Camera Cage</option>
+        <option value="accessories.cameraSupport">Camera Support</option>
         <option value="accessories.chargers">Charger</option>
       </select>
     </div>

--- a/script.js
+++ b/script.js
@@ -5869,7 +5869,7 @@ function refreshDeviceLists() {
   renderDeviceList("batteries", batteryListElem);
   renderDeviceList("accessories.batteries", accessoryBatteryListElem);
   renderDeviceList("accessories.cables", cableListElem);
-  renderDeviceList("accessories.cages", cameraSupportListElem);
+  renderDeviceList("accessories.cameraSupport", cameraSupportListElem);
   renderDeviceList("accessories.chargers", chargerListElem);
 
   filterDeviceList(cameraListElem, cameraListFilterInput.value);

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -163,6 +163,16 @@ test('filter options include diopter', () => {
   expect(gear.filterOptions).toContain('Diopter');
 });
 
+test('camera support list renders camera support devices', () => {
+  setupDom(false);
+  devices.accessories.cameraSupport = { SupportA: {} };
+  require('../translations.js');
+  require('../script.js');
+  const listHtml = document.getElementById('cameraSupportList').innerHTML;
+  expect(listHtml).toContain('SupportA');
+  expect(listHtml).not.toContain(cageNames[0]);
+});
+
 test('restores project requirements from storage when gear list element is absent', () => {
   setupDom(true);
   const storedHtml = '<h2>Proj</h2><h3>Project Requirements</h3><div class="requirements-grid"><div class="requirement-box"><span class="req-label">Codec</span><span class="req-value">ProRes</span></div></div>';
@@ -469,6 +479,12 @@ describe('script.js functions', () => {
     const select = document.getElementById('newCategory');
     const hasHotswap = Array.from(select.options).some(o => o.value === 'batteryHotswaps');
     expect(hasHotswap).toBe(true);
+  });
+
+  test('new device form includes camera support category option', () => {
+    const select = document.getElementById('newCategory');
+    const hasSupport = Array.from(select.options).some(o => o.value === 'accessories.cameraSupport');
+    expect(hasSupport).toBe(true);
   });
 
   test('populateLensDropdown fills lens list without duplicates and adds attributes', () => {

--- a/translations.js
+++ b/translations.js
@@ -1906,6 +1906,7 @@ const categoryNames = {
     "accessories.batteries": "Accessory Battery",
     "accessories.cables": "Cable",
     "accessories.cages": "Camera Cage",
+    "accessories.cameraSupport": "Camera Support",
     "accessories.chargers": "Charger"
   },
   it: {
@@ -1921,6 +1922,7 @@ const categoryNames = {
     "accessories.batteries": "Batteria per accessori",
     "accessories.cables": "Cavo",
     "accessories.cages": "Gabbia",
+    "accessories.cameraSupport": "Supporto camera",
     "accessories.chargers": "Caricatore"
   },
   es: {
@@ -1936,6 +1938,7 @@ const categoryNames = {
     "accessories.batteries": "Batería para accesorios",
     "accessories.cables": "Cable",
     "accessories.cages": "Jaula de cámara",
+    "accessories.cameraSupport": "Soporte de cámara",
     "accessories.chargers": "Cargador"
   },
   fr: {
@@ -1951,6 +1954,7 @@ const categoryNames = {
     "accessories.batteries": "Batterie accessoire",
     "accessories.cables": "Câble",
     "accessories.cages": "Cage",
+    "accessories.cameraSupport": "Support caméra",
     "accessories.chargers": "Chargeur"
   },
   de: {
@@ -1966,6 +1970,7 @@ const categoryNames = {
     "accessories.batteries": "Zubehör-Akku",
     "accessories.cables": "Kabel",
     "accessories.cages": "Cage",
+    "accessories.cameraSupport": "Kamera-Support",
     "accessories.chargers": "Ladegerät"
   },
 };


### PR DESCRIPTION
## Summary
- include camera support option in device editor
- translate camera support category for all locales
- ensure camera support devices list correctly renders

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bd6d88837c832090d1eb48505ed2b0