### PR TITLE
Restore removed schema attributes

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -27,6 +27,23 @@
           "useCase"
         ]
       },
+      "fiz": {
+        "attributes": [
+          "brand",
+          "compatibleCameras",
+          "compatibleControllers",
+          "compatibleDevices",
+          "connectors",
+          "from",
+          "kNumber",
+          "lengthM",
+          "notes",
+          "orientation",
+          "to",
+          "type",
+          "useCase"
+        ]
+      },
       "power": {
         "attributes": [
           "from",
@@ -82,9 +99,19 @@
     },
     "chargers": {
       "attributes": [
+        "chargeModes",
         "chargingSpeedAmps",
+        "dimensions_mm",
+        "inputConnector",
+        "inputVoltageV",
         "mount",
-        "slots"
+        "notes",
+        "outputs",
+        "perBayCurrentA",
+        "provenance",
+        "slots",
+        "totalPowerW",
+        "weight_g"
       ]
     },
     "filters": {
@@ -103,12 +130,17 @@
         "brand",
         "clampOn",
         "frontDiameterMm",
+        "imageCircleMm",
+        "lengthMm",
         "lensType",
+        "minFocusMeters",
         "mount",
         "needsLensSupport",
+        "notes",
         "rodLengthCm",
         "rodStandard",
-        "tStop"
+        "tStop",
+        "weight_g"
       ]
     },
     "matteboxes": {
@@ -117,12 +149,12 @@
         "compatible",
         "diameterMm",
         "kNumber",
-        "stages",
-        "type",
-        "traySize",
-        "topFlag",
+        "provenance",
         "sideFlags",
-        "provenance"
+        "stages",
+        "topFlag",
+        "traySize",
+        "type"
       ]
     },
     "media": {
@@ -285,21 +317,26 @@
       "brand",
       "clampOn",
       "frontDiameterMm",
+      "imageCircleMm",
+      "lengthMm",
       "lensType",
+      "minFocusMeters",
       "mount",
       "needsLensSupport",
+      "notes",
       "rodLengthCm",
       "rodStandard",
-      "tStop"
+      "tStop",
+      "weight_g"
     ]
   },
   "monitors": {
     "attributes": [
+      "brand",
       "audioInput",
       "audioIo",
       "audioOutput",
       "bluetooth",
-      "brand",
       "brightnessNits",
       "latencyMs",
       "power",


### PR DESCRIPTION
## Summary
- regenerate schema.json so accessory categories (including FIZ cables and charger metadata) match the latest device data
- restore the original cable/lens categories and brand attributes while still exposing the new metadata additions

## Testing
- npm run test:unit -- --runTestsByPath tests/generateSchema.test.js

------
https://chatgpt.com/codex/tasks/task_e_68c86fd2fce88320b2a849bfa93e610d