### PR TITLE
Enhance help dialog search experience

### DIFF
--- a/script.js
+++ b/script.js
@@ -12203,24 +12203,45 @@ if (helpButton && helpDialog) {
       });
     };
     elements.forEach(el => {
+      const isFaqItem = el.classList.contains('faq-item');
       // Save original HTML once so that repeated filtering doesn't permanently
-      // insert <mark> tags; restore it before applying a new highlight.
+      // insert <mark> tags; restore it before applying a new highlight. While
+      // doing so, capture the default open state for FAQ <details> elements so
+      // the search can temporarily expand matches and restore the original
+      // collapsed/expanded configuration when cleared.
       if (!el.dataset.origHtml) {
         el.dataset.origHtml = el.innerHTML;
+        if (isFaqItem) {
+          el.dataset.defaultOpen = el.hasAttribute('open') ? 'true' : 'false';
+        }
       } else {
         el.innerHTML = el.dataset.origHtml;
       }
       const text = el.textContent.toLowerCase().replace(/\s+/g, '');
-      if (!query || text.includes(query)) {
+      const matches = !query || text.includes(query);
+      if (matches) {
         if (query && highlightPattern) {
           // Highlight the matching text while preserving the rest of the content
           highlightMatches(el, highlightPattern);
         }
         el.removeAttribute('hidden');
+        if (isFaqItem) {
+          if (query) {
+            el.setAttribute('open', '');
+          } else if (el.dataset.defaultOpen === 'true') {
+            el.setAttribute('open', '');
+          } else {
+            el.removeAttribute('open');
+          }
+        }
         anyVisible = true;
       } else {
-        // Hide entries that do not match
+        // Hide entries that do not match and collapse FAQ answers while they
+        // are filtered out so reopening the dialog starts from a clean state.
         el.setAttribute('hidden', '');
+        if (isFaqItem) {
+          el.removeAttribute('open');
+        }
       }
     });
     if (helpNoResults) {

--- a/tests/dom/helpDialog.test.js
+++ b/tests/dom/helpDialog.test.js
@@ -1,0 +1,44 @@
+const { setupScriptEnvironment } = require('../helpers/scriptEnvironment');
+
+describe('help dialog search behaviour', () => {
+  let env;
+  let helpSearch;
+  let helpSearchClear;
+  let helpDialog;
+
+  const typeInHelpSearch = value => {
+    helpSearch.value = value;
+    helpSearch.dispatchEvent(new Event('input', { bubbles: true }));
+  };
+
+  beforeEach(() => {
+    env = setupScriptEnvironment();
+    helpSearch = document.getElementById('helpSearch');
+    helpSearchClear = document.getElementById('helpSearchClear');
+    helpDialog = document.getElementById('helpDialog');
+  });
+
+  afterEach(() => {
+    env?.cleanup();
+  });
+
+  test('matching FAQ answers expand while search is active', () => {
+    const faqItems = Array.from(helpDialog.querySelectorAll('.faq-item'));
+    const targetFaq = faqItems.find(item =>
+      item.querySelector('summary')?.textContent.includes('clear cached files')
+    );
+    expect(targetFaq).toBeTruthy();
+    const defaultOpen = targetFaq.hasAttribute('open');
+    expect(helpSearchClear.hasAttribute('hidden')).toBe(true);
+
+    typeInHelpSearch('force reload');
+
+    expect(targetFaq.hasAttribute('open')).toBe(true);
+    expect(helpSearchClear.hasAttribute('hidden')).toBe(false);
+
+    typeInHelpSearch('');
+
+    expect(targetFaq.hasAttribute('open')).toBe(defaultOpen);
+    expect(helpSearchClear.hasAttribute('hidden')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- remember the original open state of help FAQ entries so filtering can expand matches without losing the baseline layout
- automatically expand matching FAQ answers while a query is active and collapse non-matching entries when they are filtered out
- cover the behaviour with a DOM test that also checks the clear button toggles while typing

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c96f92fec88320b7c8faf75553d8e3