### PR TITLE
Save existing project before importing new gear list

### DIFF
--- a/script.js
+++ b/script.js
@@ -11087,6 +11087,68 @@ function exportCurrentGearList() {
     URL.revokeObjectURL(a.href);
 }
 
+function clearCurrentProjectForImport() {
+    if (setupSelect && typeof setupSelect.dispatchEvent === 'function') {
+        setupSelect.value = '';
+        setupSelect.dispatchEvent(new Event('change', { bubbles: true }));
+        return;
+    }
+
+    if (setupNameInput) setupNameInput.value = '';
+
+    const resetSelectable = sel => {
+        if (!sel) return;
+        const options = Array.from(sel.options || []);
+        const noneOption = options.find(opt => opt.value === 'None');
+        if (noneOption) {
+            sel.value = 'None';
+        } else if (options.length > 0) {
+            sel.selectedIndex = 0;
+        }
+    };
+
+    [
+        cameraSelect,
+        monitorSelect,
+        videoSelect,
+        cageSelect,
+        distanceSelect,
+        batterySelect,
+        hotswapSelect,
+        batteryPlateSelect
+    ].forEach(resetSelectable);
+
+    const sliderBowlSelect = typeof getSliderBowlSelect === 'function' ? getSliderBowlSelect() : null;
+    if (sliderBowlSelect) sliderBowlSelect.value = '';
+
+    motorSelects.forEach(sel => {
+        if (sel && sel.options && sel.options.length) sel.value = 'None';
+    });
+    controllerSelects.forEach(sel => {
+        if (sel && sel.options && sel.options.length) sel.value = 'None';
+    });
+
+    if (typeof updateBatteryPlateVisibility === 'function') updateBatteryPlateVisibility();
+    if (typeof updateBatteryOptions === 'function') updateBatteryOptions();
+
+    if (gearListOutput) {
+        gearListOutput.innerHTML = '';
+        gearListOutput.classList.add('hidden');
+    }
+    if (projectRequirementsOutput) {
+        projectRequirementsOutput.innerHTML = '';
+        projectRequirementsOutput.classList.add('hidden');
+    }
+
+    currentProjectInfo = null;
+    if (projectForm) populateProjectForm({});
+    loadedSetupState = null;
+    lastSetupName = '';
+
+    if (typeof updateCalculations === 'function') updateCalculations();
+    if (typeof checkSetupChanged === 'function') checkSetupChanged();
+}
+
 function handleImportGearList(e) {
     const file = e.target.files[0];
     if (!file) return;
@@ -11095,22 +11157,24 @@ function handleImportGearList(e) {
         try {
             const obj = JSON.parse(ev.target.result);
             if (obj && obj.gearList) {
-            displayGearAndRequirements(obj.gearList);
-            currentProjectInfo = obj.projectInfo || null;
-            populateProjectForm(currentProjectInfo || {});
-            ensureGearListActions();
-            bindGearListCageListener();
-            bindGearListEasyrigListener();
-            bindGearListSliderBowlListener();
-            bindGearListEyeLeatherListener();
-            bindGearListProGaffTapeListener();
-            bindGearListDirectorMonitorListener();
-            if (setupNameInput) {
-                const base = file.name.replace(/\.json$/i, '');
-                setupNameInput.value = base;
-                setupNameInput.dispatchEvent(new Event('input'));
-            }
-            saveCurrentGearList();
+                saveCurrentGearList();
+                clearCurrentProjectForImport();
+                displayGearAndRequirements(obj.gearList);
+                currentProjectInfo = obj.projectInfo || null;
+                populateProjectForm(currentProjectInfo || {});
+                ensureGearListActions();
+                bindGearListCageListener();
+                bindGearListEasyrigListener();
+                bindGearListSliderBowlListener();
+                bindGearListEyeLeatherListener();
+                bindGearListProGaffTapeListener();
+                bindGearListDirectorMonitorListener();
+                if (setupNameInput) {
+                    const base = file.name.replace(/\.json$/i, '');
+                    setupNameInput.value = base;
+                    setupNameInput.dispatchEvent(new Event('input'));
+                }
+                saveCurrentGearList();
             }
         } catch {
             alert('Invalid gear list file.');

--- a/tests/dom/importGearList.test.js
+++ b/tests/dom/importGearList.test.js
@@ -1,0 +1,129 @@
+const { setupScriptEnvironment } = require('../helpers/scriptEnvironment');
+
+const existingHtml = `
+  <h2>Existing Project</h2>
+  <h3>Project Requirements</h3>
+  <div class="requirements-grid"></div>
+  <h3>Gear List</h3>
+  <table class="gear-table"><tr><td>Existing Item</td></tr></table>
+`;
+
+const importedHtml = `
+  <h2>Imported Project</h2>
+  <h3>Project Requirements</h3>
+  <div class="requirements-grid"></div>
+  <h3>Gear List</h3>
+  <table class="gear-table"><tr><td>Imported Item</td></tr></table>
+`;
+
+describe('gear list import workflow', () => {
+  let env;
+  let saveProjectMock;
+  let loadProjectMock;
+  let loadSetupsMock;
+  let saveSetupsMock;
+  let alertSpy;
+  let originalFileReader;
+
+  beforeEach(() => {
+    const storedSetups = {
+      Existing: {
+        camera: 'CamX',
+        monitor: 'MonX',
+        video: 'VidX',
+        distance: 'None',
+        motors: [],
+        controllers: [],
+        battery: 'BatX',
+        batteryPlate: '',
+        batteryHotswap: '',
+        sliderBowl: '',
+        easyrig: ''
+      }
+    };
+
+    loadSetupsMock = jest.fn(() => storedSetups);
+    saveSetupsMock = jest.fn();
+    loadProjectMock = jest.fn(name => (
+      name === 'Existing'
+        ? { gearList: existingHtml, projectInfo: { projectName: 'Existing Project' } }
+        : null
+    ));
+    saveProjectMock = jest.fn();
+
+    env = setupScriptEnvironment({
+      globals: {
+        loadSetups: loadSetupsMock,
+        saveSetups: saveSetupsMock,
+        loadProject: loadProjectMock,
+        saveProject: saveProjectMock,
+        saveSessionState: jest.fn()
+      }
+    });
+
+    const setupSelect = document.getElementById('setupSelect');
+    setupSelect.value = 'Existing';
+    setupSelect.dispatchEvent(new Event('change'));
+
+    saveProjectMock.mockClear();
+    saveSetupsMock.mockClear();
+
+    alertSpy = jest.spyOn(window, 'alert').mockImplementation(() => {});
+    originalFileReader = global.FileReader;
+  });
+
+  afterEach(() => {
+    alertSpy?.mockRestore();
+    if (originalFileReader === undefined) {
+      delete global.FileReader;
+    } else {
+      global.FileReader = originalFileReader;
+    }
+    env?.cleanup();
+  });
+
+  test('saves the current project before loading an imported one', () => {
+    const importInput = document.getElementById('importGearListInput');
+    expect(importInput).not.toBeNull();
+
+    const importedData = {
+      gearList: importedHtml,
+      projectInfo: { projectName: 'Imported Project' }
+    };
+
+    class FileReaderMock {
+      readAsText() {
+        if (typeof this.onload === 'function') {
+          this.onload({ target: { result: JSON.stringify(importedData) } });
+        }
+      }
+    }
+    global.FileReader = FileReaderMock;
+
+    const file = { name: 'Imported Project.json' };
+    Object.defineProperty(importInput, 'files', {
+      configurable: true,
+      value: [file]
+    });
+
+    importInput.dispatchEvent(new Event('change'));
+
+    const existingSaves = saveProjectMock.mock.calls.filter(([name]) => name === 'Existing');
+    expect(existingSaves.length).toBeGreaterThan(0);
+    expect(existingSaves.some(([, data]) => (data?.gearList || '').length > 0)).toBe(true);
+    expect(existingSaves.every(([, data]) => !data?.gearList?.includes('Imported Item'))).toBe(true);
+
+    const importedSaves = saveProjectMock.mock.calls.filter(([name]) => name === 'Imported Project');
+    expect(importedSaves.length).toBeGreaterThan(0);
+    expect(importedSaves[0][1].gearList).toContain('Imported Item');
+
+    const setupSelect = document.getElementById('setupSelect');
+    expect(setupSelect.value).toBe('');
+
+    const setupNameInput = document.getElementById('setupName');
+    expect(setupNameInput.value).toBe('Imported Project');
+
+    const gearListOutput = document.getElementById('gearListOutput');
+    expect(gearListOutput.innerHTML).toContain('Imported Item');
+  });
+});


### PR DESCRIPTION
## Summary
- add a helper to reset the planner state before loading an imported project and call it after saving the current setup
- update the gear list import flow to persist the existing project, clear the UI, and then apply the imported data
- cover the workflow with a DOM test that verifies the current project is saved and the import loads as a new project

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c9822c3fe08320b12c2c4625f99af3