### PR TITLE
feat: show lens clamp-on and focus info

### DIFF
--- a/script.js
+++ b/script.js
@@ -8489,8 +8489,14 @@ function generateGearListHtml(info = {}) {
         if (!lens) return base;
         const attrs = [];
         if (lens.weight_g) attrs.push(`${lens.weight_g}g`);
-        if (lens.frontDiameterMm) attrs.push(`${lens.frontDiameterMm}mm front`);
-        if (lens.tStop) attrs.push(`T${lens.tStop}`);
+        if (lens.clampOn) {
+            if (lens.frontDiameterMm) attrs.push(`${lens.frontDiameterMm}mm clamp-on`);
+            else attrs.push('clamp-on');
+        } else if (lens.clampOn === false) {
+            attrs.push('no clamp-on');
+        }
+        const minFocus = lens.minFocusMeters ?? lens.minFocus ?? (lens.minFocusCm ? lens.minFocusCm / 100 : null);
+        if (minFocus) attrs.push(`${minFocus}m min focus`);
         return attrs.length ? `${base} (${attrs.join(', ')})` : base;
     });
     addRow('Lens', formatItems(lensDisplayNames));
@@ -10128,8 +10134,14 @@ function populateLensDropdown() {
     const lens = lensData[name] || {};
     const attrs = [];
     if (lens.weight_g) attrs.push(`${lens.weight_g}g`);
-    if (lens.frontDiameterMm) attrs.push(`${lens.frontDiameterMm}mm front`);
-    if (lens.tStop) attrs.push(`T${lens.tStop}`);
+    if (lens.clampOn) {
+      if (lens.frontDiameterMm) attrs.push(`${lens.frontDiameterMm}mm clamp-on`);
+      else attrs.push('clamp-on');
+    } else if (lens.clampOn === false) {
+      attrs.push('no clamp-on');
+    }
+    const minFocus = lens.minFocusMeters ?? lens.minFocus ?? (lens.minFocusCm ? lens.minFocusCm / 100 : null);
+    if (minFocus) attrs.push(`${minFocus}m min focus`);
     opt.textContent = attrs.length ? `${name} (${attrs.join(', ')})` : name;
     lensSelect.appendChild(opt);
   });

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -359,7 +359,7 @@ describe('script.js functions', () => {
         }
       },
         lenses: {
-          LensA: { brand: 'TestBrand', tStop: 2.0, rodStandard: '15mm', rodLengthCm: 30, needsLensSupport: true, frontDiameterMm: 80, weight_g: 110 },
+          LensA: { brand: 'TestBrand', tStop: 2.0, rodStandard: '15mm', rodLengthCm: 30, needsLensSupport: true, frontDiameterMm: 80, weight_g: 110, clampOn: true, minFocusMeters: 0.35 },
           LensBig: { frontDiameterMm: 110 }
         },
       fiz: {
@@ -519,7 +519,8 @@ describe('script.js functions', () => {
     expect(Array.from(sel.options).map(o => o.value)).toEqual(['LensA', 'LensBig']);
     expect(sel.options[0].textContent).toContain('LensA');
     expect(sel.options[0].textContent).toContain('110g');
-    expect(sel.options[0].textContent).toContain('80mm front');
+    expect(sel.options[0].textContent).toContain('80mm clamp-on');
+    expect(sel.options[0].textContent).toContain('0.35m min focus');
     // Call again to ensure no duplication occurs
     script.populateLensDropdown();
     expect(Array.from(sel.options).map(o => o.value)).toEqual(['LensA', 'LensBig']);
@@ -545,7 +546,8 @@ describe('script.js functions', () => {
     const lensRow = rows[lensIndex + 1];
     expect(lensRow.textContent).toContain('LensA');
     expect(lensRow.textContent).toContain('110g');
-    expect(lensRow.textContent).toContain('80mm front');
+    expect(lensRow.textContent).toContain('80mm clamp-on');
+    expect(lensRow.textContent).toContain('0.35m min focus');
   });
 
   test('selected cage appears in camera support category of gear list', () => {


### PR DESCRIPTION
## Summary
- list lens weight, clamp-on support, and minimum focus in gear list
- remove lens T-stop from selector and gear list displays

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bd715573308320a7f2ceae00cb9b9d