### PR TITLE
Add Ctrl+K shortcut for global search

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -17,6 +17,7 @@ The app automatically uses your browser language on first load, and you can swit
 
 ## 🆕 Recent Features
 - Accent and typography controls in Settings let you adjust the accent color, base font size and typeface alongside dark, pink and high contrast themes.
+- Keyboard shortcut for the global search lets you press Ctrl+K (⌘K on macOS) to focus the feature search instantly, even when it sits inside the collapsed mobile side menu.
 - Force reload button clears cached service worker files so the offline app refreshes without deleting saved projects or devices.
 - Star icons in every selector pin favorite cameras, batteries and accessories to the top of the list and keep them in backups.
 - Clear local cache button wipes stored projects and settings.
@@ -58,7 +59,7 @@ The app automatically uses your browser language on first load, and you can swit
 
 ### 🧭 Interface Overview
 - A skip link and offline indicator keep the layout accessible on keyboard and touch devices—the badge appears whenever the browser loses its connection.
-- The global search bar jumps to features, device selectors or help topics; press Enter to activate the highlighted result and tap × to clear the query.
+- The global search bar jumps to features, device selectors or help topics; press Enter to activate the highlighted result, use Ctrl+K (⌘K on macOS) to focus it from anywhere (the side menu opens automatically on small screens) and tap × to clear the query.
 - Top bar controls provide language switching, dark and pink theme toggles plus a Settings dialog that exposes accent color, font size, font family, high contrast and custom logo uploads alongside backup, restore and Clear Local Cache tools.
 - The Help button opens a searchable dialog with step-by-step sections, keyboard shortcuts, FAQs and an optional hover-help mode; it can also be triggered with ?, H, F1 or Ctrl+/ even while typing.
 - The Force reload button (🔄) clears cached service worker files so the offline app updates without deleting saved projects or custom devices.
@@ -67,7 +68,7 @@ The app automatically uses your browser language on first load, and you can swit
 ### ♿ Customization & Accessibility
 - Theme preferences include dark mode, playful pink accents and a dedicated high contrast switch for improved readability.
 - Accent color, base font size and typeface changes apply instantly and persist in the browser, letting you match studio branding or accessibility needs.
-- Built-in keyboard shortcuts cover help ( ?, H, F1, Ctrl+/ ), saving (Enter or Ctrl+S/⌘S), dark mode (D) and pink mode (P).
+- Built-in keyboard shortcuts cover global search (Ctrl+K/⌘K), help ( ?, H, F1, Ctrl+/ ), saving (Enter or Ctrl+S/⌘S), dark mode (D) and pink mode (P).
 - Hover-help mode turns every button, field, dropdown and header into an on-demand tooltip so new users can learn the interface quickly.
 - Type-to-search inputs, focus-visible controls and star icons beside selectors let you filter long lists quickly and pin favourite devices to the top.
 
@@ -156,7 +157,7 @@ The generator turns your selections into a categorized packing list:
 ### 🔍 Search & Filtering
 - Type inside dropdowns to quickly find entries
 - Filter device lists with a search box
-- Use the global search bar at the top to jump to features, devices or help topics; press Enter to navigate and × to clear.
+- Use the global search bar at the top to jump to features, devices or help topics; press Enter to navigate, Ctrl+K (⌘K on macOS) to focus it instantly and × to clear.
 - Press '/' or Ctrl+F (⌘F on macOS) to focus the nearest search box instantly.
 - Click the star beside any selector to pin favourites so they stay at the top of the list and sync with backups.
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Contributions for additional languages are welcome. To add a translation, includ
 ## Recent Updates
 
 - **Accent and typography controls** – adjust the accent color, font size and typeface from the Settings dialog while dark, pink and high contrast themes remain available on every visit.
+- **Global search shortcut** – press Ctrl+K (⌘K on macOS) to focus the feature search instantly, even when it lives inside the collapsed mobile side menu.
 - **Force reload button** – clear cached service worker files and refresh the offline app without deleting saved projects or devices.
 - **Pinned favorites** – star dropdown entries to keep go-to cameras, batteries and accessories at the top of each selector and include them in backups.
 - **Clear local cache** – wipe stored projects and settings with one click.
