### PR TITLE
Ensure consumable selectors stay on one line in print

### DIFF
--- a/overview-print.css
+++ b/overview-print.css
@@ -168,6 +168,10 @@ body:not(.light-mode) .gear-table td {
   line-height: 1.4em;
 }
 
+#overviewDialogContent .gear-table .gear-item {
+  white-space: nowrap;
+}
+
 #overviewDialogContent .gear-table .category-row td,
 #overviewDialogContent.dark-mode .gear-table .category-row td,
 body:not(.light-mode) .gear-table .category-row td {


### PR DESCRIPTION
## Summary
- Prevent gear list consumable selectors from wrapping across lines when printing by applying a `white-space: nowrap` rule.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c7d59c13fc832097519464d940f00f