### PR TITLE
Improve global search matching

### DIFF
--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -6370,6 +6370,16 @@ describe('script.js functions', () => {
     expect(cameraSelect.value).toBe('Sony FX3');
   });
 
+  test('feature search matches partial device names', () => {
+    setupDom(false);
+    require('../script.js');
+    const featureSearch = document.getElementById('featureSearch');
+    const cameraSelect = document.getElementById('cameraSelect');
+    featureSearch.value = 'FX3';
+    featureSearch.dispatchEvent(new Event('change'));
+    expect(cameraSelect.value).toBe('Sony FX3');
+  });
+
   test('feature search shows predictions on input', () => {
     setupDom(false);
     require('../script.js');


### PR DESCRIPTION
## Summary
- make the global search more forgiving by finding the closest matching feature or device even when the query is partial
- keep track of device labels so successful searches normalize the input text
- cover the partial matching behavior with a dedicated script test

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c92fe65fa08320a2da3421c82931a8