### PR TITLE
Adjust help quick link chip sizing

### DIFF
--- a/style.css
+++ b/style.css
@@ -1094,13 +1094,18 @@ main.legal-content {
 .help-chip {
   display: inline-flex;
   align-items: center;
+  justify-content: center;
   gap: 0.25rem;
-  padding: 0.35rem 0.6rem;
+  padding: 0.45rem 0.75rem;
   border-radius: var(--border-radius);
   border: 1px solid var(--accent-color);
   background: none;
+  line-height: 1.3;
+  min-height: 2.5rem;
+  text-align: center;
   text-decoration: none;
   transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+  white-space: normal;
 }
 
 .help-chip:hover,


### PR DESCRIPTION
## Summary
- increase the padding and minimum height of the help "Jump to a topic" chips so wrapped labels stay fully contained and centered

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cd4077a03c832094e634bcef56c14d