### PR TITLE
Tweak desktop body font size

### DIFF
--- a/style.css
+++ b/style.css
@@ -37,7 +37,7 @@ body.pink-mode {
 }
 
 html {
-  font-size: clamp(14px, 1vw + 12px, 18px);
+  font-size: clamp(14px, 1vw + 10px, 16px);
 }
 
 html,


### PR DESCRIPTION
## Summary
- reduce root font-size clamp so desktop body text is smaller

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bdd33c4ed483208ffedccc5d8e12a2