### PR TITLE
Add ARRI wireless video transmitter and receivers

### DIFF
--- a/devices/video.js
+++ b/devices/video.js
@@ -796,6 +796,28 @@ const videoData = {
       ]
     }
   },
+  "ARRI WVT-1 TX": {
+    "powerDrawWatts": 7,
+    "videoInputs": [
+      {
+        "type": "3G-SDI"
+      }
+    ],
+    "videoOutputs": [
+      {
+        "type": "3G-SDI",
+        "notes": "loop"
+      }
+    ],
+    "frequency": "5 GHz",
+    "latencyMs": "< 1ms",
+    "power": {
+      "input": {
+        "type": "LEMO 2-pin",
+        "notes": "10.5-34V"
+      }
+    }
+  },
   "None": {
     "powerDrawWatts": 0,
     "power": {

--- a/devices/wirelessReceivers.js
+++ b/devices/wirelessReceivers.js
@@ -660,6 +660,45 @@ const wirelessReceiversData = {
         }
       ]
     }
+  },
+  "ARRI WVR-1 RX": {
+    "powerDrawWatts": 7,
+    "videoInputs": [],
+    "videoOutputs": [
+      { "type": "3G-SDI" },
+      { "type": "3G-SDI" }
+    ],
+    "frequency": "5 GHz",
+    "latencyMs": "< 1ms",
+    "power": {
+      "input": {
+        "type": "LEMO 2-pin",
+        "notes": "10.5-34V"
+      },
+      "output": {
+        "type": "LEMO 2-pin",
+        "notes": "12V, max 2.0A"
+      }
+    }
+  },
+  "ARRI WVR-1s RX": {
+    "powerDrawWatts": 7,
+    "videoInputs": [],
+    "videoOutputs": [
+      { "type": "3G-SDI" }
+    ],
+    "frequency": "5 GHz",
+    "latencyMs": "< 1ms",
+    "power": {
+      "input": {
+        "type": "LEMO 2-pin",
+        "notes": "10.5-34V"
+      },
+      "output": {
+        "type": "LEMO 2-pin",
+        "notes": "12V, max 2.0A"
+      }
+    }
   }
 };
 if (typeof registerDevice === 'function') {


### PR DESCRIPTION
## Summary
- add ARRI WVT-1 wireless video transmitter to device data
- add ARRI WVR-1 and WVR-1s wireless video receivers

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68be05487cb88320ab49dabff77c8f12