### PR TITLE
Allow multiple prep and shooting periods

### DIFF
--- a/index.html
+++ b/index.html
@@ -978,17 +978,15 @@
         <div id="crewContainer"></div>
         <button type="button" id="addPersonBtn">+</button>
       </div>
-      <div class="form-row">
-        <label for="prepStart" id="prepLabel">Prep Days:</label>
-        <input type="date" id="prepStart" name="prepStart" aria-labelledby="prepLabel" />
-        <span>to</span>
-        <input type="date" id="prepEnd" name="prepEnd" aria-labelledby="prepLabel" />
+      <div class="form-row" id="prepListRow">
+        <label id="prepLabel">Prep Days:</label>
+        <div id="prepContainer"></div>
+        <button type="button" id="addPrepBtn">+</button>
       </div>
-      <div class="form-row">
-        <label for="shootStart" id="shootLabel">Shooting Days:</label>
-        <input type="date" id="shootStart" name="shootStart" aria-labelledby="shootLabel" />
-        <span>to</span>
-        <input type="date" id="shootEnd" name="shootEnd" aria-labelledby="shootLabel" />
+      <div class="form-row" id="shootListRow">
+        <label id="shootLabel">Shooting Days:</label>
+        <div id="shootContainer"></div>
+        <button type="button" id="addShootBtn">+</button>
       </div>
       <div class="form-row">
         <label for="deliveryResolution">Delivery Resolution:</label>

--- a/script.js
+++ b/script.js
@@ -1855,6 +1855,10 @@ const viewfinderSettingsRow = document.getElementById("viewfinderSettingsRow");
 const viewfinderExtensionRow = document.getElementById("viewfinderExtensionRow");
 const crewContainer = document.getElementById("crewContainer");
 const addPersonBtn = document.getElementById("addPersonBtn");
+const prepContainer = document.getElementById("prepContainer");
+const addPrepBtn = document.getElementById("addPrepBtn");
+const shootContainer = document.getElementById("shootContainer");
+const addShootBtn = document.getElementById("addShootBtn");
 
 let monitoringConfigurationUserChanged = false;
 
@@ -1922,8 +1926,62 @@ function createCrewRow(data = {}) {
   crewContainer.appendChild(row);
 }
 
+function createPrepRow(data = {}) {
+  if (!prepContainer) return;
+  const row = document.createElement('div');
+  row.className = 'period-row';
+  const start = document.createElement('input');
+  start.type = 'date';
+  start.className = 'prep-start';
+  start.value = data.start || '';
+  start.setAttribute('aria-labelledby', 'prepLabel');
+  const span = document.createElement('span');
+  span.textContent = 'to';
+  const end = document.createElement('input');
+  end.type = 'date';
+  end.className = 'prep-end';
+  end.value = data.end || '';
+  end.setAttribute('aria-labelledby', 'prepLabel');
+  const removeBtn = document.createElement('button');
+  removeBtn.type = 'button';
+  removeBtn.textContent = '−';
+  removeBtn.addEventListener('click', () => row.remove());
+  row.append(start, span, end, removeBtn);
+  prepContainer.appendChild(row);
+}
+
+function createShootRow(data = {}) {
+  if (!shootContainer) return;
+  const row = document.createElement('div');
+  row.className = 'period-row';
+  const start = document.createElement('input');
+  start.type = 'date';
+  start.className = 'shoot-start';
+  start.value = data.start || '';
+  start.setAttribute('aria-labelledby', 'shootLabel');
+  const span = document.createElement('span');
+  span.textContent = 'to';
+  const end = document.createElement('input');
+  end.type = 'date';
+  end.className = 'shoot-end';
+  end.value = data.end || '';
+  end.setAttribute('aria-labelledby', 'shootLabel');
+  const removeBtn = document.createElement('button');
+  removeBtn.type = 'button';
+  removeBtn.textContent = '−';
+  removeBtn.addEventListener('click', () => row.remove());
+  row.append(start, span, end, removeBtn);
+  shootContainer.appendChild(row);
+}
+
 if (addPersonBtn) {
   addPersonBtn.addEventListener('click', () => createCrewRow());
+}
+if (addPrepBtn) {
+  addPrepBtn.addEventListener('click', () => createPrepRow());
+}
+if (addShootBtn) {
+  addShootBtn.addEventListener('click', () => createShootRow());
 }
 
 function updateTripodOptions() {
@@ -8214,7 +8272,6 @@ function collectProjectFormData() {
     const val = name => (projectForm.querySelector(`[name="${name}"]`)?.value || '').trim();
     const multi = name => Array.from(projectForm.querySelector(`[name="${name}"]`)?.selectedOptions || [])
         .map(o => o.value).join(', ');
-    const range = (start, end) => [val(start), val(end)].filter(Boolean).join(' to ');
     const viewfinderSettings = multi('viewfinderSettings');
     const frameGuides = multi('frameGuides');
     const aspectMaskOpacity = multi('aspectMaskOpacity');
@@ -8228,13 +8285,21 @@ function collectProjectFormData() {
         name: row.querySelector('.person-name')?.value.trim(),
         phone: row.querySelector('.person-phone')?.value.trim()
     })).filter(p => p.role && p.name);
