### PR TITLE
Add coverage for filter token parsing

### DIFF
--- a/tests/script/filterParsing.test.js
+++ b/tests/script/filterParsing.test.js
@@ -1,0 +1,40 @@
+const { setupScriptEnvironment } = require('../helpers/scriptEnvironment');
+
+describe('parseFilterTokens', () => {
+  let env;
+  let parseFilterTokens;
+
+  beforeEach(() => {
+    env = setupScriptEnvironment();
+    ({ parseFilterTokens } = env.utils);
+  });
+
+  afterEach(() => {
+    env?.cleanup();
+  });
+
+  test('parses filter definitions with explicit sizes and values', () => {
+    const tokens = parseFilterTokens(' IRND : 6x6 : 0.3 | 0.6 | 0.9 , Clear:95mm , Pol ');
+
+    expect(tokens).toEqual([
+      { type: 'IRND', size: '6x6', values: ['0.3', '0.6', '0.9'] },
+      { type: 'Clear', size: '95mm', values: undefined },
+      { type: 'Pol', size: '4x5.65', values: undefined }
+    ]);
+  });
+
+  test('filters out empty entries while preserving order', () => {
+    const tokens = parseFilterTokens('Pol,, , IRND:4x5.65:0.3|0.6|1.2, ,');
+
+    expect(tokens).toEqual([
+      { type: 'Pol', size: '4x5.65', values: undefined },
+      { type: 'IRND', size: '4x5.65', values: ['0.3', '0.6', '1.2'] }
+    ]);
+  });
+
+  test('returns an empty list for missing or blank definitions', () => {
+    expect(parseFilterTokens('')).toEqual([]);
+    expect(parseFilterTokens(' , , ')).toEqual([]);
+    expect(parseFilterTokens(null)).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- add targeted script tests for parseFilterTokens
- cover trimming, default sizing, and empty entry handling for filter definitions

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cba01d29ac83209b1c170ae7b621f4