### PR TITLE
Adjust diagram controls for mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -254,7 +254,6 @@
       <button id="zoomOut" type="button" title="Zoom out" aria-label="Zoom out">-</button>
       <button id="zoomIn" type="button" title="Zoom in" aria-label="Zoom in">+</button>
       <button id="resetView" type="button"><span class="btn-icon" aria-hidden="true">🔄</span>Reset View</button>
-      <button id="downloadDiagram" type="button">Download Diagram</button>
       <button id="gridSnapToggle" type="button" aria-pressed="false">Snap to Grid</button>
     </div>
     <p id="diagramHint" class="diagram-hint"></p>

--- a/style.css
+++ b/style.css
@@ -1615,12 +1615,26 @@ input[type="file"]:disabled::-webkit-file-upload-button {
 }
 
 @media (max-width: 600px) {
-  .diagram-controls button {
-    flex: 1 0 calc(50% - 0.5em);
+  .diagram-controls {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(var(--button-size), 1fr));
+    justify-content: center;
   }
+
+  .diagram-controls button {
+    min-width: 0;
+  }
+
   .diagram-controls #zoomOut,
   .diagram-controls #zoomIn {
-    flex: 0 0 var(--button-size);
+    width: var(--button-size);
+    justify-self: center;
+  }
+
+  .diagram-controls #resetView,
+  .diagram-controls #gridSnapToggle {
+    justify-self: stretch;
+    white-space: nowrap;
   }
 }
 


### PR DESCRIPTION
## Summary
- remove the download diagram action from the project diagram toolbar
- ensure the reset view and snap to grid controls stay on one row on small screens

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c9a75b88188320b0fdd56911a6e817