+    const collectRanges = (container, startSel, endSel) => Array.from(container?.querySelectorAll('.period-row') || [])
+        .map(row => {
+            const start = row.querySelector(startSel)?.value;
+            const end = row.querySelector(endSel)?.value;
+            return [start, end].filter(Boolean).join(' to ');
+        }).filter(Boolean);
+    const prepDays = collectRanges(prepContainer, '.prep-start', '.prep-end');
+    const shootingDays = collectRanges(shootContainer, '.shoot-start', '.shoot-end');
     return {
         projectName: val('projectName'),
         productionCompany: val('productionCompany'),
         rentalHouse: val('rentalHouse'),
         ...(people.length ? { people } : {}),
-        prepDays: range('prepStart','prepEnd'),
-        shootingDays: range('shootStart','shootEnd'),
+        prepDays,
+        shootingDays,
         deliveryResolution: val('deliveryResolution'),
         recordingResolution: val('recordingResolution'),
         aspectRatio: multi('aspectRatio'),
@@ -8303,12 +8368,28 @@ function populateProjectForm(info = {}) {
         crewContainer.innerHTML = '';
         (info.people || []).forEach(p => createCrewRow(p));
     }
-    const [prepStart, prepEnd] = (info.prepDays || '').split(' to ');
-    setVal('prepStart', prepStart);
-    setVal('prepEnd', prepEnd);
-    const [shootStart, shootEnd] = (info.shootingDays || '').split(' to ');
-    setVal('shootStart', shootStart);
-    setVal('shootEnd', shootEnd);
+    if (prepContainer) {
+        prepContainer.innerHTML = '';
+        const prepArr = Array.isArray(info.prepDays)
+            ? info.prepDays
+            : (info.prepDays ? String(info.prepDays).split('\n') : ['']);
+        if (!prepArr.length) prepArr.push('');
+        prepArr.forEach(r => {
+            const [start, end] = r.split(' to ');
+            createPrepRow({ start, end });
+        });
+    }
+    if (shootContainer) {
+        shootContainer.innerHTML = '';
+        const shootArr = Array.isArray(info.shootingDays)
+            ? info.shootingDays
+            : (info.shootingDays ? String(info.shootingDays).split('\n') : ['']);
+        if (!shootArr.length) shootArr.push('');
+        shootArr.forEach(r => {
+            const [start, end] = r.split(' to ');
+            createShootRow({ start, end });
+        });
+    }
     setVal('deliveryResolution', info.deliveryResolution);
     setMulti('aspectRatio', info.aspectRatio);
     setVal('baseFrameRate', info.baseFrameRate);
@@ -8617,6 +8698,12 @@ function generateGearListHtml(info = {}) {
         }
     }
     delete projectInfo.people;
+    if (Array.isArray(info.prepDays)) {
+        projectInfo.prepDays = info.prepDays.join('\n');
+    }
+    if (Array.isArray(info.shootingDays)) {
+        projectInfo.shootingDays = info.shootingDays.join('\n');
+    }
     if (monitoringSettings.length) {
         projectInfo.monitoringSupport = monitoringSettings.join(', ');
     }
