### PR TITLE
Improve global help search prioritization

### DIFF
--- a/tests/dom/globalFeatureSearch.test.js
+++ b/tests/dom/globalFeatureSearch.test.js
@@ -1,0 +1,65 @@
+const { setupScriptEnvironment } = require('../helpers/scriptEnvironment');
+
+describe('global feature search help navigation', () => {
+  let env;
+  let featureSearch;
+  let helpDialog;
+  let helpSearch;
+  let helpQuickLinksList;
+
+  const triggerFeatureSearch = value => {
+    featureSearch.value = value;
+    featureSearch.dispatchEvent(new Event('change', { bubbles: true }));
+  };
+
+  beforeEach(() => {
+    env = setupScriptEnvironment();
+    window.alert = jest.fn();
+    featureSearch = document.getElementById('featureSearch');
+    helpDialog = document.getElementById('helpDialog');
+    helpSearch = document.getElementById('helpSearch');
+    helpQuickLinksList = document.getElementById('helpQuickLinksList');
+  });
+
+  afterEach(() => {
+    env?.cleanup();
+  });
+
+  test('searching by help keywords highlights the best match', async () => {
+    expect(featureSearch).toBeTruthy();
+    expect(helpDialog).toBeTruthy();
+    expect(helpSearch).toBeTruthy();
+    expect(helpQuickLinksList).toBeTruthy();
+
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    const featureList = document.getElementById('featureList');
+    expect(featureList).toBeTruthy();
+    expect(featureList.childElementCount).toBeGreaterThan(0);
+    const helpOptions = Array.from(featureList.options).filter(opt =>
+      opt.value.endsWith(' (help)')
+    );
+    expect(helpOptions.length).toBeGreaterThan(0);
+
+    triggerFeatureSearch('offline mode');
+
+    expect(helpDialog.hasAttribute('hidden')).toBe(false);
+    expect(featureSearch.value).toBe('offline mode');
+    expect(helpSearch.value).toBe('offline mode');
+
+    const featuresSection = document.getElementById('featuresOverview');
+    expect(featuresSection).toBeTruthy();
+    const visibleSections = Array.from(
+      document.querySelectorAll('#helpSections [data-help-section]:not([hidden])')
+    ).map(sec => sec.id);
+    expect(visibleSections).toContain('featuresOverview');
+    expect(featuresSection.classList.contains('help-section-focus')).toBe(true);
+
+    const quickLinkButton = Array.from(
+      helpQuickLinksList.querySelectorAll('.help-quick-link')
+    ).find(btn => btn.textContent.includes('Features at a Glance'));
+    expect(quickLinkButton).toBeTruthy();
+    expect(quickLinkButton.classList.contains('active')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- populate a dedicated help map so the global search can match dialog keywords and add suggestions
- favour help sections over weaker device/feature hits and scroll/highlight the matched help content
- add a DOM test that verifies keyword searches open the help dialog and activate the correct quick link

## Testing
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68cd3b0723a483209d14d38781106a19