### PR TITLE
Use 4x5.65 as default filter size

### DIFF
--- a/script.js
+++ b/script.js
@@ -145,7 +145,7 @@ const VIDEO_OUTPUT_TYPES = new Set([
 const collator = new Intl.Collator(undefined, { numeric: true, sensitivity: 'base' });
 const localeSort = (a, b) => collator.compare(a, b);
 
-const DEFAULT_FILTER_SIZE = '4x5,65';
+const DEFAULT_FILTER_SIZE = '4x5.65';
 
 // Labels for B-Mount support are defined in translations.js using the keys
 // batteryBMountLabel, totalCurrent336Label and totalCurrent216Label.

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -14,7 +14,7 @@ const cagesData = {
 const cageCamera = 'CamA';
 const cageNames = Object.keys(cagesData);
 
-const DEFAULT_FILTER_SIZE = '4x5,65';
+const DEFAULT_FILTER_SIZE = '4x5.65';
 
 // Read and cache the body of index.html once via shared helper to avoid
 // duplicate disk access across test suites. This keeps memory usage low and


### PR DESCRIPTION
## Summary
- switch default filter size constant to use a dot (`4x5.65`)
- update tests to reflect the new default filter size

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bdfeef48e0832086972b0e1dd24394