### PR TITLE
Persist Easyrig stabiliser selection

### DIFF
--- a/script.js
+++ b/script.js
@@ -2272,7 +2272,9 @@ function getEasyrigValue() {
 }
 function setEasyrigValue(val) {
   const sel = getEasyrigSelect();
-  if (sel) sel.value = val;
+  if (sel && val && Array.from(sel.options).some(opt => opt.value === val)) {
+    sel.value = val;
+  }
 }
 
 let currentProjectInfo = null;
@@ -6199,6 +6201,7 @@ setupSelect.addEventListener("change", (event) => {
       batterySelect.value = setup.battery;
       hotswapSelect.value = setup.batteryHotswap || hotswapSelect.value;
       setSliderBowlValue(setup.sliderBowl || '');
+      setEasyrigValue(setup.easyrig || '');
       updateBatteryOptions();
       if (gearListOutput) {
         displayGearAndRequirements(setup.gearList || '');
@@ -7914,6 +7917,7 @@ function populateProjectForm(info) {
     setMulti('tripodTypes', info.tripodTypes);
     setVal('tripodSpreader', info.tripodSpreader);
     setSliderBowlValue(info.sliderBowl || '');
+    setEasyrigValue(info.easyrig || '');
     setMulti('filter', info.filter);
 }
 


### PR DESCRIPTION
## Summary
- ensure Easyrig "Serene" option persists by only applying saved values when valid
- restore Easyrig choice when loading setups or project info

## Testing
- `npm run lint`
- `npm run test:unit`
- `npx jest --runInBand tests/script.test.js -t "selected further stabilisation persists"`


------
https://chatgpt.com/codex/tasks/task_e_68bdce7f428483208aaba375f48897cc