### PR TITLE
Use plain star for favorite toggle

### DIFF
--- a/script.js
+++ b/script.js
@@ -7965,7 +7965,7 @@ function getTimecodes() {
     const favVals = getFavoriteValues(selectElem.id);
     const val = selectElem.value;
     const isFav = favVals.includes(val);
-    selectElem._favButton.innerHTML = iconMarkup(ICON_GLYPHS.circleStar, 'favorite-icon');
+    selectElem._favButton.innerHTML = iconMarkup(ICON_GLYPHS.star, 'favorite-icon');
     selectElem._favButton.classList.toggle('favorited', isFav);
     selectElem._favButton.disabled = val === 'None';
     selectElem._favButton.setAttribute('aria-pressed', isFav ? 'true' : 'false');
@@ -8026,7 +8026,7 @@ function getTimecodes() {
       const btn = document.createElement('button');
       btn.type = 'button';
       btn.className = 'favorite-toggle';
-      btn.innerHTML = iconMarkup(ICON_GLYPHS.circleStar, 'favorite-icon');
+      btn.innerHTML = iconMarkup(ICON_GLYPHS.star, 'favorite-icon');
       btn.setAttribute('aria-pressed', 'false');
       btn.addEventListener('click', () => toggleFavorite(selectElem));
       let wrapper = selectElem.parentElement;


### PR DESCRIPTION
## Summary
- swap the favorites toggle icon to use the plain star glyph instead of the circle-backed version

## Testing
- npm test -- --runTestsByPath tests/unit/storage.test.js

------
https://chatgpt.com/codex/tasks/task_e_68cd73706f348320ae6eb077f9b87958