### PR TITLE
feat: serve Ubuntu font locally

### DIFF
--- a/fonts.css
+++ b/fonts.css
@@ -1,0 +1,56 @@
+@font-face {
+  font-family: 'Ubuntu';
+  font-style: normal;
+  font-weight: 300;
+  font-display: swap;
+  src: url('Ubuntu/Ubuntu-Light.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Ubuntu';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: url('Ubuntu/Ubuntu-Regular.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Ubuntu';
+  font-style: normal;
+  font-weight: 500;
+  font-display: swap;
+  src: url('Ubuntu/Ubuntu-Medium.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Ubuntu';
+  font-style: normal;
+  font-weight: 700;
+  font-display: swap;
+  src: url('Ubuntu/Ubuntu-Bold.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Ubuntu';
+  font-style: italic;
+  font-weight: 300;
+  font-display: swap;
+  src: url('Ubuntu/Ubuntu-LightItalic.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Ubuntu';
+  font-style: italic;
+  font-weight: 400;
+  font-display: swap;
+  src: url('Ubuntu/Ubuntu-Italic.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Ubuntu';
+  font-style: italic;
+  font-weight: 500;
+  font-display: swap;
+  src: url('Ubuntu/Ubuntu-MediumItalic.ttf') format('truetype');
+}
+@font-face {
+  font-family: 'Ubuntu';
+  font-style: italic;
+  font-weight: 700;
+  font-display: swap;
+  src: url('Ubuntu/Ubuntu-BoldItalic.ttf') format('truetype');
+}

--- a/index.html
+++ b/index.html
@@ -18,8 +18,6 @@
   <meta http-equiv="Content-Security-Policy" content="script-src 'self' 'unsafe-eval' 'unsafe-inline';" />
   <meta name="color-scheme" content="light dark" />
   <title>Cine List</title>
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Ubuntu:wght@300;600;700&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="style.css" />
   <link rel="stylesheet" href="overview-print.css" media="print" />
   <link rel="icon" href="icon.svg" type="image/svg+xml" />

--- a/overview-print.css
+++ b/overview-print.css
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=Ubuntu:wght@300;600;700&display=swap');
+@import url('fonts.css');
 
 button:focus,
 select:focus,

--- a/overview.css
+++ b/overview.css
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=Ubuntu:wght@300;600;700&display=swap');
+@import url('fonts.css');
 
 button:focus,
 select:focus,

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,11 +1,20 @@
 /* eslint-env serviceworker */
-const CACHE_NAME = 'camera-power-planner-v11';
+const CACHE_NAME = 'camera-power-planner-v12';
 const ASSETS = [
   './',
   './index.html',
   './style.css',
   './overview.css',
   './overview-print.css',
+  './fonts.css',
+  './Ubuntu/Ubuntu-Bold.ttf',
+  './Ubuntu/Ubuntu-BoldItalic.ttf',
+  './Ubuntu/Ubuntu-Italic.ttf',
+  './Ubuntu/Ubuntu-Light.ttf',
+  './Ubuntu/Ubuntu-LightItalic.ttf',
+  './Ubuntu/Ubuntu-Medium.ttf',
+  './Ubuntu/Ubuntu-MediumItalic.ttf',
+  './Ubuntu/Ubuntu-Regular.ttf',
   './script.js',
   './devices/index.js',
   './devices/cameras.js',

--- a/style.css
+++ b/style.css
@@ -1,3 +1,4 @@
+@import url('fonts.css');
 /* General styles */
 :root {
   color-scheme: light dark;


### PR DESCRIPTION
## Summary
- serve Ubuntu fonts from local assets
- remove external Google Fonts dependency
- cache fonts via service worker

## Testing
- `npm run lint`
- `npm run check-consistency`
- `npm test` *(fails: "Cannot set properties of null (setting 'innerHTML')" in `tests/script.test.js`)*

------
https://chatgpt.com/codex/tasks/task_e_68bdbdb2e010832084e105f3b29cefb2