### PR TITLE
Ensure high contrast uses white accent color

### DIFF
--- a/script.js
+++ b/script.js
@@ -2518,13 +2518,31 @@ const projectRequirementsOutput = document.getElementById("projectRequirementsOu
 // Load accent color from localStorage
 let accentColor = '#001589';
 let prevAccentColor = accentColor;
+const HIGH_CONTRAST_ACCENT_COLOR = '#ffffff';
+
+const isHighContrastActive = () =>
+  typeof document !== 'undefined' &&
+  (document.documentElement.classList.contains('high-contrast') ||
+    (document.body && document.body.classList.contains('high-contrast')));
 
 const applyAccentColor = (color) => {
-  document.documentElement.style.setProperty('--accent-color', color);
-  document.documentElement.style.setProperty('--link-color', color);
+  const highContrast = isHighContrastActive();
+  const accentValue = highContrast ? HIGH_CONTRAST_ACCENT_COLOR : color;
+  const rootStyle = document.documentElement.style;
+  rootStyle.setProperty('--accent-color', accentValue);
+  if (highContrast) {
+    rootStyle.removeProperty('--link-color');
+  } else {
+    rootStyle.setProperty('--link-color', color);
+  }
   if (document.body) {
-    document.body.style.setProperty('--accent-color', color);
-    document.body.style.setProperty('--link-color', color);
+    const bodyStyle = document.body.style;
+    bodyStyle.setProperty('--accent-color', accentValue);
+    if (highContrast) {
+      bodyStyle.removeProperty('--link-color');
+    } else {
+      bodyStyle.setProperty('--link-color', color);
+    }
   }
 };
 
@@ -10753,11 +10771,24 @@ if (darkModeToggle) {
 
 function applyHighContrast(enabled) {
   if (enabled) {
-    document.body.classList.add("high-contrast");
+    if (document.body) {
+      document.body.classList.add("high-contrast");
+    }
     document.documentElement.classList.add("high-contrast");
+    applyAccentColor(accentColor);
   } else {
-    document.body.classList.remove("high-contrast");
+    if (document.body) {
+      document.body.classList.remove("high-contrast");
+    }
     document.documentElement.classList.remove("high-contrast");
+    if (document.body && document.body.classList.contains('pink-mode')) {
+      document.documentElement.style.removeProperty('--accent-color');
+      document.documentElement.style.removeProperty('--link-color');
+      document.body.style.removeProperty('--accent-color');
+      document.body.style.removeProperty('--link-color');
+    } else {
+      applyAccentColor(accentColor);
+    }
   }
 }
 

--- a/style.css
+++ b/style.css
@@ -1682,6 +1682,7 @@ html.dark-mode,
 
 html.high-contrast,
 body.high-contrast {
+  --accent-color: #fff;
   --background-color: #000;
   --surface-color: #000;
   --text-color: #fff;

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -2114,9 +2114,35 @@ describe('script.js functions', () => {
     expect(localStorage.getItem('accentColor')).toBe('#123456');
     expect(localStorage.getItem('fontSize')).toBe('18');
     expect(localStorage.getItem('fontFamily')).toBe("'Arial', sans-serif");
+    expect(document.documentElement.style.getPropertyValue('--accent-color')).toBe('#ffffff');
+    expect(document.body.style.getPropertyValue('--accent-color')).toBe('#ffffff');
+    expect(document.documentElement.style.getPropertyValue('--link-color')).toBe('');
+    expect(document.body.style.getPropertyValue('--link-color')).toBe('');
     expect(document.body.classList.contains('high-contrast')).toBe(true);
     expect(document.documentElement.classList.contains('high-contrast')).toBe(true);
     expect(dialog.hasAttribute('hidden')).toBe(true);
+  });
+
+  test('applyHighContrast forces white accent color and restores the saved choice', () => {
+    const { applyHighContrast } = script;
+    const settingsBtn = document.getElementById('settingsButton');
+    settingsBtn.click();
+    const colorInput = document.getElementById('accentColorInput');
+    colorInput.value = '#345678';
+    document.getElementById('settingsSave').click();
+    expect(document.documentElement.style.getPropertyValue('--accent-color')).toBe('#345678');
+    expect(document.body.style.getPropertyValue('--accent-color')).toBe('#345678');
+    applyHighContrast(true);
+    expect(document.body.classList.contains('high-contrast')).toBe(true);
+    expect(getComputedStyle(document.body).getPropertyValue('--accent-color').trim()).toBe('#ffffff');
+    expect(document.documentElement.style.getPropertyValue('--link-color')).toBe('');
+    expect(document.body.style.getPropertyValue('--link-color')).toBe('');
+    applyHighContrast(false);
+    expect(document.body.classList.contains('high-contrast')).toBe(false);
+    expect(document.documentElement.style.getPropertyValue('--accent-color')).toBe('#345678');
+    expect(document.body.style.getPropertyValue('--accent-color')).toBe('#345678');
+    expect(document.documentElement.style.getPropertyValue('--link-color')).toBe('#345678');
+    expect(document.body.style.getPropertyValue('--link-color')).toBe('#345678');
   });
 
   test('uploaded logo is saved and included in printable overview', async () => {


### PR DESCRIPTION
## Summary
- ensure high contrast mode drives accent updates through a dedicated helper so the UI forces a white accent while the mode is active and restores the saved tone afterwards
- set the CSS high contrast theme to use a white accent by default
- extend the Jest suite to assert the new behaviour and guarantee link colour handling and restoration logic

## Testing
- npm test *(fails: script suite exhausts container memory after lint, consistency and unit checks succeed)*
- NODE_OPTIONS=--max-old-space-size=4096 npm run test:script *(fails: script suite still exhausts container memory)*
- NODE_OPTIONS=--max-old-space-size=8192 npm run test:script *(fails: suite later aborts because jsdom lacks URL.revokeObjectURL in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c86815070c832095f276f520ef2403