### PR TITLE
Document settings personalization and cache reset

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -49,7 +49,7 @@ The app automatically uses your browser language on first load, and you can swit
 - Save, load and delete multiple camera projects (press Enter or Ctrl+S/⌘S to save quickly; the Save button stays disabled until a name is entered).
 - Automatic snapshots are created every 10 minutes while the planner is open, and the Settings dialog can trigger hourly backup exports as a reminder to archive data.
 - Download a JSON project file that bundles selections, requirements, gear lists, runtime feedback and custom devices; load it through the Shared Project picker to restore everything in one step.
-- Data is stored locally via `localStorage` and favorites are preserved in backups; use the dedicated clear button if you need to wipe cached projects and device edits.
+- Data is stored locally via `localStorage` and favorites are preserved in backups; use the dedicated **Clear Local Cache** button in Settings if you need to wipe cached projects and device edits.
 - Generate printable overviews for any saved project and add a custom logo so exports and backups match your production branding.
 - Save project requirements along with each project so gear lists retain full context.
 - Works fully offline with the installed service worker—language, theme, device data and favorites persist between sessions.
@@ -59,7 +59,7 @@ The app automatically uses your browser language on first load, and you can swit
 ### 🧭 Interface Overview
 - A skip link and offline indicator keep the layout accessible on keyboard and touch devices—the badge appears whenever the browser loses its connection.
 - The global search bar jumps to features, device selectors or help topics; press Enter to activate the highlighted result and tap × to clear the query.
-- Top bar controls provide language switching, dark and pink theme toggles plus a Settings dialog that exposes accent color, font size, font family, high contrast and custom logo uploads alongside backup and restore tools.
+- Top bar controls provide language switching, dark and pink theme toggles plus a Settings dialog that exposes accent color, font size, font family, high contrast and custom logo uploads alongside backup, restore and Clear Local Cache tools.
 - The Help button opens a searchable dialog with step-by-step sections, keyboard shortcuts, FAQs and an optional hover-help mode; it can also be triggered with ?, H, F1 or Ctrl+/ even while typing.
 - The Force reload button (🔄) clears cached service worker files so the offline app updates without deleting saved projects or custom devices.
 - On smaller screens a collapsible side menu mirrors every major section for quick navigation.
@@ -87,7 +87,8 @@ The generator turns your selections into a categorized packing list:
 - Battery rows mirror counts from the power calculator and include hotswap plates or chosen hotswap devices when required.
 - Monitoring preferences assign default monitors for each role (Director, DoP, Focus, etc.) with cable sets and wireless receivers.
 - The **Project Requirements** form feeds the list:
-  - **Project Name** and **DoP** appear in the heading of the printed requirements.
+  - **Project Name**, **Production Company**, **Rental House** and **DoP** appear in the heading of the printed requirements.
+  - **Crew** entries capture names, roles and email addresses so contact info travels with the project.
   - **Prep Days** and **Shooting Days** supply schedule notes and, when paired with outdoor scenarios, suggest weather gear.
   - **Required Scenarios** append matching rigging, gimbals and weather protection.
   - **Camera Handle** and **Viewfinder Extension** insert the chosen handle parts or extension brackets.
@@ -213,7 +214,8 @@ Serving the app over HTTP(S) installs a service worker that caches every file
 so Cine Power Planner works fully offline and updates in the background. Projects,
 runtime submissions and preferences (language, theme, pink mode and saved gear
 lists) live in your browser's `localStorage`. Clearing the site's data in the
-browser removes all stored information.
+browser removes all stored information, and the Settings dialog includes a
+**Clear Local Cache** button for the same one-click cleanup.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ See the language-specific README files for full details.
 
 - A skip link, offline indicator and responsive branding keep the interface accessible across devices; the offline badge appears whenever the browser loses its connection.
 - The global search bar jumps to features, device selectors or help topics—press Enter to navigate to the highlighted result and use × to clear the query.
