### PR TITLE
Fix project requirements lens selector width

### DIFF
--- a/style.css
+++ b/style.css
@@ -2901,7 +2901,19 @@ body.dark-mode.pink-mode .help-content { border-color: var(--accent-color); }
   height: auto;
 }
 
+#projectDialog .form-row .select-wrapper {
+  flex: 1 1 auto;
+  width: 100%;
+}
+
+#projectDialog .form-row .select-wrapper select {
+  flex: 1 1 auto;
+  width: 100%;
+}
+
 #projectDialog #lenses {
+  width: 100%;
+  min-width: 0;
   height: 15rem;
   overflow-y: auto;
 }


### PR DESCRIPTION
## Summary
- ensure the project requirements lens selector and its wrapper expand to the available width
- keep the lens list height and scrolling while allowing it to fill the dialog column

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cd6bb6c6f48320ae91519a4d9f4fff