### PR TITLE
Align DZOFILM Vespid front diameters to 80mm

### DIFF
--- a/devices/gearList.js
+++ b/devices/gearList.js
@@ -3373,7 +3373,7 @@ const gear = {
         },
         "DZOFILM Vespid Prime 12mm T2.8": {
           "brand": "DZOFILM",
-          "frontDiameterMm": 77,
+          "frontDiameterMm": 80,
           "clampOn": true,
           "tStop": 2.8,
           "rodStandard": "15mm",
@@ -3383,7 +3383,7 @@ const gear = {
         },
         "DZOFILM Vespid Prime 16mm T2.8": {
           "brand": "DZOFILM",
-          "frontDiameterMm": 77,
+          "frontDiameterMm": 80,
           "clampOn": true,
           "tStop": 2.8,
           "rodStandard": "15mm",
@@ -3393,7 +3393,7 @@ const gear = {
         },
         "DZOFILM Vespid Prime 21mm T2.1": {
           "brand": "DZOFILM",
-          "frontDiameterMm": 77,
+          "frontDiameterMm": 80,
           "clampOn": true,
           "tStop": 2.1,
           "rodStandard": "15mm",
@@ -3403,7 +3403,7 @@ const gear = {
         },
         "DZOFILM Vespid Prime 25mm T2.1": {
           "brand": "DZOFILM",
-          "frontDiameterMm": 77,
+          "frontDiameterMm": 80,
           "clampOn": true,
           "tStop": 2.1,
           "rodStandard": "15mm",
@@ -3413,7 +3413,7 @@ const gear = {
         },
         "DZOFILM Vespid Prime 35mm T2.1": {
           "brand": "DZOFILM",
-          "frontDiameterMm": 77,
+          "frontDiameterMm": 80,
           "clampOn": true,
           "tStop": 2.1,
           "rodStandard": "15mm",
@@ -3423,7 +3423,7 @@ const gear = {
         },
         "DZOFILM Vespid Prime 40mm T2.1": {
           "brand": "DZOFILM",
-          "frontDiameterMm": 77,
+          "frontDiameterMm": 80,
           "clampOn": true,
           "tStop": 2.1,
           "rodStandard": "15mm",
@@ -3433,7 +3433,7 @@ const gear = {
         },
         "DZOFILM Vespid Prime 50mm T2.1": {
           "brand": "DZOFILM",
-          "frontDiameterMm": 77,
+          "frontDiameterMm": 80,
           "clampOn": true,
           "tStop": 2.1,
           "rodStandard": "15mm",
@@ -3443,7 +3443,7 @@ const gear = {
         },
         "DZOFILM Vespid Prime 75mm T2.1": {
           "brand": "DZOFILM",
-          "frontDiameterMm": 77,
+          "frontDiameterMm": 80,
           "clampOn": true,
           "tStop": 2.1,
           "rodStandard": "15mm",
@@ -3453,7 +3453,7 @@ const gear = {
         },
         "DZOFILM Vespid Prime 90mm T2.8 Macro": {
           "brand": "DZOFILM",
-          "frontDiameterMm": 77,
+          "frontDiameterMm": 80,
           "clampOn": true,
           "tStop": 2.8,
           "rodStandard": "15mm",
@@ -3463,7 +3463,7 @@ const gear = {
         },
         "DZOFILM Vespid Prime 100mm T2.1": {
           "brand": "DZOFILM",
-          "frontDiameterMm": 77,
+          "frontDiameterMm": 80,
           "clampOn": true,
           "tStop": 2.1,
           "rodStandard": "15mm",
@@ -3473,7 +3473,7 @@ const gear = {
         },
         "DZOFILM Vespid Prime 125mm T2.1": {
           "brand": "DZOFILM",
-          "frontDiameterMm": 77,
+          "frontDiameterMm": 80,
           "clampOn": true,
           "tStop": 2.1,
           "rodStandard": "15mm",
@@ -3483,7 +3483,7 @@ const gear = {
         },
         "DZOFILM Vespid Retro 16mm T2.8": {
           "brand": "DZOFILM",
-          "frontDiameterMm": 77,
+          "frontDiameterMm": 80,
           "clampOn": true,
           "tStop": 2.8,
           "rodStandard": "15mm",
@@ -3493,7 +3493,7 @@ const gear = {
         },
         "DZOFILM Vespid Retro 25mm T2.1": {
           "brand": "DZOFILM",
-          "frontDiameterMm": 77,
+          "frontDiameterMm": 80,
           "clampOn": true,
           "tStop": 2.1,
           "rodStandard": "15mm",
@@ -3503,7 +3503,7 @@ const gear = {
         },
         "DZOFILM Vespid Retro 35mm T2.1": {
           "brand": "DZOFILM",
-          "frontDiameterMm": 77,
+          "frontDiameterMm": 80,
           "clampOn": true,
           "tStop": 2.1,
           "rodStandard": "15mm",
@@ -3513,7 +3513,7 @@ const gear = {
         },
         "DZOFILM Vespid Retro 50mm T2.1": {
           "brand": "DZOFILM",
-          "frontDiameterMm": 77,
+          "frontDiameterMm": 80,
           "clampOn": true,
           "tStop": 2.1,
           "rodStandard": "15mm",
@@ -3523,7 +3523,7 @@ const gear = {
         },
         "DZOFILM Vespid Retro 75mm T2.1": {
           "brand": "DZOFILM",
-          "frontDiameterMm": 77,
+          "frontDiameterMm": 80,
           "clampOn": true,
           "tStop": 2.1,
           "rodStandard": "15mm",
@@ -3533,7 +3533,7 @@ const gear = {
         },
         "DZOFILM Vespid Retro 100mm T2.1": {
           "brand": "DZOFILM",
-          "frontDiameterMm": 77,
+          "frontDiameterMm": 80,
           "clampOn": true,
           "tStop": 2.1,
           "rodStandard": "15mm",
@@ -3543,7 +3543,7 @@ const gear = {
         },
         "DZOFILM Vespid Retro 125mm T2.1": {
           "brand": "DZOFILM",
-          "frontDiameterMm": 77,
+          "frontDiameterMm": 80,
           "clampOn": true,
           "tStop": 2.1,
           "rodStandard": "15mm",
@@ -3553,7 +3553,7 @@ const gear = {
         },
         "DZOFILM Vespid Cyber 35mm T2.1": {
           "brand": "DZOFILM",
-          "frontDiameterMm": 86,
+          "frontDiameterMm": 80,
           "clampOn": true,
           "tStop": 2.1,
           "rodStandard": "15mm",
@@ -3563,7 +3563,7 @@ const gear = {
         },
         "DZOFILM Vespid Cyber 50mm T2.1": {
           "brand": "DZOFILM",
-          "frontDiameterMm": 86,
+          "frontDiameterMm": 80,
           "clampOn": true,
           "tStop": 2.1,
           "rodStandard": "15mm",
@@ -3573,7 +3573,7 @@ const gear = {
         },
         "DZOFILM Vespid Cyber 75mm T2.1": {
           "brand": "DZOFILM",
-          "frontDiameterMm": 86,
+          "frontDiameterMm": 80,
           "clampOn": true,
           "tStop": 2.1,
           "rodStandard": "15mm",
@@ -3583,7 +3583,7 @@ const gear = {
         },
         "DZOFILM Vespid Prime II 18mm T1.9": {
           "brand": "DZOFILM",
-          "frontDiameterMm": 77,
+          "frontDiameterMm": 80,
           "clampOn": true,
           "tStop": 1.9,
           "mount": "PL",
@@ -3594,7 +3594,7 @@ const gear = {
         },
         "DZOFILM Vespid Prime II 24mm T1.9": {
           "brand": "DZOFILM",
-          "frontDiameterMm": 77,
+          "frontDiameterMm": 80,
           "clampOn": true,
           "tStop": 1.9,
           "mount": "PL",
@@ -3605,7 +3605,7 @@ const gear = {
         },
         "DZOFILM Vespid Prime II 35mm T1.9": {
           "brand": "DZOFILM",
-          "frontDiameterMm": 77,
+          "frontDiameterMm": 80,
           "clampOn": true,
           "tStop": 1.9,
           "mount": "PL",
@@ -3616,7 +3616,7 @@ const gear = {
         },
         "DZOFILM Vespid Prime II 50mm T1.9": {
           "brand": "DZOFILM",
-          "frontDiameterMm": 77,
+          "frontDiameterMm": 80,
           "clampOn": true,
           "tStop": 1.9,
           "mount": "PL",
@@ -3627,7 +3627,7 @@ const gear = {
         },
         "DZOFILM Vespid Prime II 85mm T1.9": {
           "brand": "DZOFILM",
-          "frontDiameterMm": 77,
+          "frontDiameterMm": 80,
           "clampOn": true,
           "tStop": 1.9,
           "mount": "PL",
@@ -3638,7 +3638,7 @@ const gear = {
         },
         "DZOFILM Vespid Prime II 105mm T1.9": {
           "brand": "DZOFILM",
-          "frontDiameterMm": 77,
+          "frontDiameterMm": 80,
           "clampOn": true,
           "tStop": 1.9,
           "mount": "PL",


### PR DESCRIPTION
## Summary
- set every DZOFILM Vespid family lens entry to an 80 mm front diameter

## Testing
- npm run check-consistency

------
https://chatgpt.com/codex/tasks/task_e_68c838a31f688320ac640ab955d1b45e