### PR TITLE
feat: link gear lists to projects

### DIFF
--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -24,6 +24,7 @@ function setupDom(removeGear) {
   global.alert = jest.fn();
   global.prompt = jest.fn();
 
+
   // Use the cached HTML body instead of reading from disk each time.
   const dom = new JSDOM(`<!doctype html><html><head></head><body>${htmlBody}</body></html>`);
   global.window = dom.window;
@@ -138,6 +139,11 @@ function setupDom(removeGear) {
   global.loadFeedback = jest.fn(() => ({}));
   global.saveFeedback = jest.fn();
 }
+
+afterEach(() => {
+  if (global.localStorage) global.localStorage.clear();
+  if (global.sessionStorage) global.sessionStorage.clear();
+});
 
 test('cage data includes cage-specific attributes', () => {
   setupDom(false);
@@ -704,7 +710,7 @@ describe('script.js functions', () => {
     const cageSel = gear.querySelector('#gearListCage');
     cageSel.value = 'Cage2';
     script.saveCurrentGearList();
-    const saved = global.saveProject.mock.calls[0][0];
+    const saved = global.saveProject.mock.calls[0][1];
     expect(saved.gearList).toContain('<option value="Cage2" selected');
   });
 
@@ -717,7 +723,7 @@ describe('script.js functions', () => {
     gear.innerHTML = '<h2>Proj</h2><h3>Gear List</h3><table class="gear-table"></table>';
     gear.classList.remove('hidden');
     script.saveCurrentGearList();
-    const saved = global.saveProject.mock.calls[0][0];
+    const saved = global.saveProject.mock.calls[0][1];
     expect(saved.gearList).toContain('<div class="requirements-grid">');
     expect(saved.gearList).toContain('<table class="gear-table">');
   });
@@ -743,7 +749,7 @@ describe('script.js functions', () => {
     aspectMaskSel.options[0].selected = true;
     const form = document.getElementById('projectForm');
     form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
-    const saved = global.saveProject.mock.calls[0][0];
+    const saved = global.saveProject.mock.calls[0][1];
     const expectedKeys = [
       'projectName','dop','prepDays','shootingDays','deliveryResolution','recordingResolution','aspectRatio','codec','baseFrameRate','sensorMode','lenses','requiredScenarios','cameraHandle','viewfinderExtension','viewfinderEyeLeatherColor','mattebox','gimbal','viewfinderSettings','frameGuides','aspectMaskOpacity','videoDistribution','monitoringConfiguration','monitorUserButtons','cameraUserButtons','viewfinderUserButtons','tripodHeadBrand','tripodBowl','tripodTypes','tripodSpreader','sliderBowl','filter'
     ];
@@ -5033,7 +5039,7 @@ describe('script.js functions', () => {
     const gearOut = document.getElementById('gearListOutput');
     const sel = gearOut.querySelector('#gearListCage');
     expect(sel.value).toBe('B');
-    expect(global.saveProject).toHaveBeenCalledWith({ gearList: expect.stringContaining('gearListCage'), projectInfo: { notes: 'shoot' } });
+    expect(global.saveProject).toHaveBeenCalledWith('', { gearList: expect.stringContaining('gearListCage'), projectInfo: { notes: 'shoot' } });
   });
 
   test('applySharedSetupFromUrl restores setup name', () => {

--- a/tests/storage.test.js
+++ b/tests/storage.test.js
@@ -256,6 +256,19 @@ describe('feedback storage', () => {
   });
 });
 
+describe('project storage', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  test('saveProject stores data per project name', () => {
+    saveProject('A', { gearList: '<ul>A</ul>' });
+    saveProject('B', { gearList: '<ul>B</ul>' });
+    expect(loadProject('A')).toEqual({ gearList: '<ul>A</ul>', projectInfo: null });
+    expect(loadProject('B')).toEqual({ gearList: '<ul>B</ul>', projectInfo: null });
+  });
+});
+
 describe('clearAllData', () => {
   beforeEach(() => {
     localStorage.clear();
@@ -266,7 +279,7 @@ describe('clearAllData', () => {
     saveDeviceData(validDeviceData);
     saveSetups({ A: { foo: 1 } });
     saveFeedback({ note: 'hi' });
-    saveProject({ gearList: '<ul></ul>' });
+    saveProject('Proj', { gearList: '<ul></ul>' });
     saveSessionState({ camera: 'CamA' });
     clearAllData();
     expect(localStorage.getItem(DEVICE_KEY)).toBeNull();
@@ -288,13 +301,13 @@ describe('export/import all data', () => {
     saveSetups({ A: { foo: 1 } });
     saveSessionState({ camera: 'CamA' });
     saveFeedback({ note: 'hi' });
-    saveProject({ gearList: '<ul></ul>' });
+    saveProject('Proj', { gearList: '<ul></ul>' });
     expect(exportAllData()).toEqual({
       devices: validDeviceData,
       setups: { A: { foo: 1 } },
       session: { camera: 'CamA' },
       feedback: { note: 'hi' },
-      project: { gearList: '<ul></ul>', projectInfo: null }
+      project: { Proj: { gearList: '<ul></ul>', projectInfo: null } }
     });
   });
 
@@ -304,14 +317,14 @@ describe('export/import all data', () => {
       setups: { A: { foo: 1 } },
       session: { camera: 'CamA' },
       feedback: { note: 'hi' },
-      project: { gearList: '<ol></ol>' }
+      project: { Proj: { gearList: '<ol></ol>' } }
     };
     importAllData(data);
     expect(loadDeviceData()).toEqual(validDeviceData);
     expect(loadSetups()).toEqual({ A: { foo: 1 } });
     expect(loadSessionState()).toEqual({ camera: 'CamA' });
     expect(loadFeedback()).toEqual({ note: 'hi' });
-    expect(loadProject()).toEqual({ gearList: '<ol></ol>', projectInfo: null });
+    expect(loadProject('Proj')).toEqual({ gearList: '<ol></ol>', projectInfo: null });
   });
 });
 


### PR DESCRIPTION
## Summary
- store gear lists keyed by project name instead of single global entry
- update UI logic to save/load/delete gear lists per project
- expand storage tests for multi-project persistence

## Testing
- `NODE_OPTIONS=--max_old_space_size=4096 npm test` *(fails: 24 failed, 247 passed; 1 failed suite)*
- `NODE_OPTIONS=--max_old_space_size=4096 npm run test:script` *(fails: 24 failed, 247 passed; 1 failed suite)*

------
https://chatgpt.com/codex/tasks/task_e_68bde415f4d883209bd4644cd811aae0