### PR TITLE
feat: search dropdown selects devices

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,7 +34,7 @@
       <h1 id="mainTitle">Cine List</h1>
     </div>
     <div class="feature-search">
-      <input type="search" id="featureSearch" list="featureList" placeholder="Search features..." aria-label="Search features and help" />
+      <input type="search" id="featureSearch" list="featureList" placeholder="Search features or devices..." aria-label="Search features, devices and help" />
       <datalist id="featureList"></datalist>
     </div>
     <nav class="controls" aria-label="Main controls">

--- a/script.js
+++ b/script.js
@@ -2159,6 +2159,7 @@ const hoverHelpButton = document.getElementById("hoverHelpButton");
 const featureSearch   = document.getElementById("featureSearch");
 const featureList     = document.getElementById("featureList");
 const featureMap      = new Map();
+const deviceMap       = new Map();
 const existingDevicesHeading = document.getElementById("existingDevicesHeading");
 const batteryComparisonSection = document.getElementById("batteryComparison");
 const batteryTableElem = document.getElementById("batteryTable");
@@ -2172,6 +2173,7 @@ const projectRequirementsOutput = document.getElementById("projectRequirementsOu
 function populateFeatureSearch() {
   if (!featureList) return;
   featureMap.clear();
+  deviceMap.clear();
   featureList.innerHTML = '';
   document
     .querySelectorAll('h2[id], legend[id], h3[id]')
@@ -2190,6 +2192,20 @@ function populateFeatureSearch() {
       featureList.appendChild(opt);
     });
   }
