### PR TITLE
Adjust project requirements dialog width to 950px on desktops

### DIFF
--- a/style.css
+++ b/style.css
@@ -2891,6 +2891,12 @@ body.dark-mode.pink-mode .help-content { border-color: var(--accent-color); }
   background: var(--surface-color);
   color: var(--control-text);
 }
+
+@media (min-width: 1024px) {
+  #projectDialog {
+    max-width: 950px;
+  }
+}
 #projectDialog::backdrop {
   background: rgba(0, 0, 0, 0.5);
 }


### PR DESCRIPTION
## Summary
- adjust the project requirements dialog desktop max width to 950px for better sizing

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cd6c42a7948320b37a48063188d1f8