### PR TITLE
Match logo fill with current theme background

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,7 +34,7 @@
         <defs>
           <style>
             .cls-1 { fill: var(--accent-color); }
-            .cls-2 { fill: #fdfdfd; }
+            .cls-2 { fill: var(--background-color, #fdfdfd); }
           </style>
         </defs>
         <rect class="cls-1" width="1024" height="1024" rx="128" ry="128" />


### PR DESCRIPTION
## Summary
- update the inline logo SVG styling so the light portions track the theme background via CSS variables

## Testing
- NODE_OPTIONS=--max-old-space-size=8192 npm test *(fails: multiple pre-existing script.test.js expectations such as collectAccessories not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68c8717bc36c83208273583317f9862a