### PR TITLE
Align favorite star button with selects

### DIFF
--- a/style.css
+++ b/style.css
@@ -269,12 +269,18 @@ footer a {
 }
 
 /* Align add/remove buttons in form rows with input fields */
-.form-row > button {
+.form-row > button:not(.clear-input-btn):not(.favorite-toggle) {
   align-self: flex-end;
   margin-top: 5px;
 }
-.form-row > button + button {
+.form-row > button:not(.clear-input-btn):not(.favorite-toggle) + button:not(.clear-input-btn):not(.favorite-toggle) {
   margin-left: 0;
+}
+
+/* Ensure favorite star aligns with its select element */
+.select-wrapper .favorite-toggle {
+  align-self: center;
+  margin-top: 0;
 }
 
 /* Date range rows for prep and shooting days */


### PR DESCRIPTION
## Summary
- prevent form-row button alignment rules from affecting favorite star
- center the favorite star next to its select dropdown

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c73d1584d88320b4c537a39e17e8d7