### PR TITLE
fix: remove duplicate lenses from accessories

### DIFF
--- a/devices/gearList.js
+++ b/devices/gearList.js
@@ -3047,6 +3047,8 @@ const gear = {
 
 // Expose lenses at the top level for easier access
 gear.lenses = gear.accessories.lenses;
+// Remove lenses from accessories to avoid duplicate entries
+delete gear.accessories.lenses;
 
   if (typeof registerDevice === 'function') {
   registerDevice('viewfinders', gear.viewfinders);

--- a/tests/gearList.test.js
+++ b/tests/gearList.test.js
@@ -1,0 +1,7 @@
+const devices = require('../devices');
+
+test('lenses are only exposed at top level', () => {
+  expect(devices.lenses).toBeDefined();
+  expect(devices.accessories).toBeDefined();
+  expect(devices.accessories.lenses).toBeUndefined();
+});


### PR DESCRIPTION
## Summary
- avoid registering lenses both as accessories and top-level
- add regression test to ensure lenses only appear once

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bdc41168c08320aabcf55695aec09d