### PR TITLE
Fix missing overview translations

### DIFF
--- a/overview.js
+++ b/overview.js
@@ -51,9 +51,11 @@ function generatePrintableOverview() {
             let details = '';
             if (deviceInfo !== undefined && deviceInfo !== null) {
                 const connectors = summarizeConnectors(deviceInfo);
+                const latencyLabel = t.videoLatencyLabel || t.monitorLatencyLabel || 'Latency:';
+                const frequencyLabel = t.videoFrequencyLabel || 'Frequency:';
                 const infoBoxes =
-                    (deviceInfo.latencyMs !== undefined ? `<div class="info-box video-conn"><strong>Latency:</strong> ${escapeHtmlSafe(String(deviceInfo.latencyMs))}</div>` : '') +
-                    (deviceInfo.frequency ? `<div class="info-box video-conn"><strong>Frequency:</strong> ${escapeHtmlSafe(String(deviceInfo.frequency))}</div>` : '');
+                    (deviceInfo.latencyMs !== undefined ? `<div class="info-box video-conn"><strong>${escapeHtmlSafe(latencyLabel)}</strong> ${escapeHtmlSafe(String(deviceInfo.latencyMs))}</div>` : '') +
+                    (deviceInfo.frequency ? `<div class="info-box video-conn"><strong>${escapeHtmlSafe(frequencyLabel)}</strong> ${escapeHtmlSafe(String(deviceInfo.frequency))}</div>` : '');
                 details = connectors + infoBoxes;
             }
             addToSection(headingKey, `<div class="device-block"><strong>${safeName}</strong>${details}</div>`);
@@ -165,7 +167,8 @@ function generatePrintableOverview() {
         };
         pinsCandidates.sort((a, b) => b.hours - a.hours);
         dtapCandidates.sort((a, b) => b.hours - a.hours);
-        let tableHtml = `<h2>${t.batteryLifeHeading}</h2><table class="battery-table"><tr><th>${t.batteryLabel}</th><th>${t.batteryLifeLabel}</th><th>${t.batteryLifeHeading}</th></tr>`;
+        const runtimeHeading = t.batteryLifeHeading || t.batteryComparisonHeading || 'Runtime comparison';
+        let tableHtml = `<h2>${runtimeHeading}</h2><table class="battery-table"><tr><th>${t.batteryLabel}</th><th>${t.batteryLifeLabel}</th><th>${runtimeHeading}</th></tr>`;
         const maxHours = Math.max(
             selectedCandidate ? selectedCandidate.hours : 0,
             pinsCandidates[0] ? pinsCandidates[0].hours : 0,

--- a/translations.js
+++ b/translations.js
@@ -345,6 +345,7 @@ const texts = {
     hideDetails: "Hide Details",
 
     batteryTableLabel: "Battery",
+    batteryLifeHeading: "Runtime comparison",
     runtimeLabel: "Estimated Runtime (h)",
     batteryLifeUnit: "hrs",
     runtimeAverageNote: "Note: runtime estimate uses a weighted average of user-submitted runtimes adjusted for resolution, codec, frame rate, brightness and temperature.",
@@ -828,6 +829,7 @@ const texts = {
     showDetails: "Mostra i dettagli",
     hideDetails: "Nascondi dettagli",
     batteryTableLabel: "Batteria",
+    batteryLifeHeading: "Confronto autonomie",
     runtimeLabel: "Autonomia stimata (h)",
     batteryLifeUnit: "ore",
     runtimeAverageNote: "Nota: la stima della durata usa una media ponderata dei tempi inseriti dagli utenti, regolata per risoluzione, codec, frame rate, luminosità e temperatura.",
@@ -1375,6 +1377,7 @@ const texts = {
     hideDetails: "Ocultar Detalles",
 
     batteryTableLabel: "Batería",
+    batteryLifeHeading: "Comparación de autonomía",
     runtimeLabel: "Autonomía Estimada (h)",
     batteryLifeUnit: "h",
     runtimeAverageNote: "Nota: la estimación de autonomía usa un promedio ponderado de las duraciones enviadas por los usuarios, ajustado por resolución, códec, frecuencia de cuadro, brillo y temperatura.",
@@ -1927,6 +1930,7 @@ const texts = {
     hideDetails: "Masquer les Détails",
 
     batteryTableLabel: "Batterie",
+    batteryLifeHeading: "Comparaison d'autonomie",
     runtimeLabel: "Autonomie Estimée (h)",
     batteryLifeUnit: "h",
     runtimeAverageNote: "Note : l’estimation de l’autonomie utilise une moyenne pondérée des durées saisies par les utilisateurs, ajustée selon la résolution, le codec, la cadence, la luminosité et la température.",
@@ -2482,6 +2486,7 @@ const texts = {
     hideDetails: "Details verbergen",
 
     batteryTableLabel: "Akku",
+    batteryLifeHeading: "Laufzeitvergleich",
     runtimeLabel: "Geschätzte Laufzeit (h)",
     batteryLifeUnit: "Std.",
     runtimeAverageNote: "Hinweis: Die Laufzeitschätzung verwendet einen gewichteten Durchschnitt der Nutzereinträge, angepasst an Auflösung, Codec, Bildrate, Helligkeit und Temperatur.",


### PR DESCRIPTION
## Summary
- add a runtime comparison heading translation for each supported language
- localize the printable overview latency and frequency labels
- fall back to the battery comparison heading if the runtime heading translation is unavailable

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c96fd058a08320b325baecba000bc9