### PR TITLE
Align gear list select backgrounds in print view

### DIFF
--- a/overview-print.css
+++ b/overview-print.css
@@ -203,6 +203,10 @@ body:not(.light-mode) .gear-table .category-row td {
   border: none !important;
 }
 
+#overviewDialogContent #gearListOutput select {
+  background: var(--panel-bg) !important;
+}
+
 #overviewDialogContent .diagram-controls button {
   background: var(--surface-color) !important;
   color: var(--text-color) !important;


### PR DESCRIPTION
## Summary
- ensure printed gear list selectors use the section background color for better visual consistency

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c9807673948320986e025a3dd4d3a9