### PR TITLE
Fix accent color selector to apply sitewide

### DIFF
--- a/script.js
+++ b/script.js
@@ -2394,12 +2394,21 @@ const projectRequirementsOutput = document.getElementById("projectRequirementsOu
 // Load accent color from localStorage
 let accentColor = '#001589';
 let prevAccentColor = accentColor;
+
+const applyAccentColor = (color) => {
+  document.documentElement.style.setProperty('--accent-color', color);
+  document.documentElement.style.setProperty('--link-color', color);
+  if (document.body) {
+    document.body.style.setProperty('--accent-color', color);
+    document.body.style.setProperty('--link-color', color);
+  }
+};
+
 try {
   const storedAccent = localStorage.getItem('accentColor');
   if (storedAccent) {
     accentColor = storedAccent;
-    document.documentElement.style.setProperty('--accent-color', accentColor);
-    document.documentElement.style.setProperty('--link-color', accentColor);
+    applyAccentColor(accentColor);
   }
 } catch (e) {
   console.warn('Could not load accent color', e);
@@ -2409,14 +2418,12 @@ prevAccentColor = accentColor;
 if (accentColorInput) {
   accentColorInput.addEventListener('input', () => {
     const color = accentColorInput.value;
-    document.documentElement.style.setProperty('--accent-color', color);
-    document.documentElement.style.setProperty('--link-color', color);
+    applyAccentColor(color);
   });
 }
 
 const revertAccentColor = () => {
-  document.documentElement.style.setProperty('--accent-color', prevAccentColor);
-  document.documentElement.style.setProperty('--link-color', prevAccentColor);
+  applyAccentColor(prevAccentColor);
 };
 
 function populateFeatureSearch() {
@@ -10411,8 +10418,7 @@ if (settingsButton && settingsDialog) {
       }
       if (accentColorInput) {
         const color = accentColorInput.value;
-        document.documentElement.style.setProperty('--accent-color', color);
-        document.documentElement.style.setProperty('--link-color', color);
+        applyAccentColor(color);
         try {
           localStorage.setItem('accentColor', color);
         } catch (e) {

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -1816,6 +1816,18 @@ describe('script.js functions', () => {
     expect(dialog.hasAttribute('hidden')).toBe(true);
   });
 
+  test('accent color input updates body and root variables', () => {
+    const { applyPinkMode } = script;
+    applyPinkMode(true);
+    const colorInput = document.getElementById('accentColorInput');
+    colorInput.value = '#654321';
+    colorInput.dispatchEvent(new Event('input'));
+    expect(document.documentElement.style.getPropertyValue('--accent-color')).toBe('#654321');
+    expect(document.documentElement.style.getPropertyValue('--link-color')).toBe('#654321');
+    expect(document.body.style.getPropertyValue('--accent-color')).toBe('#654321');
+    expect(document.body.style.getPropertyValue('--link-color')).toBe('#654321');
+  });
+
   test('generatePrintableOverview includes diagram and device blocks', () => {
     const { generatePrintableOverview } = script;
     document.getElementById('setupName').value = 'Test';


### PR DESCRIPTION
## Summary
- ensure accent color updates both root and body so custom colors fully apply
- test that accent color input sets variables on root and body

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c75ac930988320a002c601e2210c54