### PR TITLE
Fix gear list deletion to clear stored project data

### DIFF
--- a/script.js
+++ b/script.js
@@ -11081,6 +11081,31 @@ function handleImportGearList(e) {
 function deleteCurrentGearList() {
     if (!confirm(texts[currentLang].confirmDeleteGearList)) return;
     if (!confirm(texts[currentLang].confirmDeleteGearListAgain)) return;
+    const projectName = getCurrentProjectName();
+    const storageKey = typeof projectName === 'string' ? projectName : '';
+    if (typeof deleteProject === 'function') {
+        deleteProject(storageKey);
+    } else if (typeof saveProject === 'function') {
+        saveProject(storageKey, { projectInfo: null, gearList: '' });
+    }
+    const setups = getSetups();
+    if (setups && typeof setups === 'object') {
+        const existingSetup = setups[storageKey];
+        if (existingSetup && typeof existingSetup === 'object') {
+            let changed = false;
+            if (Object.prototype.hasOwnProperty.call(existingSetup, 'gearList')) {
+                delete existingSetup.gearList;
+                changed = true;
+            }
+            if (Object.prototype.hasOwnProperty.call(existingSetup, 'projectInfo')) {
+                delete existingSetup.projectInfo;
+                changed = true;
+            }
+            if (changed) {
+                storeSetups(setups);
+            }
+        }
+    }
     if (gearListOutput) {
         gearListOutput.innerHTML = '';
         gearListOutput.classList.add('hidden');

--- a/tests/dom/deleteGearList.test.js
+++ b/tests/dom/deleteGearList.test.js
@@ -1,0 +1,103 @@
+const { setupScriptEnvironment } = require('../helpers/scriptEnvironment');
+
+const savedGearHtml = `
+  <h2>Project One</h2>
+  <h3>Project Requirements</h3>
+  <div class="requirements-grid">
+    <div class="requirement-box" data-field="codec">
+      <span class="req-label">Codec</span>
+      <span class="req-value">ProRes</span>
+    </div>
+  </div>
+  <h3>Gear List</h3>
+  <table class="gear-table"><tr><td>Saved Item</td></tr></table>
+`;
+
+describe('delete gear list action', () => {
+  let env;
+  let storedSetups;
+  let loadSetupsMock;
+  let saveSetupsMock;
+  let deleteProjectMock;
+  let saveSessionStateMock;
+  let confirmSpy;
+
+  beforeEach(() => {
+    storedSetups = {
+      'Project One': {
+        camera: 'CamX',
+        monitor: 'MonX',
+        video: 'VidX',
+        distance: 'None',
+        motors: [],
+        controllers: [],
+        battery: 'BatX',
+        batteryPlate: 'PlateX',
+        batteryHotswap: 'SwapX',
+        sliderBowl: '75mm',
+        easyrig: 'Stabiliser',
+        gearList: savedGearHtml,
+        projectInfo: { note: 'persisted' }
+      }
+    };
+
+    loadSetupsMock = jest.fn(() => storedSetups);
+    saveSetupsMock = jest.fn();
+    deleteProjectMock = jest.fn();
+    saveSessionStateMock = jest.fn();
+
+    env = setupScriptEnvironment({
+      globals: {
+        loadSetups: loadSetupsMock,
+        saveSetups: saveSetupsMock,
+        deleteProject: deleteProjectMock,
+        saveProject: jest.fn(),
+        saveSessionState: saveSessionStateMock
+      }
+    });
+
+    const setupSelect = document.getElementById('setupSelect');
+    setupSelect.value = 'Project One';
+    setupSelect.dispatchEvent(new Event('change'));
+
+    confirmSpy = jest.spyOn(window, 'confirm').mockReturnValue(true);
+
+    saveSetupsMock.mockClear();
+    deleteProjectMock.mockClear();
+    saveSessionStateMock.mockClear();
+  });
+
+  afterEach(() => {
+    confirmSpy?.mockRestore();
+    env?.cleanup();
+  });
+
+  test('removes persisted gear list for the active project', () => {
+    const deleteBtn = document.getElementById('deleteGearListBtn');
+    expect(deleteBtn).not.toBeNull();
+
+    deleteBtn.click();
+
+    expect(confirmSpy).toHaveBeenCalledTimes(2);
+    expect(deleteProjectMock).toHaveBeenCalledWith('Project One');
+    expect(saveSetupsMock).toHaveBeenCalledTimes(1);
+
+    const savedArg = saveSetupsMock.mock.calls[0][0];
+    expect(savedArg['Project One'].gearList).toBeUndefined();
+    expect(savedArg['Project One'].projectInfo).toBeUndefined();
+    expect(storedSetups['Project One'].gearList).toBeUndefined();
+    expect(storedSetups['Project One'].projectInfo).toBeUndefined();
+
+    const gearListOutput = document.getElementById('gearListOutput');
+    expect(gearListOutput.innerHTML).toBe('');
+    expect(gearListOutput.classList.contains('hidden')).toBe(true);
+
+    const requirementsOutput = document.getElementById('projectRequirementsOutput');
+    expect(requirementsOutput.classList.contains('hidden')).toBe(true);
+
+    expect(env.utils.getCurrentProjectInfo()).toBeNull();
+    expect(saveSessionStateMock).toHaveBeenCalledWith(expect.objectContaining({
+      projectInfo: null
+    }));
+  });
+});


### PR DESCRIPTION
## Summary
- clear saved project data when deleting the current gear list so the removal persists across reloads
- update the stored setups entry when a gear list is deleted and leave the UI/session state reset
- add a DOM test that exercises deleting a gear list and verifies stored data is removed

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c971eb6d7c832083b03ff95fa39883