### PR TITLE
Add diopter and Rota-Pol filter configurations

### DIFF
--- a/devices/gearList.js
+++ b/devices/gearList.js
@@ -785,9 +785,19 @@ const gear = {
       }
     },
     "filters": {
-      "ARRI Rota Pola Filter Holder": {
+      "ARRI K2.0009434 Rota Pola Filter Frame": {
         "brand": "ARRI",
         "kNumber": "K2.0009434"
+      },
+      "ARRI K2.0017086 Rota Pola Filter Frame": {
+        "brand": "ARRI",
+        "kNumber": "K2.0017086"
+      },
+      "Tilta 95mm Polarizer Filter für Tilta Mirage": {
+        "brand": "Tilta"
+      },
+      "Schneider CF DIOPTER FULL GEN2": {
+        "brand": "Schneider"
       }
     },
     "rigging": {

--- a/script.js
+++ b/script.js
@@ -10532,7 +10532,7 @@ function buildFilterSelectHtml(filters = []) {
     switch (type) {
       case 'Diopter': {
         const valSel = createFilterValueSelect(type, values);
-        parts.push('<span class="gear-item" data-gear-name="ARRI diopter frame">1x ARRI diopter frame</span>');
+        parts.push('<span class="gear-item" data-gear-name="ARRI Diopter Frame 138mm">1x ARRI K2.0013740 Diopter Frame 138mm</span>');
         parts.push(`<span class="gear-item" data-gear-name="Schneider CF DIOPTER FULL GEN2">1x Schneider CF DIOPTER FULL ${valSel.outerHTML} GEN2</span>`);
         break;
       }
@@ -10554,7 +10554,15 @@ function buildFilterSelectHtml(filters = []) {
       }
       case 'Rota-Pol': {
         const sizeSel = createFilterSizeSelect(type, size);
-        parts.push(`<span class="gear-item" data-gear-name="Rota Pola Filter Frame">1x ${sizeSel.outerHTML} Rota Pola Filter Frame</span>`);
+        let gearName;
+        if (size === '95mm') {
+          gearName = 'Tilta 95mm Polarizer Filter für Tilta Mirage';
+        } else if (size === '6x6') {
+          gearName = 'ARRI K2.0017086 Rota Pola Filter Frame';
+        } else {
+          gearName = 'ARRI K2.0009434 Rota Pola Filter Frame';
+        }
+        parts.push(`<span class="gear-item" data-gear-name="${gearName}">1x ${sizeSel.outerHTML} ${gearName}</span>`);
         break;
       }
       case 'ND Grad HE': {
@@ -10581,7 +10589,7 @@ function buildFilterSelectHtml(filters = []) {
 
 function collectFilterAccessories(filters = []) {
   const items = [];
-  filters.forEach(({ type, size }) => {
+  filters.forEach(({ type }) => {
     switch (type) {
       case 'ND Grad HE':
       case 'ND Grad SE':
@@ -10590,13 +10598,6 @@ function collectFilterAccessories(filters = []) {
         items.push('ARRI LMB 4x5 / LMB-6 Tray Catcher');
         break;
       case 'Rota-Pol':
-        if (size === '95mm') {
-          items.push('Tilta 95mm Polarizer Filter für Tilta Mirage');
-        } else if (size === '6x6') {
-          items.push('ARRI K2.0017086 Rota Pola Filter Frame');
-        } else {
-          items.push('ARRI K2.0009434 Rota Pola Filter Frame');
-        }
         break;
       default:
         break;

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -1741,7 +1741,7 @@ describe('script.js functions', () => {
     const { generateGearListHtml } = require('../script.js');
     const html = generateGearListHtml({ filter: 'Diopter' });
     const dom = new JSDOM(html);
-    const frame = dom.window.document.querySelector('[data-gear-name="ARRI diopter frame"]');
+    const frame = dom.window.document.querySelector('[data-gear-name="ARRI Diopter Frame 138mm"]');
     expect(frame).not.toBeNull();
     const valSel = dom.window.document.getElementById('filter-values-Diopter');
     const vals = [...valSel.selectedOptions].map(o => o.value);
@@ -1798,7 +1798,7 @@ describe('script.js functions', () => {
     expect(section).not.toContain('ARRI LMB 4x5 Clamp-On (3-Stage)');
   });
 
-  test('Rota-Pol filter provides size dropdown', () => {
+  test('Rota-Pol filter provides size dropdown and correct frame', () => {
     setupDom(false);
     require('../translations.js');
     const { generateGearListHtml } = require('../script.js');
@@ -1807,6 +1807,8 @@ describe('script.js functions', () => {
     const sel = dom.window.document.getElementById('filter-size-Rota_Pol');
     const opts = [...sel.options].map(o => o.value);
     expect(opts).toEqual(expect.arrayContaining(['4x5.65', '6x6', '95mm']));
+    const frame = dom.window.document.querySelector('[data-gear-name="ARRI K2.0017086 Rota Pola Filter Frame"]');
+    expect(frame).not.toBeNull();
   });
 
   test('standard rigging accessories are always included', () => {


### PR DESCRIPTION
## Summary
- add Schneider diopter and ARRI/Tilta Rota-Pol filter data
- render diopter and Rota-Pol selections with k-numbers and size/strength options
- test diopter defaults and Rota-Pol size handling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bdf9482ea88320afd5bdfae8ccafea