### PR TITLE
Rename app to Cine Power Planner

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -1,4 +1,4 @@
-# 🎥 Power Planner
+# 🎥 Cine Power Planner
 
 Dieses browserbasierte Tool hilft beim Planen professioneller Kamera-Setups mit V‑Mount-Akkus. Es berechnet **Stromverbrauch**, **Stromstärke** (bei 14,4 V und 12 V) sowie die **geschätzte Akkulaufzeit** und prüft, ob der Akku genügend Leistung liefert.
 

--- a/README.en.md
+++ b/README.en.md
@@ -1,4 +1,4 @@
-# 🎥 Power Planner
+# 🎥 Cine Power Planner
 
 This browser based tool helps plan professional camera projects powered by V‑Mount batteries. It calculates **total power consumption**, **current draw** (at 14.4 V and 12 V) and **estimated battery runtime** while checking that the battery can safely supply the required power.
 
@@ -180,7 +180,7 @@ Once installed, the app launches from your home screen, works offline and update
 ## 📡 Offline Use & Data Storage
 
 Serving the app over HTTP(S) installs a service worker that caches every file
-so Power Planner works fully offline and updates in the background. Projects,
+so Cine Power Planner works fully offline and updates in the background. Projects,
 runtime submissions and preferences (language, theme, pink mode and saved gear
 lists) live in your browser's `localStorage`. Clearing the site's data in the
 browser removes all stored information.

--- a/README.es.md
+++ b/README.es.md
@@ -1,4 +1,4 @@
-# 🎥 Power Planner
+# 🎥 Cine Power Planner
 
 Esta herramienta en el navegador ayuda a planificar configuraciones profesionales con baterías V‑Mount. Calcula **el consumo total**, **la corriente** (a 14,4 V y 12 V) y **la autonomía estimada**, comprobando que la batería pueda entregar la potencia necesaria.
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -1,4 +1,4 @@
-# 🎥 Power Planner
+# 🎥 Cine Power Planner
 
 Cet outil fonctionnant dans le navigateur aide à planifier des configurations professionnelles alimentées par des batteries V‑Mount. Il calcule la **consommation totale**, le **courant** (à 14,4 V et 12 V) et l'**autonomie estimée**, tout en vérifiant que la batterie peut fournir la puissance requise.
 
@@ -105,7 +105,7 @@ Vous pouvez changer la langue en haut à droite; la préférence est mémorisée
 ## 📡 Utilisation hors ligne et stockage des données
 
 Servie via HTTP(S), l'application installe un service worker qui met en cache
-tous les fichiers afin que Power Planner fonctionne hors ligne et se mette à jour en
+tous les fichiers afin que Cine Power Planner fonctionne hors ligne et se mette à jour en
 arrière-plan. Les projets, rapports d'autonomie et préférences (langue, thème,
 mode rose et listes enregistrées) sont stockés dans le `localStorage` du
 navigateur. Effacer les données du site dans le navigateur supprime toutes les

--- a/README.it.md
+++ b/README.it.md
@@ -1,4 +1,4 @@
-# 🎥 Power Planner
+# 🎥 Cine Power Planner
 
 Questo strumento basato sul browser aiuta a pianificare configurazioni professionali alimentate da batterie V‑Mount. Calcola **consumo totale**, **corrente** (a 14,4 V e 12 V) e **durata stimata della batteria**, verificando che la batteria possa fornire in sicurezza la potenza richiesta.
 ---
@@ -104,7 +104,7 @@ Puoi cambiare la lingua nell'angolo in alto a destra e la scelta viene memorizza
 ## 📡 Uso offline e conservazione dei dati
 
 Quando viene servita via HTTP(S), l'app installa un service worker che memorizza
-in cache tutti i file affinché Power Planner funzioni senza connessione e si
+in cache tutti i file affinché Cine Power Planner funzioni senza connessione e si
 aggiorni in background. I progetti, i report di autonomia e le preferenze
 (lingua, tema, modalità rosa e liste salvate) vengono salvati nel `localStorage`
 del browser. Cancellando i dati del sito nel browser si rimuovono tutte le

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Power Planner
+# Cine Power Planner
 
