### PR TITLE
Adjust runtime feedback table width

### DIFF
--- a/style.css
+++ b/style.css
@@ -1573,7 +1573,9 @@ body:not(.light-mode) #temperatureNote td {
 }
 
 #userFeedbackTable {
-  width: 100%;
+  width: auto; /* Allow the table to size to its content by default */
+  width: fit-content; /* Prevent stretching across the full viewport on wide screens */
+  max-width: 100%;
   border-collapse: collapse;
 }
 


### PR DESCRIPTION
## Summary
- prevent the runtime feedback table from stretching across the entire desktop width by letting it size to its content

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c86bae20ac8320b48b010593940251