@@ -9135,26 +9222,31 @@ function generateGearListHtml(info = {}) {
     let eyeLeatherCount = hasViewfinder ? 2 : 0;
     let shootDays = 0;
     let isWinterShoot = false;
-    if (info.shootingDays) {
-        const parts = info.shootingDays.split(' to ');
+    const shootRanges = Array.isArray(info.shootingDays)
+        ? info.shootingDays
+        : (info.shootingDays ? [info.shootingDays] : []);
+    const winterMonths = new Set([9, 10, 11, 0, 1, 2, 3, 4]);
+    shootRanges.forEach(r => {
+        const parts = r.split(' to ');
         if (parts.length === 2) {
             const start = new Date(parts[0]);
             const end = new Date(parts[1]);
             if (!isNaN(start) && !isNaN(end)) {
-                shootDays = Math.floor((end - start) / (1000 * 60 * 60 * 24)) + 1;
-                const winterMonths = new Set([9, 10, 11, 0, 1, 2, 3, 4]);
-                const m = new Date(start);
-                m.setHours(0, 0, 0, 0);
-                while (m <= end) {
-                    if (winterMonths.has(m.getMonth())) {
-                        isWinterShoot = true;
-                        break;
+                shootDays += Math.floor((end - start) / (1000 * 60 * 60 * 24)) + 1;
+                if (!isWinterShoot) {
+                    const m = new Date(start);
+                    m.setHours(0, 0, 0, 0);
+                    while (m <= end) {
+                        if (winterMonths.has(m.getMonth())) {
+                            isWinterShoot = true;
+                            break;
+                        }
+                        m.setMonth(m.getMonth() + 1);
                     }
-                    m.setMonth(m.getMonth() + 1);
                 }
             }
         }
-    }
+    });
     let multiplier = 1;
     if (shootDays > 21) {
         multiplier = 4;

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -2093,6 +2093,34 @@ describe('script.js functions', () => {
     expect(section).not.toContain('ARRI LMB 4x5 Clamp-On (3-Stage)');
   });
 
+  test('collectProjectFormData captures multiple prep and shooting periods', () => {
+    setupDom();
+    require('../translations.js');
+    const { collectProjectFormData, populateProjectForm } = require('../script.js');
+    document.getElementById('addPrepBtn').click();
+    const prepRows = document.querySelectorAll('#prepContainer .period-row');
+    prepRows[0].querySelector('.prep-start').value = '2024-01-01';
+    prepRows[0].querySelector('.prep-end').value = '2024-01-03';
+    prepRows[1].querySelector('.prep-start').value = '2024-02-01';
+    prepRows[1].querySelector('.prep-end').value = '2024-02-02';
+    document.getElementById('addShootBtn').click();
+    const shootRows = document.querySelectorAll('#shootContainer .period-row');
+    shootRows[0].querySelector('.shoot-start').value = '2024-03-01';
+    shootRows[0].querySelector('.shoot-end').value = '2024-03-05';
+    shootRows[1].querySelector('.shoot-start').value = '2024-04-01';
+    shootRows[1].querySelector('.shoot-end').value = '2024-04-04';
+    const info = collectProjectFormData();
+    expect(info.prepDays).toEqual(['2024-01-01 to 2024-01-03', '2024-02-01 to 2024-02-02']);
+    expect(info.shootingDays).toEqual(['2024-03-01 to 2024-03-05', '2024-04-01 to 2024-04-04']);
+    populateProjectForm(info);
+    const repopPrepRows = document.querySelectorAll('#prepContainer .period-row');
+    expect(repopPrepRows).toHaveLength(2);
+    expect(repopPrepRows[1].querySelector('.prep-start').value).toBe('2024-02-01');
+    const repopShootRows = document.querySelectorAll('#shootContainer .period-row');
+    expect(repopShootRows).toHaveLength(2);
+    expect(repopShootRows[1].querySelector('.shoot-end').value).toBe('2024-04-04');
+  });
+
   test('Rota-Pol filter provides size dropdown', () => {
     setupDom(false);
     require('../translations.js');


### PR DESCRIPTION
## Summary
- Enable adding multiple prep and shooting periods through dynamic form rows
- Persist and restore all prep/shoot periods and include them in calculations
- Test data collection and form population for multiple date ranges

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c711b62b048320ab8d3d4c1f0ced53