### PR TITLE
feat: add crew contacts to project form

### DIFF
--- a/index.html
+++ b/index.html
@@ -943,8 +943,17 @@
         <input type="text" id="projectName" name="projectName" />
       </div>
       <div class="form-row">
-        <label for="dop">DoP:</label>
-        <input type="text" id="dop" name="dop" />
+        <label for="productionCompany">Production Company:</label>
+        <input type="text" id="productionCompany" name="productionCompany" />
+      </div>
+      <div class="form-row">
+        <label for="rentalHouse">Rental House:</label>
+        <input type="text" id="rentalHouse" name="rentalHouse" />
+      </div>
+      <h3 id="crewHeading">Crew</h3>
+      <div class="form-row" id="crewListRow">
+        <div id="crewContainer"></div>
+        <button type="button" id="addPersonBtn">+</button>
       </div>
       <div class="form-row">
         <label for="prepStart" id="prepLabel">Prep Days:</label>

--- a/script.js
+++ b/script.js
@@ -1744,9 +1744,29 @@ const tripodSpreaderSelect = document.getElementById("tripodSpreader");
 const monitoringConfigurationSelect = document.getElementById("monitoringConfiguration");
 const viewfinderSettingsRow = document.getElementById("viewfinderSettingsRow");
 const viewfinderExtensionRow = document.getElementById("viewfinderExtensionRow");
