### PR TITLE
Map cforce motors to gear list basic sets

### DIFF
--- a/script.js
+++ b/script.js
@@ -9350,7 +9350,23 @@ function generateGearListHtml(info = {}) {
     });
     addRow('Lens Support', formatItems(lensSupportItems));
     addRow('Matte box + filter', [filterSelectHtml, formatItems(filterSelections)].filter(Boolean).join('<br>'));
-    addRow('LDS (FIZ)', formatItems([...selectedNames.motors, ...selectedNames.controllers, selectedNames.distance, ...fizCableAcc]));
+    const motorItems = selectedNames.motors.flatMap(name => {
+        const lower = name.toLowerCase();
+        if (/cforce\s*mini\s*rf|cforce\s*rf/.test(lower)) {
+            return ['ARRI KK.0040345 CFORCE MINI RF Basic Set 2'];
+        }
+        if (/cforce\s*mini/.test(lower) && !/rf/.test(lower)) {
+            return ['ARRI KK.0040344 Cforce Mini Basic Set 2'];
+        }
+        if (/cforce\s*plus/.test(lower)) {
+            return [
+                'Arri KK.0008824 cforce plus Basic Set',
+                'ARRI K2.0009335 Cforce Plus Gear M0.8/32p, 60t'
+            ];
+        }
+        return [name];
+    });
+    addRow('LDS (FIZ)', formatItems([...motorItems, ...selectedNames.controllers, selectedNames.distance, ...fizCableAcc]));
     let batteryItems = '';
     if (selectedNames.battery) {
         let count = batteryCountElem ? parseInt(batteryCountElem.textContent, 10) : NaN;

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -3112,6 +3112,29 @@ describe('script.js functions', () => {
     expect(html).toContain('Tilta Nucleus-M Hand Grip (1x single)');
   });
 
+  test('cforce motors map to basic sets in gear list', () => {
+    const { generateGearListHtml } = script;
+    const sel = document.getElementById('motor1Select');
+    sel.innerHTML = [
+      '<option value="Arri cforce mini RF (KK.0040345)">Arri cforce mini RF (KK.0040345)</option>',
+      '<option value="Arri Cforce Mini">Arri Cforce Mini</option>',
+      '<option value="Arri Cforce Plus">Arri Cforce Plus</option>'
+    ].join('');
+
+    sel.value = 'Arri cforce mini RF (KK.0040345)';
+    let html = generateGearListHtml();
+    expect(html).toContain('1x ARRI KK.0040345 CFORCE MINI RF Basic Set 2');
+
+    sel.value = 'Arri Cforce Mini';
+    html = generateGearListHtml();
+    expect(html).toContain('1x ARRI KK.0040344 Cforce Mini Basic Set 2');
+
+    sel.value = 'Arri Cforce Plus';
+    html = generateGearListHtml();
+    expect(html).toContain('1x Arri KK.0008824 cforce plus Basic Set');
+    expect(html).toContain('1x ARRI K2.0009335 Cforce Plus Gear M0.8/32p, 60t');
+  });
+
   test('director handheld and focus monitor each get wireless receiver', () => {
     const { generateGearListHtml } = script;
     global.devices.video = {


### PR DESCRIPTION
## Summary
- Expand gear list generation to translate ARRI cforce motors into their corresponding basic sets with correct K-numbers.
- Add tests ensuring cforce mini RF, cforce mini, and cforce plus selections yield proper gear list entries.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c80aebf2208320b40156ad2b53d382