### PR TITLE
Align device favorites buttons with gear list styling

### DIFF
--- a/style.css
+++ b/style.css
@@ -27,7 +27,7 @@
   --video-color: #369;
   --fiz-color: #090;
   --selected-row-bg: #e6f7ff;
-  --favorite-inactive-color: var(--control-text);
+  --favorite-inactive-color: var(--text-color);
 }
 @media (max-width: 600px) {
   :root {
@@ -604,7 +604,7 @@ textarea:disabled {
   padding: 0;
   width: var(--button-size);
   height: var(--button-size);
-  background: transparent;
+  background-color: var(--panel-bg);
   border: none;
   cursor: pointer;
   font-size: 1em;
@@ -617,11 +617,11 @@ textarea:disabled {
 }
 .favorite-toggle:hover {
   color: var(--link-color);
-  background-color: transparent;
+  background-color: var(--panel-bg);
 }
 .favorite-toggle:active {
   color: var(--link-color);
-  background-color: transparent;
+  background-color: var(--panel-bg);
 }
 .favorite-toggle.favorited {
   background-color: var(--accent-color);
@@ -1643,7 +1643,7 @@ body.dark-mode.pink-mode .help-content { border-color: var(--accent-color); }
     --panel-shadow: 0 2px 4px rgba(0, 0, 0, 0.5);
     --panel-shadow-hover: 0 4px 8px rgba(0, 0, 0, 0.6);
     --link-color: #7ec8ff;
-    --favorite-inactive-color: #bbb;
+    --favorite-inactive-color: var(--text-color);
     --diagram-node-fill: #444;
     --power-color: #ff6666;
     --video-color: #7ec8ff;


### PR DESCRIPTION
## Summary
- Match device selection favorite buttons to gear list design
- Use section background when inactive and accent color when active
- Make inactive star icons follow body text color

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c7d97850cc83208916a5de3d043db5