### PR TITLE
Ensure automated backups preserve full project data

### DIFF
--- a/tests/script/backupAutomation.test.js
+++ b/tests/script/backupAutomation.test.js
@@ -1,0 +1,191 @@
+const fs = require('fs');
+const path = require('path');
+
+defaultDeviceSetup();
+
+function defaultDeviceSetup() {
+  if (typeof window.matchMedia !== 'function') {
+    window.matchMedia = () => ({
+      matches: false,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      addListener: () => {},
+      removeListener: () => {},
+    });
+  }
+
+  if (!Element.prototype.scrollIntoView) {
+    Element.prototype.scrollIntoView = () => {};
+  }
+}
+
+const loadApp = () => {
+  jest.resetModules();
+
+  const template = fs.readFileSync(
+    path.join(__dirname, '../../index.html'),
+    'utf8',
+  );
+  const bodyMatch = template.match(/<body[^>]*>([\s\S]*)<\/body>/i);
+  const bodyHtml = bodyMatch ? bodyMatch[1] : '';
+  document.body.innerHTML = bodyHtml.replace(/<script[\s\S]*?<\/script>/gi, '');
+
+  const { texts, categoryNames, gearItems } = require('../../translations.js');
+  const devicesData = require('../../devices');
+
+  window.texts = texts;
+  global.texts = texts;
+  window.categoryNames = categoryNames;
+  global.categoryNames = categoryNames;
+  window.gearItems = gearItems;
+  global.gearItems = gearItems;
+  window.devices = JSON.parse(JSON.stringify(devicesData));
+  global.devices = window.devices;
+
+  global.loadDeviceData = jest.fn(() => null);
+  global.saveDeviceData = jest.fn();
+  global.loadSetups = jest.fn(() => ({}));
+  global.saveSetups = jest.fn();
+  global.loadSessionState = jest.fn(() => null);
+  global.saveSessionState = jest.fn();
+  global.loadProject = jest.fn(() => ({}));
+  global.saveProject = jest.fn();
+  global.deleteProject = jest.fn();
+  global.loadFavorites = jest.fn(() => ({}));
+  global.saveFavorites = jest.fn();
+  global.exportAllData = jest.fn(() => ({ exported: true }));
+  global.importAllData = jest.fn();
+  global.clearAllData = jest.fn();
+  global.showNotification = jest.fn();
+
+  return require('../../script.js');
+};
+
+beforeEach(() => {
+  document.body.innerHTML = '';
+  localStorage.clear();
+  sessionStorage.clear();
+  jest.clearAllMocks();
+  defaultDeviceSetup();
+});
+
+describe('automated backups', () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  test('autoBackup captures setup and project state', () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2024-05-06T12:30:00'));
+
+    const { autoBackup } = loadApp();
+
+    const setupSelect = document.getElementById('setupSelect');
+    const setupNameInput = document.getElementById('setupName');
+    const option = document.createElement('option');
+    option.value = 'Main Setup';
+    option.textContent = 'Main Setup';
+    setupSelect.appendChild(option);
+    setupSelect.value = 'Main Setup';
+    setupNameInput.value = 'Main Setup';
+
+    const projectNameInput = document.getElementById('projectName');
+    projectNameInput.value = 'Epic Shoot';
+
+    const gearListOutput = document.getElementById('gearListOutput');
+    gearListOutput.classList.remove('hidden');
+    gearListOutput.innerHTML = '<h3>Gear List</h3><table class="gear-table"><tr><td>1x Alexa 35</td></tr></table>';
+
+    autoBackup();
+
+    expect(global.saveSetups).toHaveBeenCalledTimes(1);
+    const savedSetups = global.saveSetups.mock.calls[0][0];
+    const backupKeys = Object.keys(savedSetups);
+    expect(backupKeys).toHaveLength(1);
+    const backupKey = backupKeys[0];
+    expect(backupKey).toMatch(/^auto-backup-\d{4}-\d{2}-\d{2}-\d{2}-\d{2}-Main Setup$/);
+
+    const projectCalls = global.saveProject.mock.calls.filter(([key]) => key === backupKey);
+    expect(projectCalls.length).toBeGreaterThan(0);
+    expect(projectCalls[projectCalls.length - 1][1]).toEqual(
+      expect.objectContaining({
+        projectInfo: expect.objectContaining({ projectName: 'Epic Shoot' }),
+        gearList: expect.stringContaining('Alexa 35'),
+      }),
+    );
+
+    expect(savedSetups[backupKey]).toEqual(
+      expect.objectContaining({
+        projectInfo: expect.objectContaining({ projectName: 'Epic Shoot' }),
+        gearList: expect.stringContaining('Alexa 35'),
+      }),
+    );
+  });
+
+  test('createSettingsBackup includes session storage snapshot', async () => {
+    const { createSettingsBackup } = loadApp();
+
+    localStorage.setItem('cameraPowerPlanner_devices', '{"cameras":{}}');
+    sessionStorage.setItem('cameraPowerPlanner_session', '{"camera":"Alexa"}');
+
+    const objectUrl = 'blob:backup';
+    const originalCreateObjectURL = URL.createObjectURL;
+    if (typeof originalCreateObjectURL !== 'function') {
+      URL.createObjectURL = () => {};
+    }
+    const originalRevokeObjectURL = URL.revokeObjectURL;
+    if (typeof originalRevokeObjectURL !== 'function') {
+      URL.revokeObjectURL = () => {};
+    }
+    const originalBlob = global.Blob;
+    class MockBlob {
+      constructor(parts) {
+        this.parts = parts;
+      }
+      text() {
+        return Promise.resolve(
+          this.parts.map(part => (typeof part === 'string' ? part : String(part))).join('')
+        );
+      }
+    }
+    global.Blob = MockBlob;
+
+    const createObjectURLSpy = jest
+      .spyOn(URL, 'createObjectURL')
+      .mockReturnValue(objectUrl);
+    const revokeObjectURLSpy = jest.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {});
+    const originalCreateElement = document.createElement.bind(document);
+    const anchorClicks = [];
+    jest.spyOn(document, 'createElement').mockImplementation((tag) => {
+      const el = originalCreateElement(tag);
+      if (tag === 'a') {
+        el.click = () => anchorClicks.push(el);
+      }
+      return el;
+    });
+
+    const fileName = createSettingsBackup(false, new Date('2024-05-06T10:00:00'));
+    expect(typeof fileName).toBe('string');
+
+    expect(createObjectURLSpy).toHaveBeenCalledTimes(1);
+    const blob = createObjectURLSpy.mock.calls[0][0];
+    const json = JSON.parse(await blob.text());
+    expect(json.settings).toHaveProperty('cameraPowerPlanner_devices', '{"cameras":{}}');
+    expect(json.sessionStorage).toHaveProperty('cameraPowerPlanner_session', '{"camera":"Alexa"}');
+    expect(json.data).toEqual({ exported: true });
+
+    expect(anchorClicks).toHaveLength(1);
+    expect(revokeObjectURLSpy).toHaveBeenCalledWith(objectUrl);
+
+    createObjectURLSpy.mockRestore();
+    revokeObjectURLSpy.mockRestore();
+    if (typeof originalCreateObjectURL !== 'function') {
+      delete URL.createObjectURL;
+    }
+    if (typeof originalRevokeObjectURL !== 'function') {
+      delete URL.revokeObjectURL;
+    }
+    global.Blob = originalBlob;
+    document.createElement.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- persist auto backup snapshots to both the setups list and project storage so each backup retains gear lists and project info
- add defensive storage snapshot helper, capture sessionStorage in scheduled full backups, and restore session data when importing backups
- flush pending autosaves when the page is hidden or closed and expose backup utilities for testing
- add integration tests covering the auto backup workflow and hourly backup export

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd13ef1e748320941d018a9dc3c51e