### PR TITLE
Add disk icons to save buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -137,7 +137,7 @@
     <div class="form-row">
       <label for="setupName" id="setupNameLabel">Project Name:</label>
       <input type="text" id="setupName" placeholder="Project name" aria-labelledby="setupNameLabel" />
-      <button id="saveSetupBtn">Save</button>
+      <button id="saveSetupBtn"><span class="btn-icon icon-glyph" aria-hidden="true">&#xE825;</span>Save</button>
     </div>
     <div class="form-row form-row-actions" role="group" aria-label="Project actions">
       <span class="form-label-spacer" aria-hidden="true"></span>
@@ -746,7 +746,7 @@
             </div>
           </div>
           <div class="button-row">
-            <button type="button" id="autoGearSaveRule">Save rule</button>
+            <button type="button" id="autoGearSaveRule"><span class="btn-icon icon-glyph" aria-hidden="true">&#xE825;</span>Save rule</button>
             <button type="button" id="autoGearCancelEdit">Cancel</button>
           </div>
         </div>
@@ -789,7 +789,7 @@
         <p><a href="https://github.com" id="supportLink" target="_blank">Support</a></p>
       </section>
       <div class="button-row action-buttons">
-        <button id="settingsSave">Save</button>
+        <button id="settingsSave"><span class="btn-icon icon-glyph" aria-hidden="true">&#xE825;</span>Save</button>
         <button id="settingsCancel">Cancel</button>
       </div>
     </div>

--- a/script.js
+++ b/script.js
@@ -2335,7 +2335,7 @@ function setLanguage(lang) {
   }
   if (autoGearSaveRuleButton) {
     const label = texts[lang].autoGearSaveRule || texts.en?.autoGearSaveRule || autoGearSaveRuleButton.textContent;
-    autoGearSaveRuleButton.textContent = label;
+    setButtonLabelWithIcon(autoGearSaveRuleButton, label);
     autoGearSaveRuleButton.setAttribute('data-help', label);
   }
   if (autoGearCancelEditButton) {
@@ -2457,8 +2457,9 @@ function setLanguage(lang) {
     supportLink.setAttribute("title", supportHelp);
   }
   if (settingsSave) {
-    settingsSave.textContent = texts[lang].saveSettings;
-    const saveHelp = texts[lang].saveSettingsHelp || texts[lang].saveSettings;
+    const label = texts[lang].saveSettings || texts.en?.saveSettings || settingsSave.textContent;
+    setButtonLabelWithIcon(settingsSave, label);
+    const saveHelp = texts[lang].saveSettingsHelp || texts[lang].saveSettings || label;
     settingsSave.setAttribute("data-help", saveHelp);
     settingsSave.setAttribute("title", saveHelp);
     settingsSave.setAttribute("aria-label", saveHelp);
@@ -2834,6 +2835,7 @@ const ICON_GLYPHS = Object.freeze({
   camera: '\uE333',
   trash: '\uF32D',
   reload: '\uE11B',
+  save: '\uE825',
   timecode: '\uF1CD',
   audioIn: '\uEC2E',
   audioOut: '\uF44C',
@@ -2872,6 +2874,13 @@ const projectFieldIcons = {
   cameraUserButtons: '\uEF14',
   viewfinderUserButtons: '\uEF14'
 };
+
+function setButtonLabelWithIcon(button, label, glyph = ICON_GLYPHS.save) {
+  if (!button) return;
+  const safeLabel = typeof label === 'string' ? escapeHtml(label) : '';
+  const iconHtml = iconMarkup(glyph, 'btn-icon');
+  button.innerHTML = `${iconHtml}${safeLabel}`;
+}
 
 function createCrewRow(data = {}) {
   if (!crewContainer) return;
@@ -6164,6 +6173,10 @@ function getCurrentSetupState() {
 
 function checkSetupChanged() {
   if (!saveSetupBtn) return;
+  const langTexts = texts[currentLang] || {};
+  const fallbackTexts = texts.en || {};
+  const saveLabel = langTexts.saveSetupBtn || fallbackTexts.saveSetupBtn || '';
+  const updateLabel = langTexts.updateSetupBtn || fallbackTexts.updateSetupBtn || saveLabel;
   if (
     loadedSetupState &&
     setupSelect.value &&
@@ -6171,11 +6184,11 @@ function checkSetupChanged() {
   ) {
     const currentSignature = computeSetupSignature(getCurrentSetupState());
     if (currentSignature !== loadedSetupStateSignature) {
-      saveSetupBtn.textContent = texts[currentLang].updateSetupBtn;
+      setButtonLabelWithIcon(saveSetupBtn, updateLabel);
       return;
     }
   }
-  saveSetupBtn.textContent = texts[currentLang].saveSetupBtn;
+  setButtonLabelWithIcon(saveSetupBtn, saveLabel);
 }
 
 const projectDialog = document.getElementById("projectDialog");


### PR DESCRIPTION
## Summary
- display floppy disk icons next to the project, auto gear rule, and settings save buttons
- centralize save button label rendering with a helper that injects the save glyph alongside translated text
- reuse the helper when toggling between “Save” and “Update” labels so icons stay visible in all states

## Testing
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68cd6ed0b3f08320b555e9c429e02b49