### PR TITLE
Add icon to clear current project button

### DIFF
--- a/index.html
+++ b/index.html
@@ -153,7 +153,7 @@
     </div>
     <div class="form-row form-row-actions">
       <span class="form-label-spacer" aria-hidden="true"></span>
-      <button id="clearSetupBtn">Clear Current Project</button>
+      <button id="clearSetupBtn"><span class="btn-icon icon-glyph" aria-hidden="true">&#xE453;</span>Clear Current Project</button>
     </div>
     <div class="form-row form-row-actions" role="group" aria-label="Project exports">
       <span class="form-label-spacer" aria-hidden="true"></span>

--- a/script.js
+++ b/script.js
@@ -1826,7 +1826,7 @@ function setLanguage(lang) {
   setupNameLabelElem.textContent = texts[lang].setupNameLabel;
   setupNameLabelElem.setAttribute("data-help", texts[lang].setupNameHelp);
   deleteSetupBtn.innerHTML = `<span class="btn-icon icon-glyph" aria-hidden="true">${ICON_GLYPHS.trash}</span>${texts[lang].deleteSetupBtn}`;
-  clearSetupBtn.textContent = texts[lang].clearSetupBtn;
+  setButtonLabelWithIcon(clearSetupBtn, texts[lang].clearSetupBtn, ICON_GLYPHS.circleX);
   const sharedLinkLabelElem = document.getElementById("sharedLinkLabel");
   sharedLinkLabelElem.textContent = texts[lang].sharedLinkLabel;
   sharedLinkLabelElem.setAttribute("data-help", texts[lang].sharedLinkHelp);


### PR DESCRIPTION
## Summary
- add the circle X glyph to the Clear Current Project button markup so it matches other action buttons
- update the runtime label setup to include the icon when translations are applied

## Testing
- npm test *(fails: jsdom does not implement window.alert during script tests)*

------
https://chatgpt.com/codex/tasks/task_e_68cd73527c3883208ec912fd6f85a62c