### PR TITLE
Improve settings logo upload UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
   <meta name="theme-color" content="#f9f9f9" />
   <meta name="application-name" content="Cine Power Planner" />
   <meta name="apple-mobile-web-app-title" content="Cine Power Planner" />
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; connect-src 'self'; img-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self'; manifest-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none';" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; connect-src 'self'; img-src 'self' data:; script-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self'; manifest-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none';" />
   <meta name="referrer" content="no-referrer" />
   <meta name="color-scheme" content="light dark" />
   <title>Cine Power Planner</title>
@@ -711,7 +711,10 @@
       </div>
       <div class="form-row">
         <label for="settingsLogo" id="settingsLogoLabel">Logo (SVG)</label>
-        <input type="file" id="settingsLogo" accept="image/svg+xml" />
+        <div class="file-input-wrapper">
+          <input type="file" id="settingsLogo" accept="image/svg+xml" />
+          <div id="settingsLogoPreview" class="logo-preview" hidden aria-live="polite"></div>
+        </div>
       </div>
       <h3 id="accessibilityHeading">Accessibility</h3>
       <div class="form-row">

--- a/style.css
+++ b/style.css
@@ -590,6 +590,39 @@ select {
   height: var(--button-size);
 }
 
+input[type="file"] {
+  padding: 2px 4px;
+  height: auto;
+  min-height: calc(var(--button-size) + 8px);
+}
+
+.file-input-wrapper {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.file-input-wrapper input[type="file"] {
+  width: 100%;
+}
+
+.logo-preview {
+  border: 1px solid var(--panel-border);
+  border-radius: var(--border-radius);
+  padding: 10px;
+  background-color: var(--surface-color);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.logo-preview img {
+  max-width: 100%;
+  max-height: 120px;
+}
+
 input[type="checkbox"] {
   width: 1.1em;
   height: 1.1em;
@@ -820,7 +853,7 @@ input[type="file"]::-webkit-file-upload-button {
   margin-right: 5px;
   cursor: pointer;
   font-size: 0.85em;
-  height: var(--button-size);
+  height: 100%;
   min-height: var(--button-size);
   display: inline-flex;
   align-items: center;

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -2110,6 +2110,16 @@ describe('script.js functions', () => {
     await new Promise(res => setTimeout(res, 0));
     const stored = localStorage.getItem('customLogo');
     expect(stored).toContain('data:image/svg+xml');
+    const preview = document.getElementById('settingsLogoPreview');
+    const previewImg = preview.querySelector('img');
+    expect(preview.hasAttribute('hidden')).toBe(false);
+    expect(previewImg).not.toBeNull();
+    expect(previewImg.getAttribute('src')).toBe(stored);
+    settingsBtn.click();
+    const reopenedImg = document.querySelector('#settingsLogoPreview img');
+    expect(reopenedImg).not.toBeNull();
+    expect(reopenedImg.getAttribute('src')).toBe(stored);
+    document.getElementById('settingsCancel').click();
     generatePrintableOverview();
     const printLogo = document.getElementById('printLogo');
     expect(printLogo).not.toBeNull();
@@ -2132,6 +2142,12 @@ describe('script.js functions', () => {
     const note = document.querySelector('#backupNotificationContainer div');
     expect(note).not.toBeNull();
     expect(note.textContent).toBe(texts.en.logoFormatError);
+    const preview = document.getElementById('settingsLogoPreview');
+    expect(preview.hasAttribute('hidden')).toBe(true);
+    expect(preview.querySelector('img')).toBeNull();
+    settingsBtn.click();
+    expect(document.querySelector('#settingsLogoPreview img')).toBeNull();
+    document.getElementById('settingsCancel').click();
   });
 
   test('accent color input updates body and root variables when pink mode off', () => {


### PR DESCRIPTION
## Summary
- allow inline SVG previews by permitting data URIs in the CSP and adding a preview container to the settings dialog
- restyle the logo file input so the button/text align correctly and add a bordered preview slot for the uploaded logo
- render the custom logo preview from uploads or stored data and update tests to cover the new behaviour

## Testing
- npm test *(fails: jest --runInBand tests/script.test.js exits with JavaScript heap out of memory even after retrying with NODE_OPTIONS=--max-old-space-size=4096)*

------
https://chatgpt.com/codex/tasks/task_e_68c867e648c88320b4b08264473cbd3b