### PR TITLE
Expand search to cross-link section headings

### DIFF
--- a/script.js
+++ b/script.js
@@ -2173,13 +2173,16 @@ function populateFeatureSearch() {
   if (!featureList) return;
   featureMap.clear();
   featureList.innerHTML = '';
-  document.querySelectorAll('h2[id], legend[id]').forEach(el => {
-    const name = el.textContent.trim();
-    featureMap.set(name.toLowerCase(), el);
-    const opt = document.createElement('option');
-    opt.value = name;
-    featureList.appendChild(opt);
-  });
+  document
+    .querySelectorAll('h2[id], legend[id], h3[id]')
+    .forEach(el => {
+      if (helpDialog && helpDialog.contains(el)) return;
+      const name = el.textContent.trim();
+      featureMap.set(name.toLowerCase(), el);
+      const opt = document.createElement('option');
+      opt.value = name;
+      featureList.appendChild(opt);
+    });
   if (helpDialog) {
     helpDialog.querySelectorAll('[data-help-section] > h3').forEach(h => {
       const opt = document.createElement('option');

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -4805,6 +4805,12 @@ describe('script.js functions', () => {
     expect(helpSearchClear.getAttribute('title')).toBe(texts.de.helpSearchClear);
   });
 
+  test('feature search includes cross links to section headings', () => {
+    const featureList = document.getElementById('featureList');
+    const options = [...featureList.querySelectorAll('option')].map(o => o.value);
+    expect(options).toContain('Add New Device');
+  });
+
   test('help button title shows keyboard shortcut and localizes', () => {
     const helpButton = document.getElementById('helpButton');
     script.setLanguage('en');


### PR DESCRIPTION
## Summary
- index `h3` section headings alongside `h2` and `legend` elements in the feature search so the search bar can jump to more anchors
- add regression test ensuring feature search includes these subsection links

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68be7d8a0bf88320972a5c2f4ac1d3e5