### PR TITLE
Adjust gear list selectors to size to content

### DIFF
--- a/script.js
+++ b/script.js
@@ -3784,6 +3784,7 @@ function displayGearAndRequirements(html) {
           el.setAttribute('data-help', desc);
         });
       });
+      adjustGearListSelectWidths(projectRequirementsOutput);
     } else {
       projectRequirementsOutput.innerHTML = '';
       projectRequirementsOutput.classList.add('hidden');
@@ -3854,6 +3855,7 @@ function displayGearAndRequirements(html) {
         sel.setAttribute('data-help', desc);
         initFavoritableSelect(sel);
       });
+      adjustGearListSelectWidths(gearListOutput);
     } else {
       gearListOutput.innerHTML = '';
       gearListOutput.classList.add('hidden');
@@ -3877,6 +3879,7 @@ function setSliderBowlValue(val) {
   const sel = getSliderBowlSelect();
   if (sel && val && Array.from(sel.options).some(opt => opt.value === val)) {
     sel.value = val;
+    adjustGearListSelectWidth(sel);
   }
 }
 function getEasyrigSelect() {
@@ -3891,6 +3894,7 @@ function setEasyrigValue(val) {
   const sel = getEasyrigSelect();
   if (sel && val && Array.from(sel.options).some(opt => opt.value === val)) {
     sel.value = val;
+    adjustGearListSelectWidth(sel);
   }
 }
 
@@ -5717,6 +5721,41 @@ function getTimecodes() {
     saveFavorites(favs);
     applyFavoritesToSelect(selectElem);
     updateFavoriteButton(selectElem);
+    adjustGearListSelectWidth(selectElem);
+  }
+
+  function adjustGearListSelectWidth(selectElem) {
+    if (!selectElem || selectElem.multiple || selectElem.size > 1) return;
+    const container = selectElem.closest('#gearListOutput, #projectRequirementsOutput');
+    if (!container) return;
+    const styles = window.getComputedStyle(selectElem);
+    if (!styles || styles.display === 'none') {
+      selectElem.style.removeProperty('--gear-select-width');
+      return;
+    }
+    const selectedOption = selectElem.selectedOptions && selectElem.selectedOptions[0];
+    const optionText = selectedOption ? selectedOption.textContent.trim() : selectElem.value || '';
+    const fontSize = parseFloat(styles.fontSize) || 16;
+    const approxCharWidth = fontSize * 0.6;
+    const textWidth = (optionText ? optionText.length : 1) * approxCharWidth;
+    const paddingLeft = parseFloat(styles.paddingLeft) || 0;
+    const paddingRight = parseFloat(styles.paddingRight) || 0;
+    const borderLeft = parseFloat(styles.borderLeftWidth) || 0;
+    const borderRight = parseFloat(styles.borderRightWidth) || 0;
+    const arrowReserve = Math.max(fontSize, 16);
+    const minWidth = Math.max(fontSize * 4, 56);
+    const widthPx = Math.max(
+      Math.ceil(textWidth + paddingLeft + paddingRight + borderLeft + borderRight + arrowReserve),
+      minWidth
+    );
+    selectElem.style.setProperty('--gear-select-width', `${widthPx}px`);
+  }
+
+  function adjustGearListSelectWidths(container) {
+    if (!container) return;
+    container
+      .querySelectorAll('select')
+      .forEach(selectElem => adjustGearListSelectWidth(selectElem));
   }
 
   function initFavoritableSelect(selectElem) {
@@ -5757,6 +5796,7 @@ function getTimecodes() {
     }
     applyFavoritesToSelect(selectElem);
     updateFavoriteButton(selectElem);
+    adjustGearListSelectWidth(selectElem);
   }
 
   // Populate dropdowns with device options
@@ -11250,6 +11290,9 @@ function ensureGearListActions() {
     if (!gearListOutput._filterListenerBound) {
         gearListOutput.addEventListener('change', e => {
             const target = e.target;
+            if (target && target.matches('select')) {
+                adjustGearListSelectWidth(target);
+            }
             let shouldSync = false;
             if (target.matches('.filter-values-container input[type="checkbox"]')) {
                 const container = target.closest('.filter-values-container');
@@ -13303,6 +13346,7 @@ function applyFilterSelectionsToGearList(info = currentProjectInfo) {
       }
     }
   });
+  adjustGearListSelectWidths(gearListOutput);
 }
 
 function buildFilterSelectHtml(filters = []) {

--- a/style.css
+++ b/style.css
@@ -2764,6 +2764,29 @@ body.dark-mode.pink-mode .help-content { border-color: var(--accent-color); }
   display: none;
 }
 
+#gearListOutput .select-wrapper,
+#projectRequirementsOutput .select-wrapper {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  flex: 0 0 auto;
+  width: auto;
+  max-width: 100%;
+  vertical-align: middle;
+}
+
+#gearListOutput .select-wrapper select,
+#projectRequirementsOutput .select-wrapper select {
+  flex: 0 0 auto;
+  width: var(--gear-select-width, auto);
+  max-width: 100%;
+}
+
+#gearListOutput .select-wrapper .favorite-toggle,
+#projectRequirementsOutput .select-wrapper .favorite-toggle {
+  flex: 0 0 auto;
+}
+
 #gearListActions {
   display: flex;
   flex-wrap: wrap;
@@ -2794,6 +2817,15 @@ body.dark-mode.pink-mode .help-content { border-color: var(--accent-color); }
   #projectRequirementsOutput select {
     width: 100%;
     max-width: 100%;
+  }
+  #gearListOutput .select-wrapper,
+  #projectRequirementsOutput .select-wrapper {
+    display: flex;
+    width: 100%;
+  }
+  #gearListOutput .select-wrapper select,
+  #projectRequirementsOutput .select-wrapper select {
+    flex: 1 1 auto;
   }
   #gearListOutput select,
   #projectRequirementsOutput select {


### PR DESCRIPTION
## Summary
- keep gear list select wrappers inline and use a CSS variable to size each selector while preserving mobile behaviour
- add helpers that approximate widths from the selected option and apply them when rendering, updating, or changing selectors
- update gear list flows to reapply sizing after restoring saved selections and when filters change

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c9ebbc93bc832096c125d4adc27c22