### PR TITLE
chore: consolidate monitoring settings

### DIFF
--- a/script.js
+++ b/script.js
@@ -1782,9 +1782,6 @@ const projectFieldIcons = {
   cameraHandle: '🛠️',
   viewfinderExtension: '🔭',
   gimbal: '🌀',
-  viewfinderSettings: '⚙️',
-  frameGuides: '🎯',
-  aspectMaskOpacity: '🔲',
   monitoringSupport: '🧰',
   monitoringConfiguration: '🎛️',
   monitorUserButtons: '🔘',
@@ -8420,6 +8417,9 @@ function generateGearListHtml(info = {}) {
         projectInfo.monitoringSupport = monitoringSettings.join(', ');
     }
     delete projectInfo.monitoringSettings;
+    delete projectInfo.viewfinderSettings;
+    delete projectInfo.frameGuides;
+    delete projectInfo.aspectMaskOpacity;
     const projectTitle = escapeHtml(info.projectName || setupNameInput.value);
     const labels = {
         productionCompany: 'Production Company',
@@ -8446,9 +8446,6 @@ function generateGearListHtml(info = {}) {
         viewfinderEyeLeatherColor: 'Viewfinder Eye Leather Color',
         mattebox: 'Mattebox',
         gimbal: 'Gimbal',
-        viewfinderSettings: 'Viewfinder Settings',
-        frameGuides: 'Frame Guides',
-        aspectMaskOpacity: 'Aspect Mask Opacity',
         videoDistribution: 'Video Distribution',
         monitoringSupport: 'Monitoring support',
         monitoringConfiguration: 'Monitoring configuration',
@@ -8474,7 +8471,10 @@ function generateGearListHtml(info = {}) {
         'tripodTypes',
         'tripodSpreader',
         'sliderBowl',
-        'lenses'
+        'lenses',
+        'viewfinderSettings',
+        'frameGuides',
+        'aspectMaskOpacity'
     ]);
     const infoEntries = Object.entries(projectInfo)
         .filter(([k, v]) => v && k !== 'projectName' && !excludedFields.has(k));

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -753,16 +753,14 @@ describe('script.js functions', () => {
     form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
     const saved = global.saveProject.mock.calls[0][1];
     const expectedKeys = [
-      'projectName','productionCompany','rentalHouse','prepDays','shootingDays','deliveryResolution','recordingResolution','aspectRatio','codec','baseFrameRate','sensorMode','lenses','requiredScenarios','cameraHandle','viewfinderExtension','viewfinderEyeLeatherColor','mattebox','gimbal','viewfinderSettings','frameGuides','aspectMaskOpacity','videoDistribution','monitoringConfiguration','monitorUserButtons','cameraUserButtons','viewfinderUserButtons','tripodHeadBrand','tripodBowl','tripodTypes','tripodSpreader','sliderBowl','filter'
+      'projectName','productionCompany','rentalHouse','prepDays','shootingDays','deliveryResolution','recordingResolution','aspectRatio','codec','baseFrameRate','sensorMode','lenses','requiredScenarios','cameraHandle','viewfinderExtension','viewfinderEyeLeatherColor','mattebox','gimbal','videoDistribution','monitoringConfiguration','monitoringSupport','monitorUserButtons','cameraUserButtons','viewfinderUserButtons','tripodHeadBrand','tripodBowl','tripodTypes','tripodSpreader','sliderBowl','filter'
     ];
     expect(Object.keys(saved.projectInfo).sort()).toEqual(expectedKeys.sort());
     expect(saved.projectInfo.lenses).toBe('LensA');
     expect(saved.projectInfo.videoDistribution).toContain('Director Monitor 5');
     expect(saved.projectInfo.tripodHeadBrand).toBe('OConnor');
     expect(saved.projectInfo.tripodBowl).toBe('100mm bowl');
-    expect(saved.projectInfo.viewfinderSettings).toBe('Viewfinder Clean Feed');
-    expect(saved.projectInfo.frameGuides).toBe('Frame Guide: Center Dot');
-    expect(saved.projectInfo.aspectMaskOpacity).toBe('Aspect Mask Opacity 100%');
+    expect(saved.projectInfo.monitoringSupport).toBe('Viewfinder Clean Feed, Frame Guide: Center Dot, Aspect Mask Opacity 100%');
     expect(saved.projectInfo.viewfinderEyeLeatherColor).toBe('Red');
   });
 
@@ -5510,7 +5508,7 @@ describe('monitor wireless metadata', () => {
     expect(value.getAttribute('data-help')).toContain('Codec: ProRes');
   });
 
-  test('project requirement boxes show icons for viewfinder settings, frame guides and aspect mask', () => {
+  test('project requirement boxes consolidate monitoring settings under monitoring support icon', () => {
     setupDom();
     require('../translations.js');
     const script = require('../script.js');
@@ -5523,7 +5521,7 @@ describe('monitor wireless metadata', () => {
     script.displayGearAndRequirements(html);
     const boxes = document.querySelectorAll('.requirement-box .req-icon');
     const icons = Array.from(boxes).map(el => el.textContent);
-    expect(icons).toEqual(['⚙️', '🎯', '🔲']);
+    expect(icons).toEqual(['🧰']);
   });
 
   test('gear list action buttons expose descriptive hover help', () => {


### PR DESCRIPTION
## Summary
- avoid duplicate requirement boxes by removing viewfinder settings, frame guides, and aspect mask opacity from project info
- aggregate monitoring selections under a single monitoring support requirement
- update tests for consolidated monitoring output

## Testing
- `NODE_OPTIONS=--max_old_space_size=4096 npm test`

------
https://chatgpt.com/codex/tasks/task_e_68be07a9df888320b043ce9664bb002d