### PR TITLE
Clear project requirements when recreating gear list

### DIFF
--- a/script.js
+++ b/script.js
@@ -9288,6 +9288,25 @@ function deleteCurrentGearList() {
         projectRequirementsOutput.innerHTML = '';
         projectRequirementsOutput.classList.add('hidden');
     }
+    currentProjectInfo = null;
+    if (projectForm) populateProjectForm({});
+    storeSession({
+        setupName: setupNameInput ? setupNameInput.value : '',
+        setupSelect: setupSelect ? setupSelect.value : '',
+        camera: cameraSelect ? cameraSelect.value : '',
+        monitor: monitorSelect ? monitorSelect.value : '',
+        video: videoSelect ? videoSelect.value : '',
+        cage: cageSelect ? cageSelect.value : '',
+        motors: motorSelects.map(sel => sel ? sel.value : ''),
+        controllers: controllerSelects.map(sel => sel ? sel.value : ''),
+        distance: distanceSelect ? distanceSelect.value : '',
+        batteryPlate: batteryPlateSelect ? batteryPlateSelect.value : '',
+        battery: batterySelect ? batterySelect.value : '',
+        batteryHotswap: hotswapSelect ? hotswapSelect.value : '',
+        sliderBowl: getSliderBowlValue(),
+        easyrig: getEasyrigValue(),
+        projectInfo: null
+    });
     if (typeof deleteProject === 'function') {
         deleteProject(getCurrentProjectName());
     }

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -824,6 +824,31 @@ describe('script.js functions', () => {
     expect(document.getElementById('editProjectBtn')).toBeNull();
   });
 
+  test('creating gear list after deletion clears project requirements', () => {
+    const addOpt = (id, value) => {
+      const sel = document.getElementById(id);
+      sel.innerHTML = `<option value="${value}">${value}</option>`;
+      sel.value = value;
+    };
+    addOpt('cameraSelect', 'CamA');
+    addOpt('batterySelect', 'BattA');
+    script.updateCalculations();
+    document.getElementById('projectName').value = 'Proj';
+    const codecSel = document.getElementById('codec');
+    codecSel.innerHTML = '<option value="ProRes">ProRes</option>';
+    codecSel.value = 'ProRes';
+    const html = script.generateGearListHtml(script.collectProjectFormData());
+    script.displayGearAndRequirements(html);
+    script.ensureGearListActions();
+    const confirmSpy = jest.spyOn(window, 'confirm').mockReturnValue(true);
+    document.getElementById('deleteGearListBtn').click();
+    confirmSpy.mockRestore();
+    expect(document.getElementById('projectName').value).toBe('');
+    expect(codecSel.value).toBe('');
+    const html2 = script.generateGearListHtml(script.collectProjectFormData());
+    expect(html2).not.toContain('Project Requirements');
+  });
+
   test('suggests chargers based on total batteries', () => {
     const addOpt = (id, value) => {
       const sel = document.getElementById(id);


### PR DESCRIPTION
## Summary
- Clear project requirements, project form, and session data when deleting the gear list so subsequent lists start fresh
- Add regression test ensuring requirements don't persist after gear list deletion

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68be01c12de0832080c5095aa44756ef