### PR TITLE
Default to English language

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -5,13 +5,13 @@ Dieses browserbasierte Tool hilft beim Planen professioneller Kamera-Setups mit 
 ---
 
 ## 🌍 Sprachen
-- 🇬🇧 [English](README.en.md)
-- 🇩🇪 Deutsch (Standard)
+- 🇬🇧 [English](README.en.md) (Standard)
+- 🇩🇪 Deutsch
 - 🇪🇸 [Español](README.es.md)
 - 🇮🇹 [Italiano](README.it.md)
 - 🇫🇷 [Français](README.fr.md)
 
-Die Sprache kann oben rechts umgeschaltet werden und wird für den nächsten Besuch gespeichert.
+Standardmäßig ist die Sprache Englisch. Die Sprache kann oben rechts umgeschaltet werden und wird für den nächsten Besuch gespeichert.
 
 ---
 

--- a/README.en.md
+++ b/README.en.md
@@ -11,7 +11,7 @@ This browser based tool helps plan professional camera projects powered by V‑M
 - 🇮🇹 [Italiano](README.it.md)
 - 🇫🇷 [Français](README.fr.md)
 
-The app automatically uses your browser language on first load, and you can switch the language in the top right corner. The choice is remembered for your next visit.
+The app defaults to English on first load, and you can switch the language in the top right corner. The choice is remembered for your next visit.
 
 ---
 

--- a/README.es.md
+++ b/README.es.md
@@ -5,13 +5,13 @@ Esta herramienta en el navegador ayuda a planificar configuraciones profesionale
 ---
 
 ## 🌍 Idiomas
-- 🇬🇧 [English](README.en.md)
+- 🇬🇧 [English](README.en.md) (predeterminado)
 - 🇩🇪 [Deutsch](README.de.md)
-- 🇪🇸 Español (predeterminado si el navegador está en español)
+- 🇪🇸 Español
 - 🇮🇹 [Italiano](README.it.md)
 - 🇫🇷 [Français](README.fr.md)
 
-El idioma puede cambiarse en la esquina superior derecha y se recuerda para la próxima visita.
+El idioma predeterminado es el inglés. Puedes cambiarlo en la esquina superior derecha y se recuerda para la próxima visita.
 
 ---
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -5,13 +5,13 @@ Cet outil fonctionnant dans le navigateur aide à planifier des configurations p
 ---
 
 ## 🌍 Langues
-- 🇬🇧 [English](README.en.md)
+- 🇬🇧 [English](README.en.md) (par défaut)
 - 🇩🇪 [Deutsch](README.de.md)
 - 🇪🇸 [Español](README.es.md)
 - 🇮🇹 [Italiano](README.it.md)
-- 🇫🇷 Français (par défaut si le navigateur est en français)
+- 🇫🇷 Français
 
-La langue se change en haut à droite et est mémorisée pour la prochaine visite.
+La langue par défaut est l'anglais. Vous pouvez la changer en haut à droite; la préférence est mémorisée pour la prochaine visite.
 
 ---
 

--- a/README.it.md
+++ b/README.it.md
@@ -4,13 +4,13 @@ Questo strumento basato sul browser aiuta a pianificare configurazioni professio
 ---
 
 ## 🌍 Lingue
-- 🇬🇧 [English](README.en.md)
+- 🇬🇧 [English](README.en.md) (predefinito)
 - 🇩🇪 [Deutsch](README.de.md)
 - 🇪🇸 [Español](README.es.md)
-- 🇮🇹 Italiano (predefinito se il browser è in italiano)
+- 🇮🇹 Italiano
 - 🇫🇷 [Français](README.fr.md)
 
-Puoi cambiare lingua nell'angolo in alto a destra. La scelta viene memorizzata per la prossima visita.
+La lingua predefinita è l'inglese. Puoi cambiarla nell'angolo in alto a destra e la scelta viene memorizzata per la prossima visita.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -31,10 +31,10 @@ that future visits work offline and pick up updates automatically.
 
 ## Translations
 
-Documentation is available in multiple languages. The app detects your browser
-language on first load, and you can switch languages in the top right corner:
+Documentation is available in multiple languages. The app defaults to English
+on first load, and you can switch languages in the top right corner:
 
-- 🇬🇧 [English](README.en.md)
+- 🇬🇧 [English](README.en.md) (default)
 - 🇩🇪 [Deutsch](README.de.md)
 - 🇪🇸 [Español](README.es.md)
 - 🇮🇹 [Italiano](README.it.md)
@@ -71,7 +71,7 @@ See the language-specific README files for full details.
 - Save, load, share and clear projects (project requirements included); import/export them as JSON, and generate gear lists and printable overviews.
 - Visualize power and video connections with an interactive diagram.
 - Customize the device database with your own gear.
-- Automatically selects your browser language on first load, lets you switch languages, toggle dark or playful pink themes, and swap between V‑ and B‑Mount plates on supported cameras.
+- Defaults to English on first load, lets you switch languages, toggle dark or playful pink themes, and swap between V‑ and B‑Mount plates on supported cameras.
 - Works completely offline and offers a searchable help dialog with hover help for every button, field, dropdown and header.
 
 ## Runtime Data Weighting

--- a/script.js
+++ b/script.js
@@ -1156,17 +1156,6 @@ try {
   const supported = ["en", "de", "es", "fr", "it"];
   if (savedLang && supported.includes(savedLang)) {
     currentLang = savedLang;
-  } else if (typeof navigator !== "undefined") {
-    const navLangs = Array.isArray(navigator.languages)
-      ? navigator.languages
-      : [navigator.language];
-    for (const lang of navLangs) {
-      const short = String(lang).slice(0, 2).toLowerCase();
-      if (supported.includes(short)) {
-        currentLang = short;
-        break;
-      }
-    }
   }
 } catch (e) {
   console.warn("Could not load language from localStorage", e);

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -1364,7 +1364,7 @@ describe('script.js functions', () => {
     expect(document.getElementById('offlineIndicator').textContent).toBe(texts.es.offlineIndicator);
   });
 
-  test('defaults to browser language when no preference saved', () => {
+  test('defaults to English when no preference saved', () => {
     jest.resetModules();
 
     global.alert = jest.fn();
@@ -1392,8 +1392,8 @@ describe('script.js functions', () => {
     require('../translations.js');
     require('../script.js');
 
-    expect(document.documentElement.lang).toBe('fr');
-    expect(localStorage.getItem('language')).toBe('fr');
+    expect(document.documentElement.lang).toBe('en');
+    expect(localStorage.getItem('language')).toBe('en');
   });
 
   test('unifyDevices normalizes videoOutputs', () => {


### PR DESCRIPTION
## Summary
- Default the app's language to English instead of the browser's locale
- Update tests to reflect English as the default language
- Revise documentation in all languages to note English as default

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68be6ba35f8c83208f49eeb75cb2133b