### PR TITLE
Keep favorite toggle icon consistent

### DIFF
--- a/script.js
+++ b/script.js
@@ -7921,8 +7921,7 @@ function getTimecodes() {
     const favVals = getFavoriteValues(selectElem.id);
     const val = selectElem.value;
     const isFav = favVals.includes(val);
-    const glyph = isFav ? ICON_GLYPHS.star : ICON_GLYPHS.circleStar;
-    selectElem._favButton.innerHTML = iconMarkup(glyph, 'favorite-icon');
+    selectElem._favButton.innerHTML = iconMarkup(ICON_GLYPHS.circleStar, 'favorite-icon');
     selectElem._favButton.classList.toggle('favorited', isFav);
     selectElem._favButton.disabled = val === 'None';
     selectElem._favButton.setAttribute('aria-pressed', isFav ? 'true' : 'false');


### PR DESCRIPTION
## Summary
- keep the favorites toggle button using the same circle-star glyph regardless of its active state
- rely on the existing favorited styling to communicate state changes through color instead of swapping icons

## Testing
- npm run test:script

------
https://chatgpt.com/codex/tasks/task_e_68cd6f2028c88320845ad8f130fe949f