### PR TITLE
Include user data in backup and restore

### DIFF
--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -331,6 +331,69 @@ describe('auto backup', () => {
   });
 });
 
+describe('settings backup and restore', () => {
+  test('includes user data in backup and restores it', async () => {
+    jest.useFakeTimers();
+    setupDom(false);
+    global.loadSetups = jest.fn(() => ({}));
+    global.saveSetups = jest.fn();
+    global.loadDeviceData = jest.fn(() => ({}));
+    global.saveDeviceData = jest.fn();
+    global.loadSessionState = jest.fn(() => null);
+    global.saveSessionState = jest.fn();
+    global.loadProject = jest.fn(() => ({}));
+    global.saveProject = jest.fn();
+    global.deleteProject = jest.fn();
+    global.loadFavorites = jest.fn(() => ({}));
+    global.saveFavorites = jest.fn();
+
+    const backupBtn = document.createElement('button');
+    backupBtn.id = 'backupSettings';
+    document.body.appendChild(backupBtn);
+    const restoreBtn = document.createElement('button');
+    restoreBtn.id = 'restoreSettings';
+    document.body.appendChild(restoreBtn);
+    const restoreInput = document.createElement('input');
+    restoreInput.type = 'file';
+    restoreInput.id = 'restoreSettingsInput';
+    document.body.appendChild(restoreInput);
+
+    global.exportAllData = jest.fn(() => ({ foo: 'bar' }));
+    global.importAllData = jest.fn();
+
+    require('../translations.js');
+    const script = require('../script.js');
+    script.setLanguage('en');
+
+    global.URL.createObjectURL = jest.fn(() => 'blob:url');
+    global.URL.revokeObjectURL = jest.fn();
+    const origCreateElement = document.createElement.bind(document);
+    const anchor = { href: '', download: '', click: jest.fn() };
+    document.createElement = jest.fn(tag => tag === 'a' ? anchor : origCreateElement(tag));
+
+    backupBtn.dispatchEvent(new window.Event('click'));
+    expect(global.exportAllData).toHaveBeenCalled();
+    const blob = global.URL.createObjectURL.mock.calls[0][0];
+    const text = await blob.text();
+    const obj = JSON.parse(text);
+    expect(obj.data).toEqual({ foo: 'bar' });
+
+    document.createElement = origCreateElement;
+
+    const fileData = JSON.stringify(obj);
+    global.FileReader = class {
+      readAsText() {
+        this.onload({ target: { result: fileData } });
+      }
+    };
+    Object.defineProperty(restoreInput, 'files', { value: [new Blob()] });
+    restoreBtn.dispatchEvent(new window.Event('click'));
+    restoreInput.dispatchEvent(new window.Event('change'));
+    expect(global.importAllData).toHaveBeenCalledWith({ foo: 'bar' });
+    jest.useRealTimers();
+  });
+});
+
 describe('script.js functions', () => {
   let script;
 


### PR DESCRIPTION
## Summary
- Extend settings backup to include all planner data by exporting stored devices, setups, projects, feedback, and session state
- Restore backups by reapplying settings and importing saved planner data
- Test backup/restore pipeline to ensure user data persists

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c75e2053cc832094308a0264418db0