### PR TITLE
refactor: streamline clipboard and offline indicator

### DIFF
--- a/script.js
+++ b/script.js
@@ -48,8 +48,8 @@ if (typeof window !== 'undefined' && 'serviceWorker' in navigator) {
  */
 function setupOfflineIndicator() {
   const offlineIndicator = document.getElementById('offlineIndicator');
+  if (!offlineIndicator) return;
   const updateOnlineStatus = () => {
-    if (!offlineIndicator) return;
     offlineIndicator.style.display = navigator.onLine ? 'none' : 'block';
   };
   window.addEventListener('online', updateOnlineStatus);
@@ -110,15 +110,15 @@ function copyTextToClipboard(text) {
     textarea.select();
     try {
       const successful = globalThis.document.execCommand('copy');
-      globalThis.document.body.removeChild(textarea);
       if (successful) {
         resolve();
       } else {
         reject(new Error('execCommand failed'));
       }
     } catch (err) {
-      globalThis.document.body.removeChild(textarea);
       reject(err);
+    } finally {
+      globalThis.document.body.removeChild(textarea);
     }
   });
 }


### PR DESCRIPTION
## Summary
- avoid adding event listeners when offline indicator is missing
- ensure temporary textarea is always removed when copying to clipboard

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bdaf2e3a4083208c6d6fb356c04f55