### PR TITLE
Align legal pages with app styling

### DIFF
--- a/datenschutz.html
+++ b/datenschutz.html
@@ -1,41 +1,83 @@
 <!DOCTYPE html>
 <html lang="de">
 <head>
-  <meta charset="UTF-8">
-  <title>Datenschutz</title>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+  <meta name="color-scheme" content="light dark" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; connect-src 'self'; img-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self'; manifest-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none';" />
   <meta name="referrer" content="no-referrer" />
-  <link rel="stylesheet" href="style.css">
+  <meta name="theme-color" content="#f9f9f9" />
+  <title>Datenschutz</title>
+  <link rel="icon" href="icon.svg" type="image/svg+xml" />
+  <link rel="icon" href="icon.png" type="image/png" />
+  <link rel="apple-touch-icon" href="icon.png" />
+  <link rel="stylesheet" href="style.css" />
+  <script src="static-theme.js" defer></script>
 </head>
-<body>
-  <main>
+<body class="static-page">
+  <a href="#mainContent" class="skip-link">Zum Inhalt springen</a>
+  <div id="offlineIndicator" role="status" aria-live="polite">Offline</div>
+  <header id="topBar">
+    <div class="branding">
+      <svg id="logo" viewBox="0 0 1024 1024" aria-hidden="true">
+        <defs>
+          <style>
+            .cls-1 { fill: var(--accent-color); }
+            .cls-2 { fill: #fff; }
+          </style>
+        </defs>
+        <rect class="cls-1" width="1024" height="1024" rx="128" ry="128" />
+        <path class="cls-1" d="M332.79,264.29c-66.13,6.4-105.19,79.54-74.31,138.73,35.25,67.58,131.84,67.97,167.69.65,35.6-66.85-18.81-146.6-93.38-139.38ZM532.8,264.3c-51.89,4.85-90.78,55.06-84.79,106.19,9.73,82.92,118.85,114.08,169.97,46.99,51.33-67.37-2.29-160.92-85.18-153.18ZM689.21,517.2l.28,157.8,82.46,50.54c9.27,5.08,19.04.97,20.1-10-.62-80.73,1-161.7-.82-242.28-2.55-6.41-9.86-10.22-16.21-6.74l-85.81,50.68ZM274.74,468.24c-12.21,3.53-19.68,12.51-20.77,25.23l.05,221.03c1.77,14.87,11.57,24.26,26.45,25.55h326.07c14.13-1.11,25.08-10,26.51-24.49v-223.08c-1.21-13.19-11.34-23.3-24.5-24.5l-333.8.28ZM672,530h-19v134h19v-134Z" />
+        <path class="cls-2" d="M274.74,468.24l333.8-.28c13.16,1.2,23.29,11.31,24.5,24.5v223.08c-1.43,14.49-12.37,23.38-26.51,24.49h-326.07c-14.89-1.28-24.69-10.68-26.45-25.55l-.05-221.03c1.09-12.71,8.56-21.7,20.77-25.23ZM467,582l14.91-68.61c-3.75-14.34-10.29-10.19-17.88-1.86-28.03,30.79-51.9,68.87-79.85,100.15-4.19,3.66-1.94,14.32,3.32,14.32h42.5l-14.07,67.5c.6,11.86,10.68,13.88,17.04,3.97l79.87-102.13c3.57-4.95,1.6-13.34-5.34-13.34h-40.5Z" />
+        <path class="cls-2" d="M532.8,264.3c82.89-7.74,136.51,85.82,85.18,153.18-51.12,67.08-160.24,35.92-169.97-46.99-6-51.12,32.9-101.34,84.79-106.19ZM539.79,321.27c-49.71,4.46-43.19,80.2,6.71,75.72,49.16-4.42,42.05-80.09-6.71-75.72Z" />
+        <path class="cls-2" d="M332.79,264.29c74.57-7.22,128.98,72.53,93.38,139.38-35.85,67.31-132.44,66.92-167.69-.65-30.87-59.18,8.09-132.33,74.31-138.73ZM315.35,332.35c-32.21,32.16,12.32,84.81,49.14,57.64,43.84-32.35-11.25-95.49-49.14-57.64Z" />
+        <path class="cls-2" d="M689.21,517.2l85.81-50.68c6.35-3.48,13.67.34,16.21,6.74,1.82,80.58.2,161.55.82,242.28-1.06,10.97-10.83,15.09-20.1,10l-82.46-50.54-.28-157.8Z" />
+        <rect class="cls-2" x="653" y="530" width="19" height="134" />
+        <path class="cls-1" d="M467,582h40.5c6.94,0,8.9,8.4,5.34,13.34l-79.87,102.13c-6.36,9.92-16.44,7.89-17.04-3.97l14.07-67.5h-42.5c-5.26,0-7.51-10.65-3.32-14.32,27.95-31.29,51.81-69.37,79.85-100.15,7.59-8.33,14.13-12.49,17.88,1.86l-14.91,68.61Z" />
+        <path class="cls-1" d="M539.79,321.27c48.76-4.38,55.87,71.3,6.71,75.72-49.9,4.48-56.42-71.26-6.71-75.72Z" />
+        <path class="cls-1" d="M315.35,332.35c37.9-37.85,92.98,25.3,49.14,57.64-36.82,27.17-81.35-25.48-49.14-57.64Z" />
+      </svg>
+      <h1 id="mainTitle">Cine Power Planner</h1>
+    </div>
+    <nav class="static-nav" aria-label="Sekundärnavigation">
+      <a class="button-link" href="index.html">Zurück zur App</a>
+    </nav>
+  </header>
+  <main id="mainContent" class="legal-content" tabindex="-1">
     <h1>Datenschutzerklärung</h1>
-    <h2>Verantwortliche Stelle</h2>
-    <p>Luca Zanner<br>Brünnsteinstraße 5<br>81541 München<br>E-Mail: <a href="mailto:info@lucazanner.com">info@lucazanner.com</a></p>
-    <h2>Erhebung und Speicherung personenbezogener Daten sowie Art und Zweck von deren Verwendung</h2>
-    <p><strong>Beim Besuch der Website:</strong> Der Provider dieser Seite erhebt und speichert automatisch Informationen in sogenannten Server-Log-Dateien, die Ihr Browser automatisch übermittelt (z. B. IP-Adresse, Datum und Uhrzeit der Anfrage, Referrer-URL, verwendeter Browser). Diese Daten dienen ausschließlich zur Gewährleistung eines störungsfreien Betriebs und zur Verbesserung des Angebots. Eine Zuordnung zu bestimmten Personen findet nicht statt.</p>
-    <p><strong>Bei Kontaktaufnahme per E-Mail:</strong> Die von Ihnen übermittelten personenbezogenen Daten werden ausschließlich zur Bearbeitung Ihrer Anfrage verwendet.</p>
-    <h2>Weitergabe von Daten</h2>
-    <p>Eine Übermittlung Ihrer persönlichen Daten an Dritte zu anderen als den im Folgenden aufgeführten Zwecken findet nicht statt. Wir geben Ihre persönlichen Daten nur an Dritte weiter, wenn:</p>
-    <ul>
-      <li>Sie Ihre ausdrückliche Einwilligung dazu erteilt haben,</li>
-      <li>die Verarbeitung zur Abwicklung eines Vertrags erforderlich ist,</li>
-      <li>die Verarbeitung zur Erfüllung einer rechtlichen Verpflichtung erforderlich ist.</li>
-    </ul>
-    <h2>Cookies</h2>
-    <p>Diese Website verwendet Cookies. Cookies richten auf Ihrem Rechner keinen Schaden an und enthalten keine Viren. Sie dienen dazu, unser Angebot nutzerfreundlicher, effektiver und sicherer zu machen. Die meisten der von uns verwendeten Cookies sind „Session-Cookies“, die nach Ende Ihres Besuchs automatisch gelöscht werden. Sie können Ihren Browser so einstellen, dass Sie über das Setzen von Cookies informiert werden und Cookies nur im Einzelfall erlauben.</p>
-    <h2>Betroffenenrechte</h2>
-    <p>Sie haben das Recht:</p>
-    <ul>
-      <li>gemäß Art. 15 DSGVO Auskunft über Ihre von uns verarbeiteten personenbezogenen Daten zu verlangen,</li>
-      <li>gemäß Art. 16 DSGVO die Berichtigung unrichtiger oder Vervollständigung Ihrer bei uns gespeicherten personenbezogenen Daten zu verlangen,</li>
-      <li>gemäß Art. 17 DSGVO die Löschung Ihrer bei uns gespeicherten personenbezogenen Daten zu verlangen, sofern nicht gesetzliche Verpflichtungen entgegenstehen,</li>
-      <li>gemäß Art. 18 DSGVO die Einschränkung der Verarbeitung Ihrer personenbezogenen Daten zu verlangen,</li>
-      <li>gemäß Art. 20 DSGVO Ihre personenbezogenen Daten in einem strukturierten, gängigen und maschinenlesbaren Format zu erhalten oder die Übermittlung an einen anderen Verantwortlichen zu verlangen.</li>
-    </ul>
-    <h2>Beschwerderecht bei der zuständigen Aufsichtsbehörde</h2>
-    <p>Im Falle datenschutzrechtlicher Verstöße steht Ihnen ein Beschwerderecht bei einer Aufsichtsbehörde zu. Zuständige Aufsichtsbehörde ist der Landesdatenschutzbeauftragte des Bundeslandes, in dem unser Unternehmen seinen Sitz hat.</p>
-    <p>Diese Datenschutzerklärung ist ein allgemeines Muster und ersetzt keine individuelle Rechtsberatung.</p>
+    <div class="legal-card">
+      <h2>Verantwortliche Stelle</h2>
+      <p>Luca Zanner<br>Brünnsteinstraße 5<br>81541 München<br>E-Mail: <a href="mailto:info@lucazanner.com">info@lucazanner.com</a></p>
+      <h2>Erhebung und Speicherung personenbezogener Daten sowie Art und Zweck von deren Verwendung</h2>
+      <p><strong>Beim Besuch der Website:</strong> Der Provider dieser Seite erhebt und speichert automatisch Informationen in sogenannten Server-Log-Dateien, die Ihr Browser automatisch übermittelt (z. B. IP-Adresse, Datum und Uhrzeit der Anfrage, Referrer-URL, verwendeter Browser). Diese Daten dienen ausschließlich zur Gewährleistung eines störungsfreien Betriebs und zur Verbesserung des Angebots. Eine Zuordnung zu bestimmten Personen findet nicht statt.</p>
+      <p><strong>Bei Kontaktaufnahme per E-Mail:</strong> Die von Ihnen übermittelten personenbezogenen Daten werden ausschließlich zur Bearbeitung Ihrer Anfrage verwendet.</p>
+      <h2>Weitergabe von Daten</h2>
+      <p>Eine Übermittlung Ihrer persönlichen Daten an Dritte zu anderen als den im Folgenden aufgeführten Zwecken findet nicht statt. Wir geben Ihre persönlichen Daten nur an Dritte weiter, wenn:</p>
+      <ul>
+        <li>Sie Ihre ausdrückliche Einwilligung dazu erteilt haben,</li>
+        <li>die Verarbeitung zur Abwicklung eines Vertrags erforderlich ist,</li>
+        <li>die Verarbeitung zur Erfüllung einer rechtlichen Verpflichtung erforderlich ist.</li>
+      </ul>
+      <h2>Cookies</h2>
+      <p>Diese Website verwendet Cookies. Cookies richten auf Ihrem Rechner keinen Schaden an und enthalten keine Viren. Sie dienen dazu, unser Angebot nutzerfreundlicher, effektiver und sicherer zu machen. Die meisten der von uns verwendeten Cookies sind „Session-Cookies“, die nach Ende Ihres Besuchs automatisch gelöscht werden. Sie können Ihren Browser so einstellen, dass Sie über das Setzen von Cookies informiert werden und Cookies nur im Einzelfall erlauben.</p>
+      <h2>Betroffenenrechte</h2>
+      <p>Sie haben das Recht:</p>
+      <ul>
+        <li>gemäß Art. 15 DSGVO Auskunft über Ihre von uns verarbeiteten personenbezogenen Daten zu verlangen,</li>
+        <li>gemäß Art. 16 DSGVO die Berichtigung unrichtiger oder Vervollständigung Ihrer bei uns gespeicherten personenbezogenen Daten zu verlangen,</li>
+        <li>gemäß Art. 17 DSGVO die Löschung Ihrer bei uns gespeicherten personenbezogenen Daten zu verlangen, sofern nicht gesetzliche Verpflichtungen entgegenstehen,</li>
+        <li>gemäß Art. 18 DSGVO die Einschränkung der Verarbeitung Ihrer personenbezogenen Daten zu verlangen,</li>
+        <li>gemäß Art. 20 DSGVO Ihre personenbezogenen Daten in einem strukturierten, gängigen und maschinenlesbaren Format zu erhalten oder die Übermittlung an einen anderen Verantwortlichen zu verlangen.</li>
+      </ul>
+      <h2>Beschwerderecht bei der zuständigen Aufsichtsbehörde</h2>
+      <p>Im Falle datenschutzrechtlicher Verstöße steht Ihnen ein Beschwerderecht bei einer Aufsichtsbehörde zu. Zuständige Aufsichtsbehörde ist der Landesdatenschutzbeauftragte des Bundeslandes, in dem unser Unternehmen seinen Sitz hat.</p>
+      <p>Diese Datenschutzerklärung ist ein allgemeines Muster und ersetzt keine individuelle Rechtsberatung.</p>
+    </div>
   </main>
+  <footer id="siteFooter">
+    <a href="impressum.html">Impressum</a>
+    |
+    <a href="datenschutz.html">Datenschutz</a>
+  </footer>
 </body>
 </html>

--- a/impressum.html
+++ b/impressum.html
@@ -1,27 +1,69 @@
 <!DOCTYPE html>
 <html lang="de">
 <head>
-  <meta charset="UTF-8">
-  <title>Impressum</title>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+  <meta name="color-scheme" content="light dark" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; connect-src 'self'; img-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self'; manifest-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none';" />
   <meta name="referrer" content="no-referrer" />
-  <link rel="stylesheet" href="style.css">
+  <meta name="theme-color" content="#f9f9f9" />
+  <title>Impressum</title>
+  <link rel="icon" href="icon.svg" type="image/svg+xml" />
+  <link rel="icon" href="icon.png" type="image/png" />
+  <link rel="apple-touch-icon" href="icon.png" />
+  <link rel="stylesheet" href="style.css" />
+  <script src="static-theme.js" defer></script>
 </head>
-<body>
-  <main>
+<body class="static-page">
+  <a href="#mainContent" class="skip-link">Zum Inhalt springen</a>
+  <div id="offlineIndicator" role="status" aria-live="polite">Offline</div>
+  <header id="topBar">
+    <div class="branding">
+      <svg id="logo" viewBox="0 0 1024 1024" aria-hidden="true">
+        <defs>
+          <style>
+            .cls-1 { fill: var(--accent-color); }
+            .cls-2 { fill: #fff; }
+          </style>
+        </defs>
+        <rect class="cls-1" width="1024" height="1024" rx="128" ry="128" />
+        <path class="cls-1" d="M332.79,264.29c-66.13,6.4-105.19,79.54-74.31,138.73,35.25,67.58,131.84,67.97,167.69.65,35.6-66.85-18.81-146.6-93.38-139.38ZM532.8,264.3c-51.89,4.85-90.78,55.06-84.79,106.19,9.73,82.92,118.85,114.08,169.97,46.99,51.33-67.37-2.29-160.92-85.18-153.18ZM689.21,517.2l.28,157.8,82.46,50.54c9.27,5.08,19.04.97,20.1-10-.62-80.73,1-161.7-.82-242.28-2.55-6.41-9.86-10.22-16.21-6.74l-85.81,50.68ZM274.74,468.24c-12.21,3.53-19.68,12.51-20.77,25.23l.05,221.03c1.77,14.87,11.57,24.26,26.45,25.55h326.07c14.13-1.11,25.08-10,26.51-24.49v-223.08c-1.21-13.19-11.34-23.3-24.5-24.5l-333.8.28ZM672,530h-19v134h19v-134Z" />
+        <path class="cls-2" d="M274.74,468.24l333.8-.28c13.16,1.2,23.29,11.31,24.5,24.5v223.08c-1.43,14.49-12.37,23.38-26.51,24.49h-326.07c-14.89-1.28-24.69-10.68-26.45-25.55l-.05-221.03c1.09-12.71,8.56-21.7,20.77-25.23ZM467,582l14.91-68.61c-3.75-14.34-10.29-10.19-17.88-1.86-28.03,30.79-51.9,68.87-79.85,100.15-4.19,3.66-1.94,14.32,3.32,14.32h42.5l-14.07,67.5c.6,11.86,10.68,13.88,17.04,3.97l79.87-102.13c3.57-4.95,1.6-13.34-5.34-13.34h-40.5Z" />
+        <path class="cls-2" d="M532.8,264.3c82.89-7.74,136.51,85.82,85.18,153.18-51.12,67.08-160.24,35.92-169.97-46.99-6-51.12,32.9-101.34,84.79-106.19ZM539.79,321.27c-49.71,4.46-43.19,80.2,6.71,75.72,49.16-4.42,42.05-80.09-6.71-75.72Z" />
+        <path class="cls-2" d="M332.79,264.29c74.57-7.22,128.98,72.53,93.38,139.38-35.85,67.31-132.44,66.92-167.69-.65-30.87-59.18,8.09-132.33,74.31-138.73ZM315.35,332.35c-32.21,32.16,12.32,84.81,49.14,57.64,43.84-32.35-11.25-95.49-49.14-57.64Z" />
+        <path class="cls-2" d="M689.21,517.2l85.81-50.68c6.35-3.48,13.67.34,16.21,6.74,1.82,80.58.2,161.55.82,242.28-1.06,10.97-10.83,15.09-20.1,10l-82.46-50.54-.28-157.8Z" />
+        <rect class="cls-2" x="653" y="530" width="19" height="134" />
+        <path class="cls-1" d="M467,582h40.5c6.94,0,8.9,8.4,5.34,13.34l-79.87,102.13c-6.36,9.92-16.44,7.89-17.04-3.97l14.07-67.5h-42.5c-5.26,0-7.51-10.65-3.32-14.32,27.95-31.29,51.81-69.37,79.85-100.15,7.59-8.33,14.13-12.49,17.88,1.86l-14.91,68.61Z" />
+        <path class="cls-1" d="M539.79,321.27c48.76-4.38,55.87,71.3,6.71,75.72-49.9,4.48-56.42-71.26-6.71-75.72Z" />
+        <path class="cls-1" d="M315.35,332.35c37.9-37.85,92.98,25.3,49.14,57.64-36.82,27.17-81.35-25.48-49.14-57.64Z" />
+      </svg>
+      <h1 id="mainTitle">Cine Power Planner</h1>
+    </div>
+    <nav class="static-nav" aria-label="Sekundärnavigation">
+      <a class="button-link" href="index.html">Zurück zur App</a>
+    </nav>
+  </header>
+  <main id="mainContent" class="legal-content" tabindex="-1">
     <h1>Impressum</h1>
-    <h2>Angaben gemäß § 5 TMG</h2>
-    <p>Luca Zanner<br>Brünnsteinstraße 5<br>81541 München</p>
-    <h2>Kontakt</h2>
-    <p>E-Mail: <a href="mailto:info@lucazanner.com">info@lucazanner.com</a></p>
-    <h2>Verantwortlich für den Inhalt nach § 55 Abs. 2 RStV</h2>
-    <p>Luca Zanner<br>Brünnsteinstraße 5<br>81541 München</p>
-    <h2>Haftung für Inhalte</h2>
-    <p>Als Diensteanbieter sind wir gemäß § 7 Abs. 1 TMG für eigene Inhalte auf diesen Seiten nach den allgemeinen Gesetzen verantwortlich. Nach §§ 8 bis 10 TMG sind wir als Diensteanbieter jedoch nicht verpflichtet, übermittelte oder gespeicherte fremde Informationen zu überwachen oder nach Umständen zu forschen, die auf eine rechtswidrige Tätigkeit hinweisen. Verpflichtungen zur Entfernung oder Sperrung der Nutzung von Informationen nach den allgemeinen Gesetzen bleiben hiervon unberührt. Eine diesbezügliche Haftung ist jedoch erst ab dem Zeitpunkt der Kenntnis einer konkreten Rechtsverletzung möglich. Bei Bekanntwerden von Rechtsverletzungen werden wir diese Inhalte umgehend entfernen.</p>
-    <h2>Haftung für Links</h2>
-    <p>Unser Angebot enthält Links zu externen Websites Dritter, auf deren Inhalte wir keinen Einfluss haben. Deshalb können wir für diese fremden Inhalte auch keine Gewähr übernehmen. Für die Inhalte der verlinkten Seiten ist stets der jeweilige Anbieter oder Betreiber der Seiten verantwortlich. Die verlinkten Seiten wurden zum Zeitpunkt der Verlinkung auf mögliche Rechtsverstöße überprüft. Rechtswidrige Inhalte waren zum Zeitpunkt der Verlinkung nicht erkennbar. Eine permanente inhaltliche Kontrolle der verlinkten Seiten ist jedoch ohne konkrete Anhaltspunkte einer Rechtsverletzung nicht zumutbar. Bei Bekanntwerden von Rechtsverletzungen werden wir derartige Links umgehend entfernen.</p>
-    <h2>Urheberrecht</h2>
-    <p>Die durch die Seitenbetreiber erstellten Inhalte und Werke auf diesen Seiten unterliegen dem deutschen Urheberrecht. Die Vervielfältigung, Bearbeitung, Verbreitung und jede Art der Verwertung außerhalb der Grenzen des Urheberrechtes bedürfen der schriftlichen Zustimmung des jeweiligen Autors bzw. Erstellers. Downloads und Kopien dieser Seite sind nur für den privaten, nicht kommerziellen Gebrauch gestattet. Soweit die Inhalte auf dieser Seite nicht vom Betreiber erstellt wurden, werden die Urheberrechte Dritter beachtet. Insbesondere werden Inhalte Dritter als solche gekennzeichnet. Sollten Sie trotzdem auf eine Urheberrechtsverletzung aufmerksam werden, bitten wir um einen entsprechenden Hinweis. Bei Bekanntwerden von Rechtsverletzungen werden wir derartige Inhalte umgehend entfernen.</p>
+    <div class="legal-card">
+      <h2>Angaben gemäß § 5 TMG</h2>
+      <p>Luca Zanner<br>Brünnsteinstraße 5<br>81541 München</p>
+      <h2>Kontakt</h2>
+      <p>E-Mail: <a href="mailto:info@lucazanner.com">info@lucazanner.com</a></p>
+      <h2>Verantwortlich für den Inhalt nach § 55 Abs. 2 RStV</h2>
+      <p>Luca Zanner<br>Brünnsteinstraße 5<br>81541 München</p>
+      <h2>Haftung für Inhalte</h2>
+      <p>Als Diensteanbieter sind wir gemäß § 7 Abs. 1 TMG für eigene Inhalte auf diesen Seiten nach den allgemeinen Gesetzen verantwortlich. Nach §§ 8 bis 10 TMG sind wir als Diensteanbieter jedoch nicht verpflichtet, übermittelte oder gespeicherte fremde Informationen zu überwachen oder nach Umständen zu forschen, die auf eine rechtswidrige Tätigkeit hinweisen. Verpflichtungen zur Entfernung oder Sperrung der Nutzung von Informationen nach den allgemeinen Gesetzen bleiben hiervon unberührt. Eine diesbezügliche Haftung ist jedoch erst ab dem Zeitpunkt der Kenntnis einer konkreten Rechtsverletzung möglich. Bei Bekanntwerden von Rechtsverletzungen werden wir diese Inhalte umgehend entfernen.</p>
+      <h2>Haftung für Links</h2>
+      <p>Unser Angebot enthält Links zu externen Websites Dritter, auf deren Inhalte wir keinen Einfluss haben. Deshalb können wir für diese fremden Inhalte auch keine Gewähr übernehmen. Für die Inhalte der verlinkten Seiten ist stets der jeweilige Anbieter oder Betreiber der Seiten verantwortlich. Die verlinkten Seiten wurden zum Zeitpunkt der Verlinkung auf mögliche Rechtsverstöße überprüft. Rechtswidrige Inhalte waren zum Zeitpunkt der Verlinkung nicht erkennbar. Eine permanente inhaltliche Kontrolle der verlinkten Seiten ist jedoch ohne konkrete Anhaltspunkte einer Rechtsverletzung nicht zumutbar. Bei Bekanntwerden von Rechtsverletzungen werden wir derartige Links umgehend entfernen.</p>
+      <h2>Urheberrecht</h2>
+      <p>Die durch die Seitenbetreiber erstellten Inhalte und Werke auf diesen Seiten unterliegen dem deutschen Urheberrecht. Die Vervielfältigung, Bearbeitung, Verbreitung und jede Art der Verwertung außerhalb der Grenzen des Urheberrechtes bedürfen der schriftlichen Zustimmung des jeweiligen Autors bzw. Erstellers. Downloads und Kopien dieser Seite sind nur für den privaten, nicht kommerziellen Gebrauch gestattet. Soweit die Inhalte auf dieser Seite nicht vom Betreiber erstellt wurden, werden die Urheberrechte Dritter beachtet. Insbesondere werden Inhalte Dritter als solche gekennzeichnet. Sollten Sie trotzdem auf eine Urheberrechtsverletzung aufmerksam werden, bitten wir um einen entsprechenden Hinweis. Bei Bekanntwerden von Rechtsverletzungen werden wir derartige Inhalte umgehend entfernen.</p>
+    </div>
   </main>
+  <footer id="siteFooter">
+    <a href="impressum.html">Impressum</a>
+    |
+    <a href="datenschutz.html">Datenschutz</a>
+  </footer>
 </body>
 </html>

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,11 +1,12 @@
 /* eslint-env serviceworker */
-const CACHE_NAME = 'cine-power-planner-v14';
+const CACHE_NAME = 'cine-power-planner-v15';
 const ASSETS = [
   './',
   './index.html',
   './impressum.html',
   './datenschutz.html',
   './style.css',
+  './static-theme.js',
   './overview.css',
   './overview-print.css',
   './overview.js',

--- a/static-theme.js
+++ b/static-theme.js
@@ -1,0 +1,97 @@
+(function () {
+  const DEFAULT_ACCENT = '#001589';
+  const HIGH_CONTRAST_ACCENT = '#ffffff';
+  let storageErrorLogged = false;
+
+  const safeGet = key => {
+    try {
+      return window.localStorage ? localStorage.getItem(key) : null;
+    } catch (err) {
+      if (!storageErrorLogged) {
+        console.warn('Unable to read localStorage preference', err);
+        storageErrorLogged = true;
+      }
+      return null;
+    }
+  };
+
+  const updateThemeColor = isDark => {
+    const meta = document.querySelector('meta[name="theme-color"]');
+    if (meta) {
+      meta.setAttribute('content', isDark ? '#1c1c1e' : '#f9f9f9');
+    }
+  };
+
+  const applyAccent = (color, root, body) => {
+    const highContrastActive =
+      root.classList.contains('high-contrast') ||
+      (body && body.classList.contains('high-contrast'));
+    const accentValue = highContrastActive ? HIGH_CONTRAST_ACCENT : color;
+
+    root.style.setProperty('--accent-color', accentValue);
+    if (highContrastActive) {
+      root.style.removeProperty('--link-color');
+    } else {
+      root.style.setProperty('--link-color', color);
+    }
+
+    if (body) {
+      body.style.setProperty('--accent-color', accentValue);
+      if (highContrastActive) {
+        body.style.removeProperty('--link-color');
+      } else {
+        body.style.setProperty('--link-color', color);
+      }
+    }
+  };
+
+  const applyPreferences = () => {
+    const root = document.documentElement;
+    const body = document.body;
+    if (!root || !body) return;
+
+    const highContrastEnabled = safeGet('highContrast') === 'true';
+    root.classList.toggle('high-contrast', highContrastEnabled);
+    body.classList.toggle('high-contrast', highContrastEnabled);
+
+    const pinkModeEnabled = safeGet('pinkMode') === 'true';
+    body.classList.toggle('pink-mode', pinkModeEnabled);
+
+    const storedFontSize = safeGet('fontSize');
+    if (storedFontSize) {
+      root.style.fontSize = `${storedFontSize}px`;
+    }
+
+    const storedFontFamily = safeGet('fontFamily');
+    if (storedFontFamily) {
+      root.style.setProperty('--font-family', storedFontFamily);
+    }
+
+    let storedDarkMode = safeGet('darkMode');
+    if (storedDarkMode === null && typeof window !== 'undefined' && typeof window.matchMedia === 'function') {
+      storedDarkMode = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'true' : 'false';
+    }
+    const darkModeEnabled = storedDarkMode === 'true';
+    root.classList.toggle('dark-mode', darkModeEnabled);
+    body.classList.toggle('dark-mode', darkModeEnabled);
+    root.classList.toggle('light-mode', !darkModeEnabled);
+    body.classList.toggle('light-mode', !darkModeEnabled);
+    updateThemeColor(darkModeEnabled);
+
+    const accentColor = safeGet('accentColor') || DEFAULT_ACCENT;
+    if (pinkModeEnabled) {
+      root.style.removeProperty('--accent-color');
+      root.style.removeProperty('--link-color');
+      body.style.removeProperty('--accent-color');
+      body.style.removeProperty('--link-color');
+    } else {
+      applyAccent(accentColor, root, body);
+    }
+  };
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', applyPreferences);
+  } else {
+    applyPreferences();
+  }
+})();

--- a/style.css
+++ b/style.css
@@ -3,6 +3,7 @@
 :root {
   color-scheme: light dark;
   --accent-color: #001589;
+  --link-color: var(--accent-color);
   --background-color: #f9f9f9;
   --surface-color: #ffffff;
   --text-color: #000000;
@@ -233,6 +234,77 @@ footer {
 
 footer a {
   margin: 0 0.5em;
+}
+
+/* Static legal pages */
+body.static-page {
+  display: flex;
+  flex-direction: column;
+  min-height: 100%;
+}
+
+body.static-page main {
+  flex: 1;
+}
+
+main.legal-content {
+  max-width: 960px;
+}
+
+.legal-content h1 {
+  margin-bottom: 0.6em;
+}
+
+.legal-card {
+  background: var(--panel-bg);
+  border: 1px solid var(--panel-border);
+  border-radius: var(--border-radius);
+  padding: 20px;
+  box-shadow: var(--panel-shadow);
+}
+
+.legal-card h2:first-of-type {
+  margin-top: 0;
+}
+
+.legal-card h2 {
+  border-bottom: 1px solid var(--accent-color);
+  padding-bottom: 0.4em;
+}
+
+.static-nav {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.button-link,
+.button-link:visited {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: var(--button-size);
+  min-height: var(--button-size);
+  padding: 0 12px;
+  border-radius: var(--border-radius);
+  background-color: var(--control-bg);
+  color: var(--control-text);
+  font-size: 0.85em;
+  text-decoration: none;
+  transition: background-color 0.2s, color 0.2s, transform 0.2s;
+}
+
+.button-link:hover {
+  background-color: var(--accent-color);
+  color: var(--inverse-text-color);
+  transform: translateY(-2px);
+}
+
+.button-link:active {
+  background-color: var(--accent-color);
+  color: var(--inverse-text-color);
+  filter: brightness(0.9);
+  transform: translateY(0);
 }
 
 /* Form layout */

--- a/tests/service-worker.test.js
+++ b/tests/service-worker.test.js
@@ -9,6 +9,10 @@ describe('service worker configuration', () => {
     expect(ASSETS).toEqual(expect.arrayContaining(['./impressum.html', './datenschutz.html']));
   });
 
+  test('caches the shared theme helper for legal pages', () => {
+    expect(ASSETS).toEqual(expect.arrayContaining(['./static-theme.js']));
+  });
+
   test('exposes a cache name', () => {
     expect(typeof CACHE_NAME).toBe('string');
     expect(CACHE_NAME).not.toBe('');


### PR DESCRIPTION
## Summary
- give the Impressum and Datenschutz pages the same skip link, header, navigation and footer structure as the main app while loading the shared theme helper
- add static page styles and the new helper script so legal pages honor stored accent, font and theme settings
- cache the helper through the service worker and extend the tests to cover the additional asset

## Testing
- `npm run lint`
- `npm run check-consistency`
- `npm run test:unit`
- `NODE_OPTIONS=--max-old-space-size=8192 npm run test:script` *(fails: command exhausts Node heap before completing the legacy suite)*

------
https://chatgpt.com/codex/tasks/task_e_68c93c4f3bf88320839a96c2f06f4301