### PR TITLE
Translate Bluestar color names to English

### DIFF
--- a/script.js
+++ b/script.js
@@ -8916,7 +8916,7 @@ function generateGearListHtml(info = {}) {
     const miscItems = [...miscAcc].filter(item => !miscExcluded.has(item));
     const consumables = [];
     const hasViewfinder = Array.isArray(cam?.viewfinder) && cam.viewfinder.length > 0;
-    let eyeLeatherColor = 'rot';
+    let eyeLeatherColor = 'red';
     const gaffTapeSelections = [
         { id: 1, color: 'red', width: '24mm' },
         { id: 2, color: 'blue', width: '24mm' }
@@ -9045,18 +9045,18 @@ function generateGearListHtml(info = {}) {
     let eyeLeatherHtml = '';
     if (eyeLeatherCount) {
         const colors = [
-            ['rot', 'Rot'],
-            ['blau', 'Blau'],
-            ['natur', 'Natur'],
-            ['grün', 'Grün'],
-            ['lila', 'Lila'],
+            ['red', 'Red'],
+            ['blue', 'Blue'],
+            ['natural', 'Natural'],
+            ['green', 'Green'],
+            ['purple', 'Purple'],
             ['orange', 'Orange'],
-            ['grau', 'Grau'],
-            ['gelb', 'Gelb'],
+            ['gray', 'Gray'],
+            ['yellow', 'Yellow'],
             ['jaguar', 'Jaguar'],
             ['killer bee', 'Killer Bee'],
             ['green rabbit', 'Green Rabbit'],
-            ['schwarz', 'Schwarz']
+            ['black', 'Black']
         ];
         const options = colors.map(([val, label]) => `<option value="${val}"${val === eyeLeatherColor ? ' selected' : ''}>${label}</option>`).join('');
         eyeLeatherHtml = `<span class="gear-item" data-gear-name="Bluestar eye leather made of microfiber oval, large">${eyeLeatherCount}x Bluestar eye leather made of microfiber oval, large <select id="gearListEyeLeatherColor">${options}</select></span>`;

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -3016,7 +3016,7 @@ describe('script.js functions', () => {
     expect(gaff2Color.parentElement.textContent).toContain('1x Pro Gaff Tape');
     const eyeSel = consumRow.querySelector('#gearListEyeLeatherColor');
     expect(eyeSel).not.toBeNull();
-    expect(eyeSel.value).toBe('rot');
+    expect(eyeSel.value).toBe('red');
     expect(eyeSel.parentElement.textContent).toContain('2x Bluestar eye leather made of microfiber oval, large');
     expect(consumText).toContain('2x Clapper Stick');
   });
@@ -3044,7 +3044,7 @@ describe('script.js functions', () => {
       expect(consumText).toContain('1x Sprigs Red 1/4"');
       expect(consumText).toContain(clapper);
       const eyeSel = consumRow.querySelector('#gearListEyeLeatherColor');
-      expect(eyeSel.value).toBe('rot');
+      expect(eyeSel.value).toBe('red');
       expect(eyeSel.parentElement.textContent).toContain(`${eyeCount}x Bluestar eye leather made of microfiber oval, large`);
     });
   });


### PR DESCRIPTION
## Summary
- localize Bluestar eye leather color options in gear list to English names
- update gear list tests to expect English color values

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bdbfab698c83208891cbc1dbfce04f