### PR TITLE
Normalize spelling variants in feature search

### DIFF
--- a/tests/script/featureSearch.test.js
+++ b/tests/script/featureSearch.test.js
@@ -159,6 +159,33 @@ describe('global feature search helpers', () => {
     );
   });
 
+  test('search handles British and American spelling variants', () => {
+    expect(searchKey('Favourite Colour Settings')).toBe(
+      searchKey('Favorite Color Settings')
+    );
+
+    expect(searchTokens('Favourite Colour Settings')).toEqual(
+      expect.arrayContaining(['favourite', 'favorite', 'colour', 'color'])
+    );
+
+    const entries = new Map();
+    entries.set(
+      searchKey('Favorite Color Settings'),
+      {
+        label: 'Favorite Color Settings',
+        tokens: searchTokens('Favorite Color Settings')
+      }
+    );
+
+    const result = findBestSearchMatch(
+      entries,
+      searchKey('favourite colour settings'),
+      searchTokens('favourite colour settings')
+    );
+
+    expect(result?.value.label).toBe('Favorite Color Settings');
+  });
+
   test('findBestSearchMatch handles degree and by queries', () => {
     const entries = new Map();
     entries.set(


### PR DESCRIPTION
## Summary
- normalizes common British and American spelling variants when computing search keys and tokens
- ensures token generation still includes both forms so queries like "favourites" match existing labels
- adds a regression test covering the new spelling normalisation behaviour

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c9ea69c73883209ae72cc54959a9e5