-- Language, dark mode and pink mode buttons sit alongside the Settings dialog, which exposes accent color, font size, font family, high contrast and custom logo uploads plus backup and restore tools.
+- Language, dark mode and pink mode buttons sit alongside the Settings dialog, which exposes accent color, font size, font family, high contrast and custom logo uploads plus backup, restore and Clear Local Cache tools.
 - The Help button opens a searchable dialog with step-by-step sections, keyboard shortcuts, FAQs and an optional hover-help mode; it can also be triggered with ?, H, F1 or Ctrl+/ even while typing.
 - The Force reload button (🔄) removes cached service worker files and refreshes the app without touching saved projects or device data.
 
@@ -138,7 +138,8 @@ The planner expands your selections into a detailed packing table:
 - Battery rows reflect counts from the power calculator and include a hotswap plate or the selected hotswap device when needed.
 - Monitoring preferences provide default monitors for each role and bundle cable sets for every screen.
 - The **Project Requirements** form feeds the list:
-  - **Project Name** and **DoP** appear in the heading of the printed requirements.
+  - **Project Name**, **Production Company**, **Rental House** and **DoP** appear in the heading of the printed requirements.
+  - **Crew** entries capture names, roles and email addresses so contact lists stay attached to each project.
   - **Prep Days** and **Shooting Days** supply schedule notes and, when paired with outdoor scenarios, suggest weather gear.
   - **Required Scenarios** append matching rigging, gimbals and weather protection.
   - **Camera Handle** and **Viewfinder Extension** insert the chosen handle parts or extension brackets.
@@ -185,8 +186,8 @@ files so the planner runs entirely offline and pulls updates in the
 background. Projects, runtime submissions and preferences (language, theme,
 pink mode and saved gear lists) are stored locally via `localStorage` in your
 browser. Clearing the site's data in your browser removes all saved
