### PR TITLE
Improve global search token matching

### DIFF
--- a/tests/script/featureSearch.test.js
+++ b/tests/script/featureSearch.test.js
@@ -1,0 +1,113 @@
+const fs = require('fs');
+const path = require('path');
+
+const loadScript = () => {
+  jest.resetModules();
+
+  const { texts, categoryNames, gearItems } = require('../../translations.js');
+  const devicesData = require('../../devices');
+
+  const template = fs.readFileSync(
+    path.join(__dirname, '../../index.html'),
+    'utf8'
+  );
+  const bodyMatch = template.match(/<body[^>]*>([\s\S]*)<\/body>/i);
+  const bodyHtml = bodyMatch ? bodyMatch[1] : '';
+  document.body.innerHTML = bodyHtml.replace(/<script[\s\S]*?<\/script>/gi, '');
+
+  if (typeof window.matchMedia !== 'function') {
+    window.matchMedia = () => ({
+      matches: false,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      addListener: () => {},
+      removeListener: () => {}
+    });
+  }
+
+  if (!Element.prototype.scrollIntoView) {
+    Element.prototype.scrollIntoView = () => {};
+  }
+
+  delete window.defaultDevices;
+  window.devices = JSON.parse(JSON.stringify(devicesData));
+  global.devices = window.devices;
+  window.texts = texts;
+  global.texts = texts;
+  window.categoryNames = categoryNames;
+  global.categoryNames = categoryNames;
+  window.gearItems = gearItems;
+  global.gearItems = gearItems;
+
+  global.loadDeviceData = jest.fn(() => null);
+  global.saveDeviceData = jest.fn();
+  global.loadSetups = jest.fn(() => ({}));
+  global.saveSetups = jest.fn();
+  global.loadSessionState = jest.fn(() => null);
+  global.saveSessionState = jest.fn();
+  global.loadProject = jest.fn(() => null);
+  global.saveProject = jest.fn();
+  global.deleteProject = jest.fn();
+  global.loadFavorites = jest.fn(() => ({}));
+  global.saveFavorites = jest.fn();
+  global.exportAllData = jest.fn();
+  global.importAllData = jest.fn();
+
+  return require('../../script.js');
+};
+
+describe('global feature search helpers', () => {
+  let searchKey;
+  let searchTokens;
+  let findBestSearchMatch;
+
+  beforeEach(() => {
+    ({ searchKey, searchTokens, findBestSearchMatch } = loadScript());
+  });
+
+  test('searchTokens exposes hyphenated and numeric tokens', () => {
+    const tokens = searchTokens('12V Power Input');
+    expect(tokens).toEqual(
+      expect.arrayContaining(['12v', 'power', 'input'])
+    );
+  });
+
+  test('findBestSearchMatch matches words regardless of order', () => {
+    const entries = new Map();
+    entries.set(
+      searchKey('12V Power Input'),
+      { label: '12V Power Input', tokens: searchTokens('12V Power Input') }
+    );
+    entries.set(
+      searchKey('Power Distribution'),
+      { label: 'Power Distribution', tokens: searchTokens('Power Distribution') }
+    );
+
+    const result = findBestSearchMatch(
+      entries,
+      searchKey('power 12v'),
+      searchTokens('power 12v')
+    );
+
+    expect(result?.value.label).toBe('12V Power Input');
+  });
+
+  test('findBestSearchMatch pairs combined queries with split tokens', () => {
+    const entries = new Map();
+    entries.set(
+      searchKey('B-Mount Battery Plate'),
+      {
+        label: 'B-Mount Battery Plate',
+        tokens: searchTokens('B-Mount Battery Plate')
+      }
+    );
+
+    const result = findBestSearchMatch(
+      entries,
+      searchKey('b mount battery'),
+      searchTokens('b mount battery')
+    );
+
+    expect(result?.value.label).toBe('B-Mount Battery Plate');
+  });
+});


### PR DESCRIPTION
## Summary
- add token-aware search helpers so the global search can match words regardless of order or punctuation
- index features and device options with the new tokens and reuse them when resolving search queries
- cover the token matching logic with a dedicated Jest test harness that loads the app markup in jsdom

## Testing
- npm test --silent

------
https://chatgpt.com/codex/tasks/task_e_68c959b0bcbc8320a0b013e0915e083e