### PR TITLE
fix: restore stabiliser selection after reload

### DIFF
--- a/script.js
+++ b/script.js
@@ -9509,8 +9509,6 @@ function restoreSessionState() {
     }
     if (batterySelect && state.battery) batterySelect.value = state.battery;
     if (hotswapSelect && state.batteryHotswap) hotswapSelect.value = state.batteryHotswap;
-    setSliderBowlValue(state.sliderBowl);
-    setEasyrigValue(state.easyrig);
     if (setupSelect && state.setupSelect) setupSelect.value = state.setupSelect;
     if (state.projectInfo) {
       currentProjectInfo = state.projectInfo;
@@ -9542,6 +9540,8 @@ function restoreSessionState() {
         bindGearListEyeLeatherListener();
         bindGearListProGaffTapeListener();
         bindGearListDirectorsMonitorListener();
+        setSliderBowlValue(state && state.sliderBowl);
+        setEasyrigValue(state && state.easyrig);
       }
     } else if (!state && typeof deleteProject === 'function') {
       deleteProject();

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -2632,8 +2632,8 @@ describe('script.js functions', () => {
     // capture stored state
     const state = global.saveSessionState.mock.calls.pop()[0];
     expect(state.easyrig).toBe('FlowCine Serene Spring Arm');
-    const savedHtml = global.saveProject.mock.calls.pop()[0].gearList;
-    // Simulate reload using captured state and saved gear list
+    const savedHtml = html; // original HTML without updated selection
+    // Simulate reload using captured state and stale gear list
     global.loadSessionState.mockReturnValue(state);
     global.loadProject = jest.fn(() => ({ gearList: savedHtml }));
     document.getElementById('gearListOutput').innerHTML = '';


### PR DESCRIPTION
## Summary
- keep slider bowl and stabiliser selections when reloading a saved session
- test: ensure Easyrig stabiliser choice is restored even if gear list HTML is stale

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bdbf8a34188320ac0779415ae731d5