### PR TITLE
Ensure selectors and buttons share consistent height

### DIFF
--- a/overview-print.css
+++ b/overview-print.css
@@ -208,6 +208,7 @@ body:not(.light-mode) .gear-table .category-row td {
   color: var(--text-color) !important;
   border: none !important;
   min-width: var(--button-size) !important;
+  height: var(--button-size) !important;
   min-height: var(--button-size) !important;
 }
 

--- a/overview.css
+++ b/overview.css
@@ -125,6 +125,7 @@ th { background-color: var(--control-bg); font-weight: 700; }
 
 .diagram-controls button {
   min-width: var(--button-size);
+  height: var(--button-size);
   min-height: var(--button-size);
 }
 

--- a/style.css
+++ b/style.css
@@ -710,6 +710,7 @@ button {
   margin: 5px;
   cursor: pointer;
   font-size: 0.85em;
+  height: var(--button-size);
   min-height: var(--button-size);
   display: inline-flex;
   align-items: center;
@@ -749,6 +750,7 @@ input[type="file"]::-webkit-file-upload-button {
   margin-right: 5px;
   cursor: pointer;
   font-size: 0.85em;
+  height: var(--button-size);
   min-height: var(--button-size);
   display: inline-flex;
   align-items: center;
@@ -1197,6 +1199,7 @@ input[type="file"]:disabled::-webkit-file-upload-button {
 
 .diagram-controls button {
   min-width: var(--button-size);
+  height: var(--button-size);
   min-height: var(--button-size);
 }
 


### PR DESCRIPTION
## Summary
- set shared button styling to apply the global `--button-size` height so buttons match the surrounding selects
- updated file upload and diagram control buttons (including overview styles) to use the unified control height

## Testing
- `npm test` *(fails: JavaScript heap out of memory while executing tests/script.test.js)*
- `NODE_OPTIONS=--max_old_space_size=4096 npm run test:script` *(fails: JavaScript heap out of memory while executing tests/script.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68c832ee1aec832094b3d46cf537e1a1