### PR TITLE
Limit setup diagram auto scale to body font size

### DIFF
--- a/script.js
+++ b/script.js
@@ -5738,8 +5738,10 @@ function renderSetupDiagram() {
   if (svgEl) {
     svgEl.style.width = '100%';
     if (!isTouchDevice) {
-      const MAX_AUTO_SCALE = 3;
-      svgEl.style.maxWidth = `${viewWidth * MAX_AUTO_SCALE}px`;
+      const bodyFontSize = parseFloat(getComputedStyle(document.body).fontSize) || 16;
+      const MAX_NODE_FONT = 12; // largest base font size used in diagram text
+      const maxAutoScale = bodyFontSize / MAX_NODE_FONT;
+      svgEl.style.maxWidth = `${viewWidth * maxAutoScale}px`;
     }
   }
 

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -4554,7 +4554,11 @@ describe('script.js functions', () => {
     script.renderSetupDiagram();
 
     const svg = document.querySelector('#diagramArea svg');
-    expect(svg.style.maxWidth).toBe('1500px');
+    const bodyFontSize = parseFloat(getComputedStyle(document.body).fontSize);
+    const viewBox = svg.getAttribute('viewBox').split(' ');
+    const viewWidth = parseFloat(viewBox[2]);
+    const expected = viewWidth * (bodyFontSize / 12);
+    expect(parseFloat(svg.style.maxWidth)).toBeCloseTo(expected);
   });
 
   test('touch devices do not cap diagram auto scaling', () => {


### PR DESCRIPTION
## Summary
- Cap automatic setup diagram scaling so text never exceeds the page's body font size
- Update tests for dynamic max-width calculation based on body font size

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68be6b97aac8832094e535718e2d4c2f