### PR TITLE
Prevent settings menu from auto-opening language picker

### DIFF
--- a/script.js
+++ b/script.js
@@ -10421,7 +10421,8 @@ if (settingsButton && settingsDialog) {
       accentColorInput.value = stored || accentColor;
     }
     settingsDialog.removeAttribute('hidden');
-    const first = settingsDialog.querySelector('select, input');
+    // Focus the first control except the language selector to avoid opening it automatically
+    const first = settingsDialog.querySelector('input, select:not(#settingsLanguage)');
     if (first) first.focus();
   });
 


### PR DESCRIPTION
## Summary
- avoid focusing the language dropdown when opening settings to stop the selector from opening automatically

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c75df8bc68832082e0232aef033f45