### PR TITLE
Wrap cage select dropdown across two lines

### DIFF
--- a/script.js
+++ b/script.js
@@ -9285,7 +9285,7 @@ function generateGearListHtml(info = {}) {
     let cageSelectHtml = '';
     if (compatibleCages.length) {
         const options = compatibleCages.map(c => `<option value="${escapeHtml(c)}"${c === selectedNames.cage ? ' selected' : ''}>${escapeHtml(addArriKNumber(c))}</option>`).join('');
-        cageSelectHtml = `1x <select id="gearListCage">${options}</select>`;
+        cageSelectHtml = `<span class="cage-select-wrapper"><span>1x</span><select id="gearListCage">${options}</select></span>`;
     }
     addRow('Camera Support', [cameraSupportText, cageSelectHtml].filter(Boolean).join('<br>'));
     let mediaItems = '';

--- a/style.css
+++ b/style.css
@@ -2074,6 +2074,17 @@ body.dark-mode.pink-mode .help-content { border-color: var(--accent-color); }
   line-height: 1.4em;
 }
 
+#gearListOutput .cage-select-wrapper {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.25rem;
+}
+
+#gearListOutput .cage-select-wrapper select {
+  max-width: 100%;
+}
+
 .gear-table .category-row td {
   border-top: 1px solid var(--accent-color);
   border-bottom: 1px solid var(--accent-color);

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -936,7 +936,7 @@ describe('script.js functions', () => {
   test('gear list cage selection is stored with selected attribute', () => {
     global.saveProject = jest.fn();
     const gear = document.getElementById('gearListOutput');
-    gear.innerHTML = '1x <select id="gearListCage"><option value="Cage1">Cage1</option><option value="Cage2">Cage2</option></select>';
+    gear.innerHTML = '<span class="cage-select-wrapper"><span>1x</span><select id="gearListCage"><option value="Cage1">Cage1</option><option value="Cage2">Cage2</option></select></span>';
     gear.classList.remove('hidden');
     const cageSel = gear.querySelector('#gearListCage');
     cageSel.value = 'Cage2';
@@ -2263,7 +2263,7 @@ describe('script.js functions', () => {
       expect(html).toContain('Camera');
       expect(html).toContain(`1x ${cageCamera}`);
       expect(html).toContain('Camera Support');
-      expect(html).toContain('1x <select id="gearListCage"');
+      expect(html).toContain('<span class="cage-select-wrapper"><span>1x</span><select id="gearListCage"');
       expect(html).toContain(`<option value="${cageNames[0]}"`);
       expect(html).toContain('LDS (FIZ)');
       expect(html).toContain('1x LBUS to LBUS');


### PR DESCRIPTION
## Summary
- Wrap the gear list cage selector markup in a wrapper so the dropdown can appear on its own line.
- Style the new wrapper to stack and space the count and select control.
- Update the script test fixtures to reflect the cage selector markup change.

## Testing
- npm test *(fails: script.test.js exhausts memory in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c838500fa48320917286e498d1fd20