### PR TITLE
Show share link inline and copy status

### DIFF
--- a/index.html
+++ b/index.html
@@ -68,6 +68,7 @@
     <input type="file" id="importSetupsInput" accept=".json" class="hidden" />
     <button id="generateOverviewBtn">Generate Overview</button>
       <button id="shareSetupBtn">Share Project Link</button>
+    <p id="shareLinkMessage" class="hidden" role="status" aria-live="polite"></p>
     <div class="form-row hidden" id="sharedLinkRow">
       <label for="sharedLinkInput" id="sharedLinkLabel">Shared Link:</label>
       <input type="url" id="sharedLinkInput" placeholder="Paste shared link" aria-labelledby="sharedLinkLabel" />

--- a/script.js
+++ b/script.js
@@ -1877,6 +1877,7 @@ const clearSetupBtn   = document.getElementById("clearSetupBtn");
 const shareSetupBtn   = document.getElementById("shareSetupBtn");
 const sharedLinkRow   = document.getElementById("sharedLinkRow");
 const sharedLinkInput = document.getElementById("sharedLinkInput");
+const shareLinkMessage = document.getElementById("shareLinkMessage");
 const applySharedLinkBtn = document.getElementById("applySharedLinkBtn");
 const deviceManagerSection = document.getElementById("device-manager");
 const toggleDeviceBtn = document.getElementById("toggleDeviceManager");
@@ -7338,9 +7339,22 @@ shareSetupBtn.addEventListener('click', () => {
     alert(texts[currentLang].shareLinkTooLong || 'Shared link is too long.');
     return;
   }
+  if (sharedLinkInput && sharedLinkRow) {
+    sharedLinkInput.value = link;
+    sharedLinkRow.classList.remove('hidden');
+    sharedLinkInput.focus();
+    sharedLinkInput.select();
+  }
+  const showMessage = msg => {
+    if (shareLinkMessage) {
+      shareLinkMessage.textContent = msg;
+      shareLinkMessage.classList.remove('hidden');
+      setTimeout(() => shareLinkMessage.classList.add('hidden'), 4000);
+    }
+  };
   copyTextToClipboard(link)
-    .then(() => alert(texts[currentLang].shareLinkCopied))
-    .catch(() => prompt(texts[currentLang].shareSetupPrompt, link));
+    .then(() => showMessage(texts[currentLang].shareLinkCopied))
+    .catch(() => showMessage(texts[currentLang].shareSetupPrompt));
 });
 
 if (applySharedLinkBtn && sharedLinkInput) {


### PR DESCRIPTION
## Summary
- display generated share link in a dedicated input and auto-select it
- show non-blocking status messages instead of alerts when copying

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bdce9c5c3483209e3198a30d86d416