-![Power Planner icon](icon.svg)
+![Cine Power Planner icon](icon.svg)
 
-Power Planner is a standalone web app for planning professional camera
+Cine Power Planner is a standalone web app for planning professional camera
 rigs powered by V‑Mount or B‑Mount batteries. It calculates total power draw,
 checks that batteries can safely deliver the required output, and estimates how
 long your project will run. The tool runs entirely in the browser and even works
@@ -140,7 +140,7 @@ Set up a development environment:
 
 ## Install as an App
 
-Power Planner is a Progressive Web App and can be installed for quick
+Cine Power Planner is a Progressive Web App and can be installed for quick
 access:
 
 1. Open `index.html` in a supported browser.
@@ -153,7 +153,7 @@ access:
 
 ## Offline Use and Data Storage
 
-When served over HTTP(S), Power Planner installs a service worker that caches all
+When served over HTTP(S), Cine Power Planner installs a service worker that caches all
 files so the planner runs entirely offline and pulls updates in the
 background. Projects, runtime submissions and preferences (language, theme,
 pink mode and saved gear lists) are stored locally via `localStorage` in your
@@ -162,7 +162,7 @@ information.
 
 ## Browser Support
 
-Power Planner relies on modern web APIs and is tested in current versions of Chrome, Firefox, Edge and Safari. Older browsers may lack support for features like installation or offline caching. For the best experience, use a browser with up-to-date Progressive Web App (PWA) capabilities.
+Cine Power Planner relies on modern web APIs and is tested in current versions of Chrome, Firefox, Edge and Safari. Older browsers may lack support for features like installation or offline caching. For the best experience, use a browser with up-to-date Progressive Web App (PWA) capabilities.
 
 ## Development
 

--- a/index.html
+++ b/index.html
@@ -7,17 +7,17 @@
   <meta name="mobile-web-app-capable" content="yes" />
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
   <meta name="description" content="Plan your film rig and calculate power consumption &amp; battery life." />
-  <meta property="og:title" content="Power Planner" />
+  <meta property="og:title" content="Cine Power Planner" />
   <meta property="og:description" content="Plan your film rig and calculate power consumption &amp; battery life." />
   <meta property="og:type" content="website" />
   <meta property="og:image" content="icon.png" />
   <meta name="theme-color" content="#f9f9f9" />
-  <meta name="application-name" content="Power Planner" />
-  <meta name="apple-mobile-web-app-title" content="Power Planner" />
+  <meta name="application-name" content="Cine Power Planner" />
+  <meta name="apple-mobile-web-app-title" content="Cine Power Planner" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; connect-src 'self'; img-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self'; manifest-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none';" />
   <meta name="referrer" content="no-referrer" />
   <meta name="color-scheme" content="light dark" />
-  <title>Power Planner</title>
+  <title>Cine Power Planner</title>
   <link rel="stylesheet" href="style.css" />
   <link rel="stylesheet" href="overview-print.css" media="print" />
   <link rel="icon" href="icon.svg" type="image/svg+xml" />
@@ -31,7 +31,7 @@
   <header id="topBar">
     <div class="branding">
       <img src="icon.svg" alt="" id="logo" />
-      <h1 id="mainTitle">Power Planner</h1>
+      <h1 id="mainTitle">Cine Power Planner</h1>
     </div>
     <button id="menuToggle" aria-label="Menu" aria-expanded="false">☰</button>
     <div class="feature-search">

