### PR TITLE
Preserve camera connector metadata in device details

### DIFF
--- a/script.js
+++ b/script.js
@@ -634,23 +634,25 @@ function unifyDevices(devicesData) {
       });
     }
     cam.videoOutputs = ensureList(cam.videoOutputs, { type: '', notes: '' }).flatMap(vo => {
-      const norm = normalizeVideoType(vo.type);
+      const { count, ...rest } = vo || {};
+      const norm = normalizeVideoType(rest.type);
       if (!VIDEO_OUTPUT_TYPES.has(norm)) return [];
-      const count = parseInt(vo.count, 10);
-      const num = Number.isFinite(count) && count > 0 ? count : 1;
-      const notes = vo.notes || '';
-      return Array.from({ length: num }, () => ({ type: norm, notes }));
+      const parsedCount = parseInt(count, 10);
+      const num = Number.isFinite(parsedCount) && parsedCount > 0 ? parsedCount : 1;
+      const base = { ...rest, type: norm, notes: rest.notes || '' };
+      return Array.from({ length: num }, () => ({ ...base }));
     });
-    cam.fizConnectors = ensureList(cam.fizConnectors, { type: '', notes: '' }).map(fc => ({
-      type: normalizeFizConnectorType(fc.type),
-      notes: fc.notes
-    }));
-    cam.viewfinder = ensureList(cam.viewfinder, { type: '', resolution: '', connector: '', notes: '' }).map(vf => ({
-      type: normalizeViewfinderType(vf.type),
-      resolution: vf.resolution,
-      connector: vf.connector,
-      notes: vf.notes
-    }));
+    cam.fizConnectors = ensureList(cam.fizConnectors, { type: '', notes: '' }).map(fc => {
+      const { type, ...rest } = fc || {};
+      return { ...rest, type: normalizeFizConnectorType(type) };
+    });
+    cam.viewfinder = ensureList(cam.viewfinder, { type: '', resolution: '', connector: '', notes: '' }).map(vf => {
+      const { type, ...rest } = vf || {};
+      return {
+        ...rest,
+        type: normalizeViewfinderType(type)
+      };
+    });
     cam.recordingMedia = ensureList(cam.recordingMedia, { type: '', notes: '' }).map(m => {
       let { type = '', notes = '' } = m || {};
       const match = type.match(/^(.*?)(?:\((.*)\))?$/);

--- a/tests/dom/deviceDetails.test.js
+++ b/tests/dom/deviceDetails.test.js
@@ -1,0 +1,32 @@
+const { setupScriptEnvironment } = require('../helpers/scriptEnvironment');
+const fullDevices = require('../../devices');
+
+describe('device manager details', () => {
+  let env;
+
+  afterEach(() => {
+    env?.cleanup();
+  });
+
+  function openDetails(name) {
+    const item = Array.from(document.querySelectorAll('#cameraList li')).find(li =>
+      li.querySelector('.device-summary span')?.textContent.includes(name)
+    );
+    expect(item).toBeTruthy();
+    item.querySelector('.detail-toggle').click();
+    const details = item.querySelector('.device-details');
+    return details.textContent;
+  }
+
+  test('renders HDMI metadata for Sony Venice 2 outputs', () => {
+    env = setupScriptEnvironment({ devices: { cameras: fullDevices.cameras } });
+    const text = openDetails('Sony Venice 2');
+    expect(text).toContain('Version:Type A');
+  });
+
+  test('shows integrated monitor size for Sony Burano viewfinder', () => {
+    env = setupScriptEnvironment({ devices: { cameras: fullDevices.cameras } });
+    const text = openDetails('Sony Burano');
+    expect(text).toContain('Size:3.5-inch');
+  });
+});


### PR DESCRIPTION
## Summary
- preserve auxiliary fields when normalizing camera video outputs, FIZ connectors, and viewfinder entries so details show all metadata
- add DOM regression tests covering Sony Venice 2 HDMI version data and Sony Burano viewfinder size information

## Testing
- npm run test:dom

------
https://chatgpt.com/codex/tasks/task_e_68cd308338588320bddb0996528239bc