### PR TITLE
Document JSON project sharing workflow

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -24,7 +24,7 @@ The app automatically uses your browser language on first load, and you can swit
 - High contrast theme option for improved readability.
 - Device forms populate category fields dynamically based on schema attributes.
 - Revamped interface design with improved contrast and spacing for a cleaner experience on any device.
-- Simplified project sharing – export and import buttons were removed; share links now handle project transfer.
+- Simplified project sharing – download a JSON project file that bundles selections, requirements, gear lists, runtime feedback and custom devices, then load it to restore the full setup.
 - Unique icons for required scenarios to distinguish project requirements.
 - Interactive project diagram that lets you drag devices, zoom, snap nodes to a grid and export the layout as SVG or JPG.
 - Playful pink accent theme that persists between visits.
@@ -44,7 +44,7 @@ The app automatically uses your browser language on first load, and you can swit
 
 -### ✅ Project Management
 - Save, load and delete multiple camera projects (press Enter or Ctrl+S to save quickly; the Save button stays disabled until a name is entered)
-- Share a project via link or clear the current configuration
+- Download a JSON project file for sharing or backup, load it with the Shared Project picker or clear the current configuration
 - Data is stored locally via `localStorage`
 - Generate a printable overview for any saved project
 - Save project requirements along with each project
@@ -78,7 +78,7 @@ The generator turns your selections into a categorized packing list:
   - **Monitoring Configuration**, **Video Distribution** and **Viewfinder** settings add monitors, cables and overlays for each role.
   - **User Button** selections and **Tripod Preferences** are listed for quick reference.
 - Items inside each category are sorted alphabetically and display tooltips on hover.
-- The gear list is included in printable overviews and shared setup links.
+- The gear list is included in printable overviews and shared project files.
 - **Save Gear List** stores the current list with the project.
 - **Export Gear List** downloads a JSON file; **Import Gear List** restores it.
 - **Delete Gear List** removes the saved list and hides the output.

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Contributions for additional languages are welcome. To add a translation, includ
 - **High contrast mode** – switch to a high contrast theme for improved readability.
 - **Dynamic device forms** – category fields populate automatically from the schema in new device forms.
 - **Refreshed interface design** – cleaner layout and improved contrast make the planner easier to use on desktop and mobile.
-- **Simplified project sharing** – export and import buttons were removed; share links now handle project transfer.
+- **Simplified project sharing** – download a single project file that bundles selections, requirements, gear lists, runtime feedback and custom devices, then load it to restore the full setup.
 - **Unique icons for required scenarios** – each required scenario now shows its own icon for quick recognition.
 - **Persistent diagram popups on touch** – tapping a node on touch devices keeps its popup visible until another node is selected.
 - **Interactive project diagram** – drag devices, zoom, snap nodes to a grid, and export layouts as SVG or JPG.
@@ -130,7 +130,7 @@ The planner expands your selections into a detailed packing table:
   - **Monitoring Configuration**, **Video Distribution** and **Viewfinder** settings add monitors, cables and overlays for each role.
   - **User Button** selections and **Tripod Preferences** are listed for quick reference.
 - Items are sorted alphabetically within their category and each exposes a tooltip on hover.
-- The gear list appears in printable overviews and shared setup links so collaborators see the full context.
+- The gear list appears in printable overviews and shared project files so collaborators see the full context.
 - **Save Gear List** stores the current table with the project.
 - **Export Gear List** downloads a JSON file; **Import Gear List** restores it.
 - **Delete Gear List** removes the saved list and hides the output.

--- a/index.html
+++ b/index.html
@@ -776,9 +776,9 @@
           <h3><span class="help-icon" aria-hidden="true">🗂️</span>Managing Projects</h3>
           <ul>
             <li>Use <strong>Save</strong> to store the current configuration in your browser. Press Enter or Ctrl+S (⌘S on macOS) to save quickly; the Save button stays disabled until a name is entered.</li>
-            <li>Use the action buttons to import, export or delete projects.</li>
-            <li><strong>Share Project Link</strong> copies a URL for the current configuration.</li>
-            <li><strong>Clear Current Project</strong> removes all selected devices.</li>
+            <li><strong>Share Project</strong> downloads a JSON file containing your selections, project requirements, gear list, runtime feedback and any custom devices so you can back up or share the setup.</li>
+            <li>Select a JSON file in <strong>Shared Project</strong> and click <strong>Load</strong> to restore a shared configuration.</li>
+            <li>Use <strong>Delete</strong> to remove the saved entry or <strong>Clear Current Project</strong> to wipe the current selection without touching saved copies.</li>
             <li><strong>Generate Overview</strong> produces a printable summary of any saved project.</li>
             </ul>
           </section>
@@ -827,7 +827,7 @@
                   <li><strong>Viewfinder Settings</strong> and <strong>Tripod Preferences</strong> add EVF mounts, extension brackets, tripod heads, spreaders and counterbalance details.</li>
                 </ul>
               </li>
-              <li>The resulting gear list appears in printable overviews and shared setup links so collaborators see full context.</li>
+              <li>The resulting gear list appears in printable overviews and shared project files so collaborators see full context.</li>
               <li>The <strong>Save Gear List</strong> button stores the current list with the project; <strong>Export</strong> downloads a JSON file, <strong>Import</strong> restores it and <strong>Delete</strong> removes the saved list and shows the generator again.</li>
               <li>Gear list forms use fork buttons to duplicate your entries instantly, making alternate configurations easy to explore.</li>
             </ul>
@@ -977,8 +977,8 @@
             <p>Enter a name in the Project Name field and click Save. It will then appear in the Saved Projects list.</p>
           </details>
           <details class="faq-item">
-            <summary>Can I export my projects?</summary>
-            <p>Yes. Use the Export All Projects button to download a JSON file containing every saved project.</p>
+            <summary>How do I share or back up a project?</summary>
+            <p>Click <em>Share Project</em> to download a JSON file with your selections, project requirements, gear list, runtime feedback and any custom devices. Send the file to collaborators or keep it as a backup, then choose it in the <em>Shared Project</em> field and press <em>Load</em> to restore it.</p>
           </details>
           <details class="faq-item">
             <summary>How do I edit device data?</summary>
@@ -994,7 +994,7 @@
           </details>
           <details class="faq-item">
             <summary>Where are my projects saved?</summary>
-            <p>Projects and device edits are stored in your browser's <code>localStorage</code>. Use Export/Import to back them up or share them.</p>
+            <p>Projects and device edits are stored in your browser's <code>localStorage</code>. Use <em>Share Project</em> to download a setup file, and use the Device Database Editor's <em>Export</em>/<em>Import</em> buttons to back up custom gear.</p>
           </details>
           <details class="faq-item">
             <summary>Does the planner work offline?</summary>


### PR DESCRIPTION
## Summary
- update the in-app help dialog to explain that Share Project downloads a JSON file and how to reload it
- refresh FAQ guidance so users know to use Share Project files and where the data is stored
- revise README.md and README.en.md to describe the new project file sharing flow and note that shared project files carry the full context

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c8364d50088320be252d2aa5444e9f