### PR TITLE
Remove gear list export and import buttons

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -99,7 +99,6 @@ The generator turns your selections into a categorized packing list:
 - Items inside each category are sorted alphabetically and display tooltips on hover.
 - The gear list is included in printable overviews and shared project files.
 - **Save Gear List** stores the current list with the project.
-- **Export Gear List** downloads a JSON file; **Import Gear List** restores it.
 - **Delete Gear List** removes the saved list and hides the output.
 - Gear list forms provide fork buttons to duplicate user entries instantly.
 

--- a/README.es.md
+++ b/README.es.md
@@ -143,7 +143,6 @@ El generador amplía tus selecciones en una tabla de equipamiento detallada:
 - Los elementos se ordenan alfabéticamente dentro de cada categoría y muestran un tooltip al pasar el cursor.
 - La lista de equipo aparece en las vistas imprimibles y en los archivos de proyectos compartidos, de modo que los colaboradores ven todo el contexto.
 - **Guardar lista de equipo** almacena la tabla actual con el proyecto.
-- **Exportar lista de equipo** descarga un archivo JSON; **Importar lista de equipo** lo restaura.
 - **Eliminar lista de equipo** borra la lista guardada y oculta la salida.
 - Los formularios de la lista utilizan botones de bifurcación para duplicar las entradas personalizadas al instante.
 

--- a/README.md
+++ b/README.md
@@ -209,7 +209,6 @@ The planner expands your selections into a detailed packing table:
 - Items are sorted alphabetically within their category and each exposes a tooltip on hover.
 - The gear list appears in printable overviews and shared project files so collaborators see the full context.
 - **Save Gear List** stores the current table with the project.
-- **Export Gear List** downloads a JSON file; **Import Gear List** restores it.
 - **Delete Gear List** removes the saved list and hides the output.
 - Gear list forms use fork buttons to duplicate your entries instantly.
 

--- a/script.js
+++ b/script.js
@@ -11063,63 +11063,6 @@ function saveCurrentGearList() {
     }
 }
 
