### PR TITLE
feat: confirm gear list saving

### DIFF
--- a/script.js
+++ b/script.js
@@ -9196,6 +9196,11 @@ function deleteCurrentGearList() {
     updateGearListButtonVisibility();
 }
 
+function confirmSaveCurrentGearList() {
+    if (!confirm(texts[currentLang].confirmSaveGearList)) return;
+    saveCurrentGearList();
+}
+
 function ensureGearListActions() {
     if (!gearListOutput) return;
     let actions = document.getElementById('gearListActions');
@@ -9218,7 +9223,7 @@ function ensureGearListActions() {
         deleteBtn.id = 'deleteGearListBtn';
         actions.append(saveBtn, exportBtn, importBtn, importInput, deleteBtn);
         gearListOutput.appendChild(actions);
-        saveBtn.addEventListener('click', saveCurrentGearList);
+        saveBtn.addEventListener('click', confirmSaveCurrentGearList);
         exportBtn.addEventListener('click', exportCurrentGearList);
         importBtn.addEventListener('click', () => importInput.click());
         importInput.addEventListener('change', handleImportGearList);

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -5372,6 +5372,28 @@ describe('monitor wireless metadata', () => {
     expect(deleteBtn.getAttribute('data-help')).toBe(texts.en.deleteGearListBtnHelp);
   });
 
+  test('saving gear list via button requires confirmation', () => {
+    setupDom();
+    require('../translations.js');
+    const script = require('../script.js');
+    script.setLanguage('en');
+    const html = script.generateGearListHtml({ projectName: 'Proj' });
+    script.displayGearAndRequirements(html);
+    script.ensureGearListActions();
+    const confirmSpy = jest.spyOn(window, 'confirm');
+    const saveSpy = jest.spyOn(script, 'saveCurrentGearList');
+    confirmSpy.mockReturnValueOnce(false).mockReturnValueOnce(true);
+    const btn = document.getElementById('saveGearListBtn');
+    btn.click();
+    expect(confirmSpy).toHaveBeenCalledTimes(1);
+    expect(saveSpy).not.toHaveBeenCalled();
+    btn.click();
+    expect(confirmSpy).toHaveBeenCalledTimes(2);
+    expect(saveSpy).toHaveBeenCalledTimes(1);
+    confirmSpy.mockRestore();
+    saveSpy.mockRestore();
+  });
+
   test('detail toggle responds to keyboard events', () => {
     const detailToggle = document.querySelector('#device-manager .detail-toggle');
     const details = detailToggle.closest('li').querySelector('.device-details');

--- a/translations.js
+++ b/translations.js
@@ -317,6 +317,7 @@ const texts = {
       "Load a gear list from a JSON file, replacing the current table.",
     deleteGearListBtnHelp:
       "Remove the saved gear list from this project and hide the table.",
+    confirmSaveGearList: "Save gear list?",
     confirmDeleteGearList: "Delete gear list?",
     confirmDeleteGearListAgain: "This will permanently delete the gear list. Are you sure?",
     alertNoSetupsToExport: "There are no saved projects to export.",
@@ -691,6 +692,7 @@ const texts = {
       "Carica un elenco attrezzatura da un file JSON sostituendo la tabella corrente.",
     deleteGearListBtnHelp:
       "Rimuovi l'elenco attrezzatura salvato dal progetto e nascondi la tabella.",
+    confirmSaveGearList: "Salvare l'elenco attrezzatura?",
     confirmDeleteGearList: "Eliminare elenco attrezzatura?",
     confirmDeleteGearListAgain: "Questo eliminerà definitivamente l'elenco attrezzatura. Sei sicuro?",
     alertNoSetupsToExport: "Non ci sono configurazioni salvate per l'esportazione.",
@@ -1070,6 +1072,7 @@ const texts = {
       "Carga una lista de equipo desde un archivo JSON reemplazando la tabla actual.",
     deleteGearListBtnHelp:
       "Elimina la lista de equipo guardada de este proyecto y oculta la tabla.",
+    confirmSaveGearList: "¿Guardar lista de equipo?",
     confirmDeleteGearList: "¿Eliminar lista de equipo?",
     confirmDeleteGearListAgain: "Esto eliminará permanentemente la lista de equipo. ¿Estás seguro?",
     alertNoSetupsToExport: "No hay configuraciones para exportar.",
@@ -1451,6 +1454,7 @@ const texts = {
       "Charge une liste du matériel depuis un fichier JSON en remplaçant la table actuelle.",
     deleteGearListBtnHelp:
       "Supprime la liste du matériel enregistrée du projet et masque le tableau.",
+    confirmSaveGearList: "Enregistrer la liste du matériel ?",
     confirmDeleteGearList: "Supprimer la liste du matériel ?",
     confirmDeleteGearListAgain: "Cela supprimera définitivement la liste du matériel. Êtes-vous sûr ?",
     alertNoSetupsToExport: "Aucune configuration à exporter.",
@@ -1835,6 +1839,7 @@ const texts = {
       "Lädt eine Gear-Liste aus einer JSON-Datei und ersetzt damit die aktuelle Tabelle.",
     deleteGearListBtnHelp:
       "Entfernt die gespeicherte Gear-Liste aus diesem Projekt und blendet die Tabelle aus.",
+    confirmSaveGearList: "Gear-Liste speichern?",
     confirmDeleteGearList: "Gear-Liste löschen?",
     confirmDeleteGearListAgain: "Dies wird die Gear-Liste dauerhaft löschen. Bist du sicher?",
     alertNoSetupsToExport: "Es gibt keine gespeicherten Setups zum Exportieren.",


### PR DESCRIPTION
## Summary
- add confirmation prompt before saving gear list
- localize new prompt in English, Italian, Spanish, French, and German
- test that save button requires user confirmation before persisting gear list

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bde84877bc832081d708a32816982f