### PR TITLE
Label spigot usage for focus umbrella

### DIFF
--- a/script.js
+++ b/script.js
@@ -8746,7 +8746,7 @@ function generateGearListHtml(info = {}) {
         gripItems.push('Tango Beam');
     }
     if (scenarios.includes('Outdoor')) {
-        riggingAcc.push('spigot with male 3/8" and 1/4"');
+        riggingAcc.push('spigot with male 3/8" and 1/4" (Focus Umbrella)');
     }
     if (['Extreme heat', 'Extreme rain', 'Rain Machine'].some(s => scenarios.includes(s))) {
         gripItems.push('Large Umbrella');

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -2750,7 +2750,7 @@ describe('script.js functions', () => {
     expect(miscText).toContain('Rain Cover "CamA"');
     expect(miscText).toContain('1x Umbrella for Focus Monitor');
     expect(miscText).toContain('1x Umbrella Magliner incl Mounting to Magliner');
-      expect(rigText).toContain('4x spigot with male 3/8" and 1/4"');
+      expect(rigText).toContain('4x spigot with male 3/8" and 1/4" (1x Focus Umbrella, 3x Spare)');
       expect(gripText).not.toContain('Large Umbrella');
       expect(gripText).not.toContain('Avenger A5036CS Roller 36 Low Base with Umbrella Mounting');
       expect(miscText).not.toContain('Manfrotto 635 Quick-Action Super Clamp');


### PR DESCRIPTION
## Summary
- Clarify outdoor spigot by annotating it for the Focus Umbrella
- Adjust related test to expect the contextual label

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bdab92bde88320b69ff3b0346872da