### PR TITLE
Ensure main layout spans full width on mobile

### DIFF
--- a/style.css
+++ b/style.css
@@ -33,6 +33,10 @@
   :root {
     --page-padding: 5px;
   }
+  main {
+    max-width: none;
+    margin: 0;
+  }
   h2 {
     padding-bottom: 0.3em;
   }


### PR DESCRIPTION
## Summary
- remove the fixed-width centering from the main container on small screens so content spans edge-to-edge again

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c83095a4cc832081640c01ced03f5b