### PR TITLE
Adjust diagram box proportions

### DIFF
--- a/script.js
+++ b/script.js
@@ -5311,8 +5311,8 @@ function renderSetupDiagram() {
   }
 
   // Determine node heights and widths based on label length so text fits inside
-  const DEFAULT_NODE_H = 80;
-  const DEFAULT_NODE_W = 160;
+  const DEFAULT_NODE_H = 120;
+  const DEFAULT_NODE_W = 120;
   const nodeHeights = {};
   const nodeWidths = {};
   nodes.forEach(id => {


### PR DESCRIPTION
## Summary
- Set default diagram node width to 120 to match height 120, making boxes square

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68be6e09a2dc8320ac6243001b016f24