### PR TITLE
Improve mobile spacing under section headers

### DIFF
--- a/overview.css
+++ b/overview.css
@@ -10,6 +10,7 @@ select:focus-visible {
 body { font-family: 'Ubuntu', sans-serif; font-weight: 300; margin: 25px; color: var(--control-text); font-size: 0.9em; -webkit-print-color-adjust: exact; print-color-adjust: exact; }
 @media (max-width: 600px) {
   body { margin: 10px; }
+  h2 { padding-bottom: 8px; }
 }
 h1, h2, h3 { font-family: 'Ubuntu', sans-serif; font-weight: 400; color: var(--accent-color); }
 h1 { font-size: 1.8em; margin-bottom: 0.2em; }

--- a/style.css
+++ b/style.css
@@ -32,6 +32,9 @@
   :root {
     --page-padding: 5px;
   }
+  h2 {
+    padding-bottom: 0.3em;
+  }
 }
 body.pink-mode {
   --accent-color: #ff69b4;


### PR DESCRIPTION
## Summary
- Increase padding below section headers on small screens for better visual separation
- Adjust mobile overview styles to provide more room between headers and underline

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bfaa673d5c8320bc8e313e8c58572c