### PR TITLE
Fix mobile layout for prep and shooting dates

### DIFF
--- a/style.css
+++ b/style.css
@@ -277,6 +277,36 @@ footer a {
   margin-left: 0;
 }
 
+/* Date range rows for prep and shooting days */
+.period-row {
+  display: flex;
+  align-items: center;
+  gap: var(--gap-size);
+  flex-wrap: wrap;
+  margin-bottom: var(--gap-size);
+}
+.period-row input {
+  flex: 1;
+  min-width: 120px;
+}
+.period-row span {
+  white-space: nowrap;
+}
+
+@media (max-width: 600px) {
+  .period-row {
+    flex-direction: column;
+    align-items: stretch;
+  }
+  .period-row span {
+    display: none;
+  }
+  .period-row button {
+    align-self: flex-end;
+  }
+}
+
+
 /* Small wrapper to show labels even when a value is present */
 .field-with-label {
   display: flex;


### PR DESCRIPTION
## Summary
- style period rows with flexbox and responsive tweaks for cleaner prep and shooting date inputs

## Testing
- `npm run test:unit`
- `npm run test:script` *(fails: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory)*


------
https://chatgpt.com/codex/tasks/task_e_68c7208baf0c8320b62eebdd4f3d704e