### PR TITLE
Display filter selectors horizontally

### DIFF
--- a/script.js
+++ b/script.js
@@ -10597,7 +10597,7 @@ function buildFilterSelectHtml(filters = []) {
       }
     }
   });
-  return parts.join('<br>');
+  return parts.join(' ');
 }
 
 function collectFilterAccessories(filters = []) {

--- a/style.css
+++ b/style.css
@@ -1779,6 +1779,7 @@ body.dark-mode.pink-mode .help-content { border-color: var(--accent-color); }
   display: inline-flex;
   align-items: center;
   gap: 0.25rem;
+  margin-right: 0.5rem;
 }
 
 #gearListOutput .filter-item select {


### PR DESCRIPTION
## Summary
- Show filter entries side-by-side by joining markup with spaces
- Add margin to filter items for clearer horizontal spacing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bdfbbeb3408320ac3bb2c907fa6c57