### PR TITLE
Fix backup timestamps to use local timezone

### DIFF
--- a/script.js
+++ b/script.js
@@ -11037,8 +11037,24 @@ function formatFullBackupFilename(date) {
   const safeDate = date instanceof Date && !Number.isNaN(date.valueOf())
     ? date
     : new Date();
-  const iso = safeDate.toISOString();
-  const safeIso = iso.replace(/[:]/g, '-').replace(/\.\d{3}Z$/, 'Z');
+  const pad = n => String(n).padStart(2, '0');
+  const year = safeDate.getFullYear();
+  const month = pad(safeDate.getMonth() + 1);
+  const day = pad(safeDate.getDate());
+  const hours = pad(safeDate.getHours());
+  const minutes = pad(safeDate.getMinutes());
+  const seconds = pad(safeDate.getSeconds());
+  const offsetMinutes = safeDate.getTimezoneOffset();
+  let offsetSuffix = 'Z';
+  if (offsetMinutes !== 0) {
+    const sign = offsetMinutes > 0 ? '-' : '+';
+    const abs = Math.abs(offsetMinutes);
+    const offsetHours = pad(Math.floor(abs / 60));
+    const offsetMins = pad(abs % 60);
+    offsetSuffix = `${sign}${offsetHours}:${offsetMins}`;
+  }
+  const iso = `${year}-${month}-${day}T${hours}:${minutes}:${seconds}${offsetSuffix}`;
+  const safeIso = iso.replace(/[:]/g, '-');
   return {
     iso,
     fileName: `${safeIso} full app backup.json`,
@@ -12217,5 +12233,6 @@ if (typeof module !== "undefined" && module.exports) {
     setCurrentProjectInfo,
     getCurrentProjectInfo,
     crewRoles,
+    formatFullBackupFilename,
   };
 }


### PR DESCRIPTION
## Summary
- format `formatFullBackupFilename` to build filenames from the local time and export it for tests
- update the settings backup test to assert the timestamp and filename match the localized format

## Testing
- npm run lint
- npm run check-consistency
- npm run test:unit
- NODE_OPTIONS=--max_old_space_size=4096 npm run test:script *(fails: JavaScript heap out of memory even with the higher limit)*

------
https://chatgpt.com/codex/tasks/task_e_68c884ff31808320a7f13fc3ddfffd20