### PR TITLE
Expand help dialog with new features

### DIFF
--- a/index.html
+++ b/index.html
@@ -746,6 +746,8 @@
             <li>Visualize power and video connections with an interactive diagram—drag to rearrange, pan, snap to grid, reset the view, zoom and download the layout.</li>
             <li>Compare battery runtimes and check against safe output limits.</li>
             <li>Customize the device database with your own gear.</li>
+            <li>Generate categorized gear lists and printable project overviews with one click.</li>
+            <li>Refine runtime estimates with user feedback and a visual weighting dashboard.</li>
             <li>Open a searchable help dialog with step-by-step guides and FAQ.</li>
             <li>Switch languages, toggle dark or playful pink themes and work fully offline. Theme settings persist.</li>
             <li>Cameras with both V- and B-Mount plates let you swap battery types; the list updates automatically.</li>
@@ -870,7 +872,7 @@
             <li>Click <strong>Reset View</strong> to restore the default layout and zoom.</li>
             <li>Export the diagram as SVG or JPG via the <em>Download</em> button.</li>
             <li>Icons denote device types and warn when FIZ brands are incompatible.</li>
-            <li>Hover or tap devices to see popup details.</li>
+            <li>Hover or tap devices to see popup details; on touch devices, tapping a node keeps its popup until another is selected.</li>
           </ul>
         </section>
         <section data-help-section id="deviceEditorHelp">
@@ -905,7 +907,7 @@
         <section data-help-section id="helpDialogHelp">
           <h3><span class="help-icon" aria-hidden="true">❓</span>Help Dialog</h3>
           <ul>
-            <li>Open with the <strong>?</strong> button or press <kbd>?</kbd>, <kbd>H</kbd> or <kbd>F1</kbd>.</li>
+            <li>Open with the <strong>?</strong> button or press <kbd>?</kbd>, <kbd>H</kbd>, <kbd>F1</kbd> or <kbd>Ctrl</kbd>+<kbd>/</kbd> (works even while typing).</li>
             <li>Use the search field to filter topics; the query resets when closed.</li>
             <li>Press <kbd>/</kbd> or <kbd>Ctrl</kbd>+<kbd>F</kbd> (<kbd>⌘</kbd>+<kbd>F</kbd> on macOS) to jump to the search box.</li>
             <li>Close the dialog with <kbd>Escape</kbd> or by clicking outside.</li>
@@ -944,7 +946,7 @@
         <section data-help-section id="shortcuts">
           <h3><span class="help-icon" aria-hidden="true">⌨️</span>Keyboard Shortcuts</h3>
           <ul>
-            <li><kbd>?</kbd>, <kbd>H</kbd> or <kbd>F1</kbd> – toggle help</li>
+            <li><kbd>?</kbd>, <kbd>H</kbd>, <kbd>F1</kbd> or <kbd>Ctrl</kbd>+<kbd>/</kbd> – toggle help</li>
             <li><kbd>Escape</kbd> – close dialogs</li>
             <li><kbd>D</kbd> – toggle dark mode</li>
             <li><kbd>P</kbd> – toggle pink mode</li>

--- a/style.css
+++ b/style.css
@@ -395,6 +395,9 @@ footer a {
   max-height: 80vh;
   overflow-y: auto;
   color: var(--text-color);
+  width: min(90vw, 700px);
+  border-radius: var(--border-radius);
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.2);
 }
 
 


### PR DESCRIPTION
## Summary
- document new gear list and runtime feedback features in help
- mention touch popup behavior for the diagram
- document Ctrl+/ help shortcut and tweak help dialog styling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c764aef57c832091f19a99e2ff7ab3