### PR TITLE
Clear gear list and requirements when switching projects

### DIFF
--- a/script.js
+++ b/script.js
@@ -2259,64 +2259,71 @@ function displayGearAndRequirements(html) {
     }
   }
   if (gearListOutput) {
-    gearListOutput.innerHTML = gearHtml;
-    gearListOutput.classList.remove('hidden');
-    const findDevice = name => {
-      for (const [catName, cat] of Object.entries(devices)) {
-        if (cat && typeof cat === 'object') {
-          if (cat[name]) return { info: cat[name], category: catName };
-          for (const sub of Object.values(cat)) {
-            if (sub && sub[name]) return { info: sub[name], category: catName };
+    if (gearHtml) {
+      gearListOutput.innerHTML = gearHtml;
+      gearListOutput.classList.remove('hidden');
+      const findDevice = name => {
+        for (const [catName, cat] of Object.entries(devices)) {
+          if (cat && typeof cat === 'object') {
+            if (cat[name]) return { info: cat[name], category: catName };
+            for (const sub of Object.values(cat)) {
+              if (sub && sub[name]) return { info: sub[name], category: catName };
+            }
           }
         }
-      }
-      return { info: null, category: '' };
-    };
-    gearListOutput.querySelectorAll('.gear-item').forEach(span => {
-      const name = span.getAttribute('data-gear-name');
-      const { info, category } = findDevice(name);
-      const countMatch = span.textContent.trim().match(/^(\d+)x\s+/);
-      const count = countMatch ? `${countMatch[1]}x ` : '';
-      const parts = [];
-      parts.push(`${count}${name}`.trim());
-      if (category) parts.push(`Category: ${category}`);
-      if (info) {
-        let summary = generateConnectorSummary(info);
-        summary = summary
-          ? summary.replace(/<[^>]+>/g, '').replace(/\s+/g, ' ').trim()
-          : '';
-        if (info.notes)
-          summary = summary ? `${summary}; Notes: ${info.notes}` : info.notes;
-        if (summary) parts.push(summary);
-      }
-      const desc = parts.join(' – ');
-      span.setAttribute('title', desc);
-      span.setAttribute('data-help', desc);
-      span.querySelectorAll('select').forEach(sel => {
+        return { info: null, category: '' };
+      };
+      gearListOutput.querySelectorAll('.gear-item').forEach(span => {
+        const name = span.getAttribute('data-gear-name');
+        const { info, category } = findDevice(name);
+        const countMatch = span.textContent.trim().match(/^(\d+)x\s+/);
+        const count = countMatch ? `${countMatch[1]}x ` : '';
+        const parts = [];
+        parts.push(`${count}${name}`.trim());
+        if (category) parts.push(`Category: ${category}`);
+        if (info) {
+          let summary = generateConnectorSummary(info);
+          summary = summary
+            ? summary.replace(/<[^>]+>/g, '').replace(/\s+/g, ' ').trim()
+            : '';
+          if (info.notes)
+            summary = summary ? `${summary}; Notes: ${info.notes}` : info.notes;
+          if (summary) parts.push(summary);
+        }
+        const desc = parts.join(' – ');
+        span.setAttribute('title', desc);
+        span.setAttribute('data-help', desc);
+        span.querySelectorAll('select').forEach(sel => {
+          sel.setAttribute('title', desc);
+          sel.setAttribute('data-help', desc);
+        });
+      });
+      // Standalone selects (not wrapped in .gear-item) still need descriptive help
+      gearListOutput.querySelectorAll('select').forEach(sel => {
+        if (sel.getAttribute('data-help')) return;
+        const selected = sel.selectedOptions && sel.selectedOptions[0];
+        const name = selected ? selected.textContent.trim() : sel.value;
+        const { info, category } = findDevice(name);
+        const parts = [];
+        parts.push(`1x ${name}`.trim());
+        if (category) parts.push(`Category: ${category}`);
+        if (info) {
+          let summary = generateConnectorSummary(info);
+          summary = summary
+            ? summary.replace(/<[^>]+>/g, '').replace(/\s+/g, ' ').trim()
+            : '';
+          if (info.notes)
+            summary = summary ? `${summary}; Notes: ${info.notes}` : info.notes;
+          if (summary) parts.push(summary);
+        }
+        const desc = parts.join(' – ');
         sel.setAttribute('title', desc);
         sel.setAttribute('data-help', desc);
       });
-    });
-    // Standalone selects (not wrapped in .gear-item) still need descriptive help
-    gearListOutput.querySelectorAll('select').forEach(sel => {
-      if (sel.getAttribute('data-help')) return;
-      const selected = sel.selectedOptions && sel.selectedOptions[0];
-      const name = selected ? selected.textContent.trim() : sel.value;
-      const { info, category } = findDevice(name);
-      const parts = [];
-      parts.push(`1x ${name}`.trim());
-      if (category) parts.push(`Category: ${category}`);
-      if (info) {
-        let summary = generateConnectorSummary(info);
-        summary = summary ? summary.replace(/<[^>]+>/g, '').replace(/\s+/g, ' ').trim() : '';
-        if (info.notes)
-          summary = summary ? `${summary}; Notes: ${info.notes}` : info.notes;
-        if (summary) parts.push(summary);
-      }
-      const desc = parts.join(' – ');
-      sel.setAttribute('title', desc);
-      sel.setAttribute('data-help', desc);
-    });
+    } else {
+      gearListOutput.innerHTML = '';
+      gearListOutput.classList.add('hidden');
+    }
   }
   if (loadedSetupState) {
     setSliderBowlValue(loadedSetupState.sliderBowl || '');
@@ -6293,7 +6300,7 @@ setupSelect.addEventListener("change", (event) => {
       if (gearListOutput) {
         displayGearAndRequirements(setup.gearList || '');
         currentProjectInfo = setup.projectInfo || null;
-        if (currentProjectInfo) populateProjectForm(currentProjectInfo);
+        populateProjectForm(currentProjectInfo || {});
         if (setup.gearList) {
           ensureGearListActions();
       bindGearListCageListener();
@@ -7975,8 +7982,8 @@ function collectProjectFormData() {
     };
 }
 
-function populateProjectForm(info) {
-    if (!projectForm || !info) return;
+function populateProjectForm(info = {}) {
+    if (!projectForm) return;
     const setVal = (name, value) => {
         const field = projectForm.querySelector(`[name="${name}"]`);
         if (field) field.value = value || '';
@@ -9193,7 +9200,7 @@ function handleImportGearList(e) {
             if (obj && obj.gearList) {
             displayGearAndRequirements(obj.gearList);
             currentProjectInfo = obj.projectInfo || null;
-            if (currentProjectInfo) populateProjectForm(currentProjectInfo);
+            populateProjectForm(currentProjectInfo || {});
             ensureGearListActions();
             bindGearListCageListener();
             bindGearListEasyrigListener();
@@ -9475,10 +9482,8 @@ function restoreSessionState() {
     setSelectValue(batterySelect, state.battery);
     setSelectValue(hotswapSelect, state.batteryHotswap);
     setSelectValue(setupSelect, state.setupSelect);
-    if (state.projectInfo) {
-      currentProjectInfo = state.projectInfo;
-      if (projectForm) populateProjectForm(currentProjectInfo);
-    }
+    currentProjectInfo = state.projectInfo || null;
+    if (projectForm) populateProjectForm(currentProjectInfo || {});
   } else {
     if (gearListOutput) {
       gearListOutput.innerHTML = '';
@@ -9493,10 +9498,8 @@ function restoreSessionState() {
     const projectName = setupSelect ? setupSelect.value : '';
     const storedProject = typeof loadProject === 'function' ? loadProject(projectName) : null;
     if (storedProject && (storedProject.gearList || storedProject.projectInfo)) {
-      if (storedProject.projectInfo) {
-        currentProjectInfo = storedProject.projectInfo;
-        if (projectForm) populateProjectForm(currentProjectInfo);
-      }
+      currentProjectInfo = storedProject.projectInfo || null;
+      if (projectForm) populateProjectForm(currentProjectInfo || {});
       displayGearAndRequirements(storedProject.gearList);
       if (gearListOutput) {
         ensureGearListActions();
@@ -9552,10 +9555,8 @@ function applySharedSetup(shared) {
       fb[key] = (fb[key] || []).concat(decoded.feedback);
       saveFeedbackSafe(fb);
     }
-    if (decoded.projectInfo) {
-      currentProjectInfo = decoded.projectInfo;
-      if (projectForm) populateProjectForm(currentProjectInfo);
-    }
+    currentProjectInfo = decoded.projectInfo || null;
+    if (projectForm) populateProjectForm(currentProjectInfo || {});
     let gearDisplayed = false;
     if (decoded.gearList) {
       displayGearAndRequirements(decoded.gearList);

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -1364,6 +1364,7 @@ describe('script.js functions', () => {
     Object.defineProperty(navigator, 'languages', { value: ['fr-FR'], configurable: true });
 
     require('../translations.js');
+    require('../translations.js');
     require('../script.js');
 
     expect(document.documentElement.lang).toBe('fr');
@@ -2795,6 +2796,39 @@ describe('script.js functions', () => {
     displayGearAndRequirements(html2);
     bindGearListEasyrigListener();
     expect(document.querySelector('#gearListEasyrig').value).toBe('FlowCine Serene Spring Arm');
+  });
+
+  test('loading a different project replaces gear list and requirements', () => {
+    setupDom(false);
+    const buildHtml = (name) => `\
+<h2>Gear List</h2>
+<h3>Project Requirements</h3>
+<div class="requirements-grid"><div class="requirement-box"><span class="req-label">Project Name</span><span class="req-value">${name}</span></div></div>
+<h3>Gear List</h3>
+<table class="gear-table"><tr><td>${name} item</td></tr></table>`;
+    global.loadSetups.mockReturnValue({
+      Proj1: { gearList: buildHtml('Proj1'), projectInfo: { projectName: 'Proj1' } },
+      Proj2: { gearList: buildHtml('Proj2'), projectInfo: { projectName: 'Proj2' } }
+    });
+    global.loadProject = jest.fn(() => null);
+    global.saveProject = jest.fn();
+    global.deleteProject = jest.fn();
+    require('../script.js');
+    const setupSelect = document.getElementById('setupSelect');
+    setupSelect.value = 'Proj1';
+    setupSelect.dispatchEvent(new Event('change'));
+    const gearOut = document.getElementById('gearListOutput');
+    const reqOut = document.getElementById('projectRequirementsOutput');
+    expect(gearOut.innerHTML).toContain('Proj1 item');
+    expect(reqOut.innerHTML).toContain('Proj1');
+    expect(document.querySelector('[name="projectName"]').value).toBe('Proj1');
+    setupSelect.value = 'Proj2';
+    setupSelect.dispatchEvent(new Event('change'));
+    expect(gearOut.innerHTML).toContain('Proj2 item');
+    expect(gearOut.innerHTML).not.toContain('Proj1 item');
+    expect(reqOut.innerHTML).toContain('Proj2');
+    expect(reqOut.innerHTML).not.toContain('Proj1');
+    expect(document.querySelector('[name="projectName"]').value).toBe('Proj2');
   });
 
   test('Grip section always includes a friction arm', () => {


### PR DESCRIPTION
## Summary
- Reset gear and requirement displays when a project has no saved list
- Always repopulate project form, clearing stale values on project change
- Add regression test for switching between projects with different gear lists

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bdebfb690c83208547be5e4f62d1cb