### PR TITLE
Improve mobile settings dialog

### DIFF
--- a/index.html
+++ b/index.html
@@ -724,7 +724,7 @@
       <h3 id="aboutHeading">About &amp; Support</h3>
       <p id="aboutVersion">Version 1.0.0</p>
       <p><a href="https://github.com" id="supportLink" target="_blank">Support</a></p>
-      <div class="button-row">
+      <div class="button-row action-buttons">
         <button id="settingsSave">Save</button>
         <button id="settingsCancel">Cancel</button>
       </div>

--- a/script.js
+++ b/script.js
@@ -131,7 +131,14 @@ function setupResponsiveControls() {
   const featureSearch = topBar?.querySelector('.feature-search');
   const controls = topBar?.querySelector('.controls');
   const sidebarControls = document.querySelector('#sideMenu .sidebar-controls');
-  if (!topBar || !featureSearch || !controls || !sidebarControls) return;
+  if (
+    !topBar ||
+    !featureSearch ||
+    !controls ||
+    !sidebarControls ||
+    typeof window.matchMedia !== 'function'
+  )
+    return;
 
   const mql = window.matchMedia('(max-width: 768px)');
 

--- a/style.css
+++ b/style.css
@@ -427,6 +427,31 @@ footer a {
   margin-top: auto;
 }
 
+@media (max-width: 600px) {
+  #settingsDialog {
+    align-items: stretch;
+    justify-content: flex-start;
+  }
+
+  .settings-content {
+    width: 100vw;
+    height: 100vh;
+    max-height: none;
+    border-radius: 0;
+    box-shadow: none;
+    padding-bottom: 80px;
+  }
+
+  .settings-content .action-buttons {
+    position: sticky;
+    bottom: 0;
+    background: var(--surface-color);
+    padding-top: 10px;
+    border-top: 1px solid var(--accent-color);
+    justify-content: space-between;
+  }
+}
+
 .help-content p,
 .help-content li {
   line-height: 1.6;


### PR DESCRIPTION
## Summary
- Make settings dialog fill the screen on small devices with sticky action buttons
- Add safeguard for missing `matchMedia` to avoid runtime errors

## Testing
- `NODE_OPTIONS=--max_old_space_size=4096 npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c7d638e74c8320b3d43a40cee33a33