### PR TITLE
Keep favorites next to selector

### DIFF
--- a/script.js
+++ b/script.js
@@ -4510,7 +4510,14 @@ function getTimecodes() {
       btn.className = 'favorite-toggle';
       btn.textContent = '☆';
       btn.addEventListener('click', () => toggleFavorite(selectElem));
-      selectElem.insertAdjacentElement('afterend', btn);
+      let wrapper = selectElem.parentElement;
+      if (!wrapper || !wrapper.classList.contains('select-wrapper')) {
+        wrapper = document.createElement('div');
+        wrapper.className = 'select-wrapper';
+        selectElem.insertAdjacentElement('beforebegin', wrapper);
+        wrapper.appendChild(selectElem);
+      }
+      wrapper.appendChild(btn);
       selectElem._favButton = btn;
       selectElem._favInit = true;
       selectElem.addEventListener('change', () => updateFavoriteButton(selectElem));

--- a/style.css
+++ b/style.css
@@ -453,7 +453,7 @@ body.hover-help-active * {
 /* Wrapper for selects to allow flexible layout */
 .select-wrapper {
   display: flex;
-  flex-direction: column;
+  align-items: center;
   flex: 1;
   min-width: 0; /* allow wrapper to shrink on narrow screens */
   position: relative;
@@ -461,7 +461,8 @@ body.hover-help-active * {
 
 /* Prevent long option text from widening selects on mobile */
 .select-wrapper select {
-  width: 100%;
+  flex: 1;
+  width: auto;
   max-width: 100%;
 }
 


### PR DESCRIPTION
## Summary
- Ensure favorites buttons sit inside selector wrappers
- Adjust select-wrapper styling to keep selects and favorite toggles on one line across layouts

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c71fc0a4e8832091e49a629e192017