### PR TITLE
Enhance settings dialog styling

### DIFF
--- a/script.js
+++ b/script.js
@@ -2393,6 +2393,7 @@ const projectRequirementsOutput = document.getElementById("projectRequirementsOu
 
 // Load accent color from localStorage
 let accentColor = '#001589';
+let prevAccentColor = accentColor;
 try {
   const storedAccent = localStorage.getItem('accentColor');
   if (storedAccent) {
@@ -2403,6 +2404,20 @@ try {
 } catch (e) {
   console.warn('Could not load accent color', e);
 }
+prevAccentColor = accentColor;
+
+if (accentColorInput) {
+  accentColorInput.addEventListener('input', () => {
+    const color = accentColorInput.value;
+    document.documentElement.style.setProperty('--accent-color', color);
+    document.documentElement.style.setProperty('--link-color', color);
+  });
+}
+
+const revertAccentColor = () => {
+  document.documentElement.style.setProperty('--accent-color', prevAccentColor);
+  document.documentElement.style.setProperty('--link-color', prevAccentColor);
+};
 
 function populateFeatureSearch() {
   if (!featureList) return;
@@ -10361,6 +10376,7 @@ if (pinkModeToggle) {
 
 if (settingsButton && settingsDialog) {
   settingsButton.addEventListener('click', () => {
+    prevAccentColor = accentColor;
     if (settingsLanguage) settingsLanguage.value = currentLang;
     if (settingsDarkMode) settingsDarkMode.checked = document.body.classList.contains('dark-mode');
     if (accentColorInput) {
@@ -10374,6 +10390,7 @@ if (settingsButton && settingsDialog) {
 
   if (settingsCancel) {
     settingsCancel.addEventListener('click', () => {
+      revertAccentColor();
       settingsDialog.setAttribute('hidden', '');
     });
   }
@@ -10402,13 +10419,17 @@ if (settingsButton && settingsDialog) {
           console.warn('Could not save accent color', e);
         }
         accentColor = color;
+        prevAccentColor = color;
       }
       settingsDialog.setAttribute('hidden', '');
     });
   }
 
   settingsDialog.addEventListener('click', e => {
-    if (e.target === settingsDialog) settingsDialog.setAttribute('hidden', '');
+    if (e.target === settingsDialog) {
+      revertAccentColor();
+      settingsDialog.setAttribute('hidden', '');
+    }
   });
 }
 
@@ -10798,6 +10819,7 @@ if (helpButton && helpDialog) {
     } else if (
       e.key === 'Escape' && settingsDialog && !settingsDialog.hasAttribute('hidden')
     ) {
+      revertAccentColor();
       settingsDialog.setAttribute('hidden', '');
     } else if (
       e.key === 'F1' ||

--- a/style.css
+++ b/style.css
@@ -397,18 +397,27 @@ footer a {
   color: var(--text-color);
 }
 
+
 .settings-content {
   background: var(--surface-color);
   border: 2px solid var(--accent-color);
   padding: 20px;
   color: var(--text-color);
+  width: min(90vw, 400px);
+  max-height: 80vh;
+  overflow-y: auto;
+  border-radius: var(--border-radius);
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.2);
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
 }
 
 .settings-content .button-row {
   display: flex;
   justify-content: flex-end;
   gap: 10px;
-  margin-top: 10px;
+  margin-top: auto;
 }
 
 .help-content p,


### PR DESCRIPTION
## Summary
- Add responsive layout, scrolling, and border radius to settings dialog
- Live preview of accent color with option to cancel changes
- Revert accent color when dialog dismissed

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c73df226d0832085c34ffbded670b9