### PR TITLE
feat: reintroduce subtle drop shadows

### DIFF
--- a/overview-print.css
+++ b/overview-print.css
@@ -124,7 +124,7 @@ table, th, td {
 #overviewDialogContent #diagramArea {
   background: var(--surface-color) !important;
   border-color: var(--text-color);
-  box-shadow: none;
+  box-shadow: var(--panel-shadow);
 }
 #overviewDialogContent th {
   background-color: var(--control-bg) !important;
@@ -140,7 +140,7 @@ table, th, td {
 .requirement-box {
   background: var(--surface-color);
   border: 1px solid var(--text-color);
-  box-shadow: none;
+  box-shadow: var(--panel-shadow);
 }
 #overviewDialogContent .gear-table td {
   padding: 4px 0;
@@ -163,7 +163,7 @@ table, th, td {
 .device-block,
 .device-category {
   border: 1px solid var(--text-color);
-  box-shadow: none;
+  box-shadow: var(--panel-shadow);
 }
 
 #overviewDialogContent .barContainer {

--- a/overview.css
+++ b/overview.css
@@ -70,7 +70,7 @@ th { background-color: var(--control-bg); font-weight: 700; }
   border: 1px solid var(--control-text);
   border-radius: 6px;
   padding: 6px 10px;
-  box-shadow: none;
+  box-shadow: var(--panel-shadow);
   font-size: 12px;
 }
 .device-block strong { display: block; margin-bottom: 4px; }
@@ -83,7 +83,7 @@ th { background-color: var(--control-bg); font-weight: 700; }
   margin-bottom: 10px;
   flex: 1 1 calc((100% - 20px) / 3);
   box-sizing: border-box;
-  box-shadow: none;
+  box-shadow: var(--panel-shadow);
 }
 .device-category h3 {
   font-family: 'Ubuntu', sans-serif;
@@ -129,9 +129,9 @@ th { background-color: var(--control-bg); font-weight: 700; }
   h2 { border-bottom: 2px solid var(--inverse-text-color); }
   th { background-color: var(--control-bg); font-weight: 700; }
   .print-btn, .back-btn { background: var(--control-bg); color: var(--text-color); }
-  .device-category { background: var(--panel-bg); border-color: var(--panel-border); box-shadow: none; }
+  .device-category { background: var(--panel-bg); border-color: var(--panel-border); box-shadow: var(--panel-shadow); }
   .device-category h3 { border-bottom: 1px solid var(--inverse-text-color); color: var(--inverse-text-color); }
-  .device-block { background: rgba(255,255,255,0.1); border-color: var(--control-border); box-shadow: none; }
+  .device-block { background: rgba(255,255,255,0.1); border-color: var(--control-border); box-shadow: var(--panel-shadow); }
   .connector-block, .info-box { background-color: rgba(255,255,255,0.1); }
   .power-conn { background-color: rgba(244,67,54,0.3); }
   .fiz-conn { background-color: rgba(76,175,80,0.3); }

--- a/style.css
+++ b/style.css
@@ -15,7 +15,8 @@
   --control-disabled-bg: #cccccc;
   --panel-bg: #f9f9f9;
   --panel-border: #ddd;
-  --panel-shadow: none;
+  --panel-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  --panel-shadow-hover: 0 4px 8px rgba(0, 0, 0, 0.15);
   --border-radius: 5px;
   --page-padding: 20px;
   --gap-size: 10px;
@@ -518,12 +519,12 @@ section {
   border-radius: var(--border-radius);
   padding: 15px;
   margin-top: 1.5em;
-  box-shadow: none;
+  box-shadow: var(--panel-shadow);
   transition: transform 0.2s;
 }
 
 section:hover {
-  box-shadow: none;
+  box-shadow: var(--panel-shadow-hover);
   transform: translateY(-2px);
 }
 
@@ -580,13 +581,13 @@ button:disabled {
   border: 1px solid var(--panel-border);
   border-radius: var(--border-radius);
   padding: 10px;
-  box-shadow: none;
+  box-shadow: var(--panel-shadow);
   transition: transform 0.2s;
   box-sizing: border-box;
 }
 
 .device-category:hover {
-  box-shadow: none;
+  box-shadow: var(--panel-shadow-hover);
   transform: translateY(-2px);
 }
 
@@ -692,7 +693,7 @@ button:disabled {
   flex-wrap: wrap;
   background: linear-gradient(to bottom, var(--surface-color), var(--panel-bg));
   border-bottom: 1px solid var(--panel-border);
-  box-shadow: none;
+  box-shadow: var(--panel-shadow);
   z-index: 100;
 }
 
@@ -957,7 +958,7 @@ button:disabled {
   font-size: 12px;
   padding: 6px 10px;
   border-radius: 6px;
-  box-shadow: none;
+  box-shadow: var(--panel-shadow);
   z-index: 10;
   max-width: 320px;
   overflow: auto;
@@ -1149,12 +1150,12 @@ button:disabled {
   margin-top: 1em; /* Match section margin */
   border: 1px solid var(--panel-border); /* Match section border */
   border-radius: var(--border-radius); /* Match section border-radius */
-  box-shadow: none;
+  box-shadow: var(--panel-shadow);
   transition: transform 0.2s;
 }
 
 #batteryComparison:hover {
-  box-shadow: none;
+  box-shadow: var(--panel-shadow-hover);
   transform: translateY(-2px);
 }
 #batteryTableContainer {
@@ -1293,7 +1294,8 @@ html.dark-mode,
   --control-disabled-bg: #555;
   --panel-bg: #1c1c1e;
   --panel-border: #333;
-  --panel-shadow: none;
+  --panel-shadow: 0 2px 4px rgba(0, 0, 0, 0.5);
+  --panel-shadow-hover: 0 4px 8px rgba(0, 0, 0, 0.6);
   --link-color: #7ec8ff;
   --diagram-node-fill: #444;
   --power-color: #ff6666;
@@ -1333,7 +1335,7 @@ body.dark-mode.pink-mode {
 .dark-mode #batteryComparison {
   background-color: #1c1c1e;
   border-color: #333;
-  box-shadow: none;
+  box-shadow: var(--panel-shadow);
 }
 .dark-mode fieldset { border-color: var(--inverse-text-color); }
 .dark-mode legend { color: var(--inverse-text-color); }
@@ -1345,7 +1347,7 @@ body.dark-mode.pink-mode {
   background: rgba(51, 51, 51, 0.95);
   color: var(--inverse-text-color);
   border-color: #888;
-  box-shadow: none;
+  box-shadow: var(--panel-shadow);
 }
 .dark-mode .connector-block,
 .dark-mode .info-box { background-color: rgba(255,255,255,0.1); }
@@ -1380,7 +1382,8 @@ body.dark-mode.pink-mode .help-content { border-color: var(--accent-color); }
     --control-disabled-bg: #555;
     --panel-bg: #1c1c1e;
     --panel-border: #333;
-    --panel-shadow: none;
+    --panel-shadow: 0 2px 4px rgba(0, 0, 0, 0.5);
+    --panel-shadow-hover: 0 4px 8px rgba(0, 0, 0, 0.6);
     --link-color: #7ec8ff;
     --diagram-node-fill: #444;
     --power-color: #ff6666;
@@ -1416,7 +1419,7 @@ body.dark-mode.pink-mode .help-content { border-color: var(--accent-color); }
     background: rgba(51, 51, 51, 0.95);
     color: var(--inverse-text-color);
     border-color: #888;
-    box-shadow: none;
+    box-shadow: var(--panel-shadow);
   }
   body:not(.light-mode) .connector-block,
   body:not(.light-mode) .info-box { background-color: rgba(255,255,255,0.1); }
