### PR TITLE
Remove 5" options from video distribution dropdown

### DIFF
--- a/index.html
+++ b/index.html
@@ -1143,14 +1143,11 @@
       <div class="form-row">
         <label for="videoDistribution">Video distribution:</label>
         <select id="videoDistribution" name="videoDistribution" multiple size="10">
-          <option value="Director Monitor 5&quot; handheld">Director Monitor 5&quot; handheld</option>
           <option value="Director Monitor 7&quot; handheld">Director Monitor 7&quot; handheld</option>
-          <option value="Gaffer Monitor 5&quot; handheld">Gaffer Monitor 5&quot; handheld</option>
           <option value="Gaffer Monitor 7&quot; handheld">Gaffer Monitor 7&quot; handheld</option>
           <option value="Director Monitor 15-21&quot;">Director Monitor 15-21&quot;</option>
           <option value="Combo Monitor 15-21&quot;">Combo Monitor 15-21&quot;</option>
           <option value="IOS Video (Teradek Serv + Link)">IOS Video (Teradek Serv + Link)</option>
-          <option value="DoP Monitor 5&quot; handheld">DoP Monitor 5&quot; handheld</option>
           <option value="DoP Monitor 7&quot; handheld">DoP Monitor 7&quot; handheld</option>
           <option value="DoP Monitor 15-21&quot;">DoP Monitor 15-21&quot;</option>
         </select>

--- a/script.js
+++ b/script.js
@@ -10107,7 +10107,6 @@ function updateRequiredScenariosSummary() {
         videoDistributionSelect.appendChild(opt);
       }
     };
-    ensureOption('DoP Monitor 5" handheld');
     ensureOption('DoP Monitor 7" handheld');
     ensureOption('DoP Monitor 15-21"');
   }

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -1867,13 +1867,13 @@ describe('script.js functions', () => {
   expect(miscSection).not.toContain('D-Tap to Lemo-2-pin Cable 0,3m (1x Director handheld, 1x Spare)');
   });
 
-  test('Director 5" handheld monitor adds dropdown, batteries and grip items', () => {
+  test('Director 7" handheld monitor adds dropdown, batteries and grip items', () => {
     const { generateGearListHtml } = script;
     global.devices.monitors = {
       'SmallHD Ultra 7': { screenSizeInches: 7 },
       MonA: { screenSizeInches: 5 }
     };
-    const html = generateGearListHtml({ videoDistribution: 'Director Monitor 5" handheld' });
+    const html = generateGearListHtml({ videoDistribution: 'Director Monitor 7" handheld' });
     expect(html).toContain('<select id="gearListDirectorMonitor"');
     expect(html).toContain('Directors cage, shoulder strap, sunhood, rigging for teradeks');
     expect(html).toContain('3x Bebob V98micro (3x Director handheld)');
@@ -3248,14 +3248,16 @@ describe('script.js functions', () => {
     expect(html).not.toContain('<span class="req-value">IRND</span>');
   });
 
-  test('project requirements form includes handheld monitor size options', () => {
+  test('project requirements form includes handheld monitor 7" options', () => {
     setupDom(true);
     const sel = document.getElementById('videoDistribution');
     const values = Array.from(sel.options).map(o => o.value);
-    expect(values).toContain('Director Monitor 5" handheld');
     expect(values).toContain('Director Monitor 7" handheld');
-    expect(values).toContain('Gaffer Monitor 5" handheld');
     expect(values).toContain('Gaffer Monitor 7" handheld');
+    expect(values).toContain('DoP Monitor 7" handheld');
+    expect(values).not.toContain('Director Monitor 5" handheld');
+    expect(values).not.toContain('Gaffer Monitor 5" handheld');
+    expect(values).not.toContain('DoP Monitor 5" handheld');
   });
 
   test('sensor mode appears in project requirements when provided', () => {


### PR DESCRIPTION
## Summary
- drop 5" handheld monitor options from Video distribution list
- update logic to only inject 7" and larger DoP monitor choices
- adjust tests to verify 7" options and absence of 5" entries

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bdd4990b888320a393c70b8cac0b86