### PR TITLE
Add factory reset option to settings dialog

### DIFF
--- a/index.html
+++ b/index.html
@@ -748,6 +748,7 @@
           <button id="backupSettings">Backup</button>
           <input type="file" id="restoreSettingsInput" accept="application/json" hidden />
           <button id="restoreSettings">Restore</button>
+          <button id="factoryResetSettings">Factory Reset</button>
         </div>
       </section>
       <section class="settings-section" aria-labelledby="aboutHeading">

--- a/script.js
+++ b/script.js
@@ -1,5 +1,5 @@
 // script.js – Main logic for the Cine Power Planner app
-/* global texts, categoryNames, gearItems, loadSessionState, saveSessionState, loadProject, saveProject, deleteProject, registerDevice, loadFavorites, saveFavorites, exportAllData, importAllData */
+/* global texts, categoryNames, gearItems, loadSessionState, saveSessionState, loadProject, saveProject, deleteProject, registerDevice, loadFavorites, saveFavorites, exportAllData, importAllData, clearAllData */
 
 // Use `var` here instead of `let` because `index.html` loads the lz-string
 // library from a CDN which defines a global `LZString` variable. Using `let`
@@ -1916,6 +1916,14 @@ function setLanguage(lang) {
     restoreSettings.setAttribute("title", restoreHelp);
     restoreSettings.setAttribute("aria-label", restoreHelp);
   }
+  if (factoryResetSettings) {
+    factoryResetSettings.textContent = texts[lang].factoryResetSettings;
+    const resetHelp =
+      texts[lang].factoryResetSettingsHelp || texts[lang].factoryResetSettings;
+    factoryResetSettings.setAttribute("data-help", resetHelp);
+    factoryResetSettings.setAttribute("title", resetHelp);
+    factoryResetSettings.setAttribute("aria-label", resetHelp);
+  }
   const aboutHeading = document.getElementById("aboutHeading");
   if (aboutHeading) {
     aboutHeading.textContent = texts[lang].aboutHeading;
@@ -3075,6 +3083,7 @@ const settingsHighContrast = document.getElementById("settingsHighContrast");
 const backupSettings = document.getElementById("backupSettings");
 const restoreSettings = document.getElementById("restoreSettings");
 const restoreSettingsInput = document.getElementById("restoreSettingsInput");
+const factoryResetSettings = document.getElementById("factoryResetSettings");
 const aboutVersionElem = document.getElementById("aboutVersion");
 const supportLink = document.getElementById("supportLink");
 const settingsSave    = document.getElementById("settingsSave");
@@ -12015,6 +12024,58 @@ if (restoreSettings && restoreSettingsInput) {
       }
     };
     reader.readAsText(file);
+  });
+}
+
+if (factoryResetSettings) {
+  factoryResetSettings.addEventListener('click', () => {
+    const lang = texts[currentLang] ? currentLang : 'en';
+    const confirmMessage =
+      texts[lang].factoryResetConfirm
+      || 'Factory reset will permanently delete all saved data and personalization. Continue?';
+    if (!window.confirm(confirmMessage)) return;
+
+    const finalConfirm =
+      texts[lang].factoryResetConfirmFinal
+      || 'This is the final confirmation. Erase everything and reload?';
+    if (!window.confirm(finalConfirm)) return;
+
+    try {
+      if (typeof clearAllData === 'function') {
+        clearAllData();
+      }
+    } catch (err) {
+      console.warn('Factory reset clearAllData failed', err);
+    }
+
+    try {
+      if (typeof localStorage !== 'undefined' && localStorage && typeof localStorage.clear === 'function') {
+        localStorage.clear();
+      }
+    } catch (err) {
+      console.warn('Factory reset localStorage clear failed', err);
+    }
+
+    try {
+      if (typeof sessionStorage !== 'undefined' && sessionStorage && typeof sessionStorage.clear === 'function') {
+        sessionStorage.clear();
+      }
+    } catch (err) {
+      console.warn('Factory reset sessionStorage clear failed', err);
+    }
+
+    try {
+      if (typeof window !== 'undefined' && typeof window.alert === 'function') {
+        const successMessage =
+          texts[lang].factoryResetSuccess
+          || 'All data has been erased. The planner will reload now.';
+        window.alert(successMessage);
+      }
+    } catch (err) {
+      console.warn('Factory reset alert failed', err);
+    }
+
+    window.location.reload(true);
   });
 }
 

