### PR TITLE
Enable multi-select for filter strength options

### DIFF
--- a/script.js
+++ b/script.js
@@ -10478,7 +10478,10 @@ function createFilterSizeSelect(type, selected = '4x5.65') {
 function createFilterValueSelect(type, selected = []) {
   const sel = document.createElement('select');
   sel.id = `filter-values-${filterId(type)}`;
+  // Allow selecting multiple strengths for a given filter
+  // Use both the property and attribute to ensure HTML serialization
   sel.multiple = true;
+  sel.setAttribute('multiple', '');
   const { opts, defaults } = getFilterValueConfig(type);
   const selectedVals = selected.length ? selected : defaults;
   opts.forEach(o => {

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -1731,6 +1731,7 @@ describe('script.js functions', () => {
     const html = generateGearListHtml({ filter: 'BPM' });
     const dom = new JSDOM(html);
     const valSel = dom.window.document.getElementById('filter-values-BPM');
+    expect(valSel.multiple).toBe(true);
     const vals = [...valSel.selectedOptions].map(o => o.value);
     expect(vals).toEqual(expect.arrayContaining(['1/2', '1/4', '1/8']));
   });
@@ -1744,6 +1745,7 @@ describe('script.js functions', () => {
     const frame = dom.window.document.querySelector('[data-gear-name="ARRI diopter frame"]');
     expect(frame).not.toBeNull();
     const valSel = dom.window.document.getElementById('filter-values-Diopter');
+    expect(valSel.multiple).toBe(true);
     const vals = [...valSel.selectedOptions].map(o => o.value);
     expect(vals).toEqual(expect.arrayContaining(['+1/2', '+1', '+2', '+4']));
   });


### PR DESCRIPTION
## Summary
- Ensure filter strength selectors render as multi-select elements
- Extend tests to verify default filter strengths and multi-select behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bdf877ddd88320bad2861efa59cbb1