### PR TITLE
Preserve attributes when editing generic devices

### DIFF
--- a/script.js
+++ b/script.js
@@ -6765,10 +6765,17 @@ addDeviceBtn.addEventListener("click", () => {
       alert(texts[currentLang].alertDeviceWatt);
       return;
     }
+    const existing = isEditing ? targetCategory[originalName] : undefined;
     if (isEditing && name !== originalName) {
       delete targetCategory[originalName];
     }
-    targetCategory[name] = { powerDrawWatts: watt };
+    if (existing && typeof existing === 'object' && !Array.isArray(existing)) {
+      targetCategory[name] = { ...existing, powerDrawWatts: watt };
+    } else if (existing !== undefined && typeof existing !== 'object') {
+      targetCategory[name] = watt;
+    } else {
+      targetCategory[name] = { powerDrawWatts: watt };
+    }
   }
 
   // After adding/updating, reset form and refresh lists

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -4972,6 +4972,22 @@ describe('monitor wireless metadata', () => {
     expect(document.getElementById('videoFrequency').value).toBe('5GHz');
   });
 
+  test('editing accessory charger preserves existing attributes', () => {
+    const addDeviceBtn = document.getElementById('addDeviceBtn');
+    document.getElementById('newCategory').value = 'accessories.chargers';
+    document.getElementById('newName').value = 'Single V-Mount Charger';
+    document.getElementById('newWatt').value = '30';
+    addDeviceBtn.dataset.mode = 'edit';
+    addDeviceBtn.dataset.originalName = 'Single V-Mount Charger';
+    addDeviceBtn.click();
+    expect(devices.accessories.chargers['Single V-Mount Charger']).toEqual({
+      mount: 'V-Mount',
+      slots: 1,
+      chargingSpeedAmps: 3,
+      powerDrawWatts: 30
+    });
+  });
+
   test('runtime feedback dialog pre-fills resolution and codec', () => {
     const cam = devices.cameras.CamA;
     cam.resolutions = ['1920x1080'];


### PR DESCRIPTION
## Summary
- Keep existing properties when updating generic device categories so edits don't wipe other fields
- Test editing accessory charger retains mount, slot, and charging speed data

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bd6be004808320b2960e006997b0c2