### PR TITLE
Persist large monitor selections

### DIFF
--- a/script.js
+++ b/script.js
@@ -9185,7 +9185,8 @@ function generateGearListHtml(info = {}) {
             .join('');
         const idSuffix = role === 'DoP' ? 'Dop' : role;
         const size = dirDb[defaultName]?.screenSizeInches || '';
-        monitoringItems += (monitoringItems ? '<br>' : '') + `1x <strong>${role} Monitor</strong> - ${size}&quot; - <select id="gearList${idSuffix}Monitor15">${opts}</select> incl. sunhood, V-Mount, AC Adapter and Wooden Camera Ultra QR Monitor Mount (Baby Pin, C-Stand)`;
+        monitoringItems += (monitoringItems ? '<br>' : '') +
+            `1x <strong>${role} Monitor</strong> - <span id="monitorSize${idSuffix}15">${size}&quot;</span> - <select id="gearList${idSuffix}Monitor15">${opts}</select> incl. sunhood, V-Mount, AC Adapter and Wooden Camera Ultra QR Monitor Mount (Baby Pin, C-Stand)`;
         if (size) monitorSizes.push(size);
     });
     if (hasMotor) {
@@ -9967,6 +9968,19 @@ function bindGearListDirectorMonitorListener() {
             sel.addEventListener('change', () => {
                 const monitorInfo = devices && devices.monitors && devices.monitors[sel.value];
                 const span = gearListOutput.querySelector(`#monitorSize${role}`);
+                if (span && monitorInfo && monitorInfo.screenSizeInches) {
+                    span.textContent = `${monitorInfo.screenSizeInches}"`;
+                }
+                saveCurrentGearList();
+            });
+        }
+    });
+    ['Director', 'Combo', 'Dop'].forEach(role => {
+        const sel = gearListOutput.querySelector(`#gearList${role}Monitor15`);
+        if (sel) {
+            sel.addEventListener('change', () => {
+                const monitorInfo = devices && devices.directorMonitors && devices.directorMonitors[sel.value];
+                const span = gearListOutput.querySelector(`#monitorSize${role}15`);
                 if (span && monitorInfo && monitorInfo.screenSizeInches) {
                     span.textContent = `${monitorInfo.screenSizeInches}"`;
                 }

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -3090,6 +3090,41 @@ describe('script.js functions', () => {
     expect(document.getElementById('monitorSizeDirector').textContent).toBe('8"');
   });
 
+  test('director large monitor selection persists after regenerating gear list', () => {
+    setupDom(false);
+    require('../translations.js');
+    const script = require('../script.js');
+    const {
+      generateGearListHtml,
+      displayGearAndRequirements,
+      bindGearListDirectorMonitorListener,
+      getCurrentProjectInfo,
+    } = script;
+
+    // provide large monitor options
+    devices.directorMonitors = {
+      'SmallHD Cine 24" 4K High-Bright Monitor': { screenSizeInches: 24 },
+      MonB: { screenSizeInches: 17 },
+    };
+
+    // initial render with default selection
+    let html = generateGearListHtml({ videoDistribution: 'Director Monitor 15-21"' });
+    displayGearAndRequirements(html);
+    bindGearListDirectorMonitorListener();
+
+    const sel = document.getElementById('gearListDirectorMonitor15');
+    const newVal = Array.from(sel.options).find(o => o.value !== sel.value).value;
+    sel.value = newVal;
+    sel.dispatchEvent(new Event('change', { bubbles: true }));
+
+    expect(getCurrentProjectInfo().directorMonitor15).toBe(newVal);
+
+    html = generateGearListHtml(getCurrentProjectInfo());
+    const gear = document.getElementById('gearListOutput');
+    gear.innerHTML = html;
+    expect(gear.querySelector('#gearListDirectorMonitor15').value).toBe(newVal);
+  });
+
   test('gear list includes battery count in camera batteries row', () => {
     const { generateGearListHtml } = script;
     const addOpt = (id, value) => {


### PR DESCRIPTION
## Summary
- preserve large monitor choices by saving changes and updating screen sizes
- add dedicated tests ensuring large monitor selections survive gear list regeneration

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c7d4eabc1c832097471209588ddaa4