### PR TITLE
feat: allow favorites for selectors

### DIFF
--- a/storage.js
+++ b/storage.js
@@ -6,6 +6,7 @@ const SETUP_STORAGE_KEY = 'cameraPowerPlanner_setups';
 const SESSION_STATE_KEY = 'cameraPowerPlanner_session';
 const FEEDBACK_STORAGE_KEY = 'cameraPowerPlanner_feedback';
 const PROJECT_STORAGE_KEY = 'cameraPowerPlanner_project';
+const FAVORITES_STORAGE_KEY = 'cameraPowerPlanner_favorites';
 
 // Safely detect usable localStorage. Some environments (like private browsing)
 // may block access and throw errors. If unavailable, fall back to a simple
@@ -415,6 +416,27 @@ function deleteProject(name) {
   }
 }
 
+// --- Favorites Storage ---
+function loadFavorites() {
+  const parsed = loadJSONFromStorage(
+    SAFE_LOCAL_STORAGE,
+    FAVORITES_STORAGE_KEY,
+    "Error loading favorites from localStorage:",
+    {},
+  );
+  return isPlainObject(parsed) ? parsed : {};
+}
+
+function saveFavorites(favs) {
+  if (!isPlainObject(favs)) return;
+  saveJSONToStorage(
+    SAFE_LOCAL_STORAGE,
+    FAVORITES_STORAGE_KEY,
+    favs,
+    "Error saving favorites to localStorage:",
+  );
+}
+
 // --- User Feedback Storage ---
 function loadFeedback() {
   const parsed = loadJSONFromStorage(
@@ -503,6 +525,8 @@ if (typeof module !== "undefined" && module.exports) {
     deleteProject,
     loadSessionState,
     saveSessionState,
+    loadFavorites,
+    saveFavorites,
     loadFeedback,
     saveFeedback,
     clearAllData,

--- a/style.css
+++ b/style.css
@@ -492,6 +492,18 @@ textarea:disabled {
   color: var(--accent-color);
 }
 
+.favorite-toggle {
+  margin-left: 4px;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  font-size: 1em;
+}
+
+.favorite-toggle.favorited {
+  color: var(--accent-color);
+}
+
 #setup-config .form-row:first-of-type {
   clear: both;
 }

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -140,6 +140,8 @@ function setupDom(removeGear) {
   global.deleteSetup = jest.fn();
   global.loadFeedback = jest.fn(() => ({}));
   global.saveFeedback = jest.fn();
+  global.loadFavorites = jest.fn(() => ({}));
+  global.saveFavorites = jest.fn();
 }
 
 afterEach(() => {
@@ -537,6 +539,21 @@ describe('script.js functions', () => {
     const [alpha, beta] = sel.options;
     expect(alpha.hidden).toBe(true);
     expect(beta.hidden).toBe(false);
+  });
+
+  test('favorited option moves to top', () => {
+    localStorage.clear();
+    const sel = document.createElement('select');
+    sel.id = 'favTest';
+    document.body.appendChild(sel);
+    script.populateSelect(sel, { Alpha: {}, Beta: {}, Gamma: {} }, true);
+    sel.value = 'Gamma';
+    const btn = sel.nextElementSibling;
+    btn.click();
+    expect(Array.from(sel.options).map(o => o.value)).toEqual(['None', 'Gamma', 'Alpha', 'Beta']);
+    // Re-populate to ensure persistence
+    script.populateSelect(sel, { Alpha: {}, Beta: {}, Gamma: {} }, true);
+    expect(Array.from(sel.options).map(o => o.value)).toEqual(['None', 'Gamma', 'Alpha', 'Beta']);
   });
 
 

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -20,8 +20,10 @@ beforeAll(() => {
   global.saveSetup = jest.fn();
   global.loadSetup = jest.fn();
   global.deleteSetup = jest.fn();
-
+  
   require('../translations.js');
+  global.loadFavorites = jest.fn(() => ({}));
+  global.saveFavorites = jest.fn();
   utils = require('../script.js');
 });
 


### PR DESCRIPTION
## Summary
- let users mark selector options as favorites stored in local storage
- display favorite toggle buttons and elevate favorites to top of each list
- document and test favorites behaviour

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c71173b928832094d324bd6c6ceefd