### PR TITLE
Adjust header icons for help, settings, and reload

### DIFF
--- a/index.html
+++ b/index.html
@@ -94,13 +94,47 @@
         <span class="icon-glyph" aria-hidden="true">&#xF38D;</span>
       </button>
       <button id="settingsButton" aria-label="Settings" aria-haspopup="dialog" aria-controls="settingsDialog" title="Settings">
-        <span class="icon-glyph" aria-hidden="true">&#xE8AF;</span>
+        <span class="icon-glyph icon-svg" aria-hidden="true">
+          <svg viewBox="0 0 24 24" fill="none" aria-hidden="true">
+            <path
+              d="M9.593 3.94c.09-.542.559-.94 1.11-.94h2.594c.55 0 1.019.398 1.11.94l.213 1.281c.062.374.312.686.644.87.074.041.147.083.22.127.326.196.721.257 1.076.124l1.217-.456a1.125 1.125 0 0 1 1.369.491l1.297 2.246a1.125 1.125 0 0 1-.259 1.431l-1.004.826c-.293.241-.438.612-.431.991.001.042.002.084.002.127s0 .085-.002.127c-.007.379.138.75.431.991l1.004.827a1.125 1.125 0 0 1 .259 1.43l-1.297 2.247a1.125 1.125 0 0 1-1.369.49l-1.217-.455a1.35 1.35 0 0 0-1.076.124 5.58 5.58 0 0 1-.864.495 1.35 1.35 0 0 0-.644.87l-.213 1.281c-.09.542-.559.94-1.11.94H10.703a1.125 1.125 0 0 1-1.11-.94l-.214-1.281a1.35 1.35 0 0 0-.644-.87 5.446 5.446 0 0 1-.864-.495 1.35 1.35 0 0 0-1.076-.124l-1.217.455a1.125 1.125 0 0 1-1.369-.49L3.557 15.377a1.125 1.125 0 0 1 .259-1.431l1.004-.826c.292-.241.437-.613.43-.992a4.643 4.643 0 0 1-.002-.254c0-.042.001-.084.002-.127.007-.379-.138-.75-.43-.991l-1.005-.827A1.125 1.125 0 0 1 3.557 8.623l1.297-2.246a1.125 1.125 0 0 1 1.369-.491l1.217.456c.355.133.75.072 1.076-.124.073-.044.147-.086.22-.127.332-.183.582-.495.644-.87l.213-1.281Z"
+              stroke="currentColor"
+              stroke-width="1.5"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            />
+            <path
+              d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z"
+              stroke="currentColor"
+              stroke-width="1.5"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            />
+          </svg>
+        </span>
       </button>
       <button id="helpButton" aria-label="Help" aria-haspopup="dialog" aria-controls="helpDialog" title="Help (press ?, H, F1 or Ctrl+/)">
-        <span class="icon-glyph" aria-hidden="true">&#xEEFB;</span>
+        <span class="icon-glyph icon-text" aria-hidden="true">?</span>
       </button>
       <button id="reloadButton" title="Force reload" aria-label="Force reload">
-        <span class="icon-glyph" aria-hidden="true">&#xE11B;</span>
+        <span class="icon-glyph icon-svg" aria-hidden="true">
+          <svg viewBox="0 0 24 24" fill="none" aria-hidden="true">
+            <path
+              d="M16.023 9.348h4.992m0-.002V4.356m0 4.99-3.18-3.181c-.99-.992-2.247-1.745-3.699-2.134-4.401-1.179-8.925 1.433-10.104 5.834"
+              stroke="currentColor"
+              stroke-width="1.5"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            />
+            <path
+              d="M2.984 19.644v-4.992h4.993m0 0L4.5 15l-3 3m6.477-3.348c.99.992 2.247 1.745 3.699 2.134 4.401 1.179 8.925-1.433 10.104-5.834"
+              stroke="currentColor"
+              stroke-width="1.5"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            />
+          </svg>
+        </span>
       </button>
     </nav>
   </header>

--- a/style.css
+++ b/style.css
@@ -1306,6 +1306,23 @@ main.legal-content {
   color: var(--icon-color, currentColor);
 }
 
+.icon-glyph.icon-text {
+  font-family: 'Ubuntu', sans-serif;
+  font-weight: 600;
+}
+
+.icon-glyph.icon-svg {
+  font-family: inherit;
+}
+
+.icon-glyph.icon-svg svg {
+  width: 1em;
+  height: 1em;
+  display: block;
+  stroke: currentColor;
+  fill: none;
+}
+
 #featureSearchClear .icon-glyph,
 #helpSearchClear .icon-glyph,
 .clear-input-btn .icon-glyph,


### PR DESCRIPTION
## Summary
- replace the help button glyph with a standard question mark character
- switch the settings button to a custom inline SVG cog icon
- update the reload button to use a new inline SVG arrow-path icon and style support classes

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cd76ed122c832089e811fa2ef1bb96