-information. See [Backup and Recovery](#backup-and-recovery) for tips on keeping
-your data safe.
+information, and the Settings dialog includes a **Clear Local Cache** button for a one-click reset when you need a fresh start.
+See [Backup and Recovery](#backup-and-recovery) for tips on keeping your data safe.
 
 ## Backup and Recovery
 
@@ -203,6 +204,9 @@ controls to export your work:
   the internal `exportAllData()` routine. Restoring the file automatically saves
   a safety copy of your current data before importing the new settings and warns
   when the file was produced with a different app version.
+- **Clear Local Cache:** In **Settings → Backup & Restore**, wipe saved projects,
+  custom gear, favorites and runtime feedback with one click when you need to
+  start over.
 - **Regular reminders:** While the planner is running, an hourly background job
   triggers the same backup export so you always have a recent download prompt as
   a reminder to archive your data.

--- a/index.html
+++ b/index.html
@@ -777,6 +777,8 @@
             <li>Refine runtime estimates with user feedback and a visual weighting dashboard.</li>
             <li>Open a searchable help dialog with step-by-step guides and FAQ.</li>
             <li>Switch languages, toggle dark or playful pink themes and work fully offline. Theme settings persist.</li>
+            <li>Personalize the interface from Settings—adjust accent color, base font size and typeface, toggle high contrast and upload a custom logo that appears in backups and printable overviews.</li>
+            <li>Start fresh at any time with the Clear Local Cache button in Settings, which removes saved projects, custom devices, favorites and runtime feedback in one click.</li>
             <li>Force reload clears cached files and updates the app without deleting saved data.</li>
             <li>Cameras with both V- and B-Mount plates let you swap battery types; the list updates automatically.</li>
           </ul>
@@ -794,15 +796,17 @@
           <ul>
             <li>Use <strong>Save</strong> to store the current configuration in your browser. Press Enter or Ctrl+S (⌘S on macOS) to save quickly; the Save button stays disabled until a name is entered.</li>
             <li><strong>Share Project</strong> downloads a JSON file containing your selections, project requirements, gear list, runtime feedback and any custom devices so you can back up or share the setup.</li>
+            <li>Open <strong>Settings</strong> to fine-tune accent color, base font size, typeface and high contrast mode, upload a custom logo and manage full planner backups or restores.</li>
             <li>Select a JSON file in <strong>Shared Project</strong> and click <strong>Load</strong> to restore a shared configuration.</li>
             <li>Use <strong>Delete</strong> to remove the saved entry or <strong>Clear Current Project</strong> to wipe the current selection without touching saved copies.</li>
             <li><strong>Generate Overview</strong> produces a printable summary of any saved project.</li>
+            <li>Need a clean slate? Choose <strong>Clear Local Cache</strong> in Settings → Backup &amp; Restore to erase saved projects, custom devices, favorites and runtime submissions in one step.</li>
             </ul>
           </section>
         <section data-help-section id="projectRequirementsHelp">
           <h3><span class="help-icon" aria-hidden="true">🗒️</span>Project Requirements</h3>
           <ul>
-            <li>Capture details like DoP, shooting dates, resolutions, codecs and more for each project.</li>
+            <li>Capture production details such as production company, rental house, DoP, crew roles with email contacts, shooting dates, resolutions, codecs and more for each project.</li>
             <li>Multi-select lists let you specify multiple scenarios, accessories or monitoring setups.</li>
             <li>The information is saved with the project and included in printed overviews and gear lists.</li>
           </ul>
@@ -836,7 +840,8 @@
               <li>Monitoring preferences contribute default screens for each role (Director, DoP, Focus Puller, Client), matching video transmitters and pre‑bundled cable sets.</li>
               <li>The <strong>Project Requirements</strong> form acts as a template for the list. Each field adds context and gear:
                 <ul>
-                  <li><strong>Project Name</strong>, <strong>DoP</strong>, <strong>Prep</strong> and <strong>Shooting Days</strong> populate the printed header and can trigger weather gear with outdoor scenarios.</li>
+                  <li><strong>Project Name</strong>, <strong>Production Company</strong>, <strong>Rental House</strong>, <strong>DoP</strong>, <strong>Prep</strong> and <strong>Shooting Days</strong> populate the printed header and can trigger weather gear with outdoor scenarios.</li>
+                  <li><strong>Crew</strong> entries keep names, roles and email addresses attached so contact lists and call sheets stay current.</li>
                   <li><strong>Required Scenarios</strong> toggle accessory packs as described above.</li>
                   <li><strong>Camera Handle</strong>, <strong>Viewfinder Extension</strong> and <strong>User Button Layouts</strong> supply matching handles, VF extensions and notes for operators.</li>
                   <li><strong>Matte Box</strong> and <strong>Filter Set</strong> selections insert filter trays, donuts, adapters and storage cases.</li>
@@ -1029,7 +1034,7 @@
           </details>
           <details class="faq-item">
             <summary>How do I reset everything to the defaults?</summary>
-            <p>Open the device editor and choose <em>Export and Revert</em> to restore the default database. Delete projects individually using the Delete button.</p>
+            <p>Open the device editor and choose <em>Export and Revert</em> to restore the default database. Delete projects individually using the Delete button, or open <em>Settings → Backup &amp; Restore</em> and press <em>Clear Local Cache</em> to wipe saved projects, favorites and runtime data at once.</p>
           </details>
           <details class="faq-item">
             <summary>How do I change the language?</summary>


### PR DESCRIPTION
## Summary
- expand the in-app help to cover settings customization, the Clear Local Cache control and updated project requirement fields
- describe the new production company and crew email details captured in gear lists across README variants
- document the Clear Local Cache option alongside backup workflows in the primary documentation

## Testing
- not run (documentation changes only)

------
https://chatgpt.com/codex/tasks/task_e_68c8830dc81083209e11f07290cd41c7