### PR TITLE
feat: add hover help descriptions for gear list and requirements

### DIFF
--- a/script.js
+++ b/script.js
@@ -2208,6 +2208,10 @@ function displayGearAndRequirements(html) {
         const desc = logic ? `${baseDesc} – ${logic}` : baseDesc;
         box.setAttribute('title', desc);
         box.setAttribute('data-help', desc);
+        box.querySelectorAll('.req-label, .req-value').forEach(el => {
+          el.setAttribute('title', desc);
+          el.setAttribute('data-help', desc);
+        });
       });
     } else {
       projectRequirementsOutput.innerHTML = '';
@@ -2248,6 +2252,30 @@ function displayGearAndRequirements(html) {
       const desc = parts.join(' – ');
       span.setAttribute('title', desc);
       span.setAttribute('data-help', desc);
+      span.querySelectorAll('select').forEach(sel => {
+        sel.setAttribute('title', desc);
+        sel.setAttribute('data-help', desc);
+      });
+    });
+    // Standalone selects (not wrapped in .gear-item) still need descriptive help
+    gearListOutput.querySelectorAll('select').forEach(sel => {
+      if (sel.getAttribute('data-help')) return;
+      const selected = sel.selectedOptions && sel.selectedOptions[0];
+      const name = selected ? selected.textContent.trim() : sel.value;
+      const { info, category } = findDevice(name);
+      const parts = [];
+      parts.push(`1x ${name}`.trim());
+      if (category) parts.push(`Category: ${category}`);
+      if (info) {
+        let summary = generateConnectorSummary(info);
+        summary = summary ? summary.replace(/<[^>]+>/g, '').replace(/\s+/g, ' ').trim() : '';
+        if (info.notes)
+          summary = summary ? `${summary}; Notes: ${info.notes}` : info.notes;
+        if (summary) parts.push(summary);
+      }
+      const desc = parts.join(' – ');
+      sel.setAttribute('title', desc);
+      sel.setAttribute('data-help', desc);
     });
   }
   updateGearListButtonVisibility();

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -5178,6 +5178,21 @@ describe('monitor wireless metadata', () => {
     expect(item.getAttribute('data-help')).toContain('Power: 10 W');
   });
 
+  test('gear list selects expose descriptive hover help', () => {
+    setupDom();
+    require('../translations.js');
+    const script = require('../script.js');
+    script.setLanguage('en');
+    const cameraSelect = document.getElementById('cameraSelect');
+    cameraSelect.innerHTML = '<option value="CamA">CamA</option>';
+    cameraSelect.value = 'CamA';
+    const html = script.generateGearListHtml();
+    script.displayGearAndRequirements(html);
+    const sel = document.getElementById('gearListCage');
+    expect(sel).not.toBeNull();
+    expect(sel.getAttribute('data-help')).toContain('CageOne');
+  });
+
   test('project requirements boxes expose descriptive hover help', () => {
     setupDom();
     require('../translations.js');
@@ -5187,6 +5202,19 @@ describe('monitor wireless metadata', () => {
     script.displayGearAndRequirements(html);
     const box = document.querySelector('.requirement-box');
     expect(box.getAttribute('data-help')).toContain('Codec: ProRes');
+  });
+
+  test('project requirements children expose descriptive hover help', () => {
+    setupDom();
+    require('../translations.js');
+    const script = require('../script.js');
+    script.setLanguage('en');
+    const html = script.generateGearListHtml({ codec: 'ProRes' });
+    script.displayGearAndRequirements(html);
+    const label = document.querySelector('.requirement-box .req-label');
+    const value = document.querySelector('.requirement-box .req-value');
+    expect(label.getAttribute('data-help')).toContain('Codec: ProRes');
+    expect(value.getAttribute('data-help')).toContain('Codec: ProRes');
   });
 
   test('gear list action buttons expose descriptive hover help', () => {


### PR DESCRIPTION
## Summary
- ensure project requirement boxes and their labels/values include descriptive `title` and `data-help`
- add hover-help descriptions to gear list items and standalone selects
- expand tests to verify gear list selects and requirement children expose hover help

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bdcebf4ad883208bd29e704ee5f6b2