### PR TITLE
Fix ordering in battery comparison

### DIFF
--- a/script.js
+++ b/script.js
@@ -4884,8 +4884,13 @@ if (!battery || battery === "None" || !devices.batteries[battery]) {
     }
 
     // Sort by runtime (hours) descending within each group
-    pinsCandidates.sort((a, b) => b.hours - a.hours);
-    dtapCandidates.sort((a, b) => b.hours - a.hours);
+    // Ensure stable ordering: sort by runtime descending, then by name
+    const sortByHoursThenName = (a, b) => {
+      const diff = b.hours - a.hours;
+      return diff !== 0 ? diff : collator.compare(a.name, b.name);
+    };
+    pinsCandidates.sort(sortByHoursThenName);
+    dtapCandidates.sort(sortByHoursThenName);
 
     // Prepare table HTML
     let tableHtml = `<tr><th>${texts[currentLang].batteryTableLabel}</th><th>${texts[currentLang].runtimeLabel}</th><th></th></tr>`;


### PR DESCRIPTION
## Summary
- Sort battery comparison candidates by runtime and name for consistent ordering

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bfab05bf988320b35cfaba5188f632