### PR TITLE
Improve global search matching

### DIFF
--- a/script.js
+++ b/script.js
@@ -11676,6 +11676,22 @@ if (helpButton && helpDialog) {
     });
   }
 
+  const findSearchMatch = (map, key) => {
+    if (!key) return null;
+    if (map.has(key)) return map.get(key);
+    for (const [mapKey, value] of map) {
+      if (mapKey.startsWith(key)) {
+        return value;
+      }
+    }
+    for (const [mapKey, value] of map) {
+      if (mapKey.includes(key)) {
+        return value;
+      }
+    }
+    return null;
+  };
+
   const runFeatureSearch = query => {
     if (!query) return;
     const value = query.trim();
@@ -11724,17 +11740,19 @@ if (helpButton && helpDialog) {
       }
     };
 
-    const device = deviceMap.get(cleanKey);
-    if (device && !isHelp) {
-      device.select.value = device.value;
-      device.select.dispatchEvent(new Event('change', { bubbles: true }));
-      focusFeature(device.select);
-      return;
-    }
-    const featureEl = featureMap.get(cleanKey);
-    if (featureEl && !isHelp) {
-      focusFeature(featureEl);
-      return;
+    if (!isHelp) {
+      const device = findSearchMatch(deviceMap, cleanKey);
+      if (device) {
+        device.select.value = device.value;
+        device.select.dispatchEvent(new Event('change', { bubbles: true }));
+        focusFeature(device.select);
+        return;
+      }
+      const featureEl = findSearchMatch(featureMap, cleanKey);
+      if (featureEl) {
+        focusFeature(featureEl);
+        return;
+      }
     }
     openHelp();
     if (helpSearch) {

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -6370,6 +6370,29 @@ describe('script.js functions', () => {
     expect(cameraSelect.value).toBe('Sony FX3');
   });
 
+  test('feature search matches partial device names', () => {
+    setupDom(false);
+    require('../script.js');
+    const featureSearch = document.getElementById('featureSearch');
+    const cameraSelect = document.getElementById('cameraSelect');
+    featureSearch.value = 'fx3';
+    featureSearch.dispatchEvent(new Event('change'));
+    expect(cameraSelect.value).toBe('Sony FX3');
+  });
+
+  test('feature search matches partial feature headings', () => {
+    setupDom(false);
+    require('../script.js');
+    const featureSearch = document.getElementById('featureSearch');
+    const heading = document.getElementById('deviceSelectionHeading');
+    heading.scrollIntoView = jest.fn();
+    heading.focus = jest.fn();
+    featureSearch.value = 'device';
+    featureSearch.dispatchEvent(new Event('change'));
+    expect(heading.scrollIntoView).toHaveBeenCalled();
+    expect(heading.focus).toHaveBeenCalled();
+  });
+
   test('feature search shows predictions on input', () => {
     setupDom(false);
     require('../script.js');


### PR DESCRIPTION
## Summary
- add a helper that finds the best feature or device match for partial global-search queries
- update the global search handler to use the helper so typing fragments still activates the closest feature or device
- extend the script test suite to cover partial device and heading matches

## Testing
- NODE_OPTIONS=--max_old_space_size=8192 npm test *(fails: numerous existing `tests/script.test.js` assertions expecting full dataset; see logs)*

------
https://chatgpt.com/codex/tasks/task_e_68c8a992d9108320b2f2db07c827c9a0