### PR TITLE
Normalize filter size and cover filter defaults

### DIFF
--- a/script.js
+++ b/script.js
@@ -8019,7 +8019,8 @@ function expandFilterSelections(filters = []) {
     const parseVals = v => v ? v.split('|').map(s => s.trim()).filter(Boolean) : [];
     filters.forEach(f => {
         if (!f) return;
-        const [type, size = '4x5.65', rawVals = ''] = f.split(':').map(s => s.trim());
+        const [type, rawSize = '4x5.65', rawVals = ''] = f.split(':').map(s => s.trim());
+        const size = rawSize.replace(',', '.');
         const values = parseVals(rawVals);
         switch (type) {
             case 'Clear':

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -1690,6 +1690,33 @@ describe('script.js functions', () => {
     expect(filterSection).toContain('95mm Pol Filter');
   });
 
+  test('clear filter uses default size', () => {
+    setupDom(false);
+    require('../translations.js');
+    const { generateGearListHtml } = require('../script.js');
+    const html = generateGearListHtml({ filter: 'Clear' });
+    const section = html.slice(html.indexOf('Matte box + filter'), html.indexOf('LDS (FIZ)'));
+    expect(section).toContain('4x5.65 Clear Filter');
+  });
+
+  test('pol filter uses default size', () => {
+    setupDom(false);
+    require('../translations.js');
+    const { generateGearListHtml } = require('../script.js');
+    const html = generateGearListHtml({ filter: 'Pol' });
+    const section = html.slice(html.indexOf('Matte box + filter'), html.indexOf('LDS (FIZ)'));
+    expect(section).toContain('4x5.65 Pol Filter');
+  });
+
+  test('default filter set includes 1/2, 1/4 and 1/8', () => {
+    setupDom(false);
+    require('../translations.js');
+    const { generateGearListHtml } = require('../script.js');
+    const html = generateGearListHtml({ filter: 'BPM' });
+    const section = html.slice(html.indexOf('Matte box + filter'), html.indexOf('LDS (FIZ)'));
+    expect(section).toContain('4x5.65 BPM Filter Set 1/2 + 1/4 + 1/8');
+  });
+
   test('diopter filter includes frame and default strengths', () => {
     setupDom(false);
     require('../translations.js');


### PR DESCRIPTION
## Summary
- Normalize filter size strings to handle comma notation
- Add tests verifying default Clear, Pol and generic filter sets

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bddda16f808320bafdc5b6508700bc