### PR TITLE
Sync theme toggles and prioritize pink accent

### DIFF
--- a/script.js
+++ b/script.js
@@ -2424,6 +2424,7 @@ prevAccentColor = accentColor;
 
 if (accentColorInput) {
   accentColorInput.addEventListener('input', () => {
+    if (document.body.classList.contains('pink-mode')) return;
     const color = accentColorInput.value;
     applyAccentColor(color);
   });
@@ -10326,6 +10327,9 @@ function applyDarkMode(enabled) {
     }
   }
   updateThemeColor(enabled);
+  if (settingsDarkMode) {
+    settingsDarkMode.checked = enabled;
+  }
 }
 
 let darkModeEnabled = false;
@@ -10375,12 +10379,25 @@ applyHighContrast(highContrastEnabled);
 function applyPinkMode(enabled) {
   if (enabled) {
     document.body.classList.add("pink-mode");
+    if (accentColorInput) {
+      accentColorInput.disabled = true;
+    }
+    document.documentElement.style.removeProperty('--accent-color');
+    document.documentElement.style.removeProperty('--link-color');
+    if (document.body) {
+      document.body.style.removeProperty('--accent-color');
+      document.body.style.removeProperty('--link-color');
+    }
     if (pinkModeToggle) {
       pinkModeToggle.textContent = "🦄";
       pinkModeToggle.setAttribute("aria-pressed", "true");
     }
   } else {
     document.body.classList.remove("pink-mode");
+    if (accentColorInput) {
+      accentColorInput.disabled = false;
+    }
+    applyAccentColor(accentColor);
     if (pinkModeToggle) {
       pinkModeToggle.textContent = "🐴";
       pinkModeToggle.setAttribute("aria-pressed", "false");

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -1818,32 +1818,45 @@ describe('script.js functions', () => {
     const { applyDarkMode } = script;
     const toggle = document.getElementById('darkModeToggle');
     const meta = document.querySelector('meta[name="theme-color"]');
+    const checkbox = document.getElementById('settingsDarkMode');
     applyDarkMode(true);
     expect(document.body.classList.contains('dark-mode')).toBe(true);
     expect(document.documentElement.classList.contains('dark-mode')).toBe(true);
     expect(toggle.textContent).toBe('☀️');
     expect(toggle.getAttribute('aria-pressed')).toBe('true');
     expect(meta.getAttribute('content')).toBe('#1c1c1e');
+    expect(checkbox.checked).toBe(true);
     applyDarkMode(false);
     expect(document.body.classList.contains('dark-mode')).toBe(false);
     expect(document.documentElement.classList.contains('dark-mode')).toBe(false);
     expect(toggle.textContent).toBe('🌙');
     expect(toggle.getAttribute('aria-pressed')).toBe('false');
     expect(meta.getAttribute('content')).toBe('#ffffff');
+    expect(checkbox.checked).toBe(false);
   });
 
-  test('applyPinkMode toggles class and aria-pressed', () => {
+  test('applyPinkMode overrides accent color and disables input', () => {
     const { applyPinkMode } = script;
     const toggle = document.getElementById('pinkModeToggle');
+    const colorInput = document.getElementById('accentColorInput');
+    colorInput.value = '#123456';
+    colorInput.dispatchEvent(new Event('input'));
+    expect(document.documentElement.style.getPropertyValue('--accent-color')).toBe('#123456');
     applyPinkMode(true);
     expect(document.body.classList.contains('pink-mode')).toBe(true);
     expect(toggle.textContent).toBe('🦄');
     expect(toggle.getAttribute('aria-pressed')).toBe('true');
+    expect(colorInput.disabled).toBe(true);
+    expect(getComputedStyle(document.body).getPropertyValue('--accent-color').trim()).toBe('#ff69b4');
+    colorInput.value = '#654321';
+    colorInput.dispatchEvent(new Event('input'));
     expect(getComputedStyle(document.body).getPropertyValue('--accent-color').trim()).toBe('#ff69b4');
     applyPinkMode(false);
     expect(document.body.classList.contains('pink-mode')).toBe(false);
     expect(toggle.textContent).toBe('🐴');
     expect(toggle.getAttribute('aria-pressed')).toBe('false');
+    expect(colorInput.disabled).toBe(false);
+    expect(document.documentElement.style.getPropertyValue('--accent-color')).toBe('#123456');
   });
 
   test('settings dialog saves preferences to localStorage', () => {
@@ -1869,9 +1882,9 @@ describe('script.js functions', () => {
     expect(dialog.hasAttribute('hidden')).toBe(true);
   });
 
-  test('accent color input updates body and root variables', () => {
+  test('accent color input updates body and root variables when pink mode off', () => {
     const { applyPinkMode } = script;
-    applyPinkMode(true);
+    applyPinkMode(false);
     const colorInput = document.getElementById('accentColorInput');
     colorInput.value = '#654321';
     colorInput.dispatchEvent(new Event('input'));


### PR DESCRIPTION
## Summary
- ensure pink mode takes precedence over custom accent color and disables the selector
- keep dark mode toggle and settings checkbox in sync for consistent theming
- expand tests for accent color override and dark mode linkage

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c7621c0c688320afb3b92b4edd7ab4