### PR TITLE
Remove button and select focus outlines

### DIFF
--- a/overview-print.css
+++ b/overview-print.css
@@ -1,5 +1,12 @@
 @import url('https://fonts.googleapis.com/css2?family=Ubuntu:wght@300;700&display=swap');
 
+button:focus,
+select:focus,
+button:focus-visible,
+select:focus-visible {
+  outline: none;
+}
+
 @page {
   size: A4;
   margin: 1cm;

--- a/overview.css
+++ b/overview.css
@@ -1,5 +1,12 @@
 @import url('https://fonts.googleapis.com/css2?family=Ubuntu:wght@300;700&display=swap');
 
+button:focus,
+select:focus,
+button:focus-visible,
+select:focus-visible {
+  outline: none;
+}
+
 body { font-family: 'Ubuntu', sans-serif; font-weight: 300; margin: 25px; color: var(--control-text); font-size: 0.9em; -webkit-print-color-adjust: exact; print-color-adjust: exact; }
 @media (max-width: 600px) {
   body { margin: 10px; }

--- a/style.css
+++ b/style.css
@@ -125,7 +125,7 @@ textarea {
   display: none !important;
 }
 
-/* Improve keyboard accessibility by clearly showing focus only when using the keyboard */
+/* Improve keyboard accessibility by clearly showing focus outlines for links, inputs, and textareas */
 button:focus,
 a:focus,
 input:focus,
@@ -133,10 +133,8 @@ select:focus,
 textarea:focus {
   outline: none;
 }
-button:focus-visible,
 a:focus-visible,
 input:focus-visible,
-select:focus-visible,
 textarea:focus-visible {
   outline: 2px solid var(--accent-color);
   outline-offset: 2px;


### PR DESCRIPTION
## Summary
- suppress focus outlines on buttons and selects
- apply outline removal in overview stylesheets

## Testing
- `npm test` *(fails: tests/script.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68bdb062fd288320a1f5ab89e803693e