### PR TITLE
Ensure favorites are backed up and auto-backup before restore

### DIFF
--- a/script.js
+++ b/script.js
@@ -10471,24 +10471,26 @@ if (settingsButton && settingsDialog) {
   });
 }
 
+function createSettingsBackup() {
+  try {
+    const backup = {
+      settings: { ...localStorage },
+      data: typeof exportAllData === 'function' ? exportAllData() : {},
+    };
+    const blob = new Blob([JSON.stringify(backup)], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'planner-backup.json';
+    a.click();
+    URL.revokeObjectURL(url);
+  } catch (e) {
+    console.warn('Backup failed', e);
+  }
+}
+
 if (backupSettings) {
-  backupSettings.addEventListener('click', () => {
-    try {
-      const backup = {
-        settings: { ...localStorage },
-        data: typeof exportAllData === 'function' ? exportAllData() : {},
-      };
-      const blob = new Blob([JSON.stringify(backup)], { type: 'application/json' });
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement('a');
-      a.href = url;
-      a.download = 'planner-backup.json';
-      a.click();
-      URL.revokeObjectURL(url);
-    } catch (e) {
-      console.warn('Backup failed', e);
-    }
-  });
+  backupSettings.addEventListener('click', createSettingsBackup);
 }
 
 if (restoreSettings && restoreSettingsInput) {
@@ -10496,6 +10498,7 @@ if (restoreSettings && restoreSettingsInput) {
   restoreSettingsInput.addEventListener('change', () => {
     const file = restoreSettingsInput.files[0];
     if (!file) return;
+    createSettingsBackup();
     const reader = new FileReader();
     reader.onload = e => {
       try {

--- a/storage.js
+++ b/storage.js
@@ -482,6 +482,7 @@ function exportAllData() {
     session: loadSessionState(),
     feedback: loadFeedback(),
     project: loadProject(),
+    favorites: loadFavorites(),
   };
 }
 
@@ -498,6 +499,9 @@ function importAllData(allData) {
     }
     if (allData.feedback) {
       saveFeedback(allData.feedback);
+    }
+    if (allData.favorites) {
+      saveFavorites(allData.favorites);
     }
     if (allData.project) {
       Object.entries(allData.project).forEach(([name, proj]) => {

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -358,7 +358,7 @@ describe('settings backup and restore', () => {
     restoreInput.id = 'restoreSettingsInput';
     document.body.appendChild(restoreInput);
 
-    global.exportAllData = jest.fn(() => ({ foo: 'bar' }));
+    global.exportAllData = jest.fn(() => ({ foo: 'bar', favorites: { cat: ['A'] } }));
     global.importAllData = jest.fn();
 
     require('../translations.js');
@@ -372,11 +372,11 @@ describe('settings backup and restore', () => {
     document.createElement = jest.fn(tag => tag === 'a' ? anchor : origCreateElement(tag));
 
     backupBtn.dispatchEvent(new window.Event('click'));
-    expect(global.exportAllData).toHaveBeenCalled();
+    expect(global.exportAllData).toHaveBeenCalledTimes(1);
     const blob = global.URL.createObjectURL.mock.calls[0][0];
     const text = await blob.text();
     const obj = JSON.parse(text);
-    expect(obj.data).toEqual({ foo: 'bar' });
+    expect(obj.data).toEqual({ foo: 'bar', favorites: { cat: ['A'] } });
 
     document.createElement = origCreateElement;
 
@@ -389,7 +389,8 @@ describe('settings backup and restore', () => {
     Object.defineProperty(restoreInput, 'files', { value: [new Blob()] });
     restoreBtn.dispatchEvent(new window.Event('click'));
     restoreInput.dispatchEvent(new window.Event('change'));
-    expect(global.importAllData).toHaveBeenCalledWith({ foo: 'bar' });
+    expect(global.exportAllData).toHaveBeenCalledTimes(2);
+    expect(global.importAllData).toHaveBeenCalledWith({ foo: 'bar', favorites: { cat: ['A'] } });
     jest.useRealTimers();
   });
 });

--- a/tests/storage.test.js
+++ b/tests/storage.test.js
@@ -13,6 +13,8 @@ const {
     saveFeedback,
     saveProject,
     loadProject,
+    loadFavorites,
+    saveFavorites,
     clearAllData,
     exportAllData,
     importAllData,
@@ -302,12 +304,14 @@ describe('export/import all data', () => {
     saveSessionState({ camera: 'CamA' });
     saveFeedback({ note: 'hi' });
     saveProject('Proj', { gearList: '<ul></ul>' });
+    saveFavorites({ cat: ['A'] });
     expect(exportAllData()).toEqual({
       devices: validDeviceData,
       setups: { A: { foo: 1 } },
       session: { camera: 'CamA' },
       feedback: { note: 'hi' },
-      project: { Proj: { gearList: '<ul></ul>', projectInfo: null } }
+      project: { Proj: { gearList: '<ul></ul>', projectInfo: null } },
+      favorites: { cat: ['A'] }
     });
   });
 
@@ -317,7 +321,8 @@ describe('export/import all data', () => {
       setups: { A: { foo: 1 } },
       session: { camera: 'CamA' },
       feedback: { note: 'hi' },
-      project: { Proj: { gearList: '<ol></ol>' } }
+      project: { Proj: { gearList: '<ol></ol>' } },
+      favorites: { cat: ['B'] }
     };
     importAllData(data);
     expect(loadDeviceData()).toEqual(validDeviceData);
@@ -325,6 +330,7 @@ describe('export/import all data', () => {
     expect(loadSessionState()).toEqual({ camera: 'CamA' });
     expect(loadFeedback()).toEqual({ note: 'hi' });
     expect(loadProject('Proj')).toEqual({ gearList: '<ol></ol>', projectInfo: null });
+    expect(loadFavorites()).toEqual({ cat: ['B'] });
   });
 });
 


### PR DESCRIPTION
## Summary
- Include favorites in exported planner data and restore them when importing
- Add `createSettingsBackup` utility and trigger it before loading restored data
- Update tests for favorites backup/restore and automatic backup

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c765278c0883208cfc0d387477183c