### PR TITLE
Improve device database import/export workflow

### DIFF
--- a/tests/dom/deviceDetails.test.js
+++ b/tests/dom/deviceDetails.test.js
@@ -9,7 +9,7 @@ describe('device manager details', () => {
   });
 
   function openDetails(name) {
-    const item = Array.from(document.querySelectorAll('#cameraList li')).find(li =>
+    const item = Array.from(document.querySelectorAll('#camerasList li')).find(li =>
       li.querySelector('.device-summary span')?.textContent.includes(name)
     );
     expect(item).toBeTruthy();


### PR DESCRIPTION
## Summary
- normalize imported device databases against the expected schema before storing them and report validation issues
- centralize UI refresh logic so selector options, filters, and calculations update after database imports or edits
- clear and rebuild the filter dropdown while keeping the previous selection and align the device details test with the generated cameras list id

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd6d51509c8320b177859665b3ee1a