### PR TITLE
Limit project diagram auto scaling on desktop

### DIFF
--- a/script.js
+++ b/script.js
@@ -5170,6 +5170,8 @@ function applyDeviceChanges(changes) {
 function renderSetupDiagram() {
   if (!setupDiagramContainer) return;
 
+  const isTouchDevice = (navigator.maxTouchPoints || 0) > 0;
+
   const camName = cameraSelect.value;
   const cam = devices.cameras[camName];
   const monitorName = monitorSelect.value;
@@ -5732,6 +5734,15 @@ function renderSetupDiagram() {
   setupDiagramContainer.appendChild(popup);
   setupDiagramContainer.insertAdjacentHTML('beforeend', svg);
 
+  const svgEl = setupDiagramContainer.querySelector('svg');
+  if (svgEl) {
+    svgEl.style.width = '100%';
+    if (!isTouchDevice) {
+      const MAX_AUTO_SCALE = 3;
+      svgEl.style.maxWidth = `${viewWidth * MAX_AUTO_SCALE}px`;
+    }
+  }
+
   lastDiagramPositions = JSON.parse(JSON.stringify(pos));
 
   attachDiagramPopups(nodeMap);
@@ -5823,6 +5834,8 @@ function enableDiagramInteractions() {
   if (cleanupDiagramInteractions) cleanupDiagramInteractions();
 
   const root = svg.querySelector('#diagramRoot') || svg;
+  const isTouchDevice = (navigator.maxTouchPoints || 0) > 0;
+  const MAX_SCALE = isTouchDevice ? Infinity : 3;
   let pan = { x: 0, y: 0 };
   let scale = 1;
   let panning = false;
@@ -5833,6 +5846,7 @@ function enableDiagramInteractions() {
     return { x: e.clientX, y: e.clientY };
   };
   const apply = () => {
+    if (scale > MAX_SCALE) scale = MAX_SCALE;
     root.setAttribute('transform', `translate(${pan.x},${pan.y}) scale(${scale})`);
   };
   if (zoomInBtn) {

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -4518,6 +4518,63 @@ describe('script.js functions', () => {
     expect(endY).toBeCloseTo(snap(startY + 27 / scale));
   });
 
+  test('desktop zoom is limited to max scale', () => {
+    Object.defineProperty(navigator, 'maxTouchPoints', { value: 0, configurable: true });
+    const addOpt = (id, value) => {
+      const sel = document.getElementById(id);
+      sel.innerHTML = `<option value="${value}">${value}</option>`;
+      sel.value = value;
+    };
+    addOpt('cameraSelect', 'CamA');
+    addOpt('batterySelect', 'BattA');
+
+    script.renderSetupDiagram();
+
+    const zoomBtn = document.getElementById('zoomIn');
+    const svg = document.querySelector('#diagramArea svg');
+
+    for (let i = 0; i < 20; i++) {
+      zoomBtn.click();
+    }
+
+    const root = svg.querySelector('#diagramRoot') || svg;
+    expect(root.getAttribute('transform')).toBe('translate(0,0) scale(3)');
+  });
+
+  test('diagram auto scaling is capped on desktop', () => {
+    Object.defineProperty(navigator, 'maxTouchPoints', { value: 0, configurable: true });
+    const addOpt = (id, value) => {
+      const sel = document.getElementById(id);
+      sel.innerHTML = `<option value="${value}">${value}</option>`;
+      sel.value = value;
+    };
+    addOpt('cameraSelect', 'CamA');
+    addOpt('batterySelect', 'BattA');
+
+    script.renderSetupDiagram();
+
+    const svg = document.querySelector('#diagramArea svg');
+    expect(svg.style.maxWidth).toBe('1500px');
+  });
+
+  test('touch devices do not cap diagram auto scaling', () => {
+    Object.defineProperty(navigator, 'maxTouchPoints', { value: 1, configurable: true });
+    const addOpt = (id, value) => {
+      const sel = document.getElementById(id);
+      sel.innerHTML = `<option value="${value}">${value}</option>`;
+      sel.value = value;
+    };
+    addOpt('cameraSelect', 'CamA');
+    addOpt('batterySelect', 'BattA');
+
+    script.renderSetupDiagram();
+
+    const svg = document.querySelector('#diagramArea svg');
+    expect(svg.style.maxWidth).toBe('');
+
+    Object.defineProperty(navigator, 'maxTouchPoints', { value: 0, configurable: true });
+  });
+
   test('reset view restores default pan and zoom', () => {
     const addOpt = (id, value) => {
       const sel = document.getElementById(id);


### PR DESCRIPTION
## Summary
- cap initial project diagram scaling at 3× on desktop by limiting SVG max width
- add tests to verify auto scale cap and ensure touch devices remain uncapped

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68be0b9b6f848320ae10079773d78066