### PR TITLE
Centralize default filter size

### DIFF
--- a/script.js
+++ b/script.js
@@ -10478,11 +10478,13 @@ function getFilterValueConfig(type) {
   }
 }
 
-function createFilterSizeSelect(type, selected = '4x5.65') {
+const DEFAULT_FILTER_SIZE = '4x5.65';
+
+function createFilterSizeSelect(type, selected = DEFAULT_FILTER_SIZE) {
   const sel = document.createElement('select');
   sel.id = `filter-size-${filterId(type)}`;
-  let sizes = ['4x4', '4x5.65', '6x6', '95mm'];
-  if (type === 'Rota-Pol') sizes = ['4x5.65', '6x6', '95mm'];
+  let sizes = [DEFAULT_FILTER_SIZE, '4x4', '6x6', '95mm'];
+  if (type === 'Rota-Pol') sizes = [DEFAULT_FILTER_SIZE, '6x6', '95mm'];
   sizes.forEach(s => {
     const o = document.createElement('option');
     o.value = s;
@@ -10528,7 +10530,7 @@ function collectFilterSelections() {
   const selected = Array.from(filterSelectElem.selectedOptions).map(o => o.value);
   const tokens = selected.map(type => {
     const sizeSel = document.getElementById(`filter-size-${filterId(type)}`);
-    const size = sizeSel ? sizeSel.value : '4x5.65';
+    const size = sizeSel ? sizeSel.value : DEFAULT_FILTER_SIZE;
     const valSel = document.getElementById(`filter-values-${filterId(type)}`);
     let vals = valSel ? Array.from(valSel.selectedOptions).map(o => o.value) : [];
     if (!valSel || vals.length === 0) {
@@ -10542,14 +10544,14 @@ function collectFilterSelections() {
 function parseFilterTokens(str) {
   if (!str) return [];
   return str.split(',').map(s => {
-    const [type, size = '4x5.65', vals = ''] = s.split(':').map(p => p.trim());
+    const [type, size = DEFAULT_FILTER_SIZE, vals = ''] = s.split(':').map(p => p.trim());
     return { type, size, values: vals ? vals.split('|').map(v => v.trim()) : [] };
   }).filter(t => t.type);
 }
 
 function buildFilterSelectHtml(filters = []) {
   const parts = [];
-  filters.forEach(({ type, size = '4x5.65', values = [] }) => {
+  filters.forEach(({ type, size = DEFAULT_FILTER_SIZE, values = [] }) => {
     switch (type) {
       case 'Diopter': {
         const valSel = createFilterValueSelect(type, values);
@@ -10719,5 +10721,6 @@ if (typeof module !== "undefined" && module.exports) {
     renderFilterDetails,
     collectFilterSelections,
     parseFilterTokens,
+    DEFAULT_FILTER_SIZE,
   };
 }

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -14,6 +14,8 @@ const cagesData = {
 const cageCamera = 'CamA';
 const cageNames = Object.keys(cagesData);
 
+const DEFAULT_FILTER_SIZE = '4x5.65';
+
 // Read and cache the body of index.html once via shared helper to avoid
 // duplicate disk access across test suites. This keeps memory usage low and
 // speeds up setup when multiple tests need the DOM skeleton.
@@ -1636,8 +1638,8 @@ describe('script.js functions', () => {
       expect(html).toContain('<span class="req-value">Handheld, Slider</span>');
       expect(html).not.toContain('Filter: IRND');
       expect(html).toContain('Matte box + filter');
-      expect(html).toContain('4x5.65 IRND Filter 0.3');
-      expect(html).toContain('4x5.65 IRND Filter 1.2');
+      expect(html).toContain(`${DEFAULT_FILTER_SIZE} IRND Filter 0.3`);
+      expect(html).toContain(`${DEFAULT_FILTER_SIZE} IRND Filter 1.2`);
       expect(html).toContain('<table class="gear-table">');
       expect(html).toContain('Camera');
       expect(html).toContain(`1x ${cageCamera}`);
@@ -1711,7 +1713,7 @@ describe('script.js functions', () => {
     const html = generateGearListHtml({ filter: 'Clear' });
     const dom = new JSDOM(html);
     const sizeSel = dom.window.document.getElementById('filter-size-Clear');
-    expect(sizeSel.value).toBe('4x5.65');
+    expect(sizeSel.value).toBe(DEFAULT_FILTER_SIZE);
   });
 
   test('pol filter uses default size', () => {
@@ -1721,7 +1723,7 @@ describe('script.js functions', () => {
     const html = generateGearListHtml({ filter: 'Pol' });
     const dom = new JSDOM(html);
     const sizeSel = dom.window.document.getElementById('filter-size-Pol');
-    expect(sizeSel.value).toBe('4x5.65');
+    expect(sizeSel.value).toBe(DEFAULT_FILTER_SIZE);
   });
 
   test('default filter set includes 1/2, 1/4 and 1/8', () => {
@@ -1759,7 +1761,7 @@ describe('script.js functions', () => {
     opt.selected = true;
     filterSelect.dispatchEvent(new window.Event('change'));
     const info = collectProjectFormData();
-    expect(info.filter).toBe('BPM:4x5.65:1/2|1/4|1/8');
+    expect(info.filter).toBe(`BPM:${DEFAULT_FILTER_SIZE}:1/2|1/4|1/8`);
   });
 
   test('collectProjectFormData handles custom filter selections', () => {
@@ -1788,11 +1790,11 @@ describe('script.js functions', () => {
     const html = generateGearListHtml({ filter: 'ND Grad HE,ND Grad SE', mattebox: 'ARRI LMB 4x5 Clamp-On (3-Stage)' });
     const dom = new JSDOM(html);
     const sizeHE = dom.window.document.getElementById('filter-size-ND_Grad_HE');
-    expect(sizeHE.value).toBe('4x5.65');
+    expect(sizeHE.value).toBe(DEFAULT_FILTER_SIZE);
     const valHE = [...dom.window.document.getElementById('filter-values-ND_Grad_HE').selectedOptions].map(o => o.value);
     expect(valHE).toEqual(expect.arrayContaining(['0.3 HE Horizontal']));
     const sizeSE = dom.window.document.getElementById('filter-size-ND_Grad_SE');
-    expect(sizeSE.value).toBe('4x5.65');
+    expect(sizeSE.value).toBe(DEFAULT_FILTER_SIZE);
     const valSE = [...dom.window.document.getElementById('filter-values-ND_Grad_SE').selectedOptions].map(o => o.value);
     expect(valSE).toEqual(expect.arrayContaining(['0.3 SE Horizontal']));
     const section = html.slice(html.indexOf('Matte box + filter'), html.indexOf('LDS (FIZ)'));
@@ -1808,7 +1810,7 @@ describe('script.js functions', () => {
     const dom = new JSDOM(html);
     const sel = dom.window.document.getElementById('filter-size-Rota_Pol');
     const opts = [...sel.options].map(o => o.value);
-    expect(opts).toEqual(expect.arrayContaining(['4x5.65', '6x6', '95mm']));
+    expect(opts).toEqual(expect.arrayContaining([DEFAULT_FILTER_SIZE, '6x6', '95mm']));
   });
 
   test('standard rigging accessories are always included', () => {
@@ -2441,7 +2443,7 @@ describe('script.js functions', () => {
     expect(itemsRow.textContent).toContain('1x ARRI LMB Flag Holders');
     expect(itemsRow.textContent).toContain('1x ARRI LMB 4x5 Set of Mattes spherical');
     expect(itemsRow.textContent).toContain('1x ARRI LMB Accessory Adapter');
-    expect(itemsRow.textContent).toContain('1x ARRI Anti-Reflection Frame 4x5.65');
+    expect(itemsRow.textContent).toContain(`1x ARRI Anti-Reflection Frame ${DEFAULT_FILTER_SIZE}`);
   });
 
   test('Clamp On mattebox adds LMB 4x5 Clamp-On set and accessories to gear list', () => {
@@ -2460,7 +2462,7 @@ describe('script.js functions', () => {
     expect(itemsRow.textContent).toContain('1x ARRI LMB Flag Holders');
     expect(itemsRow.textContent).toContain('1x ARRI LMB 4x5 Set of Mattes spherical');
     expect(itemsRow.textContent).toContain('1x ARRI LMB Accessory Adapter');
-    expect(itemsRow.textContent).toContain('1x ARRI Anti-Reflection Frame 4x5.65');
+    expect(itemsRow.textContent).toContain(`1x ARRI Anti-Reflection Frame ${DEFAULT_FILTER_SIZE}`);
     expect(itemsRow.textContent).toContain('1x ARRI LMB 4x5 Clamp Adapter Set Pro');
     expect(itemsRow.textContent).toContain('1x ARRI LMB 4x5 Clamp Adapter 80mm');
     expect(itemsRow.textContent).toContain('1x ARRI LMB 4x5 Clamp Adapter 95mm');


### PR DESCRIPTION
## Summary
- Define a `DEFAULT_FILTER_SIZE` constant and use it across filter size selection, parsing, and HTML building
- Reorder size dropdowns so 4x5.65 is the first option and fallback value
- Update tests to reference the shared default filter size

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bdfbe64d4c8320a91f5c6d54ab8196