### PR TITLE
Normalize saved setups to plain objects

### DIFF
--- a/tests/unit/storage.test.js
+++ b/tests/unit/storage.test.js
@@ -153,6 +153,18 @@ describe('setup storage', () => {
     expect(loadSetups()).toEqual({});
   });
 
+  test('loadSetups removes entries that are not plain objects', () => {
+    const stored = {
+      A: { foo: 1 },
+      B: null,
+      C: ['not-an-object'],
+      D: 'string value'
+    };
+    localStorage.setItem(SETUP_KEY, JSON.stringify(stored));
+    expect(loadSetups()).toEqual({ A: { foo: 1 } });
+    expect(JSON.parse(localStorage.getItem(SETUP_KEY))).toEqual({ A: { foo: 1 } });
+  });
+
   test('saveSetup adds and persists single setup', () => {
     const initial = {A: {foo: 1}};
     localStorage.setItem(SETUP_KEY, JSON.stringify(initial));


### PR DESCRIPTION
## Summary
- sanitize loaded setup collections by filtering out entries that are not plain objects
- persist normalized setup data back to storage and reuse it when saving
- add a regression test covering removal of corrupt saved setup entries

## Testing
- npm run lint
- npm run test:unit

------
https://chatgpt.com/codex/tasks/task_e_68c9eaa85a308320bcfe0032d52795eb