### PR TITLE
Handle primitive port entries in normalization

### DIFF
--- a/tests/unifyPorts.test.js
+++ b/tests/unifyPorts.test.js
@@ -182,6 +182,14 @@ describe('cleanPort', () => {
   it('handles primitive values without throwing', () => {
     expect(() => cleanPort('USB-C')).not.toThrow();
   });
+  it('converts string entries inside arrays to objects', () => {
+    const arr = ['USB Type-C', { portType: 'HDMI port' }];
+    cleanPort(arr);
+    expect(arr).toEqual([
+      { type: 'USB-C' },
+      { type: 'HDMI' }
+    ]);
+  });
 });
 
 describe('normalizeVideoPorts', () => {

--- a/unifyPorts.js
+++ b/unifyPorts.js
@@ -99,7 +99,15 @@ function deepClean(obj) {
 function cleanPort(port) {
   if (!port) return;
   if (Array.isArray(port)) {
-    port.forEach(cleanPort);
+    // Convert primitive entries (e.g. strings) into port objects so that
+    // arrays can be normalized consistently. Recursively clean any newly
+    // created objects as well as existing ones.
+    port.forEach((p, i) => {
+      if (typeof p === 'string') {
+        port[i] = { type: cleanTypeName(p) };
+      }
+      cleanPort(port[i]);
+    });
     return;
   }
   // Guard against primitive values (e.g. strings) which would cause the


### PR DESCRIPTION
## Summary
- ensure `cleanPort` converts string entries in port arrays into normalized objects
- add regression test for array handling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c764ca84248320be6984b061ceb331