### PR TITLE
Style favorites buttons like other controls

### DIFF
--- a/style.css
+++ b/style.css
@@ -632,7 +632,8 @@ textarea:disabled {
   padding: 0;
   width: var(--button-size);
   height: var(--button-size);
-  background: none;
+  background-color: var(--control-bg);
+  border-radius: var(--border-radius);
   border: none;
   outline: none;
   cursor: pointer;
@@ -642,13 +643,18 @@ textarea:disabled {
   align-items: center;
   justify-content: center;
   line-height: 1;
-  transition: color 0.2s ease;
+  transition: background-color 0.2s ease, color 0.2s ease, transform 0.2s ease;
 }
 .favorite-toggle:hover {
-  color: var(--link-color);
+  background-color: var(--accent-color);
+  color: var(--inverse-text-color);
+  transform: translateY(-2px);
 }
 .favorite-toggle:active {
-  color: var(--link-color);
+  background-color: var(--accent-color);
+  color: var(--inverse-text-color);
+  filter: brightness(0.9);
+  transform: translateY(0);
 }
 .favorite-toggle.favorited {
   background-color: var(--accent-color);


### PR DESCRIPTION
## Summary
- give the favorite toggle button the same neutral background and hover effects as other buttons
- keep the inactive star coloring while matching the shared button spacing and transitions

## Testing
- npm test *(fails: JavaScript heap out of memory while running tests/script.test.js)*
- NODE_OPTIONS=--max-old-space-size=4096 npm run test:script *(terminated after hanging for several minutes)*

------
https://chatgpt.com/codex/tasks/task_e_68c8513bba2c8320a9616b90f194c69d