### PR TITLE
Name gear list and diagram exports with timestamp and project

### DIFF
--- a/script.js
+++ b/script.js
@@ -9188,7 +9188,14 @@ function exportCurrentGearList() {
     const blob = new Blob([JSON.stringify({ projectInfo: proj, gearList: html })], { type: 'application/json' });
     const a = document.createElement('a');
     a.href = URL.createObjectURL(blob);
-    a.download = 'gear-list.json';
+
+    const pad = n => String(n).padStart(2, '0');
+    const now = new Date();
+    const datePart = `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())}_${pad(now.getHours())}-${pad(now.getMinutes())}`;
+    const namePart = (getCurrentProjectName() || 'gear-list')
+        .replace(/\s+/g, '-').replace(/[^a-z0-9-_]/gi, '');
+    a.download = `${datePart}_${namePart}_gear-list.json`;
+
     document.body.appendChild(a);
     a.click();
     document.body.removeChild(a);
@@ -9213,6 +9220,11 @@ function handleImportGearList(e) {
             bindGearListEyeLeatherListener();
             bindGearListProGaffTapeListener();
             bindGearListDirectorMonitorListener();
+            if (setupNameInput) {
+                const base = file.name.replace(/\.json$/i, '');
+                setupNameInput.value = base;
+                setupNameInput.dispatchEvent(new Event('input'));
+            }
             saveCurrentGearList();
             }
         } catch {
@@ -9810,13 +9822,19 @@ if (downloadDiagramBtn) {
     if (!source) return;
 
     navigator.clipboard.writeText(source).catch(() => {});
+    const pad = n => String(n).padStart(2, '0');
+    const now = new Date();
+    const datePart = `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())}_${pad(now.getHours())}-${pad(now.getMinutes())}`;
+    const namePart = (getCurrentProjectName() || 'setup')
+        .replace(/\s+/g, '-').replace(/[^a-z0-9-_]/gi, '');
+    const baseName = `${datePart}_${namePart}_diagram`;
 
     const saveSvg = () => {
       const blob = new Blob([source], { type: 'image/svg+xml;charset=utf-8' });
       const url = URL.createObjectURL(blob);
       const a = document.createElement('a');
       a.href = url;
-      a.download = 'setup-diagram.svg';
+      a.download = `${baseName}.svg`;
       a.click();
       URL.revokeObjectURL(url);
     };
@@ -9833,7 +9851,7 @@ if (downloadDiagramBtn) {
           const url = URL.createObjectURL(blob);
           const a = document.createElement('a');
           a.href = url;
-          a.download = 'setup-diagram.jpg';
+          a.download = `${baseName}.jpg`;
           a.click();
           URL.revokeObjectURL(url);
         }, 'image/jpeg', 0.95);

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -5459,6 +5459,119 @@ describe('monitor wireless metadata', () => {
     saveSpy.mockRestore();
   });
 
+  test('export gear list file name includes timestamp and project name', () => {
+    setupDom();
+    require('../translations.js');
+    jest.useFakeTimers().setSystemTime(new Date('2024-01-02T03:04:00Z'));
+    const script = require('../script.js');
+    script.setLanguage('en');
+    const html = script.generateGearListHtml({ projectName: 'Proj' });
+    script.displayGearAndRequirements(html);
+    document.getElementById('setupName').value = 'Test Proj';
+    script.ensureGearListActions();
+    global.URL.createObjectURL = jest.fn(() => 'blob:url');
+    global.URL.revokeObjectURL = jest.fn();
+    const origCreate = document.createElement.bind(document);
+    let anchor;
+    document.createElement = (tag) => {
+      const el = origCreate(tag);
+      if (tag === 'a') {
+        anchor = el;
+        el.click = jest.fn();
+      }
+      return el;
+    };
+    document.getElementById('exportGearListBtn').click();
+    expect(anchor.download).toBe('2024-01-02_03-04_Test-Proj_gear-list.json');
+    document.createElement = origCreate;
+    jest.useRealTimers();
+  });
+
+  test('import gear list sets setup name from file name', () => {
+    setupDom();
+    require('../translations.js');
+    const script = require('../script.js');
+    script.setLanguage('en');
+    const html = script.generateGearListHtml({ projectName: 'Proj' });
+    script.displayGearAndRequirements(html);
+    script.ensureGearListActions();
+    const data = JSON.stringify({ projectInfo: { projectName: 'Proj' }, gearList: '<table></table>' });
+    const RealFileReader = global.FileReader;
+    global.FileReader = class { constructor(){ this.onload = null; } readAsText(){ this.onload({ target: { result: data } }); } };
+    const file = { name: '2024-01-02_03-04_Proj_gear-list.json' };
+    const input = document.getElementById('importGearListInput');
+    Object.defineProperty(input, 'files', { value: [file], configurable: true });
+    jest.spyOn(script, 'saveCurrentGearList').mockImplementation(() => {});
+    input.dispatchEvent(new window.Event('change'));
+    expect(document.getElementById('setupName').value).toBe('2024-01-02_03-04_Proj_gear-list');
+    global.FileReader = RealFileReader;
+  });
+
+  test('download diagram SVG file name includes timestamp and project name', () => {
+    setupDom();
+    require('../translations.js');
+    jest.useFakeTimers().setSystemTime(new Date('2024-01-02T03:04:00Z'));
+    const script = require('../script.js');
+    script.setLanguage('en');
+    document.getElementById('setupName').value = 'Test Proj';
+    const area = document.getElementById('diagramArea');
+    area.innerHTML = '<svg></svg>';
+    global.URL.createObjectURL = jest.fn(() => 'blob:url');
+    global.URL.revokeObjectURL = jest.fn();
+    const origCreate = document.createElement.bind(document);
+    let anchor;
+    document.createElement = (tag) => {
+      const el = origCreate(tag);
+      if (tag === 'a') {
+        anchor = el;
+        el.click = jest.fn();
+      }
+      return el;
+    };
+    document.getElementById('downloadDiagram').click();
+    expect(anchor.download).toBe('2024-01-02_03-04_Test-Proj_diagram.svg');
+    document.createElement = origCreate;
+    jest.useRealTimers();
+  });
+
+  test('download diagram JPG file name includes timestamp and project name', () => {
+    setupDom();
+    require('../translations.js');
+    jest.useFakeTimers().setSystemTime(new Date('2024-01-02T03:04:00Z'));
+    const script = require('../script.js');
+    script.setLanguage('en');
+    document.getElementById('setupName').value = 'Test Proj';
+    const area = document.getElementById('diagramArea');
+    area.innerHTML = '<svg></svg>';
+    global.URL.createObjectURL = jest.fn(() => 'blob:url');
+    global.URL.revokeObjectURL = jest.fn();
+    const origCreate = document.createElement.bind(document);
+    let anchor;
+    document.createElement = (tag) => {
+      const el = origCreate(tag);
+      if (tag === 'a') {
+        anchor = el;
+        el.click = jest.fn();
+      }
+      if (tag === 'canvas') {
+        el.getContext = () => ({ drawImage: jest.fn() });
+        el.toBlob = cb => cb(new Blob(['']));
+      }
+      return el;
+    };
+    const OrigImage = global.Image;
+    global.Image = class {
+      set onload(fn) { this._onload = fn; }
+      set src(val) { if (this._onload) this._onload(); }
+    };
+    const btn = document.getElementById('downloadDiagram');
+    btn.dispatchEvent(new window.MouseEvent('click', { shiftKey: true }));
+    expect(anchor.download).toBe('2024-01-02_03-04_Test-Proj_diagram.jpg');
+    document.createElement = origCreate;
+    global.Image = OrigImage;
+    jest.useRealTimers();
+  });
+
   test('detail toggle responds to keyboard events', () => {
     const detailToggle = document.querySelector('#device-manager .detail-toggle');
     const details = detailToggle.closest('li').querySelector('.device-details');


### PR DESCRIPTION
## Summary
- Include formatted date, time, project name and a gear-list suffix when exporting a gear list
- Automatically name imported gear lists from their file names
- Apply the same timestamp and project naming to downloaded project diagrams
- Test gear list and diagram import/export naming

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bdf414b9b48320b23c01c98fa7811a