### PR TITLE
Ensure large monitor selections persist across reloads

### DIFF
--- a/script.js
+++ b/script.js
@@ -9643,6 +9643,20 @@ function getCurrentGearListHtml() {
                 });
             }
         });
+        ['Director', 'Combo', 'Dop'].forEach(role => {
+            const sel = clone.querySelector(`#gearList${role}Monitor15`);
+            if (sel) {
+                const originalSel = gearListOutput.querySelector(`#gearList${role}Monitor15`);
+                const val = originalSel ? originalSel.value : sel.value;
+                Array.from(sel.options).forEach(opt => {
+                    if (opt.value === val) {
+                        opt.setAttribute('selected', '');
+                    } else {
+                        opt.removeAttribute('selected');
+                    }
+                });
+            }
+        });
         const cageSel = clone.querySelector('#gearListCage');
         if (cageSel) {
             const originalSel = gearListOutput.querySelector('#gearListCage');
@@ -11716,6 +11730,7 @@ if (typeof module !== "undefined" && module.exports) {
     getCurrentSetupKey,
     renderFeedbackTable,
     saveCurrentGearList,
+    getCurrentGearListHtml,
     getGearListSelectors,
     applyGearListSelectors,
     autoSaveCurrentSetup,

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -3179,6 +3179,40 @@ describe('script.js functions', () => {
     expect(gear.querySelector('#gearListDirectorMonitor15').value).toBe(newVal);
   });
 
+  test('director large monitor selection persists after reload', () => {
+    setupDom(false);
+    require('../translations.js');
+    const script = require('../script.js');
+    const {
+      generateGearListHtml,
+      displayGearAndRequirements,
+      bindGearListDirectorMonitorListener,
+      getCurrentGearListHtml,
+    } = script;
+
+    devices.directorMonitors = {
+      'SmallHD Cine 24" 4K High-Bright Monitor': { screenSizeInches: 24 },
+      MonB: { screenSizeInches: 17 },
+    };
+
+    let html = generateGearListHtml({ videoDistribution: 'Director Monitor 15-21"' });
+    displayGearAndRequirements(html);
+    bindGearListDirectorMonitorListener();
+
+    const sel = document.getElementById('gearListDirectorMonitor15');
+    const newVal = Array.from(sel.options).find(o => o.value !== sel.value).value;
+    sel.value = newVal;
+    sel.dispatchEvent(new Event('change', { bubbles: true }));
+
+    const savedHtml = getCurrentGearListHtml();
+
+    displayGearAndRequirements(savedHtml);
+    bindGearListDirectorMonitorListener();
+
+    expect(document.getElementById('gearListDirectorMonitor15').value).toBe(newVal);
+    expect(document.getElementById('monitorSizeDirector15').textContent).toBe(`${devices.directorMonitors[newVal].screenSizeInches}"`);
+  });
+
   test('gear list includes battery count in camera batteries row', () => {
     const { generateGearListHtml } = script;
     const addOpt = (id, value) => {


### PR DESCRIPTION
## Summary
- Persist selected large monitor options when exporting the gear list
- Test that director monitor selection is restored after reload

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c7e4bbee04832084435a57bf84f5fa