### PR TITLE
Normalize heading font weights to 400

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
   <meta name="color-scheme" content="light dark" />
   <title>Cine List</title>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Ubuntu:wght@300;600;700&display=swap" rel="stylesheet" />
+  <link href="https://fonts.googleapis.com/css2?family=Ubuntu:wght@300;400;700&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="style.css" />
   <link rel="stylesheet" href="overview-print.css" media="print" />
   <link rel="icon" href="icon.svg" type="image/svg+xml" />

--- a/overview-print.css
+++ b/overview-print.css
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=Ubuntu:wght@300;600;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Ubuntu:wght@300;400;700&display=swap');
 
 button:focus,
 select:focus,
@@ -76,7 +76,7 @@ body.dark-mode {
 #overviewDialogContent h2,
 #overviewDialogContent h3 {
   font-family: 'Ubuntu', sans-serif;
-  font-weight: 600;
+  font-weight: 400;
   border-color: var(--text-color) !important;
 }
 
@@ -127,7 +127,7 @@ table, th, td {
 }
 #overviewDialogContent th {
   background-color: var(--control-bg) !important;
-  font-weight: 700;
+  font-weight: 400;
 }
 #overviewDialogContent tr {
   background-color: var(--surface-color) !important;
@@ -154,7 +154,7 @@ table, th, td {
 #overviewDialogContent .gear-table .category-row td {
   border-top: 1px solid var(--accent-color);
   border-bottom: 1px solid var(--accent-color);
-  font-weight: 700;
+  font-weight: 400;
   color: var(--accent-color);
 }
 

--- a/overview.css
+++ b/overview.css
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=Ubuntu:wght@300;600;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Ubuntu:wght@300;400;700&display=swap');
 
 button:focus,
 select:focus,
