### PR TITLE
Expand font size settings options

### DIFF
--- a/index.html
+++ b/index.html
@@ -695,9 +695,14 @@
       <div class="form-row">
         <label for="settingsFontSize" id="settingsFontSizeLabel">Font size</label>
         <select id="settingsFontSize">
+          <option value="10">10px</option>
+          <option value="12">12px</option>
           <option value="14">14px</option>
           <option value="16">16px</option>
           <option value="18">18px</option>
+          <option value="20">20px</option>
+          <option value="22">22px</option>
+          <option value="24">24px</option>
         </select>
       </div>
       <div class="form-row">

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -399,7 +399,7 @@ describe('settings backup and restore', () => {
     localStorage.setItem('darkMode', 'true');
     localStorage.setItem('pinkMode', 'true');
     localStorage.setItem('highContrast', 'true');
-    localStorage.setItem('fontSize', '18');
+    localStorage.setItem('fontSize', '22');
     localStorage.setItem('fontFamily', 'Inter');
     localStorage.setItem('accentColor', '#123456');
 
@@ -422,7 +422,7 @@ describe('settings backup and restore', () => {
     expect(obj.settings.darkMode).toBe('true');
     expect(obj.settings.pinkMode).toBe('true');
     expect(obj.settings.highContrast).toBe('true');
-    expect(obj.settings.fontSize).toBe('18');
+    expect(obj.settings.fontSize).toBe('22');
     expect(obj.settings.fontFamily).toBe('Inter');
     expect(obj.settings.accentColor).toBe('#123456');
     expect(anchor.download).toBe('2024-05-01T12-34-56Z full app backup.json');
@@ -2101,18 +2101,20 @@ describe('script.js functions', () => {
     const colorInput = document.getElementById('accentColorInput');
     const sizeSelect = document.getElementById('settingsFontSize');
     const familySelect = document.getElementById('settingsFontFamily');
+    const sizeValues = Array.from(sizeSelect.options).map(opt => opt.value);
+    expect(sizeValues).toEqual(['10', '12', '14', '16', '18', '20', '22', '24']);
     langSelect.value = 'de';
     darkCheck.checked = true;
     contrastCheck.checked = true;
     colorInput.value = '#123456';
-    sizeSelect.value = '18';
+    sizeSelect.value = '10';
     familySelect.value = "'Arial', sans-serif";
     document.getElementById('settingsSave').click();
     expect(localStorage.getItem('language')).toBe('de');
     expect(localStorage.getItem('darkMode')).toBe('true');
     expect(localStorage.getItem('highContrast')).toBe('true');
     expect(localStorage.getItem('accentColor')).toBe('#123456');
-    expect(localStorage.getItem('fontSize')).toBe('18');
+    expect(localStorage.getItem('fontSize')).toBe('10');
     expect(localStorage.getItem('fontFamily')).toBe("'Arial', sans-serif");
     expect(document.body.classList.contains('high-contrast')).toBe(true);
     expect(document.documentElement.classList.contains('high-contrast')).toBe(true);


### PR DESCRIPTION
## Summary
- add 10px and 12px options to the settings font-size selector alongside the larger sizes so users have more control over text size
- update the script integration test to assert the dropdown values and confirm saving the smallest font preference

## Testing
- npm run lint
- npm run check-consistency
- npm run test:unit
- NODE_OPTIONS=--max-old-space-size=4096 npx jest --runInBand tests/script.test.js --testNamePattern="settings dialog saves preferences to localStorage"

------
https://chatgpt.com/codex/tasks/task_e_68c870e82f5c8320adf585ae8d1c56e6