### PR TITLE
Use lighter font weight for headings

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
   <meta name="color-scheme" content="light dark" />
   <title>Cine List</title>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Ubuntu:wght@300;700&display=swap" rel="stylesheet" />
+  <link href="https://fonts.googleapis.com/css2?family=Ubuntu:wght@300;600;700&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="style.css" />
   <link rel="stylesheet" href="overview-print.css" media="print" />
   <link rel="icon" href="icon.svg" type="image/svg+xml" />

--- a/overview-print.css
+++ b/overview-print.css
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=Ubuntu:wght@300;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Ubuntu:wght@300;600;700&display=swap');
 
 @page {
   size: A4;
@@ -69,7 +69,7 @@ body.dark-mode {
 #overviewDialogContent h2,
 #overviewDialogContent h3 {
   font-family: 'Ubuntu', sans-serif;
-  font-weight: 700;
+  font-weight: 600;
   border-color: var(--text-color) !important;
 }
 

--- a/overview.css
+++ b/overview.css
@@ -1,10 +1,10 @@
-@import url('https://fonts.googleapis.com/css2?family=Ubuntu:wght@300;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Ubuntu:wght@300;600;700&display=swap');
 
 body { font-family: 'Ubuntu', sans-serif; font-weight: 300; margin: 25px; color: var(--control-text); font-size: 0.9em; -webkit-print-color-adjust: exact; print-color-adjust: exact; }
 @media (max-width: 600px) {
   body { margin: 10px; }
 }
-h1, h2, h3 { font-family: 'Ubuntu', sans-serif; font-weight: 700; color: var(--accent-color); }
+h1, h2, h3 { font-family: 'Ubuntu', sans-serif; font-weight: 600; color: var(--accent-color); }
 h1 { font-size: 1.8em; margin-bottom: 0.2em; }
 h2 { font-size: 1.4em; margin-top: 1.3em; border-bottom: 2px solid var(--accent-color); padding-bottom: 5px; }
 h3 { font-size: 1.1em; margin-top: 1em; }

--- a/style.css
+++ b/style.css
@@ -170,7 +170,7 @@ textarea:focus-visible {
 }
 h1, h2, h3 {
   font-family: 'Ubuntu', sans-serif;
-  font-weight: 700;
+  font-weight: 600;
   color: var(--accent-color);
 }
 h1 {
@@ -590,7 +590,7 @@ button:disabled {
 
 .device-category h4 {
   font-family: 'Ubuntu', sans-serif;
-  font-weight: 700;
+  font-weight: 600;
   color: var(--accent-color);
   margin-top: 0;
   margin-bottom: 10px;
@@ -1567,7 +1567,7 @@ body.dark-mode.pink-mode .help-content { border-color: var(--accent-color); }
 #overviewDialogContent h2,
 #overviewDialogContent h3 {
   font-family: 'Ubuntu', sans-serif;
-  font-weight: 700;
+  font-weight: 600;
   color: var(--accent-color);
 }
 #overviewDialogContent h1 {


### PR DESCRIPTION
## Summary
- Soften heading appearance by switching to font-weight 600 across global, dialog, and device category headings
- Include 600 weight in Google Font imports for main page and overview styles

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bdb0b274648320b274b8aeb9915b5c