### PR TITLE
Avoid duplicate favorites on hidden selects

### DIFF
--- a/script.js
+++ b/script.js
@@ -4594,7 +4594,7 @@ function getTimecodes() {
   }
 
   function initFavoritableSelect(selectElem) {
-    if (!selectElem || !selectElem.id || selectElem.multiple) return;
+    if (!selectElem || !selectElem.id || selectElem.multiple || selectElem.hidden) return;
     if (!selectElem._favInit) {
       const btn = document.createElement('button');
       btn.type = 'button';

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -700,6 +700,14 @@ describe('script.js functions', () => {
     expect(Array.from(sel.options).map(o => o.value)).toEqual(['None', 'Alpha', 'Beta']);
   });
 
+  test('hidden select does not get favorite star', () => {
+    document.body.innerHTML = '<select id="hiddenSel" hidden></select>';
+    const sel = document.getElementById('hiddenSel');
+    script.populateSelect(sel, { Alpha: {}, Beta: {} }, true);
+    const btn = document.querySelector('.favorite-toggle');
+    expect(btn).toBeNull();
+  });
+
 
   test('gear list lens row includes lens attributes', () => {
     const html = script.generateGearListHtml({ lenses: 'LensA' });


### PR DESCRIPTION
## Summary
- Skip adding favorites star to hidden selects to stop duplicate favorites button appearing for Wireless Video
- Add regression test ensuring hidden selects do not receive a favorites button

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c7d2dce16883209395843aeb9028b5