### PR TITLE
Update help guidance for factory reset workflow

### DIFF
--- a/index.html
+++ b/index.html
@@ -792,7 +792,7 @@
             <li>Open a searchable help dialog with step-by-step guides and FAQ.</li>
             <li>Switch languages, toggle dark or playful pink themes and work fully offline. Theme settings persist.</li>
             <li>Personalize the interface from Settings—adjust accent color, base font size and typeface, toggle high contrast and upload a custom logo that appears in backups and printable overviews.</li>
-            <li>Start fresh at any time with the Clear Local Cache button in Settings, which removes saved projects, custom devices, favorites and runtime feedback in one click.</li>
+            <li>Start fresh at any time with the Factory reset button in Settings. It automatically downloads a backup before removing saved projects, custom devices, favorites and runtime feedback in one step.</li>
             <li>Force reload clears cached files and updates the app without deleting saved data.</li>
             <li>Cameras with both V- and B-Mount plates let you swap battery types; the list updates automatically.</li>
           </ul>
@@ -814,7 +814,7 @@
             <li>Select a JSON file in <strong>Shared Project</strong> and click <strong>Load</strong> to restore a shared configuration.</li>
             <li>Use <strong>Delete</strong> to remove the saved entry or <strong>Clear Current Project</strong> to wipe the current selection without touching saved copies.</li>
             <li><strong>Generate Overview</strong> produces a printable summary of any saved project.</li>
-            <li>Need a clean slate? Choose <strong>Clear Local Cache</strong> in Settings → Backup &amp; Restore to erase saved projects, custom devices, favorites and runtime submissions in one step.</li>
+            <li>Need a clean slate? Choose <strong>Factory reset</strong> in Settings → Backup &amp; Restore. The tool prompts you to download a backup, then clears saved projects, custom devices, favorites and runtime submissions.</li>
             </ul>
           </section>
         <section data-help-section id="settingsHelp">
@@ -1058,7 +1058,7 @@
           </details>
           <details class="faq-item">
             <summary>How do I reset everything to the defaults?</summary>
-            <p>Open the device editor and choose <em>Export and Revert</em> to restore the default database. Delete projects individually using the Delete button, or open <em>Settings → Backup &amp; Restore</em> and press <em>Clear Local Cache</em> to wipe saved projects, favorites and runtime data at once.</p>
+            <p>Open the device editor and choose <em>Export and Revert</em> to restore the default database. Delete projects individually using the Delete button, or open <em>Settings → Backup &amp; Restore</em> and press <em>Factory reset</em> to download a safety backup and wipe saved projects, favorites and runtime data at once.</p>
           </details>
           <details class="faq-item">
             <summary>How do I change the language?</summary>


### PR DESCRIPTION
## Summary
- clarify help dialog bullets to reference the Factory reset button instead of the old Clear Local Cache label
- explain that Factory reset automatically downloads a backup before removing saved data
- update FAQ guidance so users know where to trigger the backup-and-clear workflow

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c98fec68d48320876898e279e13e55