### PR TITLE
Align button hover styles with form controls

### DIFF
--- a/style.css
+++ b/style.css
@@ -1719,15 +1719,12 @@ button {
   margin: 0 5px 5px 5px;
 }
 button:hover {
-  background-color: var(--accent-color);
-  color: var(--inverse-text-color);
-  transform: translateY(-2px);
+  background-color: var(--control-hover-bg);
+  color: var(--control-text);
 }
 button:active {
-  background-color: var(--accent-color);
-  color: var(--inverse-text-color);
-  filter: brightness(0.9);
-  transform: translateY(0);
+  background-color: var(--control-active-bg);
+  color: var(--control-text);
 }
 button:disabled {
   background-color: var(--control-disabled-bg);
@@ -1755,17 +1752,14 @@ input[type="file"]::-webkit-file-upload-button {
 
 input[type="file"]::file-selector-button:hover,
 input[type="file"]::-webkit-file-upload-button:hover {
-  background-color: var(--accent-color);
-  color: var(--inverse-text-color);
-  transform: translateY(-2px);
+  background-color: var(--control-hover-bg);
+  color: var(--control-text);
 }
 
 input[type="file"]::file-selector-button:active,
 input[type="file"]::-webkit-file-upload-button:active {
-  background-color: var(--accent-color);
-  color: var(--inverse-text-color);
-  filter: brightness(0.9);
-  transform: translateY(0);
+  background-color: var(--control-active-bg);
+  color: var(--control-text);
 }
 
 input[type="file"]:disabled::file-selector-button,
@@ -2025,10 +2019,13 @@ input[type="file"]:disabled::-webkit-file-upload-button {
   border-radius: 50%;
 }
 
-.controls button:hover,
+.controls button:hover {
+  background-color: var(--control-hover-bg);
+  color: var(--control-text);
+}
 .controls button:active {
-  background-color: var(--accent-color);
-  color: var(--inverse-text-color);
+  background-color: var(--control-active-bg);
+  color: var(--control-text);
 }
 
 @supports (padding: env(safe-area-inset-top)) {


### PR DESCRIPTION
## Summary
- use the same hover and active colors for buttons as for form selectors to keep control styling consistent
- mirror the updated hover and active treatments on file input buttons and circular toolbar buttons

## Testing
- npm test *(fails: jsdom environment lacks window.alert implementation in tests/script/autoGearRules.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68cd72ee37a08320bd75734070c136e9