### PR TITLE
Improve project overview action button layout

### DIFF
--- a/overview-print.css
+++ b/overview-print.css
@@ -116,7 +116,8 @@ p {
 #topBar,
 .print-btn,
 .back-btn,
-.favorite-toggle {
+.favorite-toggle,
+.overview-actions {
   display: none !important;
 }
 

--- a/overview.css
+++ b/overview.css
@@ -65,6 +65,18 @@ th { background-color: var(--control-bg); font-weight: 700; }
   color: var(--control-text);
   margin: 5px;
 }
+.overview-actions {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+  margin: 0 0 15px;
+}
+.overview-actions .print-btn,
+.overview-actions .back-btn {
+  margin: 0;
+}
 .device-block-grid {
   display: grid;
   gap: 8px;
@@ -105,6 +117,15 @@ th { background-color: var(--control-bg); font-weight: 700; }
 }
 
 @media (max-width: 600px) {
+  .overview-actions {
+    flex-direction: column;
+    align-items: stretch;
+    justify-content: flex-start;
+  }
+  .overview-actions .print-btn,
+  .overview-actions .back-btn {
+    width: 100%;
+  }
   .device-category-container {
     flex-direction: column;
   }

--- a/overview.js
+++ b/overview.js
@@ -254,8 +254,10 @@ function generatePrintableOverview() {
     const contentClass = customLogo ? 'logo-present' : '';
     const overviewHtml = `
         <div id="overviewDialogContent" class="${contentClass}">
-            <button id="closeOverviewBtn" class="back-btn">${t.backToAppBtn}</button>
-            <button id="printOverviewBtn" class="print-btn">${t.printBtn}</button>
+            <div class="overview-actions">
+                <button id="closeOverviewBtn" class="back-btn">${t.backToAppBtn}</button>
+                <button id="printOverviewBtn" class="print-btn">${t.printBtn}</button>
+            </div>
             ${logoHtml}
             <h1>${t.overviewTitle}</h1>
             <p><strong>${t.setupNameLabel}</strong> ${safeSetupName}</p>


### PR DESCRIPTION
## Summary
- wrap the project overview action buttons in a flex container to align them neatly on wide screens
- add responsive styling so the buttons stretch on narrow layouts and stay hidden in print output

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cd2d5fadb083209758f4ad4f874b07