### PR TITLE
Reduce default button dimensions

### DIFF
--- a/overview-print.css
+++ b/overview-print.css
@@ -16,7 +16,7 @@ body,
 body.dark-mode {
   --surface-color: #fff;
   --text-color: #000;
-  --button-size: 32px;
+  --button-size: 24px;
   font-family: 'Ubuntu', sans-serif;
   font-weight: 300;
   font-size: 12pt;

--- a/style.css
+++ b/style.css
@@ -19,7 +19,7 @@
   --border-radius: 5px;
   --page-padding: 20px;
   --gap-size: 10px;
-  --button-size: 32px;
+  --button-size: 24px;
   --link-color: var(--accent-color);
   --diagram-node-fill: #f0f0f0;
   --power-color: #d33;
@@ -533,7 +533,7 @@ button {
   color: var(--control-text);
   border: none;
   border-radius: var(--border-radius);
-  padding: 0 10px;
+  padding: 0 8px;
   margin: 5px;
   cursor: pointer;
   font-size: 0.85em;


### PR DESCRIPTION
## Summary
- Shrink global button size variable to 24px
- Tighten button padding for a more compact look
- Update print stylesheet to use the smaller buttons

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68be0b745f3c832098b91d83bf383a04