### PR TITLE
Clarify Tilta Nucleus Nano II gear swapping capability

### DIFF
--- a/devices/fiz.js
+++ b/devices/fiz.js
@@ -65,11 +65,9 @@ const fizData = {
       "internalController": true,
       "torqueNm": null,
       "gearTypes": [
-        "0.8 mod",
-        "0.5 mod",
-        "0.6 mod"
+        "0.8 mod"
       ],
-      "notes": "Enhanced version of the Nano. Power draw calculated at 2.5A max at 14.8V. USB-C for power and data. Compatible with standard 0.8 mod lens gears of various diameters.",
+      "notes": "Enhanced version of the Nano. Power draw calculated at 2.5A max at 14.8V. USB-C for power and data. Ships with Tilta's fixed 0.8 mod gear ring and does not support swapping to other gear rings.",
       "fizConnectors": [
         {
           "type": "USB-C"


### PR DESCRIPTION
## Summary
- state that the Tilta Nucleus Nano II ships with a fixed 0.8 mod gear ring
- note that the motor does not support swapping to other gear rings

## Testing
- npm run check-consistency
- npm run test:data

------
https://chatgpt.com/codex/tasks/task_e_68cd0ffc137c8320b1d30a1220056071