### PR TITLE
Fix language selector alignment

### DIFF
--- a/style.css
+++ b/style.css
@@ -731,6 +731,8 @@ button:disabled {
 #topBar select {
   font-size: 1em;
   padding: 2px 4px;
+  text-align: center;
+  text-align-last: center;
 }
 
 #topBar button {


### PR DESCRIPTION
## Summary
- center text in the language selection dropdown so the label is properly aligned

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68be0d349b5083209342e9fca5fe644a