### PR TITLE
Fix misaligned favorite stars next to selects

### DIFF
--- a/style.css
+++ b/style.css
@@ -528,6 +528,16 @@ body.hover-help-active * {
   margin: 5px 5px 0 0;
 }
 
+/* Give wrappers the same margin so favorite stars line up with selects */
+.field-with-label .select-wrapper {
+  margin: 5px 5px 0 0;
+}
+
+/* Remove the default margin from selects inside wrappers */
+.field-with-label .select-wrapper select {
+  margin: 0;
+}
+
 /* Wrapper for selects to allow flexible layout */
 .select-wrapper {
   display: flex;


### PR DESCRIPTION
## Summary
- Apply margin to select wrappers so favorite star buttons align vertically with their corresponding selects
- Remove default margin from selects inside wrappers to keep heights consistent

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c7d8bfdd588320b8de4932f8ddafb0