### PR TITLE
Reorder gear list after project diagram

### DIFF
--- a/index.html
+++ b/index.html
@@ -197,7 +197,6 @@
   </section>
 
   <section id="projectRequirementsOutput" class="hidden"></section>
-  <section id="gearListOutput" class="hidden"></section>
 
   <section id="setupDiagram">
     <h2 id="setupDiagramHeading">Project Diagram</h2>
@@ -216,6 +215,8 @@
     </div>
     <p id="diagramHint" class="diagram-hint"></p>
   </section>
+
+  <section id="gearListOutput" class="hidden"></section>
 
   <section id="batteryComparison" class="hidden">
     <h2 id="batteryComparisonHeading">Battery Comparison</h2>

--- a/script.js
+++ b/script.js
@@ -2827,13 +2827,14 @@ function createViewfinderVideoInputRow(value = '') {
   removeBtn.type = 'button';
   removeBtn.textContent = '−';
   removeBtn.addEventListener('click', () => {
-    if (viewfinderVideoInputsContainer.children.length > 1) row.remove();
+    if (viewfinderVideoInputsContainer && viewfinderVideoInputsContainer.children.length > 1) row.remove();
   });
   row.appendChild(removeBtn);
   return row;
 }
 
 function setViewfinderVideoInputs(list) {
+  if (!viewfinderVideoInputsContainer) return;
   viewfinderVideoInputsContainer.innerHTML = '';
   const filtered = filterNoneEntries(list, 'type');
   if (filtered.length) {
@@ -2847,6 +2848,7 @@ function setViewfinderVideoInputs(list) {
 }
 
 function getViewfinderVideoInputs() {
+  if (!viewfinderVideoInputsContainer) return [];
   return Array.from(viewfinderVideoInputsContainer.querySelectorAll('select'))
     .map(sel => ({ type: sel.value }))
     .filter(v => v.type && v.type !== 'None');
@@ -7718,9 +7720,9 @@ function generatePrintableOverview() {
             ${resultsHtml}
             ${warningHtml}
 
-            ${gearListHtmlWithBreak}
-
             ${diagramSectionHtmlWithBreak}
+
+            ${gearListHtmlWithBreak}
             ${batteryTableHtmlWithBreak}
         </div>
     `;


### PR DESCRIPTION
## Summary
- Move gear list section below project diagram for clearer layout
- Update printable overview to place diagram before gear list

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bd722601d48320b7f66035e7479947