### PR TITLE
Add smaller and bitter font sizes

### DIFF
--- a/index.html
+++ b/index.html
@@ -704,9 +704,11 @@
         <div class="form-row">
           <label for="settingsFontSize" id="settingsFontSizeLabel">Font size</label>
           <select id="settingsFontSize">
+            <option value="12">12px (Smaller)</option>
             <option value="14">14px</option>
             <option value="16">16px</option>
             <option value="18">18px</option>
+            <option value="20">20px (Bitter)</option>
           </select>
         </div>
         <div class="form-row">

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -2151,19 +2151,26 @@ describe('script.js functions', () => {
     const contrastCheck = document.getElementById('settingsHighContrast');
     const colorInput = document.getElementById('accentColorInput');
     const sizeSelect = document.getElementById('settingsFontSize');
+    expect(Array.from(sizeSelect.options).map((option) => option.value)).toEqual([
+      '12',
+      '14',
+      '16',
+      '18',
+      '20',
+    ]);
     const familySelect = document.getElementById('settingsFontFamily');
     langSelect.value = 'de';
     darkCheck.checked = true;
     contrastCheck.checked = true;
     colorInput.value = '#123456';
-    sizeSelect.value = '18';
+    sizeSelect.value = '20';
     familySelect.value = "'Arial', sans-serif";
     document.getElementById('settingsSave').click();
     expect(localStorage.getItem('language')).toBe('de');
     expect(localStorage.getItem('darkMode')).toBe('true');
     expect(localStorage.getItem('highContrast')).toBe('true');
     expect(localStorage.getItem('accentColor')).toBe('#123456');
-    expect(localStorage.getItem('fontSize')).toBe('18');
+    expect(localStorage.getItem('fontSize')).toBe('20');
     expect(localStorage.getItem('fontFamily')).toBe("'Arial', sans-serif");
     expect(document.documentElement.style.getPropertyValue('--accent-color')).toBe('#ffffff');
     expect(document.body.style.getPropertyValue('--accent-color')).toBe('#ffffff');


### PR DESCRIPTION
## Summary
- add 12px (Smaller) and 20px (Bitter) options to the settings font-size dropdown
- extend the settings dialog test to cover the new font size choices and verify storing the 20px selection

## Testing
- npm test *(fails: JavaScript heap out of memory)*
- NODE_OPTIONS=--max-old-space-size=4096 npm test *(fails: JavaScript heap out of memory when running script tests)*
- NODE_OPTIONS=--max-old-space-size=6144 npm run test:script *(fails: existing script.js suite failures in jsdom such as missing URL.revokeObjectURL)*

------
https://chatgpt.com/codex/tasks/task_e_68c88571a3088320bf61d6dc6ba636a0