### PR TITLE
Use compact keys to shrink shared setup links

### DIFF
--- a/script.js
+++ b/script.js
@@ -1879,6 +1879,41 @@ const sharedLinkRow   = document.getElementById("sharedLinkRow");
 const sharedLinkInput = document.getElementById("sharedLinkInput");
 const shareLinkMessage = document.getElementById("shareLinkMessage");
 const applySharedLinkBtn = document.getElementById("applySharedLinkBtn");
+const sharedKeyMap = {
+  setupName: "s",
+  camera: "c",
+  monitor: "m",
+  video: "v",
+  cage: "g",
+  motors: "o",
+  controllers: "r",
+  distance: "d",
+  batteryPlate: "p",
+  battery: "b",
+  batteryHotswap: "h",
+  projectInfo: "i",
+  gearSelectors: "e",
+  changedDevices: "x",
+  feedback: "f"
+};
+
+function encodeSharedSetup(setup) {
+  const out = {};
+  Object.keys(sharedKeyMap).forEach(key => {
+    if (setup[key] != null) out[sharedKeyMap[key]] = setup[key];
+  });
+  return out;
+}
+
+function decodeSharedSetup(setup) {
+  if (setup.setupName || setup.camera) return setup;
+  const out = {};
+  Object.keys(sharedKeyMap).forEach(key => {
+    const short = sharedKeyMap[key];
+    if (setup[short] != null) out[key] = setup[short];
+  });
+  return out;
+}
 const deviceManagerSection = document.getElementById("device-manager");
 const toggleDeviceBtn = document.getElementById("toggleDeviceManager");
 const cameraListElem  = document.getElementById("cameraList");
@@ -7389,7 +7424,9 @@ shareSetupBtn.addEventListener('click', () => {
   if (feedback.length) {
     currentSetup.feedback = feedback;
   }
-  const encoded = LZString.compressToEncodedURIComponent(JSON.stringify(currentSetup));
+  const encoded = LZString.compressToEncodedURIComponent(
+    JSON.stringify(encodeSharedSetup(currentSetup))
+  );
   const link = `${window.location.origin}${window.location.pathname}?shared=${encoded}`;
   if (link.length > 2000) {
     alert(texts[currentLang].shareLinkTooLong || 'Shared link is too long.');
@@ -9477,7 +9514,9 @@ function restoreSessionState() {
 
 function applySharedSetup(shared) {
   try {
-    const decoded = JSON.parse(LZString.decompressFromEncodedURIComponent(shared));
+    const decoded = decodeSharedSetup(
+      JSON.parse(LZString.decompressFromEncodedURIComponent(shared))
+    );
     if (decoded.changedDevices) {
       applyDeviceChanges(decoded.changedDevices);
     }
@@ -10488,6 +10527,8 @@ if (typeof module !== "undefined" && module.exports) {
     generatePrintableOverview,
     generateGearListHtml,
     ensureZoomRemoteSetup,
+    encodeSharedSetup,
+    decodeSharedSetup,
     applySharedSetupFromUrl,
     applySharedSetup,
     updateBatteryPlateVisibility,

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -4960,7 +4960,9 @@ describe('script.js functions', () => {
     expect(navigator.clipboard.writeText).toHaveBeenCalled();
     const link = navigator.clipboard.writeText.mock.calls[0][0];
     const encoded = new URL(link).searchParams.get('shared');
-    const decoded = JSON.parse(LZString.decompressFromEncodedURIComponent(encoded));
+    const decoded = script.decodeSharedSetup(
+      JSON.parse(LZString.decompressFromEncodedURIComponent(encoded))
+    );
     expect(decoded.setupName).toBe('My Setup');
   });
 
@@ -4989,20 +4991,26 @@ describe('script.js functions', () => {
     expect(navigator.clipboard.writeText).toHaveBeenCalled();
     const link = navigator.clipboard.writeText.mock.calls[0][0];
     const encoded = new URL(link).searchParams.get('shared');
-    const decoded = JSON.parse(LZString.decompressFromEncodedURIComponent(encoded));
+    const decoded = script.decodeSharedSetup(
+      JSON.parse(LZString.decompressFromEncodedURIComponent(encoded))
+    );
     expect(decoded.changedDevices.cameras.CamA.powerDrawWatts).toBe(20);
     expect(decoded.feedback[0].runtime).toBe('1h');
   });
 
-  test('shareSetupBtn generates shorter encoded link than base64', () => {
+  test('shareSetupBtn shortens link with compact keys', () => {
     const btn = document.getElementById('shareSetupBtn');
     btn.click();
     expect(navigator.clipboard.writeText).toHaveBeenCalled();
     const link = navigator.clipboard.writeText.mock.calls[0][0];
     const encoded = new URL(link).searchParams.get('shared');
-    const decodedObj = JSON.parse(LZString.decompressFromEncodedURIComponent(encoded));
-    const base64 = Buffer.from(JSON.stringify(decodedObj)).toString('base64');
-    expect(encoded.length).toBeLessThan(base64.length);
+    const decodedObj = script.decodeSharedSetup(
+      JSON.parse(LZString.decompressFromEncodedURIComponent(encoded))
+    );
+    const longEncoded = LZString.compressToEncodedURIComponent(
+      JSON.stringify(decodedObj)
+    );
+    expect(encoded.length).toBeLessThan(longEncoded.length);
   });
 
   test('shareSetupBtn includes gear selectors and project info', () => {
@@ -5014,7 +5022,9 @@ describe('script.js functions', () => {
     btn.click();
     const link = navigator.clipboard.writeText.mock.calls[0][0];
     const encoded = new URL(link).searchParams.get('shared');
-    const decoded = JSON.parse(LZString.decompressFromEncodedURIComponent(encoded));
+    const decoded = script.decodeSharedSetup(
+      JSON.parse(LZString.decompressFromEncodedURIComponent(encoded))
+    );
     expect(decoded.gearList).toBeUndefined();
     expect(decoded.gearSelectors.gearListCage).toBe('CageA');
     expect(decoded.projectInfo.notes).toBe('shoot');


### PR DESCRIPTION
## Summary
- compress shared setup data with short keys to reduce URL length
- decode compact keys when applying shared setups
- update tests for new compact key encoding

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bde93966f88320a15615f4e7620525