### PR TITLE
Align favorite buttons with selects on mobile

### DIFF
--- a/style.css
+++ b/style.css
@@ -1794,6 +1794,14 @@ body.dark-mode.pink-mode .help-content { border-color: var(--accent-color); }
     margin: 5px 0 0 0;
   }
 
+  .form-row .select-wrapper {
+    margin: 5px 0 0 0;
+  }
+
+  .form-row .select-wrapper select {
+    margin: 0;
+  }
+
   .form-row > button {
     width: 100%;
     margin: 5px 0 0 0;


### PR DESCRIPTION
## Summary
- shift the mobile layout spacing from selects to their wrappers so the favorite toggle stays aligned
- keep selects inside wrappers flush with the wrapper margin to match the adjacent control

## Testing
- `npm test` *(fails: script test runs out of memory in this environment)*
- `NODE_OPTIONS=--max_old_space_size=4096 npm run test:script` *(fails: script test runs out of memory in this environment)*
- `NODE_OPTIONS=--max_old_space_size=8192 npm run test:script` *(fails: existing script assertions unrelated to this CSS change)*

------
https://chatgpt.com/codex/tasks/task_e_68c82f6fcad0832082901e00b62c3589