### PR TITLE
Prevent empty project info from being persisted

### DIFF
--- a/script.js
+++ b/script.js
@@ -4984,6 +4984,89 @@ let currentProjectInfo = null;
 let loadedSetupState = null;
 let restoringSession = false;
 
+let defaultProjectInfoSnapshot = null;
+
+function sanitizeProjectInfoValue(value) {
+  if (value === null || value === undefined) return undefined;
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    return trimmed ? trimmed : undefined;
+  }
+  if (typeof value === 'number') {
+    return Number.isNaN(value) ? undefined : value;
+  }
+  if (typeof value === 'boolean') {
+    return value ? value : undefined;
+  }
+  if (Array.isArray(value)) {
+    const sanitized = value
+      .map((item) => sanitizeProjectInfoValue(item))
+      .filter((item) => item !== undefined);
+    return sanitized.length ? sanitized : undefined;
+  }
+  if (typeof value === 'object') {
+    const sanitizedObj = sanitizeProjectInfo(value);
+    return sanitizedObj || undefined;
+  }
+  return undefined;
+}
+
+function sanitizeProjectInfo(info) {
+  if (!info || typeof info !== 'object') return null;
+  const result = {};
+  Object.entries(info).forEach(([key, value]) => {
+    const sanitized = sanitizeProjectInfoValue(value);
+    if (sanitized !== undefined) {
+      result[key] = sanitized;
+    }
+  });
+  return Object.keys(result).length > 0 ? result : null;
+}
+
+function projectInfoEquals(a, b) {
+  if (a === b) return true;
+  if (!a || !b) return false;
+  if (Array.isArray(a) && Array.isArray(b)) {
+    if (a.length !== b.length) return false;
+    for (let i = 0; i < a.length; i += 1) {
+      if (!projectInfoEquals(a[i], b[i])) return false;
+    }
+    return true;
+  }
+  if (typeof a === 'object' && typeof b === 'object') {
+    const aKeys = Object.keys(a);
+    const bKeys = Object.keys(b);
+    if (aKeys.length !== bKeys.length) return false;
+    return aKeys.every((key) => projectInfoEquals(a[key], b[key]));
+  }
+  return false;
+}
+
+function ensureDefaultProjectInfoSnapshot() {
+  if (defaultProjectInfoSnapshot !== null) return;
+  if (!projectForm) {
+    defaultProjectInfoSnapshot = {};
+    return;
+  }
+  const baseInfo = collectProjectFormData ? collectProjectFormData() : {};
+  baseInfo.sliderBowl = getSliderBowlValue();
+  baseInfo.easyrig = getEasyrigValue();
+  defaultProjectInfoSnapshot = sanitizeProjectInfo(baseInfo) || {};
+}
+
+function deriveProjectInfo(info) {
+  ensureDefaultProjectInfoSnapshot();
+  const sanitized = sanitizeProjectInfo(info);
+  if (!sanitized) return null;
+  if (
+    defaultProjectInfoSnapshot &&
+    projectInfoEquals(sanitized, defaultProjectInfoSnapshot)
+  ) {
+    return null;
+  }
+  return sanitized;
+}
+
 function setCurrentProjectInfo(info) {
   currentProjectInfo = info;
 }
@@ -4996,7 +5079,7 @@ function getCurrentSetupState() {
   const info = projectForm ? collectProjectFormData() : {};
   info.sliderBowl = getSliderBowlValue();
   info.easyrig = getEasyrigValue();
-  const projectInfo = Object.values(info).some(v => v) ? info : null;
+  const projectInfo = deriveProjectInfo(info);
   return {
     camera: cameraSelect.value,
     monitor: monitorSelect.value,
@@ -12234,7 +12317,7 @@ function saveCurrentGearList() {
     const info = projectForm ? collectProjectFormData() : {};
     info.sliderBowl = getSliderBowlValue();
     info.easyrig = getEasyrigValue();
-    currentProjectInfo = Object.values(info).some(v => v) ? info : null;
+    currentProjectInfo = deriveProjectInfo(info);
     const projectName = getCurrentProjectName();
     if (typeof saveProject === 'function') {
         saveProject(projectName, { projectInfo: currentProjectInfo, gearList: html });
@@ -12552,10 +12635,10 @@ function refreshGearListIfVisible() {
         const info = collectProjectFormData();
         info.sliderBowl = getSliderBowlValue();
         info.easyrig = getEasyrigValue();
-        currentProjectInfo = Object.values(info).some(v => v) ? info : null;
+        currentProjectInfo = deriveProjectInfo(info);
     } else {
         const info = { sliderBowl: getSliderBowlValue(), easyrig: getEasyrigValue() };
-        currentProjectInfo = Object.values(info).some(v => v) ? info : null;
+        currentProjectInfo = deriveProjectInfo(info);
     }
 
     const html = generateGearListHtml(currentProjectInfo || {});
@@ -12583,7 +12666,7 @@ function saveCurrentSession() {
   const info = projectForm ? collectProjectFormData() : {};
   info.sliderBowl = getSliderBowlValue();
   info.easyrig = getEasyrigValue();
-  currentProjectInfo = Object.values(info).some(v => v) ? info : null;
+  currentProjectInfo = deriveProjectInfo(info);
   const state = {
     setupName: setupNameInput ? setupNameInput.value : '',
     setupSelect: setupSelect ? setupSelect.value : '',
@@ -14480,6 +14563,7 @@ function initApp() {
   setLanguage(currentLang);
   maybeShowIosPwaHelp();
   resetDeviceForm();
+  ensureDefaultProjectInfoSnapshot();
   restoreSessionState();
   applySharedSetupFromUrl();
   if (requiredScenariosSelect) {

--- a/tests/dom/saveCurrentGearList.test.js
+++ b/tests/dom/saveCurrentGearList.test.js
@@ -1,0 +1,42 @@
+const { setupScriptEnvironment } = require('../helpers/scriptEnvironment');
+
+describe('saveCurrentGearList project info handling', () => {
+  let env;
+
+  afterEach(() => {
+    env?.cleanup();
+    env = null;
+  });
+
+  test('skips persisting empty project info into setups', () => {
+    env = setupScriptEnvironment({
+      globals: {
+        saveProject: jest.fn(),
+        saveSetups: jest.fn(),
+        loadSetups: jest.fn(() => ({})),
+        saveSessionState: jest.fn(),
+        loadSessionState: jest.fn(() => ({})),
+      },
+    });
+
+    const { utils, globals } = env;
+    const setupNameInput = document.getElementById('setupName');
+    expect(setupNameInput).not.toBeNull();
+
+    setupNameInput.value = 'Empty Project';
+    setupNameInput.dispatchEvent(new Event('input'));
+
+    globals.saveProject.mockClear();
+    globals.saveSetups.mockClear();
+
+    utils.saveCurrentGearList();
+
+    expect(globals.saveProject).toHaveBeenCalled();
+    const lastCall = globals.saveProject.mock.calls[globals.saveProject.mock.calls.length - 1];
+    expect(lastCall[0]).toBe('Empty Project');
+    expect(lastCall[1]).toMatchObject({ projectInfo: null, gearList: '' });
+
+    expect(globals.saveSetups).not.toHaveBeenCalled();
+    expect(utils.getCurrentProjectInfo()).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- sanitize project info values and avoid saving default or empty data
- update gear list and session persistence to use the derived project info and capture the default snapshot during init
- add a regression test to ensure empty project info does not write into saved setups

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd126cc7948320bc3908b0ddf27ae6