### PR TITLE
Persist handheld monitor selection on reload

### DIFF
--- a/script.js
+++ b/script.js
@@ -9403,6 +9403,7 @@ function applyGearListSelectors(selectors) {
                 sel.dispatchEvent(new Event('change'));
             } else {
                 sel.value = value;
+                sel.dispatchEvent(new Event('change'));
             }
         }
     });

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -2568,6 +2568,46 @@ describe('script.js functions', () => {
     expect(msSection).toContain('3x Antenna 5,8GHz 5dBi Long (3x Spare)');
   });
 
+  test('director handheld monitor selection persists after reload', () => {
+    setupDom(false);
+    const script = require('../script.js');
+    const {
+      generateGearListHtml,
+      displayGearAndRequirements,
+      getGearListSelectors,
+      applyGearListSelectors,
+      bindGearListDirectorMonitorListener,
+    } = script;
+
+    // add alternate monitor option
+    devices.monitors.MonB = {
+      powerDrawWatts: 5,
+      screenSizeInches: 8,
+      power: { input: { type: 'LEMO 2-pin' } },
+      videoInputs: [{ type: '3G-SDI' }],
+    };
+
+    // initial render with default selection
+    let html = generateGearListHtml({ videoDistribution: 'Director Monitor 7" handheld' });
+    displayGearAndRequirements(html);
+    bindGearListDirectorMonitorListener();
+
+    const sel = document.getElementById('gearListDirectorMonitor');
+    sel.value = 'MonB';
+    sel.dispatchEvent(new Event('change', { bubbles: true }));
+
+    const selectors = getGearListSelectors();
+
+    // simulate reload by regenerating and reapplying selectors
+    html = generateGearListHtml({ videoDistribution: 'Director Monitor 7" handheld' });
+    displayGearAndRequirements(html);
+    bindGearListDirectorMonitorListener();
+    applyGearListSelectors(selectors);
+
+    expect(document.getElementById('gearListDirectorMonitor').value).toBe('MonB');
+    expect(document.getElementById('monitorSizeDirector').textContent).toBe('8"');
+  });
+
   test('gear list includes battery count in camera batteries row', () => {
     const { generateGearListHtml } = script;
     const addOpt = (id, value) => {


### PR DESCRIPTION
## Summary
- ensure gear list selectors trigger change events for single-select fields so handheld monitor choices persist
- add regression test verifying director handheld monitor selection is restored after reload

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bfad4c34888320b32cd693ff11d98e