@@ -106,7 +107,7 @@ See the language-specific README files for full details.
 ### Top bar controls
 
 - A skip link, offline indicator and responsive branding keep the interface accessible across devices; the offline badge appears whenever the browser loses its connection.
-- The global search bar jumps to features, device selectors or help topics—press Enter to navigate to the highlighted result and use × to clear the query.
+- The global search bar jumps to features, device selectors or help topics—press Enter to navigate to the highlighted result, use Ctrl+K (⌘K on macOS) to focus it from anywhere (the side menu opens automatically on small screens), and use × to clear the query.
 - Language, dark mode and pink mode buttons sit alongside the Settings dialog, which exposes accent color, font size, font family, high contrast and custom logo uploads plus backup, restore and Clear Local Cache tools.
 - The Help button opens a searchable dialog with step-by-step sections, keyboard shortcuts, FAQs and an optional hover-help mode; it can also be triggered with ?, H, F1 or Ctrl+/ even while typing.
 - The Force reload button (🔄) removes cached service worker files and refreshes the app without touching saved projects or device data.
@@ -122,7 +123,7 @@ See the language-specific README files for full details.
 - Theme preferences include dark mode, playful pink accents and a dedicated high contrast switch for improved readability.
 - Accent color, base font size and typeface can be customised in Settings; choices are applied immediately and remembered with other preferences.
 - A keyboard-friendly skip link, focus-visible controls, offline indicator and responsive layout improve navigation on desktops, tablets and phones.
-- Built-in keyboard shortcuts cover help ( ?, H, F1, Ctrl+/ ), saving (Enter or Ctrl+S/⌘S), dark mode (D) and pink mode (P).
+- Built-in keyboard shortcuts cover global search (Ctrl+K/⌘K), help ( ?, H, F1, Ctrl+/ ), saving (Enter or Ctrl+S/⌘S), dark mode (D) and pink mode (P).
 - The hover-help toggle turns every button, field, dropdown and header into an on-demand tooltip so new users can learn the interface quickly.
 
 ## Gear List

