### PR TITLE
feat: add Zeiss Lightweight Zoom lenses

### DIFF
--- a/devices/gearList.js
+++ b/devices/gearList.js
@@ -2170,6 +2170,28 @@ const gear = {
           "needsLensSupport": true,
           "lensType": "spherical"
         },
+        "ZEISS Lightweight Zoom LWZ.3 15-30mm T2.9": {
+          "brand": "ZEISS",
+          "frontDiameterMm": 114,
+          "clampOn": true,
+          "tStop": 2.9,
+          "mount": "PL",
+          "rodStandard": "15mm",
+          "rodLengthCm": 45,
+          "needsLensSupport": true,
+          "lensType": "spherical"
+        },
+        "ZEISS Lightweight Zoom LWZ.3 21-100mm T2.9-3.9": {
+          "brand": "ZEISS",
+          "frontDiameterMm": 114,
+          "clampOn": true,
+          "tStop": 2.9,
+          "mount": "PL",
+          "rodStandard": "15mm",
+          "rodLengthCm": 45,
+          "needsLensSupport": true,
+          "lensType": "spherical"
+        },
         "ZEISS Nano Prime 18mm T1.5": {
           "brand": "ZEISS",
           "frontDiameterMm": 95,


### PR DESCRIPTION
## Summary
- expand lens catalog with Zeiss Lightweight Zoom LWZ.3 15-30mm T2.9
- add Zeiss Lightweight Zoom LWZ.3 21-100mm T2.9-3.9

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c712cc3244832083e415fdfc28ce6f