### PR TITLE
Soften print shadows

### DIFF
--- a/overview-print.css
+++ b/overview-print.css
@@ -16,6 +16,7 @@ body,
 body.dark-mode {
   --surface-color: #fff;
   --text-color: #000;
+  --panel-shadow: 0 2px 6px rgba(0, 0, 0, 0.05);
   --button-size: 24px;
   font-family: 'Ubuntu', sans-serif;
   font-weight: 300;


### PR DESCRIPTION
## Summary
- reduce the panel shadow intensity for the print stylesheet to avoid overly dark boxes on paper

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cba341a124832094c0dd0c18267fd7