--- a/script.js
+++ b/script.js
@@ -86,6 +86,22 @@ function closeSideMenu() {
 }
 
 /**
+ * Open the sidebar menu if it is currently closed.
+ */
+function openSideMenu() {
+  const menu = document.getElementById('sideMenu');
+  const overlay = document.getElementById('menuOverlay');
+  const toggle = document.getElementById('menuToggle');
+  if (!menu || !overlay || !toggle) return;
+  if (menu.classList.contains('open')) return;
+  menu.classList.add('open');
+  menu.removeAttribute('hidden');
+  overlay.classList.remove('hidden');
+  toggle.setAttribute('aria-expanded', 'true');
+  toggle.setAttribute('aria-label', 'Close menu');
+}
+
+/**
  * Initialize sidebar menu toggle.
  */
 function setupSideMenu() {
@@ -95,14 +111,10 @@ function setupSideMenu() {
   if (!toggle || !menu || !overlay) return;
 
   toggle.addEventListener('click', () => {
-    const isOpen = menu.classList.toggle('open');
-    if (isOpen) {
-      menu.removeAttribute('hidden');
-      overlay.classList.remove('hidden');
-      toggle.setAttribute('aria-expanded', 'true');
-      toggle.setAttribute('aria-label', 'Close menu');
-    } else {
+    if (menu.classList.contains('open')) {
       closeSideMenu();
+    } else {
+      openSideMenu();
     }
   });
 
@@ -11676,6 +11688,26 @@ if (helpButton && helpDialog) {
     });
   }
 
+  const focusFeatureSearchInput = () => {
+    if (!featureSearch) return;
+    const sideMenu = document.getElementById('sideMenu');
+    if (sideMenu?.contains(featureSearch)) {
+      openSideMenu();
+    }
+    if (typeof featureSearch.scrollIntoView === 'function') {
+      featureSearch.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    }
+    try {
+      featureSearch.focus({ preventScroll: true });
+    } catch {
+      featureSearch.focus();
+    }
+    if (typeof featureSearch.select === 'function') {
+      featureSearch.select();
+    }
+    featureSearch.showPicker?.();
+  };
+
   const runFeatureSearch = query => {
     if (!query) return;
     const value = query.trim();
@@ -11766,7 +11798,7 @@ if (helpButton && helpDialog) {
       if (featureSearch) {
         featureSearch.value = '';
         featureSearchClear.setAttribute('hidden', '');
-        featureSearch.focus();
+        focusFeatureSearchInput();
       }
     });
     if (featureSearch && featureSearch.value) {
@@ -11822,6 +11854,9 @@ if (helpButton && helpDialog) {
       // When the dialog is open, / or Ctrl+F moves focus to the search box
       e.preventDefault();
       if (helpSearch) helpSearch.focus();
+    } else if (e.key.toLowerCase() === 'k' && (e.ctrlKey || e.metaKey)) {
+      e.preventDefault();
+      focusFeatureSearchInput();
     } else if (e.key.toLowerCase() === 'd' && !isTextField) {
       darkModeEnabled = !document.body.classList.contains('dark-mode');
       applyDarkMode(darkModeEnabled);

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -6379,6 +6379,48 @@ describe('script.js functions', () => {
     expect(featureSearch.showPicker).toHaveBeenCalled();
   });
 
+  test('Ctrl+K focuses the global feature search', () => {
+    setupDom(false);
+    require('../script.js');
+    const featureSearch = document.getElementById('featureSearch');
+    const setupName = document.getElementById('setupName');
+    featureSearch.value = 'Sony FX3';
+    featureSearch.showPicker = jest.fn();
+    setupName.focus();
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'k', ctrlKey: true }));
+
+    expect(document.activeElement).toBe(featureSearch);
+    expect(featureSearch.selectionStart).toBe(0);
+    expect(featureSearch.selectionEnd).toBe(featureSearch.value.length);
+    expect(featureSearch.showPicker).toHaveBeenCalled();
+  });
+
+  test('Ctrl+K opens the side menu when the feature search is inside it', () => {
+    setupDom(false);
+    require('../script.js');
+    const featureContainer = document.querySelector('.feature-search');
+    const sideMenu = document.getElementById('sideMenu');
+    const sidebarControls = sideMenu.querySelector('.sidebar-controls');
+    const overlay = document.getElementById('menuOverlay');
+    const toggle = document.getElementById('menuToggle');
+    sidebarControls.appendChild(featureContainer);
+    sideMenu.classList.remove('open');
+    sideMenu.setAttribute('hidden', '');
+    overlay.classList.add('hidden');
+    toggle.setAttribute('aria-expanded', 'false');
+    toggle.setAttribute('aria-label', 'Menu');
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'k', ctrlKey: true }));
+
+    expect(sideMenu.classList.contains('open')).toBe(true);
+    expect(sideMenu.hasAttribute('hidden')).toBe(false);
+    expect(overlay.classList.contains('hidden')).toBe(false);
+    expect(toggle.getAttribute('aria-expanded')).toBe('true');
+    expect(toggle.getAttribute('aria-label')).toBe('Close menu');
+    expect(document.activeElement).toBe(document.getElementById('featureSearch'));
+  });
+
   test('feature clear button resets search', () => {
     setupDom(false);
     require('../script.js');

--- a/translations.js
+++ b/translations.js
@@ -40,7 +40,7 @@ const texts = {
     featureSearchPlaceholder: "Search features or devices...",
     featureSearchLabel: "Search features, devices and help",
     featureSearchHelp:
-      "Type to jump to features, devices or help topics. Press Enter to navigate and use × to clear the query.",
+      "Type to jump to features, devices or help topics. Press Enter to navigate, Ctrl+K (Cmd+K on Mac) to focus the search from anywhere, and use × to clear the query.",
     featureSearchClear: "Clear search",
     featureSearchClearHelp: "Clear the search box and show all results again.",
     darkModeHelp:
@@ -463,7 +463,7 @@ const texts = {
     featureSearchPlaceholder: "Cerca funzionalità o dispositivi...",
     featureSearchLabel: "Cerca funzionalità, dispositivi e aiuto",
     featureSearchHelp:
-      "Digita per andare alle funzionalità, ai dispositivi o aprire gli argomenti di aiuto correlati. Premi Invio per navigare e × per cancellare la ricerca.",
+      "Digita per andare alle funzionalità, ai dispositivi o aprire gli argomenti di aiuto correlati. Premi Invio per navigare, Ctrl+K (Cmd+K su Mac) per mettere a fuoco la ricerca ovunque e × per cancellare la ricerca.",
     featureSearchClear: "Cancella ricerca",
     featureSearchClearHelp: "Cancella il campo di ricerca e mostra di nuovo tutti i risultati.",
     darkModeHelp:
@@ -861,7 +861,7 @@ const texts = {
     featureSearchPlaceholder: "Buscar funciones o dispositivos...",
     featureSearchLabel: "Buscar funciones, dispositivos y ayuda",
     featureSearchHelp:
-      "Escribe para ir a funciones, dispositivos o temas de ayuda relacionados. Pulsa Enter para navegar y × para limpiar la búsqueda.",
+      "Escribe para ir a funciones, dispositivos o temas de ayuda relacionados. Pulsa Enter para navegar, Ctrl+K (Cmd+K en Mac) para enfocar la búsqueda desde cualquier lugar y × para limpiar la búsqueda.",
     featureSearchClear: "Borrar búsqueda",
     featureSearchClearHelp: "Limpia el campo de búsqueda y muestra todos los resultados de nuevo.",
     darkModeHelp:
@@ -1273,7 +1273,7 @@ const texts = {
     featureSearchPlaceholder: "Rechercher des fonctionnalités ou des appareils...",
     featureSearchLabel: "Rechercher des fonctionnalités, des appareils et de l'aide",
     featureSearchHelp:
-      "Tapez pour accéder aux fonctionnalités, appareils ou sujets d'aide associés. Appuyez sur Entrée pour naviguer et sur × pour effacer la requête.",
+      "Tapez pour accéder aux fonctionnalités, appareils ou sujets d'aide associés. Appuyez sur Entrée pour naviguer, sur Ctrl+K (Cmd+K sur Mac) pour placer le focus sur la recherche où que vous soyez, puis sur × pour effacer la requête.",
     featureSearchClear: "Effacer la recherche",
     featureSearchClearHelp: "Efface le champ de recherche et affiche à nouveau tous les résultats.",
     darkModeHelp:
@@ -1687,7 +1687,7 @@ const texts = {
     featureSearchPlaceholder: "Funktionen oder Geräte durchsuchen...",
     featureSearchLabel: "Funktionen, Geräte und Hilfe durchsuchen",
     featureSearchHelp:
-      "Tippen, um zu Funktionen, Geräten oder Hilfethemen zu springen. Mit Enter springen und mit × die Suche leeren.",
+      "Tippen, um zu Funktionen, Geräten oder Hilfethemen zu springen. Drücke Enter zum Navigieren, Strg+K (Cmd+K auf dem Mac), um die Suche überall zu fokussieren, und ×, um die Eingabe zu löschen.",
     featureSearchClear: "Suche löschen",
     featureSearchClearHelp: "Suchfeld leeren und alle Ergebnisse wieder anzeigen.",
     darkModeHelp:


### PR DESCRIPTION
## Summary
- focus the global search from anywhere with a new Ctrl+K shortcut that opens the sidebar on small screens
- add unit coverage for the new keyboard shortcut behaviour
- document the shortcut and update the localized help text

## Testing
- NODE_OPTIONS=--max-old-space-size=4096 npm test *(fails: JavaScript heap out of memory)*
- NODE_OPTIONS=--max-old-space-size=4096 npm run test:script -- --testNamePattern "Ctrl+K"

------
https://chatgpt.com/codex/tasks/task_e_68c8a97c2808832094e2b264c3b927cc