@@ -11,7 +11,7 @@ body { font-family: 'Ubuntu', sans-serif; font-weight: 300; margin: 25px; color:
 @media (max-width: 600px) {
   body { margin: 10px; }
 }
-h1, h2, h3 { font-family: 'Ubuntu', sans-serif; font-weight: 600; color: var(--accent-color); }
+h1, h2, h3 { font-family: 'Ubuntu', sans-serif; font-weight: 400; color: var(--accent-color); }
 h1 { font-size: 1.8em; margin-bottom: 0.2em; }
 h2 { font-size: 1.4em; margin-top: 1.3em; border-bottom: 2px solid var(--accent-color); padding-bottom: 5px; }
 h3 { font-size: 1.1em; margin-top: 1em; }
@@ -25,7 +25,7 @@ table {
   table-layout: fixed;
 }
 th, td { border: 1px solid var(--panel-border); padding: 8px; text-align: left; font-size: 0.9em; overflow: hidden; }
-th { background-color: var(--control-bg); font-weight: 700; }
+th { background-color: var(--control-bg); font-weight: 400; }
 .warning { color: red; font-weight: bold; margin-top: 10px; }
 
 .gear-table td {
@@ -41,7 +41,7 @@ th { background-color: var(--control-bg); font-weight: 700; }
 .gear-table .category-row td {
   border-top: 1px solid var(--accent-color);
   border-bottom: 1px solid var(--accent-color);
-  font-weight: bold;
+  font-weight: 400;
   color: var(--accent-color);
 }
 .print-btn,
@@ -87,7 +87,7 @@ th { background-color: var(--control-bg); font-weight: 700; }
 }
 .device-category h3 {
   font-family: 'Ubuntu', sans-serif;
-  font-weight: 700;
+  font-weight: 400;
   margin-top: 0;
   margin-bottom: 5px;
   border-bottom: 1px solid #eee;
@@ -126,7 +126,7 @@ th { background-color: var(--control-bg); font-weight: 700; }
   body { background-color: var(--background-color); color: var(--text-color); }
   h1, h2, h3 { color: var(--inverse-text-color); }
   h2 { border-bottom: 2px solid var(--inverse-text-color); }
-  th { background-color: var(--control-bg); font-weight: 700; }
+  th { background-color: var(--control-bg); font-weight: 400; }
   .print-btn, .back-btn { background: var(--control-bg); color: var(--text-color); border-color: var(--panel-border); }
   .device-category { background: var(--panel-bg); border-color: var(--panel-border); box-shadow: var(--panel-shadow); }
   .device-category h3 { border-bottom: 1px solid var(--inverse-text-color); color: var(--inverse-text-color); }

--- a/style.css
+++ b/style.css
@@ -168,7 +168,7 @@ textarea:focus-visible {
 }
 h1, h2, h3 {
   font-family: 'Ubuntu', sans-serif;
-  font-weight: 600;
+  font-weight: 400;
   color: var(--accent-color);
 }
 h1 {
@@ -588,7 +588,7 @@ button:disabled {
 
 .device-category h4 {
   font-family: 'Ubuntu', sans-serif;
-  font-weight: 600;
+  font-weight: 400;
   color: var(--accent-color);
   margin-top: 0;
   margin-bottom: 10px;
@@ -992,6 +992,7 @@ button:disabled {
   text-align: left;
   padding: 2px 6px 2px 0;
   white-space: nowrap;
+  font-weight: 400;
 }
 .port-table td {
   padding: 2px 0;
@@ -1141,6 +1142,7 @@ button:disabled {
 
 #batteryComparison th {
   background-color: #ffffff;
+  font-weight: 400;
 }
 
 /* User runtime feedback table */
@@ -1165,6 +1167,7 @@ button:disabled {
 
 #userFeedbackTable th {
   background-color: #ffffff;
+  font-weight: 400;
 }
 
 body:not(.light-mode) #userFeedbackTable th {
@@ -1533,7 +1536,7 @@ body.dark-mode.pink-mode .help-content { border-color: var(--accent-color); }
   margin-bottom: 5px;
 }
 .requirement-box .req-label {
-  font-weight: 700;
+  font-weight: 400;
   display: block;
 }
 .requirement-box .req-value {
@@ -1564,7 +1567,7 @@ body.dark-mode.pink-mode .help-content { border-color: var(--accent-color); }
 #overviewDialogContent h2,
 #overviewDialogContent h3 {
   font-family: 'Ubuntu', sans-serif;
-  font-weight: 600;
+  font-weight: 400;
   color: var(--accent-color);
 }
 #overviewDialogContent h1 {
@@ -1597,7 +1600,7 @@ body.dark-mode.pink-mode .help-content { border-color: var(--accent-color); }
 }
 #overviewDialogContent th {
   background-color: var(--control-bg);
-  font-weight: 700;
+  font-weight: 400;
 }
 #overviewDialogContent tr:nth-child(even) {
   background-color: var(--panel-bg);
@@ -1631,7 +1634,7 @@ body.dark-mode.pink-mode .help-content { border-color: var(--accent-color); }
 }
 #overviewDialogContent .device-category h3 {
   font-family: 'Ubuntu', sans-serif;
-  font-weight: 700;
+  font-weight: 400;
   margin-top: 0;
   margin-bottom: 5px;
   border-bottom: 1px solid #eee;
@@ -1695,7 +1698,7 @@ body.dark-mode.pink-mode .help-content { border-color: var(--accent-color); }
 .gear-table .category-row td {
   border-top: 1px solid var(--accent-color);
   border-bottom: 1px solid var(--accent-color);
-  font-weight: bold;
+  font-weight: 400;
   color: var(--accent-color);
 }
 
@@ -1723,7 +1726,7 @@ body.dark-mode.pink-mode .help-content { border-color: var(--accent-color); }
 #overviewDialogContent .gear-table .category-row td {
   border-top: 1px solid var(--accent-color);
   border-bottom: 1px solid var(--accent-color);
-  font-weight: bold;
+  font-weight: 400;
   color: var(--accent-color);
 }
 


### PR DESCRIPTION
## Summary
- Load Ubuntu font with weight 400
- Use font-weight:400 for all headings, table headers, and gear category rows

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bdbec6d2048320a8929f56a21be09a