### PR TITLE
Remove 'for' from sand bag context labels

### DIFF
--- a/script.js
+++ b/script.js
@@ -8819,8 +8819,8 @@ function generateGearListHtml(info = {}) {
         gripItems.push('Apple Box Set / Bühnenkisten Set');
         gripItems.push('Apple Box Set / Bühnenkisten Set');
         gripItems.push('Paganini set');
-        gripItems.push('sand bag (for Slider)');
-        gripItems.push('sand bag (for Slider)');
+        gripItems.push('sand bag (Slider)');
+        gripItems.push('sand bag (Slider)');
         gripItems.push('cable mat');
         gripItems.push('cable mat');
         gripItems.push('cable mat');
@@ -8865,10 +8865,10 @@ function generateGearListHtml(info = {}) {
             gripItems.push(base);
         }
         if (t === 'Frog Tripod') {
-            gripItems.push('sand bag (for Frog Tripod)');
+            gripItems.push('sand bag (Frog Tripod)');
         }
         if (t === 'Hi-Head') {
-            gripItems.push('sand bag (for Hi-Head)');
+            gripItems.push('sand bag (Hi-Head)');
         }
     });
     if (needsStandardTripod && !gripItems.some(item => /Standard Tripod/.test(item))) {

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -2522,7 +2522,7 @@ describe('script.js functions', () => {
     expect(text).toContain('2x Avenger Combo Stand 20 A1020B 110-198 cm black');
     expect(text).toContain('2x Apple Box Set / Bühnenkisten Set');
     expect(text).toContain('1x Paganini set');
-    expect(text).toContain('2x sand bag (2x for Slider)');
+    expect(text).toContain('2x sand bag (2x Slider)');
     expect(text).toContain('3x cable mat');
     expect(text).toContain('12x tennis ball');
   });
@@ -2548,7 +2548,7 @@ describe('script.js functions', () => {
     const rows = Array.from(wrap.querySelectorAll('.gear-table tr'));
     const gripIdx = rows.findIndex(r => r.textContent === 'Grip');
     const text = rows[gripIdx + 1].textContent;
-    expect(text).toContain('4x sand bag (1x for Frog Tripod, 1x for Hi-Head, 2x for Slider)');
+    expect(text).toContain('4x sand bag (1x Frog Tripod, 1x Hi-Head, 2x Slider)');
   });
 
   test('Jib scenario adds EJib Arm, counter weights, and tripod legs', () => {
@@ -2599,7 +2599,7 @@ describe('script.js functions', () => {
     expect(text).toContain('1x 100mm bowl Standard Tripod + Mid-Level Spreader');
     expect(text).toContain('1x 100mm bowl Frog Tripod + Mid-Level Spreader');
     expect(text).toContain('1x 100mm bowl Hi-Head');
-    expect(text).toContain('2x sand bag (1x for Frog Tripod, 1x for Hi-Head)');
+    expect(text).toContain('2x sand bag (1x Frog Tripod, 1x Hi-Head)');
   });
 
   test('Easyrig scenario adds stabiliser with dropdown options', () => {


### PR DESCRIPTION
## Summary
- remove word "for" from context labels when listing sand bags
- update tests to expect new sand bag context format

## Testing
- `npm test` *(fails: `npm run test:script` hangs after starting)*

------
https://chatgpt.com/codex/tasks/task_e_68bdc2bbc9a08320a1157e23d69413c1