### PR TITLE
Fix high contrast mode toggle

### DIFF
--- a/script.js
+++ b/script.js
@@ -10360,8 +10360,10 @@ if (darkModeToggle) {
 function applyHighContrast(enabled) {
   if (enabled) {
     document.body.classList.add("high-contrast");
+    document.documentElement.classList.add("high-contrast");
   } else {
     document.body.classList.remove("high-contrast");
+    document.documentElement.classList.remove("high-contrast");
   }
 }
 

--- a/style.css
+++ b/style.css
@@ -1471,6 +1471,7 @@ html.dark-mode,
   --selected-row-bg: #003366;
 }
 
+html.high-contrast,
 body.high-contrast {
   --background-color: #000;
   --surface-color: #000;

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -1814,6 +1814,7 @@ describe('script.js functions', () => {
     expect(localStorage.getItem('highContrast')).toBe('true');
     expect(localStorage.getItem('accentColor')).toBe('#123456');
     expect(document.body.classList.contains('high-contrast')).toBe(true);
+    expect(document.documentElement.classList.contains('high-contrast')).toBe(true);
     expect(dialog.hasAttribute('hidden')).toBe(true);
   });
 


### PR DESCRIPTION
## Summary
- Apply `high-contrast` class to both `<body>` and `<html>` when setting is enabled
- Update CSS and tests to cover high contrast styling

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c75fc8b300832096a00abfbc82f244