### PR TITLE
Improve mobile top bar layout

### DIFF
--- a/style.css
+++ b/style.css
@@ -1455,7 +1455,18 @@ body.dark-mode.pink-mode .help-content { border-color: var(--accent-color); }
 @media (max-width: 768px) {
   #topBar {
     flex-direction: column;
-    align-items: flex-start;
+    align-items: stretch;
+  }
+
+  #topBar .branding,
+  #topBar .feature-search,
+  #topBar .controls {
+    width: 100%;
+    justify-content: center;
+  }
+
+  #featureSearch {
+    max-width: 100%;
   }
 }
 


### PR DESCRIPTION
## Summary
- Stack top bar sections and center content on small screens
- Allow search field to use full width for better mobile usability

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68be7c3b0a60832099c611491fb9f1c5