### PR TITLE
Add Frame Grab monitor user button

### DIFF
--- a/script.js
+++ b/script.js
@@ -11051,7 +11051,8 @@ function populateUserButtonDropdowns() {
     'Playback',
     'Record',
     'Zoom',
-    'Frame Lines'
+    'Frame Lines',
+    'Frame Grab'
   ];
   ['monitorUserButtons', 'cameraUserButtons', 'viewfinderUserButtons'].forEach(id => {
     const sel = document.getElementById(id);

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -477,7 +477,7 @@ describe('script.js functions', () => {
       expect(sel.multiple).toBe(true);
       expect(sel.size).toBe(sel.options.length);
       const values = Array.from(sel.options).map(o => o.value);
-      expect(values).toEqual(expect.arrayContaining(['Toggle LUT', 'False Color', 'Peaking']));
+      expect(values).toEqual(expect.arrayContaining(['Toggle LUT', 'False Color', 'Peaking', 'Frame Grab']));
     });
   });
 


### PR DESCRIPTION
## Summary
- Add "Frame Grab" to available user button functions
- Update tests to include new user button option

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c713daa5b883208fcf8bd861aed3bf