### PR TITLE
Refine printable overview sections and layout

### DIFF
--- a/overview-print.css
+++ b/overview-print.css
@@ -117,12 +117,46 @@ p {
 .print-btn,
 .back-btn,
 .favorite-toggle {
-  display: none;
+  display: none !important;
 }
 
 h2, h3, table, .device-block, .device-category, .requirement-box {
   page-break-inside: avoid;
   break-inside: avoid;
+}
+
+#overviewDialogContent .print-section {
+  break-inside: avoid;
+  page-break-inside: avoid;
+}
+
+#overviewDialogContent .print-section > * {
+  break-inside: avoid;
+  page-break-inside: avoid;
+}
+
+#overviewDialogContent .project-requirements-section {
+  break-before: page;
+  page-break-before: always;
+}
+
+#overviewDialogContent .diagram-section {
+  break-inside: avoid;
+  page-break-inside: avoid;
+}
+
+#overviewDialogContent #resultsSection {
+  page-break-inside: avoid;
+  break-inside: avoid;
+}
+
+#overviewDialogContent #resultsSection .results-body {
+  page-break-inside: avoid;
+  break-inside: avoid;
+}
+
+#overviewDialogContent #resultsSection .results-warnings {
+  margin-top: 0.5em;
 }
 
 .device-category-container,
@@ -154,6 +188,15 @@ table, th, td {
   background: none !important;
   border: none !important;
   box-shadow: none !important;
+  page-break-inside: avoid;
+  break-inside: avoid;
+}
+#overviewDialogContent #setupDiagram svg {
+  width: 90% !important;
+  max-width: 90%;
+  height: auto !important;
+  margin: 0 auto;
+  display: block;
 }
 #overviewDialogContent #setupDiagram #diagramArea {
   background: none !important;
@@ -198,7 +241,22 @@ body:not(.light-mode) .gear-table tbody {
 }
 
 #overviewDialogContent .gear-table .gear-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4em;
+  flex-wrap: nowrap;
   white-space: nowrap;
+}
+
+#overviewDialogContent .gear-table .gear-item select {
+  width: auto;
+  min-width: 0;
+  max-width: 100%;
+  flex: 0 0 auto;
+}
+
+#overviewDialogContent .gear-table .gear-item select + select {
+  margin-left: 0.4em;
 }
 
 #overviewDialogContent .gear-table .category-row td,

--- a/overview.js
+++ b/overview.js
@@ -102,6 +102,16 @@ function generatePrintableOverview() {
         warningHtml += `<p style="color: ${dtapWarnElem.style.color}; font-weight: bold;">${dtapWarnElem.textContent}</p>`;
     }
 
+    const resultsSectionHtml = `
+        <section id="resultsSection" class="results-section print-section">
+            <h2>${t.resultsHeading}</h2>
+            <div class="results-body">
+                ${resultsHtml}
+                ${warningHtml ? `<div class="results-warnings">${warningHtml}</div>` : ''}
+            </div>
+        </section>
+    `;
+
     // REGENERATE BATTERY TABLE HTML WITH BARS FOR OVERVIEW
     let batteryTableHtml = '';
     const totalWatt = parseFloat(totalPowerElem.textContent);
@@ -214,8 +224,9 @@ function generatePrintableOverview() {
     const diagramControlsHtml = document.querySelector('.diagram-controls') ? document.querySelector('.diagram-controls').outerHTML : '';
     const diagramHintHtml = diagramHint ? diagramHint.outerHTML : '';
     const diagramDescHtml = document.getElementById('diagramDesc') ? document.getElementById('diagramDesc').outerHTML : '';
-    const diagramSectionHtml = diagramAreaHtml ? `<section id="setupDiagram"><h2>${t.setupDiagramHeading}</h2>${diagramDescHtml}${diagramAreaHtml}${diagramLegendHtml}${diagramControlsHtml}${diagramHintHtml}</section>` : '';
-    const diagramSectionHtmlWithBreak = diagramSectionHtml ? `<div class="page-break"></div>${diagramSectionHtml}` : '';
+    const diagramSectionHtml = diagramAreaHtml
+        ? `<section id="setupDiagram" class="diagram-section print-section"><h2>${t.setupDiagramHeading}</h2>${diagramDescHtml}${diagramAreaHtml}${diagramLegendHtml}${diagramControlsHtml}${diagramHintHtml}</section>`
+        : '';
     const batteryTableHtmlWithBreak = batteryTableHtml ? `<div class="page-break"></div>${batteryTableHtml}` : '';
 
     let gearListCombined = getCurrentGearListHtml();
@@ -229,14 +240,14 @@ function generatePrintableOverview() {
             ? splitGearListHtml(gearListCombined)
             : { projectHtml: '', gearHtml: '' };
         if (parts.projectHtml) {
-            projectSectionHtml = `<section id="projectRequirementsOutput">${parts.projectHtml}</section>`;
+            projectSectionHtml = `<section id="projectRequirementsOutput" class="print-section project-requirements-section">${parts.projectHtml}</section>`;
         }
         if (parts.gearHtml) {
-            gearSectionHtml = `<section id="gearListOutput">${parts.gearHtml}</section>`;
+            gearSectionHtml = `<section id="gearListOutput" class="gear-list-section">${parts.gearHtml}</section>`;
         }
     }
-    const gearListHtmlWithBreak = projectSectionHtml || gearSectionHtml
-        ? `<div class="page-break"></div>${projectSectionHtml}${gearSectionHtml}`
+    const gearListHtmlCombined = projectSectionHtml || gearSectionHtml
+        ? `${projectSectionHtml || ''}${gearSectionHtml || ''}`
         : '';
 
     const logoHtml = customLogo ? `<img id="printLogo" src="${customLogo}" alt="Logo" />` : '';
@@ -253,13 +264,11 @@ function generatePrintableOverview() {
             <h2>${t.overviewDeviceSelectionHeading || t.deviceSelectionHeading}</h2>
             ${deviceListHtml}
 
-            <h2>${t.resultsHeading}</h2>
-            ${resultsHtml}
-            ${warningHtml}
+            ${resultsSectionHtml}
 
-            ${diagramSectionHtmlWithBreak}
+            ${diagramSectionHtml}
 
-            ${gearListHtmlWithBreak}
+            ${gearListHtmlCombined}
             ${batteryTableHtmlWithBreak}
         </div>
     `;


### PR DESCRIPTION
## Summary
- mark printable overview sections so the results, diagram, and project requirements stay intact and force the requirements block onto a new page
- adjust print styles to hide any favorite buttons, keep gear list selectors on one line, and scale the diagram down for extra padding

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cd083c80b4832098addf97cea00ec4