### PR TITLE
Fix Italian overview translation

### DIFF
--- a/translations.js
+++ b/translations.js
@@ -672,7 +672,7 @@ const texts = {
       "Esporta, importa o condividi le configurazioni.",
     exportSetupsBtn: "Esporta tutte le configurazioni",
     importSetupsBtn: "Importa configurazioni",
-    generateOverviewBtn: "Generare panoramica",
+    generateOverviewBtn: "Genera panoramica",
     generateGearListBtn: "Genera elenco attrezzatura e requisiti del progetto",
     editProjectBtn: "Modifica requisiti del progetto",
     saveGearListBtn: "Salva elenco attrezzatura",


### PR DESCRIPTION
## Summary
- use imperative "Genera panoramica" for Italian overview button

## Testing
- `NODE_OPTIONS=--max-old-space-size=4096 npm run test:script` *(fails: TypeError cannot set properties of null, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68bdaab128888320aaffb7b0e5a0caf8