### PR TITLE
Make header logo link return to main page

### DIFF
--- a/datenschutz.html
+++ b/datenschutz.html
@@ -18,7 +18,7 @@
   <a href="#mainContent" class="skip-link">Zum Inhalt springen</a>
   <div id="offlineIndicator" role="status" aria-live="polite">Offline</div>
   <header id="topBar">
-    <div class="branding">
+    <a class="branding" href="index.html">
       <svg id="logo" viewBox="0 0 1024 1024" aria-hidden="true">
         <defs>
           <style>
@@ -38,7 +38,7 @@
         <path class="cls-1" d="M315.35,332.35c37.9-37.85,92.98,25.3,49.14,57.64-36.82,27.17-81.35-25.48-49.14-57.64Z" />
       </svg>
       <h1 id="mainTitle">Cine Power Planner</h1>
-    </div>
+    </a>
     <nav class="static-nav" aria-label="Sekundärnavigation">
       <a class="button-link" href="index.html">Zurück zur App</a>
     </nav>

--- a/impressum.html
+++ b/impressum.html
@@ -18,7 +18,7 @@
   <a href="#mainContent" class="skip-link">Zum Inhalt springen</a>
   <div id="offlineIndicator" role="status" aria-live="polite">Offline</div>
   <header id="topBar">
-    <div class="branding">
+    <a class="branding" href="index.html">
       <svg id="logo" viewBox="0 0 1024 1024" aria-hidden="true">
         <defs>
           <style>
@@ -38,7 +38,7 @@
         <path class="cls-1" d="M315.35,332.35c37.9-37.85,92.98,25.3,49.14,57.64-36.82,27.17-81.35-25.48-49.14-57.64Z" />
       </svg>
       <h1 id="mainTitle">Cine Power Planner</h1>
-    </div>
+    </a>
     <nav class="static-nav" aria-label="Sekundärnavigation">
       <a class="button-link" href="index.html">Zurück zur App</a>
     </nav>

--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
   <a href="#mainContent" class="skip-link" id="skipLink">Skip to content</a>
   <div id="offlineIndicator" role="status" aria-live="polite">Offline</div>
   <header id="topBar">
-    <div class="branding">
+    <a class="branding" href="index.html">
       <svg id="logo" viewBox="0 0 1024 1024" aria-hidden="true">
         <defs>
           <style>
@@ -49,7 +49,7 @@
         <path class="cls-1" d="M315.35,332.35c37.9-37.85,92.98,25.3,49.14,57.64-36.82,27.17-81.35-25.48-49.14-57.64Z" />
       </svg>
       <h1 id="mainTitle">Cine Power Planner</h1>
-    </div>
+    </a>
     <button id="menuToggle" aria-label="Menu" aria-expanded="false">☰</button>
     <div class="feature-search">
       <div id="featureSearchContainer">

--- a/style.css
+++ b/style.css
@@ -1328,6 +1328,14 @@ input[type="file"]:disabled::-webkit-file-upload-button {
   display: flex;
   align-items: center;
   gap: 10px;
+  color: inherit;
+  text-decoration: none;
+}
+
+#topBar .branding:focus-visible {
+  outline: 2px solid var(--accent-color);
+  outline-offset: 2px;
+  border-radius: 6px;
 }
 
 #topBar #logo {


### PR DESCRIPTION
## Summary
- wrap the header branding in an anchor so clicking the logo returns to the main planner
- apply the same navigation link to the static legal pages and keep their layout intact
- ensure the linked branding remains visually consistent with new focus styling

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c9ed635aa48320b10d1aaf6c08f44b