### PR TITLE
feat: standardise button size

### DIFF
--- a/overview-print.css
+++ b/overview-print.css
@@ -16,6 +16,7 @@ body,
 body.dark-mode {
   --surface-color: #fff;
   --text-color: #000;
+  --button-size: 32px;
   font-family: 'Ubuntu', sans-serif;
   font-weight: 300;
   font-size: 12pt;
@@ -183,6 +184,8 @@ table, th, td {
   background: var(--surface-color) !important;
   color: var(--text-color) !important;
   border: none !important;
+  min-width: var(--button-size) !important;
+  min-height: var(--button-size) !important;
 }
 
 .power-conn {

--- a/overview.css
+++ b/overview.css
@@ -111,7 +111,8 @@ th { background-color: var(--control-bg); font-weight: 700; }
 }
 
 .diagram-controls button {
-  min-width: 32px;
+  min-width: var(--button-size);
+  min-height: var(--button-size);
 }
 
 @media (max-width: 600px) {

--- a/style.css
+++ b/style.css
@@ -19,6 +19,7 @@
   --border-radius: 5px;
   --page-padding: 20px;
   --gap-size: 10px;
+  --button-size: 32px;
   --link-color: var(--accent-color);
   --diagram-node-fill: #f0f0f0;
   --power-color: #d33;
@@ -532,10 +533,14 @@ button {
   color: var(--control-text);
   border: none;
   border-radius: var(--border-radius);
-  padding: 5px 10px; /* Adjusted padding to make buttons smaller */
+  padding: 0 10px;
   margin: 5px;
   cursor: pointer;
-  font-size: 0.85em; /* Adjusted font size to make buttons smaller */
+  font-size: 0.85em;
+  min-height: var(--button-size);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   transition:
     background-color 0.2s,
     color 0.2s,
@@ -708,7 +713,7 @@ button:disabled {
 
 #topBar select,
 #topBar button {
-  height: 32px;
+  height: var(--button-size);
   margin: 0;
 }
 
@@ -718,11 +723,8 @@ button:disabled {
 }
 
 #topBar button {
-  min-width: 32px;
-  width: 32px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
+  min-width: var(--button-size);
+  width: var(--button-size);
   padding: 0;
   border-radius: 50%;
 }
@@ -902,7 +904,8 @@ button:disabled {
 }
 
 .diagram-controls button {
-  min-width: 32px;
+  min-width: var(--button-size);
+  min-height: var(--button-size);
 }
 
 .diagram-controls button.active {


### PR DESCRIPTION
## Summary
- introduce `--button-size` variable for consistent button dimensions
- align top bar and diagram control buttons across main, overview, and print views

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68be089567c08320984d7b22bba1b2b3