### PR TITLE
Include gear lists and requirements in project exports

### DIFF
--- a/script.js
+++ b/script.js
@@ -7699,11 +7699,27 @@ importFileInput.addEventListener("change", (event) => {
 
 // Export all saved setups to a JSON file
 exportSetupsBtn.addEventListener('click', () => {
-    const setupsToExport = getSetups();
-    if (Object.keys(setupsToExport).length === 0) {
+    const setups = getSetups();
+    if (Object.keys(setups).length === 0) {
         alert(texts[currentLang].alertNoSetupsToExport);
         return;
     }
+
+    const projects = typeof loadProject === 'function' ? loadProject() : {};
+    const setupsToExport = {};
+    Object.entries(setups).forEach(([name, setup]) => {
+        setupsToExport[name] = { ...setup };
+        const proj = projects[name];
+        if (proj) {
+            if (Object.prototype.hasOwnProperty.call(proj, 'gearList')) {
+                setupsToExport[name].gearList = proj.gearList;
+            }
+            if (Object.prototype.hasOwnProperty.call(proj, 'projectInfo')) {
+                setupsToExport[name].projectInfo = proj.projectInfo;
+            }
+        }
+    });
+
     const dataStr = JSON.stringify(setupsToExport, null, 2);
     const dataBlob = new Blob([dataStr], { type: 'application/json' });
     const url = URL.createObjectURL(dataBlob);

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -6378,6 +6378,34 @@ describe('monitor wireless metadata', () => {
     jest.useRealTimers();
   });
 
+  test('export all projects includes gear lists and requirements', async () => {
+    setupDom();
+    global.loadSetups = jest.fn(() => ({ Proj: { camera: 'CamA' } }));
+    global.saveSetups = jest.fn();
+    global.loadProject = jest.fn(() => ({ Proj: { gearList: '<ul>G</ul>', projectInfo: { projectName: 'Proj' } } }));
+    global.saveProject = jest.fn();
+    require('../translations.js');
+    const script = require('../script.js');
+    script.setLanguage('en');
+    let exportedBlob;
+    global.URL.createObjectURL = jest.fn((blob) => { exportedBlob = blob; return 'blob:url'; });
+    global.URL.revokeObjectURL = jest.fn();
+    const origCreate = document.createElement.bind(document);
+    document.createElement = (tag) => {
+      const el = origCreate(tag);
+      if (tag === 'a') {
+        el.click = jest.fn();
+      }
+      return el;
+    };
+    document.getElementById('exportSetupsBtn').click();
+    const text = await exportedBlob.text();
+    expect(JSON.parse(text)).toEqual({
+      Proj: { camera: 'CamA', gearList: '<ul>G</ul>', projectInfo: { projectName: 'Proj' } }
+    });
+    document.createElement = origCreate;
+  });
+
   test('import gear list sets setup name from file name', () => {
     setupDom();
     require('../translations.js');


### PR DESCRIPTION
## Summary
- include up-to-date gear lists and project requirements for each project when exporting all setups
- test export of all projects to ensure gear lists and requirements are included

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c721b213548320951b0eb6f2f2d39c