### PR TITLE
Ensure footer legal links are white in dark mode

### DIFF
--- a/style.css
+++ b/style.css
@@ -304,6 +304,18 @@ footer a {
   margin: 0 0.5em;
 }
 
+body.dark-mode:not(.pink-mode) footer {
+  color: var(--inverse-text-color);
+}
+
+body.dark-mode:not(.pink-mode) footer a {
+  color: var(--inverse-text-color);
+}
+
+body.dark-mode:not(.pink-mode) footer a:visited {
+  color: var(--inverse-text-color);
+}
+
 /* Static legal pages */
 body.static-page {
   display: flex;


### PR DESCRIPTION
## Summary
- set footer legal text to use the inverse text color when dark mode is active
- keep pink accent when pink mode is enabled by limiting the selector

## Testing
- not run (CSS change)

------
https://chatgpt.com/codex/tasks/task_e_68cd2e4adb388320bbc537ace06a2a27