### PR TITLE
Add multilingual legal pages and refresh privacy policy

### DIFF
--- a/datenschutz-en.html
+++ b/datenschutz-en.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+  <meta name="color-scheme" content="light dark" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; connect-src 'self'; img-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self'; manifest-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none';" />
+  <meta name="referrer" content="no-referrer" />
+  <meta name="theme-color" content="#f9f9f9" />
+  <title>Privacy Policy</title>
+  <link rel="icon" href="icon.svg" type="image/svg+xml" />
+  <link rel="icon" href="icon.png" type="image/png" />
+  <link rel="apple-touch-icon" href="icon.png" />
+  <link rel="stylesheet" href="style.css" />
+  <script src="static-theme.js" defer></script>
+</head>
+<body class="static-page">
+  <a href="#mainContent" class="skip-link">Skip to content</a>
+  <div id="offlineIndicator" role="status" aria-live="polite">Offline</div>
+  <header id="topBar">
+    <div class="branding">
+      <svg id="logo" viewBox="0 0 1024 1024" aria-hidden="true">
+        <defs>
+          <style>
+            .cls-1 { fill: var(--accent-color); }
+            .cls-2 { fill: #fff; }
+          </style>
+        </defs>
+        <rect class="cls-1" width="1024" height="1024" rx="128" ry="128" />
+        <path class="cls-1" d="M332.79,264.29c-66.13,6.4-105.19,79.54-74.31,138.73,35.25,67.58,131.84,67.97,167.69.65,35.6-66.85-18.81-146.6-93.38-139.38ZM532.8,264.3c-51.89,4.85-90.78,55.06-84.79,106.19,9.73,82.92,118.85,114.08,169.97,46.99,51.33-67.37-2.29-160.92-85.18-153.18ZM689.21,517.2l.28,157.8,82.46,50.54c9.27,5.08,19.04.97,20.1-10-.62-80.73,1-161.7-.82-242.28-2.55-6.41-9.86-10.22-16.21-6.74l-85.81,50.68ZM274.74,468.24c-12.21,3.53-19.68,12.51-20.77,25.23l.05,221.03c1.77,14.87,11.57,24.26,26.45,25.55h326.07c14.13-1.11,25.08-10,26.51-24.49v-223.08c-1.21-13.19-11.34-23.3-24.5-24.5l-333.8.28ZM672,530h-19v134h19v-134Z" />
+        <path class="cls-2" d="M274.74,468.24l333.8-.28c13.16,1.2,23.29,11.31,24.5,24.5v223.08c-1.43,14.49-12.37,23.38-26.51,24.49h-326.07c-14.89-1.28-24.69-10.68-26.45-25.55l-.05-221.03c1.09-12.71,8.56-21.7,20.77-25.23ZM467,582l14.91-68.61c-3.75-14.34-10.29-10.19-17.88-1.86-28.03,30.79-51.9,68.87-79.85,100.15-4.19,3.66-1.94,14.32,3.32,14.32h42.5l-14.07,67.5c.6,11.86,10.68,13.88,17.04,3.97l79.87-102.13c3.57-4.95,1.6-13.34-5.34-13.34h-40.5Z" />
+        <path class="cls-2" d="M532.8,264.3c82.89-7.74,136.51,85.82,85.18,153.18-51.12,67.08-160.24,35.92-169.97-46.99-6-51.12,32.9-101.34,84.79-106.19ZM539.79,321.27c-49.71,4.46-43.19,80.2,6.71,75.72,49.16-4.42,42.05-80.09-6.71-75.72Z" />
+        <path class="cls-2" d="M332.79,264.29c74.57-7.22,128.98,72.53,93.38,139.38-35.85,67.31-132.44,66.92-167.69-.65-30.87-59.18,8.09-132.33,74.31-138.73ZM315.35,332.35c-32.21,32.16,12.32,84.81,49.14,57.64,43.84-32.35-11.25-95.49-49.14-57.64Z" />
+        <path class="cls-2" d="M689.21,517.2l85.81-50.68c6.35-3.48,13.67.34,16.21,6.74,1.82,80.58.2,161.55.82,242.28-1.06,10.97-10.83,15.09-20.1,10l-82.46-50.54-.28-157.8Z" />
+        <rect class="cls-2" x="653" y="530" width="19" height="134" />
+        <path class="cls-1" d="M467,582h40.5c6.94,0,8.9,8.4,5.34,13.34l-79.87,102.13c-6.36,9.92-16.44,7.89-17.04-3.97l14.07-67.5h-42.5c-5.26,0-7.51-10.65-3.32-14.32,27.95-31.29,51.81-69.37,79.85-100.15,7.59-8.33,14.13-12.49,17.88,1.86l-14.91,68.61Z" />
+        <path class="cls-1" d="M539.79,321.27c48.76-4.38,55.87,71.3,6.71,75.72-49.9,4.48-56.42-71.26-6.71-75.72Z" />
+        <path class="cls-1" d="M315.35,332.35c37.9-37.85,92.98,25.3,49.14,57.64-36.82,27.17-81.35-25.48-49.14-57.64Z" />
+      </svg>
+      <h1 id="mainTitle">Cine Power Planner</h1>
+    </div>
+    <nav class="static-nav" aria-label="Secondary navigation">
+      <a class="button-link" href="index.html">Back to the app</a>
+    </nav>
+  </header>
+  <main id="mainContent" class="legal-content" tabindex="-1">
+    <h1>Privacy Policy</h1>
+    <nav class="legal-language-nav" aria-label="Language selection">
+      <ul>
+        <li><a href="datenschutz.html" lang="de">Deutsch</a></li>
+        <li><a href="datenschutz-en.html" lang="en" aria-current="page">English</a></li>
+        <li><a href="datenschutz-es.html" lang="es">Español</a></li>
+        <li><a href="datenschutz-fr.html" lang="fr">Français</a></li>
+        <li><a href="datenschutz-it.html" lang="it">Italiano</a></li>
+      </ul>
+    </nav>
+    <div class="legal-card">
+      <h2>Controller</h2>
+      <p>Luca Zanner<br>Brünnsteinstraße 5<br>81541 Munich<br>Germany<br>E-mail: <a href="mailto:info@lucazanner.com">info@lucazanner.com</a></p>
+      <h2>General information</h2>
+      <p>We take the protection of your personal data very seriously. This application is built as a purely client-side web app and processes only the data that is technically necessary to operate the service. No profiling, tracking or disclosure of data for advertising purposes takes place.</p>
+      <h2>Server log files</h2>
+      <p>When you access the website, technically necessary information is automatically stored in server log files (e.g. truncated IP address, date and time of access, requested resource, user agent). Processing takes place on the basis of Article&nbsp;6(1)(f) GDPR in order to ensure the secure operation of the website. The log data is not merged with other data sources and is usually deleted automatically after a short period.</p>
+      <h2>Contacting us</h2>
+      <p>If you contact us by e-mail, we process the information you provide solely for the purpose of handling your enquiry. Processing is based on Article&nbsp;6(1)(b) GDPR where your request relates to pre-contractual measures or the performance of a contract, and otherwise on Article&nbsp;6(1)(f) GDPR due to our legitimate interest in responding to enquiries. The data will be deleted as soon as it is no longer required for processing and there are no statutory retention obligations.</p>
+      <h2>Local storage &amp; offline functionality</h2>
+      <p>The application stores project data and settings exclusively on your device (e.g. in the browser's local storage and in the service worker cache) and does not transmit this information to us. This storage is necessary to buffer the configurations you enter, enable offline use and improve the user experience. The legal basis is Article&nbsp;6(1)(b) GDPR in conjunction with Section&nbsp;25(2)(2) TTDSG, as the storage is technically required to provide the features you request. You can delete the locally stored data at any time in the app settings or via your browser.</p>
+      <h2>Recipients of data</h2>
+      <p>Personal data is only transferred to third parties if this is required to comply with legal obligations or if we use service providers that process personal data on our behalf (e.g. hosting or e-mail providers). These service providers are contractually obliged to comply with data protection requirements.</p>
+      <h2>Legal bases for processing</h2>
+      <p>If we obtain your consent to process personal data, Article&nbsp;6(1)(a) GDPR serves as the legal basis. Where processing is necessary for the performance of a contract or pre-contractual measures, Article&nbsp;6(1)(b) GDPR applies. Insofar as processing is necessary for the purposes of our legitimate interests, it is carried out on the basis of Article&nbsp;6(1)(f) GDPR.</p>
+      <h2>Storage duration</h2>
+      <p>We store personal data only for as long as is necessary for the purposes stated or as required by statutory retention obligations. Thereafter, the data is deleted or blocked.</p>
+      <h2>Your rights</h2>
+      <p>You have the right to obtain information free of charge about the personal data stored about you (Article&nbsp;15 GDPR), its origin and recipients and the purpose of the data processing. You also have the right to rectification (Article&nbsp;16 GDPR), erasure (Article&nbsp;17 GDPR), restriction of processing (Article&nbsp;18 GDPR) and data portability (Article&nbsp;20 GDPR). Where we process data on the basis of Article&nbsp;6(1)(e) or (f) GDPR, you have the right to object pursuant to Article&nbsp;21 GDPR.</p>
+      <h2>Right to lodge a complaint</h2>
+      <p>You have the right to lodge a complaint with a data protection supervisory authority, in particular in the Member State of your habitual residence, place of work or the place of the alleged infringement. In Bavaria, this is the Bavarian State Office for Data Protection Supervision (BayLDA), Promenade 27, 91522 Ansbach, Germany.</p>
+      <h2>Updates to this policy</h2>
+      <p>We reserve the right to adapt this privacy policy when necessary to ensure it always meets current legal requirements or to reflect changes to our services. The latest version is available at any time on this page.</p>
+      <p><strong>Effective date:</strong> March&nbsp;2025</p>
+    </div>
+  </main>
+  <footer id="siteFooter">
+    <a href="impressum-en.html">Imprint</a>
+    |
+    <a href="datenschutz-en.html">Privacy Policy</a>
+  </footer>
+</body>
+</html>

--- a/datenschutz-es.html
+++ b/datenschutz-es.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+  <meta name="color-scheme" content="light dark" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; connect-src 'self'; img-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self'; manifest-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none';" />
+  <meta name="referrer" content="no-referrer" />
+  <meta name="theme-color" content="#f9f9f9" />
+  <title>Política de privacidad</title>
+  <link rel="icon" href="icon.svg" type="image/svg+xml" />
+  <link rel="icon" href="icon.png" type="image/png" />
+  <link rel="apple-touch-icon" href="icon.png" />
+  <link rel="stylesheet" href="style.css" />
+  <script src="static-theme.js" defer></script>
+</head>
+<body class="static-page">
+  <a href="#mainContent" class="skip-link">Saltar al contenido</a>
+  <div id="offlineIndicator" role="status" aria-live="polite">Sin conexión</div>
+  <header id="topBar">
+    <div class="branding">
+      <svg id="logo" viewBox="0 0 1024 1024" aria-hidden="true">
+        <defs>
+          <style>
+            .cls-1 { fill: var(--accent-color); }
+            .cls-2 { fill: #fff; }
+          </style>
+        </defs>
+        <rect class="cls-1" width="1024" height="1024" rx="128" ry="128" />
+        <path class="cls-1" d="M332.79,264.29c-66.13,6.4-105.19,79.54-74.31,138.73,35.25,67.58,131.84,67.97,167.69.65,35.6-66.85-18.81-146.6-93.38-139.38ZM532.8,264.3c-51.89,4.85-90.78,55.06-84.79,106.19,9.73,82.92,118.85,114.08,169.97,46.99,51.33-67.37-2.29-160.92-85.18-153.18ZM689.21,517.2l.28,157.8,82.46,50.54c9.27,5.08,19.04.97,20.1-10-.62-80.73,1-161.7-.82-242.28-2.55-6.41-9.86-10.22-16.21-6.74l-85.81,50.68ZM274.74,468.24c-12.21,3.53-19.68,12.51-20.77,25.23l.05,221.03c1.77,14.87,11.57,24.26,26.45,25.55h326.07c14.13-1.11,25.08-10,26.51-24.49v-223.08c-1.21-13.19-11.34-23.3-24.5-24.5l-333.8.28ZM672,530h-19v134h19v-134Z" />
+        <path class="cls-2" d="M274.74,468.24l333.8-.28c13.16,1.2,23.29,11.31,24.5,24.5v223.08c-1.43,14.49-12.37,23.38-26.51,24.49h-326.07c-14.89-1.28-24.69-10.68-26.45-25.55l-.05-221.03c1.09-12.71,8.56-21.7,20.77-25.23ZM467,582l14.91-68.61c-3.75-14.34-10.29-10.19-17.88-1.86-28.03,30.79-51.9,68.87-79.85,100.15-4.19,3.66-1.94,14.32,3.32,14.32h42.5l-14.07,67.5c.6,11.86,10.68,13.88,17.04,3.97l79.87-102.13c3.57-4.95,1.6-13.34-5.34-13.34h-40.5Z" />
+        <path class="cls-2" d="M532.8,264.3c82.89-7.74,136.51,85.82,85.18,153.18-51.12,67.08-160.24,35.92-169.97-46.99-6-51.12,32.9-101.34,84.79-106.19ZM539.79,321.27c-49.71,4.46-43.19,80.2,6.71,75.72,49.16-4.42,42.05-80.09-6.71-75.72Z" />
+        <path class="cls-2" d="M332.79,264.29c74.57-7.22,128.98,72.53,93.38,139.38-35.85,67.31-132.44,66.92-167.69-.65-30.87-59.18,8.09-132.33,74.31-138.73ZM315.35,332.35c-32.21,32.16,12.32,84.81,49.14,57.64,43.84-32.35-11.25-95.49-49.14-57.64Z" />
+        <path class="cls-2" d="M689.21,517.2l85.81-50.68c6.35-3.48,13.67.34,16.21,6.74,1.82,80.58.2,161.55.82,242.28-1.06,10.97-10.83,15.09-20.1,10l-82.46-50.54-.28-157.8Z" />
+        <rect class="cls-2" x="653" y="530" width="19" height="134" />
+        <path class="cls-1" d="M467,582h40.5c6.94,0,8.9,8.4,5.34,13.34l-79.87,102.13c-6.36,9.92-16.44,7.89-17.04-3.97l14.07-67.5h-42.5c-5.26,0-7.51-10.65-3.32-14.32,27.95-31.29,51.81-69.37,79.85-100.15,7.59-8.33,14.13-12.49,17.88,1.86l-14.91,68.61Z" />
+        <path class="cls-1" d="M539.79,321.27c48.76-4.38,55.87,71.3,6.71,75.72-49.9,4.48-56.42-71.26-6.71-75.72Z" />
+        <path class="cls-1" d="M315.35,332.35c37.9-37.85,92.98,25.3,49.14,57.64-36.82,27.17-81.35-25.48-49.14-57.64Z" />
+      </svg>
+      <h1 id="mainTitle">Cine Power Planner</h1>
+    </div>
+    <nav class="static-nav" aria-label="Navegación secundaria">
+      <a class="button-link" href="index.html">Volver a la aplicación</a>
+    </nav>
+  </header>
+  <main id="mainContent" class="legal-content" tabindex="-1">
+    <h1>Política de privacidad</h1>
+    <nav class="legal-language-nav" aria-label="Selección de idioma">
+      <ul>
+        <li><a href="datenschutz.html" lang="de">Deutsch</a></li>
+        <li><a href="datenschutz-en.html" lang="en">English</a></li>
+        <li><a href="datenschutz-es.html" lang="es" aria-current="page">Español</a></li>
+        <li><a href="datenschutz-fr.html" lang="fr">Français</a></li>
+        <li><a href="datenschutz-it.html" lang="it">Italiano</a></li>
+      </ul>
+    </nav>
+    <div class="legal-card">
+      <h2>Responsable del tratamiento</h2>
+      <p>Luca Zanner<br>Brünnsteinstraße 5<br>81541 Múnich<br>Alemania<br>Correo electrónico: <a href="mailto:info@lucazanner.com">info@lucazanner.com</a></p>
+      <h2>Información general</h2>
+      <p>Nos tomamos muy en serio la protección de sus datos personales. Esta aplicación está diseñada como una aplicación web puramente del lado del cliente y solo procesa los datos técnicamente necesarios para el funcionamiento del servicio. No se realiza perfilado, seguimiento ni cesión de datos con fines publicitarios.</p>
+      <h2>Archivos de registro del servidor</h2>
+      <p>Cuando accede al sitio web, se almacenan automáticamente en archivos de registro del servidor datos técnicamente necesarios (p.&nbsp;ej. dirección IP abreviada, fecha y hora, recurso solicitado, agente de usuario). El tratamiento se realiza sobre la base del art. 6 apdo. 1 letra f del RGPD para garantizar el funcionamiento seguro del sitio web. Los datos de registro no se combinan con otras fuentes y, por lo general, se eliminan automáticamente tras un breve periodo.</p>
+      <h2>Contacto por correo electrónico</h2>
+      <p>Si se pone en contacto con nosotros por correo electrónico, trataremos los datos que nos proporcione exclusivamente para tramitar su solicitud. El tratamiento se basa en el art. 6 apdo. 1 letra b del RGPD cuando su solicitud esté relacionada con medidas precontractuales o la ejecución de un contrato, y en caso contrario en el art. 6 apdo. 1 letra f del RGPD en virtud de nuestro interés legítimo en responder a las consultas. Los datos se eliminarán tan pronto como dejen de ser necesarios y no existan obligaciones legales de conservación.</p>
+      <h2>Almacenamiento local y funciones sin conexión</h2>
+      <p>La aplicación guarda los datos de proyectos y ajustes exclusivamente en su dispositivo (por ejemplo, en el almacenamiento local del navegador y en la caché del service worker) y no los transmite a nosotros. Este almacenamiento es necesario para conservar temporalmente las configuraciones introducidas, permitir el uso sin conexión y mejorar la experiencia de usuario. La base jurídica es el art. 6 apdo. 1 letra b del RGPD en relación con el § 25 apdo. 2 núm. 2 TTDSG, dado que el almacenamiento es técnicamente imprescindible para ofrecer las funciones solicitadas. Puede eliminar los datos almacenados localmente en cualquier momento desde los ajustes de la aplicación o a través de su navegador.</p>
+      <h2>Destinatarios de los datos</h2>
+      <p>Sus datos personales solo se comunicarán a terceros cuando sea necesario para cumplir obligaciones legales o cuando utilicemos proveedores de servicios que traten datos personales por encargo nuestro (p.&nbsp;ej. proveedores de alojamiento o de correo electrónico). Estos proveedores están contractualmente obligados a cumplir la normativa de protección de datos.</p>
+      <h2>Bases jurídicas del tratamiento</h2>
+      <p>Cuando obtenemos su consentimiento para tratar datos personales, la base jurídica es el art. 6 apdo. 1 letra a del RGPD. Si el tratamiento es necesario para la ejecución de un contrato o medidas precontractuales, se aplica el art. 6 apdo. 1 letra b del RGPD. En la medida en que el tratamiento sea necesario para salvaguardar nuestros intereses legítimos, se basa en el art. 6 apdo. 1 letra f del RGPD.</p>
+      <h2>Periodo de conservación</h2>
+      <p>Conservamos los datos personales únicamente durante el tiempo necesario para los fines indicados o mientras existan obligaciones legales de conservación. A continuación, los datos se eliminan o bloquean.</p>
+      <h2>Sus derechos</h2>
+      <p>En virtud de la normativa aplicable, tiene derecho a obtener información gratuita sobre los datos personales almacenados acerca de usted (art. 15 RGPD), su origen y destinatarios, así como la finalidad del tratamiento. También tiene derecho, en su caso, a la rectificación (art. 16 RGPD), supresión (art. 17 RGPD), limitación del tratamiento (art. 18 RGPD) y portabilidad de los datos (art. 20 RGPD). Cuando tratemos datos basándonos en el art. 6 apdo. 1 letras e o f del RGPD, tiene derecho a oponerse conforme al art. 21 RGPD.</p>
+      <h2>Derecho a presentar una reclamación</h2>
+      <p>Tiene derecho a presentar una reclamación ante una autoridad de control de protección de datos, especialmente en el Estado miembro de su residencia habitual, lugar de trabajo o lugar de la presunta infracción. En Baviera, la autoridad competente es el Bayerisches Landesamt für Datenschutzaufsicht (BayLDA), Promenade 27, 91522 Ansbach, Alemania.</p>
+      <h2>Actualización de esta política</h2>
+      <p>Nos reservamos el derecho de adaptar esta política de privacidad cuando sea necesario para cumplir los requisitos legales vigentes o para reflejar cambios en nuestros servicios. La versión actualizada estará siempre disponible en esta página.</p>
+      <p><strong>Vigente desde:</strong> marzo de 2025</p>
+    </div>
+  </main>
+  <footer id="siteFooter">
+    <a href="impressum-es.html">Aviso legal</a>
+    |
+    <a href="datenschutz-es.html">Política de privacidad</a>
+  </footer>
+</body>
+</html>

--- a/datenschutz-fr.html
+++ b/datenschutz-fr.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+  <meta name="color-scheme" content="light dark" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; connect-src 'self'; img-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self'; manifest-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none';" />
+  <meta name="referrer" content="no-referrer" />
+  <meta name="theme-color" content="#f9f9f9" />
+  <title>Politique de confidentialité</title>
+  <link rel="icon" href="icon.svg" type="image/svg+xml" />
+  <link rel="icon" href="icon.png" type="image/png" />
+  <link rel="apple-touch-icon" href="icon.png" />
+  <link rel="stylesheet" href="style.css" />
+  <script src="static-theme.js" defer></script>
+</head>
+<body class="static-page">
+  <a href="#mainContent" class="skip-link">Aller au contenu</a>
+  <div id="offlineIndicator" role="status" aria-live="polite">Hors ligne</div>
+  <header id="topBar">
+    <div class="branding">
+      <svg id="logo" viewBox="0 0 1024 1024" aria-hidden="true">
+        <defs>
+          <style>
+            .cls-1 { fill: var(--accent-color); }
+            .cls-2 { fill: #fff; }
+          </style>
+        </defs>
+        <rect class="cls-1" width="1024" height="1024" rx="128" ry="128" />
+        <path class="cls-1" d="M332.79,264.29c-66.13,6.4-105.19,79.54-74.31,138.73,35.25,67.58,131.84,67.97,167.69.65,35.6-66.85-18.81-146.6-93.38-139.38ZM532.8,264.3c-51.89,4.85-90.78,55.06-84.79,106.19,9.73,82.92,118.85,114.08,169.97,46.99,51.33-67.37-2.29-160.92-85.18-153.18ZM689.21,517.2l.28,157.8,82.46,50.54c9.27,5.08,19.04.97,20.1-10-.62-80.73,1-161.7-.82-242.28-2.55-6.41-9.86-10.22-16.21-6.74l-85.81,50.68ZM274.74,468.24c-12.21,3.53-19.68,12.51-20.77,25.23l.05,221.03c1.77,14.87,11.57,24.26,26.45,25.55h326.07c14.13-1.11,25.08-10,26.51-24.49v-223.08c-1.21-13.19-11.34-23.3-24.5-24.5l-333.8.28ZM672,530h-19v134h19v-134Z" />
+        <path class="cls-2" d="M274.74,468.24l333.8-.28c13.16,1.2,23.29,11.31,24.5,24.5v223.08c-1.43,14.49-12.37,23.38-26.51,24.49h-326.07c-14.89-1.28-24.69-10.68-26.45-25.55l-.05-221.03c1.09-12.71,8.56-21.7,20.77-25.23ZM467,582l14.91-68.61c-3.75-14.34-10.29-10.19-17.88-1.86-28.03,30.79-51.9,68.87-79.85,100.15-4.19,3.66-1.94,14.32,3.32,14.32h42.5l-14.07,67.5c.6,11.86,10.68,13.88,17.04,3.97l79.87-102.13c3.57-4.95,1.6-13.34-5.34-13.34h-40.5Z" />
+        <path class="cls-2" d="M532.8,264.3c82.89-7.74,136.51,85.82,85.18,153.18-51.12,67.08-160.24,35.92-169.97-46.99-6-51.12,32.9-101.34,84.79-106.19ZM539.79,321.27c-49.71,4.46-43.19,80.2,6.71,75.72,49.16-4.42,42.05-80.09-6.71-75.72Z" />
+        <path class="cls-2" d="M332.79,264.29c74.57-7.22,128.98,72.53,93.38,139.38-35.85,67.31-132.44,66.92-167.69-.65-30.87-59.18,8.09-132.33,74.31-138.73ZM315.35,332.35c-32.21,32.16,12.32,84.81,49.14,57.64,43.84-32.35-11.25-95.49-49.14-57.64Z" />
+        <path class="cls-2" d="M689.21,517.2l85.81-50.68c6.35-3.48,13.67.34,16.21,6.74,1.82,80.58.2,161.55.82,242.28-1.06,10.97-10.83,15.09-20.1,10l-82.46-50.54-.28-157.8Z" />
+        <rect class="cls-2" x="653" y="530" width="19" height="134" />
+        <path class="cls-1" d="M467,582h40.5c6.94,0,8.9,8.4,5.34,13.34l-79.87,102.13c-6.36,9.92-16.44,7.89-17.04-3.97l14.07-67.5h-42.5c-5.26,0-7.51-10.65-3.32-14.32,27.95-31.29,51.81-69.37,79.85-100.15,7.59-8.33,14.13-12.49,17.88,1.86l-14.91,68.61Z" />
+        <path class="cls-1" d="M539.79,321.27c48.76-4.38,55.87,71.3,6.71,75.72-49.9,4.48-56.42-71.26-6.71-75.72Z" />
+        <path class="cls-1" d="M315.35,332.35c37.9-37.85,92.98,25.3,49.14,57.64-36.82,27.17-81.35-25.48-49.14-57.64Z" />
+      </svg>
+      <h1 id="mainTitle">Cine Power Planner</h1>
+    </div>
+    <nav class="static-nav" aria-label="Navigation secondaire">
+      <a class="button-link" href="index.html">Retour à l'application</a>
+    </nav>
+  </header>
+  <main id="mainContent" class="legal-content" tabindex="-1">
+    <h1>Politique de confidentialité</h1>
+    <nav class="legal-language-nav" aria-label="Choix de la langue">
+      <ul>
+        <li><a href="datenschutz.html" lang="de">Deutsch</a></li>
+        <li><a href="datenschutz-en.html" lang="en">English</a></li>
+        <li><a href="datenschutz-es.html" lang="es">Español</a></li>
+        <li><a href="datenschutz-fr.html" lang="fr" aria-current="page">Français</a></li>
+        <li><a href="datenschutz-it.html" lang="it">Italiano</a></li>
+      </ul>
+    </nav>
+    <div class="legal-card">
+      <h2>Responsable du traitement</h2>
+      <p>Luca Zanner<br>Brünnsteinstraße 5<br>81541 Munich<br>Allemagne<br>E-mail&nbsp;: <a href="mailto:info@lucazanner.com">info@lucazanner.com</a></p>
+      <h2>Informations générales</h2>
+      <p>Nous accordons une grande importance à la protection de vos données personnelles. Cette application est conçue comme une application web entièrement côté client et ne traite que les données techniquement nécessaires au fonctionnement du service. Aucune activité de profilage, de suivi ou de transmission à des fins publicitaires n'est effectuée.</p>
+      <h2>Fichiers journaux du serveur</h2>
+      <p>Lors de l'accès au site web, des informations techniquement nécessaires sont automatiquement enregistrées dans des fichiers journaux du serveur (par exemple adresse IP abrégée, date et heure, ressource demandée, user agent). Le traitement repose sur l'article&nbsp;6, paragraphe&nbsp;1, point f) du RGPD afin d'assurer le fonctionnement sécurisé du site. Les données de journal ne sont pas recoupées avec d'autres sources et sont en règle générale supprimées automatiquement après une courte période.</p>
+      <h2>Contact par e-mail</h2>
+      <p>Si vous nous contactez par e-mail, nous traitons les informations fournies uniquement pour répondre à votre demande. Le traitement repose sur l'article&nbsp;6, paragraphe&nbsp;1, point b) du RGPD lorsqu'il est nécessaire pour des mesures précontractuelles ou l'exécution d'un contrat, et sinon sur l'article&nbsp;6, paragraphe&nbsp;1, point f) du RGPD en raison de notre intérêt légitime à répondre aux demandes. Les données sont supprimées dès qu'elles ne sont plus nécessaires et qu'aucune obligation légale de conservation n'existe.</p>
+      <h2>Stockage local et fonctions hors ligne</h2>
+      <p>L'application enregistre les données de projet et les paramètres exclusivement sur votre appareil (par exemple dans le stockage local du navigateur et dans le cache du service worker) et ne les transmet pas à nos serveurs. Ce stockage est nécessaire pour sauvegarder vos configurations, permettre l'utilisation hors ligne et améliorer l'expérience utilisateur. La base juridique est l'article&nbsp;6, paragraphe&nbsp;1, point b) du RGPD combiné au § 25, paragraphe 2, numéro 2 TTDSG, car ce stockage est techniquement indispensable pour fournir les fonctionnalités souhaitées. Vous pouvez supprimer les données stockées localement à tout moment via les paramètres de l'application ou votre navigateur.</p>
+      <h2>Destinataires des données</h2>
+      <p>Les données personnelles ne sont transmises à des tiers que lorsque cela est nécessaire pour remplir des obligations légales ou lorsque nous faisons appel à des prestataires de services traitant des données en notre nom (par exemple hébergeurs ou fournisseurs de messagerie). Ces prestataires sont contractuellement tenus de respecter la législation sur la protection des données.</p>
+      <h2>Bases juridiques du traitement</h2>
+      <p>Lorsque nous recueillons votre consentement pour traiter des données personnelles, la base juridique est l'article&nbsp;6, paragraphe&nbsp;1, point a) du RGPD. Si le traitement est nécessaire à l'exécution d'un contrat ou de mesures précontractuelles, l'article&nbsp;6, paragraphe&nbsp;1, point b) du RGPD s'applique. Lorsque le traitement est nécessaire à la sauvegarde de nos intérêts légitimes, il repose sur l'article&nbsp;6, paragraphe&nbsp;1, point f) du RGPD.</p>
+      <h2>Durée de conservation</h2>
+      <p>Nous conservons les données personnelles uniquement pendant la durée nécessaire aux finalités mentionnées ou conformément aux obligations légales de conservation. Ensuite, les données sont supprimées ou bloquées.</p>
+      <h2>Vos droits</h2>
+      <p>Vous disposez d'un droit d'accès gratuit aux données personnelles vous concernant (article&nbsp;15 RGPD), à leur origine, leurs destinataires et à la finalité du traitement. Vous pouvez également demander, le cas échéant, la rectification (article&nbsp;16 RGPD), l'effacement (article&nbsp;17 RGPD), la limitation du traitement (article&nbsp;18 RGPD) ainsi que la portabilité des données (article&nbsp;20 RGPD). Lorsque nous traitons des données sur la base de l'article&nbsp;6, paragraphe&nbsp;1, points e) ou f) du RGPD, vous disposez d'un droit d'opposition conformément à l'article&nbsp;21 RGPD.</p>
+      <h2>Droit d'introduire une réclamation</h2>
+      <p>Vous avez le droit d'introduire une réclamation auprès d'une autorité de contrôle, en particulier dans l'État membre de votre résidence habituelle, de votre lieu de travail ou du lieu de l'infraction présumée. En Bavière, l'autorité compétente est notamment le Bayerisches Landesamt für Datenschutzaufsicht (BayLDA), Promenade 27, 91522 Ansbach, Allemagne.</p>
+      <h2>Évolution de cette politique</h2>
+      <p>Nous nous réservons le droit d'adapter la présente politique de confidentialité si nécessaire afin de respecter les exigences légales en vigueur ou de refléter des modifications de nos services. La version la plus récente est disponible à tout moment sur cette page.</p>
+      <p><strong>Date d'effet&nbsp;:</strong> mars 2025</p>
+    </div>
+  </main>
+  <footer id="siteFooter">
+    <a href="impressum-fr.html">Mentions légales</a>
+    |
+    <a href="datenschutz-fr.html">Politique de confidentialité</a>
+  </footer>
+</body>
+</html>

