### PR TITLE
feat: modernize layout spacing and fonts

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <meta name="apple-mobile-web-app-capable" content="yes" />
   <meta name="mobile-web-app-capable" content="yes" />
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
@@ -18,6 +18,7 @@
   <meta http-equiv="Content-Security-Policy" content="script-src 'self' 'unsafe-eval' 'unsafe-inline';" />
   <meta name="color-scheme" content="light dark" />
   <title>Cine List</title>
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Ubuntu:wght@300;700&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="style.css" />
   <link rel="stylesheet" href="overview-print.css" media="print" />

--- a/style.css
+++ b/style.css
@@ -17,6 +17,7 @@
   --panel-shadow: 0 2px 6px rgba(0, 0, 0, 0.05);
   --border-radius: 5px;
   --page-padding: 20px;
+  --gap-size: 10px;
   --link-color: var(--accent-color);
   --diagram-node-fill: #e8f0fe;
   --power-color: #d33;
@@ -32,6 +33,10 @@
 body.pink-mode {
   --accent-color: #ff69b4;
   --link-color: #ff69b4;
+}
+
+html {
+  font-size: clamp(14px, 1vw + 12px, 18px);
 }
 
 html,
@@ -53,7 +58,7 @@ body {
   margin: 0;
   background-color: var(--background-color);
   color: var(--text-color);
-  font-size: 0.9em;
+  font-size: 1rem;
 }
 
 main {
@@ -206,6 +211,7 @@ a:focus {
   display: flex;
   align-items: center;
   margin: 5px 0;
+  gap: var(--gap-size);
   flex-wrap: wrap; /* allow inputs to wrap on smaller screens */
 }
 .form-row label {
@@ -216,7 +222,6 @@ a:focus {
 .form-row select,
 .form-row input {
   flex: 1;
-  margin: 5px 5px 0 0;
   min-width: 0; /* allow shrinking inside flex container */
 }
 
@@ -228,11 +233,10 @@ a:focus {
   .form-row label {
     flex: 1 0 100%;
     min-width: unset;
-    margin-bottom: 5px;
   }
   .form-row select,
   .form-row input {
-    margin: 5px 0 0 0;
+    margin: 0;
   }
 }
 
@@ -249,10 +253,10 @@ a:focus {
 /* Align add/remove buttons in form rows with input fields */
 .form-row > button {
   align-self: flex-end;
-  margin: 5px 0 0 0;
+  margin-top: 5px;
 }
 .form-row > button + button {
-  margin-left: 5px;
+  margin-left: 0;
 }
 
 /* Small wrapper to show labels even when a value is present */


### PR DESCRIPTION
## Summary
- use CSS `clamp` and variables for responsive base font
- replace form-row margins with gap-based spacing
- improve head with `viewport-fit=cover` and preconnect for fonts

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bdaf18e58883208e60215532d3870a