### PR TITLE
Clarify saved project storage

### DIFF
--- a/index.html
+++ b/index.html
@@ -986,7 +986,7 @@
         <section
           data-help-section
           id="managingSetups"
-          data-help-keywords="save saved projects load manage share backup restore export import delete rename factory reset clear project"
+          data-help-keywords="save saved projects load manage share backup restore export import delete rename factory reset clear project cache local storage browser reopen"
         >
           <h3><span class="help-icon" aria-hidden="true">🗂️</span>Managing Projects</h3>
           <ul>
@@ -1016,6 +1016,10 @@
                 data-help-highlight="#setup-manager"
               ><strong>Save</strong></a>
               again to update the entry.
+            </li>
+            <li>
+              Saved projects live in your browser&rsquo;s cache so they stay available after closing or reopening tabs and browsers,
+              as long as the cache isn&rsquo;t cleared.
             </li>
             <li>
               <a

--- a/translations.js
+++ b/translations.js
@@ -436,7 +436,8 @@ const texts = {
     noBatterySupports: "No battery can supply this load.",
 
     alertSetupName: "Please enter a name for the project.",
-    alertSetupSaved: "Project \"{name}\" saved.",
+    alertSetupSaved:
+      "Project \"{name}\" saved in this browser. It stays available after closing or reopening tabs unless you clear the browser cache.",
     alertNoSetupSelected: "Please select a saved project to delete.",
     alertSetupDeleted: "Project \"{name}\" deleted.",
     confirmClearSetup: "Clear current project?",
@@ -943,7 +944,8 @@ const texts = {
     batteryCountTempLabel: "Batterie necessarie",
     noBatterySupports: "Nessuna batteria può fornire questo carico.",
     alertSetupName: "Immettere un nome per l'installazione.",
-    alertSetupSaved: "Setup \"{name}\" salvato.",
+    alertSetupSaved:
+      "Setup \"{name}\" salvato nel browser. Rimane disponibile dopo aver chiuso o riaperto le schede finché non svuoti la cache del browser.",
     alertNoSetupSelected: "Selezionare una configurazione salvata da eliminare.",
     alertSetupDeleted: "Setup \"{name}\" eliminato.",
     confirmClearSetup: "Cancella configurazione corrente?",
@@ -1569,7 +1571,8 @@ const texts = {
     noBatterySupports: "Ninguna batería puede suministrar esta carga.",
 
     alertSetupName: "Ingresa un nombre para el proyecto.",
-    alertSetupSaved: "Proyecto \"{name}\" guardado.",
+    alertSetupSaved:
+      "Proyecto \"{name}\" guardado en este navegador. Permanece disponible al cerrar o volver a abrir pestañas mientras no borres la caché del navegador.",
     alertNoSetupSelected: "Selecciona un proyecto para eliminar.",
     alertSetupDeleted: "Proyecto \"{name}\" eliminado.",
     confirmClearSetup: "¿Borrar el proyecto actual?",
@@ -2198,7 +2201,8 @@ const texts = {
     noBatterySupports: "Aucune batterie ne peut fournir cette charge.",
 
     alertSetupName: "Veuillez saisir un nom pour la configuration.",
-    alertSetupSaved: "Configuration \"{name}\" enregistrée.",
+    alertSetupSaved:
+      "Configuration \"{name}\" enregistrée dans ce navigateur. Elle reste disponible après avoir fermé ou rouvert des onglets tant que vous ne videz pas le cache du navigateur.",
     alertNoSetupSelected: "Sélectionnez une configuration à supprimer.",
     alertSetupDeleted: "Configuration \"{name}\" supprimée.",
     confirmClearSetup: "Effacer la configuration actuelle ?",
@@ -2830,7 +2834,8 @@ const texts = {
     noBatterySupports: "Kein Akku kann diese Last liefern.",
 
     alertSetupName: "Bitte einen Namen für das Projekt eingeben.",
-    alertSetupSaved: "Projekt \"{name}\" gespeichert.",
+    alertSetupSaved:
+      "Projekt \"{name}\" in diesem Browser gespeichert. Es bleibt verfügbar, wenn Sie Tabs oder den Browser schließen und erneut öffnen, solange Sie den Browsercache nicht löschen.",
     alertNoSetupSelected: "Wählen Sie ein gespeichertes Projekt zum Löschen aus.",
     alertSetupDeleted: "Projekt \"{name}\" gelöscht.",
     confirmClearSetup: "Aktuelles Projekt zurücksetzen?",


### PR DESCRIPTION
## Summary
- explain in the help dialog that saved projects stay in the browser cache until it is cleared
- remind users after saving a project that it remains available in the browser cache, with translations updated

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cd130da28c8320a4a43bf701d77ea2