### PR TITLE
Hide filter field from project requirements overview

### DIFF
--- a/script.js
+++ b/script.js
@@ -8493,6 +8493,7 @@ function generateGearListHtml(info = {}) {
         'mattebox',
         'videoDistribution',
         'monitoringConfiguration',
+        'filter',
         'tripodHeadBrand',
         'tripodBowl',
         'tripodTypes',

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -3172,6 +3172,13 @@ describe('script.js functions', () => {
     expect(html).not.toContain('<span class="req-label">Monitoring support</span><span class="req-value">IOS Video (Teradek Serv + Link)</span>');
   });
 
+  test('filter selection is not included in project requirements', () => {
+    const { generateGearListHtml } = script;
+    const html = generateGearListHtml({ filter: 'IRND' });
+    expect(html).not.toContain('<span class="req-label">Filter</span>');
+    expect(html).not.toContain('<span class="req-value">IRND</span>');
+  });
+
   test('project requirements form includes handheld monitor size options', () => {
     setupDom(true);
     const sel = document.getElementById('videoDistribution');


### PR DESCRIPTION
## Summary
- Exclude `filter` selection from the project requirements summary so filter choices aren't duplicated above the gear table
- Test ensures project requirements overview omits filter selections

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bdbf6c0e488320b452966b6ac483a7