+const crewContainer = document.getElementById("crewContainer");
+const addPersonBtn = document.getElementById("addPersonBtn");
+
+const crewRoles = [
+  'DoP',
+  'Production Manager',
+  'Camera Operator',
+  'B-Camera Operator',
+  '1st AC',
+  '2nd AC',
+  'Video Operator'
+];
 
 const projectFieldIcons = {
+  productionCompany: '🏢',
+  rentalHouse: '🏬',
   dop: '👤',
+  productionManager: '👔',
+  cameraOperator: '🎥',
+  bCameraOperator: '🎥',
+  firstAc: '🎚️',
+  secondAc: '🎚️',
+  videoOperator: '📡',
   prepDays: '📅',
   shootingDays: '🎬',
   deliveryResolution: '📺',
@@ -1766,6 +1786,40 @@ const projectFieldIcons = {
   cameraUserButtons: '🔘',
   viewfinderUserButtons: '🔘'
 };
+
+function createCrewRow(data = {}) {
+  if (!crewContainer) return;
+  const row = document.createElement('div');
+  row.className = 'person-row';
+  const roleSel = document.createElement('select');
+  crewRoles.forEach(r => {
+    const opt = document.createElement('option');
+    opt.value = r;
+    opt.textContent = r;
+    roleSel.appendChild(opt);
+  });
+  if (data.role) roleSel.value = data.role;
+  const nameInput = document.createElement('input');
+  nameInput.type = 'text';
+  nameInput.placeholder = 'Name';
+  nameInput.className = 'person-name';
+  nameInput.value = data.name || '';
+  const phoneInput = document.createElement('input');
+  phoneInput.type = 'tel';
+  phoneInput.placeholder = 'Phone';
+  phoneInput.className = 'person-phone';
+  phoneInput.value = data.phone || '';
+  const removeBtn = document.createElement('button');
+  removeBtn.type = 'button';
+  removeBtn.textContent = '−';
+  removeBtn.addEventListener('click', () => row.remove());
+  row.append(roleSel, nameInput, phoneInput, removeBtn);
+  crewContainer.appendChild(row);
+}
+
+if (addPersonBtn) {
+  addPersonBtn.addEventListener('click', () => createCrewRow());
+}
 
 function updateTripodOptions() {
   const headBrand = tripodHeadBrandSelect ? tripodHeadBrandSelect.value : '';
@@ -7952,9 +8006,16 @@ function collectProjectFormData() {
     const matteboxVal = filterTypes.some(t => t === 'ND Grad HE' || t === 'ND Grad SE')
         ? 'Swing Away'
         : val('mattebox');
+    const people = Array.from(crewContainer?.querySelectorAll('.person-row') || []).map(row => ({
+        role: row.querySelector('select')?.value,
+        name: row.querySelector('.person-name')?.value.trim(),
+        phone: row.querySelector('.person-phone')?.value.trim()
+    })).filter(p => p.role && p.name);
     return {
         projectName: val('projectName'),
-        dop: val('dop'),
+        productionCompany: val('productionCompany'),
+        rentalHouse: val('rentalHouse'),
+        ...(people.length ? { people } : {}),
         prepDays: range('prepStart','prepEnd'),
         shootingDays: range('shootStart','shootEnd'),
         deliveryResolution: val('deliveryResolution'),
@@ -8007,7 +8068,12 @@ function populateProjectForm(info = {}) {
     populateCodecDropdown(info.codec);
 
     setVal('projectName', info.projectName);
-    setVal('dop', info.dop);
+    setVal('productionCompany', info.productionCompany);
+    setVal('rentalHouse', info.rentalHouse);
+    if (crewContainer) {
+        crewContainer.innerHTML = '';
+        (info.people || []).forEach(p => createCrewRow(p));
+    }
     const [prepStart, prepEnd] = (info.prepDays || '').split(' to ');
     setVal('prepStart', prepStart);
     setVal('prepEnd', prepEnd);
@@ -8382,13 +8448,39 @@ function generateGearListHtml(info = {}) {
         supportAccNoCages.push('ARRI KK.0037820 Handle Extension Set');
     }
     const projectInfo = { ...info };
+    if (Array.isArray(info.people)) {
+        const roleMap = {
+            'DoP': 'dop',
+            'Production Manager': 'productionManager',
+            'Camera Operator': 'cameraOperator',
+            'B-Camera Operator': 'bCameraOperator',
+            '1st AC': 'firstAc',
+            '2nd AC': 'secondAc',
+            'Video Operator': 'videoOperator'
+        };
+        info.people.forEach(p => {
+            const key = roleMap[p.role];
+            if (key && p.name) {
+                projectInfo[key] = p.phone ? `${p.name} (${p.phone})` : p.name;
+            }
+        });
+    }
+    delete projectInfo.people;
     if (monitoringSettings.length) {
         projectInfo.monitoringSupport = monitoringSettings.join(', ');
     }
     delete projectInfo.monitoringSettings;
     const projectTitle = escapeHtml(info.projectName || setupNameInput.value);
     const labels = {
+        productionCompany: 'Production Company',
+        rentalHouse: 'Rental House',
         dop: 'DoP',
+        productionManager: 'Production Manager',
+        cameraOperator: 'Camera Operator',
+        bCameraOperator: 'B-Camera Operator',
+        firstAc: '1st AC',
+        secondAc: '2nd AC',
+        videoOperator: 'Video Operator',
         prepDays: 'Prep Days',
         shootingDays: 'Shooting Days',
         deliveryResolution: 'Delivery Resolution',

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -751,7 +751,7 @@ describe('script.js functions', () => {
     form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
     const saved = global.saveProject.mock.calls[0][1];
     const expectedKeys = [
-      'projectName','dop','prepDays','shootingDays','deliveryResolution','recordingResolution','aspectRatio','codec','baseFrameRate','sensorMode','lenses','requiredScenarios','cameraHandle','viewfinderExtension','viewfinderEyeLeatherColor','mattebox','gimbal','viewfinderSettings','frameGuides','aspectMaskOpacity','videoDistribution','monitoringConfiguration','monitorUserButtons','cameraUserButtons','viewfinderUserButtons','tripodHeadBrand','tripodBowl','tripodTypes','tripodSpreader','sliderBowl','filter'
+      'projectName','productionCompany','rentalHouse','prepDays','shootingDays','deliveryResolution','recordingResolution','aspectRatio','codec','baseFrameRate','sensorMode','lenses','requiredScenarios','cameraHandle','viewfinderExtension','viewfinderEyeLeatherColor','mattebox','gimbal','viewfinderSettings','frameGuides','aspectMaskOpacity','videoDistribution','monitoringConfiguration','monitorUserButtons','cameraUserButtons','viewfinderUserButtons','tripodHeadBrand','tripodBowl','tripodTypes','tripodSpreader','sliderBowl','filter'
     ];
     expect(Object.keys(saved.projectInfo).sort()).toEqual(expectedKeys.sort());
     expect(saved.projectInfo.lenses).toBe('LensA');
@@ -1624,14 +1624,14 @@ describe('script.js functions', () => {
       document.getElementById('batteryCount').textContent = '1';
       const html = generateGearListHtml({
         projectName: 'Proj',
-        dop: 'DopName',
+        people: [{ role: 'DoP', name: 'DopName', phone: '123' }],
         requiredScenarios: 'Handheld, Slider',
         filter: 'IRND'
       });
       expect(html).toContain('<h2>Proj</h2>');
       expect(html).toContain('<h3>Project Requirements</h3>');
       expect(html).toContain('<span class="req-label">DoP</span>');
-      expect(html).toContain('<span class="req-value">DopName</span>');
+      expect(html).toContain('<span class="req-value">DopName (123)</span>');
       expect(html).toContain('<span class="req-label">Required Scenarios</span>');
       expect(html).toContain('<span class="req-value">Handheld, Slider</span>');
       expect(html).not.toContain('Filter: IRND');
@@ -5066,7 +5066,8 @@ describe('script.js functions', () => {
 
   test('shareSetupBtn includes current project requirements', () => {
     document.getElementById('setupName').value = 'Proj';
-    document.getElementById('dop').value = 'Alice';
+    const crew = document.getElementById('crewContainer');
+    crew.innerHTML = '<div class="person-row"><select><option value="DoP" selected>DoP</option></select><input class="person-name" value="Alice"/><input class="person-phone" value="555"/></div>';
     global.loadProject = jest.fn(() => null);
     global.saveProject = jest.fn();
     const btn = document.getElementById('shareSetupBtn');
@@ -5076,7 +5077,7 @@ describe('script.js functions', () => {
     const decoded = script.decodeSharedSetup(
       JSON.parse(LZString.decompressFromEncodedURIComponent(encoded))
     );
-    expect(decoded.projectInfo.dop).toBe('Alice');
+    expect(decoded.projectInfo.people[0]).toEqual({ role: 'DoP', name: 'Alice', phone: '555' });
   });
 
   test('shareSetupBtn link stays under 2000 chars with selectors', () => {


### PR DESCRIPTION
## Summary
- add production company and rental house inputs to project requirements
- allow dynamic crew members with role selection and phone number
- include crew contacts in generated requirements and project sharing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bdf65e9ab88320b37192919ac2a6a1