### PR TITLE
Add share icons to share project button

### DIFF
--- a/index.html
+++ b/index.html
@@ -142,7 +142,7 @@
     <div class="form-row form-row-actions" role="group" aria-label="Project actions">
       <span class="form-label-spacer" aria-hidden="true"></span>
       <div class="form-actions">
-        <button id="shareSetupBtn">Share Project</button>
+        <button id="shareSetupBtn"><span class="btn-icon icon-glyph" aria-hidden="true">&#xF046;</span>Share Project</button>
       </div>
     </div>
     <p id="shareLinkMessage" class="hidden" role="status" aria-live="polite"></p>

--- a/script.js
+++ b/script.js
@@ -2549,7 +2549,7 @@ function setLanguage(lang) {
   // NEW SETUP MANAGEMENT BUTTONS TEXTS
   document.getElementById("generateOverviewBtn").textContent = texts[lang].generateOverviewBtn;
   document.getElementById("generateGearListBtn").textContent = texts[lang].generateGearListBtn;
-  document.getElementById("shareSetupBtn").textContent = texts[lang].shareSetupBtn;
+  shareSetupBtn.innerHTML = `<span class="btn-icon icon-glyph" aria-hidden="true">${ICON_GLYPHS.share}</span>${texts[lang].shareSetupBtn}`;
   const exportRevert = document.getElementById("exportAndRevertBtn");
   if (exportRevert) {
     exportRevert.textContent = texts[lang].exportAndRevertBtn;
@@ -2834,6 +2834,7 @@ const ICON_GLYPHS = Object.freeze({
   camera: '\uE333',
   trash: '\uF32D',
   reload: '\uE11B',
+  share: '\uF046',
   timecode: '\uF1CD',
   audioIn: '\uEC2E',
   audioOut: '\uF44C',


### PR DESCRIPTION
## Summary
- add the share glyph to the Share Project button markup
- render the translated Share Project button label with the new icon
- expose the share glyph in the shared ICON_GLYPHS set for reuse

## Testing
- npm run test:dom

------
https://chatgpt.com/codex/tasks/task_e_68cd6ee9d2e08320a3b7bb5c02da1a81