-function exportCurrentGearList() {
-    const html = getCurrentGearListHtml();
-    if (!html) return;
-    const info = projectForm ? collectProjectFormData() : {};
-    info.sliderBowl = getSliderBowlValue();
-    info.easyrig = getEasyrigValue();
-    const proj = Object.values(info).some(v => v) ? info : null;
-    const blob = new Blob([JSON.stringify({ projectInfo: proj, gearList: html })], { type: 'application/json' });
-    const a = document.createElement('a');
-    a.href = URL.createObjectURL(blob);
-
-    const pad = n => String(n).padStart(2, '0');
-    const now = new Date();
-    const datePart = `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())}_${pad(now.getHours())}-${pad(now.getMinutes())}`;
-    const namePart = (getCurrentProjectName() || 'gear-list')
-        .replace(/\s+/g, '-').replace(/[^a-z0-9-_]/gi, '');
-    a.download = `${datePart}_${namePart}_gear-list.json`;
-
-    document.body.appendChild(a);
-    a.click();
-    document.body.removeChild(a);
-    URL.revokeObjectURL(a.href);
-}
-
-function handleImportGearList(e) {
-    const file = e.target.files[0];
-    if (!file) return;
-    const reader = new FileReader();
-    reader.onload = ev => {
-        try {
-            const obj = JSON.parse(ev.target.result);
-            if (obj && obj.gearList) {
-            displayGearAndRequirements(obj.gearList);
-            currentProjectInfo = obj.projectInfo || null;
-            populateProjectForm(currentProjectInfo || {});
-            ensureGearListActions();
-            bindGearListCageListener();
-            bindGearListEasyrigListener();
-            bindGearListSliderBowlListener();
-            bindGearListEyeLeatherListener();
-            bindGearListProGaffTapeListener();
-            bindGearListDirectorMonitorListener();
-            if (setupNameInput) {
-                const base = file.name.replace(/\.json$/i, '');
-                setupNameInput.value = base;
-                setupNameInput.dispatchEvent(new Event('input'));
-            }
-            saveCurrentGearList();
-            }
-        } catch {
-            alert('Invalid gear list file.');
-        }
-        e.target.value = '';
-    };
-    reader.readAsText(file);
-}
-
 function deleteCurrentGearList() {
     if (!confirm(texts[currentLang].confirmDeleteGearList)) return;
     if (!confirm(texts[currentLang].confirmDeleteGearListAgain)) return;
@@ -11191,44 +11134,21 @@ function ensureGearListActions() {
         actions.id = 'gearListActions';
         const saveBtn = document.createElement('button');
         saveBtn.id = 'saveGearListBtn';
-        const exportBtn = document.createElement('button');
-        exportBtn.id = 'exportGearListBtn';
-        const importBtn = document.createElement('button');
-        importBtn.id = 'importGearListBtn';
-        const importInput = document.createElement('input');
-        importInput.type = 'file';
-        importInput.accept = '.json';
-        importInput.id = 'importGearListInput';
-        importInput.className = 'hidden';
-        importInput.name = 'importGearList';
         const deleteBtn = document.createElement('button');
         deleteBtn.id = 'deleteGearListBtn';
-        actions.append(saveBtn, exportBtn, importBtn, importInput, deleteBtn);
+        actions.append(saveBtn, deleteBtn);
         gearListOutput.appendChild(actions);
         saveBtn.addEventListener('click', confirmSaveCurrentGearList);
-        exportBtn.addEventListener('click', exportCurrentGearList);
-        importBtn.addEventListener('click', () => importInput.click());
-        importInput.addEventListener('change', handleImportGearList);
         deleteBtn.addEventListener('click', deleteCurrentGearList);
     }
     // Update texts for current language
     const saveBtn = document.getElementById('saveGearListBtn');
-    const exportBtn = document.getElementById('exportGearListBtn');
-    const importBtn = document.getElementById('importGearListBtn');
     const deleteBtn = document.getElementById('deleteGearListBtn');
     const saveHelp = texts[currentLang].saveGearListBtnHelp || texts[currentLang].saveGearListBtn;
-    const exportHelp = texts[currentLang].exportGearListBtnHelp || texts[currentLang].exportGearListBtn;
-    const importHelp = texts[currentLang].importGearListBtnHelp || texts[currentLang].importGearListBtn;
     const deleteHelp = texts[currentLang].deleteGearListBtnHelp || texts[currentLang].deleteGearListBtn;
     saveBtn.textContent = texts[currentLang].saveGearListBtn;
     saveBtn.setAttribute('title', saveHelp);
     saveBtn.setAttribute('data-help', saveHelp);
-    exportBtn.textContent = texts[currentLang].exportGearListBtn;
-    exportBtn.setAttribute('title', exportHelp);
-    exportBtn.setAttribute('data-help', exportHelp);
-    importBtn.textContent = texts[currentLang].importGearListBtn;
-    importBtn.setAttribute('title', importHelp);
-    importBtn.setAttribute('data-help', importHelp);
     deleteBtn.textContent = texts[currentLang].deleteGearListBtn;
     deleteBtn.setAttribute('title', deleteHelp);
     deleteBtn.setAttribute('data-help', deleteHelp);

--- a/translations.js
+++ b/translations.js
@@ -496,15 +496,9 @@ const texts = {
       "Rigging Grip": "Rigging Grip"
     },
     saveGearListBtn: "Save Gear List",
-    exportGearListBtn: "Export Gear List",
-    importGearListBtn: "Import Gear List",
     deleteGearListBtn: "Delete Gear List",
     saveGearListBtnHelp:
       "Store the current gear list with the project so it reloads automatically and prints in overviews.",
-    exportGearListBtnHelp:
-      "Download the saved gear list and project notes as a JSON file.",
-    importGearListBtnHelp:
-      "Load a gear list from a JSON file, replacing the current table.",
     deleteGearListBtnHelp:
       "Remove the saved gear list from this project and hide the table.",
     confirmSaveGearList: "Save gear list?",
@@ -976,15 +970,9 @@ const texts = {
       "Rigging Grip": "Macchinista rigging"
     },
     saveGearListBtn: "Salva elenco attrezzatura",
-    exportGearListBtn: "Esporta elenco attrezzatura",
-    importGearListBtn: "Importa elenco attrezzatura",
     deleteGearListBtn: "Elimina elenco attrezzatura",
     saveGearListBtnHelp:
       "Salva l'elenco attrezzatura corrente con il progetto così da ricaricarlo e stamparlo nelle panoramiche.",
-    exportGearListBtnHelp:
-      "Scarica l'elenco attrezzatura salvato e le note del progetto come file JSON.",
-    importGearListBtnHelp:
-      "Carica un elenco attrezzatura da un file JSON sostituendo la tabella corrente.",
     deleteGearListBtnHelp:
       "Rimuovi l'elenco attrezzatura salvato dal progetto e nascondi la tabella.",
     confirmSaveGearList: "Salvare l'elenco attrezzatura?",
@@ -1540,15 +1528,9 @@ const texts = {
       "Rigging Grip": "Grip de rigging"
     },
     saveGearListBtn: "Guardar lista de equipo",
-    exportGearListBtn: "Exportar lista de equipo",
-    importGearListBtn: "Importar lista de equipo",
     deleteGearListBtn: "Eliminar lista de equipo",
     saveGearListBtnHelp:
       "Guarda la lista de equipo actual con el proyecto para que se recargue y aparezca en los resúmenes.",
-    exportGearListBtnHelp:
-      "Descarga la lista de equipo guardada y las notas del proyecto como archivo JSON.",
-    importGearListBtnHelp:
-      "Carga una lista de equipo desde un archivo JSON reemplazando la tabla actual.",
     deleteGearListBtnHelp:
       "Elimina la lista de equipo guardada de este proyecto y oculta la tabla.",
     confirmSaveGearList: "¿Guardar lista de equipo?",
@@ -2106,15 +2088,9 @@ const texts = {
       "Rigging Grip": "Machiniste rigging"
     },
     saveGearListBtn: "Enregistrer la liste du matériel",
-    exportGearListBtn: "Exporter la liste du matériel",
-    importGearListBtn: "Importer la liste du matériel",
     deleteGearListBtn: "Supprimer la liste du matériel",
     saveGearListBtnHelp:
       "Enregistre la liste du matériel actuelle avec le projet afin qu'elle se recharge et s'imprime dans les aperçus.",
-    exportGearListBtnHelp:
-      "Télécharge la liste du matériel enregistrée et les notes du projet au format JSON.",
-    importGearListBtnHelp:
-      "Charge une liste du matériel depuis un fichier JSON en remplaçant la table actuelle.",
     deleteGearListBtnHelp:
       "Supprime la liste du matériel enregistrée du projet et masque le tableau.",
     confirmSaveGearList: "Enregistrer la liste du matériel ?",
@@ -2675,15 +2651,9 @@ const texts = {
       "Rigging Grip": "Rigging-Grip"
     },
     saveGearListBtn: "Gear-Liste speichern",
-    exportGearListBtn: "Gear-Liste exportieren",
-    importGearListBtn: "Gear-Liste importieren",
     deleteGearListBtn: "Gear-Liste löschen",
     saveGearListBtnHelp:
       "Speichert die aktuelle Gear-Liste im Projekt, damit sie automatisch geladen und in Übersichten gedruckt wird.",
-    exportGearListBtnHelp:
-      "Lädt die gespeicherte Gear-Liste und Projektnotizen als JSON-Datei herunter.",
-    importGearListBtnHelp:
-      "Lädt eine Gear-Liste aus einer JSON-Datei und ersetzt damit die aktuelle Tabelle.",
     deleteGearListBtnHelp:
       "Entfernt die gespeicherte Gear-Liste aus diesem Projekt und blendet die Tabelle aus.",
     confirmSaveGearList: "Gear-Liste speichern?",


### PR DESCRIPTION
## Summary
- remove the gear list export/import controls and related handlers
- drop translation strings for the removed buttons across supported languages
- update README documentation to match the remaining gear list actions

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c980c8e26083209745bdf347984126