### PR TITLE
Add monitor metadata and update schema

### DIFF
--- a/devices/gearList.js
+++ b/devices/gearList.js
@@ -26,6 +26,8 @@ const gear = {
   },
   "directorMonitors": {
     "Directors Monitor 17\" (SmallHD/FSI)": {
+      "brand": "SmallHD/FSI",
+      "model": "Directors Monitor 17\"",
       "screenSizeInches": 17,
       "brightnessNits": 1000,
       "powerDrawWatts": 45,
@@ -52,6 +54,8 @@ const gear = {
       ]
     },
     "Directors Monitor 13\" (SmallHD/FSI)": {
+      "brand": "SmallHD/FSI",
+      "model": "Directors Monitor 13\"",
       "screenSizeInches": 13,
       "brightnessNits": 1000,
       "powerDrawWatts": 30,
@@ -124,6 +128,8 @@ const gear = {
       ]
     },
     "Sony PVM-A170 17\" OLED": {
+      "brand": "Sony",
+      "model": "PVM-A170",
       "screenSizeInches": 17,
       "brightnessNits": 250,
       "powerDrawWatts": 54,

--- a/schema.json
+++ b/schema.json
@@ -177,6 +177,13 @@
       "weight_g"
     ]
   },
+  "batteryHotswaps": {
+    "attributes": [
+      "capacity",
+      "mount_type",
+      "pinA"
+    ]
+  },
   "cameras": {
     "attributes": [
       "fizConnectors",
@@ -195,7 +202,9 @@
   },
   "directorMonitors": {
     "attributes": [
+      "brand",
       "brightnessNits",
+      "model",
       "power",
       "powerDrawWatts",
       "screenSizeInches",


### PR DESCRIPTION
## Summary
- include brand and model details for SmallHD/FSI director monitors and Sony PVM-A170
- regenerate schema to expose new battery hotswap and director monitor attributes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd6d8c128083209977ad4f4fd697fb