### PR TITLE
Adjust print styling for setup diagram

### DIFF
--- a/overview-print.css
+++ b/overview-print.css
@@ -141,6 +141,16 @@ table, th, td {
   border-color: var(--text-color);
   box-shadow: var(--panel-shadow);
 }
+#overviewDialogContent #setupDiagram {
+  background: none !important;
+  border: none !important;
+  box-shadow: none !important;
+}
+#overviewDialogContent #setupDiagram #diagramArea {
+  background: none !important;
+  border: none !important;
+  box-shadow: none !important;
+}
 #overviewDialogContent th {
   background-color: var(--control-bg) !important;
   font-weight: 700;


### PR DESCRIPTION
## Summary
- remove the print-only border and shadow from the setup diagram section so the diagram appears without a box

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cba2c2ed908320abefc6fb45312441