### PR TITLE
Fix wireless transmitter favorite button height

### DIFF
--- a/style.css
+++ b/style.css
@@ -631,10 +631,10 @@ main.legal-content {
   opacity: 0.8;
 }
 
-/* Ensure favorite star aligns with its select element */
+/* Ensure favorite star aligns with its select element without stretching */
 .select-wrapper .favorite-toggle {
-  align-self: stretch;
-  height: 100%;
+  align-self: center;
+  height: var(--button-size);
   margin-top: 0;
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- prevent favorite toggle buttons inside select wrappers from stretching taller than other controls

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68cd3af5a3248320a8cb9f869898dd6d