### PR TITLE
Enable hover help for all sections

### DIFF
--- a/script.js
+++ b/script.js
@@ -1182,13 +1182,27 @@ function setLanguage(lang) {
     "data-help",
     texts[lang].setupManageHeadingHelp
   );
+  const setupManagerSection = document.getElementById("setup-manager");
+  if (setupManagerSection)
+    setupManagerSection.setAttribute(
+      "data-help",
+      texts[lang].setupManageHeadingHelp
+    );
 
-  const deviceSelectionHeadingElem = document.getElementById("deviceSelectionHeading");
+  const deviceSelectionHeadingElem = document.getElementById(
+    "deviceSelectionHeading"
+  );
   deviceSelectionHeadingElem.textContent = texts[lang].deviceSelectionHeading;
   deviceSelectionHeadingElem.setAttribute(
     "data-help",
     texts[lang].deviceSelectionHeadingHelp
   );
+  const setupConfigSection = document.getElementById("setup-config");
+  if (setupConfigSection)
+    setupConfigSection.setAttribute(
+      "data-help",
+      texts[lang].deviceSelectionHeadingHelp
+    );
 
   const resultsHeadingElem = document.getElementById("resultsHeading");
   resultsHeadingElem.textContent = texts[lang].resultsHeading; // Fixed typo here
@@ -1196,20 +1210,39 @@ function setLanguage(lang) {
     "data-help",
     texts[lang].resultsHeadingHelp
   );
+  const resultsSection = document.getElementById("results");
+  if (resultsSection)
+    resultsSection.setAttribute("data-help", texts[lang].resultsHeadingHelp);
 
-  const deviceManagerHeadingElem = document.getElementById("deviceManagerHeading");
+  const deviceManagerHeadingElem = document.getElementById(
+    "deviceManagerHeading"
+  );
   deviceManagerHeadingElem.textContent = texts[lang].deviceManagerHeading;
   deviceManagerHeadingElem.setAttribute(
     "data-help",
     texts[lang].deviceManagerHeadingHelp
   );
+  const deviceManagerSection = document.getElementById("device-manager");
+  if (deviceManagerSection)
+    deviceManagerSection.setAttribute(
+      "data-help",
+      texts[lang].deviceManagerHeadingHelp
+    );
 
-  const batteryComparisonHeadingElem = document.getElementById("batteryComparisonHeading");
+  const batteryComparisonHeadingElem = document.getElementById(
+    "batteryComparisonHeading"
+  );
   batteryComparisonHeadingElem.textContent = texts[lang].batteryComparisonHeading;
   batteryComparisonHeadingElem.setAttribute(
     "data-help",
     texts[lang].batteryComparisonHeadingHelp
   );
+  const batteryComparisonSection = document.getElementById("batteryComparison");
+  if (batteryComparisonSection)
+    batteryComparisonSection.setAttribute(
+      "data-help",
+      texts[lang].batteryComparisonHeadingHelp
+    );
 
   const setupDiagramHeadingElem = document.getElementById("setupDiagramHeading");
   setupDiagramHeadingElem.textContent = texts[lang].setupDiagramHeading;
@@ -1217,6 +1250,12 @@ function setLanguage(lang) {
     "data-help",
     texts[lang].setupDiagramHeadingHelp
   );
+  const setupDiagramSection = document.getElementById("setupDiagram");
+  if (setupDiagramSection)
+    setupDiagramSection.setAttribute(
+      "data-help",
+      texts[lang].setupDiagramHeadingHelp
+    );
   // Setup manager labels and buttons
   const savedSetupsLabelElem = document.getElementById("savedSetupsLabel");
   savedSetupsLabelElem.textContent = texts[lang].savedSetupsLabel;
@@ -9789,8 +9828,7 @@ if (helpButton && helpDialog) {
     const el = e.target.closest(
       '[data-help], [aria-label], [title], [aria-labelledby], [alt]'
     );
-    // Ignore non-descriptive elements such as generic sections
-    if (!el || el.tagName === 'SECTION') {
+    if (!el) {
       hoverHelpTooltip.setAttribute('hidden', '');
       return;
     }

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -4529,6 +4529,19 @@ describe('script.js functions', () => {
     document.dispatchEvent(new MouseEvent('click', { bubbles: true }));
   });
 
+  test('hover help shows descriptions for entire sections', () => {
+    const hoverHelpButton = document.getElementById('hoverHelpButton');
+    const section = document.getElementById('setup-manager');
+
+    hoverHelpButton.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    section.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
+
+    const tooltip = document.getElementById('hoverHelpTooltip');
+    expect(tooltip.textContent).toBe(texts.en.setupManageHeadingHelp);
+
+    document.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+  });
+
   test('saved setups label has descriptive hover help', () => {
     const label = document.getElementById('savedSetupsLabel');
     expect(label.getAttribute('data-help')).toBe(texts.en.setupSelectHelp);


### PR DESCRIPTION
## Summary
- Show section descriptions in hover-help mode by assigning help text to each major section
- Allow hover-help tooltips to appear when pointing at sections
- Test section hover-help behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bd711599148320801e1069702a02ce