### PR TITLE
fix: ensure edit device form updates based on category

### DIFF
--- a/script.js
+++ b/script.js
@@ -7165,9 +7165,9 @@ deviceManagerSection.addEventListener("click", (event) => {
 
     // Set form for editing
     newCategorySelect.value = categoryKey;
-    newCategorySelect.disabled = true; // Prevent changing category during edit
     // Trigger change handler so fields are cleared
     newCategorySelect.dispatchEvent(new Event('change'));
+    newCategorySelect.disabled = true; // Prevent changing category during edit
     // After the change handler runs, restore the device name for editing
     newNameInput.value = name;
 


### PR DESCRIPTION
## Summary
- trigger category change before disabling the selector when editing
- ensures fields update for wireless receivers and other device types

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c7f086b9488320b11434672b7c3994