### PR TITLE
Improve feature search interactions for hidden panels

### DIFF
--- a/script.js
+++ b/script.js
@@ -7054,23 +7054,35 @@ if (typeof hourlyBackupInterval.unref === 'function') {
   hourlyBackupInterval.unref();
 }
 
+function showDeviceManagerSection() {
+  if (!deviceManagerSection || !toggleDeviceBtn) return;
+  if (!deviceManagerSection.classList.contains('hidden')) return;
+  deviceManagerSection.classList.remove('hidden');
+  toggleDeviceBtn.textContent = texts[currentLang].hideDeviceManager;
+  toggleDeviceBtn.setAttribute('title', texts[currentLang].hideDeviceManager);
+  toggleDeviceBtn.setAttribute('data-help', texts[currentLang].hideDeviceManagerHelp);
+  toggleDeviceBtn.setAttribute('aria-expanded', 'true');
+  refreshDeviceLists();
+  updateCalculations();
+}
+
+function hideDeviceManagerSection() {
+  if (!deviceManagerSection || !toggleDeviceBtn) return;
+  if (deviceManagerSection.classList.contains('hidden')) return;
+  deviceManagerSection.classList.add('hidden');
+  toggleDeviceBtn.textContent = texts[currentLang].toggleDeviceManager;
+  toggleDeviceBtn.setAttribute('title', texts[currentLang].toggleDeviceManager);
+  toggleDeviceBtn.setAttribute('data-help', texts[currentLang].toggleDeviceManagerHelp);
+  toggleDeviceBtn.setAttribute('aria-expanded', 'false');
+}
+
 // Toggle device manager visibility
 if (toggleDeviceBtn) {
-  toggleDeviceBtn.addEventListener("click", () => {
+  toggleDeviceBtn.addEventListener('click', () => {
     if (deviceManagerSection.classList.contains('hidden')) {
-      deviceManagerSection.classList.remove('hidden');
-      toggleDeviceBtn.textContent = texts[currentLang].hideDeviceManager;
-      toggleDeviceBtn.setAttribute('title', texts[currentLang].hideDeviceManager);
-      toggleDeviceBtn.setAttribute('data-help', texts[currentLang].hideDeviceManagerHelp);
-      toggleDeviceBtn.setAttribute('aria-expanded', 'true');
-      refreshDeviceLists(); // Refresh lists when shown
-      updateCalculations(); // Ensure calculations are up to date
+      showDeviceManagerSection();
     } else {
-      deviceManagerSection.classList.add('hidden');
-      toggleDeviceBtn.textContent = texts[currentLang].toggleDeviceManager;
-      toggleDeviceBtn.setAttribute('title', texts[currentLang].toggleDeviceManager);
-      toggleDeviceBtn.setAttribute('data-help', texts[currentLang].toggleDeviceManagerHelp);
-      toggleDeviceBtn.setAttribute('aria-expanded', 'false');
+      hideDeviceManagerSection();
     }
   });
 }
@@ -11336,18 +11348,56 @@ if (helpButton && helpDialog) {
     const isHelp = lower.endsWith(' (help)');
     const clean = isHelp ? value.slice(0, -7).trim() : value;
     const cleanKey = searchKey(clean);
+
+    const focusFeature = element => {
+      if (!element) return;
+
+      const settingsSection = element.closest('#settingsDialog');
+      if (settingsSection && settingsSection.hasAttribute('hidden')) {
+        settingsButton?.click?.();
+      }
+
+      const dialog = element.closest('dialog');
+      if (dialog && !dialog.open) {
+        if (dialog.id === 'projectDialog') {
+          generateGearListBtn?.click?.();
+        } else if (dialog.id === 'feedbackDialog') {
+          runtimeFeedbackBtn?.click?.();
+        } else if (dialog.id === 'overviewDialog') {
+          generateOverviewBtn?.click?.();
+        } else {
+          openDialog(dialog);
+        }
+      }
+
+      const deviceManager = element.closest('#device-manager');
+      if (deviceManager) {
+        showDeviceManagerSection();
+      }
+
+      if (typeof element.scrollIntoView === 'function') {
+        element.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      }
+
+      if (typeof element.focus === 'function') {
+        try {
+          element.focus({ preventScroll: true });
+        } catch {
+          element.focus();
+        }
+      }
+    };
+
     const device = deviceMap.get(cleanKey);
     if (device && !isHelp) {
       device.select.value = device.value;
       device.select.dispatchEvent(new Event('change', { bubbles: true }));
-      device.select.scrollIntoView({ behavior: 'smooth' });
-      device.select.focus?.();
+      focusFeature(device.select);
       return;
     }
     const featureEl = featureMap.get(cleanKey);
     if (featureEl && !isHelp) {
-      featureEl.scrollIntoView({ behavior: 'smooth' });
-      featureEl.focus?.();
+      focusFeature(featureEl);
       return;
     }
     openHelp();

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -6164,6 +6164,30 @@ describe('script.js functions', () => {
     expect(options).toContain('Add New Device');
   });
 
+  test('feature search opens settings dialog entries', () => {
+    setupDom(false);
+    require('../translations.js');
+    require('../script.js');
+    const featureSearch = document.getElementById('featureSearch');
+    const settingsDialog = document.getElementById('settingsDialog');
+    expect(settingsDialog.hasAttribute('hidden')).toBe(true);
+    featureSearch.value = 'Settings';
+    featureSearch.dispatchEvent(new Event('change'));
+    expect(settingsDialog.hasAttribute('hidden')).toBe(false);
+  });
+
+  test('feature search reveals device manager section', () => {
+    setupDom(false);
+    require('../translations.js');
+    require('../script.js');
+    const featureSearch = document.getElementById('featureSearch');
+    const deviceManager = document.getElementById('device-manager');
+    expect(deviceManager.classList.contains('hidden')).toBe(true);
+    featureSearch.value = 'Add New Device';
+    featureSearch.dispatchEvent(new Event('change'));
+    expect(deviceManager.classList.contains('hidden')).toBe(false);
+  });
+
   test('feature search selects devices', () => {
     setupDom(false);
     require('../script.js');


### PR DESCRIPTION
## Summary
- update the feature search handler so suggestions open the settings dialog, reveal the device manager, and trigger the existing modal buttons when needed
- add explicit helpers to show/hide the device manager without depending on the toggle button click behaviour
- cover the new behaviour with targeted Jest tests for settings and device manager suggestions

## Testing
- `npm run lint`
- `NODE_OPTIONS=--max-old-space-size=4096 npx jest --runInBand tests/script.test.js -t "feature search opens settings dialog entries|feature search reveals device manager section"`
- `NODE_OPTIONS=--max-old-space-size=4096 npm run test:script` *(fails: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_68c866fd773483208e58ac219e6f5e2e