### PR TITLE
Normalize search queries and extend coverage

### DIFF
--- a/script.js
+++ b/script.js
@@ -2815,7 +2815,29 @@ const featureSearchClear = document.getElementById("featureSearchClear");
 const featureList     = document.getElementById("featureList");
 const featureMap      = new Map();
 const deviceMap       = new Map();
-const searchKey       = str => str.toLowerCase().replace(/\s+/g, '');
+// Normalise strings for search comparisons by removing punctuation, diacritics
+// and treating symbols like “&”/“+” as their word equivalents. Falls back to
+// whitespace-stripping when no meaningful characters remain (e.g. emoji-only
+// headings) so legacy behaviour is preserved for those edge cases.
+const searchKey       = str => {
+  if (!str) return '';
+  const value = String(str);
+  let normalized = value.toLowerCase();
+  if (typeof normalized.normalize === 'function') {
+    normalized = normalized.normalize('NFD');
+  }
+  normalized = normalized
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/ß/g, 'ss')
+    .replace(/æ/g, 'ae')
+    .replace(/œ/g, 'oe')
+    .replace(/ø/g, 'o')
+    .replace(/&/g, 'and')
+    .replace(/\+/g, 'plus');
+  const simplified = normalized.replace(/[^a-z0-9]+/g, '');
+  if (simplified) return simplified;
+  return value.toLowerCase().replace(/\s+/g, '');
+};
 const existingDevicesHeading = document.getElementById("existingDevicesHeading");
 const batteryComparisonSection = document.getElementById("batteryComparison");
 const batteryTableElem = document.getElementById("batteryTable");

--- a/tests/script.test.js
+++ b/tests/script.test.js
@@ -6380,6 +6380,32 @@ describe('script.js functions', () => {
     expect(cameraSelect.value).toBe('Sony FX3');
   });
 
+  test('feature search tolerates punctuation in queries', () => {
+    setupDom(false);
+    require('../script.js');
+    const featureSearch = document.getElementById('featureSearch');
+    const cameraSelect = document.getElementById('cameraSelect');
+    featureSearch.value = 'Sony FX-3';
+    featureSearch.dispatchEvent(new Event('change'));
+    expect(cameraSelect.value).toBe('Sony FX3');
+  });
+
+  test('feature search matches ampersands when typing "and"', () => {
+    setupDom(false);
+    require('../translations.js');
+    require('../script.js');
+    const featureSearch = document.getElementById('featureSearch');
+    const settingsDialog = document.getElementById('settingsDialog');
+    const helpDialog = document.getElementById('helpDialog');
+    expect(settingsDialog.hasAttribute('hidden')).toBe(true);
+    expect(helpDialog.hasAttribute('hidden')).toBe(true);
+    featureSearch.value = 'Backup and Restore';
+    featureSearch.dispatchEvent(new Event('change'));
+    expect(settingsDialog.hasAttribute('hidden')).toBe(false);
+    expect(helpDialog.hasAttribute('hidden')).toBe(true);
+    expect(featureSearch.value).toBe('Backup & Restore');
+  });
+
   test('feature search shows predictions on input', () => {
     setupDom(false);
     require('../script.js');


### PR DESCRIPTION
## Summary
- normalize search keys so feature/device lookups ignore punctuation, diacritics and common symbols
- extend the feature search test suite with cases for punctuation-heavy device names and "and" vs "&" headings

## Testing
- NODE_OPTIONS=--max-old-space-size=4096 npm run test:script *(fails: Node.js ran out of memory in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c9337589a08320a5b372e824ba5bdd