@@ -1572,7 +1575,7 @@ body.dark-mode.pink-mode .help-content { border-color: var(--accent-color); }
   border-radius: 8px;
   text-align: center;
   padding: 10px;
-  box-shadow: none;
+  box-shadow: var(--panel-shadow);
 }
 .requirement-box .req-icon {
   font-size: 1.5em;
@@ -1659,7 +1662,7 @@ body.dark-mode.pink-mode .help-content { border-color: var(--accent-color); }
   border: 1px solid var(--control-text);
   border-radius: 6px;
   padding: 6px 10px;
-  box-shadow: none;
+  box-shadow: var(--panel-shadow);
   font-size: 12px;
 }
 #overviewDialogContent .device-block strong {
@@ -1679,7 +1682,7 @@ body.dark-mode.pink-mode .help-content { border-color: var(--accent-color); }
   margin-bottom: 10px;
   flex: 1 1 calc((100% - 20px) / 3);
   box-sizing: border-box;
-  box-shadow: none;
+  box-shadow: var(--panel-shadow);
 }
 #overviewDialogContent .device-category h3 {
   font-family: 'Ubuntu', sans-serif;
@@ -1721,12 +1724,12 @@ body.dark-mode.pink-mode .help-content { border-color: var(--accent-color); }
 #overviewDialogContent.dark-mode .device-category {
   background: var(--panel-bg);
   border-color: var(--panel-border);
-  box-shadow: none;
+  box-shadow: var(--panel-shadow);
 }
 #overviewDialogContent.dark-mode .device-block {
   background: rgba(255, 255, 255, 0.1);
   border-color: var(--control-border);
-  box-shadow: none;
+  box-shadow: var(--panel-shadow);
 }
 
 .gear-table {


### PR DESCRIPTION
## Summary
- add reusable CSS variables for subtle panel shadows
- apply lighter shadows to sections, cards, popups, and overview styles

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68be7d1ba16c8320b5d3f34bfc8753d4