### PR TITLE
Expand crew list with lighting and grip roles

### DIFF
--- a/script.js
+++ b/script.js
@@ -1859,13 +1859,30 @@ const addPersonBtn = document.getElementById("addPersonBtn");
 let monitoringConfigurationUserChanged = false;
 
 const crewRoles = [
-  'DoP',
+  // Production
+  'Producer',
   'Production Manager',
+  'Director',
+  'Assistant Director',
+
+  // Camera
+  'DoP',
   'Camera Operator',
   'B-Camera Operator',
   '1st AC',
   '2nd AC',
-  'Video Operator'
+  'DIT',
+  'Video Operator',
+
+  // Lighting
+  'Key Gaffer',
+  'Gaffer',
+  'Best Boy Electric',
+
+  // Grip
+  'Key Grip',
+  'Best Boy Grip',
+  'Grip'
 ];
 
 const projectFieldIcons = {
@@ -11136,5 +11153,6 @@ if (typeof module !== "undefined" && module.exports) {
     applyFilterSelectionsToGearList,
     setCurrentProjectInfo,
     getCurrentProjectInfo,
+    crewRoles,
   };
 }

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -1843,6 +1843,31 @@ describe('script.js functions', () => {
       expect(html).not.toContain('HDMI Cable');
     });
 
+  test('crew roles are ordered by department and include lighting and grip', () => {
+    setupDom();
+    require('../translations.js');
+    const { crewRoles } = require('../script.js');
+    expect(crewRoles).toEqual([
+      'Producer',
+      'Production Manager',
+      'Director',
+      'Assistant Director',
+      'DoP',
+      'Camera Operator',
+      'B-Camera Operator',
+      '1st AC',
+      '2nd AC',
+      'DIT',
+      'Video Operator',
+      'Key Gaffer',
+      'Gaffer',
+      'Best Boy Electric',
+      'Key Grip',
+      'Best Boy Grip',
+      'Grip'
+    ]);
+  });
+
   test('renders multiple crew members on separate lines in project requirements summary', () => {
     setupDom();
     require('../translations.js');


### PR DESCRIPTION
## Summary
- Add production, camera, lighting, and grip roles to crew list
- Export crew role list and test its ordering

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c7129106588320b1d8f1923bb674ce