### PR TITLE
Remove standalone gear list export/import controls

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -99,7 +99,7 @@ The generator turns your selections into a categorized packing list:
 - Items inside each category are sorted alphabetically and display tooltips on hover.
 - The gear list is included in printable overviews and shared project files.
 - Gear lists save automatically with the project.
-- **Export Gear List** downloads a JSON file; **Import Gear List** restores it.
+- Shared project downloads automatically bundle the current gear list and project requirements so loading the JSON restores the full table.
 - **Delete Gear List** removes the saved list and hides the output.
 - Gear list forms provide fork buttons to duplicate user entries instantly.
 

--- a/README.es.md
+++ b/README.es.md
@@ -143,7 +143,7 @@ El generador amplía tus selecciones en una tabla de equipamiento detallada:
 - Los elementos se ordenan alfabéticamente dentro de cada categoría y muestran un tooltip al pasar el cursor.
 - La lista de equipo aparece en las vistas imprimibles y en los archivos de proyectos compartidos, de modo que los colaboradores ven todo el contexto.
 - La lista de equipo se guarda automáticamente con el proyecto.
-- **Exportar lista de equipo** descarga un archivo JSON; **Importar lista de equipo** lo restaura.
+- Las descargas de proyectos compartidos incluyen automáticamente la lista y los requisitos para que, al cargar el JSON, se recupere la tabla completa.
 - **Eliminar lista de equipo** borra la lista guardada y oculta la salida.
 - Los formularios de la lista utilizan botones de bifurcación para duplicar las entradas personalizadas al instante.
 

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ The planner expands your selections into a detailed packing table:
 - Items are sorted alphabetically within their category and each exposes a tooltip on hover.
 - The gear list appears in printable overviews and shared project files so collaborators see the full context.
 - Gear lists save automatically with the project.
-- **Export Gear List** downloads a JSON file; **Import Gear List** restores it.
+- Shared project downloads automatically bundle the current gear list and project requirements so loading the JSON restores the full table.
 - **Delete Gear List** removes the saved list and hides the output.
 - Gear list forms use fork buttons to duplicate your entries instantly.
 

--- a/translations.js
+++ b/translations.js
@@ -496,13 +496,7 @@ const texts = {
       "Rigging Grip": "Rigging Grip"
     },
     gearListAutosaveNote: "Gear lists save automatically with the project.",
-    exportGearListBtn: "Export Gear List",
-    importGearListBtn: "Import Gear List",
     deleteGearListBtn: "Delete Gear List",
-    exportGearListBtnHelp:
-      "Download the saved gear list and project notes as a JSON file.",
-    importGearListBtnHelp:
-      "Load a gear list from a JSON file, replacing the current table.",
     deleteGearListBtnHelp:
       "Remove the saved gear list from this project and hide the table.",
     confirmDeleteGearList: "Delete gear list?",
@@ -973,13 +967,7 @@ const texts = {
       "Rigging Grip": "Macchinista rigging"
     },
     gearListAutosaveNote: "L'elenco attrezzatura viene salvato automaticamente con il progetto.",
-    exportGearListBtn: "Esporta elenco attrezzatura",
-    importGearListBtn: "Importa elenco attrezzatura",
     deleteGearListBtn: "Elimina elenco attrezzatura",
-    exportGearListBtnHelp:
-      "Scarica l'elenco attrezzatura salvato e le note del progetto come file JSON.",
-    importGearListBtnHelp:
-      "Carica un elenco attrezzatura da un file JSON sostituendo la tabella corrente.",
     deleteGearListBtnHelp:
       "Rimuovi l'elenco attrezzatura salvato dal progetto e nascondi la tabella.",
     confirmDeleteGearList: "Eliminare elenco attrezzatura?",
@@ -1534,13 +1522,7 @@ const texts = {
       "Rigging Grip": "Grip de rigging"
     },
     gearListAutosaveNote: "La lista de equipo se guarda automáticamente con el proyecto.",
-    exportGearListBtn: "Exportar lista de equipo",
-    importGearListBtn: "Importar lista de equipo",
     deleteGearListBtn: "Eliminar lista de equipo",
-    exportGearListBtnHelp:
-      "Descarga la lista de equipo guardada y las notas del proyecto como archivo JSON.",
-    importGearListBtnHelp:
-      "Carga una lista de equipo desde un archivo JSON reemplazando la tabla actual.",
     deleteGearListBtnHelp:
       "Elimina la lista de equipo guardada de este proyecto y oculta la tabla.",
     confirmDeleteGearList: "¿Eliminar lista de equipo?",
@@ -2097,13 +2079,7 @@ const texts = {
       "Rigging Grip": "Machiniste rigging"
     },
     gearListAutosaveNote: "La liste du matériel est enregistrée automatiquement avec le projet.",
-    exportGearListBtn: "Exporter la liste du matériel",
-    importGearListBtn: "Importer la liste du matériel",
     deleteGearListBtn: "Supprimer la liste du matériel",
-    exportGearListBtnHelp:
-      "Télécharge la liste du matériel enregistrée et les notes du projet au format JSON.",
-    importGearListBtnHelp:
-      "Charge une liste du matériel depuis un fichier JSON en remplaçant la table actuelle.",
     deleteGearListBtnHelp:
       "Supprime la liste du matériel enregistrée du projet et masque le tableau.",
     confirmDeleteGearList: "Supprimer la liste du matériel ?",
@@ -2663,13 +2639,7 @@ const texts = {
       "Rigging Grip": "Rigging-Grip"
     },
     gearListAutosaveNote: "Die Gear-Liste wird automatisch mit dem Projekt gespeichert.",
-    exportGearListBtn: "Gear-Liste exportieren",
-    importGearListBtn: "Gear-Liste importieren",
     deleteGearListBtn: "Gear-Liste löschen",
-    exportGearListBtnHelp:
-      "Lädt die gespeicherte Gear-Liste und Projektnotizen als JSON-Datei herunter.",
-    importGearListBtnHelp:
-      "Lädt eine Gear-Liste aus einer JSON-Datei und ersetzt damit die aktuelle Tabelle.",
     deleteGearListBtnHelp:
       "Entfernt die gespeicherte Gear-Liste aus diesem Projekt und blendet die Tabelle aus.",
     confirmDeleteGearList: "Gear-Liste löschen?",


### PR DESCRIPTION
## Summary
- remove the gear list export/import controls and rely on the project autosave
- ensure shared project downloads reuse stored gear list data when the table is hidden
- drop the unused translation strings and update documentation to reflect the workflow

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c98ab6c76c8320b122e9c1bb9406c6