### PR TITLE
Rename Gobo Head to Avenger D200B Grip Head

### DIFF
--- a/script.js
+++ b/script.js
@@ -8716,7 +8716,7 @@ function generateGearListHtml(info = {}) {
     const frictionArmCount = hasGimbal ? 2 : 1;
     gripItems.push(...Array(frictionArmCount).fill('Manfrotto 244N Friktion Arm'));
     if (hasGimbal) {
-        gripItems.push('Gobo Head');
+        gripItems.push('Avenger D200B Grip Head');
         gripItems.push('spigot with male 3/8" and 1/4"');
     }
     if (scenarios.includes('Cine Saddle')) gripItems.push('Cinekinetic Cinesaddle');

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -2662,7 +2662,7 @@ describe('script.js functions', () => {
     const itemsRow = rows[gripIdx + 1];
     const text = itemsRow.textContent;
       expect(text).toContain('2x Manfrotto 244N Friktion Arm');
-      expect(text).toContain('1x Gobo Head');
+      expect(text).toContain('1x Avenger D200B Grip Head');
       expect(text).toContain('1x spigot with male 3/8" and 1/4"');
   });
 


### PR DESCRIPTION
## Summary
- rename Gobo Head item to Avenger D200B Grip Head
- adjust tests to expect the new name

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bdab2d65588320a6c92b058c95a847