### PR TITLE
Remove manual gear list save button

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -98,7 +98,7 @@ The generator turns your selections into a categorized packing list:
   - **User Button** selections and **Tripod Preferences** are listed for quick reference.
 - Items inside each category are sorted alphabetically and display tooltips on hover.
 - The gear list is included in printable overviews and shared project files.
-- **Save Gear List** stores the current list with the project.
+- Gear lists save automatically with the project.
 - **Export Gear List** downloads a JSON file; **Import Gear List** restores it.
 - **Delete Gear List** removes the saved list and hides the output.
 - Gear list forms provide fork buttons to duplicate user entries instantly.

--- a/README.es.md
+++ b/README.es.md
@@ -142,7 +142,7 @@ El generador amplía tus selecciones en una tabla de equipamiento detallada:
   - Las selecciones de **botones de usuario** y **preferencias de trípode** se listan para consulta rápida.
 - Los elementos se ordenan alfabéticamente dentro de cada categoría y muestran un tooltip al pasar el cursor.
 - La lista de equipo aparece en las vistas imprimibles y en los archivos de proyectos compartidos, de modo que los colaboradores ven todo el contexto.
-- **Guardar lista de equipo** almacena la tabla actual con el proyecto.
+- La lista de equipo se guarda automáticamente con el proyecto.
 - **Exportar lista de equipo** descarga un archivo JSON; **Importar lista de equipo** lo restaura.
 - **Eliminar lista de equipo** borra la lista guardada y oculta la salida.
 - Los formularios de la lista utilizan botones de bifurcación para duplicar las entradas personalizadas al instante.

--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ The planner expands your selections into a detailed packing table:
   - **User Button** selections and **Tripod Preferences** are listed for quick reference.
 - Items are sorted alphabetically within their category and each exposes a tooltip on hover.
 - The gear list appears in printable overviews and shared project files so collaborators see the full context.
-- **Save Gear List** stores the current table with the project.
+- Gear lists save automatically with the project.
 - **Export Gear List** downloads a JSON file; **Import Gear List** restores it.
 - **Delete Gear List** removes the saved list and hides the output.
 - Gear list forms use fork buttons to duplicate your entries instantly.

--- a/index.html
+++ b/index.html
@@ -874,7 +874,7 @@
                 </ul>
               </li>
               <li>The resulting gear list appears in printable overviews and shared project files so collaborators see full context.</li>
-              <li>The <strong>Save Gear List</strong> button stores the current list with the project; <strong>Export</strong> downloads a JSON file, <strong>Import</strong> restores it and <strong>Delete</strong> removes the saved list and shows the generator again.</li>
+              <li>Gear lists save automatically with the project; <strong>Export</strong> downloads a JSON file, <strong>Import</strong> restores it and <strong>Delete</strong> removes the saved list and shows the generator again.</li>
               <li>Gear list forms use fork buttons to duplicate your entries instantly, making alternate configurations easy to explore.</li>
             </ul>
           </section>

--- a/script.js
+++ b/script.js
@@ -7787,8 +7787,8 @@ saveSetupBtn.addEventListener("click", () => {
   saveCurrentSession(); // Persist selection so refreshes restore this setup
   loadedSetupState = getCurrentSetupState();
   checkSetupChanged();
-  // Ensure the current gear list is persisted with the project so it can be
-  // restored even without a manual "Save Gear List" action.
+  // Ensure the current gear list stays persisted with the project so setups
+  // remain in sync with the automatically saved table.
   saveCurrentGearList();
   alert(texts[currentLang].alertSetupSaved.replace("{name}", setupName));
 });
@@ -11178,19 +11178,12 @@ function deleteCurrentGearList() {
     updateGearListButtonVisibility();
 }
 
