### PR TITLE
Ensure service worker caches runtime dependencies

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -1,5 +1,5 @@
 /* eslint-env serviceworker */
-const CACHE_NAME = 'cine-power-planner-v16';
+const CACHE_NAME = 'cine-power-planner-v17';
 const ASSETS = [
   './',
   './index.html',
@@ -27,6 +27,7 @@ const ASSETS = [
   './Ubuntu/Ubuntu-Medium.ttf',
   './Ubuntu/Ubuntu-MediumItalic.ttf',
   './Ubuntu/Ubuntu-Regular.ttf',
+  './globalthis-polyfill.js',
   './script.js',
   './devices/index.js',
   './devices/cameras.js',
@@ -34,8 +35,11 @@ const ASSETS = [
   './devices/video.js',
   './devices/fiz.js',
   './devices/batteries.js',
+  './devices/batteryHotswaps.js',
   './devices/cages.js',
+  './devices/chargers.js',
   './devices/gearList.js',
+  './devices/wirelessReceivers.js',
   './translations.js',
   './storage.js',
   './normalizeData.js',

--- a/tests/unit/service-worker.test.js
+++ b/tests/unit/service-worker.test.js
@@ -5,6 +5,17 @@ describe('service worker configuration', () => {
     expect(ASSETS).toEqual(expect.arrayContaining(['./overview.css', './overview-print.css', './overview.js']));
   });
 
+  test('caches runtime JavaScript dependencies for offline usage', () => {
+    expect(ASSETS).toEqual(
+      expect.arrayContaining([
+        './globalthis-polyfill.js',
+        './devices/batteryHotswaps.js',
+        './devices/chargers.js',
+        './devices/wirelessReceivers.js',
+      ]),
+    );
+  });
+
   test('caches legal pages for offline usage', () => {
     expect(ASSETS).toEqual(
       expect.arrayContaining([


### PR DESCRIPTION
## Summary
- add the missing runtime modules and polyfill to the service worker pre-cache list and bump the cache version
- extend the service worker unit tests to ensure new runtime dependencies stay cached for offline use

## Testing
- npm run test:unit

------
https://chatgpt.com/codex/tasks/task_e_68cba09dd320832083c147e7ee78549e