### PR TITLE
Align crew form layout with other project fields

### DIFF
--- a/index.html
+++ b/index.html
@@ -2008,7 +2008,8 @@
       </div>
       <h3 id="crewHeading">Crew</h3>
       <div class="form-row" id="crewListRow">
-        <div id="crewContainer"></div>
+        <label id="crewLabel">Crew:</label>
+        <div id="crewContainer" aria-labelledby="crewLabel"></div>
         <button type="button" id="addPersonBtn">+</button>
       </div>
       <div class="form-row" id="prepListRow">

--- a/script.js
+++ b/script.js
@@ -2601,6 +2601,12 @@ function setLanguage(lang) {
     setLabelText(productionCompanyLabel, 'productionCompany');
     setLabelText(rentalHouseLabel, 'rentalHouse');
     setLabelText(crewHeadingElem, 'crewHeading');
+    if (crewLabelElem) {
+      const crewLabelText = projectFormTexts.crewHeading || fallbackProjectForm.crewHeading;
+      if (crewLabelText) {
+        crewLabelElem.textContent = `${crewLabelText}:`;
+      }
+    }
     setLabelText(prepLabelElem, 'prepLabel');
     setLabelText(shootLabelElem, 'shootLabel');
     setLabelText(deliveryResolutionLabel, 'deliveryResolution');
@@ -2736,6 +2742,7 @@ const projectNameLabel = document.getElementById("projectNameLabel");
 const productionCompanyLabel = document.getElementById("productionCompanyLabel");
 const rentalHouseLabel = document.getElementById("rentalHouseLabel");
 const crewHeadingElem = document.getElementById("crewHeading");
+const crewLabelElem = document.getElementById("crewLabel");
 const prepLabelElem = document.getElementById("prepLabel");
 const shootLabelElem = document.getElementById("shootLabel");
 const deliveryResolutionLabel = document.getElementById("deliveryResolutionLabel");

--- a/style.css
+++ b/style.css
@@ -423,6 +423,34 @@ main.legal-content {
   min-width: 0; /* allow shrinking inside flex container */
 }
 
+#crewContainer {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: var(--gap-size);
+}
+
+.person-row {
+  display: flex;
+  align-items: center;
+  gap: var(--gap-size);
+  flex-wrap: wrap;
+}
+
+.person-row select {
+  flex: 0 0 160px;
+  min-width: 140px;
+}
+
+.person-row input {
+  flex: 1 1 180px;
+  min-width: 160px;
+}
+
+.person-row button {
+  flex: 0 0 auto;
+}
+
 #dynamicFields {
   margin-top: 10px;
 }


### PR DESCRIPTION
## Summary
- add a dedicated crew label to match the other project form rows and wire it to existing translations
- ensure the crew container layout uses flex to provide consistent spacing between the role, name, phone, email, and remove controls
- keep the add button alongside the labeled row while adding spacing between individual crew fields

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cd6c21bad083209ce9f9726148cbba