+
+  document.querySelectorAll('select').forEach(sel => {
+    sel.querySelectorAll('option').forEach(opt => {
+      const name = opt.textContent.trim();
+      if (!name || opt.value === 'None') return;
+      const key = name.toLowerCase();
+      if (!deviceMap.has(key)) {
+        deviceMap.set(key, { select: sel, value: opt.value });
+        const dlOpt = document.createElement('option');
+        dlOpt.value = name;
+        featureList.appendChild(dlOpt);
+      }
+    });
+  });
 }
 
 function setEditProjectBtnText() {
@@ -10191,7 +10207,16 @@ if (helpButton && helpDialog) {
     const lower = value.toLowerCase();
     const isHelp = lower.endsWith(' (help)');
     const clean = isHelp ? value.slice(0, -7).trim() : value;
-    const featureEl = featureMap.get(clean.toLowerCase());
+    const cleanLower = clean.toLowerCase();
+    const device = deviceMap.get(cleanLower);
+    if (device && !isHelp) {
+      device.select.value = device.value;
+      device.select.dispatchEvent(new Event('change', { bubbles: true }));
+      device.select.scrollIntoView({ behavior: 'smooth' });
+      device.select.focus?.();
+      return;
+    }
+    const featureEl = featureMap.get(cleanLower);
     if (featureEl && !isHelp) {
       featureEl.scrollIntoView({ behavior: 'smooth' });
       featureEl.focus?.();

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -4811,6 +4811,19 @@ describe('script.js functions', () => {
     expect(options).toContain('Add New Device');
   });
 
+  test('feature search selects devices', () => {
+    setupDom(false);
+    require('../script.js');
+    const featureSearch = document.getElementById('featureSearch');
+    const cameraSelect = document.getElementById('cameraSelect');
+    const featureList = document.getElementById('featureList');
+    const options = [...featureList.querySelectorAll('option')].map(o => o.value);
+    expect(options).toContain('Sony FX3');
+    featureSearch.value = 'Sony FX3';
+    featureSearch.dispatchEvent(new Event('change'));
+    expect(cameraSelect.value).toBe('Sony FX3');
+  });
+
   test('help button title shows keyboard shortcut and localizes', () => {
     const helpButton = document.getElementById('helpButton');
     script.setLanguage('en');

--- a/translations.js
+++ b/translations.js
@@ -37,10 +37,10 @@ const texts = {
     existingDevicesHeading: "Existing Devices",
     darkModeLabel: "Toggle dark mode",
     pinkModeLabel: "Toggle pink mode",
-    featureSearchPlaceholder: "Search features...",
-    featureSearchLabel: "Search features and help",
+    featureSearchPlaceholder: "Search features or devices...",
+    featureSearchLabel: "Search features, devices and help",
     featureSearchHelp:
-      "Type to jump to features or open related help topics.",
+      "Type to jump to features or devices or open related help topics.",
     darkModeHelp:
       "Switch between light and dark themes for comfortable viewing. Press D to toggle. The preference is saved.",
     pinkModeHelp:
@@ -435,10 +435,10 @@ const texts = {
     existingDevicesHeading: "Dispositivi esistenti",
     darkModeLabel: "Attiva modalità scura",
     pinkModeLabel: "Attiva modalità rosa",
-    featureSearchPlaceholder: "Cerca funzionalità...",
-    featureSearchLabel: "Cerca funzionalità e aiuto",
+    featureSearchPlaceholder: "Cerca funzionalità o dispositivi...",
+    featureSearchLabel: "Cerca funzionalità, dispositivi e aiuto",
     featureSearchHelp:
-      "Digita per andare alle funzionalità o aprire le guide correlate.",
+      "Digita per andare alle funzionalità o ai dispositivi o aprire le guide correlate.",
     darkModeHelp:
       "Passa tra tema chiaro e scuro; premi D per attivarlo. La scelta viene ricordata.",
     pinkModeHelp:
@@ -807,10 +807,10 @@ const texts = {
     existingDevicesHeading: "Dispositivos Existentes",
     darkModeLabel: "Alternar modo oscuro",
     pinkModeLabel: "Alternar modo rosa",
-    featureSearchPlaceholder: "Buscar funciones...",
-    featureSearchLabel: "Buscar funciones y ayuda",
+    featureSearchPlaceholder: "Buscar funciones o dispositivos...",
+    featureSearchLabel: "Buscar funciones, dispositivos y ayuda",
     featureSearchHelp:
-      "Escribe para ir a las funciones o ver los temas de ayuda relacionados.",
+      "Escribe para ir a las funciones o a los dispositivos o ver los temas de ayuda relacionados.",
     darkModeHelp:
       "Alterna entre temas claro y oscuro; pulsa D para cambiar. La preferencia se guarda.",
     pinkModeHelp:
@@ -1193,10 +1193,10 @@ const texts = {
     existingDevicesHeading: "Appareils Existants",
     darkModeLabel: "Basculer en mode sombre",
     pinkModeLabel: "Basculer en mode rose",
-    featureSearchPlaceholder: "Rechercher des fonctionnalités...",
-    featureSearchLabel: "Rechercher des fonctionnalités et l'aide",
+    featureSearchPlaceholder: "Rechercher des fonctionnalités ou des appareils...",
+    featureSearchLabel: "Rechercher des fonctionnalités, des appareils et de l'aide",
     featureSearchHelp:
-      "Tapez pour accéder aux fonctionnalités ou ouvrir les rubriques d'aide associées.",
+      "Tapez pour accéder aux fonctionnalités ou appareils ou ouvrir les sujets d'aide associés.",
     darkModeHelp:
       "Basculer entre thème clair et sombre; appuyez sur D pour changer. Le choix est mémorisé.",
     pinkModeHelp:
@@ -1581,10 +1581,10 @@ const texts = {
     existingDevicesHeading: "Vorhandene Geräte",
     darkModeLabel: "Dunkelmodus umschalten",
     pinkModeLabel: "Pinkmodus umschalten",
-    featureSearchPlaceholder: "Funktionen durchsuchen...",
-    featureSearchLabel: "Funktionen und Hilfe durchsuchen",
+    featureSearchPlaceholder: "Funktionen oder Geräte durchsuchen...",
+    featureSearchLabel: "Funktionen, Geräte und Hilfe durchsuchen",
     featureSearchHelp:
-      "Tippe, um zu Funktionen zu springen oder passende Hilfethemen zu öffnen.",
+      "Tippen, um zu Funktionen oder Geräten zu springen oder passende Hilfethemen zu öffnen.",
     darkModeHelp:
       "Zwischen hellem und dunklem Design wechseln; mit D umschalten. Die Einstellung wird gespeichert.",
     pinkModeHelp:


### PR DESCRIPTION
## Summary
- allow global search to jump directly to devices and select them
- mention device lookup in search field labels and translations
- test that feature search selects a camera by name

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68be7f55fdd4832099afbab3b15d571e