### PR TITLE
Simplify device editor attribute layout

### DIFF
--- a/script.js
+++ b/script.js
@@ -3679,34 +3679,45 @@ function createSchemaField(category, attr, value) {
   }
 
   if (inputType === 'boolean') {
-    const field = document.createElement('div');
-    field.className = 'schema-field schema-field--checkbox';
+    const row = document.createElement('div');
+    row.className = 'form-row schema-form-row';
+
+    const label = document.createElement('label');
+    label.setAttribute('for', attrId);
+    label.textContent = labelText;
+    row.appendChild(label);
+
+    const controlContainer = document.createElement('div');
+    controlContainer.className = 'schema-control schema-control--checkbox';
+    const inlineWrap = document.createElement('div');
+    inlineWrap.className = 'schema-control-inline';
+
     const input = document.createElement('input');
     input.type = 'checkbox';
     input.id = attrId;
     input.className = 'schema-input schema-input--checkbox';
     input.dataset.attrType = 'boolean';
     input.checked = value === undefined ? !!config.default : !!value;
-    const label = document.createElement('label');
-    label.setAttribute('for', attrId);
-    label.textContent = labelText;
-    field.appendChild(input);
-    field.appendChild(label);
+    inlineWrap.appendChild(input);
+
+    controlContainer.appendChild(inlineWrap);
     if (config.help) {
       const help = document.createElement('p');
       help.className = 'schema-field-help';
       help.textContent = config.help;
-      field.appendChild(help);
+      controlContainer.appendChild(help);
     }
-    return field;
+
+    row.appendChild(controlContainer);
+    return row;
   }
 
-  const field = document.createElement('div');
-  field.className = 'schema-field';
+  const row = document.createElement('div');
+  row.className = 'form-row schema-form-row';
   const label = document.createElement('label');
   label.setAttribute('for', attrId);
   label.textContent = labelText;
-  field.appendChild(label);
+  row.appendChild(label);
 
   let control;
   if (inputType === 'list' || inputType === 'json' || inputType === 'textarea') {
@@ -3740,25 +3751,29 @@ function createSchemaField(category, attr, value) {
     control.placeholder = config.placeholder;
   }
 
-  const controlWrap = document.createElement('div');
-  controlWrap.className = 'schema-field-control';
-  controlWrap.appendChild(control);
+  const controlContainer = document.createElement('div');
+  controlContainer.className = 'schema-control';
+  const inlineWrap = document.createElement('div');
+  inlineWrap.className = 'schema-control-inline';
+  inlineWrap.appendChild(control);
   if (config.suffix) {
     const suffix = document.createElement('span');
     suffix.className = 'schema-field-suffix';
     suffix.textContent = config.suffix;
-    controlWrap.appendChild(suffix);
+    inlineWrap.appendChild(suffix);
   }
-  field.appendChild(controlWrap);
+  controlContainer.appendChild(inlineWrap);
 
   if (config.help) {
     const help = document.createElement('p');
     help.className = 'schema-field-help';
     help.textContent = config.help;
-    field.appendChild(help);
+    controlContainer.appendChild(help);
   }
 
-  return field;
+  row.appendChild(controlContainer);
+
+  return row;
 }
 
 function getSchemaAttributesForCategory(category) {
@@ -3818,13 +3833,13 @@ function buildDynamicFields(category, data = {}, exclude = []) {
   if (dynamicFieldsDiv.dataset) {
     dynamicFieldsDiv.dataset.attrs = JSON.stringify(attrs);
   }
-  const grid = document.createElement('div');
-  grid.className = 'schema-attribute-grid';
+  const list = document.createElement('div');
+  list.className = 'schema-attribute-list';
   for (const attr of attrs) {
     const value = data && data[attr] !== undefined ? data[attr] : undefined;
-    grid.appendChild(createSchemaField(category, attr, value));
+    list.appendChild(createSchemaField(category, attr, value));
   }
-  dynamicFieldsDiv.appendChild(grid);
+  dynamicFieldsDiv.appendChild(list);
 }
 
 function collectDynamicFieldValues(category, exclude = []) {

--- a/style.css
+++ b/style.css
@@ -427,33 +427,35 @@ main.legal-content {
   margin-top: 10px;
 }
 
-.schema-attribute-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-  gap: 15px;
+.schema-attribute-list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
   margin: 15px 0;
 }
 
-.schema-field {
+.schema-form-row {
+  align-items: flex-start;
+}
+
+.schema-control {
+  flex: 1;
   display: flex;
   flex-direction: column;
   gap: 0.35rem;
-  padding: 12px;
-  border-radius: var(--border-radius);
-  border: 1px solid var(--panel-border);
-  background: var(--panel-bg);
-  box-shadow: var(--panel-shadow);
+  width: 100%;
 }
 
-.schema-field label {
-  font-weight: 600;
-  color: var(--text-color);
-}
-
-.schema-field-control {
+.schema-control-inline {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   gap: 0.5rem;
+  flex-wrap: wrap;
+  width: 100%;
+}
+
+.schema-control--checkbox .schema-control-inline {
+  align-items: center;
 }
 
 .schema-input {
@@ -480,32 +482,19 @@ main.legal-content {
   width: auto;
   min-width: 16px;
   height: 16px;
+  flex: 0 0 auto;
 }
 
 .schema-field-suffix {
   font-size: 0.9em;
-  color: var(--control-text);
+  color: var(--muted-text-color);
 }
 
 .schema-field-help {
   margin: 0;
   font-size: 0.85em;
-  color: var(--control-text);
-  opacity: 0.85;
-}
-
-.schema-field--checkbox {
-  flex-direction: row;
-  align-items: center;
-  justify-content: flex-start;
-}
-
-.schema-field--checkbox label {
-  margin: 0;
-}
-
-.schema-field--checkbox .schema-field-help {
-  margin-left: calc(16px + 0.6rem);
+  color: var(--muted-text-color);
+  line-height: 1.4;
 }
 
 /* Keep controls aligned within Project Overview and Configure Devices */


### PR DESCRIPTION
## Summary
- replace the dynamic device attribute grid with standard form rows so the editor matches the rest of the form
- restyle schema-specific controls to remove floating card styling while keeping suffix and help text support
- update dynamic field builder to append the new list container

## Testing
- npm test -- --runTestsByPath tests/dom/deviceManager-edit.test.js *(fails to complete – interrupted after several minutes)*
- npm run check-consistency *(fails to complete – interrupted after hanging without output)*

------
https://chatgpt.com/codex/tasks/task_e_68cd6ce1c3b88320b2a0551c61fa94c2