### PR TITLE
Ensure each filter renders on its own line

### DIFF
--- a/script.js
+++ b/script.js
@@ -10599,7 +10599,7 @@ function buildFilterSelectHtml(filters = []) {
       }
     }
   });
-  return parts.join(' ');
+  return parts.join('<br>');
 }
 
 function collectFilterAccessories(filters = []) {

--- a/style.css
+++ b/style.css
@@ -1776,10 +1776,10 @@ body.dark-mode.pink-mode .help-content { border-color: var(--accent-color); }
 }
 
 #gearListOutput .filter-item {
-  display: inline-flex;
+  display: flex;
   align-items: center;
   gap: 0.25rem;
-  margin-right: 0.5rem;
+  margin-bottom: 0.5rem;
 }
 
 #gearListOutput .filter-item select {

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -1738,6 +1738,19 @@ describe('script.js functions', () => {
     expect(vals).toEqual(expect.arrayContaining(['1/2', '1/4', '1/8']));
   });
 
+  test('multiple filters render on separate lines', () => {
+    setupDom(false);
+    require('../translations.js');
+    const { generateGearListHtml } = require('../script.js');
+    const html = generateGearListHtml({ filter: 'IRND,Pol' });
+    const dom = new JSDOM(html);
+    const rows = [...dom.window.document.querySelectorAll('#gearListOutput table tr')];
+    const idx = rows.findIndex(r => r.textContent.trim() === 'Matte box + filter');
+    const filterRow = rows[idx + 1];
+    const cellHtml = filterRow.querySelector('td').innerHTML;
+    expect(cellHtml).toMatch(/filter-item[^>]*>.*?<\/span><br><span class="gear-item filter-item"/);
+  });
+
   test('diopter filter includes frame and default strengths', () => {
     setupDom(false);
     require('../translations.js');


### PR DESCRIPTION
## Summary
- Render filter entries with line breaks so each selected filter appears on its own line
- Adjust gear list filter styles to stack vertically
- Test that multiple filters render on separate lines

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bdffe6270c8320b17df8b064a0e976