### PR TITLE
Make overview device list single column on mobile

### DIFF
--- a/script.js
+++ b/script.js
@@ -12912,7 +12912,7 @@ if (helpButton && helpDialog) {
     if (!hadTabIndex) heading.setAttribute('tabindex', '-1');
     try {
       heading.focus({ preventScroll: true });
-    } catch (err) {
+    } catch {
       heading.focus();
     }
     if (!hadTabIndex) {

--- a/style.css
+++ b/style.css
@@ -2688,6 +2688,20 @@ body.dark-mode.pink-mode .help-content { border-color: var(--accent-color); }
 #overviewDialogContent .device-block-grid.two-column {
   grid-template-columns: repeat(2, 1fr);
 }
+
+@media screen and (max-width: 600px) {
+  #overviewDialogContent .device-category-container {
+    flex-direction: column;
+  }
+
+  #overviewDialogContent .device-category {
+    flex: 1 1 100%;
+  }
+
+  #overviewDialogContent .device-block-grid.two-column {
+    grid-template-columns: 1fr;
+  }
+}
 #overviewDialogContent.pink-mode {
   --accent-color: #ff69b4;
 }


### PR DESCRIPTION
## Summary
- ensure the overview dialog's device categories stack in a single column on small screens
- use optional catch binding in help dialog focus helper to satisfy lint requirements

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c9f02e52c8832080a2f18bb9eccfa1