### PR TITLE
Restore gear list button to project actions

### DIFF
--- a/index.html
+++ b/index.html
@@ -112,6 +112,7 @@
       <span class="form-label-spacer" aria-hidden="true"></span>
       <div class="form-actions">
         <button id="generateOverviewBtn">Generate Overview</button>
+        <button id="generateGearListBtn" type="button">Generate Gear List and Project Requirements</button>
         <button id="shareSetupBtn">Share Project</button>
       </div>
     </div>
@@ -238,7 +239,6 @@
     <button id="runtimeFeedbackBtn" type="button">Submit User Runtime Feedback</button>
     <div class="button-row">
       <button id="copySummaryBtn" type="button">Copy Summary</button>
-      <button id="generateGearListBtn" type="button">Generate Gear List and Project Requirements</button>
     </div>
     <div id="feedbackTableContainer" class="hidden">
       <table id="userFeedbackTable" class="hidden"></table>


### PR DESCRIPTION
## Summary
- move the Generate Gear List button back into the Manage Project action row so it is visible alongside other project actions
- remove the duplicate button from the Results section, leaving Copy Summary on its own row

## Testing
- npm run test:dom

------
https://chatgpt.com/codex/tasks/task_e_68c99a909cb48320b7ef970413c69278