-function confirmSaveCurrentGearList() {
-    if (!confirm(texts[currentLang].confirmSaveGearList)) return;
-    saveCurrentGearList();
-}
-
 function ensureGearListActions() {
     if (!gearListOutput) return;
     let actions = document.getElementById('gearListActions');
     if (!actions) {
         actions = document.createElement('div');
         actions.id = 'gearListActions';
-        const saveBtn = document.createElement('button');
-        saveBtn.id = 'saveGearListBtn';
         const exportBtn = document.createElement('button');
         exportBtn.id = 'exportGearListBtn';
         const importBtn = document.createElement('button');
@@ -11203,26 +11196,31 @@ function ensureGearListActions() {
         importInput.name = 'importGearList';
         const deleteBtn = document.createElement('button');
         deleteBtn.id = 'deleteGearListBtn';
-        actions.append(saveBtn, exportBtn, importBtn, importInput, deleteBtn);
+        const autoSaveNote = document.createElement('p');
+        autoSaveNote.id = 'gearListAutosaveNote';
+        autoSaveNote.className = 'gear-list-autosave-note';
+        actions.append(exportBtn, importBtn, importInput, deleteBtn, autoSaveNote);
         gearListOutput.appendChild(actions);
-        saveBtn.addEventListener('click', confirmSaveCurrentGearList);
         exportBtn.addEventListener('click', exportCurrentGearList);
         importBtn.addEventListener('click', () => importInput.click());
         importInput.addEventListener('change', handleImportGearList);
         deleteBtn.addEventListener('click', deleteCurrentGearList);
     }
     // Update texts for current language
-    const saveBtn = document.getElementById('saveGearListBtn');
     const exportBtn = document.getElementById('exportGearListBtn');
     const importBtn = document.getElementById('importGearListBtn');
     const deleteBtn = document.getElementById('deleteGearListBtn');
-    const saveHelp = texts[currentLang].saveGearListBtnHelp || texts[currentLang].saveGearListBtn;
+    const autoSaveNote = document.getElementById('gearListAutosaveNote');
     const exportHelp = texts[currentLang].exportGearListBtnHelp || texts[currentLang].exportGearListBtn;
     const importHelp = texts[currentLang].importGearListBtnHelp || texts[currentLang].importGearListBtn;
     const deleteHelp = texts[currentLang].deleteGearListBtnHelp || texts[currentLang].deleteGearListBtn;
-    saveBtn.textContent = texts[currentLang].saveGearListBtn;
-    saveBtn.setAttribute('title', saveHelp);
-    saveBtn.setAttribute('data-help', saveHelp);
+    if (autoSaveNote) {
+        const noteText = texts[currentLang].gearListAutosaveNote
+            || 'Gear lists save automatically with the project.';
+        autoSaveNote.textContent = noteText;
+        autoSaveNote.setAttribute('title', noteText);
+        autoSaveNote.setAttribute('data-help', noteText);
+    }
     exportBtn.textContent = texts[currentLang].exportGearListBtn;
     exportBtn.setAttribute('title', exportHelp);
     exportBtn.setAttribute('data-help', exportHelp);
@@ -11235,29 +11233,46 @@ function ensureGearListActions() {
 
     if (!gearListOutput._filterListenerBound) {
         gearListOutput.addEventListener('change', e => {
-            const cb = e.target;
-            if (cb.matches('.filter-values-container input[type="checkbox"]')) {
-                const container = cb.closest('.filter-values-container');
+            const target = e.target;
+            let shouldSync = false;
+            if (target.matches('.filter-values-container input[type="checkbox"]')) {
+                const container = target.closest('.filter-values-container');
                 const sel = container && container.querySelector('select');
                 if (sel) {
-                    const opt = Array.from(sel.options).find(opt => opt.value === cb.value);
-                    if (opt) opt.selected = cb.checked;
+                    const opt = Array.from(sel.options).find(opt => opt.value === target.value);
+                    if (opt) opt.selected = target.checked;
                     sel.dispatchEvent(new Event('change'));
                 }
-                saveCurrentGearList();
-                saveCurrentSession();
-                checkSetupChanged();
-            } else if (cb.id && cb.id.startsWith('filter-size-')) {
-                saveCurrentGearList();
-                saveCurrentSession();
-                checkSetupChanged();
-            } else if (cb.id && cb.id.startsWith('filter-values-')) {
+                shouldSync = true;
+            } else if (target.id && target.id.startsWith('filter-size-')) {
+                shouldSync = true;
+            } else if (target.id && target.id.startsWith('filter-values-')) {
+                shouldSync = true;
+            } else if (target.matches('input, select, textarea') && !target.closest('#gearListActions')) {
+                shouldSync = true;
+            }
+
+            if (shouldSync) {
                 saveCurrentGearList();
                 saveCurrentSession();
                 checkSetupChanged();
             }
         });
         gearListOutput._filterListenerBound = true;
+    }
+
+    if (!gearListOutput._inputListenerBound) {
+        gearListOutput.addEventListener('input', e => {
+            const target = e.target;
+            if (!target || target.id === 'importGearListInput') return;
+            if (target.closest('#gearListActions')) return;
+            if (target.matches('input, textarea')) {
+                saveCurrentGearList();
+                saveCurrentSession();
+                checkSetupChanged();
+            }
+        });
+        gearListOutput._inputListenerBound = true;
     }
 }
 

--- a/style.css
+++ b/style.css
@@ -2724,6 +2724,25 @@ body.dark-mode.pink-mode .help-content { border-color: var(--accent-color); }
   display: none;
 }
 
+#gearListActions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+
+#gearListActions button {
+  margin: 0;
+}
+
+#gearListActions .gear-list-autosave-note {
+  flex-basis: 100%;
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--muted-text-color);
+}
+
 @media (max-width: 600px) {
   #gearListOutput,
   #projectRequirementsOutput {

--- a/translations.js
+++ b/translations.js
@@ -495,19 +495,16 @@ const texts = {
       "Dolly Grip": "Dolly Grip",
       "Rigging Grip": "Rigging Grip"
     },
-    saveGearListBtn: "Save Gear List",
+    gearListAutosaveNote: "Gear lists save automatically with the project.",
     exportGearListBtn: "Export Gear List",
     importGearListBtn: "Import Gear List",
     deleteGearListBtn: "Delete Gear List",
-    saveGearListBtnHelp:
-      "Store the current gear list with the project so it reloads automatically and prints in overviews.",
     exportGearListBtnHelp:
       "Download the saved gear list and project notes as a JSON file.",
     importGearListBtnHelp:
       "Load a gear list from a JSON file, replacing the current table.",
     deleteGearListBtnHelp:
       "Remove the saved gear list from this project and hide the table.",
-    confirmSaveGearList: "Save gear list?",
     confirmDeleteGearList: "Delete gear list?",
     confirmDeleteGearListAgain: "This will permanently delete the gear list. Are you sure?",
     alertSelectSetupForOverview: "Please select a saved project to generate an overview.",
@@ -975,19 +972,16 @@ const texts = {
       "Dolly Grip": "Operatore dolly",
       "Rigging Grip": "Macchinista rigging"
     },
-    saveGearListBtn: "Salva elenco attrezzatura",
+    gearListAutosaveNote: "L'elenco attrezzatura viene salvato automaticamente con il progetto.",
     exportGearListBtn: "Esporta elenco attrezzatura",
     importGearListBtn: "Importa elenco attrezzatura",
     deleteGearListBtn: "Elimina elenco attrezzatura",
-    saveGearListBtnHelp:
-      "Salva l'elenco attrezzatura corrente con il progetto così da ricaricarlo e stamparlo nelle panoramiche.",
     exportGearListBtnHelp:
       "Scarica l'elenco attrezzatura salvato e le note del progetto come file JSON.",
     importGearListBtnHelp:
       "Carica un elenco attrezzatura da un file JSON sostituendo la tabella corrente.",
     deleteGearListBtnHelp:
       "Rimuovi l'elenco attrezzatura salvato dal progetto e nascondi la tabella.",
-    confirmSaveGearList: "Salvare l'elenco attrezzatura?",
     confirmDeleteGearList: "Eliminare elenco attrezzatura?",
     confirmDeleteGearListAgain: "Questo eliminerà definitivamente l'elenco attrezzatura. Sei sicuro?",
     alertSelectSetupForOverview: "Selezionare una configurazione salvata per generare una panoramica.",
@@ -1539,19 +1533,16 @@ const texts = {
       "Dolly Grip": "Operador de dolly",
       "Rigging Grip": "Grip de rigging"
     },
-    saveGearListBtn: "Guardar lista de equipo",
+    gearListAutosaveNote: "La lista de equipo se guarda automáticamente con el proyecto.",
     exportGearListBtn: "Exportar lista de equipo",
     importGearListBtn: "Importar lista de equipo",
     deleteGearListBtn: "Eliminar lista de equipo",
-    saveGearListBtnHelp:
-      "Guarda la lista de equipo actual con el proyecto para que se recargue y aparezca en los resúmenes.",
     exportGearListBtnHelp:
       "Descarga la lista de equipo guardada y las notas del proyecto como archivo JSON.",
     importGearListBtnHelp:
       "Carga una lista de equipo desde un archivo JSON reemplazando la tabla actual.",
     deleteGearListBtnHelp:
       "Elimina la lista de equipo guardada de este proyecto y oculta la tabla.",
-    confirmSaveGearList: "¿Guardar lista de equipo?",
     confirmDeleteGearList: "¿Eliminar lista de equipo?",
     confirmDeleteGearListAgain: "Esto eliminará permanentemente la lista de equipo. ¿Estás seguro?",
     alertSelectSetupForOverview: "Selecciona una configuración para generar un resumen.",
@@ -2105,19 +2096,16 @@ const texts = {
       "Dolly Grip": "Machiniste dolly",
       "Rigging Grip": "Machiniste rigging"
     },
-    saveGearListBtn: "Enregistrer la liste du matériel",
+    gearListAutosaveNote: "La liste du matériel est enregistrée automatiquement avec le projet.",
     exportGearListBtn: "Exporter la liste du matériel",
     importGearListBtn: "Importer la liste du matériel",
     deleteGearListBtn: "Supprimer la liste du matériel",
-    saveGearListBtnHelp:
-      "Enregistre la liste du matériel actuelle avec le projet afin qu'elle se recharge et s'imprime dans les aperçus.",
     exportGearListBtnHelp:
       "Télécharge la liste du matériel enregistrée et les notes du projet au format JSON.",
     importGearListBtnHelp:
       "Charge une liste du matériel depuis un fichier JSON en remplaçant la table actuelle.",
     deleteGearListBtnHelp:
       "Supprime la liste du matériel enregistrée du projet et masque le tableau.",
-    confirmSaveGearList: "Enregistrer la liste du matériel ?",
     confirmDeleteGearList: "Supprimer la liste du matériel ?",
     confirmDeleteGearListAgain: "Cela supprimera définitivement la liste du matériel. Êtes-vous sûr ?",
     alertSelectSetupForOverview: "Sélectionnez une configuration pour générer un résumé.",
@@ -2674,19 +2662,16 @@ const texts = {
       "Dolly Grip": "Dolly-Grip",
       "Rigging Grip": "Rigging-Grip"
     },
-    saveGearListBtn: "Gear-Liste speichern",
+    gearListAutosaveNote: "Die Gear-Liste wird automatisch mit dem Projekt gespeichert.",
     exportGearListBtn: "Gear-Liste exportieren",
     importGearListBtn: "Gear-Liste importieren",
     deleteGearListBtn: "Gear-Liste löschen",
-    saveGearListBtnHelp:
-      "Speichert die aktuelle Gear-Liste im Projekt, damit sie automatisch geladen und in Übersichten gedruckt wird.",
     exportGearListBtnHelp:
       "Lädt die gespeicherte Gear-Liste und Projektnotizen als JSON-Datei herunter.",
     importGearListBtnHelp:
       "Lädt eine Gear-Liste aus einer JSON-Datei und ersetzt damit die aktuelle Tabelle.",
     deleteGearListBtnHelp:
       "Entfernt die gespeicherte Gear-Liste aus diesem Projekt und blendet die Tabelle aus.",
-    confirmSaveGearList: "Gear-Liste speichern?",
     confirmDeleteGearList: "Gear-Liste löschen?",
     confirmDeleteGearListAgain: "Dies wird die Gear-Liste dauerhaft löschen. Bist du sicher?",
     alertSelectSetupForOverview: "Bitte wählen Sie ein gespeichertes Setup, um eine Übersicht zu erstellen.",


### PR DESCRIPTION
## Summary
- remove the manual Save Gear List action and surface an autosave note instead
- extend autosave coverage for gear list inputs and update styling/translations
- refresh help text and documentation to explain automatic saving

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c980b3daa88320a4cbf573ebe2a769