### PR TITLE
style: grey out inactive favorite buttons

### DIFF
--- a/style.css
+++ b/style.css
@@ -27,7 +27,7 @@
   --video-color: #369;
   --fiz-color: #090;
   --selected-row-bg: #e6f7ff;
-  --favorite-inactive-color: var(--text-color);
+  --favorite-inactive-color: #bbb;
 }
 @media (max-width: 600px) {
   :root {
@@ -1660,7 +1660,7 @@ body.dark-mode.pink-mode .help-content { border-color: var(--accent-color); }
     --panel-shadow: 0 2px 4px rgba(0, 0, 0, 0.5);
     --panel-shadow-hover: 0 4px 8px rgba(0, 0, 0, 0.6);
     --link-color: #7ec8ff;
-    --favorite-inactive-color: var(--text-color);
+    --favorite-inactive-color: #bbb;
     --diagram-node-fill: #444;
     --power-color: #ff6666;
     --video-color: #7ec8ff;


### PR DESCRIPTION
## Summary
- Tone down inactive favorite star color for device selection
- Apply consistent gray styling in light and dark modes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c7e373079c8320b800211b8938ccae