### PR TITLE
feat: add email field to crew list

### DIFF
--- a/script.js
+++ b/script.js
@@ -1980,11 +1980,16 @@ function createCrewRow(data = {}) {
   phoneInput.placeholder = 'Phone';
   phoneInput.className = 'person-phone';
   phoneInput.value = data.phone || '';
+  const emailInput = document.createElement('input');
+  emailInput.type = 'email';
+  emailInput.placeholder = 'Email';
+  emailInput.className = 'person-email';
+  emailInput.value = data.email || '';
   const removeBtn = document.createElement('button');
   removeBtn.type = 'button';
   removeBtn.textContent = '−';
   removeBtn.addEventListener('click', () => row.remove());
-  row.append(roleSel, nameInput, phoneInput, removeBtn);
+  row.append(roleSel, nameInput, phoneInput, emailInput, removeBtn);
   crewContainer.appendChild(row);
 }
 
@@ -8442,7 +8447,8 @@ function collectProjectFormData() {
     const people = Array.from(crewContainer?.querySelectorAll('.person-row') || []).map(row => ({
         role: row.querySelector('select')?.value,
         name: row.querySelector('.person-name')?.value.trim(),
-        phone: row.querySelector('.person-phone')?.value.trim()
+        phone: row.querySelector('.person-phone')?.value.trim(),
+        email: row.querySelector('.person-email')?.value?.trim()
     })).filter(p => p.role && p.name);
     const collectRanges = (container, startSel, endSel) => Array.from(container?.querySelectorAll('.period-row') || [])
         .map(row => {
@@ -8851,7 +8857,10 @@ function generateGearListHtml(info = {}) {
     if (Array.isArray(info.people)) {
         const crewEntries = info.people
             .filter(p => p.role && p.name)
-            .map(p => p.phone ? `${p.role}: ${p.name} (${p.phone})` : `${p.role}: ${p.name}`);
+            .map(p => {
+                const details = [p.phone, p.email].filter(Boolean).join(', ');
+                return details ? `${p.role}: ${p.name} (${details})` : `${p.role}: ${p.name}`;
+            });
         if (crewEntries.length) {
             projectInfo.crew = crewEntries.join('\n');
         }

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -2217,11 +2217,11 @@ describe('script.js functions', () => {
     document.getElementById('batteryCount').textContent = '1';
     const html = generateGearListHtml({
       people: [
-        { role: 'DoP', name: 'Alice', phone: '111' },
+        { role: 'DoP', name: 'Alice', phone: '111', email: 'alice@example.com' },
         { role: 'AC', name: 'Bob', phone: '222' }
       ]
     });
-    expect(html).toContain('<span class="req-value">DoP: Alice (111)<br>AC: Bob (222)</span>');
+    expect(html).toContain('<span class="req-value">DoP: Alice (111, alice@example.com)<br>AC: Bob (222)</span>');
   });
 
   test('custom filter selections override defaults', () => {
@@ -6249,14 +6249,14 @@ describe('script.js functions', () => {
     global.URL.createObjectURL = jest.fn(() => 'blob:url');
     document.getElementById('setupName').value = 'Proj';
     const crew = document.getElementById('crewContainer');
-    crew.innerHTML = '<div class="person-row"><select><option value="DoP" selected>DoP</option></select><input class="person-name" value="Alice"/><input class="person-phone" value="555"/></div>';
+    crew.innerHTML = '<div class="person-row"><select><option value="DoP" selected>DoP</option></select><input class="person-name" value="Alice"/><input class="person-phone" value="555"/><input class="person-email" value="alice@example.com"/></div>';
     global.loadProject = jest.fn(() => null);
     global.saveProject = jest.fn();
     document.getElementById('shareSetupBtn').click();
     const blob = URL.createObjectURL.mock.calls[0][0];
     const text = await blob.text();
     const data = JSON.parse(text);
-    expect(data.projectInfo.people[0]).toEqual({ role: 'DoP', name: 'Alice', phone: '555' });
+    expect(data.projectInfo.people[0]).toEqual({ role: 'DoP', name: 'Alice', phone: '555', email: 'alice@example.com' });
   });
 
   test('applySharedSetup applies gear selectors and project info', () => {


### PR DESCRIPTION
## Summary
- allow entering an email alongside phone and role for crew members
- capture crew emails when gathering project info and display them in summaries
- extend tests for sharing setups and gear list summary with crew emails

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c7cd8645408320be4c600878c154a2