### PR TITLE
Exclude certain gear from project requirements summary

### DIFF
--- a/script.js
+++ b/script.js
@@ -8676,7 +8676,17 @@ function generateGearListHtml(info = {}) {
         'frameGuides',
         'aspectMaskOpacity',
         'filter',
-        'viewfinderEyeLeatherColor'
+        'viewfinderEyeLeatherColor',
+        'directorMonitor',
+        'dopMonitor',
+        'gafferMonitor',
+        'directorMonitor15',
+        'comboMonitor15',
+        'dopMonitor15',
+        'proGaffColor1',
+        'proGaffWidth1',
+        'proGaffColor2',
+        'proGaffWidth2'
     ]);
     const infoEntries = Object.entries(projectInfo)
         .filter(([k, v]) => v && k !== 'projectName' && !excludedFields.has(k));

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -3217,6 +3217,40 @@ describe('script.js functions', () => {
     expect(projOut.querySelector('[data-field="viewfinderEyeLeatherColor"]')).toBeNull();
   });
 
+  test('monitor and gaff tape fields hidden from project requirements summary', () => {
+    setupDom();
+    require('../translations.js');
+    const { generateGearListHtml, displayGearAndRequirements } = require('../script.js');
+    const html = generateGearListHtml({
+      directorMonitor: 'SmallHD Ultra 7',
+      dopMonitor: 'SmallHD Ultra 7',
+      gafferMonitor: 'SmallHD Ultra 7',
+      directorMonitor15: 'SmallHD Cine 24',
+      comboMonitor15: 'SmallHD Cine 24',
+      dopMonitor15: 'SmallHD Cine 24',
+      proGaffColor1: 'red',
+      proGaffWidth1: '24mm',
+      proGaffColor2: 'blue',
+      proGaffWidth2: '24mm'
+    });
+    displayGearAndRequirements(html);
+    const projOut = document.getElementById('projectRequirementsOutput');
+    [
+      'directorMonitor',
+      'dopMonitor',
+      'gafferMonitor',
+      'directorMonitor15',
+      'comboMonitor15',
+      'dopMonitor15',
+      'proGaffColor1',
+      'proGaffWidth1',
+      'proGaffColor2',
+      'proGaffWidth2'
+    ].forEach(field => {
+      expect(projOut.querySelector(`[data-field="${field}"]`)).toBeNull();
+    });
+  });
+
   test('gear list remains visible after session reload with only setup name', () => {
     global.saveSessionState = jest.fn();
     global.loadSessionState = jest.fn();


### PR DESCRIPTION
## Summary
- hide monitor and gaff tape selections in project requirements summary
- test that monitor and gaff tape fields are omitted

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c710e1d9c08320aa525824179c370d