### PR TITLE
Ensure clearAllData removes favorites

### DIFF
--- a/storage.js
+++ b/storage.js
@@ -466,6 +466,9 @@ function clearAllData() {
   deleteFromStorage(SAFE_LOCAL_STORAGE, DEVICE_STORAGE_KEY, msg);
   deleteFromStorage(SAFE_LOCAL_STORAGE, SETUP_STORAGE_KEY, msg);
   deleteFromStorage(SAFE_LOCAL_STORAGE, FEEDBACK_STORAGE_KEY, msg);
+  // Favorites were added later and can be forgotten if not explicitly cleared.
+  // Ensure they are removed alongside other stored planner data.
+  deleteFromStorage(SAFE_LOCAL_STORAGE, FAVORITES_STORAGE_KEY, msg);
   deleteFromStorage(SAFE_LOCAL_STORAGE, PROJECT_STORAGE_KEY, msg);
   deleteFromStorage(SAFE_LOCAL_STORAGE, SESSION_STATE_KEY, msg);
   if (typeof sessionStorage !== 'undefined') {

--- a/tests/storage.test.js
+++ b/tests/storage.test.js
@@ -25,6 +25,7 @@ const SETUP_KEY = 'cameraPowerPlanner_setups';
 const SESSION_KEY = 'cameraPowerPlanner_session';
 const FEEDBACK_KEY = 'cameraPowerPlanner_feedback';
 const PROJECT_KEY = 'cameraPowerPlanner_project';
+const FAVORITES_KEY = 'cameraPowerPlanner_favorites';
 
 const validDeviceData = {
   cameras: {},
@@ -282,6 +283,7 @@ describe('clearAllData', () => {
     saveSetups({ A: { foo: 1 } });
     saveFeedback({ note: 'hi' });
     saveProject('Proj', { gearList: '<ul></ul>' });
+    saveFavorites({ cat: ['A'] });
     saveSessionState({ camera: 'CamA' });
     clearAllData();
     expect(localStorage.getItem(DEVICE_KEY)).toBeNull();
@@ -289,6 +291,7 @@ describe('clearAllData', () => {
     expect(localStorage.getItem(FEEDBACK_KEY)).toBeNull();
     expect(localStorage.getItem(PROJECT_KEY)).toBeNull();
     expect(localStorage.getItem(SESSION_KEY)).toBeNull();
+    expect(localStorage.getItem(FAVORITES_KEY)).toBeNull();
   });
 });
 


### PR DESCRIPTION
## Summary
- Clear stored favorites when wiping planner data
- Add regression test verifying favorites removal

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c76758f7a8832086e06529e123cbf1