### PR TITLE
Return null when no connectors parsed in power inputs

### DIFF
--- a/tests/unifyPorts.test.js
+++ b/tests/unifyPorts.test.js
@@ -105,6 +105,10 @@ describe('parsePowerInput', () => {
     expect(parsePowerInput(123)).toBeNull();
   });
 
+  it('returns null when no connectors are found', () => {
+    expect(parsePowerInput(' / ')).toBeNull();
+  });
+
   it('returns a fresh copy on repeated calls', () => {
     const first = parsePowerInput('D-Tap');
     first[0].type = 'Changed';

--- a/unifyPorts.js
+++ b/unifyPorts.js
@@ -268,15 +268,17 @@ function parsePowerInput(str) {
     return cached.map(obj => ({ ...obj }));
   }
 
-  const arr = splitOutside(normalized)
+  const segments = splitOutside(normalized)
     .map(p => p.trim())
-    .filter(Boolean)
-    .map(segment => {
-      const { type, notes } = extractTypeAndNotes(segment);
-      const obj = { type: cleanTypeName(type) };
-      if (notes) obj.notes = notes;
-      return obj;
-    });
+    .filter(Boolean);
+  if (segments.length === 0) return null;
+
+  const arr = segments.map(segment => {
+    const { type, notes } = extractTypeAndNotes(segment);
+    const obj = { type: cleanTypeName(type) };
+    if (notes) obj.notes = notes;
+    return obj;
+  });
 
   // Store a defensive copy to keep the cached data immutable.
   powerInputCache.set(


### PR DESCRIPTION
## Summary
- Guard `parsePowerInput` to return `null` when no valid connector segments are found
- Add regression test for empty input segments

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bdc1af54e483208fa858b87c93d924