### PR TITLE
Normalize heading font weights to 400

### DIFF
--- a/overview-print.css
+++ b/overview-print.css
@@ -76,7 +76,7 @@ body.dark-mode {
 #overviewDialogContent h2,
 #overviewDialogContent h3 {
   font-family: 'Ubuntu', sans-serif;
-  font-weight: 600;
+  font-weight: 400;
   border-color: var(--text-color) !important;
 }
 

--- a/overview.css
+++ b/overview.css
@@ -11,7 +11,7 @@ body { font-family: 'Ubuntu', sans-serif; font-weight: 300; margin: 25px; color:
 @media (max-width: 600px) {
   body { margin: 10px; }
 }
-h1, h2, h3 { font-family: 'Ubuntu', sans-serif; font-weight: 600; color: var(--accent-color); }
+h1, h2, h3 { font-family: 'Ubuntu', sans-serif; font-weight: 400; color: var(--accent-color); }
 h1 { font-size: 1.8em; margin-bottom: 0.2em; }
 h2 { font-size: 1.4em; margin-top: 1.3em; border-bottom: 2px solid var(--accent-color); padding-bottom: 5px; }
 h3 { font-size: 1.1em; margin-top: 1em; }
@@ -87,7 +87,7 @@ th { background-color: var(--control-bg); font-weight: 700; }
 }
 .device-category h3 {
   font-family: 'Ubuntu', sans-serif;
-  font-weight: 700;
+  font-weight: 400;
   margin-top: 0;
   margin-bottom: 5px;
   border-bottom: 1px solid #eee;

--- a/style.css
+++ b/style.css
@@ -169,7 +169,7 @@ textarea:focus-visible {
 }
 h1, h2, h3 {
   font-family: 'Ubuntu', sans-serif;
-  font-weight: 600;
+  font-weight: 400;
   color: var(--accent-color);
 }
 h1 {
@@ -599,7 +599,7 @@ button:disabled {
 
 .device-category h4 {
   font-family: 'Ubuntu', sans-serif;
-  font-weight: 600;
+  font-weight: 400;
   color: var(--accent-color);
   margin-top: 0;
   margin-bottom: 10px;
@@ -1580,7 +1580,7 @@ body.dark-mode.pink-mode .help-content { border-color: var(--accent-color); }
 #overviewDialogContent h2,
 #overviewDialogContent h3 {
   font-family: 'Ubuntu', sans-serif;
-  font-weight: 600;
+  font-weight: 400;
   color: var(--accent-color);
 }
 #overviewDialogContent h1 {
@@ -1647,7 +1647,7 @@ body.dark-mode.pink-mode .help-content { border-color: var(--accent-color); }
 }
 #overviewDialogContent .device-category h3 {
   font-family: 'Ubuntu', sans-serif;
-  font-weight: 700;
+  font-weight: 400;
   margin-top: 0;
   margin-bottom: 5px;
   border-bottom: 1px solid #eee;


### PR DESCRIPTION
## Summary
- Use font-weight 400 for all h1–h4 heading styles
- Apply normal-weight headings in overview and print styles

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bdc15eab108320ac48071629b28318