### PR TITLE
Improve storage fallback resilience

### DIFF
--- a/tests/script/autoGearRules.test.js
+++ b/tests/script/autoGearRules.test.js
@@ -176,7 +176,8 @@ describe('applyAutoGearRulesToTableHtml', () => {
 
     const scenarios = document.getElementById('autoGearScenarios');
     expect(scenarios.options.length).toBeGreaterThan(0);
-    scenarios.options[0].selected = true;
+    const firstSelectable = Array.from(scenarios.options).find(opt => opt.value);
+    if (firstSelectable) firstSelectable.selected = true;
 
     const ruleNameInput = document.getElementById('autoGearRuleName');
     ruleNameInput.value = 'Test confirmation';

--- a/tests/unit/storageFallback.test.js
+++ b/tests/unit/storageFallback.test.js
@@ -1,0 +1,58 @@
+const FAVORITES_KEY = 'cameraPowerPlanner_favorites';
+
+describe('SAFE_LOCAL_STORAGE fallback behaviour', () => {
+  let originalLocalStorageDescriptor;
+  let storageModule;
+
+  beforeEach(() => {
+    jest.resetModules();
+
+    if (typeof window === 'undefined') {
+      global.window = {};
+    }
+
+    originalLocalStorageDescriptor = Object.getOwnPropertyDescriptor(global.window, 'localStorage');
+
+    const session = global.sessionStorage;
+    session.clear();
+
+    Object.defineProperty(global.window, 'sessionStorage', {
+      configurable: true,
+      value: session,
+    });
+
+    Object.defineProperty(global.window, 'localStorage', {
+      configurable: true,
+      get() {
+        throw new Error('blocked');
+      },
+    });
+
+    storageModule = require('../../storage');
+  });
+
+  afterEach(() => {
+    jest.resetModules();
+
+    if (originalLocalStorageDescriptor) {
+      Object.defineProperty(global.window, 'localStorage', originalLocalStorageDescriptor);
+    } else {
+      delete global.window.localStorage;
+    }
+
+    delete global.window.sessionStorage;
+  });
+
+  test('falls back to sessionStorage when localStorage is unavailable', () => {
+    const { saveFavorites, loadFavorites } = storageModule;
+
+    saveFavorites({ cameraSelect: ['Alexa Mini'] });
+
+    expect(global.sessionStorage.getItem(FAVORITES_KEY)).toBe(
+      JSON.stringify({ cameraSelect: ['Alexa Mini'] })
+    );
+    expect(global.localStorage.getItem(FAVORITES_KEY)).toBeNull();
+    expect(loadFavorites()).toEqual({ cameraSelect: ['Alexa Mini'] });
+  });
+});
+


### PR DESCRIPTION
## Summary
- try sessionStorage before falling back to in-memory storage so favorites persist across reloads when localStorage is blocked
- cover the sessionStorage fallback path with a new unit test
- update the auto gear rules integration test to pick a real scenario option instead of the disabled placeholder

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd706e1c0c8320afbc3cf3850faaa4