### PR TITLE
fix: persist Easyrig selection on reload

### DIFF
--- a/script.js
+++ b/script.js
@@ -2279,6 +2279,10 @@ function displayGearAndRequirements(html) {
       sel.setAttribute('data-help', desc);
     });
   }
+  if (loadedSetupState) {
+    setSliderBowlValue(loadedSetupState.sliderBowl || '');
+    setEasyrigValue(loadedSetupState.easyrig || '');
+  }
   updateGearListButtonVisibility();
 }
 function getSliderBowlSelect() {
@@ -2297,7 +2301,8 @@ function getEasyrigSelect() {
 }
 function getEasyrigValue() {
   const sel = getEasyrigSelect();
-  return sel ? sel.value : '';
+  if (sel) return sel.value;
+  return loadedSetupState && loadedSetupState.easyrig ? loadedSetupState.easyrig : '';
 }
 function setEasyrigValue(val) {
   const sel = getEasyrigSelect();
@@ -9358,6 +9363,7 @@ function setSelectValue(select, value) {
 function restoreSessionState() {
   restoringSession = true;
   const state = loadSession();
+  loadedSetupState = state || null;
   if (state) {
     if (setupNameInput) {
       setupNameInput.value = state.setupName || '';

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -2710,6 +2710,31 @@ describe('script.js functions', () => {
     expect(document.querySelector('#gearListEasyrig').value).toBe('FlowCine Serene Spring Arm');
   });
 
+  test('Easyrig selection restored when generating gear list after session reload without saved list', () => {
+    global.saveSessionState = jest.fn();
+    global.loadSessionState = jest.fn();
+    global.saveProject = jest.fn();
+    const { generateGearListHtml, displayGearAndRequirements, ensureGearListActions, bindGearListEasyrigListener, restoreSessionState } = script;
+    const html = generateGearListHtml({ requiredScenarios: 'Easyrig' });
+    displayGearAndRequirements(html);
+    ensureGearListActions();
+    bindGearListEasyrigListener();
+    const sel = document.querySelector('#gearListEasyrig');
+    sel.value = 'FlowCine Serene Spring Arm';
+    sel.dispatchEvent(new Event('change'));
+    const state = global.saveSessionState.mock.calls.pop()[0];
+    expect(state.easyrig).toBe('FlowCine Serene Spring Arm');
+    global.loadSessionState.mockReturnValue(state);
+    global.loadProject = jest.fn(() => null);
+    document.getElementById('gearListOutput').innerHTML = '';
+    restoreSessionState();
+    expect(document.querySelector('#gearListEasyrig')).toBeNull();
+    const html2 = generateGearListHtml({ requiredScenarios: 'Easyrig' });
+    displayGearAndRequirements(html2);
+    bindGearListEasyrigListener();
+    expect(document.querySelector('#gearListEasyrig').value).toBe('FlowCine Serene Spring Arm');
+  });
+
   test('Grip section always includes a friction arm', () => {
     const { generateGearListHtml } = script;
     const addOpt = (id, value) => {


### PR DESCRIPTION
## Summary
- ensure easyrig choice survives session restore even when gear list is regenerated
- keep previously selected stabiliser in session state when no select element exists
- exercise easyrig persistence with new regression test

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68bdd441dcf48320a71bc9307c1d93ee