### PR TITLE
feat: expand crew roles

### DIFF
--- a/script.js
+++ b/script.js
@@ -1885,11 +1885,14 @@ const crewRoles = [
   'Production Manager',
   'Director',
   'Assistant Director',
+  'Production Assistant',
 
   // Camera
   'DoP',
   'Camera Operator',
   'B-Camera Operator',
+  'Steadicam Operator',
+  'Drone Operator',
   '1st AC',
   '2nd AC',
   'DIT',
@@ -1899,11 +1902,15 @@ const crewRoles = [
   'Key Gaffer',
   'Gaffer',
   'Best Boy Electric',
+  'Electrician',
+  'Rigging Gaffer',
 
   // Grip
   'Key Grip',
   'Best Boy Grip',
-  'Grip'
+  'Grip',
+  'Dolly Grip',
+  'Rigging Grip'
 ];
 
 const projectFieldIcons = {

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -1887,9 +1887,12 @@ describe('script.js functions', () => {
       'Production Manager',
       'Director',
       'Assistant Director',
+      'Production Assistant',
       'DoP',
       'Camera Operator',
       'B-Camera Operator',
+      'Steadicam Operator',
+      'Drone Operator',
       '1st AC',
       '2nd AC',
       'DIT',
@@ -1897,9 +1900,13 @@ describe('script.js functions', () => {
       'Key Gaffer',
       'Gaffer',
       'Best Boy Electric',
+      'Electrician',
+      'Rigging Gaffer',
       'Key Grip',
       'Best Boy Grip',
-      'Grip'
+      'Grip',
+      'Dolly Grip',
+      'Rigging Grip'
     ]);
   });
 


### PR DESCRIPTION
## Summary
- broaden crew list with production assistants, additional camera ops, lighting techs, and grip roles
- keep crew roles ordered by department: Production, Camera, Lighting, Grip

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c71e7ac8d88320a660a740f066e657