--- a/translations.js
+++ b/translations.js
@@ -97,6 +97,15 @@ const texts = {
     restoreSettings: "Restore",
     restoreSettingsHelp:
       "Load a previously exported JSON snapshot to restore your planner data.",
+    factoryResetSettings: "Factory Reset",
+    factoryResetSettingsHelp:
+      "Erase all saved projects, custom devices, favorites, feedback and personalization settings from this browser.",
+    factoryResetConfirm:
+      "Factory reset will permanently delete all saved data, customizations and backups stored in this browser. Continue?",
+    factoryResetConfirmFinal:
+      "Final confirmation: erase everything and reload the planner?",
+    factoryResetSuccess:
+      "All data has been erased. The planner will reload now.",
     aboutHeading: "About & Support",
     aboutHeadingHelp:
       "Review version details and reach support resources.",
@@ -1031,6 +1040,15 @@ const texts = {
     restoreSettings: "Ripristina",
     restoreSettingsHelp:
       "Carica uno snapshot JSON esportato in precedenza per ripristinare dati e impostazioni.",
+    factoryResetSettings: "Ripristino di fabbrica",
+    factoryResetSettingsHelp:
+      "Cancella tutti i progetti salvati, i dispositivi personalizzati, i preferiti, i feedback e le impostazioni personalizzate da questo browser.",
+    factoryResetConfirm:
+      "Il ripristino di fabbrica eliminerà definitivamente tutti i dati salvati, le personalizzazioni e i backup presenti in questo browser. Continuare?",
+    factoryResetConfirmFinal:
+      "Conferma finale: eliminare tutto e ricaricare il planner?",
+    factoryResetSuccess:
+      "Tutti i dati sono stati eliminati. Il planner verrà ricaricato ora.",
     aboutHeading: "Informazioni e supporto",
     aboutHeadingHelp:
       "Consulta dettagli sulla versione e i collegamenti al supporto.",
@@ -1581,6 +1599,15 @@ const texts = {
     restoreSettings: "Restaurar",
     restoreSettingsHelp:
       "Carga una instantánea JSON exportada previamente para restaurar datos y ajustes.",
+    factoryResetSettings: "Restablecimiento de fábrica",
+    factoryResetSettingsHelp:
+      "Borra todos los proyectos guardados, dispositivos personalizados, favoritos, comentarios y ajustes personalizados de este navegador.",
+    factoryResetConfirm:
+      "El restablecimiento de fábrica eliminará de forma permanente todos los datos guardados, las personalizaciones y las copias de seguridad almacenadas en este navegador. ¿Continuar?",
+    factoryResetConfirmFinal:
+      "Confirmación final: ¿borrar todo y recargar el planificador?",
+    factoryResetSuccess:
+      "Todos los datos se han eliminado. El planificador se recargará ahora.",
     aboutHeading: "Acerca de y soporte",
     aboutHeadingHelp:
       "Consulta la versión y accede a los recursos de soporte.",
@@ -2133,6 +2160,15 @@ const texts = {
     restoreSettings: "Restaurer",
     restoreSettingsHelp:
       "Chargez une sauvegarde JSON exportée auparavant pour restaurer données et réglages.",
+    factoryResetSettings: "Réinitialisation d'usine",
+    factoryResetSettingsHelp:
+      "Efface tous les projets enregistrés, les appareils personnalisés, les favoris, les retours et les réglages personnalisés de ce navigateur.",
+    factoryResetConfirm:
+      "La réinitialisation d'usine supprimera définitivement toutes les données enregistrées, les personnalisations et les sauvegardes stockées dans ce navigateur. Continuer ?",
+    factoryResetConfirmFinal:
+      "Confirmation finale : tout effacer et recharger le planificateur ?",
+    factoryResetSuccess:
+      "Toutes les données ont été effacées. Le planificateur va se recharger.",
     aboutHeading: "À propos et support",
     aboutHeadingHelp:
       "Consultez les informations de version et les ressources d’assistance.",
@@ -2688,6 +2724,15 @@ const texts = {
     restoreSettings: "Wiederherstellen",
     restoreSettingsHelp:
       "Importiere eine zuvor exportierte JSON-Sicherung, um Daten und Einstellungen wiederherzustellen.",
+    factoryResetSettings: "Werkseinstellungen",
+    factoryResetSettingsHelp:
+      "Löscht alle gespeicherten Projekte, benutzerdefinierten Geräte, Favoriten, Rückmeldungen und persönlichen Einstellungen aus diesem Browser.",
+    factoryResetConfirm:
+      "Das Zurücksetzen auf Werkseinstellungen entfernt dauerhaft alle gespeicherten Daten, Anpassungen und Sicherungen in diesem Browser. Fortfahren?",
+    factoryResetConfirmFinal:
+      "Letzte Bestätigung: alles löschen und den Planner neu laden?",
+    factoryResetSuccess:
+      "Alle Daten wurden gelöscht. Der Planner wird jetzt neu geladen.",
     aboutHeading: "Info & Support",
     aboutHeadingHelp:
       "Zeigt Versionsinfos und Links zum Support.",


### PR DESCRIPTION
## Summary
- add a Factory Reset control alongside backup and restore in the settings dialog
- localize the new button and prompt strings and clear all stored data after a double confirmation before reloading the app

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c970d47ad48320934bb75a6d3ae95d