### PR TITLE
Use 4x5,65 as default filter size

### DIFF
--- a/script.js
+++ b/script.js
@@ -145,6 +145,8 @@ const VIDEO_OUTPUT_TYPES = new Set([
 const collator = new Intl.Collator(undefined, { numeric: true, sensitivity: 'base' });
 const localeSort = (a, b) => collator.compare(a, b);
 
+const DEFAULT_FILTER_SIZE = '4x5,65';
+
 // Labels for B-Mount support are defined in translations.js using the keys
 // batteryBMountLabel, totalCurrent336Label and totalCurrent216Label.
 
@@ -10460,11 +10462,11 @@ function getFilterValueConfig(type) {
   }
 }
 
-function createFilterSizeSelect(type, selected = '4x5,65') {
+function createFilterSizeSelect(type, selected = DEFAULT_FILTER_SIZE) {
   const sel = document.createElement('select');
   sel.id = `filter-size-${filterId(type)}`;
-  let sizes = ['4x4', '4x5,65', '6x6', '95mm'];
-  if (type === 'Rota-Pol') sizes = ['4x5,65', '6x6', '95mm'];
+  let sizes = ['4x4', DEFAULT_FILTER_SIZE, '6x6', '95mm'];
+  if (type === 'Rota-Pol') sizes = [DEFAULT_FILTER_SIZE, '6x6', '95mm'];
   sizes.forEach(s => {
     const o = document.createElement('option');
     o.value = s;
@@ -10507,7 +10509,7 @@ function collectFilterSelections() {
   const selected = Array.from(filterSelectElem.selectedOptions).map(o => o.value);
   const tokens = selected.map(type => {
     const sizeSel = document.getElementById(`filter-size-${filterId(type)}`);
-    const size = sizeSel ? sizeSel.value : '4x5,65';
+    const size = sizeSel ? sizeSel.value : DEFAULT_FILTER_SIZE;
     const valSel = document.getElementById(`filter-values-${filterId(type)}`);
     let vals = valSel ? Array.from(valSel.selectedOptions).map(o => o.value) : [];
     if (!valSel || vals.length === 0) {
@@ -10521,14 +10523,14 @@ function collectFilterSelections() {
 function parseFilterTokens(str) {
   if (!str) return [];
   return str.split(',').map(s => {
-    const [type, size = '4x5,65', vals = ''] = s.split(':').map(p => p.trim());
+    const [type, size = DEFAULT_FILTER_SIZE, vals = ''] = s.split(':').map(p => p.trim());
     return { type, size, values: vals ? vals.split('|').map(v => v.trim()) : [] };
   }).filter(t => t.type);
 }
 
 function buildFilterSelectHtml(filters = []) {
   const parts = [];
-  filters.forEach(({ type, size = '4x5,65', values = [] }) => {
+  filters.forEach(({ type, size = DEFAULT_FILTER_SIZE, values = [] }) => {
     switch (type) {
       case 'Diopter': {
         const valSel = createFilterValueSelect(type, values);

--- a/script.js
+++ b/script.js
@@ -10460,11 +10460,11 @@ function getFilterValueConfig(type) {
   }
 }
 
-function createFilterSizeSelect(type, selected = '4x5.65') {
+function createFilterSizeSelect(type, selected = '4x5,65') {
   const sel = document.createElement('select');
   sel.id = `filter-size-${filterId(type)}`;
-  let sizes = ['4x4', '4x5.65', '6x6', '95mm'];
-  if (type === 'Rota-Pol') sizes = ['4x5.65', '6x6', '95mm'];
+  let sizes = ['4x4', '4x5,65', '6x6', '95mm'];
+  if (type === 'Rota-Pol') sizes = ['4x5,65', '6x6', '95mm'];
   sizes.forEach(s => {
     const o = document.createElement('option');
     o.value = s;
@@ -10507,7 +10507,7 @@ function collectFilterSelections() {
   const selected = Array.from(filterSelectElem.selectedOptions).map(o => o.value);
   const tokens = selected.map(type => {
     const sizeSel = document.getElementById(`filter-size-${filterId(type)}`);
-    const size = sizeSel ? sizeSel.value : '4x5.65';
+    const size = sizeSel ? sizeSel.value : '4x5,65';
     const valSel = document.getElementById(`filter-values-${filterId(type)}`);
     let vals = valSel ? Array.from(valSel.selectedOptions).map(o => o.value) : [];
     if (!valSel || vals.length === 0) {
@@ -10521,14 +10521,14 @@ function collectFilterSelections() {
 function parseFilterTokens(str) {
   if (!str) return [];
   return str.split(',').map(s => {
-    const [type, size = '4x5.65', vals = ''] = s.split(':').map(p => p.trim());
+    const [type, size = '4x5,65', vals = ''] = s.split(':').map(p => p.trim());
     return { type, size, values: vals ? vals.split('|').map(v => v.trim()) : [] };
   }).filter(t => t.type);
 }
 
 function buildFilterSelectHtml(filters = []) {
   const parts = [];
-  filters.forEach(({ type, size = '4x5.65', values = [] }) => {
+  filters.forEach(({ type, size = '4x5,65', values = [] }) => {
     switch (type) {
       case 'Diopter': {
         const valSel = createFilterValueSelect(type, values);

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -1636,8 +1636,8 @@ describe('script.js functions', () => {
       expect(html).toContain('<span class="req-value">Handheld, Slider</span>');
       expect(html).not.toContain('Filter: IRND');
       expect(html).toContain('Matte box + filter');
-      expect(html).toContain('4x5.65 IRND Filter 0.3');
-      expect(html).toContain('4x5.65 IRND Filter 1.2');
+      expect(html).toContain('4x5,65 IRND Filter 0.3');
+      expect(html).toContain('4x5,65 IRND Filter 1.2');
       expect(html).toContain('<table class="gear-table">');
       expect(html).toContain('Camera');
       expect(html).toContain(`1x ${cageCamera}`);
@@ -1711,7 +1711,7 @@ describe('script.js functions', () => {
     const html = generateGearListHtml({ filter: 'Clear' });
     const dom = new JSDOM(html);
     const sizeSel = dom.window.document.getElementById('filter-size-Clear');
-    expect(sizeSel.value).toBe('4x5.65');
+    expect(sizeSel.value).toBe('4x5,65');
   });
 
   test('pol filter uses default size', () => {
@@ -1721,7 +1721,7 @@ describe('script.js functions', () => {
     const html = generateGearListHtml({ filter: 'Pol' });
     const dom = new JSDOM(html);
     const sizeSel = dom.window.document.getElementById('filter-size-Pol');
-    expect(sizeSel.value).toBe('4x5.65');
+    expect(sizeSel.value).toBe('4x5,65');
   });
 
   test('default filter set includes 1/2, 1/4 and 1/8', () => {
@@ -1757,7 +1757,7 @@ describe('script.js functions', () => {
     opt.selected = true;
     filterSelect.dispatchEvent(new window.Event('change'));
     const info = collectProjectFormData();
-    expect(info.filter).toBe('BPM:4x5.65:1/2|1/4|1/8');
+    expect(info.filter).toBe('BPM:4x5,65:1/2|1/4|1/8');
   });
 
   test('collectProjectFormData handles custom filter selections', () => {
@@ -1786,11 +1786,11 @@ describe('script.js functions', () => {
     const html = generateGearListHtml({ filter: 'ND Grad HE,ND Grad SE', mattebox: 'ARRI LMB 4x5 Clamp-On (3-Stage)' });
     const dom = new JSDOM(html);
     const sizeHE = dom.window.document.getElementById('filter-size-ND_Grad_HE');
-    expect(sizeHE.value).toBe('4x5.65');
+    expect(sizeHE.value).toBe('4x5,65');
     const valHE = [...dom.window.document.getElementById('filter-values-ND_Grad_HE').selectedOptions].map(o => o.value);
     expect(valHE).toEqual(expect.arrayContaining(['0.3 HE Horizontal']));
     const sizeSE = dom.window.document.getElementById('filter-size-ND_Grad_SE');
-    expect(sizeSE.value).toBe('4x5.65');
+    expect(sizeSE.value).toBe('4x5,65');
     const valSE = [...dom.window.document.getElementById('filter-values-ND_Grad_SE').selectedOptions].map(o => o.value);
     expect(valSE).toEqual(expect.arrayContaining(['0.3 SE Horizontal']));
     const section = html.slice(html.indexOf('Matte box + filter'), html.indexOf('LDS (FIZ)'));
@@ -1806,7 +1806,7 @@ describe('script.js functions', () => {
     const dom = new JSDOM(html);
     const sel = dom.window.document.getElementById('filter-size-Rota_Pol');
     const opts = [...sel.options].map(o => o.value);
-    expect(opts).toEqual(expect.arrayContaining(['4x5.65', '6x6', '95mm']));
+    expect(opts).toEqual(expect.arrayContaining(['4x5,65', '6x6', '95mm']));
   });
 
   test('standard rigging accessories are always included', () => {

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -14,6 +14,8 @@ const cagesData = {
 const cageCamera = 'CamA';
 const cageNames = Object.keys(cagesData);
 
+const DEFAULT_FILTER_SIZE = '4x5,65';
+
 // Read and cache the body of index.html once via shared helper to avoid
 // duplicate disk access across test suites. This keeps memory usage low and
 // speeds up setup when multiple tests need the DOM skeleton.
@@ -1636,8 +1638,8 @@ describe('script.js functions', () => {
       expect(html).toContain('<span class="req-value">Handheld, Slider</span>');
       expect(html).not.toContain('Filter: IRND');
       expect(html).toContain('Matte box + filter');
-      expect(html).toContain('4x5,65 IRND Filter 0.3');
-      expect(html).toContain('4x5,65 IRND Filter 1.2');
+      expect(html).toContain(`${DEFAULT_FILTER_SIZE} IRND Filter 0.3`);
+      expect(html).toContain(`${DEFAULT_FILTER_SIZE} IRND Filter 1.2`);
       expect(html).toContain('<table class="gear-table">');
       expect(html).toContain('Camera');
       expect(html).toContain(`1x ${cageCamera}`);
@@ -1711,7 +1713,7 @@ describe('script.js functions', () => {
     const html = generateGearListHtml({ filter: 'Clear' });
     const dom = new JSDOM(html);
     const sizeSel = dom.window.document.getElementById('filter-size-Clear');
-    expect(sizeSel.value).toBe('4x5,65');
+    expect(sizeSel.value).toBe(DEFAULT_FILTER_SIZE);
   });
 
   test('pol filter uses default size', () => {
@@ -1721,7 +1723,7 @@ describe('script.js functions', () => {
     const html = generateGearListHtml({ filter: 'Pol' });
     const dom = new JSDOM(html);
     const sizeSel = dom.window.document.getElementById('filter-size-Pol');
-    expect(sizeSel.value).toBe('4x5,65');
+    expect(sizeSel.value).toBe(DEFAULT_FILTER_SIZE);
   });
 
   test('default filter set includes 1/2, 1/4 and 1/8', () => {
@@ -1757,7 +1759,7 @@ describe('script.js functions', () => {
     opt.selected = true;
     filterSelect.dispatchEvent(new window.Event('change'));
     const info = collectProjectFormData();
-    expect(info.filter).toBe('BPM:4x5,65:1/2|1/4|1/8');
+    expect(info.filter).toBe(`BPM:${DEFAULT_FILTER_SIZE}:1/2|1/4|1/8`);
   });
 
   test('collectProjectFormData handles custom filter selections', () => {
@@ -1786,11 +1788,11 @@ describe('script.js functions', () => {
     const html = generateGearListHtml({ filter: 'ND Grad HE,ND Grad SE', mattebox: 'ARRI LMB 4x5 Clamp-On (3-Stage)' });
     const dom = new JSDOM(html);
     const sizeHE = dom.window.document.getElementById('filter-size-ND_Grad_HE');
-    expect(sizeHE.value).toBe('4x5,65');
+    expect(sizeHE.value).toBe(DEFAULT_FILTER_SIZE);
     const valHE = [...dom.window.document.getElementById('filter-values-ND_Grad_HE').selectedOptions].map(o => o.value);
     expect(valHE).toEqual(expect.arrayContaining(['0.3 HE Horizontal']));
     const sizeSE = dom.window.document.getElementById('filter-size-ND_Grad_SE');
-    expect(sizeSE.value).toBe('4x5,65');
+    expect(sizeSE.value).toBe(DEFAULT_FILTER_SIZE);
     const valSE = [...dom.window.document.getElementById('filter-values-ND_Grad_SE').selectedOptions].map(o => o.value);
     expect(valSE).toEqual(expect.arrayContaining(['0.3 SE Horizontal']));
     const section = html.slice(html.indexOf('Matte box + filter'), html.indexOf('LDS (FIZ)'));
@@ -1806,7 +1808,7 @@ describe('script.js functions', () => {
     const dom = new JSDOM(html);
     const sel = dom.window.document.getElementById('filter-size-Rota_Pol');
     const opts = [...sel.options].map(o => o.value);
-    expect(opts).toEqual(expect.arrayContaining(['4x5,65', '6x6', '95mm']));
+    expect(opts).toEqual(expect.arrayContaining([DEFAULT_FILTER_SIZE, '6x6', '95mm']));
   });
 
   test('standard rigging accessories are always included', () => {


### PR DESCRIPTION
## Summary
- default filter size is now 4x5,65 across filter utilities
- adjust script tests for new default

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bdf8667d20832095c9a59a04be5fed