--- a/datenschutz-it.html
+++ b/datenschutz-it.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="it">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+  <meta name="color-scheme" content="light dark" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; connect-src 'self'; img-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self'; manifest-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none';" />
+  <meta name="referrer" content="no-referrer" />
+  <meta name="theme-color" content="#f9f9f9" />
+  <title>Informativa sulla privacy</title>
+  <link rel="icon" href="icon.svg" type="image/svg+xml" />
+  <link rel="icon" href="icon.png" type="image/png" />
+  <link rel="apple-touch-icon" href="icon.png" />
+  <link rel="stylesheet" href="style.css" />
+  <script src="static-theme.js" defer></script>
+</head>
+<body class="static-page">
+  <a href="#mainContent" class="skip-link">Vai al contenuto</a>
+  <div id="offlineIndicator" role="status" aria-live="polite">Offline</div>
+  <header id="topBar">
+    <div class="branding">
+      <svg id="logo" viewBox="0 0 1024 1024" aria-hidden="true">
+        <defs>
+          <style>
+            .cls-1 { fill: var(--accent-color); }
+            .cls-2 { fill: #fff; }
+          </style>
+        </defs>
+        <rect class="cls-1" width="1024" height="1024" rx="128" ry="128" />
+        <path class="cls-1" d="M332.79,264.29c-66.13,6.4-105.19,79.54-74.31,138.73,35.25,67.58,131.84,67.97,167.69.65,35.6-66.85-18.81-146.6-93.38-139.38ZM532.8,264.3c-51.89,4.85-90.78,55.06-84.79,106.19,9.73,82.92,118.85,114.08,169.97,46.99,51.33-67.37-2.29-160.92-85.18-153.18ZM689.21,517.2l.28,157.8,82.46,50.54c9.27,5.08,19.04.97,20.1-10-.62-80.73,1-161.7-.82-242.28-2.55-6.41-9.86-10.22-16.21-6.74l-85.81,50.68ZM274.74,468.24c-12.21,3.53-19.68,12.51-20.77,25.23l.05,221.03c1.77,14.87,11.57,24.26,26.45,25.55h326.07c14.13-1.11,25.08-10,26.51-24.49v-223.08c-1.21-13.19-11.34-23.3-24.5-24.5l-333.8.28ZM672,530h-19v134h19v-134Z" />
+        <path class="cls-2" d="M274.74,468.24l333.8-.28c13.16,1.2,23.29,11.31,24.5,24.5v223.08c-1.43,14.49-12.37,23.38-26.51,24.49h-326.07c-14.89-1.28-24.69-10.68-26.45-25.55l-.05-221.03c1.09-12.71,8.56-21.7,20.77-25.23ZM467,582l14.91-68.61c-3.75-14.34-10.29-10.19-17.88-1.86-28.03,30.79-51.9,68.87-79.85,100.15-4.19,3.66-1.94,14.32,3.32,14.32h42.5l-14.07,67.5c.6,11.86,10.68,13.88,17.04,3.97l79.87-102.13c3.57-4.95,1.6-13.34-5.34-13.34h-40.5Z" />
+        <path class="cls-2" d="M532.8,264.3c82.89-7.74,136.51,85.82,85.18,153.18-51.12,67.08-160.24,35.92-169.97-46.99-6-51.12,32.9-101.34,84.79-106.19ZM539.79,321.27c-49.71,4.46-43.19,80.2,6.71,75.72,49.16-4.42,42.05-80.09-6.71-75.72Z" />
+        <path class="cls-2" d="M332.79,264.29c74.57-7.22,128.98,72.53,93.38,139.38-35.85,67.31-132.44,66.92-167.69-.65-30.87-59.18,8.09-132.33,74.31-138.73ZM315.35,332.35c-32.21,32.16,12.32,84.81,49.14,57.64,43.84-32.35-11.25-95.49-49.14-57.64Z" />
+        <path class="cls-2" d="M689.21,517.2l85.81-50.68c6.35-3.48,13.67.34,16.21,6.74,1.82,80.58.2,161.55.82,242.28-1.06,10.97-10.83,15.09-20.1,10l-82.46-50.54-.28-157.8Z" />
+        <rect class="cls-2" x="653" y="530" width="19" height="134" />
+        <path class="cls-1" d="M467,582h40.5c6.94,0,8.9,8.4,5.34,13.34l-79.87,102.13c-6.36,9.92-16.44,7.89-17.04-3.97l14.07-67.5h-42.5c-5.26,0-7.51-10.65-3.32-14.32,27.95-31.29,51.81-69.37,79.85-100.15,7.59-8.33,14.13-12.49,17.88,1.86l-14.91,68.61Z" />
+        <path class="cls-1" d="M539.79,321.27c48.76-4.38,55.87,71.3,6.71,75.72-49.9,4.48-56.42-71.26-6.71-75.72Z" />
+        <path class="cls-1" d="M315.35,332.35c37.9-37.85,92.98,25.3,49.14,57.64-36.82,27.17-81.35-25.48-49.14-57.64Z" />
+      </svg>
+      <h1 id="mainTitle">Cine Power Planner</h1>
+    </div>
+    <nav class="static-nav" aria-label="Navigazione secondaria">
+      <a class="button-link" href="index.html">Torna all'app</a>
+    </nav>
+  </header>
+  <main id="mainContent" class="legal-content" tabindex="-1">
+    <h1>Informativa sulla privacy</h1>
+    <nav class="legal-language-nav" aria-label="Selezione della lingua">
+      <ul>
+        <li><a href="datenschutz.html" lang="de">Deutsch</a></li>
+        <li><a href="datenschutz-en.html" lang="en">English</a></li>
+        <li><a href="datenschutz-es.html" lang="es">Español</a></li>
+        <li><a href="datenschutz-fr.html" lang="fr">Français</a></li>
+        <li><a href="datenschutz-it.html" lang="it" aria-current="page">Italiano</a></li>
+      </ul>
+    </nav>
+    <div class="legal-card">
+      <h2>Titolare del trattamento</h2>
+      <p>Luca Zanner<br>Brünnsteinstraße 5<br>81541 Monaco di Baviera<br>Germania<br>E-mail: <a href="mailto:info@lucazanner.com">info@lucazanner.com</a></p>
+      <h2>Informazioni generali</h2>
+      <p>Tutela dei dati personali è una priorità per noi. Questa applicazione è progettata come web app puramente client-side e tratta solo i dati tecnicamente necessari al funzionamento del servizio. Non vengono effettuati profilazione, tracciamento o trasferimenti a fini pubblicitari.</p>
+      <h2>File di log del server</h2>
+      <p>Quando accede al sito web, vengono memorizzati automaticamente nei file di log del server dati tecnicamente necessari (ad esempio indirizzo IP abbreviato, data e ora, risorsa richiesta, user agent). Il trattamento si basa sull'art. 6 par. 1 lett. f GDPR per garantire il funzionamento sicuro del sito. I dati di log non vengono combinati con altre fonti e, di norma, vengono cancellati automaticamente dopo un breve periodo.</p>
+      <h2>Contatto via e-mail</h2>
+      <p>Se ci contatta via e-mail, tratteremo le informazioni fornite esclusivamente per rispondere alla sua richiesta. Il trattamento si basa sull'art. 6 par. 1 lett. b GDPR quando la richiesta riguarda misure precontrattuali o l'esecuzione di un contratto, e in caso contrario sull'art. 6 par. 1 lett. f GDPR in virtù del nostro legittimo interesse a rispondere alle richieste. I dati vengono cancellati non appena non sono più necessari e non sussistono obblighi legali di conservazione.</p>
+      <h2>Memorizzazione locale e funzioni offline</h2>
+      <p>L'applicazione memorizza dati di progetto e impostazioni esclusivamente sul suo dispositivo (ad esempio nel local storage del browser e nella cache del service worker) e non li trasmette ai nostri server. Questa memorizzazione è necessaria per salvare le configurazioni inserite, consentire l'utilizzo offline e migliorare l'esperienza d'uso. La base giuridica è l'art. 6 par. 1 lett. b GDPR in combinazione con il § 25 par. 2 n. 2 TTDSG, poiché la memorizzazione è tecnicamente indispensabile per fornire le funzionalità richieste. Può cancellare in qualsiasi momento i dati locali tramite le impostazioni dell'app o tramite il browser.</p>
+      <h2>Destinatari dei dati</h2>
+      <p>I dati personali vengono comunicati a terzi solo quando è necessario per adempiere a obblighi di legge o quando utilizziamo fornitori di servizi che trattano dati personali per nostro conto (ad esempio provider di hosting o e-mail). Tali fornitori sono contrattualmente obbligati a rispettare la normativa sulla protezione dei dati.</p>
+      <h2>Basi giuridiche del trattamento</h2>
+      <p>Quando otteniamo il suo consenso al trattamento di dati personali, la base giuridica è l'art. 6 par. 1 lett. a GDPR. Se il trattamento è necessario per l'esecuzione di un contratto o di misure precontrattuali, si applica l'art. 6 par. 1 lett. b GDPR. Qualora il trattamento sia necessario per la tutela dei nostri interessi legittimi, esso si basa sull'art. 6 par. 1 lett. f GDPR.</p>
+      <h2>Periodo di conservazione</h2>
+      <p>Conserviamo i dati personali solo per il tempo necessario alle finalità indicate o per quanto richiesto dagli obblighi legali di conservazione. Successivamente i dati vengono cancellati o bloccati.</p>
+      <h2>Diritti dell'interessato</h2>
+      <p>Ha il diritto di ottenere gratuitamente informazioni sui dati personali che la riguardano (art. 15 GDPR), sulla loro origine, sui destinatari e sulle finalità del trattamento. Ha inoltre diritto, se del caso, alla rettifica (art. 16 GDPR), alla cancellazione (art. 17 GDPR), alla limitazione del trattamento (art. 18 GDPR) e alla portabilità dei dati (art. 20 GDPR). Quando il trattamento avviene sulla base dell'art. 6 par. 1 lett. e o f GDPR, ha diritto di opposizione ai sensi dell'art. 21 GDPR.</p>
+      <h2>Diritto di reclamo</h2>
+      <p>Ha il diritto di proporre reclamo a un'autorità di controllo, in particolare nello Stato membro in cui risiede abitualmente, lavora o nel luogo della presunta violazione. In Baviera l'autorità competente è il Bayerisches Landesamt für Datenschutzaufsicht (BayLDA), Promenade 27, 91522 Ansbach, Germania.</p>
+      <h2>Aggiornamenti della presente informativa</h2>
+      <p>Ci riserviamo il diritto di modificare la presente informativa sulla privacy quando necessario, per garantire il rispetto delle norme vigenti o per riflettere cambiamenti nei nostri servizi. La versione più recente è sempre disponibile su questa pagina.</p>
+      <p><strong>Data di entrata in vigore:</strong> marzo 2025</p>
+    </div>
+  </main>
+  <footer id="siteFooter">
+    <a href="impressum-it.html">Note legali</a>
+    |
+    <a href="datenschutz-it.html">Informativa sulla privacy</a>
+  </footer>
+</body>
+</html>

--- a/datenschutz.html
+++ b/datenschutz.html
@@ -45,33 +45,39 @@
   </header>
   <main id="mainContent" class="legal-content" tabindex="-1">
     <h1>Datenschutzerklärung</h1>
+    <nav class="legal-language-nav" aria-label="Sprachauswahl">
+      <ul>
+        <li><a href="datenschutz.html" lang="de" aria-current="page">Deutsch</a></li>
+        <li><a href="datenschutz-en.html" lang="en">English</a></li>
+        <li><a href="datenschutz-es.html" lang="es">Español</a></li>
+        <li><a href="datenschutz-fr.html" lang="fr">Français</a></li>
+        <li><a href="datenschutz-it.html" lang="it">Italiano</a></li>
+      </ul>
+    </nav>
     <div class="legal-card">
       <h2>Verantwortliche Stelle</h2>
-      <p>Luca Zanner<br>Brünnsteinstraße 5<br>81541 München<br>E-Mail: <a href="mailto:info@lucazanner.com">info@lucazanner.com</a></p>
-      <h2>Erhebung und Speicherung personenbezogener Daten sowie Art und Zweck von deren Verwendung</h2>
-      <p><strong>Beim Besuch der Website:</strong> Der Provider dieser Seite erhebt und speichert automatisch Informationen in sogenannten Server-Log-Dateien, die Ihr Browser automatisch übermittelt (z. B. IP-Adresse, Datum und Uhrzeit der Anfrage, Referrer-URL, verwendeter Browser). Diese Daten dienen ausschließlich zur Gewährleistung eines störungsfreien Betriebs und zur Verbesserung des Angebots. Eine Zuordnung zu bestimmten Personen findet nicht statt.</p>
-      <p><strong>Bei Kontaktaufnahme per E-Mail:</strong> Die von Ihnen übermittelten personenbezogenen Daten werden ausschließlich zur Bearbeitung Ihrer Anfrage verwendet.</p>
-      <h2>Weitergabe von Daten</h2>
-      <p>Eine Übermittlung Ihrer persönlichen Daten an Dritte zu anderen als den im Folgenden aufgeführten Zwecken findet nicht statt. Wir geben Ihre persönlichen Daten nur an Dritte weiter, wenn:</p>
-      <ul>
-        <li>Sie Ihre ausdrückliche Einwilligung dazu erteilt haben,</li>
-        <li>die Verarbeitung zur Abwicklung eines Vertrags erforderlich ist,</li>
-        <li>die Verarbeitung zur Erfüllung einer rechtlichen Verpflichtung erforderlich ist.</li>
-      </ul>
-      <h2>Cookies</h2>
-      <p>Diese Website verwendet Cookies. Cookies richten auf Ihrem Rechner keinen Schaden an und enthalten keine Viren. Sie dienen dazu, unser Angebot nutzerfreundlicher, effektiver und sicherer zu machen. Die meisten der von uns verwendeten Cookies sind „Session-Cookies“, die nach Ende Ihres Besuchs automatisch gelöscht werden. Sie können Ihren Browser so einstellen, dass Sie über das Setzen von Cookies informiert werden und Cookies nur im Einzelfall erlauben.</p>
+      <p>Luca Zanner<br>Brünnsteinstraße 5<br>81541 München<br>Deutschland<br>E-Mail: <a href="mailto:info@lucazanner.com">info@lucazanner.com</a></p>
+      <h2>Allgemeine Hinweise</h2>
+      <p>Wir nehmen den Schutz Ihrer personenbezogenen Daten sehr ernst. Diese Anwendung ist als rein clientseitige Web-App konzipiert und verarbeitet nur diejenigen Daten, die für den Betrieb technisch erforderlich sind. Es findet keine Profilbildung, kein Tracking und keine Weitergabe zu Werbezwecken statt.</p>
+      <h2>Server-Logdateien</h2>
+      <p>Beim Aufruf der Website werden technisch notwendige Daten automatisch in Server-Logdateien gespeichert (z.&nbsp;B. IP-Adresse in gekürzter Form, Datum und Uhrzeit, angeforderte Ressource, User-Agent). Die Verarbeitung erfolgt auf Grundlage von Art. 6 Abs. 1 lit. f DSGVO, um den sicheren Betrieb der Website zu gewährleisten. Die Logdaten werden nicht mit anderen Datenquellen zusammengeführt und in der Regel nach kurzer Zeit automatisch gelöscht.</p>
+      <h2>Kontaktaufnahme</h2>
+      <p>Wenn Sie uns per E-Mail kontaktieren, verarbeiten wir die von Ihnen übermittelten Angaben ausschließlich zur Bearbeitung Ihres Anliegens. Die Verarbeitung beruht auf Art. 6 Abs. 1 lit. b DSGVO, sofern es um vorvertragliche Maßnahmen oder Vertragsabwicklung geht, und ansonsten auf Art. 6 Abs. 1 lit. f DSGVO aufgrund unseres berechtigten Interesses an der Beantwortung von Anfragen. Die Daten werden gelöscht, sobald sie für die Bearbeitung nicht mehr erforderlich sind und keine gesetzlichen Aufbewahrungspflichten bestehen.</p>
+      <h2>Lokale Speicherung &amp; Offline-Funktionen</h2>
+      <p>Die Anwendung speichert Projekt- und Einstellungsdaten ausschließlich lokal auf Ihrem Endgerät (z.&nbsp;B. im Local Storage des Browsers sowie im Service-Worker-Cache) und übermittelt diese nicht an uns. Diese Speicherung ist erforderlich, um von Ihnen eingegebene Konfigurationen zwischenzuspeichern, eine Offline-Nutzung zu ermöglichen und das Nutzererlebnis zu verbessern. Rechtsgrundlage ist Art. 6 Abs. 1 lit. b DSGVO in Verbindung mit § 25 Abs. 2 Nr. 2 TTDSG, da die Speicherung für die Bereitstellung der von Ihnen gewünschten Funktionen technisch notwendig ist. Sie können die lokal gespeicherten Daten jederzeit in den Einstellungen der App oder über Ihren Browser löschen.</p>
+      <h2>Empfänger von Daten</h2>
+      <p>Eine Übermittlung personenbezogener Daten an Dritte erfolgt nur, wenn dies zur Erfüllung gesetzlicher Pflichten erforderlich ist oder wenn wir Dienstleister einsetzen, die personenbezogene Daten in unserem Auftrag verarbeiten (z.&nbsp;B. Hosting- oder E-Mail-Dienstleister). Diese Dienstleister sind vertraglich zur Einhaltung der Datenschutzvorschriften verpflichtet.</p>
+      <h2>Rechtsgrundlagen der Verarbeitung</h2>
+      <p>Sofern wir zur Verarbeitung personenbezogener Daten Ihre Einwilligung einholen, dient Art. 6 Abs. 1 lit. a DSGVO als Rechtsgrundlage. Bei der Verarbeitung personenbezogener Daten, die zur Erfüllung eines Vertrags oder vorvertraglicher Maßnahmen erforderlich ist, beruht die Verarbeitung auf Art. 6 Abs. 1 lit. b DSGVO. Soweit die Verarbeitung zur Wahrung unserer berechtigten Interessen erforderlich ist, erfolgt sie auf Basis von Art. 6 Abs. 1 lit. f DSGVO.</p>
+      <h2>Speicherdauer</h2>
+      <p>Wir speichern personenbezogene Daten nur so lange, wie dies für die genannten Zwecke erforderlich ist oder wie es gesetzliche Aufbewahrungspflichten vorsehen. Danach werden die Daten gelöscht oder gesperrt.</p>
       <h2>Betroffenenrechte</h2>
-      <p>Sie haben das Recht:</p>
-      <ul>
-        <li>gemäß Art. 15 DSGVO Auskunft über Ihre von uns verarbeiteten personenbezogenen Daten zu verlangen,</li>
-        <li>gemäß Art. 16 DSGVO die Berichtigung unrichtiger oder Vervollständigung Ihrer bei uns gespeicherten personenbezogenen Daten zu verlangen,</li>
-        <li>gemäß Art. 17 DSGVO die Löschung Ihrer bei uns gespeicherten personenbezogenen Daten zu verlangen, sofern nicht gesetzliche Verpflichtungen entgegenstehen,</li>
-        <li>gemäß Art. 18 DSGVO die Einschränkung der Verarbeitung Ihrer personenbezogenen Daten zu verlangen,</li>
-        <li>gemäß Art. 20 DSGVO Ihre personenbezogenen Daten in einem strukturierten, gängigen und maschinenlesbaren Format zu erhalten oder die Übermittlung an einen anderen Verantwortlichen zu verlangen.</li>
-      </ul>
-      <h2>Beschwerderecht bei der zuständigen Aufsichtsbehörde</h2>
-      <p>Im Falle datenschutzrechtlicher Verstöße steht Ihnen ein Beschwerderecht bei einer Aufsichtsbehörde zu. Zuständige Aufsichtsbehörde ist der Landesdatenschutzbeauftragte des Bundeslandes, in dem unser Unternehmen seinen Sitz hat.</p>
-      <p>Diese Datenschutzerklärung ist ein allgemeines Muster und ersetzt keine individuelle Rechtsberatung.</p>
+      <p>Sie haben im Rahmen der geltenden gesetzlichen Bestimmungen jederzeit das Recht auf unentgeltliche Auskunft über Ihre gespeicherten personenbezogenen Daten (Art. 15 DSGVO), deren Herkunft und Empfänger sowie den Zweck der Datenverarbeitung. Außerdem haben Sie gegebenenfalls ein Recht auf Berichtigung (Art. 16 DSGVO), Löschung (Art. 17 DSGVO), Einschränkung der Verarbeitung (Art. 18 DSGVO) sowie auf Datenübertragbarkeit (Art. 20 DSGVO). Soweit wir die Verarbeitung auf Art. 6 Abs. 1 lit. e oder f DSGVO stützen, steht Ihnen das Recht zum Widerspruch gemäß Art. 21 DSGVO zu.</p>
+      <h2>Beschwerderecht</h2>
+      <p>Sie haben das Recht, sich bei einer Datenschutzaufsichtsbehörde zu beschweren, insbesondere in dem Mitgliedstaat Ihres Aufenthaltsorts, Ihres Arbeitsplatzes oder des Orts des mutmaßlichen Verstoßes. Für Bayern ist dies insbesondere das Bayerische Landesamt für Datenschutzaufsicht (BayLDA), Promenade 27, 91522 Ansbach.</p>
+      <h2>Aktualität dieser Datenschutzerklärung</h2>
+      <p>Wir behalten uns vor, diese Datenschutzerklärung bei Bedarf anzupassen, damit sie stets den aktuellen rechtlichen Anforderungen entspricht oder um Änderungen unserer Leistungen in der Erklärung umzusetzen. Die jeweils aktuelle Version finden Sie jederzeit auf dieser Seite.</p>
+      <p><strong>Stand:</strong> März 2025</p>
     </div>
   </main>
   <footer id="siteFooter">

--- a/impressum-en.html
+++ b/impressum-en.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="de">
+<html lang="en">
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
@@ -7,7 +7,7 @@
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; connect-src 'self'; img-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self'; manifest-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none';" />
   <meta name="referrer" content="no-referrer" />
   <meta name="theme-color" content="#f9f9f9" />
-  <title>Impressum</title>
+  <title>Imprint</title>
   <link rel="icon" href="icon.svg" type="image/svg+xml" />
   <link rel="icon" href="icon.png" type="image/png" />
   <link rel="apple-touch-icon" href="icon.png" />
@@ -15,7 +15,7 @@
   <script src="static-theme.js" defer></script>
 </head>
 <body class="static-page">
-  <a href="#mainContent" class="skip-link">Zum Inhalt springen</a>
+  <a href="#mainContent" class="skip-link">Skip to content</a>
   <div id="offlineIndicator" role="status" aria-live="polite">Offline</div>
   <header id="topBar">
     <div class="branding">
@@ -39,43 +39,43 @@
       </svg>
       <h1 id="mainTitle">Cine Power Planner</h1>
     </div>
-    <nav class="static-nav" aria-label="Sekundärnavigation">
-      <a class="button-link" href="index.html">Zurück zur App</a>
+    <nav class="static-nav" aria-label="Secondary navigation">
+      <a class="button-link" href="index.html">Back to the app</a>
     </nav>
   </header>
   <main id="mainContent" class="legal-content" tabindex="-1">
-    <h1>Impressum</h1>
-    <nav class="legal-language-nav" aria-label="Sprachauswahl">
+    <h1>Imprint</h1>
+    <nav class="legal-language-nav" aria-label="Language selection">
       <ul>
-        <li><a href="impressum.html" lang="de" aria-current="page">Deutsch</a></li>
-        <li><a href="impressum-en.html" lang="en">English</a></li>
+        <li><a href="impressum.html" lang="de">Deutsch</a></li>
+        <li><a href="impressum-en.html" lang="en" aria-current="page">English</a></li>
         <li><a href="impressum-es.html" lang="es">Español</a></li>
         <li><a href="impressum-fr.html" lang="fr">Français</a></li>
         <li><a href="impressum-it.html" lang="it">Italiano</a></li>
       </ul>
     </nav>
     <div class="legal-card">
-      <h2>Angaben gemäß § 5 TMG</h2>
-      <p>Luca Zanner<br>Brünnsteinstraße 5<br>81541 München<br>Deutschland</p>
-      <h2>Kontakt</h2>
-      <p>E-Mail: <a href="mailto:info@lucazanner.com">info@lucazanner.com</a></p>
-      <h2>Verantwortlich für den Inhalt nach § 18 Abs. 2 MStV</h2>
-      <p>Luca Zanner<br>Brünnsteinstraße 5<br>81541 München</p>
-      <h2>Haftung für Inhalte</h2>
-      <p>Als Diensteanbieter sind wir gemäß § 7 Abs. 1 TMG für eigene Inhalte auf diesen Seiten nach den allgemeinen Gesetzen verantwortlich. Nach §§ 8 bis 10 TMG sind wir als Diensteanbieter jedoch nicht verpflichtet, übermittelte oder gespeicherte fremde Informationen zu überwachen oder nach Umständen zu forschen, die auf eine rechtswidrige Tätigkeit hinweisen. Verpflichtungen zur Entfernung oder Sperrung der Nutzung von Informationen nach den allgemeinen Gesetzen bleiben hiervon unberührt. Eine diesbezügliche Haftung ist jedoch erst ab dem Zeitpunkt der Kenntnis einer konkreten Rechtsverletzung möglich. Bei Bekanntwerden von Rechtsverletzungen werden wir diese Inhalte umgehend entfernen.</p>
-      <h2>Haftung für Links</h2>
-      <p>Unser Angebot enthält Links zu externen Websites Dritter, auf deren Inhalte wir keinen Einfluss haben. Deshalb können wir für diese fremden Inhalte auch keine Gewähr übernehmen. Für die Inhalte der verlinkten Seiten ist stets der jeweilige Anbieter oder Betreiber der Seiten verantwortlich. Die verlinkten Seiten wurden zum Zeitpunkt der Verlinkung auf mögliche Rechtsverstöße überprüft. Rechtswidrige Inhalte waren zum Zeitpunkt der Verlinkung nicht erkennbar. Eine permanente inhaltliche Kontrolle der verlinkten Seiten ist jedoch ohne konkrete Anhaltspunkte einer Rechtsverletzung nicht zumutbar. Bei Bekanntwerden von Rechtsverletzungen werden wir derartige Links umgehend entfernen.</p>
-      <h2>Urheberrecht</h2>
-      <p>Die durch die Seitenbetreiber erstellten Inhalte und Werke auf diesen Seiten unterliegen dem deutschen Urheberrecht. Die Vervielfältigung, Bearbeitung, Verbreitung und jede Art der Verwertung außerhalb der Grenzen des Urheberrechts bedürfen der schriftlichen Zustimmung des jeweiligen Autors bzw. Erstellers. Downloads und Kopien dieser Seite sind nur für den privaten, nicht kommerziellen Gebrauch gestattet. Soweit die Inhalte auf dieser Seite nicht vom Betreiber erstellt wurden, werden die Urheberrechte Dritter beachtet und entsprechende Inhalte als solche gekennzeichnet. Sollten Sie trotzdem auf eine Urheberrechtsverletzung aufmerksam werden, bitten wir um einen entsprechenden Hinweis. Bei Bekanntwerden von Rechtsverletzungen werden wir derartige Inhalte umgehend entfernen.</p>
-      <h2>Streitschlichtung</h2>
-      <p>Die Europäische Kommission stellt eine Plattform zur Online-Streitbeilegung (OS) bereit: <a href="https://ec.europa.eu/consumers/odr" rel="noopener" target="_blank">https://ec.europa.eu/consumers/odr</a>. Unsere E-Mail-Adresse finden Sie oben im Impressum.</p>
-      <p>Wir sind weder verpflichtet noch bereit, an Streitbeilegungsverfahren vor einer Verbraucherschlichtungsstelle teilzunehmen.</p>
+      <h2>Provider identification pursuant to Section&nbsp;5 German Telemedia Act (TMG)</h2>
+      <p>Luca Zanner<br>Brünnsteinstraße 5<br>81541 Munich<br>Germany</p>
+      <h2>Contact</h2>
+      <p>E-mail: <a href="mailto:info@lucazanner.com">info@lucazanner.com</a></p>
+      <h2>Responsible for editorial content pursuant to Section&nbsp;18 (2) Interstate Media Treaty (MStV)</h2>
+      <p>Luca Zanner<br>Brünnsteinstraße 5<br>81541 Munich</p>
+      <h2>Liability for content</h2>
+      <p>As a service provider we are responsible for our own content on these pages in accordance with Section&nbsp;7 (1) TMG and general legislation. However, pursuant to Sections&nbsp;8 to 10 TMG we are not obligated to monitor transmitted or stored third-party information or to investigate circumstances indicating illegal activity. Obligations to remove or block the use of information under general laws remain unaffected. Liability in this respect is only possible from the time we become aware of a specific infringement. Upon notification of such violations we will remove the content immediately.</p>
+      <h2>Liability for links</h2>
+      <p>Our offer contains links to external third-party websites over whose content we have no control. Therefore we cannot assume any liability for such third-party content. The respective provider or operator of the sites is always responsible for the content of the linked pages. The linked pages were checked for possible legal violations at the time of linking. Unlawful content was not recognizable at the time of linking. However, permanent monitoring of the content of the linked pages is not reasonable without concrete evidence of an infringement. If we become aware of any legal infringements, we will remove such links immediately.</p>
+      <h2>Copyright</h2>
+      <p>The content and works created by the site operators on these pages are subject to German copyright law. Duplication, processing, distribution or any kind of exploitation beyond the limits of copyright law require the written consent of the respective author or creator. Downloads and copies of this site are permitted only for private, non-commercial use. Where the content on this site was not created by the operator, the copyrights of third parties are respected and such content is identified accordingly. Should you nevertheless become aware of a copyright infringement, please inform us. Upon notification of violations we will remove the content immediately.</p>
+      <h2>Dispute resolution</h2>
+      <p>The European Commission provides a platform for online dispute resolution (ODR): <a href="https://ec.europa.eu/consumers/odr" rel="noopener" target="_blank">https://ec.europa.eu/consumers/odr</a>. Our e-mail address can be found above in this imprint.</p>
+      <p>We are neither obliged nor willing to participate in dispute resolution proceedings before a consumer arbitration board.</p>
     </div>
   </main>
   <footer id="siteFooter">
-    <a href="impressum.html">Impressum</a>
+    <a href="impressum-en.html">Imprint</a>
     |
-    <a href="datenschutz.html">Datenschutz</a>
+    <a href="datenschutz-en.html">Privacy Policy</a>
   </footer>
 </body>
 </html>

--- a/impressum-es.html
+++ b/impressum-es.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="de">
+<html lang="es">
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
@@ -7,7 +7,7 @@
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; connect-src 'self'; img-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self'; manifest-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none';" />
   <meta name="referrer" content="no-referrer" />
   <meta name="theme-color" content="#f9f9f9" />
-  <title>Impressum</title>
+  <title>Aviso legal</title>
   <link rel="icon" href="icon.svg" type="image/svg+xml" />
   <link rel="icon" href="icon.png" type="image/png" />
   <link rel="apple-touch-icon" href="icon.png" />
@@ -15,8 +15,8 @@
   <script src="static-theme.js" defer></script>
 </head>
 <body class="static-page">
-  <a href="#mainContent" class="skip-link">Zum Inhalt springen</a>
-  <div id="offlineIndicator" role="status" aria-live="polite">Offline</div>
+  <a href="#mainContent" class="skip-link">Saltar al contenido</a>
+  <div id="offlineIndicator" role="status" aria-live="polite">Sin conexión</div>
   <header id="topBar">
     <div class="branding">
       <svg id="logo" viewBox="0 0 1024 1024" aria-hidden="true">
@@ -39,43 +39,43 @@
       </svg>
       <h1 id="mainTitle">Cine Power Planner</h1>
     </div>
-    <nav class="static-nav" aria-label="Sekundärnavigation">
-      <a class="button-link" href="index.html">Zurück zur App</a>
+    <nav class="static-nav" aria-label="Navegación secundaria">
+      <a class="button-link" href="index.html">Volver a la aplicación</a>
     </nav>
   </header>
   <main id="mainContent" class="legal-content" tabindex="-1">
-    <h1>Impressum</h1>
-    <nav class="legal-language-nav" aria-label="Sprachauswahl">
+    <h1>Aviso legal</h1>
+    <nav class="legal-language-nav" aria-label="Selección de idioma">
       <ul>
-        <li><a href="impressum.html" lang="de" aria-current="page">Deutsch</a></li>
+        <li><a href="impressum.html" lang="de">Deutsch</a></li>
         <li><a href="impressum-en.html" lang="en">English</a></li>
-        <li><a href="impressum-es.html" lang="es">Español</a></li>
+        <li><a href="impressum-es.html" lang="es" aria-current="page">Español</a></li>
         <li><a href="impressum-fr.html" lang="fr">Français</a></li>
         <li><a href="impressum-it.html" lang="it">Italiano</a></li>
       </ul>
     </nav>
     <div class="legal-card">
-      <h2>Angaben gemäß § 5 TMG</h2>
-      <p>Luca Zanner<br>Brünnsteinstraße 5<br>81541 München<br>Deutschland</p>
-      <h2>Kontakt</h2>
-      <p>E-Mail: <a href="mailto:info@lucazanner.com">info@lucazanner.com</a></p>
-      <h2>Verantwortlich für den Inhalt nach § 18 Abs. 2 MStV</h2>
-      <p>Luca Zanner<br>Brünnsteinstraße 5<br>81541 München</p>
-      <h2>Haftung für Inhalte</h2>
-      <p>Als Diensteanbieter sind wir gemäß § 7 Abs. 1 TMG für eigene Inhalte auf diesen Seiten nach den allgemeinen Gesetzen verantwortlich. Nach §§ 8 bis 10 TMG sind wir als Diensteanbieter jedoch nicht verpflichtet, übermittelte oder gespeicherte fremde Informationen zu überwachen oder nach Umständen zu forschen, die auf eine rechtswidrige Tätigkeit hinweisen. Verpflichtungen zur Entfernung oder Sperrung der Nutzung von Informationen nach den allgemeinen Gesetzen bleiben hiervon unberührt. Eine diesbezügliche Haftung ist jedoch erst ab dem Zeitpunkt der Kenntnis einer konkreten Rechtsverletzung möglich. Bei Bekanntwerden von Rechtsverletzungen werden wir diese Inhalte umgehend entfernen.</p>
-      <h2>Haftung für Links</h2>
-      <p>Unser Angebot enthält Links zu externen Websites Dritter, auf deren Inhalte wir keinen Einfluss haben. Deshalb können wir für diese fremden Inhalte auch keine Gewähr übernehmen. Für die Inhalte der verlinkten Seiten ist stets der jeweilige Anbieter oder Betreiber der Seiten verantwortlich. Die verlinkten Seiten wurden zum Zeitpunkt der Verlinkung auf mögliche Rechtsverstöße überprüft. Rechtswidrige Inhalte waren zum Zeitpunkt der Verlinkung nicht erkennbar. Eine permanente inhaltliche Kontrolle der verlinkten Seiten ist jedoch ohne konkrete Anhaltspunkte einer Rechtsverletzung nicht zumutbar. Bei Bekanntwerden von Rechtsverletzungen werden wir derartige Links umgehend entfernen.</p>
-      <h2>Urheberrecht</h2>
-      <p>Die durch die Seitenbetreiber erstellten Inhalte und Werke auf diesen Seiten unterliegen dem deutschen Urheberrecht. Die Vervielfältigung, Bearbeitung, Verbreitung und jede Art der Verwertung außerhalb der Grenzen des Urheberrechts bedürfen der schriftlichen Zustimmung des jeweiligen Autors bzw. Erstellers. Downloads und Kopien dieser Seite sind nur für den privaten, nicht kommerziellen Gebrauch gestattet. Soweit die Inhalte auf dieser Seite nicht vom Betreiber erstellt wurden, werden die Urheberrechte Dritter beachtet und entsprechende Inhalte als solche gekennzeichnet. Sollten Sie trotzdem auf eine Urheberrechtsverletzung aufmerksam werden, bitten wir um einen entsprechenden Hinweis. Bei Bekanntwerden von Rechtsverletzungen werden wir derartige Inhalte umgehend entfernen.</p>
-      <h2>Streitschlichtung</h2>
-      <p>Die Europäische Kommission stellt eine Plattform zur Online-Streitbeilegung (OS) bereit: <a href="https://ec.europa.eu/consumers/odr" rel="noopener" target="_blank">https://ec.europa.eu/consumers/odr</a>. Unsere E-Mail-Adresse finden Sie oben im Impressum.</p>
-      <p>Wir sind weder verpflichtet noch bereit, an Streitbeilegungsverfahren vor einer Verbraucherschlichtungsstelle teilzunehmen.</p>
+      <h2>Información según el § 5 de la Ley alemana de Telemedios (TMG)</h2>
+      <p>Luca Zanner<br>Brünnsteinstraße 5<br>81541 Múnich<br>Alemania</p>
+      <h2>Contacto</h2>
+      <p>Correo electrónico: <a href="mailto:info@lucazanner.com">info@lucazanner.com</a></p>
+      <h2>Responsable del contenido editorial según el art. 18 apdo. 2 del Tratado Estatal de Medios (MStV)</h2>
+      <p>Luca Zanner<br>Brünnsteinstraße 5<br>81541 Múnich</p>
+      <h2>Responsabilidad por los contenidos</h2>
+      <p>Como proveedores de servicios somos responsables de nuestros propios contenidos en estas páginas de conformidad con el § 7 apdo. 1 TMG y las leyes generales. Sin embargo, según los §§ 8 a 10 TMG no estamos obligados a supervisar la información de terceros transmitida o almacenada ni a investigar circunstancias que indiquen una actividad ilícita. Las obligaciones de eliminar o bloquear el uso de información en virtud de las leyes generales permanecen inalteradas. La responsabilidad en este sentido solo es posible a partir del momento en que tengamos conocimiento de una infracción concreta. Si tenemos conocimiento de infracciones, eliminaremos los contenidos de inmediato.</p>
+      <h2>Responsabilidad por los enlaces</h2>
+      <p>Nuestra oferta contiene enlaces a sitios web externos de terceros sobre cuyos contenidos no tenemos influencia. Por ello no podemos asumir ninguna responsabilidad por esos contenidos externos. El respectivo proveedor u operador es siempre responsable del contenido de las páginas enlazadas. Las páginas enlazadas se comprobaron en el momento de enlazarlas para detectar posibles infracciones legales; en ese momento no se identificaron contenidos ilegales. Un control permanente de los contenidos de las páginas enlazadas no es razonable sin indicios concretos de una infracción. Si tenemos conocimiento de infracciones, eliminaremos dichos enlaces de inmediato.</p>
+      <h2>Derechos de autor</h2>
+      <p>Los contenidos y obras creados por los operadores del sitio en estas páginas están sujetos a la legislación alemana sobre derechos de autor. La reproducción, tratamiento, distribución o cualquier tipo de explotación fuera de los límites del derecho de autor requieren el consentimiento por escrito del autor o creador correspondiente. Las descargas y copias de esta página solo están permitidas para uso privado y no comercial. Cuando los contenidos de esta página no hayan sido creados por el operador, se respetan los derechos de autor de terceros y dichos contenidos se identifican como tales. Si a pesar de ello tuviera conocimiento de una infracción de derechos de autor, le rogamos que nos lo comunique. En cuanto tengamos conocimiento de infracciones eliminaremos los contenidos de inmediato.</p>
+      <h2>Resolución de litigios</h2>
+      <p>La Comisión Europea ofrece una plataforma para la resolución de litigios en línea (ODR): <a href="https://ec.europa.eu/consumers/odr" rel="noopener" target="_blank">https://ec.europa.eu/consumers/odr</a>. Nuestra dirección de correo electrónico figura en el aviso legal anterior.</p>
+      <p>No estamos obligados ni dispuestos a participar en procedimientos de resolución de litigios ante una junta arbitral de consumo.</p>
     </div>
   </main>
   <footer id="siteFooter">
-    <a href="impressum.html">Impressum</a>
+    <a href="impressum-es.html">Aviso legal</a>
     |
-    <a href="datenschutz.html">Datenschutz</a>
+    <a href="datenschutz-es.html">Política de privacidad</a>
   </footer>
 </body>
 </html>

--- a/impressum-fr.html
+++ b/impressum-fr.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+  <meta name="color-scheme" content="light dark" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; connect-src 'self'; img-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self'; manifest-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none';" />
+  <meta name="referrer" content="no-referrer" />
+  <meta name="theme-color" content="#f9f9f9" />
+  <title>Mentions légales</title>
+  <link rel="icon" href="icon.svg" type="image/svg+xml" />
+  <link rel="icon" href="icon.png" type="image/png" />
+  <link rel="apple-touch-icon" href="icon.png" />
+  <link rel="stylesheet" href="style.css" />
+  <script src="static-theme.js" defer></script>
+</head>
+<body class="static-page">
+  <a href="#mainContent" class="skip-link">Aller au contenu</a>
+  <div id="offlineIndicator" role="status" aria-live="polite">Hors ligne</div>
+  <header id="topBar">
+    <div class="branding">
+      <svg id="logo" viewBox="0 0 1024 1024" aria-hidden="true">
+        <defs>
+          <style>
+            .cls-1 { fill: var(--accent-color); }
+            .cls-2 { fill: #fff; }
+          </style>
+        </defs>
+        <rect class="cls-1" width="1024" height="1024" rx="128" ry="128" />
+        <path class="cls-1" d="M332.79,264.29c-66.13,6.4-105.19,79.54-74.31,138.73,35.25,67.58,131.84,67.97,167.69.65,35.6-66.85-18.81-146.6-93.38-139.38ZM532.8,264.3c-51.89,4.85-90.78,55.06-84.79,106.19,9.73,82.92,118.85,114.08,169.97,46.99,51.33-67.37-2.29-160.92-85.18-153.18ZM689.21,517.2l.28,157.8,82.46,50.54c9.27,5.08,19.04.97,20.1-10-.62-80.73,1-161.7-.82-242.28-2.55-6.41-9.86-10.22-16.21-6.74l-85.81,50.68ZM274.74,468.24c-12.21,3.53-19.68,12.51-20.77,25.23l.05,221.03c1.77,14.87,11.57,24.26,26.45,25.55h326.07c14.13-1.11,25.08-10,26.51-24.49v-223.08c-1.21-13.19-11.34-23.3-24.5-24.5l-333.8.28ZM672,530h-19v134h19v-134Z" />
+        <path class="cls-2" d="M274.74,468.24l333.8-.28c13.16,1.2,23.29,11.31,24.5,24.5v223.08c-1.43,14.49-12.37,23.38-26.51,24.49h-326.07c-14.89-1.28-24.69-10.68-26.45-25.55l-.05-221.03c1.09-12.71,8.56-21.7,20.77-25.23ZM467,582l14.91-68.61c-3.75-14.34-10.29-10.19-17.88-1.86-28.03,30.79-51.9,68.87-79.85,100.15-4.19,3.66-1.94,14.32,3.32,14.32h42.5l-14.07,67.5c.6,11.86,10.68,13.88,17.04,3.97l79.87-102.13c3.57-4.95,1.6-13.34-5.34-13.34h-40.5Z" />
+        <path class="cls-2" d="M532.8,264.3c82.89-7.74,136.51,85.82,85.18,153.18-51.12,67.08-160.24,35.92-169.97-46.99-6-51.12,32.9-101.34,84.79-106.19ZM539.79,321.27c-49.71,4.46-43.19,80.2,6.71,75.72,49.16-4.42,42.05-80.09-6.71-75.72Z" />
+        <path class="cls-2" d="M332.79,264.29c74.57-7.22,128.98,72.53,93.38,139.38-35.85,67.31-132.44,66.92-167.69-.65-30.87-59.18,8.09-132.33,74.31-138.73ZM315.35,332.35c-32.21,32.16,12.32,84.81,49.14,57.64,43.84-32.35-11.25-95.49-49.14-57.64Z" />
+        <path class="cls-2" d="M689.21,517.2l85.81-50.68c6.35-3.48,13.67.34,16.21,6.74,1.82,80.58.2,161.55.82,242.28-1.06,10.97-10.83,15.09-20.1,10l-82.46-50.54-.28-157.8Z" />
+        <rect class="cls-2" x="653" y="530" width="19" height="134" />
+        <path class="cls-1" d="M467,582h40.5c6.94,0,8.9,8.4,5.34,13.34l-79.87,102.13c-6.36,9.92-16.44,7.89-17.04-3.97l14.07-67.5h-42.5c-5.26,0-7.51-10.65-3.32-14.32,27.95-31.29,51.81-69.37,79.85-100.15,7.59-8.33,14.13-12.49,17.88,1.86l-14.91,68.61Z" />
+        <path class="cls-1" d="M539.79,321.27c48.76-4.38,55.87,71.3,6.71,75.72-49.9,4.48-56.42-71.26-6.71-75.72Z" />
+        <path class="cls-1" d="M315.35,332.35c37.9-37.85,92.98,25.3,49.14,57.64-36.82,27.17-81.35-25.48-49.14-57.64Z" />
+      </svg>
+      <h1 id="mainTitle">Cine Power Planner</h1>
+    </div>
+    <nav class="static-nav" aria-label="Navigation secondaire">
+      <a class="button-link" href="index.html">Retour à l'application</a>
+    </nav>
+  </header>
+  <main id="mainContent" class="legal-content" tabindex="-1">
+    <h1>Mentions légales</h1>
+    <nav class="legal-language-nav" aria-label="Choix de la langue">
+      <ul>
+        <li><a href="impressum.html" lang="de">Deutsch</a></li>
+        <li><a href="impressum-en.html" lang="en">English</a></li>
+        <li><a href="impressum-es.html" lang="es">Español</a></li>
+        <li><a href="impressum-fr.html" lang="fr" aria-current="page">Français</a></li>
+        <li><a href="impressum-it.html" lang="it">Italiano</a></li>
+      </ul>
+    </nav>
+    <div class="legal-card">
+      <h2>Informations conformément à l'article 5 de la loi allemande sur les télémédias (TMG)</h2>
+      <p>Luca Zanner<br>Brünnsteinstraße 5<br>81541 Munich<br>Allemagne</p>
+      <h2>Contact</h2>
+      <p>E-mail&nbsp;: <a href="mailto:info@lucazanner.com">info@lucazanner.com</a></p>
+      <h2>Responsable du contenu rédactionnel au sens de l'article 18, paragraphe 2, du traité d'État sur les médias (MStV)</h2>
+      <p>Luca Zanner<br>Brünnsteinstraße 5<br>81541 Munich</p>
+      <h2>Responsabilité pour les contenus</h2>
+      <p>En tant que prestataire de services, nous sommes responsables de nos propres contenus sur ces pages conformément à l'article 7, paragraphe 1, du TMG et aux lois générales. Toutefois, conformément aux articles 8 à 10 du TMG, nous ne sommes pas tenus de surveiller les informations de tiers transmises ou stockées ni de rechercher des circonstances indiquant une activité illégale. Les obligations de supprimer ou de bloquer l'utilisation d'informations en vertu des lois générales demeurent inchangées. Une responsabilité n'est possible qu'à partir du moment où nous avons connaissance d'une violation spécifique. Dès la notification d'infractions, nous retirerons immédiatement les contenus concernés.</p>
+      <h2>Responsabilité pour les liens</h2>
+      <p>Notre offre contient des liens vers des sites web externes de tiers sur les contenus desquels nous n'avons aucune influence. Par conséquent, nous n'assumons aucune responsabilité pour ces contenus externes. Le fournisseur ou l'exploitant respectif est toujours responsable des contenus des pages liées. Les pages liées ont été vérifiées pour d'éventuelles violations de la loi au moment de la création du lien. Aucun contenu illégal n'a été identifié à ce moment-là. Un contrôle permanent du contenu des pages liées n'est toutefois pas raisonnable sans indices concrets d'une violation. Si nous prenons connaissance d'infractions, nous supprimerons immédiatement ces liens.</p>
+      <h2>Droits d'auteur</h2>
+      <p>Les contenus et œuvres créés par les exploitants du site sur ces pages sont soumis au droit d'auteur allemand. Toute reproduction, traitement, distribution ou exploitation au-delà des limites du droit d'auteur nécessite l'accord écrit de l'auteur ou du créateur concerné. Les téléchargements et copies de ce site ne sont autorisés que pour un usage privé et non commercial. Lorsque les contenus de ce site n'ont pas été créés par l'exploitant, les droits d'auteur de tiers sont respectés et ces contenus sont identifiés comme tels. Si vous deviez néanmoins constater une violation du droit d'auteur, nous vous prions de nous en informer. Dès notification d'une violation, nous supprimerons immédiatement les contenus concernés.</p>
+      <h2>Règlement des litiges</h2>
+      <p>La Commission européenne met à disposition une plateforme de règlement en ligne des litiges (RLL)&nbsp;: <a href="https://ec.europa.eu/consumers/odr" rel="noopener" target="_blank">https://ec.europa.eu/consumers/odr</a>. Notre adresse e-mail figure ci-dessus dans les mentions légales.</p>
+      <p>Nous ne sommes ni obligés ni disposés à participer à une procédure de règlement des litiges devant une commission d'arbitrage de la consommation.</p>
+    </div>
+  </main>
+  <footer id="siteFooter">
+    <a href="impressum-fr.html">Mentions légales</a>
+    |
+    <a href="datenschutz-fr.html">Politique de confidentialité</a>
+  </footer>
+</body>
+</html>

--- a/impressum-it.html
+++ b/impressum-it.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="de">
+<html lang="it">
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
@@ -7,7 +7,7 @@
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; connect-src 'self'; img-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self'; manifest-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none';" />
   <meta name="referrer" content="no-referrer" />
   <meta name="theme-color" content="#f9f9f9" />
-  <title>Impressum</title>
+  <title>Note legali</title>
   <link rel="icon" href="icon.svg" type="image/svg+xml" />
   <link rel="icon" href="icon.png" type="image/png" />
   <link rel="apple-touch-icon" href="icon.png" />
@@ -15,7 +15,7 @@
   <script src="static-theme.js" defer></script>
 </head>
 <body class="static-page">
-  <a href="#mainContent" class="skip-link">Zum Inhalt springen</a>
+  <a href="#mainContent" class="skip-link">Vai al contenuto</a>
   <div id="offlineIndicator" role="status" aria-live="polite">Offline</div>
   <header id="topBar">
     <div class="branding">
@@ -39,43 +39,43 @@
       </svg>
       <h1 id="mainTitle">Cine Power Planner</h1>
     </div>
-    <nav class="static-nav" aria-label="Sekundärnavigation">
-      <a class="button-link" href="index.html">Zurück zur App</a>
+    <nav class="static-nav" aria-label="Navigazione secondaria">
+      <a class="button-link" href="index.html">Torna all'app</a>
     </nav>
   </header>
   <main id="mainContent" class="legal-content" tabindex="-1">
-    <h1>Impressum</h1>
-    <nav class="legal-language-nav" aria-label="Sprachauswahl">
+    <h1>Note legali</h1>
+    <nav class="legal-language-nav" aria-label="Selezione della lingua">
       <ul>
-        <li><a href="impressum.html" lang="de" aria-current="page">Deutsch</a></li>
+        <li><a href="impressum.html" lang="de">Deutsch</a></li>
         <li><a href="impressum-en.html" lang="en">English</a></li>
         <li><a href="impressum-es.html" lang="es">Español</a></li>
         <li><a href="impressum-fr.html" lang="fr">Français</a></li>
-        <li><a href="impressum-it.html" lang="it">Italiano</a></li>
+        <li><a href="impressum-it.html" lang="it" aria-current="page">Italiano</a></li>
       </ul>
     </nav>
     <div class="legal-card">
-      <h2>Angaben gemäß § 5 TMG</h2>
-      <p>Luca Zanner<br>Brünnsteinstraße 5<br>81541 München<br>Deutschland</p>
-      <h2>Kontakt</h2>
-      <p>E-Mail: <a href="mailto:info@lucazanner.com">info@lucazanner.com</a></p>
-      <h2>Verantwortlich für den Inhalt nach § 18 Abs. 2 MStV</h2>
-      <p>Luca Zanner<br>Brünnsteinstraße 5<br>81541 München</p>
-      <h2>Haftung für Inhalte</h2>
-      <p>Als Diensteanbieter sind wir gemäß § 7 Abs. 1 TMG für eigene Inhalte auf diesen Seiten nach den allgemeinen Gesetzen verantwortlich. Nach §§ 8 bis 10 TMG sind wir als Diensteanbieter jedoch nicht verpflichtet, übermittelte oder gespeicherte fremde Informationen zu überwachen oder nach Umständen zu forschen, die auf eine rechtswidrige Tätigkeit hinweisen. Verpflichtungen zur Entfernung oder Sperrung der Nutzung von Informationen nach den allgemeinen Gesetzen bleiben hiervon unberührt. Eine diesbezügliche Haftung ist jedoch erst ab dem Zeitpunkt der Kenntnis einer konkreten Rechtsverletzung möglich. Bei Bekanntwerden von Rechtsverletzungen werden wir diese Inhalte umgehend entfernen.</p>
-      <h2>Haftung für Links</h2>
-      <p>Unser Angebot enthält Links zu externen Websites Dritter, auf deren Inhalte wir keinen Einfluss haben. Deshalb können wir für diese fremden Inhalte auch keine Gewähr übernehmen. Für die Inhalte der verlinkten Seiten ist stets der jeweilige Anbieter oder Betreiber der Seiten verantwortlich. Die verlinkten Seiten wurden zum Zeitpunkt der Verlinkung auf mögliche Rechtsverstöße überprüft. Rechtswidrige Inhalte waren zum Zeitpunkt der Verlinkung nicht erkennbar. Eine permanente inhaltliche Kontrolle der verlinkten Seiten ist jedoch ohne konkrete Anhaltspunkte einer Rechtsverletzung nicht zumutbar. Bei Bekanntwerden von Rechtsverletzungen werden wir derartige Links umgehend entfernen.</p>
-      <h2>Urheberrecht</h2>
-      <p>Die durch die Seitenbetreiber erstellten Inhalte und Werke auf diesen Seiten unterliegen dem deutschen Urheberrecht. Die Vervielfältigung, Bearbeitung, Verbreitung und jede Art der Verwertung außerhalb der Grenzen des Urheberrechts bedürfen der schriftlichen Zustimmung des jeweiligen Autors bzw. Erstellers. Downloads und Kopien dieser Seite sind nur für den privaten, nicht kommerziellen Gebrauch gestattet. Soweit die Inhalte auf dieser Seite nicht vom Betreiber erstellt wurden, werden die Urheberrechte Dritter beachtet und entsprechende Inhalte als solche gekennzeichnet. Sollten Sie trotzdem auf eine Urheberrechtsverletzung aufmerksam werden, bitten wir um einen entsprechenden Hinweis. Bei Bekanntwerden von Rechtsverletzungen werden wir derartige Inhalte umgehend entfernen.</p>
-      <h2>Streitschlichtung</h2>
-      <p>Die Europäische Kommission stellt eine Plattform zur Online-Streitbeilegung (OS) bereit: <a href="https://ec.europa.eu/consumers/odr" rel="noopener" target="_blank">https://ec.europa.eu/consumers/odr</a>. Unsere E-Mail-Adresse finden Sie oben im Impressum.</p>
-      <p>Wir sind weder verpflichtet noch bereit, an Streitbeilegungsverfahren vor einer Verbraucherschlichtungsstelle teilzunehmen.</p>
+      <h2>Informazioni ai sensi del § 5 della legge tedesca sui telemedia (TMG)</h2>
+      <p>Luca Zanner<br>Brünnsteinstraße 5<br>81541 Monaco di Baviera<br>Germania</p>
+      <h2>Contatti</h2>
+      <p>E-mail: <a href="mailto:info@lucazanner.com">info@lucazanner.com</a></p>
+      <h2>Responsabile dei contenuti editoriali ai sensi del § 18 comma 2 del Trattato Statale sui Media (MStV)</h2>
+      <p>Luca Zanner<br>Brünnsteinstraße 5<br>81541 Monaco di Baviera</p>
+      <h2>Responsabilità per i contenuti</h2>
+      <p>In qualità di fornitori di servizi siamo responsabili dei nostri contenuti su queste pagine conformemente al § 7 comma 1 TMG e alle normative generali. Tuttavia, ai sensi dei §§ 8-10 TMG non siamo obbligati a monitorare le informazioni di terzi trasmesse o memorizzate né a ricercare circostanze che indichino attività illecite. Restano impregiudicati gli obblighi di rimuovere o bloccare l'utilizzo di informazioni ai sensi delle leggi generali. Una responsabilità in tal senso è possibile solo dal momento in cui veniamo a conoscenza di una violazione concreta. Non appena verremo a conoscenza di violazioni, provvederemo a rimuovere immediatamente tali contenuti.</p>
+      <h2>Responsabilità per i link</h2>
+      <p>La nostra offerta contiene collegamenti a siti web esterni di terzi sui cui contenuti non abbiamo alcuna influenza. Pertanto non possiamo assumere alcuna responsabilità per tali contenuti esterni. Il rispettivo fornitore o gestore delle pagine è sempre responsabile dei contenuti delle pagine collegate. Al momento del collegamento le pagine sono state controllate per individuare eventuali violazioni di legge; contenuti illegali non erano riconoscibili in quel momento. Un controllo permanente dei contenuti delle pagine collegate non è tuttavia ragionevole senza indicazioni concrete di una violazione. Se veniamo a conoscenza di violazioni, rimuoveremo immediatamente tali link.</p>
+      <h2>Diritto d'autore</h2>
+      <p>I contenuti e le opere creati dagli operatori del sito su queste pagine sono soggetti al diritto d'autore tedesco. La riproduzione, l'elaborazione, la distribuzione e qualsiasi tipo di utilizzo al di fuori dei limiti del diritto d'autore richiedono il consenso scritto del rispettivo autore o creatore. Download e copie di questo sito sono consentiti solo per uso privato e non commerciale. Quando i contenuti di questo sito non sono stati creati dall'operatore, vengono rispettati i diritti d'autore di terzi e tali contenuti sono contrassegnati come tali. Qualora dovesse comunque venire a conoscenza di una violazione del diritto d'autore, la preghiamo di informarci; provvederemo a rimuovere immediatamente i contenuti interessati.</p>
+      <h2>Risoluzione delle controversie</h2>
+      <p>La Commissione europea mette a disposizione una piattaforma per la risoluzione delle controversie online (ODR): <a href="https://ec.europa.eu/consumers/odr" rel="noopener" target="_blank">https://ec.europa.eu/consumers/odr</a>. Il nostro indirizzo e-mail è riportato nelle presenti note legali.</p>
+      <p>Non siamo né obbligati né disposti a partecipare a procedure di risoluzione delle controversie davanti a un organismo di conciliazione per i consumatori.</p>
     </div>
   </main>
   <footer id="siteFooter">
-    <a href="impressum.html">Impressum</a>
+    <a href="impressum-it.html">Note legali</a>
     |
-    <a href="datenschutz.html">Datenschutz</a>
+    <a href="datenschutz-it.html">Informativa sulla privacy</a>
   </footer>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -675,9 +675,9 @@
   </main>
 
   <footer id="siteFooter">
-    <a id="impressumLink" href="impressum.html">Impressum</a>
+    <a id="impressumLink" href="impressum-en.html">Imprint</a>
     |
-    <a id="privacyLink" href="datenschutz.html">Datenschutz</a>
+    <a id="privacyLink" href="datenschutz-en.html">Privacy Policy</a>
   </footer>
 
   <div id="settingsDialog" role="dialog" aria-modal="true" aria-labelledby="settingsTitle" hidden>

--- a/script.js
+++ b/script.js
@@ -42,6 +42,29 @@ try {
 
 const APP_VERSION = "1.0.1";
 
+const LEGAL_LINKS = {
+  de: {
+    imprint: "impressum.html",
+    privacy: "datenschutz.html",
+  },
+  en: {
+    imprint: "impressum-en.html",
+    privacy: "datenschutz-en.html",
+  },
+  es: {
+    imprint: "impressum-es.html",
+    privacy: "datenschutz-es.html",
+  },
+  fr: {
+    imprint: "impressum-fr.html",
+    privacy: "datenschutz-fr.html",
+  },
+  it: {
+    imprint: "impressum-it.html",
+    privacy: "datenschutz-it.html",
+  },
+};
+
 const getCssVariableValue = (name, fallback = '') => {
   if (typeof document === 'undefined') return fallback;
   const root = document.documentElement;
@@ -1299,10 +1322,21 @@ function setLanguage(lang) {
   if (skipLink) skipLink.textContent = texts[lang].skipToContent;
   const offlineElem = document.getElementById("offlineIndicator");
   if (offlineElem) offlineElem.textContent = texts[lang].offlineIndicator;
+  const legalLinks = LEGAL_LINKS[lang] || LEGAL_LINKS.en;
   const impressumElem = document.getElementById("impressumLink");
-  if (impressumElem) impressumElem.textContent = texts[lang].impressum;
+  if (impressumElem) {
+    impressumElem.textContent = texts[lang].impressum;
+    if (legalLinks?.imprint) {
+      impressumElem.setAttribute("href", legalLinks.imprint);
+    }
+  }
   const privacyElem = document.getElementById("privacyLink");
-  if (privacyElem) privacyElem.textContent = texts[lang].privacy;
+  if (privacyElem) {
+    privacyElem.textContent = texts[lang].privacy;
+    if (legalLinks?.privacy) {
+      privacyElem.setAttribute("href", legalLinks.privacy);
+    }
+  }
   // Section headings with descriptive hover help
   const setupManageHeadingElem = document.getElementById("setupManageHeading");
   setupManageHeadingElem.textContent = texts[lang].setupManageHeading;

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,10 +1,18 @@
 /* eslint-env serviceworker */
-const CACHE_NAME = 'cine-power-planner-v15';
+const CACHE_NAME = 'cine-power-planner-v16';
 const ASSETS = [
   './',
   './index.html',
   './impressum.html',
+  './impressum-en.html',
+  './impressum-es.html',
+  './impressum-fr.html',
+  './impressum-it.html',
   './datenschutz.html',
+  './datenschutz-en.html',
+  './datenschutz-es.html',
+  './datenschutz-fr.html',
+  './datenschutz-it.html',
   './style.css',
   './static-theme.js',
   './overview.css',

--- a/style.css
+++ b/style.css
@@ -282,6 +282,23 @@ main.legal-content {
   max-width: 960px;
 }
 
+.legal-language-nav {
+  margin: 0 0 1.5em;
+}
+
+.legal-language-nav ul {
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75em;
+  padding: 0;
+  margin: 0;
+}
+
+.legal-language-nav a[aria-current="page"] {
+  font-weight: 600;
+}
+
 .legal-content h1 {
   margin-bottom: 0.6em;
 }

--- a/tests/unit/service-worker.test.js
+++ b/tests/unit/service-worker.test.js
@@ -6,7 +6,20 @@ describe('service worker configuration', () => {
   });
 
   test('caches legal pages for offline usage', () => {
-    expect(ASSETS).toEqual(expect.arrayContaining(['./impressum.html', './datenschutz.html']));
+    expect(ASSETS).toEqual(
+      expect.arrayContaining([
+        './impressum.html',
+        './impressum-en.html',
+        './impressum-es.html',
+        './impressum-fr.html',
+        './impressum-it.html',
+        './datenschutz.html',
+        './datenschutz-en.html',
+        './datenschutz-es.html',
+        './datenschutz-fr.html',
+        './datenschutz-it.html',
+      ]),
+    );
   });
 
   test('caches the shared theme helper for legal pages', () => {


### PR DESCRIPTION
## Summary
- expand the German imprint and privacy policy with updated legal references, dispute resolution details, and a language switcher
- add localized imprint and privacy policy pages for English, Spanish, French, and Italian with consistent wording
- style the new language selector, retarget in-app legal links per language, and update service worker caching/tests for the additional pages

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c9ee0405648320a0cc11d4d90e6976