### PR TITLE
Move overview and gear list buttons to end of Manage Project section

### DIFF
--- a/index.html
+++ b/index.html
@@ -111,8 +111,6 @@
     <div class="form-row form-row-actions" role="group" aria-label="Project actions">
       <span class="form-label-spacer" aria-hidden="true"></span>
       <div class="form-actions">
-        <button id="generateOverviewBtn">Generate Overview</button>
-        <button id="generateGearListBtn" type="button">Generate Gear List and Project Requirements</button>
         <button id="shareSetupBtn">Share Project</button>
       </div>
     </div>
@@ -125,6 +123,13 @@
     <div class="form-row form-row-actions">
       <span class="form-label-spacer" aria-hidden="true"></span>
       <button id="clearSetupBtn">Clear Current Project</button>
+    </div>
+    <div class="form-row form-row-actions" role="group" aria-label="Project exports">
+      <span class="form-label-spacer" aria-hidden="true"></span>
+      <div class="form-actions">
+        <button id="generateOverviewBtn">Generate Overview</button>
+        <button id="generateGearListBtn" type="button">Generate Gear List and Project Requirements</button>
+      </div>
     </div>
   </section>
 


### PR DESCRIPTION
## Summary
- move the Generate Overview and Generate Gear List buttons to the bottom of the Manage Project section
- leave Share Project in the primary action row and add a dedicated row for export actions

## Testing
- not run (markup-only change)


------
https://chatgpt.com/codex/tasks/task_e_68c9af41a1bc8320965d0ce1f0e89466