### PR TITLE
Improve dark mode star button styling

### DIFF
--- a/style.css
+++ b/style.css
@@ -27,6 +27,7 @@
   --video-color: #369;
   --fiz-color: #090;
   --selected-row-bg: #e6f7ff;
+  --favorite-inactive-color: var(--control-text);
 }
 @media (max-width: 600px) {
   :root {
@@ -557,10 +558,14 @@ textarea:disabled {
   border: none;
   cursor: pointer;
   font-size: 1em;
+  color: var(--favorite-inactive-color);
+  transition: color 0.2s ease;
 }
-
+.favorite-toggle:hover {
+  color: var(--link-color);
+}
 .favorite-toggle.favorited {
-  color: var(--accent-color);
+  color: var(--link-color);
 }
 
 #setup-config .form-row:first-of-type {
@@ -1521,6 +1526,7 @@ body.dark-mode.pink-mode .help-content { border-color: var(--accent-color); }
     --panel-shadow: 0 2px 4px rgba(0, 0, 0, 0.5);
     --panel-shadow-hover: 0 4px 8px rgba(0, 0, 0, 0.6);
     --link-color: #7ec8ff;
+    --favorite-inactive-color: #bbb;
     --diagram-node-fill: #444;
     --power-color: #ff6666;
     --video-color: #7ec8ff;


### PR DESCRIPTION
## Summary
- Add `--favorite-inactive-color` CSS variable with dark mode override
- Style favorite toggle to use the new variable and `--link-color` for hover and active states

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c73dd77cac832098405c2a957a4a28