### PR TITLE
Add factory reset with backup safeguards

### DIFF
--- a/index.html
+++ b/index.html
@@ -752,6 +752,7 @@
           <button id="backupSettings">Backup</button>
           <input type="file" id="restoreSettingsInput" accept="application/json" hidden />
           <button id="restoreSettings">Restore</button>
+          <button id="factoryResetButton">Factory reset</button>
         </div>
       </section>
       <section class="settings-section" aria-labelledby="aboutHeading">

--- a/script.js
+++ b/script.js
@@ -1,5 +1,5 @@
 // script.js – Main logic for the Cine Power Planner app
-/* global texts, categoryNames, gearItems, loadSessionState, saveSessionState, loadProject, saveProject, deleteProject, registerDevice, loadFavorites, saveFavorites, exportAllData, importAllData */
+/* global texts, categoryNames, gearItems, loadSessionState, saveSessionState, loadProject, saveProject, deleteProject, registerDevice, loadFavorites, saveFavorites, exportAllData, importAllData, clearAllData */
 
 // Use `var` here instead of `let` because `index.html` loads the lz-string
 // library from a CDN which defines a global `LZString` variable. Using `let`
@@ -1939,6 +1939,15 @@ function setLanguage(lang) {
     restoreSettings.setAttribute("title", restoreHelp);
     restoreSettings.setAttribute("aria-label", restoreHelp);
   }
+  if (factoryResetButton) {
+    const resetLabel = texts[lang].factoryResetButton || "Factory reset";
+    const resetHelp =
+      texts[lang].factoryResetButtonHelp || resetLabel;
+    factoryResetButton.textContent = resetLabel;
+    factoryResetButton.setAttribute("data-help", resetHelp);
+    factoryResetButton.setAttribute("title", resetHelp);
+    factoryResetButton.setAttribute("aria-label", resetHelp);
+  }
   const aboutHeading = document.getElementById("aboutHeading");
   if (aboutHeading) {
     aboutHeading.textContent = texts[lang].aboutHeading;
@@ -3097,6 +3106,7 @@ if (settingsLogo) {
 const settingsHighContrast = document.getElementById("settingsHighContrast");
 const backupSettings = document.getElementById("backupSettings");
 const restoreSettings = document.getElementById("restoreSettings");
+const factoryResetButton = document.getElementById("factoryResetButton");
 const restoreSettingsInput = document.getElementById("restoreSettingsInput");
 const settingsShowAutoBackups = document.getElementById("settingsShowAutoBackups");
 const aboutVersionElem = document.getElementById("aboutVersion");
@@ -12090,6 +12100,66 @@ if (restoreSettings && restoreSettingsInput) {
       }
     };
     reader.readAsText(file);
+  });
+}
+
+if (factoryResetButton) {
+  factoryResetButton.addEventListener('click', () => {
+    const langTexts = texts[currentLang] || texts.en || {};
+    const confirmReset = langTexts.confirmFactoryReset
+      || 'Create a backup and wipe all planner data?';
+    if (!confirm(confirmReset)) return;
+    const confirmResetAgain = langTexts.confirmFactoryResetAgain
+      || 'This will permanently delete all saved planner data. Continue?';
+    if (!confirm(confirmResetAgain)) return;
+
+    if (typeof createSettingsBackup !== 'function') {
+      const errorMsg = langTexts.factoryResetError
+        || 'Factory reset failed. Please try again.';
+      showNotification('error', errorMsg);
+      return;
+    }
+
+    let backupFileName = null;
+    try {
+      backupFileName = createSettingsBackup(false, new Date());
+    } catch (error) {
+      console.error('Backup before factory reset failed', error);
+    }
+
+    if (!backupFileName) {
+      const backupFailedMsg = langTexts.factoryResetBackupFailed
+        || 'Backup failed. Data was not deleted.';
+      showNotification('error', backupFailedMsg);
+      return;
+    }
+
+    if (typeof clearAllData !== 'function') {
+      const errorMsg = langTexts.factoryResetError
+        || 'Factory reset failed. Please try again.';
+      showNotification('error', errorMsg);
+      return;
+    }
+
+    try {
+      clearAllData();
+      if (settingsDialog) {
+        settingsDialog.setAttribute('hidden', '');
+      }
+      const successMsg = langTexts.factoryResetSuccess
+        || 'Backup downloaded. All planner data cleared. Reloading…';
+      showNotification('success', successMsg);
+      setTimeout(() => {
+        if (typeof window !== 'undefined' && window.location && window.location.reload) {
+          window.location.reload();
+        }
+      }, 600);
+    } catch (error) {
+      console.error('Factory reset failed', error);
+      const errorMsg = langTexts.factoryResetError
+        || 'Factory reset failed. Please try again.';
+      showNotification('error', errorMsg);
+    }
   });
 }
 

