### PR TITLE
Expand settings dialog width on large screens

### DIFF
--- a/style.css
+++ b/style.css
@@ -846,7 +846,7 @@ main.legal-content {
   border: 2px solid var(--accent-color);
   padding: clamp(24px, 4vw, 48px);
   color: var(--text-color);
-  width: min(90vw, 400px);
+  width: min(90vw, 420px);
   max-height: 80vh;
   overflow-y: auto;
   border-radius: var(--border-radius);
@@ -854,6 +854,12 @@ main.legal-content {
   display: flex;
   flex-direction: column;
   gap: 20px;
+}
+
+@media (min-width: 900px) {
+  .settings-content {
+    width: min(80vw, 600px);
+  }
 }
 
 .settings-section {


### PR DESCRIPTION
## Summary
- slightly increase the base width of the settings dialog
- add a wide-screen media query so the popup uses more horizontal space on large displays

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cd2db25b188320990459f5f5aa713f