--- a/manifest.webmanifest
+++ b/manifest.webmanifest
@@ -1,6 +1,6 @@
 {
-  "name": "Power Planner",
-  "short_name": "Power Planner",
+  "name": "Cine Power Planner",
+  "short_name": "Cine Power Planner",
   "start_url": ".",
   "display": "standalone",
   "background_color": "#1a1a1a",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "power-planner",
+  "name": "cine-power-planner",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "power-planner",
+      "name": "cine-power-planner",
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "power-planner",
+  "name": "cine-power-planner",
   "version": "1.0.0",
   "description": "Browser-based tool for planning professional camera setups powered by V-Mount or B-Mount batteries. It calculates total power consumption, current draw at 14.4 V and 12 V, and estimated battery runtime while checking that the battery can safely deliver the required power.",
   "main": "data.js",

--- a/script.js
+++ b/script.js
@@ -1,4 +1,4 @@
-// script.js – Main logic for the Power Planner app
+// script.js – Main logic for the Cine Power Planner app
 /* global texts, categoryNames, gearItems, loadSessionState, saveSessionState, loadProject, saveProject, deleteProject, registerDevice, loadFavorites, saveFavorites */
 
 // Use `var` here instead of `let` because `index.html` loads the lz-string
@@ -8044,7 +8044,7 @@ if (runtimeFeedbackBtn && feedbackDialog && feedbackForm) {
     Object.entries(entry).forEach(([k, v]) => {
       lines.push(`${k}: ${v}`);
     });
-    const subject = encodeURIComponent('Power Planner Runtime Feedback');
+    const subject = encodeURIComponent('Cine Power Planner Runtime Feedback');
     const body = encodeURIComponent(lines.join('\n'));
     window.location.href = `mailto:info@lucazanner.de?subject=${subject}&body=${body}`;
     closeDialog(feedbackDialog);

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,5 +1,5 @@
 /* eslint-env serviceworker */
-const CACHE_NAME = 'camera-power-planner-v14';
+const CACHE_NAME = 'cine-power-planner-v14';
 const ASSETS = [
   './',
   './index.html',

--- a/translations.js
+++ b/translations.js
@@ -2,7 +2,7 @@
 // Translation text for English, Italian, Spanish, French and German
 const texts = {
   en: {
-    appTitle: "Power Planner",
+    appTitle: "Cine Power Planner",
     tagline: "Plan your film rig and calculate power consumption & battery life.",
     skipToContent: "Skip to content",
     offlineIndicator: "Offline",
@@ -410,7 +410,7 @@ const texts = {
     // NEW TEXTS FOR SETUP MANAGEMENT END HERE
   },
   it: {
-    appTitle: "Power Planner",
+    appTitle: "Cine Power Planner",
     tagline: "Pianifica la tua configurazione cinematografica e calcola il consumo energetico e l'autonomia delle batterie.",
     skipToContent: "Vai al contenuto",
     offlineIndicator: "Non in linea",
@@ -790,7 +790,7 @@ const texts = {
     diagramMoveHint: "Trascina i nodi per spostarli. Trascina uno spazio vuoto per spostare il diagramma.",
   },
   es: {
-    appTitle: "Power Planner",
+    appTitle: "Cine Power Planner",
     tagline: "Planifica tu equipo de rodaje y calcula el consumo de energía y la autonomía de las baterías.",
     skipToContent: "Saltar al contenido",
     offlineIndicator: "Sin conexión",
@@ -1185,7 +1185,7 @@ const texts = {
     // NEW TEXTS FOR SETUP MANAGEMENT END HERE
   },
   fr: {
-    appTitle: "Power Planner",
+    appTitle: "Cine Power Planner",
     tagline: "Planifiez votre équipement de tournage et calculez la consommation énergétique et l'autonomie des batteries.",
     skipToContent: "Aller au contenu",
     offlineIndicator: "Hors ligne",
@@ -1582,7 +1582,7 @@ const texts = {
     // NEW TEXTS FOR SETUP MANAGEMENT END HERE
   },
   de: {
-    appTitle: "Power Planner",
+    appTitle: "Cine Power Planner",
     tagline: "Plane dein Film-Setup und berechne Stromverbrauch und Akkulaufzeit.",
     skipToContent: "Zum Inhalt springen",
     offlineIndicator: "Offline",


### PR DESCRIPTION
## Summary
- Rename app references to "Cine Power Planner" across HTML, manifest, translations, and scripts
- Update package metadata and service worker cache name for new branding
- Refresh documentation headings for the new app name

## Testing
- `npm run test:unit`


------
https://chatgpt.com/codex/tasks/task_e_68c71f2eb40c83209a70fcafa4a01155