### PR TITLE
Enhance CLI help descriptions

### DIFF
--- a/checkConsistency.js
+++ b/checkConsistency.js
@@ -31,15 +31,24 @@ if (require.main === module) {
   const args = process.argv.slice(2);
   if (args.includes('--help') || args.includes('-h')) {
     console.log(
-      'Usage: node checkConsistency.js [--help]\n' +
-        '\nChecks that device entries contain required fields.\n' +
-        'Exits with code 1 when missing fields are found.\n' +
-        '\nExamples:\n' +
-        '  npm run check-consistency\n' +
-        '  npm run check-consistency -- --help\n' +
-        '  node checkConsistency.js --help\n' +
-        '\nOptions:\n' +
+      [
+        'Usage: node checkConsistency.js [--help]',
+        '',
+        'Checks device entries in data.js for required fields across key categories.',
+        'Leaves data.js untouched and exits with code 1 when a required field is missing.',
+        '',
+        'Tips:',
+        '  - Run after editing files in devices/ to catch missing power, connector or port details.',
+        '  - Include it in CI before committing updates to the shared device database.',
+        '',
+        'Examples:',
+        '  npm run check-consistency',
+        '  npm run check-consistency -- --help',
+        '  node checkConsistency.js --help',
+        '',
+        'Options:',
         '  -h, --help  Show this help message and exit.'
+      ].join('\n')
     );
     process.exit(0);
   }

--- a/generateSchema.js
+++ b/generateSchema.js
@@ -50,14 +50,22 @@ if (require.main === module) {
   const args = process.argv.slice(2);
   if (args.includes('--help') || args.includes('-h')) {
     console.log(
-      'Usage: node generateSchema.js [--help]\n' +
-        '\nGenerates schema.json from data.js.\n' +
-        '\nExamples:\n' +
-        '  npm run generate-schema\n' +
-        '  npm run generate-schema -- --help\n' +
-        '  node generateSchema.js --help\n' +
-        '\nOptions:\n' +
+      [
+        'Usage: node generateSchema.js [--help]',
+        '',
+        'Generates schema.json from data.js.',
+        '',
+        'The output lists attributes found in each device category so editors and tests can validate new entries.',
+        'It writes schema.json in the project root without modifying data.js.',
+        '',
+        'Examples:',
+        '  npm run generate-schema',
+        '  npm run generate-schema -- --help',
+        '  node generateSchema.js --help',
+        '',
+        'Options:',
         '  -h, --help  Show this help message and exit.'
+      ].join('\n')
     );
     process.exit(0);
   }

--- a/normalizeData.js
+++ b/normalizeData.js
@@ -387,14 +387,26 @@ if (require.main === module) {
   const args = process.argv.slice(2);
   if (args.includes('--help') || args.includes('-h')) {
     console.log(
-      'Usage: node normalizeData.js [--help]\n' +
-        '\nCleans and expands device data, then overwrites data.js with the result.\n' +
-        '\nExamples:\n' +
-        '  npm run normalize\n' +
-        '  npm run normalize -- --help\n' +
-        '  node normalizeData.js --help\n' +
-        '\nOptions:\n' +
+      [
+        'Usage: node normalizeData.js [--help]',
+        '',
+        'Cleans and expands device data, then overwrites data.js with the result.',
+        '',
+        'What it does:',
+        '  - Harmonizes connector names across cameras, motors and controllers (LBUS, LEMO, Hirose, etc.).',
+        '  - Normalizes recording media, timecode generators, viewfinders and lens mounts.',
+        '  - Rebuilds derived fields such as power distribution outputs and video port lists.',
+        '',
+        'The script modifies data.js in place. Review the diff and commit it with matching schema updates.',
+        '',
+        'Examples:',
+        '  npm run normalize',
+        '  npm run normalize -- --help',
+        '  node normalizeData.js --help',
+        '',
+        'Options:',
         '  -h, --help  Show this help message and exit.'
+      ].join('\n')
     );
     process.exit(0);
   }

--- a/tests/cliHelp.test.js
+++ b/tests/cliHelp.test.js
@@ -8,6 +8,8 @@ test('checkConsistency CLI --help', () => {
   const { stdout, status } = run('checkConsistency.js');
   expect(stdout).toMatch(/Usage: node checkConsistency\.js \[--help\]/);
   expect(stdout).toMatch(/-h, --help\s+Show this help message and exit/);
+  expect(stdout).toContain('Tips:');
+  expect(stdout).toContain('Leaves data.js untouched');
   expect(status).toBe(0);
 });
 
@@ -15,6 +17,8 @@ test('normalizeData CLI --help', () => {
   const { stdout, status } = run('normalizeData.js');
   expect(stdout).toMatch(/Usage: node normalizeData\.js \[--help\]/);
   expect(stdout).toMatch(/-h, --help\s+Show this help message and exit/);
+  expect(stdout).toContain('What it does:');
+  expect(stdout).toContain('Harmonizes connector names');
   expect(status).toBe(0);
 });
 
@@ -22,5 +26,15 @@ test('unifyPorts CLI --help', () => {
   const { stdout, status } = run('unifyPorts.js');
   expect(stdout).toMatch(/Usage: node unifyPorts\.js \[--help\]/);
   expect(stdout).toMatch(/-h, --help\s+Show this help message and exit/);
+  expect(stdout).toContain('Key actions:');
+  expect(stdout).toContain('Converts legacy powerInput strings');
+  expect(status).toBe(0);
+});
+
+test('generateSchema CLI --help', () => {
+  const { stdout, status } = run('generateSchema.js');
+  expect(stdout).toMatch(/Usage: node generateSchema\.js \[--help\]/);
+  expect(stdout).toMatch(/-h, --help\s+Show this help message and exit/);
+  expect(stdout).toContain('writes schema.json in the project root');
   expect(status).toBe(0);
 });

--- a/unifyPorts.js
+++ b/unifyPorts.js
@@ -328,14 +328,26 @@ if (require.main === module) {
   const args = process.argv.slice(2);
   if (args.includes('--help') || args.includes('-h')) {
     console.log(
-      'Usage: node unifyPorts.js [--help]\n' +
-        '\nNormalizes connector and port definitions in data.js and overwrites the file.\n' +
-        '\nExamples:\n' +
-        '  npm run unify-ports\n' +
-        '  npm run unify-ports -- --help\n' +
-        '  node unifyPorts.js --help\n' +
-        '\nOptions:\n' +
+      [
+        'Usage: node unifyPorts.js [--help]',
+        '',
+        'Normalizes connector and port definitions in data.js and overwrites the file.',
+        '',
+        'Key actions:',
+        '  - Converts legacy powerInput strings into structured power.input entries.',
+        '  - Cleans audio, video and FIZ ports, merging duplicates and removing blanks.',
+        '  - Aligns voltage ranges and port metadata so dropdown help stays descriptive.',
+        '',
+        'Run this after normalizeData.js to keep port information consistent. Review and commit the resulting data.js diff.',
+        '',
+        'Examples:',
+        '  npm run unify-ports',
+        '  npm run unify-ports -- --help',
+        '  node unifyPorts.js --help',
+        '',
+        'Options:',
         '  -h, --help  Show this help message and exit.'
+      ].join('\n')
     );
     process.exit(0);
   }


### PR DESCRIPTION
## Summary
- expand the `--help` text for the maintenance scripts to explain what each command does, highlight key actions and include practical tips
- add CLI tests that assert the new descriptive output and cover `generateSchema.js`

## Testing
- `npm run lint`
- `npm run check-consistency`
- `npm run test:unit`
- `NODE_OPTIONS=--max-old-space-size=4096 npm test` *(fails during `test:script` because the suite exhausts heap memory; individual lint/check/unit commands above passed)*
- `NODE_OPTIONS=--max-old-space-size=8192 npm run test:script` *(still infeasible in this environment—the long-running integration suite reports many existing expectation failures before completion)*

------
https://chatgpt.com/codex/tasks/task_e_68c8a9562e2483208e6cc072946e8b5f