### PR TITLE
Improve feature search tolerance

### DIFF
--- a/script.js
+++ b/script.js
@@ -3187,6 +3187,7 @@ const searchTokens = str => {
 const tokenMatchScore = (entryTokens = [], queryTokens = []) => {
   if (!Array.isArray(entryTokens) || entryTokens.length === 0) return 0;
   let total = 0;
+  let matched = 0;
   for (const token of queryTokens) {
     if (!token) continue;
     let best = 0;
@@ -3202,9 +3203,12 @@ const tokenMatchScore = (entryTokens = [], queryTokens = []) => {
         best = Math.max(best, 1);
       }
     }
-    if (best === 0) return 0;
-    total += best;
+    if (best > 0) {
+      matched += 1;
+      total += best;
+    }
   }
+  if (matched === 0) return 0;
   return total;
 };
 

--- a/tests/script/featureSearch.test.js
+++ b/tests/script/featureSearch.test.js
@@ -111,6 +111,32 @@ describe('global feature search helpers', () => {
     expect(result?.value.label).toBe('B-Mount Battery Plate');
   });
 
+  test('findBestSearchMatch tolerates unmatched query tokens', () => {
+    const entries = new Map();
+    entries.set(
+      searchKey('12V Power Input'),
+      {
+        label: '12V Power Input',
+        tokens: searchTokens('12V Power Input')
+      }
+    );
+    entries.set(
+      searchKey('Power Distribution'),
+      {
+        label: 'Power Distribution',
+        tokens: searchTokens('Power Distribution')
+      }
+    );
+
+    const result = findBestSearchMatch(
+      entries,
+      searchKey('power 12v camera rig'),
+      searchTokens('power 12v camera rig')
+    );
+
+    expect(result?.value.label).toBe('12V Power Input');
+  });
+
   test('searchKey normalizes degree and multiplication symbols', () => {
     expect(searchKey('35° Tilt Module')).toBe(
       searchKey('35 deg tilt module')


### PR DESCRIPTION
## Summary
- allow the token matching score to ignore unmatched query tokens so the global search can surface partial matches
- cover the relaxed scoring with a new unit test that verifies extra query words still resolve to the best entry

## Testing
- npm test -- --runTestsByPath tests/script/featureSearch.test.js

------
https://chatgpt.com/codex/tasks/task_e_68c99003dee8832093d421b43014b998