### PR TITLE
Fix stale select restoration and shared import recalculation

### DIFF
--- a/overview.js
+++ b/overview.js
@@ -20,7 +20,7 @@ function generatePrintableOverview() {
     const setupNameField = typeof document !== 'undefined' ? document.getElementById('setupName') : null;
     const setupName = setupNameField ? setupNameField.value : '';
     const now = new Date();
-    const localeMap = { de: 'de-DE', es: 'es-ES', fr: 'fr-FR', en: 'en-US' };
+    const localeMap = { de: 'de-DE', es: 'es-ES', fr: 'fr-FR', en: 'en-US', it: 'it-IT' };
     const lang = typeof currentLang === 'string' ? currentLang : 'en';
     const locale = localeMap[lang] || 'en-US';
     const dateTimeString = now.toLocaleDateString(locale) + ' ' + now.toLocaleTimeString();

--- a/script.js
+++ b/script.js
@@ -12074,13 +12074,49 @@ function scheduleProjectAutoSave(immediate = false) {
 }
 
 function setSelectValue(select, value) {
-  if (select && value) select.value = value;
+  if (!select) return;
+  if (value === undefined) return;
+  const normalized = value === null ? '' : value;
+  select.value = normalized;
+  if (select.value === normalized) return;
+  const options = Array.from(select.options || []);
+  const noneOption = options.find(opt => opt.value === 'None');
+  if (normalized === '' && !options.length) {
+    select.value = '';
+  } else if (normalized === '') {
+    if (noneOption) {
+      select.value = 'None';
+    } else {
+      select.selectedIndex = -1;
+    }
+  } else if (noneOption) {
+    select.value = 'None';
+  } else {
+    select.selectedIndex = -1;
+  }
+}
+
+function resetSelectsToNone(selects) {
+  selects.forEach(select => {
+    if (!select) return;
+    const options = Array.from(select.options || []);
+    const noneOption = options.find(opt => opt.value === 'None');
+    if (noneOption) {
+      select.value = 'None';
+    } else if (!options.length) {
+      select.value = '';
+    } else {
+      select.selectedIndex = -1;
+    }
+  });
 }
 
 function restoreSessionState() {
   restoringSession = true;
   const state = loadSession();
   loadedSetupState = state || null;
+  resetSelectsToNone(motorSelects);
+  resetSelectsToNone(controllerSelects);
   if (state) {
     if (setupNameInput) {
       setupNameInput.value = state.setupName || '';
@@ -12095,10 +12131,10 @@ function restoreSessionState() {
     setSelectValue(cageSelect, state.cage);
     setSelectValue(distanceSelect, state.distance);
     if (Array.isArray(state.motors)) {
-      state.motors.forEach((val, i) => { if (motorSelects[i]) motorSelects[i].value = val; });
+      state.motors.forEach((val, i) => { if (motorSelects[i]) setSelectValue(motorSelects[i], val); });
     }
     if (Array.isArray(state.controllers)) {
-      state.controllers.forEach((val, i) => { if (controllerSelects[i]) controllerSelects[i].value = val; });
+      state.controllers.forEach((val, i) => { if (controllerSelects[i]) setSelectValue(controllerSelects[i], val); });
     }
     setSelectValue(batterySelect, state.battery);
     setSelectValue(hotswapSelect, state.batteryHotswap);
@@ -12163,6 +12199,8 @@ function applySharedSetup(shared) {
       setupNameInput.value = decoded.setupName;
       setupNameInput.dispatchEvent(new Event('input'));
     }
+    resetSelectsToNone(motorSelects);
+    resetSelectsToNone(controllerSelects);
     setSelectValue(cameraSelect, decoded.camera);
     updateBatteryPlateVisibility();
     setSelectValue(batteryPlateSelect, decoded.batteryPlate);
@@ -12172,10 +12210,10 @@ function applySharedSetup(shared) {
     setSelectValue(cageSelect, decoded.cage);
     setSelectValue(distanceSelect, decoded.distance);
     if (Array.isArray(decoded.motors)) {
-      decoded.motors.forEach((val, i) => { if (motorSelects[i]) motorSelects[i].value = val; });
+      decoded.motors.forEach((val, i) => { if (motorSelects[i]) setSelectValue(motorSelects[i], val); });
     }
     if (Array.isArray(decoded.controllers)) {
-      decoded.controllers.forEach((val, i) => { if (controllerSelects[i]) controllerSelects[i].value = val; });
+      decoded.controllers.forEach((val, i) => { if (controllerSelects[i]) setSelectValue(controllerSelects[i], val); });
     }
     setSelectValue(batterySelect, decoded.battery);
     setSelectValue(hotswapSelect, decoded.batteryHotswap);
@@ -12229,6 +12267,9 @@ function applySharedSetupFromUrl() {
   try {
     const data = JSON.parse(LZString.decompressFromEncodedURIComponent(shared));
     applySharedSetup(data);
+    if (typeof updateCalculations === 'function') {
+      updateCalculations();
+    }
     if (window.history && window.history.replaceState) {
       history.replaceState(null, '', window.location.pathname);
     }
@@ -12946,7 +12987,7 @@ if (helpButton && helpDialog) {
     if (!hadTabIndex) heading.setAttribute('tabindex', '-1');
     try {
       heading.focus({ preventScroll: true });
-    } catch (err) {
+    } catch {
       heading.focus();
     }
     if (!hadTabIndex) {


### PR DESCRIPTION
## Summary
- allow select restoration to accept blank values and clear FIZ selections before loading session or shared setups
- recompute totals after applying shared setups from URLs so imported projects show up-to-date results
- add Italian locale for printable overview date formatting and clean up a lint warning in the help dialog

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c9ef01c1748320b88640ac90c55aff