### PR TITLE
style: improve gear list filter item layout

### DIFF
--- a/script.js
+++ b/script.js
@@ -10532,47 +10532,47 @@ function buildFilterSelectHtml(filters = []) {
     switch (type) {
       case 'Diopter': {
         const valSel = createFilterValueSelect(type, values);
-        parts.push('<span class="gear-item" data-gear-name="ARRI diopter frame">1x ARRI diopter frame</span>');
-        parts.push(`<span class="gear-item" data-gear-name="Schneider CF DIOPTER FULL GEN2">1x Schneider CF DIOPTER FULL ${valSel.outerHTML} GEN2</span>`);
+        parts.push('<span class="gear-item filter-item" data-gear-name="ARRI diopter frame">1x ARRI diopter frame</span>');
+        parts.push(`<span class="gear-item filter-item" data-gear-name="Schneider CF DIOPTER FULL GEN2">1x Schneider CF DIOPTER FULL ${valSel.outerHTML} GEN2</span>`);
         break;
       }
       case 'Clear': {
         const sizeSel = createFilterSizeSelect(type, size);
-        parts.push(`<span class="gear-item" data-gear-name="Clear Filter">1x ${sizeSel.outerHTML} Clear Filter</span>`);
+        parts.push(`<span class="gear-item filter-item" data-gear-name="Clear Filter">1x ${sizeSel.outerHTML} Clear Filter</span>`);
         break;
       }
       case 'IRND': {
         const sizeSel = createFilterSizeSelect(type, size);
         const valSel = createFilterValueSelect(type, values);
-        parts.push(`<span class="gear-item" data-gear-name="IRND Filter">1x ${sizeSel.outerHTML} IRND Filter ${valSel.outerHTML}</span>`);
+        parts.push(`<span class="gear-item filter-item" data-gear-name="IRND Filter">1x ${sizeSel.outerHTML} IRND Filter ${valSel.outerHTML}</span>`);
         break;
       }
       case 'Pol': {
         const sizeSel = createFilterSizeSelect(type, size);
-        parts.push(`<span class="gear-item" data-gear-name="Pol Filter">1x ${sizeSel.outerHTML} Pol Filter</span>`);
+        parts.push(`<span class="gear-item filter-item" data-gear-name="Pol Filter">1x ${sizeSel.outerHTML} Pol Filter</span>`);
         break;
       }
       case 'Rota-Pol': {
         const sizeSel = createFilterSizeSelect(type, size);
-        parts.push(`<span class="gear-item" data-gear-name="Rota Pola Filter Frame">1x ${sizeSel.outerHTML} Rota Pola Filter Frame</span>`);
+        parts.push(`<span class="gear-item filter-item" data-gear-name="Rota Pola Filter Frame">1x ${sizeSel.outerHTML} Rota Pola Filter Frame</span>`);
         break;
       }
       case 'ND Grad HE': {
         const sizeSel = createFilterSizeSelect(type, size);
         const valSel = createFilterValueSelect(type, values);
-        parts.push(`<span class="gear-item" data-gear-name="ND Grad HE Filter">1x ${sizeSel.outerHTML} ND Grad HE Filter ${valSel.outerHTML}</span>`);
+        parts.push(`<span class="gear-item filter-item" data-gear-name="ND Grad HE Filter">1x ${sizeSel.outerHTML} ND Grad HE Filter ${valSel.outerHTML}</span>`);
         break;
       }
       case 'ND Grad SE': {
         const sizeSel = createFilterSizeSelect(type, size);
         const valSel = createFilterValueSelect(type, values);
-        parts.push(`<span class="gear-item" data-gear-name="ND Grad SE Filter">1x ${sizeSel.outerHTML} ND Grad SE Filter ${valSel.outerHTML}</span>`);
+        parts.push(`<span class="gear-item filter-item" data-gear-name="ND Grad SE Filter">1x ${sizeSel.outerHTML} ND Grad SE Filter ${valSel.outerHTML}</span>`);
         break;
       }
       default: {
         const sizeSel = createFilterSizeSelect(type, size);
         const valSel = createFilterValueSelect(type, values);
-        parts.push(`<span class="gear-item" data-gear-name="${type} Filter Set">1x ${sizeSel.outerHTML} ${type} Filter Set ${valSel.outerHTML}</span>`);
+        parts.push(`<span class="gear-item filter-item" data-gear-name="${type} Filter Set">1x ${sizeSel.outerHTML} ${type} Filter Set ${valSel.outerHTML}</span>`);
       }
     }
   });

--- a/style.css
+++ b/style.css
@@ -1775,6 +1775,16 @@ body.dark-mode.pink-mode .help-content { border-color: var(--accent-color); }
   overflow-x: auto;
 }
 
+#gearListOutput .filter-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+#gearListOutput .filter-item select {
+  width: auto;
+}
+
 @media (max-width: 600px) {
   #gearListOutput,
   #projectRequirementsOutput {


### PR DESCRIPTION
## Summary
- add `filter-item` class to filter gear list entries
- style filter items with inline-flex layout for better spacing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bdf88b8a1c83209fc20f52e83d19b4