### PR TITLE
Add unique icons for required scenarios

### DIFF
--- a/script.js
+++ b/script.js
@@ -10164,8 +10164,9 @@ const scenarioIcons = {
   'Extreme cold (snow)': '❄️',
   'Extreme rain': '🌧️',
   'Extreme heat': '🔥',
-  'Rain Machine': '🌧️',
-  'Slow Motion': '🐌'
+  'Rain Machine': '🚿',
+  'Slow Motion': '🐌',
+  'Battery Belt': '🔋'
 };
 
 function updateSelectIconBoxes(sel) {
@@ -10484,5 +10485,6 @@ if (typeof module !== "undefined" && module.exports) {
     updateRequiredScenariosSummary,
     updateMonitoringConfigurationOptions,
     updateViewfinderExtensionVisibility,
+    scenarioIcons,
   };
 }

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -2345,6 +2345,19 @@ describe('script.js functions', () => {
     expect(boxes[2].textContent).toContain('Extreme cold (snow)');
   });
 
+  test('each Required scenario has a unique icon', () => {
+    const script = require('../script.js');
+    const select = document.getElementById('requiredScenarios');
+    const icons = new Set();
+    Array.from(select.options).forEach(opt => {
+      const icon = script.scenarioIcons[opt.value];
+      expect(icon).toBeDefined();
+      expect(icon).not.toBe('📌');
+      expect(icons.has(icon)).toBe(false);
+      icons.add(icon);
+    });
+  });
+
   test('tripod preferences selector is shown only when Tripod scenario is selected', () => {
     const select = document.getElementById('requiredScenarios');
     const tripodRow = document.getElementById('tripodPreferencesRow');


### PR DESCRIPTION
## Summary
- assign distinct icons to every required scenario including Battery Belt and Rain Machine
- export scenario icon mapping for tests and verify each scenario has a unique icon

## Testing
- `NODE_OPTIONS=--max-old-space-size=4096 npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bdc57bc85883209c05684c4457cdb1