### PR TITLE
Add detailed filter size and strength selectors

### DIFF
--- a/index.html
+++ b/index.html
@@ -1103,6 +1103,7 @@
         <label for="filter">Filter:</label>
         <select id="filter" name="filter" multiple size="10"></select>
       </div>
+      <div class="form-row" id="filterDetails"></div>
 
       <h3 id="monitoringHeading">Monitoring</h3>
       <div class="form-row">

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -1730,6 +1730,34 @@ describe('script.js functions', () => {
     expect(section).toContain('Schneider CF DIOPTER FULL +4 GEN2');
   });
 
+  test('collectProjectFormData builds default filter token', () => {
+    setupDom(false);
+    require('../translations.js');
+    const { collectProjectFormData } = require('../script.js');
+    const filterSelect = document.getElementById('filter');
+    const opt = [...filterSelect.options].find(o => o.value === 'BPM');
+    opt.selected = true;
+    filterSelect.dispatchEvent(new window.Event('change'));
+    const info = collectProjectFormData();
+    expect(info.filter).toBe('BPM:4x5.65:1/2|1/4|1/8');
+  });
+
+  test('collectProjectFormData handles custom filter selections', () => {
+    setupDom(false);
+    require('../translations.js');
+    const { collectProjectFormData } = require('../script.js');
+    const filterSelect = document.getElementById('filter');
+    const opt = [...filterSelect.options].find(o => o.value === 'IRND');
+    opt.selected = true;
+    filterSelect.dispatchEvent(new window.Event('change'));
+    const sizeSel = document.getElementById('filter-size-IRND');
+    sizeSel.value = '6x6';
+    const valSel = document.getElementById('filter-values-IRND');
+    [...valSel.options].forEach(o => { o.selected = ['0.6','1.8'].includes(o.value); });
+    const info = collectProjectFormData();
+    expect(info.filter).toBe('IRND:6x6:0.6|1.8');
+  });
+
   test('ND Grad filters force swing-away matte box', () => {
     setupDom(false);
     require('../translations.js');


### PR DESCRIPTION
## Summary
- add dynamic filter size and strength selections with defaults for special filter types
- collect filter choices with size and density and auto-switch matte box when needed
- test filter token generation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bde0ec99a48320b63486027d483db2