### PR TITLE
Standardize accessory battery mount attribute

### DIFF
--- a/devices/gearList.js
+++ b/devices/gearList.js
@@ -800,17 +800,17 @@ const gear = {
     "batteries": {
       "Sony NP-F970": {
         "capacity": 47,
-        "mount": "NP-F",
+        "mount_type": "NP-F",
         "weight_g": 225
       },
       "Sony NP-F750": {
         "capacity": 33,
-        "mount": "NP-F",
+        "mount_type": "NP-F",
         "weight_g": 220
       },
       "Sony NP-F550": {
         "capacity": 16,
-        "mount": "NP-F",
+        "mount_type": "NP-F",
         "weight_g": 110
       }
     },

--- a/schema.json
+++ b/schema.json
@@ -3,7 +3,7 @@
     "batteries": {
       "attributes": [
         "capacity",
-        "mount",
+        "mount_type",
         "weight_g"
       ]
     },


### PR DESCRIPTION
## Summary
- replace inconsistent `mount` property with `mount_type` for accessory batteries
- align schema with updated mount attribute

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68bd7074e01883208abd3ddd987bf25a