### PR TITLE
Adjust help search focus styling

### DIFF
--- a/style.css
+++ b/style.css
@@ -976,6 +976,13 @@ main.legal-content {
   margin: 10px 0;
   padding: 5px calc(var(--button-size) + 12px) 5px 10px;
   box-sizing: border-box;
+  border: 1px solid var(--panel-border);
+}
+
+#helpSearch:focus-visible {
+  outline: none;
+  border-color: var(--accent-color);
+  box-shadow: 0 0 0 1px var(--accent-color);
 }
 
 #helpSearchClear {


### PR DESCRIPTION
## Summary
- add a static border to the help dialog search field
- replace the default focus outline with a border-based highlight for the help search input

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cd400514b0832097a37df858573953