### PR TITLE
Prevent auto-saving setups on rename

### DIFF
--- a/script.js
+++ b/script.js
@@ -11458,7 +11458,17 @@ function saveCurrentSession() {
 function autoSaveCurrentSetup() {
   if (!setupNameInput) return;
   const name = setupNameInput.value.trim();
-  if (!name) return;
+  if (!name) {
+    saveCurrentSession();
+    checkSetupChanged();
+    return;
+  }
+  const selectedName = setupSelect ? setupSelect.value : '';
+  if (setupSelect && (!selectedName || name !== selectedName)) {
+    saveCurrentSession();
+    checkSetupChanged();
+    return;
+  }
   const currentSetup = { ...getCurrentSetupState() };
   const gearListHtml = getCurrentGearListHtml();
   if (gearListHtml) {


### PR DESCRIPTION
## Summary
- update the auto-save routine to bail out when the setup name input is empty or does not match the selected setup
- keep session state updates in those cases so the UI and session reflect unsaved changes without persisting a renamed setup

## Testing
- npm run test:script

------
https://chatgpt.com/codex/tasks/task_e_68c9e93f46ec83208ba5c77e77857932