### PR TITLE
Move spigots to grip inventory

### DIFF
--- a/script.js
+++ b/script.js
@@ -8183,7 +8183,6 @@ function generateGearListHtml(info = {}) {
     for (let i = 0; i < 2; i++) riggingAcc.push('Mini Magic Arm');
     for (let i = 0; i < 4; i++) riggingAcc.push('Cine Quick Release');
     riggingAcc.push('SmallRig - Super lightweight 15mm RailBlock');
-    for (let i = 0; i < 3; i++) riggingAcc.push('spigot with male 3/8" and 1/4"');
     for (let i = 0; i < 2; i++) riggingAcc.push('D-Tap Splitter');
     const cagesDb = devices.accessories?.cages || {};
     const compatibleCages = [];
@@ -8680,11 +8679,12 @@ function generateGearListHtml(info = {}) {
     let needsStandardTripod = false;
     let sliderSelectHtml = '';
     let easyrigSelectHtml = '';
+    for (let i = 0; i < 4; i++) gripItems.push('spigot with male 3/8" and 1/4"');
     handheldPrefs.forEach(p => {
         gripItems.push(`Avenger C-Stand Sliding Leg 20" (${p.role} handheld)`);
         gripItems.push(`Steelfingers Wheel C-Stand 3er Set (${p.role} handheld)`);
         gripItems.push(`Lite-Tite Swivel Aluminium Umbrella Adapter (${p.role} handheld)`);
-        riggingAcc.push(`spigot with male 3/8" and 1/4" (${p.role} handheld)`);
+        gripItems.push(`spigot with male 3/8" and 1/4" (${p.role} handheld)`);
     });
     largeMonitorPrefs.forEach(p => {
         gripItems.push(`Matthews Monitor Stand II (249562) (${p.role} 15-21")`);
@@ -8693,7 +8693,7 @@ function generateGearListHtml(info = {}) {
         gripItems.push(`Matthews BIG F'ING Monitor Rollen Set (3 Stück) (${p.role} 15-21")`);
         riggingAcc.push(`ULCS Bracket with 1/4 to 1/4 (${p.role} 15-21")`);
         gripItems.push(`Manfrotto 635 Quick-Action Super Clamp (${p.role} 15-21")`);
-        riggingAcc.push(`spigot with male 3/8" and 1/4" (${p.role} 15-21")`);
+        gripItems.push(`spigot with male 3/8" and 1/4" (${p.role} 15-21")`);
         riggingAcc.push(`Cine Quick Release (${p.role} 15-21")`);
         riggingAcc.push(`D-Tap Splitter (${p.role} 15-21")`);
         riggingAcc.push(`D-Tap Splitter (${p.role} 15-21")`);
@@ -8717,7 +8717,7 @@ function generateGearListHtml(info = {}) {
     gripItems.push(...Array(frictionArmCount).fill('Manfrotto 244N Friktion Arm'));
     if (hasGimbal) {
         gripItems.push('Gobo Head');
-        gripItems.push('spigot with male 3/8" and 1/4"');
+        gripItems.push('spigot with male 3/8" and 1/4" (Gimbal)');
     }
     if (scenarios.includes('Cine Saddle')) gripItems.push('Cinekinetic Cinesaddle');
     if (scenarios.includes('Steadybag')) gripItems.push('Steadybag');
@@ -8746,7 +8746,7 @@ function generateGearListHtml(info = {}) {
         gripItems.push('Tango Beam');
     }
     if (scenarios.includes('Outdoor')) {
-        riggingAcc.push('spigot with male 3/8" and 1/4"');
+        gripItems.push('spigot with male 3/8" and 1/4" (Outdoor)');
     }
     if (['Extreme heat', 'Extreme rain', 'Rain Machine'].some(s => scenarios.includes(s))) {
         gripItems.push('Large Umbrella');

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -1700,8 +1700,9 @@ describe('script.js functions', () => {
     expect(rigSection).toContain('2x Mini Magic Arm');
     expect(rigSection).toContain('4x Cine Quick Release');
     expect(rigSection).toContain('1x SmallRig - Super lightweight 15mm RailBlock');
-    expect(rigSection).toContain('3x spigot with male 3/8" and 1/4"');
     expect(rigSection).toContain('2x D-Tap Splitter');
+    const gripSection = html.slice(html.indexOf('Grip'), html.indexOf('Carts and Transportation'));
+    expect(gripSection).toContain('4x spigot with male 3/8" and 1/4" (4x Spare)');
   });
 
   test.each(['Trinity', 'Steadicam'])(
@@ -1818,9 +1819,9 @@ describe('script.js functions', () => {
     expect(html).toContain('Steelfingers Wheel C-Stand 3er Set (1x Directors handheld)');
     expect(html).toContain('Lite-Tite Swivel Aluminium Umbrella Adapter (1x Directors handheld)');
     const rigSection = html.slice(html.indexOf('Rigging'), html.indexOf('Power'));
-    expect(rigSection).toContain('4x spigot with male 3/8" and 1/4" (1x Directors handheld, 3x Spare)');
+    expect(rigSection).not.toContain('spigot with male 3/8" and 1/4"');
     const gripSection = html.slice(html.indexOf('Grip'), html.indexOf('Carts and Transportation'));
-    expect(gripSection).not.toContain('spigot with male 3/8" and 1/4"');
+    expect(gripSection).toContain('5x spigot with male 3/8" and 1/4" (1x Directors handheld, 4x Spare)');
     expect(html).toContain('2x Ultraslim BNC Cable 0.3 m (1x Directors handheld, 1x Spare)');
     expect(html).toContain('2x D-Tap to Lemo-2-pin Cable 0,3m (1x Directors handheld, 1x Spare)');
     const msSection = html.slice(html.indexOf('<td>Monitoring support</td>'), html.indexOf('Power'));
@@ -1845,7 +1846,9 @@ describe('script.js functions', () => {
     expect(html).toContain('Steelfingers Wheel C-Stand 3er Set (1x Directors handheld)');
     expect(html).toContain('Lite-Tite Swivel Aluminium Umbrella Adapter (1x Directors handheld)');
     const rigSection = html.slice(html.indexOf('Rigging'), html.indexOf('Power'));
-    expect(rigSection).toContain('4x spigot with male 3/8" and 1/4" (1x Directors handheld, 3x Spare)');
+    expect(rigSection).not.toContain('spigot with male 3/8" and 1/4"');
+    const gripSection = html.slice(html.indexOf('Grip'), html.indexOf('Carts and Transportation'));
+    expect(gripSection).toContain('5x spigot with male 3/8" and 1/4" (1x Directors handheld, 4x Spare)');
   });
 
   test('Gaffers 7" handheld monitor adds dropdown, batteries and grip items', () => {
@@ -1864,7 +1867,9 @@ describe('script.js functions', () => {
     expect(html).toContain('Steelfingers Wheel C-Stand 3er Set (1x Gaffers handheld)');
     expect(html).toContain('Lite-Tite Swivel Aluminium Umbrella Adapter (1x Gaffers handheld)');
     const rigSection = html.slice(html.indexOf('Rigging'), html.indexOf('Power'));
-    expect(rigSection).toContain('4x spigot with male 3/8" and 1/4" (1x Gaffers handheld, 3x Spare)');
+    expect(rigSection).not.toContain('spigot with male 3/8" and 1/4"');
+    const gripSection = html.slice(html.indexOf('Grip'), html.indexOf('Carts and Transportation'));
+    expect(gripSection).toContain('5x spigot with male 3/8" and 1/4" (1x Gaffers handheld, 4x Spare)');
     const msSection = html.slice(html.indexOf('<td>Monitoring support</td>'), html.indexOf('Power'));
     expect(msSection).toContain('2x Ultraslim BNC Cable 0.3 m (1x Gaffers handheld, 1x Spare)');
     expect(msSection).toContain('2x D-Tap to Lemo-2-pin Cable 0,3m (1x Gaffers handheld, 1x Spare)');
@@ -1886,7 +1891,9 @@ describe('script.js functions', () => {
     expect(html).toContain('Steelfingers Wheel C-Stand 3er Set (1x DoP handheld)');
     expect(html).toContain('Lite-Tite Swivel Aluminium Umbrella Adapter (1x DoP handheld)');
     const rigSection = html.slice(html.indexOf('Rigging'), html.indexOf('Power'));
-    expect(rigSection).toContain('4x spigot with male 3/8" and 1/4" (1x DoP handheld, 3x Spare)');
+    expect(rigSection).not.toContain('spigot with male 3/8" and 1/4"');
+    const gripSection = html.slice(html.indexOf('Grip'), html.indexOf('Carts and Transportation'));
+    expect(gripSection).toContain('5x spigot with male 3/8" and 1/4" (1x DoP handheld, 4x Spare)');
     const msSection = html.slice(html.indexOf('<td>Monitoring support</td>'), html.indexOf('Power'));
     expect(msSection).toContain('2x Ultraslim BNC Cable 0.3 m (1x DoP handheld, 1x Spare)');
     expect(msSection).toContain('2x D-Tap to Lemo-2-pin Cable 0,3m (1x DoP handheld, 1x Spare)');
@@ -1997,6 +2004,22 @@ describe('script.js functions', () => {
     );
     expect(gripSection).toContain(
       '3x Lite-Tite Swivel Aluminium Umbrella Adapter (1x Directors handheld, 1x Gaffers handheld, 1x DoP handheld)'
+    );
+    expect(gripSection).toContain(
+      '7x spigot with male 3/8" and 1/4" (1x Directors handheld, 1x Gaffers handheld, 1x DoP handheld, 4x Spare)'
+    );
+  });
+
+  test('all monitors add up to ten spigots', () => {
+    const { generateGearListHtml } = script;
+    global.devices.monitors = { 'SmallHD Ultra 7': { screenSizeInches: 7 } };
+    const html = generateGearListHtml({
+      videoDistribution:
+        'Directors Monitor 7" handheld, Gaffers Monitor 7" handheld, DoP Monitor 7" handheld, Directors Monitor 15-21", Combo Monitor 15-21", DoP Monitor 15-21"'
+    });
+    const gripSection = html.slice(html.indexOf('Grip'), html.indexOf('Carts and Transportation'));
+    expect(gripSection).toContain(
+      '10x spigot with male 3/8" and 1/4" (1x Directors handheld, 1x Gaffers handheld, 1x DoP handheld, 1x Directors 15-21", 1x Combo 15-21", 1x DoP 15-21", 4x Spare)'
     );
   });
 
@@ -2663,7 +2686,7 @@ describe('script.js functions', () => {
     const text = itemsRow.textContent;
       expect(text).toContain('2x Manfrotto 244N Friktion Arm');
       expect(text).toContain('1x Gobo Head');
-      expect(text).toContain('1x spigot with male 3/8" and 1/4"');
+      expect(text).toContain('5x spigot with male 3/8" and 1/4" (1x Gimbal, 4x Spare)');
   });
 
   test('Gimbal selector adds specified devices', () => {
@@ -2750,7 +2773,8 @@ describe('script.js functions', () => {
     expect(miscText).toContain('Rain Cover "CamA"');
     expect(miscText).toContain('1x Umbrella for Focus Monitor');
     expect(miscText).toContain('1x Umbrella Magliner incl Mounting to Magliner');
-      expect(rigText).toContain('4x spigot with male 3/8" and 1/4"');
+      expect(rigText).not.toContain('spigot with male 3/8" and 1/4"');
+      expect(gripText).toContain('5x spigot with male 3/8" and 1/4" (1x Outdoor, 4x Spare)');
       expect(gripText).not.toContain('Large Umbrella');
       expect(gripText).not.toContain('Avenger A5036CS Roller 36 Low Base with Umbrella Mounting');
       expect(miscText).not.toContain('Manfrotto 635 Quick-Action Super Clamp');


### PR DESCRIPTION
## Summary
- Track spigots as grip items instead of rigging accessories
- Include four spare spigots and per-monitor spigots in grip counts
- Test spigot counts across gimbal, outdoor, and multi-monitor setups

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bdac0b95f8832093d358c9fdc76c30