### PR TITLE
Remove white outline from diagram circles

### DIFF
--- a/script.js
+++ b/script.js
@@ -2367,7 +2367,7 @@ const diagramCssLight = `
 .node-box.first-fiz{stroke:none;}
 .first-fiz-highlight{stroke:url(#firstFizGrad);stroke-width:1px;fill:none;}
 .node-icon{font-size:20px;}
-.conn{stroke:#333;stroke-width:1px;}
+.conn{stroke:none;}
 .conn.red{fill:#d33;}
 .conn.blue{fill:#369;}
 .conn.green{fill:#090;}

--- a/style.css
+++ b/style.css
@@ -1055,8 +1055,7 @@ button:disabled {
   font-size: 20px;
 }
 #setupDiagram .conn {
-  stroke: var(--control-text);
-  stroke-width: 1px;
+  stroke: none;
 }
 #setupDiagram .conn.red { fill: var(--power-color); }
 #setupDiagram .conn.blue { fill: var(--video-color); }


### PR DESCRIPTION
## Summary
- Remove white stroke from connection circles in diagram styling
- Update exported diagram CSS to omit circle outline

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bdafeec6fc83208ea31cf2dfd3a332