--- a/translations.js
+++ b/translations.js
@@ -100,6 +100,16 @@ const texts = {
     restoreSettings: "Restore",
     restoreSettingsHelp:
       "Load a previously exported JSON snapshot to restore your planner data.",
+    factoryResetButton: "Factory reset",
+    factoryResetButtonHelp:
+      "Create a backup and wipe all planner data after confirmation.",
+    confirmFactoryReset: "Create a backup and wipe all planner data?",
+    confirmFactoryResetAgain:
+      "Last warning: all projects, devices, settings and feedback will be deleted. Continue?",
+    factoryResetBackupFailed: "Backup failed. Data was not deleted.",
+    factoryResetSuccess:
+      "Backup downloaded. All planner data cleared. Reloading…",
+    factoryResetError: "Factory reset failed. Please try again.",
     aboutHeading: "About & Support",
     aboutHeadingHelp:
       "Review version details and reach support resources.",
@@ -1039,6 +1049,16 @@ const texts = {
     restoreSettings: "Ripristina",
     restoreSettingsHelp:
       "Carica uno snapshot JSON esportato in precedenza per ripristinare dati e impostazioni.",
+    factoryResetButton: "Ripristino di fabbrica",
+    factoryResetButtonHelp:
+      "Crea un backup e cancella tutti i dati del planner dopo la conferma.",
+    confirmFactoryReset: "Creare un backup e cancellare tutti i dati del planner?",
+    confirmFactoryResetAgain:
+      "Ultimo avviso: tutti i progetti, dispositivi, impostazioni e feedback salvati verranno eliminati. Continuare?",
+    factoryResetBackupFailed: "Backup non riuscito. I dati non sono stati eliminati.",
+    factoryResetSuccess:
+      "Backup scaricato. Tutti i dati del planner sono stati cancellati. Ricaricamento in corso…",
+    factoryResetError: "Ripristino di fabbrica non riuscito. Riprova.",
     aboutHeading: "Informazioni e supporto",
     aboutHeadingHelp:
       "Consulta dettagli sulla versione e i collegamenti al supporto.",
@@ -1593,6 +1613,16 @@ const texts = {
     restoreSettings: "Restaurar",
     restoreSettingsHelp:
       "Carga una instantánea JSON exportada previamente para restaurar datos y ajustes.",
+    factoryResetButton: "Restablecimiento de fábrica",
+    factoryResetButtonHelp:
+      "Crea una copia de seguridad y borra todos los datos del planificador tras la confirmación.",
+    confirmFactoryReset: "¿Crear una copia de seguridad y borrar todos los datos del planificador?",
+    confirmFactoryResetAgain:
+      "Último aviso: se eliminarán todos los proyectos, dispositivos, ajustes y comentarios guardados. ¿Continuar?",
+    factoryResetBackupFailed: "La copia de seguridad falló. No se eliminaron los datos.",
+    factoryResetSuccess:
+      "Copia de seguridad descargada. Todos los datos del planificador se borraron. Recargando…",
+    factoryResetError: "El restablecimiento de fábrica falló. Inténtalo de nuevo.",
     aboutHeading: "Acerca de y soporte",
     aboutHeadingHelp:
       "Consulta la versión y accede a los recursos de soporte.",
@@ -2149,6 +2179,16 @@ const texts = {
     restoreSettings: "Restaurer",
     restoreSettingsHelp:
       "Chargez une sauvegarde JSON exportée auparavant pour restaurer données et réglages.",
+    factoryResetButton: "Réinitialisation d’usine",
+    factoryResetButtonHelp:
+      "Crée une sauvegarde puis efface toutes les données du planificateur après confirmation.",
+    confirmFactoryReset: "Créer une sauvegarde puis effacer toutes les données du planificateur ?",
+    confirmFactoryResetAgain:
+      "Dernier avertissement : tous les projets, appareils, réglages et retours enregistrés seront supprimés. Continuer ?",
+    factoryResetBackupFailed: "Échec de la sauvegarde. Aucune donnée n’a été supprimée.",
+    factoryResetSuccess:
+      "Sauvegarde téléchargée. Toutes les données du planificateur ont été effacées. Rechargement…",
+    factoryResetError: "Échec de la réinitialisation d’usine. Veuillez réessayer.",
     aboutHeading: "À propos et support",
     aboutHeadingHelp:
       "Consultez les informations de version et les ressources d’assistance.",
@@ -2708,6 +2748,16 @@ const texts = {
     restoreSettings: "Wiederherstellen",
     restoreSettingsHelp:
       "Importiere eine zuvor exportierte JSON-Sicherung, um Daten und Einstellungen wiederherzustellen.",
+    factoryResetButton: "Werkseinstellungen",
+    factoryResetButtonHelp:
+      "Erstellt ein Backup und löscht nach Bestätigung alle Planner-Daten.",
+    confirmFactoryReset: "Backup erstellen und alle Planner-Daten löschen?",
+    confirmFactoryResetAgain:
+      "Letzte Warnung: Alle gespeicherten Projekte, Geräte, Einstellungen und Rückmeldungen werden gelöscht. Fortfahren?",
+    factoryResetBackupFailed: "Backup fehlgeschlagen. Daten wurden nicht gelöscht.",
+    factoryResetSuccess:
+      "Backup heruntergeladen. Alle Planner-Daten wurden gelöscht. Seite wird neu geladen…",
+    factoryResetError: "Zurücksetzen auf Werkseinstellungen fehlgeschlagen. Bitte erneut versuchen.",
     aboutHeading: "Info & Support",
     aboutHeadingHelp:
       "Zeigt Versionsinfos und Links zum Support.",


### PR DESCRIPTION
## Summary
- add a Factory Reset control to Settings that creates a backup and confirms twice before clearing planner data
- wire the new reset flow to the existing storage utilities and reload after successful cleanup
- localize the factory reset labels, help text, and confirmation messages in English, German, Spanish, French, and Italian

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c97c71c85483208d03de8f7bbbc12f