### PR TITLE
Revamp multilingual README documentation

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -1,138 +1,298 @@
-# Cine Power Planner
+# 🎥 Cine Power Planner
 
-![Cine Power Planner icon](icon.svg)
+Dieses browserbasierte Tool hilft bei der Planung professioneller Kamera-Projekte, die mit V‑Mount-, B‑Mount- oder Gold-Mount-Akkus betrieben werden. Es berechnet **Gesamtleistung**, **Stromaufnahme** (bei 14,4 V und 12 V) sowie die **geschätzte Akkulaufzeit** und prüft gleichzeitig, ob der Akku die benötigte Leistung sicher liefern kann.
 
-Cine Power Planner ist eine offlinefähige Web-App zum Planen professioneller Kamerarigs, die mit V-Mount-, B-Mount- oder Gold-Mount-Akkus betrieben werden. Sie berechnet die Gesamtleistung, prüft, ob jeder Akku den benötigten Strom sicher liefern kann, erstellt realistische Laufzeiten aus gewichteten Praxiserfahrungen und hält Crew, Szenarien sowie Packlisten zusammen, damit zwischen den Gewerken nichts verloren geht.
-
----
-
-## Highlights
-
-### Komplexe Setups ohne Ratespiel
-- Kombiniere Kameras, Akkubasen, Funkstrecken, Monitore, Motoren und Zubehör und sieh dabei Gesamtwatt, Stromaufnahme bei 14,4 V/12 V (sowie 33,6 V/21,6 V bei B-Mount) und die erwartete Laufzeit.
-- Vergleiche kompatible Akkus nebeneinander und erhalte Warnungen, wenn die Belastung D-Tap- oder Pin-Grenzen überschreitet.
-- Visualisiere Rigs mit einem interaktiven Diagramm mit Drag&Drop, Zoom, SVG/JPG-Export und Kompatibilitäts-Hinweisen.
-
-### Alle Abteilungen im selben Bild
-- Speichere mehrere Projekte inklusive Anforderungen, Crewkontakten, Drehszenarien und eigenen Notizen.
-- Erstelle druckbare Packlisten, die Equipment nach Kategorie gruppieren, Duplikate zusammenfassen, technische Metadaten enthalten und szenariobasierte Extras ergänzen.
-- Teile JSON-Pakete, die Gerätauswahl, Laufzeitfeedback, Packlisten und eigene Geräte für eine vollständige Wiederherstellung enthalten.
-
-### Reisebereit und privat
-- Läuft vollständig im Browser – öffne `index.html` direkt oder hoste das Repository über HTTPS, um den Service Worker zu aktivieren.
-- Offline-Caching hält Sprache, Theme, Favoriten und Projekte überall verfügbar, ohne Daten an externe Server zu senden.
-- Leere den lokalen Cache oder nutze den Force-Reload, um gecachte Assets zu aktualisieren, ohne Projekte zu verlieren.
-
-### Für dein Team anpassbar
-- Wechsle sofort zwischen Englisch, Deutsch, Spanisch, Italienisch und Französisch; der Planner merkt sich die zuletzt verwendete Sprache.
-- Wähle dunkle, pinke oder kontrastreiche Themes, setze eine eigene Akzentfarbe, passe Schriftgröße an und wähle die Schriftart, die zu Stage-Branding oder Barrierefreiheit passt.
-- Tippe direkt in Dropdowns, pinne Favoriten und aktiviere Hover-Hilfe, damit die Crew am Set produktiv bleibt.
+Alle Planungen, Eingaben und Exporte bleiben auf deinem Gerät. Spracheinstellungen, Projekte, eigene Geräte, Favoriten und Laufzeit-Feedback liegen im Browser, und Service-Worker-Updates stammen direkt aus diesem Repository. So kannst du die App offline von der Festplatte starten oder intern hosten, damit jede Abteilung dieselbe geprüfte Version nutzt.
 
 ---
 
-## Schnellstart
-
-1. Repository klonen oder herunterladen.
-2. `index.html` in einem aktuellen Chromium-, Firefox- oder Safari-Browser öffnen – es ist kein Build-Schritt nötig.
-3. Optional den Ordner über HTTPS ausliefern, um den Service Worker für Offline-Updates zu installieren. Jeder Static-Server funktioniert (`npx http-server -S` o. ä.).
-4. Die App speichert Daten im Browser. Nutze **Einstellungen → Backup**, um vor einem Gerätewechsel JSON-Sicherungen zu exportieren.
-
----
-
-## Typischer Workflow
-
-1. **Projekt anlegen oder laden.** Enter oder `Strg+S` (`⌘S` auf macOS) speichern schnell. Automatische Snapshots laufen alle 10 Minuten.
-2. **Kamera, Stromversorgung und Zubehör wählen.** Dropdowns filtern beim Tippen, Favoriten bleiben angepinnt.
-3. **Leistungswerte prüfen.** Watt, Stromaufnahme, Sicherheitsindikatoren und Laufzeiten im Vergleichspanel kontrollieren.
-4. **Anforderungen erfassen.** Crewrollen, Drehtage, Szenarien und Notizen dokumentieren, damit jeder Export den passenden Kontext trägt.
-5. **Ausgaben erzeugen.** Packlisten, druckbare Übersichten und Shared-Projekt-Bundles erstellen und später mit einem Upload wiederherstellen.
-
----
-
-## Interface-Essentials
-
-- **Globale Suche** (`/` oder `Strg+K`/`⌘K`) springt zu Funktionen, Auswahlfeldern oder Hilfetexten – auch bei eingeklapptem Menü.
-- **Hilfecenter** (`?`, `H`, `F1` oder `Strg+/`) liefert durchsuchbare Guides, FAQs, Shortcuts und optionale Hover-Hilfe.
-- **Projektdiagramm** visualisiert Verbindungen; beim Download mit gedrückter Umschalttaste als JPG statt SVG exportieren.
-- **Akkuvergleich** zeigt die Leistung aller kompatiblen Packs und hebt Überlast-Risiken hervor.
-- **Packlisten-Generator** wandelt Auswahl in kategorisierte Tabellen mit Metadaten, Crew-E-Mails und szenariobasierten Ergänzungen um.
-- **Offline-Indikator & Force Reload** zeigen Verbindungsstatus und aktualisieren gecachte Assets ohne Projektverlust.
-
----
-
-## Daten- & Export-Management
-
-- Projekte, Einstellungen, Packlisten, Favoriten und eigene Geräte liegen in `localStorage`; Backups und Restores halten alles zusammen.
-- Der Einstellungsdialog bietet stündliche Backup-Erinnerungen, manuelle Sicherungen, Ein-Klick-Restore und einen **Lokalen Cache leeren**-Button.
-- Geteilte Projektdateien bündeln Auswahl, Anforderungen, Laufzeitfeedback, Packlisten und Custom Devices für nahtlose Übergaben.
-- Druckübersichten enthalten Projektnamen, Produktionsdetails, optionales Logo und die generierte Packliste.
-- Automatische Snapshots laufen im Hintergrund, um schnell zu einem früheren Stand zurückzukehren.
-
----
-
-## Akku- & Laufzeit-Intelligenz
-
-- Berechnet Gesamtverbrauch, benötigte Akkuanzahl für 10-Stunden-Tage und die Stromaufnahme jeder Verbindung.
-- Warnt ab 80 % Auslastung und blockiert unsichere Lasten, wenn die Dauer- oder D-Tap-Leistung überschritten wird.
-- Gewichtete Laufzeiten berücksichtigen Temperatur, Auflösung, Framerate, Codec, WLAN-Nutzung, Monitorhelligkeit und den Leistungsanteil jedes Geräts.
-- Ein Laufzeit-Dashboard sortiert Feedback nach Gewichtung, zeigt Beitragsprozente und markiert Ausreißer.
-- Nutzerfeedback fließt ein, um Schätzungen für reale Drehs zu präzisieren.
-
----
-
-## Anpassung & Barrierefreiheit
-
-- Dunkle, pinke oder kontrastreiche Themes und Typografie-Einstellungen lassen sich ohne Reload umschalten.
-- Eigenes Logo für Drucke hochladen, Standard-Monitorrollen setzen und Projektanforderungen vorkonfigurieren.
-- Tastaturfreundliche Navigation, sichtbare Fokuszustände und Skip-Links unterstützen Screenreader und Barrierefreiheit am Set.
-- Tippen zum Filtern, angepinnte Favoriten und Fork-Buttons in Packlisten beschleunigen wiederholte Eingaben.
-
----
-
-## Tastenkürzel
-
-| Aktion | Shortcut |
-| --- | --- |
-| Globale Suche fokussieren | `/`, `Strg+K`, `⌘K` |
-| Hilfedialog öffnen | `?`, `H`, `F1`, `Strg+/` |
-| Projekt speichern | `Enter`, `Strg+S`, `⌘S` |
-| Dark Theme umschalten | `D` |
-| Pinkes Theme umschalten | `P` |
-| Force Reload | 🔄-Symbol in der Kopfzeile klicken |
-
----
-
-## Entwicklung
-
-- Abhängigkeiten mit `npm install` installieren (für Linting, Tests und Datenskripte – kein Build erforderlich).
-- Vor Commits `npm run lint` und `npm run test` ausführen. Gezielte Suites gibt es via `npm run test:unit`, `npm run test:data`, `npm run test:dom` und `npm run test:script`.
-- Nützliche Skripte:
-  - `npm run check-consistency` prüft die Datenkonsistenz.
-  - `npm run normalize` und `npm run unify-ports` halten den Katalog sauber.
-  - `npm run generate-schema` aktualisiert das Geräteschema.
-
----
-
-## Übersetzungen
-
-Die Dokumentation steht in mehreren Sprachen bereit; die App übernimmt beim ersten Start automatisch die Browser-Sprache. Der Wechsel ist jederzeit über das Sprachmenü oben rechts möglich:
-
+## 🌍 Sprachen
 - 🇬🇧 [English](README.en.md)
 - 🇩🇪 [Deutsch](README.de.md)
 - 🇪🇸 [Español](README.es.md)
 - 🇮🇹 [Italiano](README.it.md)
 - 🇫🇷 [Français](README.fr.md)
 
-Du möchtest helfen? Folge der [Übersetzungsanleitung](docs/translation-guide.md), um neue Sprachen für Interface und Dokumentation hinzuzufügen.
+Die App übernimmt beim ersten Start automatisch die Sprache deines Browsers; über die rechte obere Ecke kannst du jederzeit umschalten. Die Auswahl wird für den nächsten Besuch gespeichert.
 
 ---
 
-## Beitrag & Support
-
-Bugreports, Feature-Ideen und Datenkorrekturen sind willkommen. Eröffne ein Issue oder sende einen Pull Request mit möglichst vielen Details. Bei falschen Laufzeiten oder fehlendem Equipment bitte Projektdatei oder Beispieldaten anhängen, damit der Katalog verlässlich bleibt.
+## 🆕 Neueste Funktionen
+- Mit den Akzent- und Typografie-Reglern in den Einstellungen passt du Akzentfarbe, Grundschriftgröße und Schriftfamilie neben den dunklen, rosa und kontrastreichen Themes an.
+- Tastenkürzel für die globale Suche lassen dich / oder Strg+K (⌘K auf macOS) drücken, um sie sofort zu fokussieren – auch wenn sie im eingeklappten mobilen Seitenmenü liegt.
+- Die Schaltfläche „Neu laden erzwingen“ leert die zwischengespeicherten Service-Worker-Dateien, damit sich die Offline-App aktualisiert, ohne gespeicherte Projekte oder Geräte zu löschen.
+- Sternsymbole in jeder Auswahl heften Lieblingskameras, -akkus und -zubehör oben an und nehmen sie in Backups auf.
+- Die Schaltfläche „Lokalen Cache löschen“ entfernt gespeicherte Projekte und Einstellungen.
+- Die Geräteliste und die druckbare Übersicht zeigen den Projektnamen für einen schnellen Überblick an.
+- Lade ein eigenes Logo hoch, das in druckbaren Übersichten und Backups erscheint.
+- Backups enthalten Favoriten und erstellen vor einer Wiederherstellung automatisch eine Sicherung.
+- Crew-Einträge besitzen jetzt ein Feld für E-Mail-Adressen.
+- Neues High-Contrast-Theme für bessere Lesbarkeit.
+- Geräteformulare füllen Kategorien dynamisch anhand der Schema-Attribute.
+- Überarbeitetes Interface mit verbessertem Kontrast und Abständen für ein aufgeräumtes Erlebnis auf allen Geräten.
+- Projekte lassen sich einfacher teilen: Lade eine JSON-Datei mit Auswahl, Anforderungen, Geräteliste, Laufzeit-Feedback und eigenen Geräten herunter und importiere sie, um alles wiederherzustellen.
+- Einzigartige Symbole für verpflichtende Szenarien helfen, Projektanforderungen auf einen Blick zu erkennen.
+- Interaktives Projekt-Diagramm zum Verschieben, Zoomen, am Raster ausrichten und als SVG oder JPG exportieren.
+- Verspieltes pinkes Akzent-Theme, das zwischen Besuchen erhalten bleibt.
+- Durchsuchbarer Hilfedialog mit Schritt-für-Schritt-Bereichen und FAQ; öffne ihn mit ?, H, F1 oder Strg+/.
+- Kontextuelle Hover-Hilfen für Schaltflächen, Felder, Dropdowns und Überschriften.
+- Globale Suchleiste zum Springen zu Funktionen, Geräteauswahlen oder Hilfethemen.
+- Unterstützung für Kameras mit V-, B- oder Gold-Mount-Akkuplatten.
+- Reiche Laufzeit-Feedback mitsamt Temperatur ein, um Schätzungen zu verbessern.
+- Visuelles Dashboard zur Gewichtung der Laufzeiten zeigt, wie Einstellungen jeden Eintrag beeinflussen, sortiert nach Gewicht mit exakten Prozentwerten.
+- Erstelle Gerätelisten, die ausgewählte Komponenten und Projektanforderungen zusammenfassen.
+- Speichere Projektanforderungen mit jedem Projekt, damit Gerätelisten den vollen Kontext behalten.
+- Dupliziere Benutzereinträge in den Gerätelistenvorlagen per Gabel-Symbol, um Felder sofort zu kopieren.
 
 ---
 
-## Lizenz
+## 🔧 Funktionen
 
-Cine Power Planner wird unter der ISC-Lizenz veröffentlicht.
+### ✨ Erweiterte Highlights
+
+- **Komplexe Rigs ohne Ratespiel.** Kombiniere Kameras, Batterieplatten,
+  Funkstrecken, Monitore, Motoren und Zubehör und sieh Gesamtleistung,
+  Stromaufnahme bei 14,4 V/12 V (bzw. 33,6 V/21,6 V bei B‑Mount) sowie
+  realistische Laufzeiten aus gewichteten Felddaten. Das Batterie-Vergleichspanel
+  warnt vor Überlastungen, bevor falsches Equipment eingepackt wird.
+- **Alle Abteilungen im Gleichklang.** Speichere mehrere Projekte mit
+  Anforderungen, Crew-Kontakten, Szenarien und Notizen. Druckbare
+  Gerätelisten gruppieren Equipment nach Kategorie, führen Duplikate zusammen,
+  zeigen technische Metadaten und berücksichtigen Szenario-Zubehör, damit
+  Kamera-, Licht- und Grip-Teams denselben Stand sehen.
+- **Produktiv überall.** Die App läuft komplett im Browser – öffne
+  `index.html` direkt oder liefere sie über HTTPS aus, um den Service Worker zu
+  aktivieren. Offline-Caching bewahrt Sprache, Themes, Favoriten und Projekte,
+  und die Aktion **Neu laden erzwingen** aktualisiert Assets ohne Datenverlust.
+- **Auf das Team zugeschnitten.** Wechsel sofort zwischen Deutsch, Englisch,
+  Spanisch, Italienisch und Französisch, passe Schriftgröße und Schriftart an,
+  wähle eine eigene Akzentfarbe, lade ein Drucklogo hoch und schalte zwischen
+  dunklem, rosa oder High-Contrast-Theme. Tippen-zum-Filtern, angepinnte
+  Favoriten, Gabel-Buttons und Hover-Hilfe sparen Zeit am Set.
+
+### ✅ Projektverwaltung
+- Speichere, lade und lösche mehrere Kamera-Projekte (drücke Enter oder Strg+S/⌘S zum schnellen Speichern; die Schaltfläche bleibt deaktiviert, bis ein Name eingegeben wurde).
+- Alle zehn Minuten entstehen automatisch Schnappschüsse, solange der Planner geöffnet ist; im Einstellungsdialog lassen sich stündliche Backup-Exporte als Erinnerung aktivieren.
+- Lade eine JSON-Datei herunter, die Auswahl, Anforderungen, Geräteliste, Laufzeit-Feedback und eigene Geräte bündelt; über den „Geteiltes Projekt“-Picker importierst du alles in einem Schritt.
+- Daten werden lokal über `localStorage` gespeichert, Favoriten landen ebenfalls in Backups; nutze die Schaltfläche **Lokalen Cache löschen** in den Einstellungen, um gespeicherte Projekte und Geräteanpassungen zu entfernen.
+- Erstelle druckbare Übersichten für jedes gespeicherte Projekt und füge ein individuelles Logo hinzu, damit Exporte und Backups zum Produktionsbranding passen.
+- Projektanforderungen werden gemeinsam mit dem Projekt gespeichert, sodass Gerätelisten den gesamten Kontext behalten.
+- Funktioniert komplett offline dank installiertem Service Worker – Sprache, Theme, Gerätedaten und Favoriten bleiben erhalten.
+- Responsives Layout passt sich nahtlos an Desktop, Tablet und Smartphone an.
+- Wähle bei kompatiblen Kameras zwischen **V‑Mount**, **B‑Mount** oder **Gold-Mount**; die Akkuliste aktualisiert sich automatisch.
+
+### 🧭 Interface-Überblick
+- **Kurzüberblick:**
+  - **Globale Suche** (`/` oder `Strg+K`/`⌘K`) springt zu Funktionen, Dropdowns
+    oder Hilfethemen – auch wenn das Seitenmenü eingeklappt ist.
+  - **Hilfecenter** (`?`, `H`, `F1` oder `Strg+/`) zeigt durchsuchbare Guides,
+    FAQ, Tastenkürzel und den optionalen Hover-Hilfemodus.
+  - **Projekt-Diagramm** visualisiert Verbindungen; mit gedrückter Umschalttaste
+    speicherst du statt SVG ein JPG und siehst Kompatibilitäts-Hinweise.
+  - **Batterievergleich** zeigt, wie kompatible Akkus performen und markiert
+    Überlastungen frühzeitig.
+  - **Gerätelisten-Generator** erstellt kategorisierte Tabellen mit Metadaten,
+    Crew-E-Mails und szenarioabhängigen Ergänzungen, die sich sauber drucken
+    lassen.
+  - **Offline-Badge & Neu laden erzwingen** zeigen den Verbindungsstatus an und
+    aktualisieren zwischengespeicherte Dateien, ohne Projekte zu löschen.
+- Ein Skip-Link und ein Offline-Indikator halten das Layout für Tastatur und Touch zugänglich; das Badge erscheint, sobald der Browser die Verbindung verliert.
+- Die globale Suchleiste springt zu Funktionen, Geräteauswahlen oder Hilfethemen; drücke Enter für das markierte Ergebnis, / oder Strg+K (⌘K auf macOS) zum sofortigen Fokussieren (auf kleinen Displays öffnet sich das Seitenmenü automatisch) und Escape oder × zum Zurücksetzen.
+- Oben findest du Sprachumschaltung, Toggles für dunkles und rosa Theme sowie den Einstellungsdialog mit Akzentfarbe, Schriftgröße, Schriftfamilie, High-Contrast-Schalter und Logo-Upload plus Backup-, Restore- und Cache-Löschen-Werkzeuge.
+- Die Hilfe-Schaltfläche öffnet einen durchsuchbaren Dialog mit Schritt-für-Schritt-Anleitungen, Tastenkürzeln, FAQ und optionalem Hover-Hilfemodus; du erreichst ihn auch mit ?, H, F1 oder Strg+/ – selbst während der Eingabe.
+- Die Schaltfläche zum Erzwingen einer Aktualisierung (🔄) löscht zwischengespeicherte Service-Worker-Dateien, damit sich die Offline-App erneuert, ohne Projekte oder Geräte zu verlieren.
+- Auf kleineren Bildschirmen spiegelt ein einklappbares Seitenmenü alle wichtigen Bereiche für schnellen Zugriff.
+
+### ♿ Anpassung und Barrierefreiheit
+- Theme-Optionen umfassen Dunkelmodus, spielerische rosa Akzente und einen eigenen High-Contrast-Schalter für bessere Lesbarkeit.
+- Änderungen an Akzentfarbe, Grundschriftgröße und Schriftfamilie greifen sofort und bleiben im Browser gespeichert – ideal für Markenfarben oder Barrierefreiheit.
+- Eingebaute Tastenkürzel decken globale Suche (/ oder Strg+K/⌘K), Hilfe ( ?, H, F1, Strg+/ ), Speichern (Enter oder Strg+S/⌘S), Dunkelmodus (D) und Rosa-Modus (P) ab.
+- Der Hover-Hilfemodus macht jede Schaltfläche, jedes Feld, Dropdown und jede Überschrift zur Sofort-Hilfe – perfekt für neue Teammitglieder.
+- Tippen zum Filtern, sichtbare Fokusmarken und Sternsymbole neben Auswahllisten erleichtern das Durchsuchen langer Listen und das Fixieren von Favoriten.
+- Lade ein eigenes Logo für Ausdrucke hoch, konfiguriere Standard-Monitoring-Rollen und passe Vorgaben für Projektanforderungen an, damit Exporte zum Produktionsbranding passen.
+- Gabel-Symbole duplizieren Formularzeilen sofort und angepinnte Favoriten halten beliebte Geräte oben in der Liste – ideal für schnelle Eingaben am Set.
+
+### 📋 Geräteliste
+Der Generator verwandelt deine Auswahl in eine kategorisierte Packliste:
+
+- Klicke auf **Geräteliste erstellen**, um ausgewähltes Equipment und Projektanforderungen in einer Tabelle zu bündeln.
+- Die Tabelle aktualisiert sich automatisch, sobald Geräteauswahl oder Anforderungen wechseln.
+- Elemente werden nach Kategorien gruppiert (Kamera, Optik, Strom, Monitoring, Rigging, Grip, Zubehör, Verbrauchsmaterial) und Duplikate zusammengeführt.
+- Benötigte Kabel, Rigging und Zubehör für Monitore, Motoren, Gimbals und Wetterszenarien werden automatisch ergänzt.
+- Szenario-Auswahlen fügen passendes Equipment hinzu:
+  - *Handheld* + *Easyrig* ergänzt einen teleskopischen Griff für stabilen Halt.
+  - *Gimbal* fügt das gewählte Gimbal, Magic-Arms, Spigots sowie Sonnenblenden oder Filtersets hinzu.
+  - *Outdoor* liefert Spigots, Schirme und CapIt-Regenhauben.
+  - Die Szenarien *Vehicle* und *Steadicam* bringen Halterungen, Iso-Arme und Saugnäpfe mit, wo nötig.
+- Objektiv-Auswahlen enthalten Frontdurchmesser, Gewicht, Rod-Daten und Mindestfokus, ergänzen Linsensupports und Matte-Box-Adapter und warnen vor inkompatiblen Rod-Standards.
+- Akkuzeilen spiegeln die Mengen aus dem Stromrechner und berücksichtigen Hotswap-Platten oder ausgewählte Hotswap-Geräte.
+- Monitoring-Präferenzen weisen Standardmonitore für jede Rolle (Regie, DoP, Fokus usw.) mit Kabelsets und Funkempfängern zu.
+- Das Formular **Projektanforderungen** speist die Liste:
+  - **Projektname**, **Produktion**, **Verleih** und **DoP** erscheinen in der Kopfzeile der gedruckten Anforderungen.
+  - **Crew**-Einträge erfassen Namen, Rollen und E-Mail-Adressen, damit Kontaktdaten mit dem Projekt reisen.
+  - **Prep-Tage** und **Drehtage** liefern Planungsnotizen und empfehlen bei Außenszenarien Wetter-Equipment.
+  - **Verpflichtende Szenarien** fügen passendes Rigging, Gimbals und Wetterschutz hinzu.
+  - **Kameragriff** und **Sucher-Erweiterung** tragen die gewählten Komponenten oder Verlängerungen ein.
+  - Optionen für **Matte Box** und **Filter** ergänzen das gewünschte System samt nötiger Trays, Clamp-Adapter oder Filter.
+  - Einstellungen für **Monitoring**, **Videoverteilung** und **Sucher** fügen Monitore, Kabel und Overlays für jede Rolle hinzu.
+  - **User Buttons** und **Stativ-Präferenzen** werden für schnellen Zugriff aufgeführt.
+- Innerhalb der Kategorien sind Einträge alphabetisch sortiert und zeigen beim Hover Tooltips an.
+- Die Geräteliste ist Teil der druckbaren Übersichten und der geteilten Projektdateien.
+- Gerätelisten werden automatisch mit dem Projekt gespeichert und in geteilte Dateien sowie Backups aufgenommen.
+- **Geräteliste löschen** entfernt die gespeicherte Liste und blendet die Ausgabe aus.
+- In den Formularen stehen Gabel-Schaltflächen bereit, um Benutzereinträge sofort zu duplizieren.
+
+### 📦 Gerätekategorien
+- **Kamera** (1)
+- **Monitor** (optional)
+- **Funk-Transmitter** (optional)
+- **FIZ-Motoren** (0–4)
+- **FIZ-Controller** (0–4)
+- **Distanzsensor** (0–1)
+- **Akkuplatte** (nur bei Kameras mit V‑ oder B‑Mount)
+- **V‑Mount-Akku** (0–1)
+
+### ⚙️ Stromberechnung
+- Gesamtverbrauch in Watt
+- Stromstärke bei 14,4 V und 12 V
+- Geschätzte Akkulaufzeit in Stunden basierend auf gewichteten Community-Werten
+- Benötigte Akkumenge für einen 10-Stunden-Dreh (inkl. Reserve)
+- Temperaturhinweis zur Anpassung der Laufzeit bei Hitze oder Kälte
+
+### 🔋 Akkuausgang prüfen
+- Warnt, wenn die Stromaufnahme den Akku-Ausgang (Pin oder D‑Tap) übersteigt
+- Zeigt an, wenn der Verbrauch in die Nähe des Limits (80 %) rückt
+
+### 📊 Akkuvergleich (optional)
+- Vergleicht Laufzeitschätzungen aller Akkus
+- Balkendiagramme für einen schnellen Überblick
+
+### 🖼 Projekt-Diagramm
+- Visualisiert Strom- und Videosignale der ausgewählten Geräte.
+- Warnt, wenn FIZ-Marken nicht kompatibel sind.
+- Ziehe Knoten, um das Layout neu zu ordnen, zoome mit den Schaltflächen und exportiere das Diagramm als SVG oder JPG.
+- Halte Shift gedrückt, während du auf Download klickst, um ein JPG statt eines SVG zu exportieren.
+- Fahre mit der Maus oder tippe auf Geräte, um Popover-Details zu sehen.
+- Nutzt [OpenMoji](https://openmoji.org/)-Icons, wenn eine Verbindung besteht, und greift sonst auf Emoji zurück: 🔋 Akku, 🎥 Kamera, 🖥️ Monitor, 📡 Video, ⚙️ Motor, 🎮 Controller, 📐 Distanz, 🎮 Griff und 🔌 Akkuplatte.
+
+### 🧮 Gewichtung der Laufzeitdaten
+- Von Nutzenden gemeldete Laufzeiten verfeinern die Schätzung.
+- Jeder Eintrag wird temperaturabhängig skaliert – von ×1 bei 25 °C auf:
+  - ×1,25 bei 0 °C
+  - ×1,6 bei −10 °C
+  - ×2 bei −20 °C
+- Kameraeinstellungen beeinflussen das Gewicht:
+  - Auflösungsfaktoren: ≥12K ×3, ≥8K ×2, ≥4K ×1,5, ≥1080p ×1; niedrigere Werte werden auf 1080p skaliert.
+  - Bildrate skaliert linear ab 24 fps (z. B. 48 fps = ×2).
+  - Aktiviertes WLAN erhöht das Gewicht um 10 %.
+  - Codec-Faktoren: RAW/BRAW/ARRIRAW/R3D/CinemaDNG/Canon RAW/X‑OCN ×1; ProRes ×1,1; DNx/AVID ×1,2; All‑Intra ×1,3; H.264/AVC ×1,5; H.265/HEVC ×1,7.
+  - Monitor-Einträge unterhalb der angegebenen Helligkeit werden gemäß ihrem Helligkeitsverhältnis gewichtet.
+- Das Endgewicht spiegelt den Anteil jedes Geräts am Gesamtverbrauch wider, sodass passende Projekte stärker zählen.
+- Der gewichtete Durchschnitt kommt zum Einsatz, sobald mindestens drei Einträge verfügbar sind.
+- Ein Dashboard sortiert die Einträge nach Gewicht und zeigt den prozentualen Anteil für den schnellen Vergleich.
+
+### 🔍 Suche & Filter
+- Tippe in Dropdowns, um Einträge schnell zu finden.
+- Filtere Gerätelisten über ein Suchfeld.
+- Nutze die globale Suche oben, um zu Funktionen, Geräten oder Hilfethemen zu springen; drücke Enter zum Navigieren, / oder Strg+K (⌘K auf macOS) zum sofortigen Fokussieren und Escape oder × zum Löschen.
+- Drücke „/“ oder Strg+F (⌘F auf macOS), um das nächstgelegene Suchfeld sofort zu fokussieren.
+- Klicke auf den Stern neben einer Auswahl, um Favoriten oben zu pinnen und in Backups mitzunehmen.
+
+### 🛠 Geräte-Datenbank-Editor
+- Geräte in allen Kategorien hinzufügen, bearbeiten oder löschen.
+- Gesamte Datenbank als JSON importieren oder exportieren.
+- Zur Standarddatenbank aus `data.js` zurückkehren.
+
+### 🌓 Dunkelmodus
+- Über die Mondschaltfläche neben dem Sprachmenü umschalten.
+- Die Einstellung wird im Browser gespeichert.
+
+### 🦄 Rosa Modus
+- Auf das Einhorn klicken oder **P** drücken, um den verspielten rosa Akzent zu aktivieren.
+- Funktioniert im hellen und dunklen Theme und bleibt zwischen Besuchen erhalten.
+
+### ⚫ High-Contrast-Modus
+- Aktiviert ein kontrastreiches Theme für bessere Lesbarkeit.
+
+### 📝 Laufzeit-Feedback
+- Klicke unter der Laufzeit auf <strong>Nutzer-Laufzeit-Feedback senden</strong>, um eigene Messungen hinzuzufügen.
+- Optional Temperatur eintragen, um die Gewichtung zu verfeinern.
+- Einträge werden im Browser gespeichert und verbessern künftige Schätzungen.
+- Ein Dashboard sortiert Beiträge nach Gewicht, zeigt prozentuale Anteile und
+  hebt Ausreißer hervor, damit Crews Feedback schneller bewerten können.
+
+### ❓ Durchsuchbare Hilfe
+- Über die Schaltfläche <strong>?</strong> oder per <kbd>?</kbd>, <kbd>H</kbd>, <kbd>F1</kbd> oder <kbd>Strg+/</kbd> öffnen.
+- Mit dem Suchfeld Themen sofort filtern; die Eingabe wird beim Schließen zurückgesetzt.
+- Mit <kbd>Escape</kbd> oder Klick außerhalb des Dialogs schließen.
+
+---
+
+## ▶️ So nutzt du die App
+1. **App starten:** Öffne `index.html` in einem modernen Browser – kein Server nötig.
+2. **Top-Bar erkunden:** Sprache wechseln, Dunkel- oder Rosa-Theme umschalten, Einstellungen für Akzent und Typografie öffnen und den Hilfedialog mit ? oder Strg+/ starten.
+3. **Geräte auswählen:** Wähle über Dropdowns das Equipment je Kategorie; tippe zum Filtern, pinne Favoriten mit dem Stern und lass Szenario-Voreinstellungen Zubehör automatisch ergänzen.
+4. **Berechnungen ansehen:** Gesamtverbrauch, Strom und Laufzeit erscheinen, sobald ein Akku gewählt ist; Warnungen markieren überschrittene Grenzen.
+5. **Projekte speichern & teilen:** Benenne und speichere deine Konfiguration, Auto-Backups erstellen Schnappschüsse und die Teilen-Schaltfläche exportiert ein JSON-Paket für das Team.
+6. **Geräteliste generieren:** Drücke **Geräteliste erstellen**, um Anforderungen in eine kategorisierte Packliste mit Tooltips und Zubehör zu verwandeln.
+7. **Gerätedaten verwalten:** Über „Gerätedaten bearbeiten…“ den Editor öffnen, Geräte anpassen, JSON exportieren/importieren oder auf Standardwerte zurücksetzen.
+8. **Laufzeit-Feedback senden:** Mit „Nutzer-Laufzeit-Feedback senden“ Messwerte aus der Praxis erfassen und die Gewichtung verbessern.
+
+## 📱 Als App installieren
+
+Der Planner ist eine Progressive Web App und lässt sich direkt aus dem Browser installieren:
+
+- **Chrome/Edge (Desktop):** Auf das Installationssymbol in der Adressleiste klicken.
+- **Android:** Browsermenü öffnen und *Zum Startbildschirm hinzufügen* wählen.
+- **iOS/iPadOS Safari:** Auf *Teilen* tippen und *Zum Home-Bildschirm* auswählen.
+
+Nach der Installation startet die App vom Startbildschirm, funktioniert offline und aktualisiert sich automatisch.
+
+## 📡 Offline-Nutzung & Datenspeicherung
+
+Beim Ausliefern über HTTP(S) installiert sich ein Service Worker, der alle Dateien cached, sodass Cine Power Planner vollständig offline läuft und Updates im Hintergrund lädt. Projekte, Laufzeit-Einreichungen und Einstellungen (Sprache, Theme, Rosa-Modus, gespeicherte Gerätelisten) liegen im `localStorage` deines Browsers. Das Löschen der Seitendaten entfernt alle Informationen; im Einstellungsdialog gibt es dafür ebenfalls die Schaltfläche **Lokalen Cache löschen**.
+Die Kopfzeile zeigt ein Offline-Badge, sobald die Verbindung wegfällt, und die
+Aktion 🔄 **Neu laden erzwingen** aktualisiert gecachte Assets, ohne Projekte
+anzutasten.
+
+---
+
+## 🗂️ Verzeichnisstruktur
+```bash
+index.html       # Zentrales HTML-Layout
+style.css        # Styles und Layout
+script.js        # Anwendungslogik
+data.js          # Standard-Geräteliste
+storage.js       # Hilfsfunktionen für LocalStorage
+README.*.md      # Dokumentation in mehreren Sprachen
+checkConsistency.js  # Prüft Pflichtfelder in den Gerätedaten
+normalizeData.js     # Bereinigt Einträge und vereinheitlicht Portnamen
+generateSchema.js    # Baut schema.json aus data.js neu
+unifyPorts.js        # Vereinheitlicht ältere Portbezeichnungen
+tests/               # Jest-Test-Suite
+```
+Schriftarten werden lokal über `fonts.css` eingebunden; sind die Assets einmal im Cache, funktioniert die Anwendung komplett offline.
+
+## 🛠️ Entwicklung
+Benötigt Node.js 18 oder neuer.
+
+```bash
+npm install
+npm run lint     # führt nur ESLint aus
+npm test         # startet Linting, Datenprüfungen und Jest-Tests
+```
+
+Nach Änderungen an den Gerätedaten die normalisierte Datenbank neu erzeugen:
+
+```bash
+npm run normalize
+npm run unify-ports
+npm run check-consistency
+npm run generate-schema
+```
+
+Mit `--help` zeigen die Skripte weitere Optionen an.
+
+## 🤝 Mitmachen
+Beiträge sind jederzeit willkommen! Eröffne gerne ein Issue oder sende einen Pull Request auf GitHub.
+Für Datenkorrekturen helfen Projekt-Backups oder Beispiel-Laufzeiten, damit die Gerätekataloge verlässlich bleiben.

--- a/README.de.md
+++ b/README.de.md
@@ -1,252 +1,138 @@
-# 🎥 Cine Power Planner
+# Cine Power Planner
 
-Dieses browserbasierte Tool hilft bei der Planung professioneller Kamera-Projekte, die mit V‑Mount-, B‑Mount- oder Gold-Mount-Akkus betrieben werden. Es berechnet **Gesamtleistung**, **Stromaufnahme** (bei 14,4 V und 12 V) sowie die **geschätzte Akkulaufzeit** und prüft gleichzeitig, ob der Akku die benötigte Leistung sicher liefern kann.
+![Cine Power Planner icon](icon.svg)
+
+Cine Power Planner ist eine offlinefähige Web-App zum Planen professioneller Kamerarigs, die mit V-Mount-, B-Mount- oder Gold-Mount-Akkus betrieben werden. Sie berechnet die Gesamtleistung, prüft, ob jeder Akku den benötigten Strom sicher liefern kann, erstellt realistische Laufzeiten aus gewichteten Praxiserfahrungen und hält Crew, Szenarien sowie Packlisten zusammen, damit zwischen den Gewerken nichts verloren geht.
 
 ---
 
-## 🌍 Sprachen
+## Highlights
+
+### Komplexe Setups ohne Ratespiel
+- Kombiniere Kameras, Akkubasen, Funkstrecken, Monitore, Motoren und Zubehör und sieh dabei Gesamtwatt, Stromaufnahme bei 14,4 V/12 V (sowie 33,6 V/21,6 V bei B-Mount) und die erwartete Laufzeit.
+- Vergleiche kompatible Akkus nebeneinander und erhalte Warnungen, wenn die Belastung D-Tap- oder Pin-Grenzen überschreitet.
+- Visualisiere Rigs mit einem interaktiven Diagramm mit Drag&Drop, Zoom, SVG/JPG-Export und Kompatibilitäts-Hinweisen.
+
+### Alle Abteilungen im selben Bild
+- Speichere mehrere Projekte inklusive Anforderungen, Crewkontakten, Drehszenarien und eigenen Notizen.
+- Erstelle druckbare Packlisten, die Equipment nach Kategorie gruppieren, Duplikate zusammenfassen, technische Metadaten enthalten und szenariobasierte Extras ergänzen.
+- Teile JSON-Pakete, die Gerätauswahl, Laufzeitfeedback, Packlisten und eigene Geräte für eine vollständige Wiederherstellung enthalten.
+
+### Reisebereit und privat
+- Läuft vollständig im Browser – öffne `index.html` direkt oder hoste das Repository über HTTPS, um den Service Worker zu aktivieren.
+- Offline-Caching hält Sprache, Theme, Favoriten und Projekte überall verfügbar, ohne Daten an externe Server zu senden.
+- Leere den lokalen Cache oder nutze den Force-Reload, um gecachte Assets zu aktualisieren, ohne Projekte zu verlieren.
+
+### Für dein Team anpassbar
+- Wechsle sofort zwischen Englisch, Deutsch, Spanisch, Italienisch und Französisch; der Planner merkt sich die zuletzt verwendete Sprache.
+- Wähle dunkle, pinke oder kontrastreiche Themes, setze eine eigene Akzentfarbe, passe Schriftgröße an und wähle die Schriftart, die zu Stage-Branding oder Barrierefreiheit passt.
+- Tippe direkt in Dropdowns, pinne Favoriten und aktiviere Hover-Hilfe, damit die Crew am Set produktiv bleibt.
+
+---
+
+## Schnellstart
+
+1. Repository klonen oder herunterladen.
+2. `index.html` in einem aktuellen Chromium-, Firefox- oder Safari-Browser öffnen – es ist kein Build-Schritt nötig.
+3. Optional den Ordner über HTTPS ausliefern, um den Service Worker für Offline-Updates zu installieren. Jeder Static-Server funktioniert (`npx http-server -S` o. ä.).
+4. Die App speichert Daten im Browser. Nutze **Einstellungen → Backup**, um vor einem Gerätewechsel JSON-Sicherungen zu exportieren.
+
+---
+
+## Typischer Workflow
+
+1. **Projekt anlegen oder laden.** Enter oder `Strg+S` (`⌘S` auf macOS) speichern schnell. Automatische Snapshots laufen alle 10 Minuten.
+2. **Kamera, Stromversorgung und Zubehör wählen.** Dropdowns filtern beim Tippen, Favoriten bleiben angepinnt.
+3. **Leistungswerte prüfen.** Watt, Stromaufnahme, Sicherheitsindikatoren und Laufzeiten im Vergleichspanel kontrollieren.
+4. **Anforderungen erfassen.** Crewrollen, Drehtage, Szenarien und Notizen dokumentieren, damit jeder Export den passenden Kontext trägt.
+5. **Ausgaben erzeugen.** Packlisten, druckbare Übersichten und Shared-Projekt-Bundles erstellen und später mit einem Upload wiederherstellen.
+
+---
+
+## Interface-Essentials
+
+- **Globale Suche** (`/` oder `Strg+K`/`⌘K`) springt zu Funktionen, Auswahlfeldern oder Hilfetexten – auch bei eingeklapptem Menü.
+- **Hilfecenter** (`?`, `H`, `F1` oder `Strg+/`) liefert durchsuchbare Guides, FAQs, Shortcuts und optionale Hover-Hilfe.
+- **Projektdiagramm** visualisiert Verbindungen; beim Download mit gedrückter Umschalttaste als JPG statt SVG exportieren.
+- **Akkuvergleich** zeigt die Leistung aller kompatiblen Packs und hebt Überlast-Risiken hervor.
+- **Packlisten-Generator** wandelt Auswahl in kategorisierte Tabellen mit Metadaten, Crew-E-Mails und szenariobasierten Ergänzungen um.
+- **Offline-Indikator & Force Reload** zeigen Verbindungsstatus und aktualisieren gecachte Assets ohne Projektverlust.
+
+---
+
+## Daten- & Export-Management
+
+- Projekte, Einstellungen, Packlisten, Favoriten und eigene Geräte liegen in `localStorage`; Backups und Restores halten alles zusammen.
+- Der Einstellungsdialog bietet stündliche Backup-Erinnerungen, manuelle Sicherungen, Ein-Klick-Restore und einen **Lokalen Cache leeren**-Button.
+- Geteilte Projektdateien bündeln Auswahl, Anforderungen, Laufzeitfeedback, Packlisten und Custom Devices für nahtlose Übergaben.
+- Druckübersichten enthalten Projektnamen, Produktionsdetails, optionales Logo und die generierte Packliste.
+- Automatische Snapshots laufen im Hintergrund, um schnell zu einem früheren Stand zurückzukehren.
+
+---
+
+## Akku- & Laufzeit-Intelligenz
+
+- Berechnet Gesamtverbrauch, benötigte Akkuanzahl für 10-Stunden-Tage und die Stromaufnahme jeder Verbindung.
+- Warnt ab 80 % Auslastung und blockiert unsichere Lasten, wenn die Dauer- oder D-Tap-Leistung überschritten wird.
+- Gewichtete Laufzeiten berücksichtigen Temperatur, Auflösung, Framerate, Codec, WLAN-Nutzung, Monitorhelligkeit und den Leistungsanteil jedes Geräts.
+- Ein Laufzeit-Dashboard sortiert Feedback nach Gewichtung, zeigt Beitragsprozente und markiert Ausreißer.
+- Nutzerfeedback fließt ein, um Schätzungen für reale Drehs zu präzisieren.
+
+---
+
+## Anpassung & Barrierefreiheit
+
+- Dunkle, pinke oder kontrastreiche Themes und Typografie-Einstellungen lassen sich ohne Reload umschalten.
+- Eigenes Logo für Drucke hochladen, Standard-Monitorrollen setzen und Projektanforderungen vorkonfigurieren.
+- Tastaturfreundliche Navigation, sichtbare Fokuszustände und Skip-Links unterstützen Screenreader und Barrierefreiheit am Set.
+- Tippen zum Filtern, angepinnte Favoriten und Fork-Buttons in Packlisten beschleunigen wiederholte Eingaben.
+
+---
+
+## Tastenkürzel
+
+| Aktion | Shortcut |
+| --- | --- |
+| Globale Suche fokussieren | `/`, `Strg+K`, `⌘K` |
+| Hilfedialog öffnen | `?`, `H`, `F1`, `Strg+/` |
+| Projekt speichern | `Enter`, `Strg+S`, `⌘S` |
+| Dark Theme umschalten | `D` |
+| Pinkes Theme umschalten | `P` |
+| Force Reload | 🔄-Symbol in der Kopfzeile klicken |
+
+---
+
+## Entwicklung
+
+- Abhängigkeiten mit `npm install` installieren (für Linting, Tests und Datenskripte – kein Build erforderlich).
+- Vor Commits `npm run lint` und `npm run test` ausführen. Gezielte Suites gibt es via `npm run test:unit`, `npm run test:data`, `npm run test:dom` und `npm run test:script`.
+- Nützliche Skripte:
+  - `npm run check-consistency` prüft die Datenkonsistenz.
+  - `npm run normalize` und `npm run unify-ports` halten den Katalog sauber.
+  - `npm run generate-schema` aktualisiert das Geräteschema.
+
+---
+
+## Übersetzungen
+
+Die Dokumentation steht in mehreren Sprachen bereit; die App übernimmt beim ersten Start automatisch die Browser-Sprache. Der Wechsel ist jederzeit über das Sprachmenü oben rechts möglich:
+
 - 🇬🇧 [English](README.en.md)
 - 🇩🇪 [Deutsch](README.de.md)
 - 🇪🇸 [Español](README.es.md)
 - 🇮🇹 [Italiano](README.it.md)
 - 🇫🇷 [Français](README.fr.md)
 
-Die App übernimmt beim ersten Start automatisch die Sprache deines Browsers; über die rechte obere Ecke kannst du jederzeit umschalten. Die Auswahl wird für den nächsten Besuch gespeichert.
+Du möchtest helfen? Folge der [Übersetzungsanleitung](docs/translation-guide.md), um neue Sprachen für Interface und Dokumentation hinzuzufügen.
 
 ---
 
-## 🆕 Neueste Funktionen
-- Mit den Akzent- und Typografie-Reglern in den Einstellungen passt du Akzentfarbe, Grundschriftgröße und Schriftfamilie neben den dunklen, rosa und kontrastreichen Themes an.
-- Tastenkürzel für die globale Suche lassen dich / oder Strg+K (⌘K auf macOS) drücken, um sie sofort zu fokussieren – auch wenn sie im eingeklappten mobilen Seitenmenü liegt.
-- Die Schaltfläche „Neu laden erzwingen“ leert die zwischengespeicherten Service-Worker-Dateien, damit sich die Offline-App aktualisiert, ohne gespeicherte Projekte oder Geräte zu löschen.
-- Sternsymbole in jeder Auswahl heften Lieblingskameras, -akkus und -zubehör oben an und nehmen sie in Backups auf.
-- Die Schaltfläche „Lokalen Cache löschen“ entfernt gespeicherte Projekte und Einstellungen.
-- Die Geräteliste und die druckbare Übersicht zeigen den Projektnamen für einen schnellen Überblick an.
-- Lade ein eigenes Logo hoch, das in druckbaren Übersichten und Backups erscheint.
-- Backups enthalten Favoriten und erstellen vor einer Wiederherstellung automatisch eine Sicherung.
-- Crew-Einträge besitzen jetzt ein Feld für E-Mail-Adressen.
-- Neues High-Contrast-Theme für bessere Lesbarkeit.
-- Geräteformulare füllen Kategorien dynamisch anhand der Schema-Attribute.
-- Überarbeitetes Interface mit verbessertem Kontrast und Abständen für ein aufgeräumtes Erlebnis auf allen Geräten.
-- Projekte lassen sich einfacher teilen: Lade eine JSON-Datei mit Auswahl, Anforderungen, Geräteliste, Laufzeit-Feedback und eigenen Geräten herunter und importiere sie, um alles wiederherzustellen.
-- Einzigartige Symbole für verpflichtende Szenarien helfen, Projektanforderungen auf einen Blick zu erkennen.
-- Interaktives Projekt-Diagramm zum Verschieben, Zoomen, am Raster ausrichten und als SVG oder JPG exportieren.
-- Verspieltes pinkes Akzent-Theme, das zwischen Besuchen erhalten bleibt.
-- Durchsuchbarer Hilfedialog mit Schritt-für-Schritt-Bereichen und FAQ; öffne ihn mit ?, H, F1 oder Strg+/.
-- Kontextuelle Hover-Hilfen für Schaltflächen, Felder, Dropdowns und Überschriften.
-- Globale Suchleiste zum Springen zu Funktionen, Geräteauswahlen oder Hilfethemen.
-- Unterstützung für Kameras mit V-, B- oder Gold-Mount-Akkuplatten.
-- Reiche Laufzeit-Feedback mitsamt Temperatur ein, um Schätzungen zu verbessern.
-- Visuelles Dashboard zur Gewichtung der Laufzeiten zeigt, wie Einstellungen jeden Eintrag beeinflussen, sortiert nach Gewicht mit exakten Prozentwerten.
-- Erstelle Gerätelisten, die ausgewählte Komponenten und Projektanforderungen zusammenfassen.
-- Speichere Projektanforderungen mit jedem Projekt, damit Gerätelisten den vollen Kontext behalten.
-- Dupliziere Benutzereinträge in den Gerätelistenvorlagen per Gabel-Symbol, um Felder sofort zu kopieren.
+## Beitrag & Support
+
+Bugreports, Feature-Ideen und Datenkorrekturen sind willkommen. Eröffne ein Issue oder sende einen Pull Request mit möglichst vielen Details. Bei falschen Laufzeiten oder fehlendem Equipment bitte Projektdatei oder Beispieldaten anhängen, damit der Katalog verlässlich bleibt.
 
 ---
 
-## 🔧 Funktionen
+## Lizenz
 
-### ✅ Projektverwaltung
-- Speichere, lade und lösche mehrere Kamera-Projekte (drücke Enter oder Strg+S/⌘S zum schnellen Speichern; die Schaltfläche bleibt deaktiviert, bis ein Name eingegeben wurde).
-- Alle zehn Minuten entstehen automatisch Schnappschüsse, solange der Planner geöffnet ist; im Einstellungsdialog lassen sich stündliche Backup-Exporte als Erinnerung aktivieren.
-- Lade eine JSON-Datei herunter, die Auswahl, Anforderungen, Geräteliste, Laufzeit-Feedback und eigene Geräte bündelt; über den „Geteiltes Projekt“-Picker importierst du alles in einem Schritt.
-- Daten werden lokal über `localStorage` gespeichert, Favoriten landen ebenfalls in Backups; nutze die Schaltfläche **Lokalen Cache löschen** in den Einstellungen, um gespeicherte Projekte und Geräteanpassungen zu entfernen.
-- Erstelle druckbare Übersichten für jedes gespeicherte Projekt und füge ein individuelles Logo hinzu, damit Exporte und Backups zum Produktionsbranding passen.
-- Projektanforderungen werden gemeinsam mit dem Projekt gespeichert, sodass Gerätelisten den gesamten Kontext behalten.
-- Funktioniert komplett offline dank installiertem Service Worker – Sprache, Theme, Gerätedaten und Favoriten bleiben erhalten.
-- Responsives Layout passt sich nahtlos an Desktop, Tablet und Smartphone an.
-- Wähle bei kompatiblen Kameras zwischen **V‑Mount**, **B‑Mount** oder **Gold-Mount**; die Akkuliste aktualisiert sich automatisch.
-
-### 🧭 Interface-Überblick
-- Ein Skip-Link und ein Offline-Indikator halten das Layout für Tastatur und Touch zugänglich; das Badge erscheint, sobald der Browser die Verbindung verliert.
-- Die globale Suchleiste springt zu Funktionen, Geräteauswahlen oder Hilfethemen; drücke Enter für das markierte Ergebnis, / oder Strg+K (⌘K auf macOS) zum sofortigen Fokussieren (auf kleinen Displays öffnet sich das Seitenmenü automatisch) und Escape oder × zum Zurücksetzen.
-- Oben findest du Sprachumschaltung, Toggles für dunkles und rosa Theme sowie den Einstellungsdialog mit Akzentfarbe, Schriftgröße, Schriftfamilie, High-Contrast-Schalter und Logo-Upload plus Backup-, Restore- und Cache-Löschen-Werkzeuge.
-- Die Hilfe-Schaltfläche öffnet einen durchsuchbaren Dialog mit Schritt-für-Schritt-Anleitungen, Tastenkürzeln, FAQ und optionalem Hover-Hilfemodus; du erreichst ihn auch mit ?, H, F1 oder Strg+/ – selbst während der Eingabe.
-- Die Schaltfläche zum Erzwingen einer Aktualisierung (🔄) löscht zwischengespeicherte Service-Worker-Dateien, damit sich die Offline-App erneuert, ohne Projekte oder Geräte zu verlieren.
-- Auf kleineren Bildschirmen spiegelt ein einklappbares Seitenmenü alle wichtigen Bereiche für schnellen Zugriff.
-
-### ♿ Anpassung und Barrierefreiheit
-- Theme-Optionen umfassen Dunkelmodus, spielerische rosa Akzente und einen eigenen High-Contrast-Schalter für bessere Lesbarkeit.
-- Änderungen an Akzentfarbe, Grundschriftgröße und Schriftfamilie greifen sofort und bleiben im Browser gespeichert – ideal für Markenfarben oder Barrierefreiheit.
-- Eingebaute Tastenkürzel decken globale Suche (/ oder Strg+K/⌘K), Hilfe ( ?, H, F1, Strg+/ ), Speichern (Enter oder Strg+S/⌘S), Dunkelmodus (D) und Rosa-Modus (P) ab.
-- Der Hover-Hilfemodus macht jede Schaltfläche, jedes Feld, Dropdown und jede Überschrift zur Sofort-Hilfe – perfekt für neue Teammitglieder.
-- Tippen zum Filtern, sichtbare Fokusmarken und Sternsymbole neben Auswahllisten erleichtern das Durchsuchen langer Listen und das Fixieren von Favoriten.
-
-### 📋 Geräteliste
-Der Generator verwandelt deine Auswahl in eine kategorisierte Packliste:
-
-- Klicke auf **Geräteliste erstellen**, um ausgewähltes Equipment und Projektanforderungen in einer Tabelle zu bündeln.
-- Die Tabelle aktualisiert sich automatisch, sobald Geräteauswahl oder Anforderungen wechseln.
-- Elemente werden nach Kategorien gruppiert (Kamera, Optik, Strom, Monitoring, Rigging, Grip, Zubehör, Verbrauchsmaterial) und Duplikate zusammengeführt.
-- Benötigte Kabel, Rigging und Zubehör für Monitore, Motoren, Gimbals und Wetterszenarien werden automatisch ergänzt.
-- Szenario-Auswahlen fügen passendes Equipment hinzu:
-  - *Handheld* + *Easyrig* ergänzt einen teleskopischen Griff für stabilen Halt.
-  - *Gimbal* fügt das gewählte Gimbal, Magic-Arms, Spigots sowie Sonnenblenden oder Filtersets hinzu.
-  - *Outdoor* liefert Spigots, Schirme und CapIt-Regenhauben.
-  - Die Szenarien *Vehicle* und *Steadicam* bringen Halterungen, Iso-Arme und Saugnäpfe mit, wo nötig.
-- Objektiv-Auswahlen enthalten Frontdurchmesser, Gewicht, Rod-Daten und Mindestfokus, ergänzen Linsensupports und Matte-Box-Adapter und warnen vor inkompatiblen Rod-Standards.
-- Akkuzeilen spiegeln die Mengen aus dem Stromrechner und berücksichtigen Hotswap-Platten oder ausgewählte Hotswap-Geräte.
-- Monitoring-Präferenzen weisen Standardmonitore für jede Rolle (Regie, DoP, Fokus usw.) mit Kabelsets und Funkempfängern zu.
-- Das Formular **Projektanforderungen** speist die Liste:
-  - **Projektname**, **Produktion**, **Verleih** und **DoP** erscheinen in der Kopfzeile der gedruckten Anforderungen.
-  - **Crew**-Einträge erfassen Namen, Rollen und E-Mail-Adressen, damit Kontaktdaten mit dem Projekt reisen.
-  - **Prep-Tage** und **Drehtage** liefern Planungsnotizen und empfehlen bei Außenszenarien Wetter-Equipment.
-  - **Verpflichtende Szenarien** fügen passendes Rigging, Gimbals und Wetterschutz hinzu.
-  - **Kameragriff** und **Sucher-Erweiterung** tragen die gewählten Komponenten oder Verlängerungen ein.
-  - Optionen für **Matte Box** und **Filter** ergänzen das gewünschte System samt nötiger Trays, Clamp-Adapter oder Filter.
-  - Einstellungen für **Monitoring**, **Videoverteilung** und **Sucher** fügen Monitore, Kabel und Overlays für jede Rolle hinzu.
-  - **User Buttons** und **Stativ-Präferenzen** werden für schnellen Zugriff aufgeführt.
-- Innerhalb der Kategorien sind Einträge alphabetisch sortiert und zeigen beim Hover Tooltips an.
-- Die Geräteliste ist Teil der druckbaren Übersichten und der geteilten Projektdateien.
-- Gerätelisten werden automatisch mit dem Projekt gespeichert und in geteilte Dateien sowie Backups aufgenommen.
-- **Geräteliste löschen** entfernt die gespeicherte Liste und blendet die Ausgabe aus.
-- In den Formularen stehen Gabel-Schaltflächen bereit, um Benutzereinträge sofort zu duplizieren.
-
-### 📦 Gerätekategorien
-- **Kamera** (1)
-- **Monitor** (optional)
-- **Funk-Transmitter** (optional)
-- **FIZ-Motoren** (0–4)
-- **FIZ-Controller** (0–4)
-- **Distanzsensor** (0–1)
-- **Akkuplatte** (nur bei Kameras mit V‑ oder B‑Mount)
-- **V‑Mount-Akku** (0–1)
-
-### ⚙️ Stromberechnung
-- Gesamtverbrauch in Watt
-- Stromstärke bei 14,4 V und 12 V
-- Geschätzte Akkulaufzeit in Stunden basierend auf gewichteten Community-Werten
-- Benötigte Akkumenge für einen 10-Stunden-Dreh (inkl. Reserve)
-- Temperaturhinweis zur Anpassung der Laufzeit bei Hitze oder Kälte
-
-### 🔋 Akkuausgang prüfen
-- Warnt, wenn die Stromaufnahme den Akku-Ausgang (Pin oder D‑Tap) übersteigt
-- Zeigt an, wenn der Verbrauch in die Nähe des Limits (80 %) rückt
-
-### 📊 Akkuvergleich (optional)
-- Vergleicht Laufzeitschätzungen aller Akkus
-- Balkendiagramme für einen schnellen Überblick
-
-### 🖼 Projekt-Diagramm
-- Visualisiert Strom- und Videosignale der ausgewählten Geräte.
-- Warnt, wenn FIZ-Marken nicht kompatibel sind.
-- Ziehe Knoten, um das Layout neu zu ordnen, zoome mit den Schaltflächen und exportiere das Diagramm als SVG oder JPG.
-- Halte Shift gedrückt, während du auf Download klickst, um ein JPG statt eines SVG zu exportieren.
-- Fahre mit der Maus oder tippe auf Geräte, um Popover-Details zu sehen.
-- Nutzt [OpenMoji](https://openmoji.org/)-Icons, wenn eine Verbindung besteht, und greift sonst auf Emoji zurück: 🔋 Akku, 🎥 Kamera, 🖥️ Monitor, 📡 Video, ⚙️ Motor, 🎮 Controller, 📐 Distanz, 🎮 Griff und 🔌 Akkuplatte.
-
-### 🧮 Gewichtung der Laufzeitdaten
-- Von Nutzenden gemeldete Laufzeiten verfeinern die Schätzung.
-- Jeder Eintrag wird temperaturabhängig skaliert – von ×1 bei 25 °C auf:
-  - ×1,25 bei 0 °C
-  - ×1,6 bei −10 °C
-  - ×2 bei −20 °C
-- Kameraeinstellungen beeinflussen das Gewicht:
-  - Auflösungsfaktoren: ≥12K ×3, ≥8K ×2, ≥4K ×1,5, ≥1080p ×1; niedrigere Werte werden auf 1080p skaliert.
-  - Bildrate skaliert linear ab 24 fps (z. B. 48 fps = ×2).
-  - Aktiviertes WLAN erhöht das Gewicht um 10 %.
-  - Codec-Faktoren: RAW/BRAW/ARRIRAW/R3D/CinemaDNG/Canon RAW/X‑OCN ×1; ProRes ×1,1; DNx/AVID ×1,2; All‑Intra ×1,3; H.264/AVC ×1,5; H.265/HEVC ×1,7.
-  - Monitor-Einträge unterhalb der angegebenen Helligkeit werden gemäß ihrem Helligkeitsverhältnis gewichtet.
-- Das Endgewicht spiegelt den Anteil jedes Geräts am Gesamtverbrauch wider, sodass passende Projekte stärker zählen.
-- Der gewichtete Durchschnitt kommt zum Einsatz, sobald mindestens drei Einträge verfügbar sind.
-- Ein Dashboard sortiert die Einträge nach Gewicht und zeigt den prozentualen Anteil für den schnellen Vergleich.
-
-### 🔍 Suche & Filter
-- Tippe in Dropdowns, um Einträge schnell zu finden.
-- Filtere Gerätelisten über ein Suchfeld.
-- Nutze die globale Suche oben, um zu Funktionen, Geräten oder Hilfethemen zu springen; drücke Enter zum Navigieren, / oder Strg+K (⌘K auf macOS) zum sofortigen Fokussieren und Escape oder × zum Löschen.
-- Drücke „/“ oder Strg+F (⌘F auf macOS), um das nächstgelegene Suchfeld sofort zu fokussieren.
-- Klicke auf den Stern neben einer Auswahl, um Favoriten oben zu pinnen und in Backups mitzunehmen.
-
-### 🛠 Geräte-Datenbank-Editor
-- Geräte in allen Kategorien hinzufügen, bearbeiten oder löschen.
-- Gesamte Datenbank als JSON importieren oder exportieren.
-- Zur Standarddatenbank aus `data.js` zurückkehren.
-
-### 🌓 Dunkelmodus
-- Über die Mondschaltfläche neben dem Sprachmenü umschalten.
-- Die Einstellung wird im Browser gespeichert.
-
-### 🦄 Rosa Modus
-- Auf das Einhorn klicken oder **P** drücken, um den verspielten rosa Akzent zu aktivieren.
-- Funktioniert im hellen und dunklen Theme und bleibt zwischen Besuchen erhalten.
-
-### ⚫ High-Contrast-Modus
-- Aktiviert ein kontrastreiches Theme für bessere Lesbarkeit.
-
-### 📝 Laufzeit-Feedback
-- Klicke unter der Laufzeit auf <strong>Nutzer-Laufzeit-Feedback senden</strong>, um eigene Messungen hinzuzufügen.
-- Optional Temperatur eintragen, um die Gewichtung zu verfeinern.
-- Einträge werden im Browser gespeichert und verbessern künftige Schätzungen.
-
-### ❓ Durchsuchbare Hilfe
-- Über die Schaltfläche <strong>?</strong> oder per <kbd>?</kbd>, <kbd>H</kbd>, <kbd>F1</kbd> oder <kbd>Strg+/</kbd> öffnen.
-- Mit dem Suchfeld Themen sofort filtern; die Eingabe wird beim Schließen zurückgesetzt.
-- Mit <kbd>Escape</kbd> oder Klick außerhalb des Dialogs schließen.
-
----
-
-## ▶️ So nutzt du die App
-1. **App starten:** Öffne `index.html` in einem modernen Browser – kein Server nötig.
-2. **Top-Bar erkunden:** Sprache wechseln, Dunkel- oder Rosa-Theme umschalten, Einstellungen für Akzent und Typografie öffnen und den Hilfedialog mit ? oder Strg+/ starten.
-3. **Geräte auswählen:** Wähle über Dropdowns das Equipment je Kategorie; tippe zum Filtern, pinne Favoriten mit dem Stern und lass Szenario-Voreinstellungen Zubehör automatisch ergänzen.
-4. **Berechnungen ansehen:** Gesamtverbrauch, Strom und Laufzeit erscheinen, sobald ein Akku gewählt ist; Warnungen markieren überschrittene Grenzen.
-5. **Projekte speichern & teilen:** Benenne und speichere deine Konfiguration, Auto-Backups erstellen Schnappschüsse und die Teilen-Schaltfläche exportiert ein JSON-Paket für das Team.
-6. **Geräteliste generieren:** Drücke **Geräteliste erstellen**, um Anforderungen in eine kategorisierte Packliste mit Tooltips und Zubehör zu verwandeln.
-7. **Gerätedaten verwalten:** Über „Gerätedaten bearbeiten…“ den Editor öffnen, Geräte anpassen, JSON exportieren/importieren oder auf Standardwerte zurücksetzen.
-8. **Laufzeit-Feedback senden:** Mit „Nutzer-Laufzeit-Feedback senden“ Messwerte aus der Praxis erfassen und die Gewichtung verbessern.
-
-## 📱 Als App installieren
-
-Der Planner ist eine Progressive Web App und lässt sich direkt aus dem Browser installieren:
-
-- **Chrome/Edge (Desktop):** Auf das Installationssymbol in der Adressleiste klicken.
-- **Android:** Browsermenü öffnen und *Zum Startbildschirm hinzufügen* wählen.
-- **iOS/iPadOS Safari:** Auf *Teilen* tippen und *Zum Home-Bildschirm* auswählen.
-
-Nach der Installation startet die App vom Startbildschirm, funktioniert offline und aktualisiert sich automatisch.
-
-## 📡 Offline-Nutzung & Datenspeicherung
-
-Beim Ausliefern über HTTP(S) installiert sich ein Service Worker, der alle Dateien cached, sodass Cine Power Planner vollständig offline läuft und Updates im Hintergrund lädt. Projekte, Laufzeit-Einreichungen und Einstellungen (Sprache, Theme, Rosa-Modus, gespeicherte Gerätelisten) liegen im `localStorage` deines Browsers. Das Löschen der Seitendaten entfernt alle Informationen; im Einstellungsdialog gibt es dafür ebenfalls die Schaltfläche **Lokalen Cache löschen**.
-
----
-
-## 🗂️ Verzeichnisstruktur
-```bash
-index.html       # Zentrales HTML-Layout
-style.css        # Styles und Layout
-script.js        # Anwendungslogik
-data.js          # Standard-Geräteliste
-storage.js       # Hilfsfunktionen für LocalStorage
-README.*.md      # Dokumentation in mehreren Sprachen
-checkConsistency.js  # Prüft Pflichtfelder in den Gerätedaten
-normalizeData.js     # Bereinigt Einträge und vereinheitlicht Portnamen
-generateSchema.js    # Baut schema.json aus data.js neu
-unifyPorts.js        # Vereinheitlicht ältere Portbezeichnungen
-tests/               # Jest-Test-Suite
-```
-Schriftarten werden lokal über `fonts.css` eingebunden; sind die Assets einmal im Cache, funktioniert die Anwendung komplett offline.
-
-## 🛠️ Entwicklung
-Benötigt Node.js 18 oder neuer.
-
-```bash
-npm install
-npm run lint     # führt nur ESLint aus
-npm test         # startet Linting, Datenprüfungen und Jest-Tests
-```
-
-Nach Änderungen an den Gerätedaten die normalisierte Datenbank neu erzeugen:
-
-```bash
-npm run normalize
-npm run unify-ports
-npm run check-consistency
-npm run generate-schema
-```
-
-Mit `--help` zeigen die Skripte weitere Optionen an.
-
-## 🤝 Mitmachen
-Beiträge sind jederzeit willkommen! Eröffne gerne ein Issue oder sende einen Pull Request auf GitHub.
+Cine Power Planner wird unter der ISC-Lizenz veröffentlicht.

--- a/README.en.md
+++ b/README.en.md
@@ -1,138 +1,307 @@
-# Cine Power Planner
+# 🎥 Cine Power Planner
 
-![Cine Power Planner icon](icon.svg)
+This browser based tool helps plan professional camera projects powered by V‑Mount, B‑Mount or Gold-Mount batteries. It calculates **total power consumption**, **current draw** (at 14.4 V and 12 V) and **estimated battery runtime** while checking that the battery can safely supply the required power.
 
-Cine Power Planner is an offline-capable web application for planning professional camera rigs that run on V‑Mount, B‑Mount or Gold‑Mount batteries. It calculates total power draw, checks that every pack can safely deliver the current you need, estimates realistic runtimes from weighted field data and keeps your crew, scenarios and gear lists together so nothing gets lost between departments.
-
----
-
-## Highlights
-
-### Plan complex builds without guesswork
-- Combine cameras, battery plates, wireless links, monitors, motors and accessories while seeing total wattage, current draw at 14.4 V/12 V (and 33.6 V/21.6 V for B‑Mount) plus expected runtime.
-- Compare compatible batteries side-by-side and get warnings when draw exceeds D‑Tap or pin limits.
-- Visualize rigs with an interactive diagram that supports drag, zoom, SVG/JPG export and compatibility notices.
-
-### Keep every department aligned
-- Save multiple projects with requirements, crew contacts, shooting scenarios and custom notes.
-- Generate printable gear lists that group kit by category, merge duplicates, include technical metadata and reflect scenario-driven accessories.
-- Share JSON bundles that contain device selections, runtime feedback, gear lists and custom devices for an end-to-end restore.
-
-### Travel-ready and private
-- Works entirely in the browser—open `index.html` directly or host the repository over HTTPS to enable the service worker.
-- Offline caching keeps language, theme, favorites and projects available everywhere without sending data to external servers.
-- Clear the local cache or trigger a force reload to refresh cached assets without touching saved projects.
-
-### Tailor it to your team
-- Switch instantly between English, Deutsch, Español, Italiano and Français; the planner remembers the last language used.
-- Choose dark, pink or high-contrast themes, set a custom accent color, adjust font size and pick the typeface that suits your stage or accessibility needs.
-- Type-to-search dropdowns, pinned favorites and hover help keep busy crews productive on set.
+All planning, inputs and exports stay on the device in front of you. Language
+choice, projects, custom equipment, favorites and runtime feedback live in your
+browser, and service worker updates are driven directly by this repository. Run
+the planner offline from disk or host it internally so every department uses the
+same audited version.
 
 ---
 
-## Quick Start
-
-1. Clone or download the repository.
-2. Open `index.html` in any modern Chromium, Firefox or Safari browser. No build step is required.
-3. Optionally serve the folder over HTTPS to install the service worker for offline updates. Any static file server works (`npx http-server -S` or similar).
-4. The app stores data in your browser. Use **Settings → Backup** to export JSON snapshots before switching machines.
-
----
-
-## Typical Workflow
-
-1. **Create or load a project.** Press Enter or `Ctrl+S` (`⌘S` on macOS) to save quickly. Automatic snapshots run every 10 minutes.
-2. **Select your camera, power and accessories.** Dropdowns filter as you type and favorites stay pinned.
-3. **Review power results.** Check wattage, draw, battery safety indicators and runtimes in the comparison panel.
-4. **Capture requirements.** Record crew roles, shooting days, scenarios and notes so every export carries the right context.
-5. **Generate deliverables.** Produce gear lists, printable overviews and shared project bundles, then restore them later with a single upload.
-
----
-
-## Interface Essentials
-
-- **Global search** (`/` or `Ctrl+K`/`⌘K`) jumps to any feature, selector or help topic—even when the side menu is collapsed.
-- **Help center** (`?`, `H`, `F1` or `Ctrl+/`) surfaces searchable guides, FAQs, shortcuts and optional hover help.
-- **Project diagram** visualizes connections; hold Shift while downloading to export a JPG snapshot instead of SVG.
-- **Battery comparison panel** reveals how each compatible pack performs and highlights overload risks.
-- **Gear list generator** turns selections into categorized tables with metadata, crew emails and scenario-driven additions.
-- **Offline indicator & force reload** badges show connectivity status and let you refresh cached assets without losing projects.
-
----
-
-## Data & Export Management
-
-- Projects, settings, gear lists, favorites and custom devices live in `localStorage`; backups and restores keep everything intact.
-- The Settings dialog offers hourly backup reminders, manual backups, one-click restore and a **Clear Local Cache** button.
-- Shared project files bundle selections, requirements, runtime feedback, gear lists and custom devices for handoff between teams.
-- Printable overviews include the project name, production details, optional custom logo and the generated gear list.
-- Automatic snapshots run in the background so it is easy to roll back to an earlier state.
-
----
-
-## Battery & Runtime Intelligence
-
-- Calculates total consumption, required battery counts for 10-hour days and the current draw each connection must supply.
-- Warns at 80 % usage and blocks unsafe loads when draw exceeds a battery's continuous or D‑Tap rating.
-- Weighted runtime estimates factor in temperature, resolution, frame rate, codec, Wi‑Fi usage, monitor brightness and each device's share of the total draw.
-- A runtime dashboard orders feedback by weight, shows contribution percentages and highlights outliers.
-- Supports user-submitted feedback to refine estimates for real-world shoots.
-
----
-
-## Customization & Accessibility
-
-- Toggle dark, pink or high-contrast themes and adjust typography without reloading the page.
-- Upload a custom logo for printed overviews, set default monitoring roles and configure project requirement defaults.
-- Keyboard-friendly navigation, focus-visible controls and skip links support screen readers and on-set accessibility needs.
-- Type-to-search selectors, pinned favorites and fork buttons for gear list rows accelerate repetitive data entry.
-
----
-
-## Keyboard Shortcuts
-
-| Action | Shortcut |
-| --- | --- |
-| Focus global search | `/`, `Ctrl+K`, `⌘K` |
-| Open help dialog | `?`, `H`, `F1`, `Ctrl+/` |
-| Save project | `Enter`, `Ctrl+S`, `⌘S` |
-| Toggle dark theme | `D` |
-| Toggle pink theme | `P` |
-| Force reload | Click the 🔄 icon in the header |
-
----
-
-## Development
-
-- Install dependencies with `npm install` (used for linting, tests and data scripts—no build step is required).
-- Run `npm run lint` and `npm run test` before committing changes. Targeted test suites are available via `npm run test:unit`, `npm run test:data`, `npm run test:dom` and `npm run test:script`.
-- Utility scripts include:
-  - `npm run check-consistency` to validate device data alignment.
-  - `npm run normalize` and `npm run unify-ports` to keep the catalog tidy.
-  - `npm run generate-schema` to refresh the device schema.
-
----
-
-## Translations
-
-Documentation is available in multiple languages, and the app automatically picks your browser language on first load. Switch anytime via the top-right language menu:
-
+## 🌍 Languages
 - 🇬🇧 [English](README.en.md)
 - 🇩🇪 [Deutsch](README.de.md)
 - 🇪🇸 [Español](README.es.md)
 - 🇮🇹 [Italiano](README.it.md)
 - 🇫🇷 [Français](README.fr.md)
 
-Want to help? Follow the [translation guide](docs/translation-guide.md) to add new locales for both the interface and documentation.
+The app automatically uses your browser language on first load, and you can switch the language in the top right corner. The choice is remembered for your next visit.
 
 ---
 
-## Contributing & Support
-
-Bug reports, feature ideas and data corrections are welcome. Open an issue or submit a pull request with as much detail as possible. If you discover incorrect runtimes or missing gear, include the project file or sample data so the catalog stays reliable.
+## 🆕 Recent Features
+- Accent and typography controls in Settings let you adjust the accent color, base font size and typeface alongside dark, pink and high contrast themes.
+- Keyboard shortcuts for the global search let you press / or Ctrl+K (⌘K on macOS) to focus the feature search instantly, even when it sits inside the collapsed mobile side menu.
+- Force reload button clears cached service worker files so the offline app refreshes without deleting saved projects or devices.
+- Star icons in every selector pin favorite cameras, batteries and accessories to the top of the list and keep them in backups.
+- Clear local cache button wipes stored projects and settings.
+- Gear list and printable overview display the project name for quick reference.
+- Upload a custom logo for printed overviews and backups.
+- Backups include favorites and create an automatic backup before restore.
+- Crew list entries now feature an email field.
+- High contrast theme option for improved readability.
+- Device forms populate category fields dynamically based on schema attributes.
+- Revamped interface design with improved contrast and spacing for a cleaner experience on any device.
+- Simplified project sharing – download a JSON project file that bundles selections, requirements, gear lists, runtime feedback and custom devices, then load it to restore the full setup.
+- Unique icons for required scenarios to distinguish project requirements.
+- Interactive project diagram that lets you drag devices, zoom, snap nodes to a grid and export the layout as SVG or JPG.
+- Playful pink accent theme that persists between visits.
+- Searchable help dialog with step-by-step sections and a FAQ; open with ?, H, F1 or Ctrl+/.
+- Contextual hover help for buttons, fields, dropdowns and headers.
+- Global search bar to jump to features, device selectors or help topics.
+- Support for cameras with V-, B- or Gold-Mount battery plates.
+- Submit user runtime feedback with temperature for better estimates.
+- Visual runtime weighting dashboard to inspect how settings influence each report, now sorted by weight and showing exact share percentages.
+- Generate gear lists to compile selected gear and project requirements.
+- Save project requirements with each project so gear lists retain full context.
+- Duplicate user entries in gear list forms using fork buttons to copy fields instantly.
 
 ---
 
-## License
+## 🔧 Features
 
-Cine Power Planner is released under the ISC License.
+### ✨ Expanded highlights
+
+- **Build complex rigs without guesswork.** Combine cameras, battery plates,
+  wireless links, monitors, motors and accessories while tracking total draw at
+  14.4 V/12 V (and 33.6 V/21.6 V for B‑Mount) plus realistic runtimes from
+  weighted field data. The battery comparison panel flags overloads before the
+  wrong kit goes on the truck.
+- **Keep every department aligned.** Save multiple projects with requirements,
+  crew contacts, scenarios and notes. Printable gear lists group equipment by
+  category, merge duplicates, surface technical metadata and include
+  scenario-driven accessories so camera, lighting and grip teams stay synced.
+- **Work confidently anywhere.** Open `index.html` directly or serve the folder
+  over HTTPS to enable the service worker. Offline caching preserves language,
+  themes, favorites and projects, and **Force reload** refreshes cached assets
+  without touching stored data.
+- **Tailor the planner to your crew.** Switch instantly between English,
+  Deutsch, Español, Italiano and Français, adjust font size and typeface, pick a
+  custom accent color, upload a print logo and toggle dark, pink or
+  high-contrast themes. Type-to-search selectors, pinned favorites, fork buttons
+  and hover help keep on-set workflows fast.
+
+### ✅ Project Management
+- Save, load and delete multiple camera projects (press Enter or Ctrl+S/⌘S to save quickly; the Save button stays disabled until a name is entered).
+- Automatic snapshots are created every 10 minutes while the planner is open, and the Settings dialog can trigger hourly backup exports as a reminder to archive data.
+- Download a JSON project file that bundles selections, requirements, gear lists, runtime feedback and custom devices; load it through the Shared Project picker to restore everything in one step.
+- Data is stored locally via `localStorage` and favorites are preserved in backups; use the dedicated **Clear Local Cache** button in Settings if you need to wipe cached projects and device edits.
+- Generate printable overviews for any saved project and add a custom logo so exports and backups match your production branding.
+- Save project requirements along with each project so gear lists retain full context.
+- Works fully offline with the installed service worker—language, theme, device data and favorites persist between sessions.
+- Responsive layout adapts seamlessly across desktops, tablets and phones.
+- Choose **V‑Mount**, **B‑Mount** or **Gold‑Mount** plates on supported cameras; the battery list adapts automatically.
+
+### 🧭 Interface Overview
+- **Quick reference:**
+  - **Global search** (`/` or `Ctrl+K`/`⌘K`) jumps to features, selectors or help
+    topics even when the side drawer is collapsed.
+  - **Help center** (`?`, `H`, `F1` or `Ctrl+/`) surfaces searchable guides,
+    FAQs, shortcuts and the optional hover-help mode.
+  - **Project diagram** visualizes connections; hold Shift when downloading to
+    save a JPG snapshot instead of SVG while seeing compatibility notices.
+  - **Battery comparison** reveals how compatible packs perform and highlights
+    overload risks before call time.
+  - **Gear list generator** outputs categorized tables with metadata, crew
+    emails and scenario-driven accessories ready for print or PDF.
+  - **Offline badge & Force reload** show connectivity status and refresh cached
+    assets without clearing projects.
+- A skip link and offline indicator keep the layout accessible on keyboard and touch devices—the badge appears whenever the browser loses its connection.
+- The global search bar jumps to features, device selectors or help topics; press Enter to activate the highlighted result, use / or Ctrl+K (⌘K on macOS) to focus it from anywhere (the side menu opens automatically on small screens) and press Escape or tap × to clear the query.
+- Top bar controls provide language switching, dark and pink theme toggles plus a Settings dialog that exposes accent color, font size, font family, high contrast and custom logo uploads alongside backup, restore and Clear Local Cache tools.
+- The Help button opens a searchable dialog with step-by-step sections, keyboard shortcuts, FAQs and an optional hover-help mode; it can also be triggered with ?, H, F1 or Ctrl+/ even while typing.
+- The Force reload button (🔄) clears cached service worker files so the offline app updates without deleting saved projects or custom devices.
+- On smaller screens a collapsible side menu mirrors every major section for quick navigation.
+
+### ♿ Customization & Accessibility
+- Theme preferences include dark mode, playful pink accents and a dedicated high contrast switch for improved readability.
+- Accent color, base font size and typeface changes apply instantly and persist in the browser, letting you match studio branding or accessibility needs.
+- Built-in keyboard shortcuts cover global search (/ or Ctrl+K/⌘K), help ( ?, H, F1, Ctrl+/ ), saving (Enter or Ctrl+S/⌘S), dark mode (D) and pink mode (P).
+- Hover-help mode turns every button, field, dropdown and header into an on-demand tooltip so new users can learn the interface quickly.
+- Type-to-search inputs, focus-visible controls and star icons beside selectors let you filter long lists quickly and pin favourite devices to the top.
+- Upload a custom logo for printouts, configure default monitoring roles and tweak project requirement presets so exports match your production branding.
+- Fork buttons duplicate gear list rows instantly, and pinned favourites keep go-to equipment at the top of selectors for faster data entry on set.
+
+### 📋 Gear List
+The generator turns your selections into a categorized packing list:
+
+- Click **Generate Gear List** to compile chosen gear and project requirements into a table.
+- The table updates automatically when device selections or requirements change.
+- Items are grouped by category (camera, lens, power, monitoring, rigging, grip, accessories, consumables) and duplicates are merged with counts.
+- Required cables, rigging and accessories are added for monitors, motors, gimbals and weather scenarios.
+- Scenario selections inject related gear:
+  - *Handheld* + *Easyrig* inserts a telescopic handle for stable support.
+  - *Gimbal* adds the selected gimbal, friction arms, spigots and sunshades or filter kits.
+  - *Outdoor* supplies spigots, umbrellas and CapIt rain covers.
+  - *Vehicle* and *Steadicam* scenarios pack in mounts, isolation arms and suction gear where applicable.
+- Lens selections append front diameter, weight, rod data and minimum focus, add lens supports and matte box adapters, and warn about incompatible rod standards.
+- Battery rows mirror counts from the power calculator and include hotswap plates or chosen hotswap devices when required.
+- Monitoring preferences assign default monitors for each role (Director, DoP, Focus, etc.) with cable sets and wireless receivers.
+- The **Project Requirements** form feeds the list:
+  - **Project Name**, **Production Company**, **Rental House** and **DoP** appear in the heading of the printed requirements.
+  - **Crew** entries capture names, roles and email addresses so contact info travels with the project.
+  - **Prep Days** and **Shooting Days** supply schedule notes and, when paired with outdoor scenarios, suggest weather gear.
+  - **Required Scenarios** append matching rigging, gimbals and weather protection.
+  - **Camera Handle** and **Viewfinder Extension** insert the chosen handle parts or extension brackets.
+  - **Matte Box** and **Filter** choices inject the selected system with any needed trays, clamp adapters or filters.
+  - **Monitoring Configuration**, **Video Distribution** and **Viewfinder** settings add monitors, cables and overlays for each role.
+  - **User Button** selections and **Tripod Preferences** are listed for quick reference.
+- Items inside each category are sorted alphabetically and display tooltips on hover.
+- The gear list is included in printable overviews and shared project files.
+- Gear lists save automatically with the project and are included in shared project files and backups.
+- **Delete Gear List** removes the saved list and hides the output.
+- Gear list forms provide fork buttons to duplicate user entries instantly.
+
+### 📦 Device Categories
+- **Camera** (1)
+- **Monitor** (optional)
+- **Wireless Transmitter** (optional)
+- **FIZ Motors** (0–4)
+- **FIZ Controllers** (0–4)
+- **Distance Sensor** (0–1)
+- **Battery Plate** (only on cameras that accept V‑ or B‑Mount)
+- **V‑Mount Battery** (0–1)
+
+### ⚙️ Power Calculations
+- Total consumption in watts
+- Current draw at 14.4 V and 12 V
+- Estimated battery runtime in hours using weighted user feedback
+- Required battery count for a 10 h shoot (incl. spare)
+- Temperature note to adjust runtime for hot or cold conditions
+
+### 🔋 Battery Output Check
+- Warns if current draw exceeds the battery output (Pin or D‑Tap)
+- Indicates when draw is close to the limit (80 % usage)
+
+### 📊 Battery Comparison (optional)
+- Compare runtime estimates across all batteries
+- Visual bar graph for quick reference
+
+### 🖼 Project Diagram
+- Visualize power and video connections for the selected devices
+- Warns when FIZ brands are incompatible
+- Drag nodes to rearrange the layout, zoom with the buttons and download the diagram as SVG or JPG
+- Hold Shift while clicking Download to export a JPG snapshot instead of SVG
+- Hover or tap devices to see popup details
+- Uses [OpenMoji](https://openmoji.org/) icons when online, falling back to emoji:
+  🔋 battery, 🎥 camera, 🖥️ monitor, 📡 video, ⚙️ motor,
+  🎮 controller, 📐 distance, 🎮 handle and 🔌 battery plate
+
+### 🧮 Runtime data weighting
+- User-submitted battery runtimes refine the runtime estimate.
+- Each entry is adjusted for temperature, scaling from ×1 at 25 °C to:
+  - ×1.25 at 0 °C
+  - ×1.6 at −10 °C
+  - ×2 at −20 °C
+- Camera settings influence the weight:
+  - Resolution multipliers: ≥12K ×3, ≥8K ×2, ≥4K ×1.5, ≥1080p ×1, lower scaled to 1080p
+  - Frame rate scales linearly from 24 fps (e.g. 48 fps = ×2)
+  - Wi‑Fi enabled adds 10 %
+  - Codec factors: RAW/BRAW/ARRIRAW/R3D/CinemaDNG/Canon RAW/X‑OCN ×1; ProRes ×1.1; DNx/AVID ×1.2; All‑Intra ×1.3; H.264/AVC ×1.5; H.265/HEVC ×1.7
+  - Monitor entries below the specified brightness are weighted by their brightness ratio
+- The final weight reflects each device's share of the total power draw, so matching projects count more.
+- The weighted average is used once at least three entries are available.
+- A dashboard orders entries by weight and displays each one's share percentage for quick comparison.
+
+### 🔍 Search & Filtering
+- Type inside dropdowns to quickly find entries
+- Filter device lists with a search box
+- Use the global search bar at the top to jump to features, devices or help topics; press Enter to navigate, use / or Ctrl+K (⌘K on macOS) to focus it instantly and press Escape or × to clear.
+- Press '/' or Ctrl+F (⌘F on macOS) to focus the nearest search box instantly.
+- Click the star beside any selector to pin favourites so they stay at the top of the list and sync with backups.
+
+### 🛠 Device Database Editor
+- Add, edit or delete devices in all categories
+- Import or export the full database as JSON
+- Revert to the default database from `data.js`
+
+### 🌓 Dark Mode
+- Toggle via the moon button next to the language selector.
+- Preference is stored in your browser.
+
+### 🦄 Pink Mode
+- Click the unicorn button or press **P** for a playful pink accent.
+- Works in both light and dark themes and persists between visits.
+
+### ⚫ High Contrast Mode
+- Toggle a high contrast theme for improved readability.
+
+### 📝 User Runtime Feedback
+- Click <strong>Submit User Runtime Feedback</strong> below the runtime to add your own measurement.
+- Optionally include temperature for more accurate weighting.
+- Entries are saved in your browser and improve future estimates.
+- A dashboard orders submissions by weight, shows contribution percentages and
+  highlights outliers so crews can review field data quickly.
+
+### ❓ Searchable Help
+- Open via the <strong>?</strong> button or press <kbd>?</kbd>, <kbd>H</kbd>, <kbd>F1</kbd> or <kbd>Ctrl+/</kbd>.
+- Use the search field to filter topics instantly; the query resets when the dialog closes.
+- Close with <kbd>Escape</kbd> or by clicking outside the dialog.
+
+---
+
+## ▶️ How to Use
+1. **Launch App:** Open `index.html` in any modern browser – no server required.
+2. **Explore the Top Bar:** Switch language, toggle dark or pink themes, open Settings for accent and typography options, and start the searchable help dialog with ? or Ctrl+/.
+3. **Select Devices:** Choose gear from each category using the dropdowns—type to filter, click the star to pin favourites and let scenario presets fill in accessories automatically.
+4. **View Calculations:** See total draw, current and runtime once a battery is selected; warnings highlight when output limits are exceeded.
+5. **Save & Share Projects:** Name and save your configuration, auto-backups capture snapshots, and the Share button exports a JSON bundle for collaborators.
+6. **Generate Gear Lists:** Press **Generate Gear List** to turn project requirements into a categorized packing list with tooltips and accessory packs.
+7. **Manage Device Data:** Click “Edit Device Data…” to open the database editor, modify devices, export/import JSON or revert to the defaults.
+8. **Submit Runtime Feedback:** Use “Submit User Runtime Feedback” to record field measurements and refine weighted estimates.
+
+## 📱 Install as an App
+
+The planner is a Progressive Web App and can be installed directly from your browser:
+
+- **Chrome/Edge (desktop):** Click the install icon in the address bar.
+- **Android:** Open the browser menu and choose *Add to Home Screen*.
+- **iOS/iPadOS Safari:** Tap the *Share* button and select *Add to Home Screen*.
+
+Once installed, the app launches from your home screen, works offline and updates itself automatically.
+
+## 📡 Offline Use & Data Storage
+
+Serving the app over HTTP(S) installs a service worker that caches every file
+so Cine Power Planner works fully offline and updates in the background. Projects,
+runtime submissions and preferences (language, theme, pink mode and saved gear
+lists) live in your browser's `localStorage`. Clearing the site's data in the
+browser removes all stored information, and the Settings dialog includes a
+**Clear Local Cache** button for the same one-click cleanup. The header shows an
+offline badge whenever connectivity drops, and the 🔄 **Force reload** action
+refreshes cached assets without disturbing saved projects.
+
+---
+
+## 🗂️ File Structure
+```bash
+index.html       # Main HTML layout
+style.css        # Styles and layout
+script.js        # Application logic
+data.js          # Default device list
+storage.js       # LocalStorage helpers
+README.*.md      # Documentation in different languages
+checkConsistency.js  # Verifies required fields in device data
+normalizeData.js     # Cleans entries and unifies connector names
+generateSchema.js    # Rebuilds schema.json from data.js
+unifyPorts.js        # Harmonizes legacy port names
+tests/               # Jest test suite
+```
+Fonts are bundled locally via `fonts.css`, so once the assets are cached the application works entirely offline.
+
+## 🛠️ Development
+Requires Node.js 18 or later.
+
+```bash
+npm install
+npm run lint     # run ESLint alone
+npm test         # runs linting, data checks and Jest tests
+```
+
+After editing device data, regenerate the normalized database:
+
+```bash
+npm run normalize
+npm run unify-ports
+npm run check-consistency
+npm run generate-schema
+```
+
+Add `--help` to any of the above scripts for usage details.
+
+## 🤝 Contributing
+Contributions are welcome! Feel free to open an issue or submit a pull request on GitHub.
+When reporting data corrections, attaching project backups or runtime samples
+helps keep the catalog accurate for everyone.

--- a/README.en.md
+++ b/README.en.md
@@ -1,259 +1,138 @@
-# 🎥 Cine Power Planner
+# Cine Power Planner
 
-This browser based tool helps plan professional camera projects powered by V‑Mount, B‑Mount or Gold-Mount batteries. It calculates **total power consumption**, **current draw** (at 14.4 V and 12 V) and **estimated battery runtime** while checking that the battery can safely supply the required power.
+![Cine Power Planner icon](icon.svg)
+
+Cine Power Planner is an offline-capable web application for planning professional camera rigs that run on V‑Mount, B‑Mount or Gold‑Mount batteries. It calculates total power draw, checks that every pack can safely deliver the current you need, estimates realistic runtimes from weighted field data and keeps your crew, scenarios and gear lists together so nothing gets lost between departments.
 
 ---
 
-## 🌍 Languages
+## Highlights
+
+### Plan complex builds without guesswork
+- Combine cameras, battery plates, wireless links, monitors, motors and accessories while seeing total wattage, current draw at 14.4 V/12 V (and 33.6 V/21.6 V for B‑Mount) plus expected runtime.
+- Compare compatible batteries side-by-side and get warnings when draw exceeds D‑Tap or pin limits.
+- Visualize rigs with an interactive diagram that supports drag, zoom, SVG/JPG export and compatibility notices.
+
+### Keep every department aligned
+- Save multiple projects with requirements, crew contacts, shooting scenarios and custom notes.
+- Generate printable gear lists that group kit by category, merge duplicates, include technical metadata and reflect scenario-driven accessories.
+- Share JSON bundles that contain device selections, runtime feedback, gear lists and custom devices for an end-to-end restore.
+
+### Travel-ready and private
+- Works entirely in the browser—open `index.html` directly or host the repository over HTTPS to enable the service worker.
+- Offline caching keeps language, theme, favorites and projects available everywhere without sending data to external servers.
+- Clear the local cache or trigger a force reload to refresh cached assets without touching saved projects.
+
+### Tailor it to your team
+- Switch instantly between English, Deutsch, Español, Italiano and Français; the planner remembers the last language used.
+- Choose dark, pink or high-contrast themes, set a custom accent color, adjust font size and pick the typeface that suits your stage or accessibility needs.
+- Type-to-search dropdowns, pinned favorites and hover help keep busy crews productive on set.
+
+---
+
+## Quick Start
+
+1. Clone or download the repository.
+2. Open `index.html` in any modern Chromium, Firefox or Safari browser. No build step is required.
+3. Optionally serve the folder over HTTPS to install the service worker for offline updates. Any static file server works (`npx http-server -S` or similar).
+4. The app stores data in your browser. Use **Settings → Backup** to export JSON snapshots before switching machines.
+
+---
+
+## Typical Workflow
+
+1. **Create or load a project.** Press Enter or `Ctrl+S` (`⌘S` on macOS) to save quickly. Automatic snapshots run every 10 minutes.
+2. **Select your camera, power and accessories.** Dropdowns filter as you type and favorites stay pinned.
+3. **Review power results.** Check wattage, draw, battery safety indicators and runtimes in the comparison panel.
+4. **Capture requirements.** Record crew roles, shooting days, scenarios and notes so every export carries the right context.
+5. **Generate deliverables.** Produce gear lists, printable overviews and shared project bundles, then restore them later with a single upload.
+
+---
+
+## Interface Essentials
+
+- **Global search** (`/` or `Ctrl+K`/`⌘K`) jumps to any feature, selector or help topic—even when the side menu is collapsed.
+- **Help center** (`?`, `H`, `F1` or `Ctrl+/`) surfaces searchable guides, FAQs, shortcuts and optional hover help.
+- **Project diagram** visualizes connections; hold Shift while downloading to export a JPG snapshot instead of SVG.
+- **Battery comparison panel** reveals how each compatible pack performs and highlights overload risks.
+- **Gear list generator** turns selections into categorized tables with metadata, crew emails and scenario-driven additions.
+- **Offline indicator & force reload** badges show connectivity status and let you refresh cached assets without losing projects.
+
+---
+
+## Data & Export Management
+
+- Projects, settings, gear lists, favorites and custom devices live in `localStorage`; backups and restores keep everything intact.
+- The Settings dialog offers hourly backup reminders, manual backups, one-click restore and a **Clear Local Cache** button.
+- Shared project files bundle selections, requirements, runtime feedback, gear lists and custom devices for handoff between teams.
+- Printable overviews include the project name, production details, optional custom logo and the generated gear list.
+- Automatic snapshots run in the background so it is easy to roll back to an earlier state.
+
+---
+
+## Battery & Runtime Intelligence
+
+- Calculates total consumption, required battery counts for 10-hour days and the current draw each connection must supply.
+- Warns at 80 % usage and blocks unsafe loads when draw exceeds a battery's continuous or D‑Tap rating.
+- Weighted runtime estimates factor in temperature, resolution, frame rate, codec, Wi‑Fi usage, monitor brightness and each device's share of the total draw.
+- A runtime dashboard orders feedback by weight, shows contribution percentages and highlights outliers.
+- Supports user-submitted feedback to refine estimates for real-world shoots.
+
+---
+
+## Customization & Accessibility
+
+- Toggle dark, pink or high-contrast themes and adjust typography without reloading the page.
+- Upload a custom logo for printed overviews, set default monitoring roles and configure project requirement defaults.
+- Keyboard-friendly navigation, focus-visible controls and skip links support screen readers and on-set accessibility needs.
+- Type-to-search selectors, pinned favorites and fork buttons for gear list rows accelerate repetitive data entry.
+
+---
+
+## Keyboard Shortcuts
+
+| Action | Shortcut |
+| --- | --- |
+| Focus global search | `/`, `Ctrl+K`, `⌘K` |
+| Open help dialog | `?`, `H`, `F1`, `Ctrl+/` |
+| Save project | `Enter`, `Ctrl+S`, `⌘S` |
+| Toggle dark theme | `D` |
+| Toggle pink theme | `P` |
+| Force reload | Click the 🔄 icon in the header |
+
+---
+
+## Development
+
+- Install dependencies with `npm install` (used for linting, tests and data scripts—no build step is required).
+- Run `npm run lint` and `npm run test` before committing changes. Targeted test suites are available via `npm run test:unit`, `npm run test:data`, `npm run test:dom` and `npm run test:script`.
+- Utility scripts include:
+  - `npm run check-consistency` to validate device data alignment.
+  - `npm run normalize` and `npm run unify-ports` to keep the catalog tidy.
+  - `npm run generate-schema` to refresh the device schema.
+
+---
+
+## Translations
+
+Documentation is available in multiple languages, and the app automatically picks your browser language on first load. Switch anytime via the top-right language menu:
+
 - 🇬🇧 [English](README.en.md)
 - 🇩🇪 [Deutsch](README.de.md)
 - 🇪🇸 [Español](README.es.md)
 - 🇮🇹 [Italiano](README.it.md)
 - 🇫🇷 [Français](README.fr.md)
 
-The app automatically uses your browser language on first load, and you can switch the language in the top right corner. The choice is remembered for your next visit.
+Want to help? Follow the [translation guide](docs/translation-guide.md) to add new locales for both the interface and documentation.
 
 ---
 
-## 🆕 Recent Features
-- Accent and typography controls in Settings let you adjust the accent color, base font size and typeface alongside dark, pink and high contrast themes.
-- Keyboard shortcuts for the global search let you press / or Ctrl+K (⌘K on macOS) to focus the feature search instantly, even when it sits inside the collapsed mobile side menu.
-- Force reload button clears cached service worker files so the offline app refreshes without deleting saved projects or devices.
-- Star icons in every selector pin favorite cameras, batteries and accessories to the top of the list and keep them in backups.
-- Clear local cache button wipes stored projects and settings.
-- Gear list and printable overview display the project name for quick reference.
-- Upload a custom logo for printed overviews and backups.
-- Backups include favorites and create an automatic backup before restore.
-- Crew list entries now feature an email field.
-- High contrast theme option for improved readability.
-- Device forms populate category fields dynamically based on schema attributes.
-- Revamped interface design with improved contrast and spacing for a cleaner experience on any device.
-- Simplified project sharing – download a JSON project file that bundles selections, requirements, gear lists, runtime feedback and custom devices, then load it to restore the full setup.
-- Unique icons for required scenarios to distinguish project requirements.
-- Interactive project diagram that lets you drag devices, zoom, snap nodes to a grid and export the layout as SVG or JPG.
-- Playful pink accent theme that persists between visits.
-- Searchable help dialog with step-by-step sections and a FAQ; open with ?, H, F1 or Ctrl+/.
-- Contextual hover help for buttons, fields, dropdowns and headers.
-- Global search bar to jump to features, device selectors or help topics.
-- Support for cameras with V-, B- or Gold-Mount battery plates.
-- Submit user runtime feedback with temperature for better estimates.
-- Visual runtime weighting dashboard to inspect how settings influence each report, now sorted by weight and showing exact share percentages.
-- Generate gear lists to compile selected gear and project requirements.
-- Save project requirements with each project so gear lists retain full context.
-- Duplicate user entries in gear list forms using fork buttons to copy fields instantly.
+## Contributing & Support
+
+Bug reports, feature ideas and data corrections are welcome. Open an issue or submit a pull request with as much detail as possible. If you discover incorrect runtimes or missing gear, include the project file or sample data so the catalog stays reliable.
 
 ---
 
-## 🔧 Features
+## License
 
-### ✅ Project Management
-- Save, load and delete multiple camera projects (press Enter or Ctrl+S/⌘S to save quickly; the Save button stays disabled until a name is entered).
-- Automatic snapshots are created every 10 minutes while the planner is open, and the Settings dialog can trigger hourly backup exports as a reminder to archive data.
-- Download a JSON project file that bundles selections, requirements, gear lists, runtime feedback and custom devices; load it through the Shared Project picker to restore everything in one step.
-- Data is stored locally via `localStorage` and favorites are preserved in backups; use the dedicated **Clear Local Cache** button in Settings if you need to wipe cached projects and device edits.
-- Generate printable overviews for any saved project and add a custom logo so exports and backups match your production branding.
-- Save project requirements along with each project so gear lists retain full context.
-- Works fully offline with the installed service worker—language, theme, device data and favorites persist between sessions.
-- Responsive layout adapts seamlessly across desktops, tablets and phones.
-- Choose **V‑Mount**, **B‑Mount** or **Gold‑Mount** plates on supported cameras; the battery list adapts automatically.
-
-### 🧭 Interface Overview
-- A skip link and offline indicator keep the layout accessible on keyboard and touch devices—the badge appears whenever the browser loses its connection.
-- The global search bar jumps to features, device selectors or help topics; press Enter to activate the highlighted result, use / or Ctrl+K (⌘K on macOS) to focus it from anywhere (the side menu opens automatically on small screens) and press Escape or tap × to clear the query.
-- Top bar controls provide language switching, dark and pink theme toggles plus a Settings dialog that exposes accent color, font size, font family, high contrast and custom logo uploads alongside backup, restore and Clear Local Cache tools.
-- The Help button opens a searchable dialog with step-by-step sections, keyboard shortcuts, FAQs and an optional hover-help mode; it can also be triggered with ?, H, F1 or Ctrl+/ even while typing.
-- The Force reload button (🔄) clears cached service worker files so the offline app updates without deleting saved projects or custom devices.
-- On smaller screens a collapsible side menu mirrors every major section for quick navigation.
-
-### ♿ Customization & Accessibility
-- Theme preferences include dark mode, playful pink accents and a dedicated high contrast switch for improved readability.
-- Accent color, base font size and typeface changes apply instantly and persist in the browser, letting you match studio branding or accessibility needs.
-- Built-in keyboard shortcuts cover global search (/ or Ctrl+K/⌘K), help ( ?, H, F1, Ctrl+/ ), saving (Enter or Ctrl+S/⌘S), dark mode (D) and pink mode (P).
-- Hover-help mode turns every button, field, dropdown and header into an on-demand tooltip so new users can learn the interface quickly.
-- Type-to-search inputs, focus-visible controls and star icons beside selectors let you filter long lists quickly and pin favourite devices to the top.
-
-### 📋 Gear List
-The generator turns your selections into a categorized packing list:
-
-- Click **Generate Gear List** to compile chosen gear and project requirements into a table.
-- The table updates automatically when device selections or requirements change.
-- Items are grouped by category (camera, lens, power, monitoring, rigging, grip, accessories, consumables) and duplicates are merged with counts.
-- Required cables, rigging and accessories are added for monitors, motors, gimbals and weather scenarios.
-- Scenario selections inject related gear:
-  - *Handheld* + *Easyrig* inserts a telescopic handle for stable support.
-  - *Gimbal* adds the selected gimbal, friction arms, spigots and sunshades or filter kits.
-  - *Outdoor* supplies spigots, umbrellas and CapIt rain covers.
-  - *Vehicle* and *Steadicam* scenarios pack in mounts, isolation arms and suction gear where applicable.
-- Lens selections append front diameter, weight, rod data and minimum focus, add lens supports and matte box adapters, and warn about incompatible rod standards.
-- Battery rows mirror counts from the power calculator and include hotswap plates or chosen hotswap devices when required.
-- Monitoring preferences assign default monitors for each role (Director, DoP, Focus, etc.) with cable sets and wireless receivers.
-- The **Project Requirements** form feeds the list:
-  - **Project Name**, **Production Company**, **Rental House** and **DoP** appear in the heading of the printed requirements.
-  - **Crew** entries capture names, roles and email addresses so contact info travels with the project.
-  - **Prep Days** and **Shooting Days** supply schedule notes and, when paired with outdoor scenarios, suggest weather gear.
-  - **Required Scenarios** append matching rigging, gimbals and weather protection.
-  - **Camera Handle** and **Viewfinder Extension** insert the chosen handle parts or extension brackets.
-  - **Matte Box** and **Filter** choices inject the selected system with any needed trays, clamp adapters or filters.
-  - **Monitoring Configuration**, **Video Distribution** and **Viewfinder** settings add monitors, cables and overlays for each role.
-  - **User Button** selections and **Tripod Preferences** are listed for quick reference.
-- Items inside each category are sorted alphabetically and display tooltips on hover.
-- The gear list is included in printable overviews and shared project files.
-- Gear lists save automatically with the project and are included in shared project files and backups.
-- **Delete Gear List** removes the saved list and hides the output.
-- Gear list forms provide fork buttons to duplicate user entries instantly.
-
-### 📦 Device Categories
-- **Camera** (1)
-- **Monitor** (optional)
-- **Wireless Transmitter** (optional)
-- **FIZ Motors** (0–4)
-- **FIZ Controllers** (0–4)
-- **Distance Sensor** (0–1)
-- **Battery Plate** (only on cameras that accept V‑ or B‑Mount)
-- **V‑Mount Battery** (0–1)
-
-### ⚙️ Power Calculations
-- Total consumption in watts
-- Current draw at 14.4 V and 12 V
-- Estimated battery runtime in hours using weighted user feedback
-- Required battery count for a 10 h shoot (incl. spare)
-- Temperature note to adjust runtime for hot or cold conditions
-
-### 🔋 Battery Output Check
-- Warns if current draw exceeds the battery output (Pin or D‑Tap)
-- Indicates when draw is close to the limit (80 % usage)
-
-### 📊 Battery Comparison (optional)
-- Compare runtime estimates across all batteries
-- Visual bar graph for quick reference
-
-### 🖼 Project Diagram
-- Visualize power and video connections for the selected devices
-- Warns when FIZ brands are incompatible
-- Drag nodes to rearrange the layout, zoom with the buttons and download the diagram as SVG or JPG
-- Hold Shift while clicking Download to export a JPG snapshot instead of SVG
-- Hover or tap devices to see popup details
-- Uses [OpenMoji](https://openmoji.org/) icons when online, falling back to emoji:
-  🔋 battery, 🎥 camera, 🖥️ monitor, 📡 video, ⚙️ motor,
-  🎮 controller, 📐 distance, 🎮 handle and 🔌 battery plate
-
-### 🧮 Runtime data weighting
-- User-submitted battery runtimes refine the runtime estimate.
-- Each entry is adjusted for temperature, scaling from ×1 at 25 °C to:
-  - ×1.25 at 0 °C
-  - ×1.6 at −10 °C
-  - ×2 at −20 °C
-- Camera settings influence the weight:
-  - Resolution multipliers: ≥12K ×3, ≥8K ×2, ≥4K ×1.5, ≥1080p ×1, lower scaled to 1080p
-  - Frame rate scales linearly from 24 fps (e.g. 48 fps = ×2)
-  - Wi‑Fi enabled adds 10 %
-  - Codec factors: RAW/BRAW/ARRIRAW/R3D/CinemaDNG/Canon RAW/X‑OCN ×1; ProRes ×1.1; DNx/AVID ×1.2; All‑Intra ×1.3; H.264/AVC ×1.5; H.265/HEVC ×1.7
-  - Monitor entries below the specified brightness are weighted by their brightness ratio
-- The final weight reflects each device's share of the total power draw, so matching projects count more.
-- The weighted average is used once at least three entries are available.
-- A dashboard orders entries by weight and displays each one's share percentage for quick comparison.
-
-### 🔍 Search & Filtering
-- Type inside dropdowns to quickly find entries
-- Filter device lists with a search box
-- Use the global search bar at the top to jump to features, devices or help topics; press Enter to navigate, use / or Ctrl+K (⌘K on macOS) to focus it instantly and press Escape or × to clear.
-- Press '/' or Ctrl+F (⌘F on macOS) to focus the nearest search box instantly.
-- Click the star beside any selector to pin favourites so they stay at the top of the list and sync with backups.
-
-### 🛠 Device Database Editor
-- Add, edit or delete devices in all categories
-- Import or export the full database as JSON
-- Revert to the default database from `data.js`
-
-### 🌓 Dark Mode
-- Toggle via the moon button next to the language selector.
-- Preference is stored in your browser.
-
-### 🦄 Pink Mode
-- Click the unicorn button or press **P** for a playful pink accent.
-- Works in both light and dark themes and persists between visits.
-
-### ⚫ High Contrast Mode
-- Toggle a high contrast theme for improved readability.
-
-### 📝 User Runtime Feedback
-- Click <strong>Submit User Runtime Feedback</strong> below the runtime to add your own measurement.
-- Optionally include temperature for more accurate weighting.
-- Entries are saved in your browser and improve future estimates.
-
-### ❓ Searchable Help
-- Open via the <strong>?</strong> button or press <kbd>?</kbd>, <kbd>H</kbd>, <kbd>F1</kbd> or <kbd>Ctrl+/</kbd>.
-- Use the search field to filter topics instantly; the query resets when the dialog closes.
-- Close with <kbd>Escape</kbd> or by clicking outside the dialog.
-
----
-
-## ▶️ How to Use
-1. **Launch App:** Open `index.html` in any modern browser – no server required.
-2. **Explore the Top Bar:** Switch language, toggle dark or pink themes, open Settings for accent and typography options, and start the searchable help dialog with ? or Ctrl+/.
-3. **Select Devices:** Choose gear from each category using the dropdowns—type to filter, click the star to pin favourites and let scenario presets fill in accessories automatically.
-4. **View Calculations:** See total draw, current and runtime once a battery is selected; warnings highlight when output limits are exceeded.
-5. **Save & Share Projects:** Name and save your configuration, auto-backups capture snapshots, and the Share button exports a JSON bundle for collaborators.
-6. **Generate Gear Lists:** Press **Generate Gear List** to turn project requirements into a categorized packing list with tooltips and accessory packs.
-7. **Manage Device Data:** Click “Edit Device Data…” to open the database editor, modify devices, export/import JSON or revert to the defaults.
-8. **Submit Runtime Feedback:** Use “Submit User Runtime Feedback” to record field measurements and refine weighted estimates.
-
-## 📱 Install as an App
-
-The planner is a Progressive Web App and can be installed directly from your browser:
-
-- **Chrome/Edge (desktop):** Click the install icon in the address bar.
-- **Android:** Open the browser menu and choose *Add to Home Screen*.
-- **iOS/iPadOS Safari:** Tap the *Share* button and select *Add to Home Screen*.
-
-Once installed, the app launches from your home screen, works offline and updates itself automatically.
-
-## 📡 Offline Use & Data Storage
-
-Serving the app over HTTP(S) installs a service worker that caches every file
-so Cine Power Planner works fully offline and updates in the background. Projects,
-runtime submissions and preferences (language, theme, pink mode and saved gear
-lists) live in your browser's `localStorage`. Clearing the site's data in the
-browser removes all stored information, and the Settings dialog includes a
-**Clear Local Cache** button for the same one-click cleanup.
-
----
-
-## 🗂️ File Structure
-```bash
-index.html       # Main HTML layout
-style.css        # Styles and layout
-script.js        # Application logic
-data.js          # Default device list
-storage.js       # LocalStorage helpers
-README.*.md      # Documentation in different languages
-checkConsistency.js  # Verifies required fields in device data
-normalizeData.js     # Cleans entries and unifies connector names
-generateSchema.js    # Rebuilds schema.json from data.js
-unifyPorts.js        # Harmonizes legacy port names
-tests/               # Jest test suite
-```
-Fonts are bundled locally via `fonts.css`, so once the assets are cached the application works entirely offline.
-
-## 🛠️ Development
-Requires Node.js 18 or later.
-
-```bash
-npm install
-npm run lint     # run ESLint alone
-npm test         # runs linting, data checks and Jest tests
-```
-
-After editing device data, regenerate the normalized database:
-
-```bash
-npm run normalize
-npm run unify-ports
-npm run check-consistency
-npm run generate-schema
-```
-
-Add `--help` to any of the above scripts for usage details.
-
-## 🤝 Contributing
-Contributions are welcome! Feel free to open an issue or submit a pull request on GitHub.
+Cine Power Planner is released under the ISC License.

--- a/README.es.md
+++ b/README.es.md
@@ -1,252 +1,138 @@
-# 🎥 Cine Power Planner
+# Cine Power Planner
 
-Esta herramienta basada en el navegador ayuda a planificar proyectos de cámara profesionales alimentados con baterías V‑Mount, B‑Mount o Gold-Mount. Calcula el **consumo total de energía**, la **corriente demandada** (a 14,4 V y 12 V) y la **autonomía estimada de la batería**, al tiempo que comprueba que el paquete puede suministrar la potencia necesaria.
+![Icono de Cine Power Planner](icon.svg)
+
+Cine Power Planner es una aplicación web con funcionamiento sin conexión para planificar rigs de cámara profesionales alimentados por baterías V‑Mount, B‑Mount o Gold‑Mount. Calcula el consumo total, comprueba que cada batería pueda suministrar con seguridad la corriente necesaria, estima autonomías realistas a partir de datos de campo ponderados y mantiene unidas a la vez a la crew, los escenarios y las listas de equipo para que ninguna información se pierda entre departamentos.
 
 ---
 
-## 🌍 Idiomas
+## Destacados
+
+### Diseña configuraciones complejas sin improvisar
+- Combina cámaras, placas de batería, enlaces inalámbricos, monitores, motores y accesorios mientras ves la potencia total, la corriente a 14,4 V/12 V (y 33,6 V/21,6 V para B‑Mount) y el tiempo de funcionamiento estimado.
+- Compara baterías compatibles en paralelo y recibe avisos cuando la demanda supera los límites de D‑Tap o de pines.
+- Visualiza los rigs con un diagrama interactivo con arrastre, zoom, exportación SVG/JPG y avisos de compatibilidad.
+
+### Mantén a todos los departamentos alineados
+- Guarda varios proyectos con requisitos, contactos de la crew, escenarios de rodaje y notas personalizadas.
+- Genera listas de equipo listas para imprimir que agrupan el material por categoría, combinan duplicados, incluyen metadatos técnicos y añaden accesorios según el escenario.
+- Comparte paquetes JSON que contienen selecciones de dispositivos, feedback de autonomía, listas de equipo y dispositivos personalizados para restaurar todo de principio a fin.
+
+### Lista para viajar y privada
+- Funciona por completo en el navegador: abre `index.html` directamente o aloja el repositorio mediante HTTPS para activar el service worker.
+- La caché sin conexión conserva idioma, tema, favoritos y proyectos disponibles en cualquier lugar sin enviar datos a servidores externos.
+- Vacía la caché local o usa el botón de recarga forzada para actualizar archivos en caché sin tocar tus proyectos.
+
+### Adáptala a tu equipo
+- Cambia al instante entre English, Deutsch, Español, Italiano y Français; la aplicación recuerda el último idioma utilizado.
+- Elige temas oscuro, rosa o de alto contraste, define un color de acento, ajusta el tamaño de fuente y selecciona la tipografía que mejor se adapte a tu marca o requisitos de accesibilidad.
+- Los desplegables con búsqueda, los favoritos fijados y la ayuda al pasar el cursor mantienen productiva a la crew en el set.
+
+---
+
+## Puesta en marcha
+
+1. Clona o descarga el repositorio.
+2. Abre `index.html` en un navegador moderno (Chromium, Firefox o Safari). No es necesario compilar nada.
+3. Opcional: sirve la carpeta mediante HTTPS para instalar el service worker y recibir actualizaciones sin conexión. Cualquier servidor estático funciona (`npx http-server -S`, por ejemplo).
+4. La aplicación almacena los datos en tu navegador. Usa **Ajustes → Copia de seguridad** para exportar instantáneas JSON antes de cambiar de equipo.
+
+---
+
+## Flujo de trabajo habitual
+
+1. **Crea o carga un proyecto.** Pulsa Intro o `Ctrl+S` (`⌘S` en macOS) para guardar al instante. Se generan instantáneas automáticas cada 10 minutos.
+2. **Selecciona cámara, alimentación y accesorios.** Los desplegables se filtran mientras escribes y los favoritos permanecen anclados.
+3. **Revisa los resultados de potencia.** Consulta vatios, corriente, avisos de seguridad de batería y autonomías en el panel comparativo.
+4. **Registra los requisitos.** Documenta roles de la crew, días de rodaje, escenarios y notas para que cada exportación incluya el contexto adecuado.
+5. **Genera entregables.** Produce listas de equipo, vistas imprimibles y paquetes de proyecto compartidos y restáuralos más adelante con una sola subida.
+
+---
+
+## Elementos clave de la interfaz
+
+- **Búsqueda global** (`/` o `Ctrl+K`/`⌘K`) te lleva a cualquier función, selector o tema de ayuda incluso con el menú lateral plegado.
+- **Centro de ayuda** (`?`, `H`, `F1` o `Ctrl+/`) ofrece guías buscables, preguntas frecuentes, atajos y ayuda contextual opcional.
+- **Diagrama del proyecto** visualiza conexiones; mantén pulsada Mayús al descargar para exportar un JPG en lugar de SVG.
+- **Panel de comparación de baterías** muestra el rendimiento de cada pack compatible y resalta riesgos de sobrecarga.
+- **Generador de listas de equipo** transforma tus selecciones en tablas categorizadas con metadatos, correos de la crew y añadidos según escenario.
+- **Indicador sin conexión y recarga forzada** muestran el estado de conectividad y actualizan archivos en caché sin perder proyectos.
+
+---
+
+## Gestión de datos y exportaciones
+
+- Los proyectos, ajustes, listas de equipo, favoritos y dispositivos personalizados viven en `localStorage`; las copias y restauraciones mantienen todo intacto.
+- El diálogo de ajustes incluye recordatorios horarios de copia de seguridad, exportaciones manuales, restauración en un clic y un botón de **Borrar caché local**.
+- Los archivos de proyecto compartidos agrupan selecciones, requisitos, feedback de autonomía, listas de equipo y dispositivos personalizados para entregas entre equipos.
+- Las vistas imprimibles incluyen el nombre del proyecto, datos de producción, un logotipo opcional y la lista de equipo generada.
+- Las instantáneas automáticas se ejecutan en segundo plano para volver fácilmente a un estado anterior.
+
+---
+
+## Inteligencia de baterías y autonomía
+
+- Calcula el consumo total, el número de baterías necesarias para días de 10 horas y la corriente que debe aportar cada conexión.
+- Avisa al superar el 80 % de uso y bloquea cargas inseguras cuando la demanda sobrepasa el valor continuo o el D‑Tap de la batería.
+- Las estimaciones ponderadas tienen en cuenta temperatura, resolución, fotogramas por segundo, códec, uso de Wi‑Fi, brillo de monitor y la cuota de consumo de cada dispositivo.
+- Un panel de autonomía ordena el feedback por peso, muestra porcentajes de contribución y destaca valores atípicos.
+- El feedback enviado por usuarios mejora las estimaciones para rodajes reales.
+
+---
+
+## Personalización y accesibilidad
+
+- Cambia entre temas oscuro, rosa o de alto contraste y ajusta la tipografía sin recargar la página.
+- Sube un logotipo personalizado para las vistas imprimibles, define roles de monitor predeterminados y configura requisitos de proyecto por defecto.
+- La navegación con teclado, los indicadores de foco visibles y los enlaces de salto favorecen el uso con lectores de pantalla y en el set.
+- Las búsquedas en desplegables, los favoritos fijados y los botones de duplicado en las listas de equipo agilizan la entrada de datos repetitiva.
+
+---
+
+## Atajos de teclado
+
+| Acción | Atajo |
+| --- | --- |
+| Enfocar la búsqueda global | `/`, `Ctrl+K`, `⌘K` |
+| Abrir el diálogo de ayuda | `?`, `H`, `F1`, `Ctrl+/` |
+| Guardar proyecto | `Intro`, `Ctrl+S`, `⌘S` |
+| Alternar tema oscuro | `D` |
+| Alternar tema rosa | `P` |
+| Recarga forzada | Haz clic en el icono 🔄 del encabezado |
+
+---
+
+## Desarrollo
+
+- Instala las dependencias con `npm install` (se usan para linting, pruebas y scripts de datos; no hay paso de compilación).
+- Ejecuta `npm run lint` y `npm run test` antes de hacer commit. Hay suites específicas con `npm run test:unit`, `npm run test:data`, `npm run test:dom` y `npm run test:script`.
+- Scripts útiles:
+  - `npm run check-consistency` valida la coherencia de los datos.
+  - `npm run normalize` y `npm run unify-ports` mantienen ordenado el catálogo.
+  - `npm run generate-schema` regenera el esquema de dispositivos.
+
+---
+
+## Traducciones
+
+La documentación está disponible en varios idiomas y la aplicación detecta automáticamente el idioma del navegador en el primer inicio. Cambia en cualquier momento desde el menú de idioma de la esquina superior derecha:
+
 - 🇬🇧 [English](README.en.md)
 - 🇩🇪 [Deutsch](README.de.md)
 - 🇪🇸 [Español](README.es.md)
 - 🇮🇹 [Italiano](README.it.md)
 - 🇫🇷 [Français](README.fr.md)
 
-La aplicación usa automáticamente el idioma de tu navegador en la primera visita y puedes cambiarlo desde la esquina superior derecha. La elección se recuerda para tu próxima sesión.
+¿Quieres colaborar? Sigue la [guía de traducción](docs/translation-guide.md) para añadir nuevos idiomas tanto a la interfaz como a la documentación.
 
 ---
 
-## 🆕 Novedades recientes
-- Los controles de acento y tipografía en Ajustes te permiten modificar el color de acento, el tamaño base de la fuente y la tipografía, junto con los temas oscuro, rosa y de alto contraste.
-- Los atajos de teclado para la búsqueda global te permiten pulsar / o Ctrl+K (⌘K en macOS) para enfocarla al instante, incluso cuando está dentro del menú lateral móvil.
-- El botón de recarga forzada borra los archivos en caché del *service worker* para que la aplicación sin conexión se actualice sin eliminar proyectos ni dispositivos guardados.
-- Los iconos de estrella en cada selector fijan las cámaras, baterías y accesorios favoritos en la parte superior de la lista y los conservan en las copias de seguridad.
-- El botón de borrar caché local elimina los proyectos y ajustes almacenados.
-- La lista de equipo y la vista imprimible muestran el nombre del proyecto para consultarlo rápidamente.
-- Sube un logotipo personalizado para que aparezca en las vistas imprimibles y en las copias de seguridad.
-- Las copias de seguridad incluyen los favoritos y crean una copia automática antes de restaurar.
-- Las entradas del equipo cuentan ahora con un campo de correo electrónico.
-- Opción de tema de alto contraste para mejorar la legibilidad.
-- Los formularios de dispositivos rellenan los campos de categoría dinámicamente según los atributos del esquema.
-- Rediseño de la interfaz con mejor contraste y espaciado para una experiencia más limpia en cualquier dispositivo.
-- Compartir proyectos es más sencillo: descarga un archivo JSON que agrupa selecciones, requisitos, listas de equipo, comentarios de autonomía y dispositivos personalizados, y cárgalo para restaurarlo todo de una vez.
-- Iconos únicos para los escenarios obligatorios que ayudan a distinguir los requisitos del proyecto.
-- Diagrama de proyecto interactivo que permite arrastrar dispositivos, hacer zoom, ajustar nodos a la cuadrícula y exportar la disposición como SVG o JPG.
-- Tema rosa lúdico que se mantiene entre visitas.
-- Diálogo de ayuda con búsqueda y secciones paso a paso y un FAQ; ábrelo con ?, H, F1 o Ctrl+/.
-- Ayudas contextuales al pasar el cursor por botones, campos, menús y encabezados.
-- Barra de búsqueda global para saltar a funciones, selectores de dispositivos o temas de ayuda.
-- Compatibilidad con cámaras con placas de batería V-, B- o Gold-Mount.
-- Envía comentarios de autonomía con temperatura para mejorar las estimaciones.
-- Panel visual de ponderación de autonomías para inspeccionar cómo influyen los ajustes en cada informe, ahora ordenado por peso y con porcentajes exactos.
-- Genera listas de equipo para compilar el material seleccionado y los requisitos del proyecto.
-- Guarda los requisitos de proyecto con cada proyecto para que las listas de equipo conserven el contexto.
-- Duplica entradas de usuario en los formularios de la lista de equipo con los botones de bifurcar para copiar campos al instante.
+## Contribuciones y soporte
+
+Se agradecen los informes de errores, nuevas ideas y correcciones de datos. Abre un issue o envía un pull request con todos los detalles posibles. Si detectas autonomías incorrectas o equipos faltantes, adjunta el archivo de proyecto o datos de ejemplo para mantener fiable el catálogo.
 
 ---
 
-## 🔧 Funciones
+## Licencia
 
-### ✅ Gestión de proyectos
-- Guarda, carga y elimina múltiples proyectos de cámara (pulsa Enter o Ctrl+S/⌘S para guardar rápido; el botón Guardar permanece desactivado hasta introducir un nombre).
-- Se crean instantáneas automáticas cada 10 minutos mientras el planificador está abierto, y el diálogo de Ajustes puede programar exportaciones de copias de seguridad cada hora como recordatorio para archivar los datos.
-- Descarga un archivo JSON que agrupa selecciones, requisitos, listas de equipo, comentarios de autonomía y dispositivos personalizados; cárgalo mediante el selector de Proyecto compartido para restaurarlo todo de una vez.
-- Los datos se almacenan localmente mediante `localStorage`, y los favoritos se conservan en las copias de seguridad; utiliza el botón **Borrar caché local** en Ajustes si necesitas limpiar proyectos en caché y ediciones de dispositivos.
-- Genera vistas imprimibles para cualquier proyecto guardado y añade un logotipo personalizado para que las exportaciones y copias coincidan con la identidad de tu producción.
-- Guarda los requisitos de proyecto junto con cada proyecto para que las listas de equipo conserven el contexto completo.
-- Funciona totalmente sin conexión con el *service worker* instalado: idioma, tema, datos de dispositivos y favoritos persisten entre sesiones.
-- El diseño adaptable se ajusta sin esfuerzo a escritorios, tabletas y teléfonos.
-- En las cámaras compatibles elige placas **V‑Mount**, **B‑Mount** o **Gold-Mount**; la lista de baterías se adapta automáticamente.
-
-### 🧭 Descripción de la interfaz
-- Un enlace de salto y un indicador sin conexión mantienen la interfaz accesible con teclado y pantallas táctiles: la insignia aparece cuando el navegador pierde la conexión.
-- La barra de búsqueda global salta a funciones, selectores de dispositivos o temas de ayuda; pulsa Enter para activar el resultado resaltado, usa / o Ctrl+K (⌘K en macOS) para enfocarla desde cualquier lugar (el menú lateral se abre automáticamente en pantallas pequeñas) y pulsa Escape o × para limpiar la consulta.
-- Los controles de la barra superior permiten cambiar el idioma, alternar los temas oscuro y rosa y abrir Ajustes con opciones de color de acento, tamaño y familia tipográfica, modo de alto contraste y carga de logotipo, además de herramientas para copia de seguridad, restauración y Borrar caché local.
-- El botón de Ayuda abre un diálogo con búsqueda, secciones paso a paso, atajos de teclado, preguntas frecuentes y un modo de ayuda emergente opcional; también puede activarse con ?, H, F1 o Ctrl+/ incluso mientras escribes.
-- El botón de recarga forzada (🔄) borra los archivos del *service worker* en caché para que la aplicación sin conexión se actualice sin eliminar proyectos ni dispositivos guardados.
-- En pantallas pequeñas, un menú lateral plegable replica cada sección principal para navegar rápidamente.
-
-### ♿ Personalización y accesibilidad
-- Las preferencias de tema incluyen modo oscuro, acentos rosas lúdicos y un interruptor dedicado de alto contraste para mejorar la legibilidad.
-- Los cambios en el color de acento, el tamaño base de la fuente y la tipografía se aplican al instante y persisten en el navegador, lo que te permite adaptarlo a la identidad del estudio o a necesidades de accesibilidad.
-- Los atajos de teclado integrados cubren la búsqueda global (/ o Ctrl+K/⌘K), la ayuda ( ?, H, F1, Ctrl+/ ), el guardado (Enter o Ctrl+S/⌘S), el modo oscuro (D) y el modo rosa (P).
-- El modo de ayuda al pasar el cursor convierte cada botón, campo, menú y encabezado en una descripción emergente bajo demanda para que las personas nuevas aprendan rápidamente.
-- Las entradas con búsqueda incremental, los controles visibles al enfocar y los iconos de estrella junto a los selectores permiten filtrar listas largas y fijar dispositivos favoritos en la parte superior.
-
-### 📋 Lista de equipo
-El generador transforma tus selecciones en una lista de empaquetado categorizada:
-
-- Haz clic en **Generar lista de equipo** para compilar el material elegido y los requisitos del proyecto en una tabla.
-- La tabla se actualiza automáticamente cuando cambian las selecciones de dispositivos o los requisitos.
-- Los elementos se agrupan por categoría (cámara, óptica, alimentación, monitorización, rigging, grip, accesorios, consumibles) y los duplicados se combinan con sus cantidades.
-- Se añaden cables, rigging y accesorios necesarios para monitores, motores, gimbals y escenarios meteorológicos.
-- Las selecciones de escenarios añaden equipo relacionado:
-  - *Handheld* + *Easyrig* inserta una empuñadura telescópica para un soporte estable.
-  - *Gimbal* añade el gimbal seleccionado, brazos articulados, espigas y parasoles o kits de filtros.
-  - *Outdoor* aporta espigas, paraguas y fundas CapIt para lluvia.
-  - Los escenarios *Vehicle* y *Steadicam* incluyen monturas, brazos de aislamiento y ventosas cuando corresponde.
-- Las selecciones de óptica incluyen diámetro frontal, peso, datos de barras y enfoque mínimo, añaden soportes de lente y adaptadores de matte box, y avisan sobre estándares de barras incompatibles.
-- Las filas de baterías reflejan los recuentos del calculador de alimentación e incluyen placas de *hotswap* o dispositivos seleccionados cuando se necesitan.
-- Las preferencias de monitorización asignan monitores predeterminados para cada rol (Director, DoP, foco, etc.) con juegos de cables y receptores inalámbricos.
-- El formulario de **Requisitos del proyecto** alimenta la lista:
-  - **Nombre del proyecto**, **productora**, **casa de alquiler** y **DoP** aparecen en el encabezado de los requisitos impresos.
-  - Las entradas de **Equipo** recogen nombres, roles y direcciones de correo electrónico para que la información de contacto viaje con el proyecto.
-  - **Días de preparación** y **días de rodaje** aportan notas de planificación y, junto con escenarios exteriores, sugieren equipo para la climatología.
-  - Los **escenarios obligatorios** añaden rigging, gimbals y protección climática correspondiente.
-  - **Empuñadura de cámara** y **extensión de visor** insertan las piezas seleccionadas o los soportes de extensión.
-  - Las opciones de **matte box** y **filtros** agregan el sistema elegido con bandejas, adaptadores de pinza o filtros necesarios.
-  - Las configuraciones de **monitorización**, **distribución de vídeo** y **visor** añaden monitores, cables y superposiciones para cada rol.
-  - Las selecciones de **botones de usuario** y **preferencias de trípode** se listan para una referencia rápida.
-- Los elementos dentro de cada categoría se ordenan alfabéticamente y muestran descripciones al pasar el cursor.
-- La lista de equipo se incluye en las vistas imprimibles y en los archivos de proyectos compartidos.
-- Las listas de equipo se guardan automáticamente con el proyecto y forman parte de los archivos compartidos y de las copias de seguridad.
-- **Eliminar lista de equipo** borra la lista guardada y oculta la salida.
-- Los formularios de la lista de equipo incluyen botones de bifurcar para duplicar entradas de usuario al instante.
-
-### 📦 Categorías de dispositivos
-- **Cámara** (1)
-- **Monitor** (opcional)
-- **Transmisor inalámbrico** (opcional)
-- **Motores FIZ** (0–4)
-- **Controladores FIZ** (0–4)
-- **Sensor de distancia** (0–1)
-- **Placa de batería** (solo en cámaras que aceptan V‑ o B‑Mount)
-- **Batería V‑Mount** (0–1)
-
-### ⚙️ Cálculos de energía
-- Consumo total en vatios
-- Corriente demandada a 14,4 V y 12 V
-- Autonomía estimada de la batería en horas usando la media ponderada de los comentarios de personas usuarias
-- Número de baterías necesarias para un rodaje de 10 h (incluida la de repuesto)
-- Nota de temperatura para ajustar la autonomía en condiciones de calor o frío
-
-### 🔋 Comprobación de entrega de batería
-- Avisa si la corriente demandada supera la salida de la batería (pin o D‑Tap)
-- Indica cuando el consumo está cerca del límite (80 % de uso)
-
-### 📊 Comparación de baterías (opcional)
-- Compara estimaciones de autonomía entre todas las baterías
-- Gráficos de barras para consulta rápida
-
-### 🖼 Diagrama del proyecto
-- Visualiza las conexiones de alimentación y vídeo de los dispositivos seleccionados.
-- Advierte cuando las marcas FIZ son incompatibles.
-- Arrastra nodos para reorganizar el esquema, haz zoom con los botones y descarga el diagrama como SVG o JPG.
-- Mantén pulsado Shift al hacer clic en Descargar para exportar una instantánea JPG en lugar de SVG.
-- Pasa el cursor o toca los dispositivos para ver detalles emergentes.
-- Utiliza iconos de [OpenMoji](https://openmoji.org/) cuando hay conexión, con emoji como alternativa: 🔋 batería, 🎥 cámara, 🖥️ monitor, 📡 vídeo, ⚙️ motor, 🎮 controlador, 📐 distancia, 🎮 empuñadura y 🔌 placa de batería.
-
-### 🧮 Ponderación de datos de autonomía
-- Los tiempos de batería aportados por la comunidad refinan la estimación de autonomía.
-- Cada registro se ajusta por temperatura, escalando desde ×1 a 25 °C hasta:
-  - ×1,25 a 0 °C
-  - ×1,6 a −10 °C
-  - ×2 a −20 °C
-- Los ajustes de cámara influyen en el peso:
-  - Multiplicadores de resolución: ≥12K ×3, ≥8K ×2, ≥4K ×1,5, ≥1080p ×1; resoluciones menores se escalan a 1080p.
-  - La frecuencia de cuadro escala linealmente desde 24 fps (por ejemplo, 48 fps = ×2).
-  - Wi‑Fi activado suma un 10 %.
-  - Factores de códec: RAW/BRAW/ARRIRAW/R3D/CinemaDNG/Canon RAW/X‑OCN ×1; ProRes ×1,1; DNx/AVID ×1,2; All‑Intra ×1,3; H.264/AVC ×1,5; H.265/HEVC ×1,7.
-  - Las entradas de monitores por debajo del brillo especificado se ponderan según su relación de brillo.
-- El peso final refleja la cuota de consumo de cada dispositivo, de modo que los proyectos equivalentes cuentan más.
-- Se usa la media ponderada cuando hay al menos tres entradas disponibles.
-- Un panel ordena los registros por peso y muestra el porcentaje que aporta cada uno para compararlos rápidamente.
-
-### 🔍 Búsqueda y filtrado
-- Escribe dentro de los menús desplegables para encontrar entradas rápidamente.
-- Filtra las listas de dispositivos con un cuadro de búsqueda.
-- Utiliza la barra de búsqueda global en la parte superior para saltar a funciones, dispositivos o temas de ayuda; pulsa Enter para navegar, usa / o Ctrl+K (⌘K en macOS) para enfocarla al instante y pulsa Escape o × para limpiar.
-- Pulsa '/' o Ctrl+F (⌘F en macOS) para enfocar al instante el cuadro de búsqueda más cercano.
-- Haz clic en la estrella junto a cualquier selector para fijar favoritos, mantenerlos en la parte superior de la lista y sincronizarlos con las copias de seguridad.
-
-### 🛠 Editor de la base de datos de dispositivos
-- Añade, edita o elimina dispositivos en todas las categorías.
-- Importa o exporta la base de datos completa como JSON.
-- Vuelve a la base de datos predeterminada de `data.js`.
-
-### 🌓 Modo oscuro
-- Actívalo con el botón de la luna junto al selector de idioma.
-- La preferencia se guarda en tu navegador.
-
-### 🦄 Modo rosa
-- Haz clic en el botón del unicornio o pulsa **P** para activar un acento rosa lúdico.
-- Funciona en los temas claro y oscuro y persiste entre visitas.
-
-### ⚫ Modo de alto contraste
-- Activa un tema de alto contraste para mejorar la legibilidad.
-
-### 📝 Comentarios de autonomía
-- Haz clic en <strong>Enviar comentarios de autonomía</strong> debajo de la autonomía para añadir tu propia medición.
-- Incluye la temperatura si quieres una ponderación más precisa.
-- Las entradas se guardan en tu navegador y mejoran las estimaciones futuras.
-
-### ❓ Ayuda con búsqueda
-- Ábrela mediante el botón <strong>?</strong> o pulsa <kbd>?</kbd>, <kbd>H</kbd>, <kbd>F1</kbd> o <kbd>Ctrl+/</kbd>.
-- Usa el campo de búsqueda para filtrar temas al instante; la consulta se restablece al cerrar el diálogo.
-- Cierra con <kbd>Escape</kbd> o haciendo clic fuera del diálogo.
-
----
-
-## ▶️ Cómo usarlo
-1. **Inicia la aplicación:** abre `index.html` en cualquier navegador moderno; no necesita servidor.
-2. **Explora la barra superior:** cambia de idioma, alterna los temas oscuro o rosa, abre Ajustes para modificar acento y tipografías, y lanza el diálogo de ayuda con ? o Ctrl+/.
-3. **Selecciona los dispositivos:** elige el equipo de cada categoría con los menús desplegables; escribe para filtrar, haz clic en la estrella para fijar favoritos y deja que los escenarios preconfigurados rellenen los accesorios automáticamente.
-4. **Consulta los cálculos:** verás consumo total, corriente y autonomía cuando selecciones una batería; los avisos resaltan cuando se supera la entrega permitida.
-5. **Guarda y comparte proyectos:** pon nombre y guarda tu configuración, las copias automáticas capturan instantáneas y el botón Compartir exporta un paquete JSON para el equipo.
-6. **Genera listas de equipo:** pulsa **Generar lista de equipo** para convertir los requisitos en una lista categorizada con descripciones y accesorios.
-7. **Gestiona los datos de dispositivos:** haz clic en “Editar datos de dispositivos…” para abrir el editor, modificar dispositivos, exportar/importar JSON o volver a los valores predeterminados.
-8. **Envía comentarios de autonomía:** usa “Enviar comentarios de autonomía” para registrar mediciones de campo y refinar las estimaciones ponderadas.
-
-## 📱 Instalar como aplicación
-
-El planificador es una aplicación web progresiva y puede instalarse directamente desde tu navegador:
-
-- **Chrome/Edge (escritorio):** haz clic en el icono de instalación de la barra de direcciones.
-- **Android:** abre el menú del navegador y elige *Añadir a la pantalla de inicio*.
-- **iOS/iPadOS Safari:** toca el botón *Compartir* y selecciona *Añadir a pantalla de inicio*.
-
-Una vez instalada, la aplicación se abre desde tu pantalla de inicio, funciona sin conexión y se actualiza automáticamente.
-
-## 📡 Uso sin conexión y almacenamiento de datos
-
-Servir la aplicación mediante HTTP(S) instala un *service worker* que almacena en caché cada archivo, de modo que Cine Power Planner funciona sin conexión y se actualiza en segundo plano. Los proyectos, los comentarios de autonomía y las preferencias (idioma, tema, modo rosa y listas de equipo guardadas) viven en el `localStorage` del navegador. Al borrar los datos del sitio en el navegador se elimina toda la información almacenada, y el diálogo de Ajustes incluye un botón de **Borrar caché local** para la misma limpieza con un solo clic.
-
----
-
-## 🗂️ Estructura de archivos
-```bash
-index.html       # Maquetación principal en HTML
-style.css        # Estilos y diseño
-script.js        # Lógica de la aplicación
-data.js          # Lista predeterminada de dispositivos
-storage.js       # Utilidades para LocalStorage
-README.*.md      # Documentación en varios idiomas
-checkConsistency.js  # Verifica campos obligatorios en los datos de dispositivos
-normalizeData.js     # Limpia entradas y unifica nombres de conectores
-generateSchema.js    # Reconstruye schema.json a partir de data.js
-unifyPorts.js        # Armoniza nombres de puertos heredados
-tests/               # Suite de pruebas de Jest
-```
-Las fuentes se incluyen localmente mediante `fonts.css`, así que una vez que los recursos están en caché la aplicación funciona completamente sin conexión.
-
-## 🛠️ Desarrollo
-Requiere Node.js 18 o posterior.
-
-```bash
-npm install
-npm run lint     # ejecuta solo ESLint
-npm test         # ejecuta linting, comprobaciones de datos y pruebas de Jest
-```
-
-Después de editar los datos de dispositivos, regenera la base de datos normalizada:
-
-```bash
-npm run normalize
-npm run unify-ports
-npm run check-consistency
-npm run generate-schema
-```
-
-Añade `--help` a cualquiera de los scripts anteriores para ver los detalles de uso.
-
-## 🤝 Contribuciones
-¡Se agradecen las contribuciones! Puedes abrir un issue o enviar un *pull request* en GitHub.
+Cine Power Planner se distribuye bajo la licencia ISC.

--- a/README.es.md
+++ b/README.es.md
@@ -1,138 +1,310 @@
-# Cine Power Planner
+# 🎥 Cine Power Planner
 
-![Icono de Cine Power Planner](icon.svg)
+Esta herramienta basada en el navegador ayuda a planificar proyectos de cámara profesionales alimentados con baterías V‑Mount, B‑Mount o Gold-Mount. Calcula el **consumo total de energía**, la **corriente demandada** (a 14,4 V y 12 V) y la **autonomía estimada de la batería**, al tiempo que comprueba que el paquete puede suministrar la potencia necesaria.
 
-Cine Power Planner es una aplicación web con funcionamiento sin conexión para planificar rigs de cámara profesionales alimentados por baterías V‑Mount, B‑Mount o Gold‑Mount. Calcula el consumo total, comprueba que cada batería pueda suministrar con seguridad la corriente necesaria, estima autonomías realistas a partir de datos de campo ponderados y mantiene unidas a la vez a la crew, los escenarios y las listas de equipo para que ninguna información se pierda entre departamentos.
-
----
-
-## Destacados
-
-### Diseña configuraciones complejas sin improvisar
-- Combina cámaras, placas de batería, enlaces inalámbricos, monitores, motores y accesorios mientras ves la potencia total, la corriente a 14,4 V/12 V (y 33,6 V/21,6 V para B‑Mount) y el tiempo de funcionamiento estimado.
-- Compara baterías compatibles en paralelo y recibe avisos cuando la demanda supera los límites de D‑Tap o de pines.
-- Visualiza los rigs con un diagrama interactivo con arrastre, zoom, exportación SVG/JPG y avisos de compatibilidad.
-
-### Mantén a todos los departamentos alineados
-- Guarda varios proyectos con requisitos, contactos de la crew, escenarios de rodaje y notas personalizadas.
-- Genera listas de equipo listas para imprimir que agrupan el material por categoría, combinan duplicados, incluyen metadatos técnicos y añaden accesorios según el escenario.
-- Comparte paquetes JSON que contienen selecciones de dispositivos, feedback de autonomía, listas de equipo y dispositivos personalizados para restaurar todo de principio a fin.
-
-### Lista para viajar y privada
-- Funciona por completo en el navegador: abre `index.html` directamente o aloja el repositorio mediante HTTPS para activar el service worker.
-- La caché sin conexión conserva idioma, tema, favoritos y proyectos disponibles en cualquier lugar sin enviar datos a servidores externos.
-- Vacía la caché local o usa el botón de recarga forzada para actualizar archivos en caché sin tocar tus proyectos.
-
-### Adáptala a tu equipo
-- Cambia al instante entre English, Deutsch, Español, Italiano y Français; la aplicación recuerda el último idioma utilizado.
-- Elige temas oscuro, rosa o de alto contraste, define un color de acento, ajusta el tamaño de fuente y selecciona la tipografía que mejor se adapte a tu marca o requisitos de accesibilidad.
-- Los desplegables con búsqueda, los favoritos fijados y la ayuda al pasar el cursor mantienen productiva a la crew en el set.
+Toda la planificación, los datos introducidos y las exportaciones permanecen en
+el dispositivo que tienes delante. El idioma, los proyectos, los equipos
+personalizados, los favoritos y los comentarios de autonomía viven en tu
+navegador, y las actualizaciones del service worker provienen directamente de
+este repositorio. Puedes ejecutar la app sin conexión desde el disco o alojarla
+internamente para que cada departamento trabaje con la misma versión auditada.
 
 ---
 
-## Puesta en marcha
-
-1. Clona o descarga el repositorio.
-2. Abre `index.html` en un navegador moderno (Chromium, Firefox o Safari). No es necesario compilar nada.
-3. Opcional: sirve la carpeta mediante HTTPS para instalar el service worker y recibir actualizaciones sin conexión. Cualquier servidor estático funciona (`npx http-server -S`, por ejemplo).
-4. La aplicación almacena los datos en tu navegador. Usa **Ajustes → Copia de seguridad** para exportar instantáneas JSON antes de cambiar de equipo.
-
----
-
-## Flujo de trabajo habitual
-
-1. **Crea o carga un proyecto.** Pulsa Intro o `Ctrl+S` (`⌘S` en macOS) para guardar al instante. Se generan instantáneas automáticas cada 10 minutos.
-2. **Selecciona cámara, alimentación y accesorios.** Los desplegables se filtran mientras escribes y los favoritos permanecen anclados.
-3. **Revisa los resultados de potencia.** Consulta vatios, corriente, avisos de seguridad de batería y autonomías en el panel comparativo.
-4. **Registra los requisitos.** Documenta roles de la crew, días de rodaje, escenarios y notas para que cada exportación incluya el contexto adecuado.
-5. **Genera entregables.** Produce listas de equipo, vistas imprimibles y paquetes de proyecto compartidos y restáuralos más adelante con una sola subida.
-
----
-
-## Elementos clave de la interfaz
-
-- **Búsqueda global** (`/` o `Ctrl+K`/`⌘K`) te lleva a cualquier función, selector o tema de ayuda incluso con el menú lateral plegado.
-- **Centro de ayuda** (`?`, `H`, `F1` o `Ctrl+/`) ofrece guías buscables, preguntas frecuentes, atajos y ayuda contextual opcional.
-- **Diagrama del proyecto** visualiza conexiones; mantén pulsada Mayús al descargar para exportar un JPG en lugar de SVG.
-- **Panel de comparación de baterías** muestra el rendimiento de cada pack compatible y resalta riesgos de sobrecarga.
-- **Generador de listas de equipo** transforma tus selecciones en tablas categorizadas con metadatos, correos de la crew y añadidos según escenario.
-- **Indicador sin conexión y recarga forzada** muestran el estado de conectividad y actualizan archivos en caché sin perder proyectos.
-
----
-
-## Gestión de datos y exportaciones
-
-- Los proyectos, ajustes, listas de equipo, favoritos y dispositivos personalizados viven en `localStorage`; las copias y restauraciones mantienen todo intacto.
-- El diálogo de ajustes incluye recordatorios horarios de copia de seguridad, exportaciones manuales, restauración en un clic y un botón de **Borrar caché local**.
-- Los archivos de proyecto compartidos agrupan selecciones, requisitos, feedback de autonomía, listas de equipo y dispositivos personalizados para entregas entre equipos.
-- Las vistas imprimibles incluyen el nombre del proyecto, datos de producción, un logotipo opcional y la lista de equipo generada.
-- Las instantáneas automáticas se ejecutan en segundo plano para volver fácilmente a un estado anterior.
-
----
-
-## Inteligencia de baterías y autonomía
-
-- Calcula el consumo total, el número de baterías necesarias para días de 10 horas y la corriente que debe aportar cada conexión.
-- Avisa al superar el 80 % de uso y bloquea cargas inseguras cuando la demanda sobrepasa el valor continuo o el D‑Tap de la batería.
-- Las estimaciones ponderadas tienen en cuenta temperatura, resolución, fotogramas por segundo, códec, uso de Wi‑Fi, brillo de monitor y la cuota de consumo de cada dispositivo.
-- Un panel de autonomía ordena el feedback por peso, muestra porcentajes de contribución y destaca valores atípicos.
-- El feedback enviado por usuarios mejora las estimaciones para rodajes reales.
-
----
-
-## Personalización y accesibilidad
-
-- Cambia entre temas oscuro, rosa o de alto contraste y ajusta la tipografía sin recargar la página.
-- Sube un logotipo personalizado para las vistas imprimibles, define roles de monitor predeterminados y configura requisitos de proyecto por defecto.
-- La navegación con teclado, los indicadores de foco visibles y los enlaces de salto favorecen el uso con lectores de pantalla y en el set.
-- Las búsquedas en desplegables, los favoritos fijados y los botones de duplicado en las listas de equipo agilizan la entrada de datos repetitiva.
-
----
-
-## Atajos de teclado
-
-| Acción | Atajo |
-| --- | --- |
-| Enfocar la búsqueda global | `/`, `Ctrl+K`, `⌘K` |
-| Abrir el diálogo de ayuda | `?`, `H`, `F1`, `Ctrl+/` |
-| Guardar proyecto | `Intro`, `Ctrl+S`, `⌘S` |
-| Alternar tema oscuro | `D` |
-| Alternar tema rosa | `P` |
-| Recarga forzada | Haz clic en el icono 🔄 del encabezado |
-
----
-
-## Desarrollo
-
-- Instala las dependencias con `npm install` (se usan para linting, pruebas y scripts de datos; no hay paso de compilación).
-- Ejecuta `npm run lint` y `npm run test` antes de hacer commit. Hay suites específicas con `npm run test:unit`, `npm run test:data`, `npm run test:dom` y `npm run test:script`.
-- Scripts útiles:
-  - `npm run check-consistency` valida la coherencia de los datos.
-  - `npm run normalize` y `npm run unify-ports` mantienen ordenado el catálogo.
-  - `npm run generate-schema` regenera el esquema de dispositivos.
-
----
-
-## Traducciones
-
-La documentación está disponible en varios idiomas y la aplicación detecta automáticamente el idioma del navegador en el primer inicio. Cambia en cualquier momento desde el menú de idioma de la esquina superior derecha:
-
+## 🌍 Idiomas
 - 🇬🇧 [English](README.en.md)
 - 🇩🇪 [Deutsch](README.de.md)
 - 🇪🇸 [Español](README.es.md)
 - 🇮🇹 [Italiano](README.it.md)
 - 🇫🇷 [Français](README.fr.md)
 
-¿Quieres colaborar? Sigue la [guía de traducción](docs/translation-guide.md) para añadir nuevos idiomas tanto a la interfaz como a la documentación.
+La aplicación usa automáticamente el idioma de tu navegador en la primera visita y puedes cambiarlo desde la esquina superior derecha. La elección se recuerda para tu próxima sesión.
 
 ---
 
-## Contribuciones y soporte
-
-Se agradecen los informes de errores, nuevas ideas y correcciones de datos. Abre un issue o envía un pull request con todos los detalles posibles. Si detectas autonomías incorrectas o equipos faltantes, adjunta el archivo de proyecto o datos de ejemplo para mantener fiable el catálogo.
+## 🆕 Novedades recientes
+- Los controles de acento y tipografía en Ajustes te permiten modificar el color de acento, el tamaño base de la fuente y la tipografía, junto con los temas oscuro, rosa y de alto contraste.
+- Los atajos de teclado para la búsqueda global te permiten pulsar / o Ctrl+K (⌘K en macOS) para enfocarla al instante, incluso cuando está dentro del menú lateral móvil.
+- El botón de recarga forzada borra los archivos en caché del *service worker* para que la aplicación sin conexión se actualice sin eliminar proyectos ni dispositivos guardados.
+- Los iconos de estrella en cada selector fijan las cámaras, baterías y accesorios favoritos en la parte superior de la lista y los conservan en las copias de seguridad.
+- El botón de borrar caché local elimina los proyectos y ajustes almacenados.
+- La lista de equipo y la vista imprimible muestran el nombre del proyecto para consultarlo rápidamente.
+- Sube un logotipo personalizado para que aparezca en las vistas imprimibles y en las copias de seguridad.
+- Las copias de seguridad incluyen los favoritos y crean una copia automática antes de restaurar.
+- Las entradas del equipo cuentan ahora con un campo de correo electrónico.
+- Opción de tema de alto contraste para mejorar la legibilidad.
+- Los formularios de dispositivos rellenan los campos de categoría dinámicamente según los atributos del esquema.
+- Rediseño de la interfaz con mejor contraste y espaciado para una experiencia más limpia en cualquier dispositivo.
+- Compartir proyectos es más sencillo: descarga un archivo JSON que agrupa selecciones, requisitos, listas de equipo, comentarios de autonomía y dispositivos personalizados, y cárgalo para restaurarlo todo de una vez.
+- Iconos únicos para los escenarios obligatorios que ayudan a distinguir los requisitos del proyecto.
+- Diagrama de proyecto interactivo que permite arrastrar dispositivos, hacer zoom, ajustar nodos a la cuadrícula y exportar la disposición como SVG o JPG.
+- Tema rosa lúdico que se mantiene entre visitas.
+- Diálogo de ayuda con búsqueda y secciones paso a paso y un FAQ; ábrelo con ?, H, F1 o Ctrl+/.
+- Ayudas contextuales al pasar el cursor por botones, campos, menús y encabezados.
+- Barra de búsqueda global para saltar a funciones, selectores de dispositivos o temas de ayuda.
+- Compatibilidad con cámaras con placas de batería V-, B- o Gold-Mount.
+- Envía comentarios de autonomía con temperatura para mejorar las estimaciones.
+- Panel visual de ponderación de autonomías para inspeccionar cómo influyen los ajustes en cada informe, ahora ordenado por peso y con porcentajes exactos.
+- Genera listas de equipo para compilar el material seleccionado y los requisitos del proyecto.
+- Guarda los requisitos de proyecto con cada proyecto para que las listas de equipo conserven el contexto.
+- Duplica entradas de usuario en los formularios de la lista de equipo con los botones de bifurcar para copiar campos al instante.
 
 ---
 
-## Licencia
+## 🔧 Funciones
 
-Cine Power Planner se distribuye bajo la licencia ISC.
+### ✨ Destacados ampliados
+
+- **Planifica rigs complejos sin conjeturas.** Combina cámaras, placas de
+  batería, enlaces inalámbricos, monitores, motores y accesorios mientras ves el
+  consumo total a 14,4 V/12 V (y 33,6 V/21,6 V para B‑Mount) junto a autonomías
+  realistas basadas en datos de campo ponderados. El panel de comparación de
+  baterías avisa de sobrecargas antes de que el equipo salga rumbo al rodaje.
+- **Mantén alineados a todos los departamentos.** Guarda varios proyectos con
+  requisitos, contactos del equipo, escenarios y notas. Las listas imprimibles
+  agrupan el material por categoría, fusionan duplicados, muestran metadatos
+  técnicos e incluyen accesorios condicionados por escenarios para que cámara,
+  iluminación y grip compartan el mismo contexto.
+- **Trabaja con confianza en cualquier lugar.** Abre `index.html` directamente o
+  sirve la carpeta por HTTPS para activar el service worker. La caché sin
+  conexión conserva idioma, temas, favoritos y proyectos, y **Forzar recarga**
+  actualiza los recursos almacenados sin tocar tus datos.
+- **Adapta el planner a tu equipo.** Cambia al instante entre español, inglés,
+  alemán, italiano y francés, ajusta el tamaño y la tipografía, define un color
+  de acento propio, sube un logotipo para impresión y alterna entre tema claro,
+  oscuro, rosa o de alto contraste. Los desplegables con búsqueda, favoritos
+  fijados, botones de bifurcación y ayudas flotantes mantienen ágil el trabajo en
+  set.
+
+### ✅ Gestión de proyectos
+- Guarda, carga y elimina múltiples proyectos de cámara (pulsa Enter o Ctrl+S/⌘S para guardar rápido; el botón Guardar permanece desactivado hasta introducir un nombre).
+- Se crean instantáneas automáticas cada 10 minutos mientras el planificador está abierto, y el diálogo de Ajustes puede programar exportaciones de copias de seguridad cada hora como recordatorio para archivar los datos.
+- Descarga un archivo JSON que agrupa selecciones, requisitos, listas de equipo, comentarios de autonomía y dispositivos personalizados; cárgalo mediante el selector de Proyecto compartido para restaurarlo todo de una vez.
+- Los datos se almacenan localmente mediante `localStorage`, y los favoritos se conservan en las copias de seguridad; utiliza el botón **Borrar caché local** en Ajustes si necesitas limpiar proyectos en caché y ediciones de dispositivos.
+- Genera vistas imprimibles para cualquier proyecto guardado y añade un logotipo personalizado para que las exportaciones y copias coincidan con la identidad de tu producción.
+- Guarda los requisitos de proyecto junto con cada proyecto para que las listas de equipo conserven el contexto completo.
+- Funciona totalmente sin conexión con el *service worker* instalado: idioma, tema, datos de dispositivos y favoritos persisten entre sesiones.
+- El diseño adaptable se ajusta sin esfuerzo a escritorios, tabletas y teléfonos.
+- En las cámaras compatibles elige placas **V‑Mount**, **B‑Mount** o **Gold-Mount**; la lista de baterías se adapta automáticamente.
+
+### 🧭 Descripción de la interfaz
+- **Resumen rápido:**
+  - **Búsqueda global** (`/` o `Ctrl+K`/`⌘K`) salta a funciones, selectores o
+    temas de ayuda incluso cuando el menú lateral está contraído.
+  - **Centro de ayuda** (`?`, `H`, `F1` o `Ctrl+/`) ofrece guías filtrables,
+    preguntas frecuentes, accesos directos y el modo de ayuda flotante.
+  - **Diagrama del proyecto** visualiza conexiones; mantén pulsada Mayús al
+    descargar para guardar un JPG en lugar de SVG y ver avisos de
+    compatibilidad.
+  - **Comparador de baterías** muestra el rendimiento de cada pack compatible y
+    resalta riesgos de sobrecarga.
+  - **Generador de listas** crea tablas por categoría con metadatos, correos de
+    la crew y añadidos según escenario listos para imprimir.
+  - **Indicador sin conexión y Forzar recarga** reflejan el estado de la
+    conexión y renuevan archivos en caché sin borrar proyectos.
+- Un enlace de salto y un indicador sin conexión mantienen la interfaz accesible con teclado y pantallas táctiles: la insignia aparece cuando el navegador pierde la conexión.
+- La barra de búsqueda global salta a funciones, selectores de dispositivos o temas de ayuda; pulsa Enter para activar el resultado resaltado, usa / o Ctrl+K (⌘K en macOS) para enfocarla desde cualquier lugar (el menú lateral se abre automáticamente en pantallas pequeñas) y pulsa Escape o × para limpiar la consulta.
+- Los controles de la barra superior permiten cambiar el idioma, alternar los temas oscuro y rosa y abrir Ajustes con opciones de color de acento, tamaño y familia tipográfica, modo de alto contraste y carga de logotipo, además de herramientas para copia de seguridad, restauración y Borrar caché local.
+- El botón de Ayuda abre un diálogo con búsqueda, secciones paso a paso, atajos de teclado, preguntas frecuentes y un modo de ayuda emergente opcional; también puede activarse con ?, H, F1 o Ctrl+/ incluso mientras escribes.
+- El botón de recarga forzada (🔄) borra los archivos del *service worker* en caché para que la aplicación sin conexión se actualice sin eliminar proyectos ni dispositivos guardados.
+- En pantallas pequeñas, un menú lateral plegable replica cada sección principal para navegar rápidamente.
+
+### ♿ Personalización y accesibilidad
+- Las preferencias de tema incluyen modo oscuro, acentos rosas lúdicos y un interruptor dedicado de alto contraste para mejorar la legibilidad.
+- Los cambios en el color de acento, el tamaño base de la fuente y la tipografía se aplican al instante y persisten en el navegador, lo que te permite adaptarlo a la identidad del estudio o a necesidades de accesibilidad.
+- Los atajos de teclado integrados cubren la búsqueda global (/ o Ctrl+K/⌘K), la ayuda ( ?, H, F1, Ctrl+/ ), el guardado (Enter o Ctrl+S/⌘S), el modo oscuro (D) y el modo rosa (P).
+- El modo de ayuda al pasar el cursor convierte cada botón, campo, menú y encabezado en una descripción emergente bajo demanda para que las personas nuevas aprendan rápidamente.
+- Las entradas con búsqueda incremental, los controles visibles al enfocar y los iconos de estrella junto a los selectores permiten filtrar listas largas y fijar dispositivos favoritos en la parte superior.
+- Sube un logotipo para las impresiones, configura roles de monitorización por
+  defecto y ajusta los presets de requisitos del proyecto para que las
+  exportaciones respeten la identidad de la productora.
+- Los botones de bifurcación duplican filas de formularios de inmediato y los
+  favoritos fijados mantienen el equipo habitual en la parte alta de cada
+  selector, algo clave cuando el tiempo en set es limitado.
+
+### 📋 Lista de equipo
+El generador transforma tus selecciones en una lista de empaquetado categorizada:
+
+- Haz clic en **Generar lista de equipo** para compilar el material elegido y los requisitos del proyecto en una tabla.
+- La tabla se actualiza automáticamente cuando cambian las selecciones de dispositivos o los requisitos.
+- Los elementos se agrupan por categoría (cámara, óptica, alimentación, monitorización, rigging, grip, accesorios, consumibles) y los duplicados se combinan con sus cantidades.
+- Se añaden cables, rigging y accesorios necesarios para monitores, motores, gimbals y escenarios meteorológicos.
+- Las selecciones de escenarios añaden equipo relacionado:
+  - *Handheld* + *Easyrig* inserta una empuñadura telescópica para un soporte estable.
+  - *Gimbal* añade el gimbal seleccionado, brazos articulados, espigas y parasoles o kits de filtros.
+  - *Outdoor* aporta espigas, paraguas y fundas CapIt para lluvia.
+  - Los escenarios *Vehicle* y *Steadicam* incluyen monturas, brazos de aislamiento y ventosas cuando corresponde.
+- Las selecciones de óptica incluyen diámetro frontal, peso, datos de barras y enfoque mínimo, añaden soportes de lente y adaptadores de matte box, y avisan sobre estándares de barras incompatibles.
+- Las filas de baterías reflejan los recuentos del calculador de alimentación e incluyen placas de *hotswap* o dispositivos seleccionados cuando se necesitan.
+- Las preferencias de monitorización asignan monitores predeterminados para cada rol (Director, DoP, foco, etc.) con juegos de cables y receptores inalámbricos.
+- El formulario de **Requisitos del proyecto** alimenta la lista:
+  - **Nombre del proyecto**, **productora**, **casa de alquiler** y **DoP** aparecen en el encabezado de los requisitos impresos.
+  - Las entradas de **Equipo** recogen nombres, roles y direcciones de correo electrónico para que la información de contacto viaje con el proyecto.
+  - **Días de preparación** y **días de rodaje** aportan notas de planificación y, junto con escenarios exteriores, sugieren equipo para la climatología.
+  - Los **escenarios obligatorios** añaden rigging, gimbals y protección climática correspondiente.
+  - **Empuñadura de cámara** y **extensión de visor** insertan las piezas seleccionadas o los soportes de extensión.
+  - Las opciones de **matte box** y **filtros** agregan el sistema elegido con bandejas, adaptadores de pinza o filtros necesarios.
+  - Las configuraciones de **monitorización**, **distribución de vídeo** y **visor** añaden monitores, cables y superposiciones para cada rol.
+  - Las selecciones de **botones de usuario** y **preferencias de trípode** se listan para una referencia rápida.
+- Los elementos dentro de cada categoría se ordenan alfabéticamente y muestran descripciones al pasar el cursor.
+- La lista de equipo se incluye en las vistas imprimibles y en los archivos de proyectos compartidos.
+- Las listas de equipo se guardan automáticamente con el proyecto y forman parte de los archivos compartidos y de las copias de seguridad.
+- **Eliminar lista de equipo** borra la lista guardada y oculta la salida.
+- Los formularios de la lista de equipo incluyen botones de bifurcar para duplicar entradas de usuario al instante.
+
+### 📦 Categorías de dispositivos
+- **Cámara** (1)
+- **Monitor** (opcional)
+- **Transmisor inalámbrico** (opcional)
+- **Motores FIZ** (0–4)
+- **Controladores FIZ** (0–4)
+- **Sensor de distancia** (0–1)
+- **Placa de batería** (solo en cámaras que aceptan V‑ o B‑Mount)
+- **Batería V‑Mount** (0–1)
+
+### ⚙️ Cálculos de energía
+- Consumo total en vatios
+- Corriente demandada a 14,4 V y 12 V
+- Autonomía estimada de la batería en horas usando la media ponderada de los comentarios de personas usuarias
+- Número de baterías necesarias para un rodaje de 10 h (incluida la de repuesto)
+- Nota de temperatura para ajustar la autonomía en condiciones de calor o frío
+
+### 🔋 Comprobación de entrega de batería
+- Avisa si la corriente demandada supera la salida de la batería (pin o D‑Tap)
+- Indica cuando el consumo está cerca del límite (80 % de uso)
+
+### 📊 Comparación de baterías (opcional)
+- Compara estimaciones de autonomía entre todas las baterías
+- Gráficos de barras para consulta rápida
+
+### 🖼 Diagrama del proyecto
+- Visualiza las conexiones de alimentación y vídeo de los dispositivos seleccionados.
+- Advierte cuando las marcas FIZ son incompatibles.
+- Arrastra nodos para reorganizar el esquema, haz zoom con los botones y descarga el diagrama como SVG o JPG.
+- Mantén pulsado Shift al hacer clic en Descargar para exportar una instantánea JPG en lugar de SVG.
+- Pasa el cursor o toca los dispositivos para ver detalles emergentes.
+- Utiliza iconos de [OpenMoji](https://openmoji.org/) cuando hay conexión, con emoji como alternativa: 🔋 batería, 🎥 cámara, 🖥️ monitor, 📡 vídeo, ⚙️ motor, 🎮 controlador, 📐 distancia, 🎮 empuñadura y 🔌 placa de batería.
+
+### 🧮 Ponderación de datos de autonomía
+- Los tiempos de batería aportados por la comunidad refinan la estimación de autonomía.
+- Cada registro se ajusta por temperatura, escalando desde ×1 a 25 °C hasta:
+  - ×1,25 a 0 °C
+  - ×1,6 a −10 °C
+  - ×2 a −20 °C
+- Los ajustes de cámara influyen en el peso:
+  - Multiplicadores de resolución: ≥12K ×3, ≥8K ×2, ≥4K ×1,5, ≥1080p ×1; resoluciones menores se escalan a 1080p.
+  - La frecuencia de cuadro escala linealmente desde 24 fps (por ejemplo, 48 fps = ×2).
+  - Wi‑Fi activado suma un 10 %.
+  - Factores de códec: RAW/BRAW/ARRIRAW/R3D/CinemaDNG/Canon RAW/X‑OCN ×1; ProRes ×1,1; DNx/AVID ×1,2; All‑Intra ×1,3; H.264/AVC ×1,5; H.265/HEVC ×1,7.
+  - Las entradas de monitores por debajo del brillo especificado se ponderan según su relación de brillo.
+- El peso final refleja la cuota de consumo de cada dispositivo, de modo que los proyectos equivalentes cuentan más.
+- Se usa la media ponderada cuando hay al menos tres entradas disponibles.
+- Un panel ordena los registros por peso y muestra el porcentaje que aporta cada uno para compararlos rápidamente.
+
+### 🔍 Búsqueda y filtrado
+- Escribe dentro de los menús desplegables para encontrar entradas rápidamente.
+- Filtra las listas de dispositivos con un cuadro de búsqueda.
+- Utiliza la barra de búsqueda global en la parte superior para saltar a funciones, dispositivos o temas de ayuda; pulsa Enter para navegar, usa / o Ctrl+K (⌘K en macOS) para enfocarla al instante y pulsa Escape o × para limpiar.
+- Pulsa '/' o Ctrl+F (⌘F en macOS) para enfocar al instante el cuadro de búsqueda más cercano.
+- Haz clic en la estrella junto a cualquier selector para fijar favoritos, mantenerlos en la parte superior de la lista y sincronizarlos con las copias de seguridad.
+
+### 🛠 Editor de la base de datos de dispositivos
+- Añade, edita o elimina dispositivos en todas las categorías.
+- Importa o exporta la base de datos completa como JSON.
+- Vuelve a la base de datos predeterminada de `data.js`.
+
+### 🌓 Modo oscuro
+- Actívalo con el botón de la luna junto al selector de idioma.
+- La preferencia se guarda en tu navegador.
+
+### 🦄 Modo rosa
+- Haz clic en el botón del unicornio o pulsa **P** para activar un acento rosa lúdico.
+- Funciona en los temas claro y oscuro y persiste entre visitas.
+
+### ⚫ Modo de alto contraste
+- Activa un tema de alto contraste para mejorar la legibilidad.
+
+### 📝 Comentarios de autonomía
+- Haz clic en <strong>Enviar comentarios de autonomía</strong> debajo de la autonomía para añadir tu propia medición.
+- Incluye la temperatura si quieres una ponderación más precisa.
+- Las entradas se guardan en tu navegador y mejoran las estimaciones futuras.
+- Un panel dedicado ordena los envíos según su peso, muestra porcentajes de
+  contribución y resalta valores atípicos para que el equipo evalúe los datos de
+  campo rápidamente.
+
+### ❓ Ayuda con búsqueda
+- Ábrela mediante el botón <strong>?</strong> o pulsa <kbd>?</kbd>, <kbd>H</kbd>, <kbd>F1</kbd> o <kbd>Ctrl+/</kbd>.
+- Usa el campo de búsqueda para filtrar temas al instante; la consulta se restablece al cerrar el diálogo.
+- Cierra con <kbd>Escape</kbd> o haciendo clic fuera del diálogo.
+
+---
+
+## ▶️ Cómo usarlo
+1. **Inicia la aplicación:** abre `index.html` en cualquier navegador moderno; no necesita servidor.
+2. **Explora la barra superior:** cambia de idioma, alterna los temas oscuro o rosa, abre Ajustes para modificar acento y tipografías, y lanza el diálogo de ayuda con ? o Ctrl+/.
+3. **Selecciona los dispositivos:** elige el equipo de cada categoría con los menús desplegables; escribe para filtrar, haz clic en la estrella para fijar favoritos y deja que los escenarios preconfigurados rellenen los accesorios automáticamente.
+4. **Consulta los cálculos:** verás consumo total, corriente y autonomía cuando selecciones una batería; los avisos resaltan cuando se supera la entrega permitida.
+5. **Guarda y comparte proyectos:** pon nombre y guarda tu configuración, las copias automáticas capturan instantáneas y el botón Compartir exporta un paquete JSON para el equipo.
+6. **Genera listas de equipo:** pulsa **Generar lista de equipo** para convertir los requisitos en una lista categorizada con descripciones y accesorios.
+7. **Gestiona los datos de dispositivos:** haz clic en “Editar datos de dispositivos…” para abrir el editor, modificar dispositivos, exportar/importar JSON o volver a los valores predeterminados.
+8. **Envía comentarios de autonomía:** usa “Enviar comentarios de autonomía” para registrar mediciones de campo y refinar las estimaciones ponderadas.
+
+## 📱 Instalar como aplicación
+
+El planificador es una aplicación web progresiva y puede instalarse directamente desde tu navegador:
+
+- **Chrome/Edge (escritorio):** haz clic en el icono de instalación de la barra de direcciones.
+- **Android:** abre el menú del navegador y elige *Añadir a la pantalla de inicio*.
+- **iOS/iPadOS Safari:** toca el botón *Compartir* y selecciona *Añadir a pantalla de inicio*.
+
+Una vez instalada, la aplicación se abre desde tu pantalla de inicio, funciona sin conexión y se actualiza automáticamente.
+
+## 📡 Uso sin conexión y almacenamiento de datos
+
+Servir la aplicación mediante HTTP(S) instala un *service worker* que almacena en caché cada archivo, de modo que Cine Power Planner funciona sin conexión y se actualiza en segundo plano. Los proyectos, los comentarios de autonomía y las preferencias (idioma, tema, modo rosa y listas de equipo guardadas) viven en el `localStorage` del navegador. Al borrar los datos del sitio en el navegador se elimina toda la información almacenada, y el diálogo de Ajustes incluye un botón de **Borrar caché local** para la misma limpieza con un solo clic.
+La cabecera muestra un indicador sin conexión cuando se pierde la red, y la
+acción 🔄 **Forzar recarga** actualiza los recursos en caché sin afectar a los
+proyectos guardados.
+
+---
+
+## 🗂️ Estructura de archivos
+```bash
+index.html       # Maquetación principal en HTML
+style.css        # Estilos y diseño
+script.js        # Lógica de la aplicación
+data.js          # Lista predeterminada de dispositivos
+storage.js       # Utilidades para LocalStorage
+README.*.md      # Documentación en varios idiomas
+checkConsistency.js  # Verifica campos obligatorios en los datos de dispositivos
+normalizeData.js     # Limpia entradas y unifica nombres de conectores
+generateSchema.js    # Reconstruye schema.json a partir de data.js
+unifyPorts.js        # Armoniza nombres de puertos heredados
+tests/               # Suite de pruebas de Jest
+```
+Las fuentes se incluyen localmente mediante `fonts.css`, así que una vez que los recursos están en caché la aplicación funciona completamente sin conexión.
+
+## 🛠️ Desarrollo
+Requiere Node.js 18 o posterior.
+
+```bash
+npm install
+npm run lint     # ejecuta solo ESLint
+npm test         # ejecuta linting, comprobaciones de datos y pruebas de Jest
+```
+
+Después de editar los datos de dispositivos, regenera la base de datos normalizada:
+
+```bash
+npm run normalize
+npm run unify-ports
+npm run check-consistency
+npm run generate-schema
+```
+
+Añade `--help` a cualquiera de los scripts anteriores para ver los detalles de uso.
+
+## 🤝 Contribuciones
+¡Se agradecen las contribuciones! Puedes abrir un issue o enviar un *pull request* en GitHub.
+Si informas de datos incorrectos, adjuntar copias de seguridad de proyectos o
+mediciones de autonomía ayuda a mantener el catálogo fiable para todos.

--- a/README.fr.md
+++ b/README.fr.md
@@ -1,252 +1,138 @@
-# 🎥 Cine Power Planner
+# Cine Power Planner
 
-Cet outil basé sur le navigateur aide à planifier des projets caméra professionnels alimentés par des batteries V‑Mount, B‑Mount ou Gold-Mount. Il calcule la **consommation totale**, l’**intensité demandée** (à 14,4 V et 12 V) et l’**autonomie estimée** tout en vérifiant que la batterie peut fournir la puissance requise en toute sécurité.
+![Icône Cine Power Planner](icon.svg)
+
+Cine Power Planner est une application Web utilisable hors ligne pour planifier des rigs caméra professionnels alimentés par des batteries V‑Mount, B‑Mount ou Gold‑Mount. Elle calcule la consommation totale, vérifie que chaque batterie peut fournir en toute sécurité le courant requis, estime des autonomies réalistes à partir de données terrain pondérées et conserve au même endroit l’équipe, les scénarios et les listes de matériel afin qu’aucune information ne se perde entre les départements.
 
 ---
 
-## 🌍 Langues
+## Points forts
+
+### Concevez des configurations complexes sans tâtonner
+- Combinez caméras, plaques batteries, liaisons sans fil, moniteurs, moteurs et accessoires tout en visualisant la puissance totale, le courant à 14,4 V/12 V (et 33,6 V/21,6 V pour le B‑Mount) ainsi que l’autonomie estimée.
+- Comparez les batteries compatibles côte à côte et recevez des alertes lorsque la demande dépasse les limites D‑Tap ou pin.
+- Visualisez vos rigs avec un diagramme interactif offrant glisser-déposer, zoom, export SVG/JPG et avertissements de compatibilité.
+
+### Gardez tous les départements alignés
+- Enregistrez plusieurs projets avec exigences, contacts d’équipe, scénarios de tournage et notes personnalisées.
+- Générez des listes de matériel imprimables qui regroupent l’équipement par catégorie, fusionnent les doublons, incluent les métadonnées techniques et ajoutent des accessoires en fonction des scénarios.
+- Partagez des paquets JSON contenant sélections d’appareils, retours d’autonomie, listes de matériel et appareils personnalisés pour une restauration complète.
+
+### Prête à voyager et respectueuse de la vie privée
+- Fonctionne entièrement dans le navigateur : ouvrez `index.html` directement ou hébergez le dépôt en HTTPS pour activer le service worker.
+- La mise en cache hors ligne conserve langue, thème, favoris et projets partout sans envoyer vos données à des serveurs externes.
+- Videz le cache local ou utilisez le bouton de rechargement forcé pour actualiser les fichiers en cache sans toucher aux projets.
+
+### Adaptez-la à votre équipe
+- Basculez instantanément entre English, Deutsch, Español, Italiano et Français ; l’application retient la dernière langue utilisée.
+- Choisissez les thèmes sombre, rose ou à fort contraste, définissez une couleur d’accent, ajustez la taille de police et sélectionnez la typographie adaptée à votre identité visuelle ou à vos besoins d’accessibilité.
+- Les menus déroulants avec recherche, les favoris épinglés et l’aide au survol gardent l’équipe productive sur le plateau.
+
+---
+
+## Démarrage rapide
+
+1. Clonez ou téléchargez le dépôt.
+2. Ouvrez `index.html` dans un navigateur moderne (Chromium, Firefox ou Safari). Aucun processus de build n’est requis.
+3. En option, servez le dossier en HTTPS pour installer le service worker et bénéficier des mises à jour hors ligne. Tout serveur statique convient (`npx http-server -S`, par exemple).
+4. L’application stocke les données dans votre navigateur. Utilisez **Paramètres → Sauvegarde** pour exporter des instantanés JSON avant de changer de machine.
+
+---
+
+## Flux de travail type
+
+1. **Créez ou chargez un projet.** Appuyez sur Entrée ou `Ctrl+S` (`⌘S` sur macOS) pour enregistrer rapidement. Des instantanés automatiques sont réalisés toutes les 10 minutes.
+2. **Sélectionnez caméra, alimentation et accessoires.** Les menus se filtrent au fil de la saisie et les favoris restent épinglés.
+3. **Analysez les résultats d’alimentation.** Vérifiez watts, intensité, alertes de sécurité batterie et autonomies dans le panneau comparatif.
+4. **Consignez les exigences.** Enregistrez rôles de l’équipe, jours de tournage, scénarios et notes pour que chaque export reflète le bon contexte.
+5. **Générez les livrables.** Produisez listes de matériel, aperçus imprimables et paquets de projet partageables, puis restaurez-les plus tard d’un simple import.
+
+---
+
+## Éléments essentiels de l’interface
+
+- **Recherche globale** (`/` ou `Ctrl+K`/`⌘K`) pour accéder à toute fonctionnalité, sélection ou sujet d’aide, même avec le menu latéral replié.
+- **Centre d’aide** (`?`, `H`, `F1` ou `Ctrl+/`) avec guides recherchables, FAQ, raccourcis et aide contextuelle optionnelle.
+- **Diagramme de projet** qui visualise les connexions ; maintenez Maj lors du téléchargement pour exporter un JPG plutôt qu’un SVG.
+- **Panneau de comparaison des batteries** affichant les performances de chaque pack compatible et les risques de surcharge.
+- **Générateur de liste de matériel** transformant les sélections en tableaux catégorisés avec métadonnées, e-mails de l’équipe et ajouts liés aux scénarios.
+- **Indicateur hors ligne & rechargement forcé** pour connaître l’état de connexion et actualiser les fichiers en cache sans perdre vos projets.
+
+---
+
+## Gestion des données et des exports
+
+- Projets, paramètres, listes de matériel, favoris et appareils personnalisés résident dans `localStorage` ; sauvegardes et restaurations préservent l’ensemble.
+- La fenêtre Paramètres propose rappels horaires de sauvegarde, exportations manuelles, restauration en un clic et un bouton **Effacer le cache local**.
+- Les fichiers de projet partagés regroupent sélections, exigences, retours d’autonomie, listes de matériel et appareils personnalisés pour un transfert fluide entre équipes.
+- Les aperçus imprimables incluent nom du projet, informations de production, logo personnalisé optionnel et liste de matériel générée.
+- Des instantanés automatiques s’exécutent en arrière-plan pour revenir facilement à un état antérieur.
+
+---
+
+## Intelligence batterie & autonomie
+
+- Calcule la consommation totale, le nombre de batteries nécessaires pour des journées de 10 h et le courant requis par chaque liaison.
+- Alerte à 80 % de charge et bloque les charges dangereuses lorsque la demande dépasse la valeur continue ou D‑Tap d’une batterie.
+- Les estimations pondérées prennent en compte température, résolution, cadence, codec, utilisation du Wi‑Fi, luminosité du moniteur et part de consommation de chaque appareil.
+- Un tableau de bord des autonomies classe les retours selon leur poids, affiche leur pourcentage de contribution et met en évidence les valeurs aberrantes.
+- Les retours envoyés par les utilisateurs affinent les estimations pour les tournages réels.
+
+---
+
+## Personnalisation & accessibilité
+
+- Passez d’un thème à l’autre (sombre, rose ou contraste élevé) et ajustez la typographie sans recharger la page.
+- Téléchargez un logo personnalisé pour les aperçus imprimables, définissez les rôles de monitoring par défaut et configurez des exigences projet prédéfinies.
+- Navigation au clavier, états de focus visibles et liens d’évitement assurent l’accessibilité sur plateau et la compatibilité lecteur d’écran.
+- Recherche dans les menus, favoris épinglés et boutons de duplication pour les lignes de liste accélèrent la saisie répétitive.
+
+---
+
+## Raccourcis clavier
+
+| Action | Raccourci |
+| --- | --- |
+| Focaliser la recherche globale | `/`, `Ctrl+K`, `⌘K` |
+| Ouvrir l’aide | `?`, `H`, `F1`, `Ctrl+/` |
+| Enregistrer le projet | `Entrée`, `Ctrl+S`, `⌘S` |
+| Activer/désactiver le thème sombre | `D` |
+| Activer/désactiver le thème rose | `P` |
+| Rechargement forcé | Cliquer sur l’icône 🔄 dans l’en-tête |
+
+---
+
+## Développement
+
+- Installez les dépendances avec `npm install` (pour le linting, les tests et les scripts de données – aucun build n’est nécessaire).
+- Exécutez `npm run lint` et `npm run test` avant de valider. Des suites ciblées existent via `npm run test:unit`, `npm run test:data`, `npm run test:dom` et `npm run test:script`.
+- Scripts utiles :
+  - `npm run check-consistency` vérifie la cohérence des données.
+  - `npm run normalize` et `npm run unify-ports` gardent le catalogue propre.
+  - `npm run generate-schema` régénère le schéma des appareils.
+
+---
+
+## Traductions
+
+La documentation existe en plusieurs langues et l’application détecte automatiquement celle de votre navigateur au premier lancement. Changez à tout moment via le menu langue en haut à droite :
+
 - 🇬🇧 [English](README.en.md)
 - 🇩🇪 [Deutsch](README.de.md)
 - 🇪🇸 [Español](README.es.md)
 - 🇮🇹 [Italiano](README.it.md)
 - 🇫🇷 [Français](README.fr.md)
 
-L’application adopte automatiquement la langue de votre navigateur lors de la première visite et vous pouvez la modifier à tout moment en haut à droite. Le choix est mémorisé pour la prochaine session.
+Envie de contribuer ? Suivez le [guide de traduction](docs/translation-guide.md) pour ajouter de nouvelles langues à l’interface et à la documentation.
 
 ---
 
-## 🆕 Nouveautés
-- Les contrôles d’accent et de typographie dans Paramètres permettent d’ajuster la couleur d’accent, la taille de base de la police et la famille de caractères, en plus des thèmes sombre, rose et à fort contraste.
-- Les raccourcis clavier de la recherche globale permettent d’appuyer sur / ou Ctrl+K (⌘K sur macOS) pour la focaliser instantanément, même lorsqu’elle se trouve dans le menu latéral mobile replié.
-- Le bouton de rechargement forcé efface les fichiers mis en cache par le service worker afin que l’application hors ligne se mette à jour sans supprimer les projets ni les appareils enregistrés.
-- Les icônes étoilées dans chaque sélecteur épinglent les caméras, batteries et accessoires favoris en haut de la liste et les incluent dans les sauvegardes.
-- Le bouton **Effacer le cache local** supprime les projets et paramètres stockés.
-- La liste de matériel et l’aperçu imprimable affichent le nom du projet pour une consultation rapide.
-- Importez un logo personnalisé pour les aperçus imprimables et les sauvegardes.
-- Les sauvegardes contiennent les favoris et créent une copie automatique avant toute restauration.
-- Les entrées d’équipe disposent désormais d’un champ e-mail.
-- Un thème à fort contraste améliore la lisibilité.
-- Les formulaires d’appareils remplissent les catégories dynamiquement selon le schéma.
-- Interface repensée avec plus de contraste et d’espacement pour une expérience plus claire sur tous les appareils.
-- Le partage de projets est simplifié : téléchargez un fichier JSON qui regroupe sélections, exigences, listes de matériel, retours d’autonomie et appareils personnalisés, puis importez-le pour tout restaurer.
-- Des icônes uniques pour les scénarios requis facilitent l’identification des contraintes du projet.
-- Diagramme de projet interactif permettant de faire glisser les appareils, de zoomer, d’aligner sur la grille et d’exporter en SVG ou JPG.
-- Thème rose ludique persistant entre les visites.
-- Boîte d’aide avec recherche, sections pas à pas et FAQ ; ouvrez-la avec ?, H, F1 ou Ctrl+/.
-- Aides contextuelles au survol pour les boutons, champs, menus déroulants et en-têtes.
-- Barre de recherche globale pour accéder rapidement aux fonctionnalités, sélecteurs d’appareils ou rubriques d’aide.
-- Compatibilité avec les caméras dotées de plaques batterie V-, B- ou Gold-Mount.
-- Soumettez des retours d’autonomie accompagnés de la température pour affiner les estimations.
-- Tableau de pondération visuel pour analyser l’impact des réglages sur chaque mesure, trié par poids avec pourcentages précis.
-- Génération de listes de matériel regroupant les équipements choisis et les exigences du projet.
-- Sauvegarde des exigences de projet avec chaque configuration afin que la liste de matériel conserve tout le contexte.
-- Duplication instantanée des entrées utilisateur dans les formulaires de liste de matériel grâce aux boutons en forme de fourche.
+## Contributions & support
+
+Bugs, idées de fonctionnalités et corrections de données sont les bienvenus. Ouvrez une issue ou soumettez une pull request en détaillant au maximum. Si vous repérez des autonomies incorrectes ou du matériel manquant, joignez le fichier projet ou des données d’exemple afin de conserver un catalogue fiable.
 
 ---
 
-## 🔧 Fonctionnalités
+## Licence
 
-### ✅ Gestion de projet
-- Enregistrez, chargez et supprimez plusieurs projets caméra (appuyez sur Entrée ou Ctrl+S/⌘S pour sauvegarder rapidement ; le bouton Enregistrer reste inactif tant qu’aucun nom n’est saisi).
-- Des instantanés automatiques sont créés toutes les 10 minutes tant que le planner est ouvert, et la boîte de dialogue Paramètres peut déclencher des exports de sauvegarde horaires pour penser à archiver vos données.
-- Téléchargez un fichier JSON qui regroupe sélections, exigences, liste de matériel, retours d’autonomie et appareils personnalisés ; chargez-le via le sélecteur Projet partagé pour tout restaurer en une étape.
-- Les données sont stockées localement via `localStorage` et les favoris sont inclus dans les sauvegardes ; utilisez le bouton **Effacer le cache local** dans Paramètres pour supprimer projets mis en cache et modifications d’appareils.
-- Générez des aperçus imprimables pour tout projet enregistré et ajoutez un logo personnalisé afin d’aligner exports et sauvegardes sur l’identité de votre production.
-- Enregistrez les exigences de projet avec chaque projet afin que la liste de matériel conserve tout le contexte.
-- Fonctionne entièrement hors ligne grâce au service worker installé : langue, thème, données d’appareils et favoris persistent entre les sessions.
-- Mise en page responsive qui s’adapte sans effort aux ordinateurs, tablettes et téléphones.
-- Sur les caméras compatibles, choisissez des plaques **V‑Mount**, **B‑Mount** ou **Gold-Mount** ; la liste de batteries se met à jour automatiquement.
-
-### 🧭 Aperçu de l’interface
-- Un lien d’évitement et un indicateur hors ligne maintiennent l’interface accessible au clavier et au tactile ; l’insigne apparaît dès que le navigateur perd la connexion.
-- La barre de recherche globale permet d’atteindre des fonctionnalités, sélecteurs d’appareils ou rubriques d’aide ; appuyez sur Entrée pour valider le résultat en surbrillance, utilisez / ou Ctrl+K (⌘K sur macOS) pour la focaliser instantanément (le menu latéral s’ouvre automatiquement sur les petits écrans) et appuyez sur Échap ou × pour effacer la requête.
-- Les commandes de la barre supérieure offrent le changement de langue, les thèmes sombre et rose, ainsi qu’une boîte de dialogue Paramètres avec la couleur d’accent, la taille et la famille de police, le mode à fort contraste et l’import de logo, ainsi que des outils de sauvegarde, restauration et nettoyage du cache local.
-- Le bouton Aide ouvre une boîte de dialogue recherchable avec des sections pas à pas, des raccourcis clavier, une FAQ et un mode aide contextuelle optionnel ; vous pouvez aussi l’ouvrir avec ?, H, F1 ou Ctrl+/ même en cours de saisie.
-- Le bouton de rechargement forcé (🔄) efface les fichiers du service worker en cache afin que l’application hors ligne se mette à jour sans supprimer projets ni appareils.
-- Sur les petits écrans, un menu latéral repliable reflète chaque section principale pour une navigation rapide.
-
-### ♿ Personnalisation et accessibilité
-- Les thèmes incluent un mode sombre, un accent rose ludique et un interrupteur dédié à fort contraste pour une meilleure lisibilité.
-- Les changements de couleur d’accent, de taille de police et de typographie s’appliquent instantanément et restent enregistrés dans le navigateur, ce qui facilite l’adaptation à la charte graphique ou aux besoins d’accessibilité.
-- Les raccourcis intégrés couvrent la recherche globale (/ ou Ctrl+K/⌘K), l’aide ( ?, H, F1, Ctrl+/ ), l’enregistrement (Entrée ou Ctrl+S/⌘S), le mode sombre (D) et le mode rose (P).
-- Le mode aide au survol transforme chaque bouton, champ, menu et en-tête en infobulle à la demande pour accélérer l’apprentissage des nouveaux utilisateurs.
-- Les champs avec recherche incrémentale, les styles visibles au focus et les icônes étoilées à côté des sélecteurs facilitent le filtrage des longues listes et l’épinglage des favoris.
-
-### 📋 Liste de matériel
-Le générateur transforme vos sélections en une liste de préparation catégorisée :
-
-- Cliquez sur **Générer la liste de matériel** pour compiler l’équipement choisi et les exigences du projet dans un tableau.
-- Le tableau se met à jour automatiquement quand les sélections ou exigences changent.
-- Les éléments sont regroupés par catégorie (caméra, optique, alimentation, monitoring, rigging, grip, accessoires, consommables) et les doublons sont fusionnés avec leur quantité.
-- Les câbles, structures et accessoires requis pour les moniteurs, moteurs, gimbals et scénarios météo sont ajoutés automatiquement.
-- Les scénarios sélectionnés injectent le matériel associé :
-  - *Handheld* + *Easyrig* ajoute une poignée télescopique pour un soutien stable.
-  - *Gimbal* ajoute le gimbal choisi, des bras articulés, des spigots et des pare-soleil ou kits de filtres.
-  - *Outdoor* fournit des spigots, des parapluies et des housses de pluie CapIt.
-  - Les scénarios *Vehicle* et *Steadicam* ajoutent fixations, bras isolants et ventouses selon le cas.
-- Les sélections d’optique incluent diamètre frontal, poids, données de rods et mise au point minimale, ajoutent des supports d’objectif et adaptateurs de matte box, et avertissent des standards incompatibles.
-- Les lignes de batteries reflètent les quantités du calculateur d’alimentation et incluent des plaques ou appareils de *hotswap* si nécessaire.
-- Les préférences de monitoring attribuent des moniteurs par défaut pour chaque rôle (réalisateur, DoP, pointeur, etc.) avec jeux de câbles et récepteurs sans fil.
-- Le formulaire **Exigences du projet** alimente la liste :
-  - **Nom du projet**, **société de production**, **loueur** et **DoP** apparaissent dans l’en-tête des exigences imprimées.
-  - Les entrées de **l’équipe** capturent noms, rôles et adresses e-mail afin que les contacts suivent le projet.
-  - **Jours de préparation** et **jours de tournage** fournissent des notes de calendrier et, combinés à des scénarios extérieurs, suggèrent l’équipement météo.
-  - Les **scénarios requis** ajoutent rigging, gimbals et protections climatiques correspondants.
-  - **Poignée caméra** et **extension viseur** ajoutent les pièces ou supports sélectionnés.
-  - Les choix de **matte box** et de **filtres** ajoutent le système retenu avec plateaux, adaptateurs à collier ou filtres nécessaires.
-  - Les réglages de **monitoring**, **distribution vidéo** et **viseur** ajoutent moniteurs, câbles et incrustations pour chaque rôle.
-  - Les sélections de **boutons utilisateur** et **préférences de trépied** sont listées pour référence rapide.
-- Les éléments de chaque catégorie sont triés alphabétiquement et affichent une info-bulle au survol.
-- La liste de matériel figure dans les aperçus imprimables et dans les fichiers de projet partagés.
-- Les listes de matériel sont sauvegardées automatiquement avec le projet et incluses dans les fichiers partagés et les sauvegardes.
-- **Supprimer la liste de matériel** efface la liste enregistrée et masque la sortie.
-- Les formulaires de liste de matériel proposent des boutons en forme de fourche pour dupliquer instantanément les entrées utilisateur.
-
-### 📦 Catégories d’appareils
-- **Caméra** (1)
-- **Moniteur** (optionnel)
-- **Transmetteur sans fil** (optionnel)
-- **Moteurs FIZ** (0–4)
-- **Contrôleurs FIZ** (0–4)
-- **Capteur de distance** (0–1)
-- **Plaque batterie** (uniquement sur les caméras compatibles V‑ ou B‑Mount)
-- **Batterie V‑Mount** (0–1)
-
-### ⚙️ Calculs de puissance
-- Consommation totale en watts
-- Intensité à 14,4 V et 12 V
-- Autonomie estimée en heures via la moyenne pondérée des retours utilisateurs
-- Nombre de batteries nécessaires pour un tournage de 10 h (avec une de secours)
-- Note de température pour ajuster l’autonomie en conditions chaudes ou froides
-
-### 🔋 Vérification de la sortie batterie
-- Avertit si l’intensité dépasse la sortie de la batterie (pin ou D‑Tap)
-- Indique lorsque la consommation approche de la limite (80 % d’utilisation)
-
-### 📊 Comparaison des batteries (optionnel)
-- Compare les estimations d’autonomie de toutes les batteries
-- Graphiques à barres pour une lecture immédiate
-
-### 🖼 Diagramme du projet
-- Visualise les connexions d’alimentation et de vidéo des appareils sélectionnés.
-- Signale les marques FIZ incompatibles.
-- Faites glisser les nœuds pour réorganiser le schéma, zoomez avec les boutons et exportez le diagramme en SVG ou JPG.
-- Maintenez Shift enfoncé lors du clic sur Télécharger pour exporter une image JPG plutôt qu’un SVG.
-- Survolez ou touchez un appareil pour afficher sa fiche détaillée.
-- Utilise les icônes [OpenMoji](https://openmoji.org/) lorsqu’une connexion est disponible et se replie sur les emoji : 🔋 batterie, 🎥 caméra, 🖥️ moniteur, 📡 vidéo, ⚙️ moteur, 🎮 contrôleur, 📐 distance, 🎮 poignée et 🔌 plaque batterie.
-
-### 🧮 Pondération des données d’autonomie
-- Les autonomies remontées par les utilisateurs affinent l’estimation.
-- Chaque saisie est ajustée en fonction de la température, en passant de ×1 à 25 °C à :
-  - ×1,25 à 0 °C
-  - ×1,6 à −10 °C
-  - ×2 à −20 °C
-- Les réglages caméra influencent la pondération :
-  - Multiplicateurs de résolution : ≥12K ×3, ≥8K ×2, ≥4K ×1,5, ≥1080p ×1 ; les résolutions inférieures sont ramenées à 1080p.
-  - La cadence est pondérée linéairement à partir de 24 i/s (ex. 48 i/s = ×2).
-  - Le Wi-Fi activé ajoute 10 %.
-  - Facteurs codecs : RAW/BRAW/ARRIRAW/R3D/CinemaDNG/Canon RAW/X‑OCN ×1 ; ProRes ×1,1 ; DNx/AVID ×1,2 ; All‑Intra ×1,3 ; H.264/AVC ×1,5 ; H.265/HEVC ×1,7.
-  - Les entrées moniteur en dessous de la luminosité spécifiée sont pondérées selon leur ratio de luminosité.
-- La pondération finale reflète la part de consommation de chaque appareil, de sorte que les projets similaires comptent davantage.
-- La moyenne pondérée est utilisée dès que trois entrées au minimum sont disponibles.
-- Un tableau de bord classe les mesures par poids et affiche le pourcentage associé pour comparer d’un coup d’œil.
-
-### 🔍 Recherche et filtrage
-- Tapez dans les menus déroulants pour trouver rapidement une entrée.
-- Filtrez les listes d’appareils via un champ de recherche.
-- Utilisez la barre de recherche globale en haut pour rejoindre une fonctionnalité, un appareil ou un sujet d’aide ; appuyez sur Entrée pour naviguer, / ou Ctrl+K (⌘K sur macOS) pour la focaliser instantanément et Échap ou × pour effacer.
-- Appuyez sur « / » ou Ctrl+F (⌘F sur macOS) pour viser immédiatement le champ de recherche le plus proche.
-- Cliquez sur l’étoile à côté d’un sélecteur pour épingler vos favoris en haut de la liste et les synchroniser avec les sauvegardes.
-
-### 🛠 Éditeur de la base d’appareils
-- Ajoutez, modifiez ou supprimez des appareils dans toutes les catégories.
-- Importez ou exportez la base complète au format JSON.
-- Revenez à la base par défaut issue de `data.js`.
-
-### 🌓 Mode sombre
-- Activez-le via le bouton lune près du sélecteur de langue.
-- La préférence est mémorisée dans votre navigateur.
-
-### 🦄 Mode rose
-- Cliquez sur l’icône licorne ou appuyez sur **P** pour activer un accent rose ludique.
-- Fonctionne avec les thèmes clair et sombre et persiste entre les visites.
-
-### ⚫ Mode à fort contraste
-- Active un thème à contraste élevé pour améliorer la lisibilité.
-
-### 📝 Retours d’autonomie
-- Cliquez sur <strong>Soumettre un retour d’autonomie</strong> sous l’autonomie pour ajouter votre mesure.
-- Ajoutez la température pour une pondération plus précise.
-- Les entrées sont sauvegardées dans votre navigateur et affinent les estimations futures.
-
-### ❓ Aide avec recherche
-- Ouvrez-la via le bouton <strong>?</strong> ou avec <kbd>?</kbd>, <kbd>H</kbd>, <kbd>F1</kbd> ou <kbd>Ctrl+/</kbd>.
-- Utilisez le champ de recherche pour filtrer instantanément les sujets ; la requête est réinitialisée à la fermeture.
-- Fermez avec <kbd>Échap</kbd> ou en cliquant hors de la boîte de dialogue.
-
----
-
-## ▶️ Mode d’emploi
-1. **Lancez l’application :** ouvrez `index.html` dans tout navigateur moderne – aucun serveur n’est requis.
-2. **Explorez la barre supérieure :** changez de langue, activez les thèmes sombre ou rose, ouvrez Paramètres pour régler l’accent et la typographie, et lancez l’aide avec ? ou Ctrl+/.
-3. **Sélectionnez les appareils :** choisissez l’équipement par catégorie via les menus déroulants ; saisissez pour filtrer, cliquez sur l’étoile pour épingler vos favoris et laissez les scénarios prédéfinis ajouter les accessoires automatiquement.
-4. **Consultez les calculs :** dès qu’une batterie est sélectionnée, la consommation, l’intensité et l’autonomie apparaissent ; des alertes signalent les limites dépassées.
-5. **Enregistrez et partagez les projets :** nommez et sauvegardez votre configuration, les sauvegardes automatiques capturent des instantanés et le bouton Partager exporte un bundle JSON pour vos partenaires.
-6. **Générez la liste de matériel :** cliquez sur **Générer la liste de matériel** pour transformer les exigences en liste catégorisée avec infobulles et accessoires.
-7. **Gérez les données d’appareils :** choisissez « Modifier les données d’appareils… » pour ouvrir l’éditeur, ajuster les appareils, exporter/importer du JSON ou revenir aux valeurs par défaut.
-8. **Soumettez des retours d’autonomie :** utilisez « Soumettre un retour d’autonomie » pour enregistrer vos mesures terrain et enrichir la pondération.
-
-## 📱 Installer l’application
-
-Le planner est une application web progressive et peut être installée directement depuis le navigateur :
-
-- **Chrome/Edge (bureau) :** cliquez sur l’icône d’installation dans la barre d’adresse.
-- **Android :** ouvrez le menu du navigateur et choisissez *Ajouter à l’écran d’accueil*.
-- **iOS/iPadOS Safari :** touchez le bouton *Partager* puis *Ajouter à l’écran d’accueil*.
-
-Une fois installée, l’application se lance depuis l’écran d’accueil, fonctionne hors ligne et se met à jour automatiquement.
-
-## 📡 Utilisation hors ligne et stockage des données
-
-Servir l’application via HTTP(S) installe un service worker qui met chaque fichier en cache pour que Cine Power Planner fonctionne totalement hors ligne et se mette à jour en arrière-plan. Les projets, retours d’autonomie et préférences (langue, thème, mode rose et listes de matériel sauvegardées) sont stockés dans le `localStorage` du navigateur. Effacer les données du site supprime toutes les informations, et la boîte de dialogue Paramètres propose également un bouton **Effacer le cache local** pour le même nettoyage en un clic.
-
----
-
-## 🗂️ Structure des fichiers
-```bash
-index.html       # Mise en page HTML principale
-style.css        # Styles et mise en page
-script.js        # Logique applicative
-data.js          # Liste d’appareils par défaut
-storage.js       # Helpers LocalStorage
-README.*.md      # Documentation multilingue
-checkConsistency.js  # Vérifie les champs requis dans les données d’appareils
-normalizeData.js     # Nettoie les entrées et unifie les noms de connecteurs
-generateSchema.js    # Reconstruit schema.json à partir de data.js
-unifyPorts.js        # Harmonise les anciens noms de ports
-tests/               # Suite de tests Jest
-```
-Les polices sont intégrées localement via `fonts.css`, ce qui permet à l’application de fonctionner entièrement hors ligne une fois les ressources en cache.
-
-## 🛠️ Développement
-Nécessite Node.js 18 ou version ultérieure.
-
-```bash
-npm install
-npm run lint     # exécute uniquement ESLint
-npm test         # lance le linting, les vérifications de données et les tests Jest
-```
-
-Après modification des données d’appareils, régénérez la base normalisée :
-
-```bash
-npm run normalize
-npm run unify-ports
-npm run check-consistency
-npm run generate-schema
-```
-
-Ajoutez `--help` à l’un de ces scripts pour afficher les options disponibles.
-
-## 🤝 Contribuer
-Les contributions sont les bienvenues ! N’hésitez pas à ouvrir un ticket ou à proposer une pull request sur GitHub.
+Cine Power Planner est publié sous licence ISC.

--- a/README.fr.md
+++ b/README.fr.md
@@ -1,138 +1,312 @@
-# Cine Power Planner
+# 🎥 Cine Power Planner
 
-![Icône Cine Power Planner](icon.svg)
+Cet outil basé sur le navigateur aide à planifier des projets caméra professionnels alimentés par des batteries V‑Mount, B‑Mount ou Gold-Mount. Il calcule la **consommation totale**, l’**intensité demandée** (à 14,4 V et 12 V) et l’**autonomie estimée** tout en vérifiant que la batterie peut fournir la puissance requise en toute sécurité.
 
-Cine Power Planner est une application Web utilisable hors ligne pour planifier des rigs caméra professionnels alimentés par des batteries V‑Mount, B‑Mount ou Gold‑Mount. Elle calcule la consommation totale, vérifie que chaque batterie peut fournir en toute sécurité le courant requis, estime des autonomies réalistes à partir de données terrain pondérées et conserve au même endroit l’équipe, les scénarios et les listes de matériel afin qu’aucune information ne se perde entre les départements.
-
----
-
-## Points forts
-
-### Concevez des configurations complexes sans tâtonner
-- Combinez caméras, plaques batteries, liaisons sans fil, moniteurs, moteurs et accessoires tout en visualisant la puissance totale, le courant à 14,4 V/12 V (et 33,6 V/21,6 V pour le B‑Mount) ainsi que l’autonomie estimée.
-- Comparez les batteries compatibles côte à côte et recevez des alertes lorsque la demande dépasse les limites D‑Tap ou pin.
-- Visualisez vos rigs avec un diagramme interactif offrant glisser-déposer, zoom, export SVG/JPG et avertissements de compatibilité.
-
-### Gardez tous les départements alignés
-- Enregistrez plusieurs projets avec exigences, contacts d’équipe, scénarios de tournage et notes personnalisées.
-- Générez des listes de matériel imprimables qui regroupent l’équipement par catégorie, fusionnent les doublons, incluent les métadonnées techniques et ajoutent des accessoires en fonction des scénarios.
-- Partagez des paquets JSON contenant sélections d’appareils, retours d’autonomie, listes de matériel et appareils personnalisés pour une restauration complète.
-
-### Prête à voyager et respectueuse de la vie privée
-- Fonctionne entièrement dans le navigateur : ouvrez `index.html` directement ou hébergez le dépôt en HTTPS pour activer le service worker.
-- La mise en cache hors ligne conserve langue, thème, favoris et projets partout sans envoyer vos données à des serveurs externes.
-- Videz le cache local ou utilisez le bouton de rechargement forcé pour actualiser les fichiers en cache sans toucher aux projets.
-
-### Adaptez-la à votre équipe
-- Basculez instantanément entre English, Deutsch, Español, Italiano et Français ; l’application retient la dernière langue utilisée.
-- Choisissez les thèmes sombre, rose ou à fort contraste, définissez une couleur d’accent, ajustez la taille de police et sélectionnez la typographie adaptée à votre identité visuelle ou à vos besoins d’accessibilité.
-- Les menus déroulants avec recherche, les favoris épinglés et l’aide au survol gardent l’équipe productive sur le plateau.
+Toute la planification, les saisies et les exports restent sur la machine sous
+vos yeux. La langue, les projets, les appareils personnalisés, les favoris et
+les retours d’autonomie sont stockés dans votre navigateur, et les mises à jour
+du service worker proviennent directement de ce dépôt. Vous pouvez lancer
+l’application hors ligne depuis le disque ou l’héberger en interne pour que
+tous les départements utilisent la même version vérifiée.
 
 ---
 
-## Démarrage rapide
-
-1. Clonez ou téléchargez le dépôt.
-2. Ouvrez `index.html` dans un navigateur moderne (Chromium, Firefox ou Safari). Aucun processus de build n’est requis.
-3. En option, servez le dossier en HTTPS pour installer le service worker et bénéficier des mises à jour hors ligne. Tout serveur statique convient (`npx http-server -S`, par exemple).
-4. L’application stocke les données dans votre navigateur. Utilisez **Paramètres → Sauvegarde** pour exporter des instantanés JSON avant de changer de machine.
-
----
-
-## Flux de travail type
-
-1. **Créez ou chargez un projet.** Appuyez sur Entrée ou `Ctrl+S` (`⌘S` sur macOS) pour enregistrer rapidement. Des instantanés automatiques sont réalisés toutes les 10 minutes.
-2. **Sélectionnez caméra, alimentation et accessoires.** Les menus se filtrent au fil de la saisie et les favoris restent épinglés.
-3. **Analysez les résultats d’alimentation.** Vérifiez watts, intensité, alertes de sécurité batterie et autonomies dans le panneau comparatif.
-4. **Consignez les exigences.** Enregistrez rôles de l’équipe, jours de tournage, scénarios et notes pour que chaque export reflète le bon contexte.
-5. **Générez les livrables.** Produisez listes de matériel, aperçus imprimables et paquets de projet partageables, puis restaurez-les plus tard d’un simple import.
-
----
-
-## Éléments essentiels de l’interface
-
-- **Recherche globale** (`/` ou `Ctrl+K`/`⌘K`) pour accéder à toute fonctionnalité, sélection ou sujet d’aide, même avec le menu latéral replié.
-- **Centre d’aide** (`?`, `H`, `F1` ou `Ctrl+/`) avec guides recherchables, FAQ, raccourcis et aide contextuelle optionnelle.
-- **Diagramme de projet** qui visualise les connexions ; maintenez Maj lors du téléchargement pour exporter un JPG plutôt qu’un SVG.
-- **Panneau de comparaison des batteries** affichant les performances de chaque pack compatible et les risques de surcharge.
-- **Générateur de liste de matériel** transformant les sélections en tableaux catégorisés avec métadonnées, e-mails de l’équipe et ajouts liés aux scénarios.
-- **Indicateur hors ligne & rechargement forcé** pour connaître l’état de connexion et actualiser les fichiers en cache sans perdre vos projets.
-
----
-
-## Gestion des données et des exports
-
-- Projets, paramètres, listes de matériel, favoris et appareils personnalisés résident dans `localStorage` ; sauvegardes et restaurations préservent l’ensemble.
-- La fenêtre Paramètres propose rappels horaires de sauvegarde, exportations manuelles, restauration en un clic et un bouton **Effacer le cache local**.
-- Les fichiers de projet partagés regroupent sélections, exigences, retours d’autonomie, listes de matériel et appareils personnalisés pour un transfert fluide entre équipes.
-- Les aperçus imprimables incluent nom du projet, informations de production, logo personnalisé optionnel et liste de matériel générée.
-- Des instantanés automatiques s’exécutent en arrière-plan pour revenir facilement à un état antérieur.
-
----
-
-## Intelligence batterie & autonomie
-
-- Calcule la consommation totale, le nombre de batteries nécessaires pour des journées de 10 h et le courant requis par chaque liaison.
-- Alerte à 80 % de charge et bloque les charges dangereuses lorsque la demande dépasse la valeur continue ou D‑Tap d’une batterie.
-- Les estimations pondérées prennent en compte température, résolution, cadence, codec, utilisation du Wi‑Fi, luminosité du moniteur et part de consommation de chaque appareil.
-- Un tableau de bord des autonomies classe les retours selon leur poids, affiche leur pourcentage de contribution et met en évidence les valeurs aberrantes.
-- Les retours envoyés par les utilisateurs affinent les estimations pour les tournages réels.
-
----
-
-## Personnalisation & accessibilité
-
-- Passez d’un thème à l’autre (sombre, rose ou contraste élevé) et ajustez la typographie sans recharger la page.
-- Téléchargez un logo personnalisé pour les aperçus imprimables, définissez les rôles de monitoring par défaut et configurez des exigences projet prédéfinies.
-- Navigation au clavier, états de focus visibles et liens d’évitement assurent l’accessibilité sur plateau et la compatibilité lecteur d’écran.
-- Recherche dans les menus, favoris épinglés et boutons de duplication pour les lignes de liste accélèrent la saisie répétitive.
-
----
-
-## Raccourcis clavier
-
-| Action | Raccourci |
-| --- | --- |
-| Focaliser la recherche globale | `/`, `Ctrl+K`, `⌘K` |
-| Ouvrir l’aide | `?`, `H`, `F1`, `Ctrl+/` |
-| Enregistrer le projet | `Entrée`, `Ctrl+S`, `⌘S` |
-| Activer/désactiver le thème sombre | `D` |
-| Activer/désactiver le thème rose | `P` |
-| Rechargement forcé | Cliquer sur l’icône 🔄 dans l’en-tête |
-
----
-
-## Développement
-
-- Installez les dépendances avec `npm install` (pour le linting, les tests et les scripts de données – aucun build n’est nécessaire).
-- Exécutez `npm run lint` et `npm run test` avant de valider. Des suites ciblées existent via `npm run test:unit`, `npm run test:data`, `npm run test:dom` et `npm run test:script`.
-- Scripts utiles :
-  - `npm run check-consistency` vérifie la cohérence des données.
-  - `npm run normalize` et `npm run unify-ports` gardent le catalogue propre.
-  - `npm run generate-schema` régénère le schéma des appareils.
-
----
-
-## Traductions
-
-La documentation existe en plusieurs langues et l’application détecte automatiquement celle de votre navigateur au premier lancement. Changez à tout moment via le menu langue en haut à droite :
-
+## 🌍 Langues
 - 🇬🇧 [English](README.en.md)
 - 🇩🇪 [Deutsch](README.de.md)
 - 🇪🇸 [Español](README.es.md)
 - 🇮🇹 [Italiano](README.it.md)
 - 🇫🇷 [Français](README.fr.md)
 
-Envie de contribuer ? Suivez le [guide de traduction](docs/translation-guide.md) pour ajouter de nouvelles langues à l’interface et à la documentation.
+L’application adopte automatiquement la langue de votre navigateur lors de la première visite et vous pouvez la modifier à tout moment en haut à droite. Le choix est mémorisé pour la prochaine session.
 
 ---
 
-## Contributions & support
-
-Bugs, idées de fonctionnalités et corrections de données sont les bienvenus. Ouvrez une issue ou soumettez une pull request en détaillant au maximum. Si vous repérez des autonomies incorrectes ou du matériel manquant, joignez le fichier projet ou des données d’exemple afin de conserver un catalogue fiable.
+## 🆕 Nouveautés
+- Les contrôles d’accent et de typographie dans Paramètres permettent d’ajuster la couleur d’accent, la taille de base de la police et la famille de caractères, en plus des thèmes sombre, rose et à fort contraste.
+- Les raccourcis clavier de la recherche globale permettent d’appuyer sur / ou Ctrl+K (⌘K sur macOS) pour la focaliser instantanément, même lorsqu’elle se trouve dans le menu latéral mobile replié.
+- Le bouton de rechargement forcé efface les fichiers mis en cache par le service worker afin que l’application hors ligne se mette à jour sans supprimer les projets ni les appareils enregistrés.
+- Les icônes étoilées dans chaque sélecteur épinglent les caméras, batteries et accessoires favoris en haut de la liste et les incluent dans les sauvegardes.
+- Le bouton **Effacer le cache local** supprime les projets et paramètres stockés.
+- La liste de matériel et l’aperçu imprimable affichent le nom du projet pour une consultation rapide.
+- Importez un logo personnalisé pour les aperçus imprimables et les sauvegardes.
+- Les sauvegardes contiennent les favoris et créent une copie automatique avant toute restauration.
+- Les entrées d’équipe disposent désormais d’un champ e-mail.
+- Un thème à fort contraste améliore la lisibilité.
+- Les formulaires d’appareils remplissent les catégories dynamiquement selon le schéma.
+- Interface repensée avec plus de contraste et d’espacement pour une expérience plus claire sur tous les appareils.
+- Le partage de projets est simplifié : téléchargez un fichier JSON qui regroupe sélections, exigences, listes de matériel, retours d’autonomie et appareils personnalisés, puis importez-le pour tout restaurer.
+- Des icônes uniques pour les scénarios requis facilitent l’identification des contraintes du projet.
+- Diagramme de projet interactif permettant de faire glisser les appareils, de zoomer, d’aligner sur la grille et d’exporter en SVG ou JPG.
+- Thème rose ludique persistant entre les visites.
+- Boîte d’aide avec recherche, sections pas à pas et FAQ ; ouvrez-la avec ?, H, F1 ou Ctrl+/.
+- Aides contextuelles au survol pour les boutons, champs, menus déroulants et en-têtes.
+- Barre de recherche globale pour accéder rapidement aux fonctionnalités, sélecteurs d’appareils ou rubriques d’aide.
+- Compatibilité avec les caméras dotées de plaques batterie V-, B- ou Gold-Mount.
+- Soumettez des retours d’autonomie accompagnés de la température pour affiner les estimations.
+- Tableau de pondération visuel pour analyser l’impact des réglages sur chaque mesure, trié par poids avec pourcentages précis.
+- Génération de listes de matériel regroupant les équipements choisis et les exigences du projet.
+- Sauvegarde des exigences de projet avec chaque configuration afin que la liste de matériel conserve tout le contexte.
+- Duplication instantanée des entrées utilisateur dans les formulaires de liste de matériel grâce aux boutons en forme de fourche.
 
 ---
 
-## Licence
+## 🔧 Fonctionnalités
 
-Cine Power Planner est publié sous licence ISC.
+### ✨ Points forts supplémentaires
+
+- **Construisez des rigs complexes sans tâtonner.** Combinez caméras, plaques
+  batteries, liaisons sans fil, moniteurs, moteurs et accessoires tout en
+  visualisant la consommation totale à 14,4 V/12 V (et 33,6 V/21,6 V pour
+  B‑Mount) ainsi que des autonomies réalistes issues de données terrain
+  pondérées. Le panneau de comparaison des batteries signale les surcharges
+  avant de charger le mauvais matériel.
+- **Gardez chaque département aligné.** Enregistrez plusieurs projets avec
+  exigences, contacts d’équipe, scénarios et notes. Les listes imprimables
+  regroupent le matériel par catégorie, fusionnent les doublons, affichent les
+  métadonnées techniques et ajoutent les accessoires dictés par les scénarios
+  pour que caméra, lumière et machinerie partagent le même contexte.
+- **Travaillez sereinement partout.** Ouvrez `index.html` directement ou servez
+  le dossier en HTTPS pour activer le service worker. La mise en cache hors
+  ligne conserve langue, thèmes, favoris et projets, et **Forcer le rechargement**
+  actualise les fichiers sans toucher aux données.
+- **Adaptez l’outil à votre équipe.** Basculez instantanément entre français,
+  anglais, allemand, espagnol et italien, ajustez taille et police, choisissez
+  une couleur d’accent personnalisée, importez un logo d’impression et alternez
+  thème clair, sombre, rose ou à fort contraste. Les menus filtrables, favoris
+  épinglés, boutons de duplication et aides contextuelles gardent un rythme
+  rapide sur le plateau.
+
+### ✅ Gestion de projet
+- Enregistrez, chargez et supprimez plusieurs projets caméra (appuyez sur Entrée ou Ctrl+S/⌘S pour sauvegarder rapidement ; le bouton Enregistrer reste inactif tant qu’aucun nom n’est saisi).
+- Des instantanés automatiques sont créés toutes les 10 minutes tant que le planner est ouvert, et la boîte de dialogue Paramètres peut déclencher des exports de sauvegarde horaires pour penser à archiver vos données.
+- Téléchargez un fichier JSON qui regroupe sélections, exigences, liste de matériel, retours d’autonomie et appareils personnalisés ; chargez-le via le sélecteur Projet partagé pour tout restaurer en une étape.
+- Les données sont stockées localement via `localStorage` et les favoris sont inclus dans les sauvegardes ; utilisez le bouton **Effacer le cache local** dans Paramètres pour supprimer projets mis en cache et modifications d’appareils.
+- Générez des aperçus imprimables pour tout projet enregistré et ajoutez un logo personnalisé afin d’aligner exports et sauvegardes sur l’identité de votre production.
+- Enregistrez les exigences de projet avec chaque projet afin que la liste de matériel conserve tout le contexte.
+- Fonctionne entièrement hors ligne grâce au service worker installé : langue, thème, données d’appareils et favoris persistent entre les sessions.
+- Mise en page responsive qui s’adapte sans effort aux ordinateurs, tablettes et téléphones.
+- Sur les caméras compatibles, choisissez des plaques **V‑Mount**, **B‑Mount** ou **Gold-Mount** ; la liste de batteries se met à jour automatiquement.
+
+### 🧭 Aperçu de l’interface
+- **Rappel express :**
+  - **Recherche globale** (`/` ou `Ctrl+K`/`⌘K`) rejoint fonctions, sélecteurs ou
+    rubriques d’aide même quand le menu latéral est replié.
+  - **Centre d’aide** (`?`, `H`, `F1` ou `Ctrl+/`) propose des guides filtrables,
+    une FAQ, des raccourcis et le mode d’aide contextuelle.
+  - **Diagramme de projet** visualise les connexions ; maintenez Maj en
+    téléchargeant pour obtenir un JPG au lieu d’un SVG et afficher les alertes de
+    compatibilité.
+  - **Comparateur de batteries** révèle les performances des packs compatibles
+    et signale les risques de surcharge.
+  - **Générateur de liste** produit des tableaux catégorisés avec métadonnées,
+    courriels de l’équipe et ajouts dépendant des scénarios prêts pour
+    l’impression.
+  - **Badge hors ligne et Forcer le rechargement** reflètent l’état de la
+    connexion et renouvellent les fichiers en cache sans effacer les projets.
+- Un lien d’évitement et un indicateur hors ligne maintiennent l’interface accessible au clavier et au tactile ; l’insigne apparaît dès que le navigateur perd la connexion.
+- La barre de recherche globale permet d’atteindre des fonctionnalités, sélecteurs d’appareils ou rubriques d’aide ; appuyez sur Entrée pour valider le résultat en surbrillance, utilisez / ou Ctrl+K (⌘K sur macOS) pour la focaliser instantanément (le menu latéral s’ouvre automatiquement sur les petits écrans) et appuyez sur Échap ou × pour effacer la requête.
+- Les commandes de la barre supérieure offrent le changement de langue, les thèmes sombre et rose, ainsi qu’une boîte de dialogue Paramètres avec la couleur d’accent, la taille et la famille de police, le mode à fort contraste et l’import de logo, ainsi que des outils de sauvegarde, restauration et nettoyage du cache local.
+- Le bouton Aide ouvre une boîte de dialogue recherchable avec des sections pas à pas, des raccourcis clavier, une FAQ et un mode aide contextuelle optionnel ; vous pouvez aussi l’ouvrir avec ?, H, F1 ou Ctrl+/ même en cours de saisie.
+- Le bouton de rechargement forcé (🔄) efface les fichiers du service worker en cache afin que l’application hors ligne se mette à jour sans supprimer projets ni appareils.
+- Sur les petits écrans, un menu latéral repliable reflète chaque section principale pour une navigation rapide.
+
+### ♿ Personnalisation et accessibilité
+- Les thèmes incluent un mode sombre, un accent rose ludique et un interrupteur dédié à fort contraste pour une meilleure lisibilité.
+- Les changements de couleur d’accent, de taille de police et de typographie s’appliquent instantanément et restent enregistrés dans le navigateur, ce qui facilite l’adaptation à la charte graphique ou aux besoins d’accessibilité.
+- Les raccourcis intégrés couvrent la recherche globale (/ ou Ctrl+K/⌘K), l’aide ( ?, H, F1, Ctrl+/ ), l’enregistrement (Entrée ou Ctrl+S/⌘S), le mode sombre (D) et le mode rose (P).
+- Le mode aide au survol transforme chaque bouton, champ, menu et en-tête en infobulle à la demande pour accélérer l’apprentissage des nouveaux utilisateurs.
+- Les champs avec recherche incrémentale, les styles visibles au focus et les icônes étoilées à côté des sélecteurs facilitent le filtrage des longues listes et l’épinglage des favoris.
+- Importez un logo pour l’impression, définissez des rôles de monitoring par
+  défaut et ajustez les préréglages des exigences projet pour coller à la charte
+  de production.
+- Les boutons de duplication dupliquent instantanément les lignes des
+  formulaires et les favoris épinglés gardent le matériel essentiel en tête de
+  liste, idéal quand le temps est compté sur le plateau.
+
+### 📋 Liste de matériel
+Le générateur transforme vos sélections en une liste de préparation catégorisée :
+
+- Cliquez sur **Générer la liste de matériel** pour compiler l’équipement choisi et les exigences du projet dans un tableau.
+- Le tableau se met à jour automatiquement quand les sélections ou exigences changent.
+- Les éléments sont regroupés par catégorie (caméra, optique, alimentation, monitoring, rigging, grip, accessoires, consommables) et les doublons sont fusionnés avec leur quantité.
+- Les câbles, structures et accessoires requis pour les moniteurs, moteurs, gimbals et scénarios météo sont ajoutés automatiquement.
+- Les scénarios sélectionnés injectent le matériel associé :
+  - *Handheld* + *Easyrig* ajoute une poignée télescopique pour un soutien stable.
+  - *Gimbal* ajoute le gimbal choisi, des bras articulés, des spigots et des pare-soleil ou kits de filtres.
+  - *Outdoor* fournit des spigots, des parapluies et des housses de pluie CapIt.
+  - Les scénarios *Vehicle* et *Steadicam* ajoutent fixations, bras isolants et ventouses selon le cas.
+- Les sélections d’optique incluent diamètre frontal, poids, données de rods et mise au point minimale, ajoutent des supports d’objectif et adaptateurs de matte box, et avertissent des standards incompatibles.
+- Les lignes de batteries reflètent les quantités du calculateur d’alimentation et incluent des plaques ou appareils de *hotswap* si nécessaire.
+- Les préférences de monitoring attribuent des moniteurs par défaut pour chaque rôle (réalisateur, DoP, pointeur, etc.) avec jeux de câbles et récepteurs sans fil.
+- Le formulaire **Exigences du projet** alimente la liste :
+  - **Nom du projet**, **société de production**, **loueur** et **DoP** apparaissent dans l’en-tête des exigences imprimées.
+  - Les entrées de **l’équipe** capturent noms, rôles et adresses e-mail afin que les contacts suivent le projet.
+  - **Jours de préparation** et **jours de tournage** fournissent des notes de calendrier et, combinés à des scénarios extérieurs, suggèrent l’équipement météo.
+  - Les **scénarios requis** ajoutent rigging, gimbals et protections climatiques correspondants.
+  - **Poignée caméra** et **extension viseur** ajoutent les pièces ou supports sélectionnés.
+  - Les choix de **matte box** et de **filtres** ajoutent le système retenu avec plateaux, adaptateurs à collier ou filtres nécessaires.
+  - Les réglages de **monitoring**, **distribution vidéo** et **viseur** ajoutent moniteurs, câbles et incrustations pour chaque rôle.
+  - Les sélections de **boutons utilisateur** et **préférences de trépied** sont listées pour référence rapide.
+- Les éléments de chaque catégorie sont triés alphabétiquement et affichent une info-bulle au survol.
+- La liste de matériel figure dans les aperçus imprimables et dans les fichiers de projet partagés.
+- Les listes de matériel sont sauvegardées automatiquement avec le projet et incluses dans les fichiers partagés et les sauvegardes.
+- **Supprimer la liste de matériel** efface la liste enregistrée et masque la sortie.
+- Les formulaires de liste de matériel proposent des boutons en forme de fourche pour dupliquer instantanément les entrées utilisateur.
+
+### 📦 Catégories d’appareils
+- **Caméra** (1)
+- **Moniteur** (optionnel)
+- **Transmetteur sans fil** (optionnel)
+- **Moteurs FIZ** (0–4)
+- **Contrôleurs FIZ** (0–4)
+- **Capteur de distance** (0–1)
+- **Plaque batterie** (uniquement sur les caméras compatibles V‑ ou B‑Mount)
+- **Batterie V‑Mount** (0–1)
+
+### ⚙️ Calculs de puissance
+- Consommation totale en watts
+- Intensité à 14,4 V et 12 V
+- Autonomie estimée en heures via la moyenne pondérée des retours utilisateurs
+- Nombre de batteries nécessaires pour un tournage de 10 h (avec une de secours)
+- Note de température pour ajuster l’autonomie en conditions chaudes ou froides
+
+### 🔋 Vérification de la sortie batterie
+- Avertit si l’intensité dépasse la sortie de la batterie (pin ou D‑Tap)
+- Indique lorsque la consommation approche de la limite (80 % d’utilisation)
+
+### 📊 Comparaison des batteries (optionnel)
+- Compare les estimations d’autonomie de toutes les batteries
+- Graphiques à barres pour une lecture immédiate
+
+### 🖼 Diagramme du projet
+- Visualise les connexions d’alimentation et de vidéo des appareils sélectionnés.
+- Signale les marques FIZ incompatibles.
+- Faites glisser les nœuds pour réorganiser le schéma, zoomez avec les boutons et exportez le diagramme en SVG ou JPG.
+- Maintenez Shift enfoncé lors du clic sur Télécharger pour exporter une image JPG plutôt qu’un SVG.
+- Survolez ou touchez un appareil pour afficher sa fiche détaillée.
+- Utilise les icônes [OpenMoji](https://openmoji.org/) lorsqu’une connexion est disponible et se replie sur les emoji : 🔋 batterie, 🎥 caméra, 🖥️ moniteur, 📡 vidéo, ⚙️ moteur, 🎮 contrôleur, 📐 distance, 🎮 poignée et 🔌 plaque batterie.
+
+### 🧮 Pondération des données d’autonomie
+- Les autonomies remontées par les utilisateurs affinent l’estimation.
+- Chaque saisie est ajustée en fonction de la température, en passant de ×1 à 25 °C à :
+  - ×1,25 à 0 °C
+  - ×1,6 à −10 °C
+  - ×2 à −20 °C
+- Les réglages caméra influencent la pondération :
+  - Multiplicateurs de résolution : ≥12K ×3, ≥8K ×2, ≥4K ×1,5, ≥1080p ×1 ; les résolutions inférieures sont ramenées à 1080p.
+  - La cadence est pondérée linéairement à partir de 24 i/s (ex. 48 i/s = ×2).
+  - Le Wi-Fi activé ajoute 10 %.
+  - Facteurs codecs : RAW/BRAW/ARRIRAW/R3D/CinemaDNG/Canon RAW/X‑OCN ×1 ; ProRes ×1,1 ; DNx/AVID ×1,2 ; All‑Intra ×1,3 ; H.264/AVC ×1,5 ; H.265/HEVC ×1,7.
+  - Les entrées moniteur en dessous de la luminosité spécifiée sont pondérées selon leur ratio de luminosité.
+- La pondération finale reflète la part de consommation de chaque appareil, de sorte que les projets similaires comptent davantage.
+- La moyenne pondérée est utilisée dès que trois entrées au minimum sont disponibles.
+- Un tableau de bord classe les mesures par poids et affiche le pourcentage associé pour comparer d’un coup d’œil.
+
+### 🔍 Recherche et filtrage
+- Tapez dans les menus déroulants pour trouver rapidement une entrée.
+- Filtrez les listes d’appareils via un champ de recherche.
+- Utilisez la barre de recherche globale en haut pour rejoindre une fonctionnalité, un appareil ou un sujet d’aide ; appuyez sur Entrée pour naviguer, / ou Ctrl+K (⌘K sur macOS) pour la focaliser instantanément et Échap ou × pour effacer.
+- Appuyez sur « / » ou Ctrl+F (⌘F sur macOS) pour viser immédiatement le champ de recherche le plus proche.
+- Cliquez sur l’étoile à côté d’un sélecteur pour épingler vos favoris en haut de la liste et les synchroniser avec les sauvegardes.
+
+### 🛠 Éditeur de la base d’appareils
+- Ajoutez, modifiez ou supprimez des appareils dans toutes les catégories.
+- Importez ou exportez la base complète au format JSON.
+- Revenez à la base par défaut issue de `data.js`.
+
+### 🌓 Mode sombre
+- Activez-le via le bouton lune près du sélecteur de langue.
+- La préférence est mémorisée dans votre navigateur.
+
+### 🦄 Mode rose
+- Cliquez sur l’icône licorne ou appuyez sur **P** pour activer un accent rose ludique.
+- Fonctionne avec les thèmes clair et sombre et persiste entre les visites.
+
+### ⚫ Mode à fort contraste
+- Active un thème à contraste élevé pour améliorer la lisibilité.
+
+### 📝 Retours d’autonomie
+- Cliquez sur <strong>Soumettre un retour d’autonomie</strong> sous l’autonomie pour ajouter votre mesure.
+- Ajoutez la température pour une pondération plus précise.
+- Les entrées sont sauvegardées dans votre navigateur et affinent les estimations futures.
+- Un tableau de bord classe les retours selon leur poids, affiche les
+  pourcentages de contribution et met en évidence les valeurs atypiques pour que
+  l’équipe puisse analyser les données terrain en un clin d’œil.
+
+### ❓ Aide avec recherche
+- Ouvrez-la via le bouton <strong>?</strong> ou avec <kbd>?</kbd>, <kbd>H</kbd>, <kbd>F1</kbd> ou <kbd>Ctrl+/</kbd>.
+- Utilisez le champ de recherche pour filtrer instantanément les sujets ; la requête est réinitialisée à la fermeture.
+- Fermez avec <kbd>Échap</kbd> ou en cliquant hors de la boîte de dialogue.
+
+---
+
+## ▶️ Mode d’emploi
+1. **Lancez l’application :** ouvrez `index.html` dans tout navigateur moderne – aucun serveur n’est requis.
+2. **Explorez la barre supérieure :** changez de langue, activez les thèmes sombre ou rose, ouvrez Paramètres pour régler l’accent et la typographie, et lancez l’aide avec ? ou Ctrl+/.
+3. **Sélectionnez les appareils :** choisissez l’équipement par catégorie via les menus déroulants ; saisissez pour filtrer, cliquez sur l’étoile pour épingler vos favoris et laissez les scénarios prédéfinis ajouter les accessoires automatiquement.
+4. **Consultez les calculs :** dès qu’une batterie est sélectionnée, la consommation, l’intensité et l’autonomie apparaissent ; des alertes signalent les limites dépassées.
+5. **Enregistrez et partagez les projets :** nommez et sauvegardez votre configuration, les sauvegardes automatiques capturent des instantanés et le bouton Partager exporte un bundle JSON pour vos partenaires.
+6. **Générez la liste de matériel :** cliquez sur **Générer la liste de matériel** pour transformer les exigences en liste catégorisée avec infobulles et accessoires.
+7. **Gérez les données d’appareils :** choisissez « Modifier les données d’appareils… » pour ouvrir l’éditeur, ajuster les appareils, exporter/importer du JSON ou revenir aux valeurs par défaut.
+8. **Soumettez des retours d’autonomie :** utilisez « Soumettre un retour d’autonomie » pour enregistrer vos mesures terrain et enrichir la pondération.
+
+## 📱 Installer l’application
+
+Le planner est une application web progressive et peut être installée directement depuis le navigateur :
+
+- **Chrome/Edge (bureau) :** cliquez sur l’icône d’installation dans la barre d’adresse.
+- **Android :** ouvrez le menu du navigateur et choisissez *Ajouter à l’écran d’accueil*.
+- **iOS/iPadOS Safari :** touchez le bouton *Partager* puis *Ajouter à l’écran d’accueil*.
+
+Une fois installée, l’application se lance depuis l’écran d’accueil, fonctionne hors ligne et se met à jour automatiquement.
+
+## 📡 Utilisation hors ligne et stockage des données
+
+Servir l’application via HTTP(S) installe un service worker qui met chaque fichier en cache pour que Cine Power Planner fonctionne totalement hors ligne et se mette à jour en arrière-plan. Les projets, retours d’autonomie et préférences (langue, thème, mode rose et listes de matériel sauvegardées) sont stockés dans le `localStorage` du navigateur. Effacer les données du site supprime toutes les informations, et la boîte de dialogue Paramètres propose également un bouton **Effacer le cache local** pour le même nettoyage en un clic.
+L’en-tête affiche un badge hors ligne dès que la connexion tombe, et l’action 🔄
+**Forcer le rechargement** actualise les fichiers mis en cache sans toucher aux
+projets enregistrés.
+
+---
+
+## 🗂️ Structure des fichiers
+```bash
+index.html       # Mise en page HTML principale
+style.css        # Styles et mise en page
+script.js        # Logique applicative
+data.js          # Liste d’appareils par défaut
+storage.js       # Helpers LocalStorage
+README.*.md      # Documentation multilingue
+checkConsistency.js  # Vérifie les champs requis dans les données d’appareils
+normalizeData.js     # Nettoie les entrées et unifie les noms de connecteurs
+generateSchema.js    # Reconstruit schema.json à partir de data.js
+unifyPorts.js        # Harmonise les anciens noms de ports
+tests/               # Suite de tests Jest
+```
+Les polices sont intégrées localement via `fonts.css`, ce qui permet à l’application de fonctionner entièrement hors ligne une fois les ressources en cache.
+
+## 🛠️ Développement
+Nécessite Node.js 18 ou version ultérieure.
+
+```bash
+npm install
+npm run lint     # exécute uniquement ESLint
+npm test         # lance le linting, les vérifications de données et les tests Jest
+```
+
+Après modification des données d’appareils, régénérez la base normalisée :
+
+```bash
+npm run normalize
+npm run unify-ports
+npm run check-consistency
+npm run generate-schema
+```
+
+Ajoutez `--help` à l’un de ces scripts pour afficher les options disponibles.
+
+## 🤝 Contribuer
+Les contributions sont les bienvenues ! N’hésitez pas à ouvrir un ticket ou à proposer une pull request sur GitHub.
+Pour corriger des données, joindre des sauvegardes de projet ou des mesures
+d’autonomie aide à garder le catalogue fiable pour tout le monde.

--- a/README.it.md
+++ b/README.it.md
@@ -1,138 +1,308 @@
-# Cine Power Planner
+# 🎥 Cine Power Planner
 
-![Icona di Cine Power Planner](icon.svg)
+Questo strumento basato sul browser aiuta a pianificare progetti camera professionali alimentati da batterie V‑Mount, B‑Mount o Gold-Mount. Calcola il **consumo energetico totale**, la **corrente assorbita** (a 14,4 V e 12 V) e l’**autonomia stimata della batteria**, verificando che il pacco possa erogare in sicurezza la potenza richiesta.
 
-Cine Power Planner è un’applicazione Web utilizzabile anche offline per pianificare rig di camera professionali alimentati da batterie V‑Mount, B‑Mount o Gold‑Mount. Calcola il consumo complessivo, verifica che ogni batteria possa erogare in sicurezza la corrente richiesta, stima autonomie realistiche a partire da dati di campo ponderati e mantiene insieme crew, scenari e liste attrezzatura così da non perdere informazioni tra i reparti.
-
----
-
-## Punti di forza
-
-### Configurazioni complesse senza tentativi alla cieca
-- Combina camere, piastre batteria, collegamenti wireless, monitor, motori e accessori visualizzando potenza totale, corrente a 14,4 V/12 V (e 33,6 V/21,6 V per B‑Mount) e runtime previsto.
-- Confronta le batterie compatibili affiancandole e ricevi avvisi quando l’assorbimento supera i limiti D‑Tap o pin.
-- Visualizza il rig con un diagramma interattivo che supporta trascinamento, zoom, export SVG/JPG e avvisi di compatibilità.
-
-### Tutti i reparti sulla stessa pagina
-- Salva più progetti con requisiti, contatti della crew, scenari di ripresa e note personalizzate.
-- Genera liste attrezzatura stampabili che raggruppano il kit per categoria, uniscono i duplicati, includono metadati tecnici e aggiungono accessori in base allo scenario.
-- Condividi pacchetti JSON che includono selezioni, feedback sulle autonomie, liste attrezzatura e dispositivi personalizzati per un ripristino completo.
-
-### Pronta a viaggiare e rispettosa della privacy
-- Funziona interamente nel browser: apri `index.html` direttamente oppure ospita il repository in HTTPS per attivare il service worker.
-- La cache offline conserva lingua, tema, preferiti e progetti ovunque senza inviare dati a server esterni.
-- Svuota la cache locale o usa il ricaricamento forzato per aggiornare gli asset in cache senza toccare i progetti salvati.
-
-### Su misura per il tuo team
-- Passa all’istante tra English, Deutsch, Español, Italiano e Français; l’app ricorda l’ultima lingua utilizzata.
-- Scegli temi scuro, rosa o ad alto contrasto, imposta un colore di accento, regola dimensione e famiglia del carattere in base al branding o alle esigenze di accessibilità.
-- Menu a discesa con ricerca, preferiti fissati e aiuto al passaggio del mouse mantengono produttiva la crew sul set.
+Tutta la pianificazione, i dati inseriti e gli export restano sul dispositivo
+davanti a te. Lingua, progetti, dispositivi personalizzati, preferiti e feedback
+sulle autonomie sono salvati nel browser, e gli aggiornamenti del service worker
+arrivano direttamente da questo repository. Puoi avviare l’app offline dal
+disco oppure ospitarla internamente così che ogni reparto utilizzi la stessa
+versione verificata.
 
 ---
 
-## Avvio rapido
-
-1. Clona o scarica il repository.
-2. Apri `index.html` in un browser moderno (Chromium, Firefox o Safari). Non serve alcuna build.
-3. Facoltativo: servi la cartella via HTTPS per installare il service worker e ricevere aggiornamenti offline. Qualsiasi server statico va bene (`npx http-server -S` o simile).
-4. L’app salva i dati nel browser. Usa **Impostazioni → Backup** per esportare snapshot JSON prima di cambiare macchina.
-
----
-
-## Flusso di lavoro tipico
-
-1. **Crea o carica un progetto.** Premi Invio o `Ctrl+S` (`⌘S` su macOS) per salvare rapidamente. Snapshot automatici ogni 10 minuti.
-2. **Seleziona camera, alimentazione e accessori.** I menu si filtrano mentre digiti e i preferiti restano fissati.
-3. **Controlla i risultati energetici.** Consulta watt, corrente, indicatori di sicurezza delle batterie e autonomie nel pannello di confronto.
-4. **Raccogli i requisiti.** Registra ruoli della crew, giorni di ripresa, scenari e note così che ogni export riporti il contesto corretto.
-5. **Genera gli output.** Produce liste attrezzatura, panoramiche stampabili e pacchetti progetto condivisi, quindi ripristinali più tardi con un solo upload.
-
----
-
-## Elementi principali dell’interfaccia
-
-- **Ricerca globale** (`/` o `Ctrl+K`/`⌘K`) per saltare a funzioni, selettori o argomenti di aiuto anche con il menu laterale chiuso.
-- **Centro assistenza** (`?`, `H`, `F1` o `Ctrl+/`) con guide ricercabili, FAQ, scorciatoie e aiuto contestuale opzionale.
-- **Diagramma del progetto** che visualizza le connessioni; tieni premuto Maiusc al download per esportare un JPG invece di un SVG.
-- **Pannello di confronto batterie** che mostra le prestazioni di ogni pack compatibile e mette in evidenza i rischi di sovraccarico.
-- **Generatore di liste attrezzatura** che trasforma le selezioni in tabelle per categoria con metadati, email della crew e aggiunte guidate dagli scenari.
-- **Indicatore offline e ricarica forzata** per controllare la connettività e aggiornare gli asset in cache senza perdere progetti.
-
----
-
-## Gestione dati ed export
-
-- Progetti, impostazioni, liste attrezzatura, preferiti e dispositivi personalizzati risiedono in `localStorage`; backup e ripristini mantengono tutto intatto.
-- La finestra Impostazioni offre promemoria orari per i backup, esportazioni manuali, ripristino con un clic e il pulsante **Cancella cache locale**.
-- I file progetto condivisi riuniscono selezioni, requisiti, feedback sulle autonomie, liste attrezzatura e dispositivi personalizzati per passaggi di consegne tra team.
-- Le anteprime stampabili includono nome progetto, dettagli di produzione, logo personalizzato opzionale e la lista attrezzatura generata.
-- Snapshot automatici in background consentono di tornare facilmente a uno stato precedente.
-
----
-
-## Intelligenza su batterie e runtime
-
-- Calcola il consumo totale, il numero di batterie necessario per giornate da 10 ore e la corrente che ogni collegamento deve fornire.
-- Avvisa oltre l’80 % di utilizzo e blocca carichi non sicuri quando l’assorbimento supera la potenza continua o D‑Tap della batteria.
-- Le stime ponderate considerano temperatura, risoluzione, frame rate, codec, uso del Wi‑Fi, luminosità del monitor e quota di consumo di ogni dispositivo.
-- Una dashboard delle autonomie ordina i feedback per peso, mostra le percentuali di contributo e evidenzia gli outlier.
-- I feedback inviati dagli utenti raffinano le stime per i set reali.
-
----
-
-## Personalizzazione e accessibilità
-
-- Passa tra temi scuro, rosa o ad alto contrasto e regola la tipografia senza ricaricare la pagina.
-- Carica un logo personalizzato per le stampe, imposta ruoli di monitoraggio predefiniti e configura requisiti di progetto standard.
-- Navigazione da tastiera, stati di focus visibili e link di salto garantiscono accessibilità e usabilità con screen reader.
-- Ricerca nei menu, preferiti fissati e pulsanti di duplicazione nelle liste accelerano l’inserimento ripetitivo dei dati.
-
----
-
-## Scorciatoie da tastiera
-
-| Azione | Scorciatoia |
-| --- | --- |
-| Mettere a fuoco la ricerca globale | `/`, `Ctrl+K`, `⌘K` |
-| Aprire il dialogo di aiuto | `?`, `H`, `F1`, `Ctrl+/` |
-| Salvare il progetto | `Invio`, `Ctrl+S`, `⌘S` |
-| Attivare/disattivare il tema scuro | `D` |
-| Attivare/disattivare il tema rosa | `P` |
-| Ricarica forzata | Clic sull’icona 🔄 nell’intestazione |
-
----
-
-## Sviluppo
-
-- Installa le dipendenze con `npm install` (utili per linting, test e script dati; nessun build step necessario).
-- Esegui `npm run lint` e `npm run test` prima del commit. Suite mirate disponibili tramite `npm run test:unit`, `npm run test:data`, `npm run test:dom` e `npm run test:script`.
-- Script utili:
-  - `npm run check-consistency` verifica l’allineamento dei dati.
-  - `npm run normalize` e `npm run unify-ports` mantengono ordinato il catalogo.
-  - `npm run generate-schema` aggiorna lo schema dei dispositivi.
-
----
-
-## Traduzioni
-
-La documentazione è disponibile in più lingue e l’app rileva automaticamente quella del browser al primo avvio. Puoi cambiare in qualsiasi momento dal menu lingua in alto a destra:
-
+## 🌍 Lingue
 - 🇬🇧 [English](README.en.md)
 - 🇩🇪 [Deutsch](README.de.md)
 - 🇪🇸 [Español](README.es.md)
 - 🇮🇹 [Italiano](README.it.md)
 - 🇫🇷 [Français](README.fr.md)
 
-Vuoi contribuire? Segui la [guida alle traduzioni](docs/translation-guide.md) per aggiungere nuove lingue all’interfaccia e alla documentazione.
+L’app usa automaticamente la lingua del browser al primo avvio e puoi cambiarla in alto a destra. La scelta viene ricordata per la visita successiva.
 
 ---
 
-## Contributi e supporto
-
-Sono ben accette segnalazioni di bug, proposte di funzionalità e correzioni dei dati. Apri una issue o invia una pull request con quanti più dettagli possibile. Se trovi autonomie errate o attrezzatura mancante, allega il file progetto o dati di esempio per mantenere affidabile il catalogo.
+## 🆕 Novità
+- I controlli di accento e tipografia nelle Impostazioni ti permettono di modificare il colore accento, la dimensione base del font e la famiglia tipografica insieme ai temi scuro, rosa e ad alto contrasto.
+- Le scorciatoie da tastiera per la ricerca globale consentono di premere / o Ctrl+K (⌘K su macOS) per focalizzarla all’istante, anche quando si trova nel menu laterale mobile compresso.
+- Il pulsante di ricarica forzata svuota i file memorizzati dal service worker così l’app offline si aggiorna senza cancellare progetti o dispositivi salvati.
+- Le icone a stella in ogni selettore fissano in alto le videocamere, le batterie e gli accessori preferiti e li includono nei backup.
+- Il pulsante **Cancella cache locale** rimuove progetti e impostazioni memorizzati.
+- La lista attrezzatura e l’anteprima stampabile mostrano il nome del progetto per un riferimento rapido.
+- Carica un logo personalizzato da usare nelle stampe e nei backup.
+- I backup includono i preferiti e creano una copia automatica prima del ripristino.
+- Le voci della troupe dispongono ora di un campo e-mail.
+- Tema ad alto contrasto per una leggibilità migliore.
+- I moduli dei dispositivi compilano dinamicamente le categorie in base agli attributi dello schema.
+- Interfaccia ridisegnata con più contrasto e spaziatura per un’esperienza più pulita su qualsiasi dispositivo.
+- Condividere i progetti è più semplice: scarica un file JSON che raggruppa selezioni, requisiti, liste attrezzatura, feedback di autonomia e dispositivi personalizzati, poi importalo per ripristinare tutto.
+- Icone dedicate per gli scenari obbligatori per riconoscere subito i requisiti del progetto.
+- Diagramma del progetto interattivo che consente di trascinare i dispositivi, fare zoom, allineare alla griglia ed esportare in SVG o JPG.
+- Tema rosa giocoso che resta attivo tra una visita e l’altra.
+- Finestra di aiuto ricercabile con sezioni passo-passo e FAQ; aprila con ?, H, F1 o Ctrl+/.
+- Suggerimenti contestuali al passaggio del mouse su pulsanti, campi, menu a discesa e intestazioni.
+- Barra di ricerca globale per raggiungere rapidamente funzioni, selettori di dispositivi o argomenti di aiuto.
+- Supporto per videocamere con piastre batteria V-, B- o Gold-Mount.
+- Invia feedback di autonomia indicando anche la temperatura per affinare le stime.
+- Dashboard visiva per la ponderazione delle autonomie che mostra l’influenza delle impostazioni su ogni misurazione, ordinata per peso con percentuali precise.
+- Genera liste attrezzatura che riassumono l’equipaggiamento selezionato e i requisiti del progetto.
+- Salva i requisiti di progetto con ogni configurazione così la lista attrezzatura mantiene tutto il contesto.
+- Duplica all’istante le voci personalizzate dei moduli della lista attrezzatura grazie ai pulsanti a forchetta.
 
 ---
 
-## Licenza
+## 🔧 Funzionalità
 
-Cine Power Planner è distribuito con licenza ISC.
+### ✨ Punti salienti aggiuntivi
+
+- **Progetta rig complessi senza tentativi.** Combina camere, piastre batteria,
+  link wireless, monitor, motori e accessori vedendo consumo totale a
+  14,4 V/12 V (e 33,6 V/21,6 V per B‑Mount) con autonomie realistiche basate su
+  dati di campo ponderati. Il pannello di confronto batterie segnala le
+  sovratensioni prima di preparare l’attrezzatura sbagliata.
+- **Mantieni allineati tutti i reparti.** Salva più progetti con requisiti,
+  contatti della troupe, scenari e note. Le liste stampabili raggruppano il
+  materiale per categoria, uniscono i duplicati, mostrano metadati tecnici e
+  includono accessori legati agli scenari così che camera, luce e grip condividano
+  lo stesso contesto.
+- **Lavora in tranquillità ovunque.** Apri `index.html` direttamente o servi la
+  cartella via HTTPS per attivare il service worker. La cache offline conserva
+  lingua, temi, preferiti e progetti, e **Forza ricarica** aggiorna gli asset
+  senza toccare i dati salvati.
+- **Adatta il planner alla tua troupe.** Passa subito tra italiano, inglese,
+  tedesco, spagnolo e francese, regola dimensione e font, scegli un colore
+  accento personalizzato, carica un logo per la stampa e alterna tema chiaro,
+  scuro, rosa o ad alto contrasto. I menu con ricerca, i preferiti fissati, i
+  pulsanti di duplicazione e le guide contestuali mantengono il ritmo sul set.
+
+### ✅ Gestione dei progetti
+- Salva, carica e cancella più progetti camera (premi Invio o Ctrl+S/⌘S per salvare rapidamente; il pulsante Salva resta disattivato finché non inserisci un nome).
+- Vengono creati automaticamente snapshot ogni 10 minuti mentre il planner è aperto e dalla finestra Impostazioni puoi attivare esportazioni di backup orarie come promemoria.
+- Scarica un file JSON che raccoglie selezioni, requisiti, lista attrezzatura, feedback di autonomia e dispositivi personalizzati; importalo dal selettore Progetto condiviso per ripristinare tutto in un passaggio.
+- I dati sono archiviati localmente tramite `localStorage` e i preferiti vengono conservati nei backup; usa il pulsante **Cancella cache locale** nelle Impostazioni per eliminare progetti e modifiche ai dispositivi memorizzati.
+- Genera anteprime stampabili per ogni progetto salvato e aggiungi un logo personalizzato così esportazioni e backup rispettano l’identità della produzione.
+- Salva i requisiti di progetto insieme a ciascun progetto, così la lista attrezzatura mantiene il contesto completo.
+- Funziona completamente offline grazie al service worker installato: lingua, tema, dati dei dispositivi e preferiti persistono tra le sessioni.
+- Layout responsive che si adatta senza sforzo a desktop, tablet e smartphone.
+- Sulle videocamere compatibili scegli piastre **V‑Mount**, **B‑Mount** o **Gold-Mount**; l’elenco batterie si aggiorna automaticamente.
+
+### 🧭 Panoramica dell’interfaccia
+- **Promemoria rapido:**
+  - **Ricerca globale** (`/` o `Ctrl+K`/`⌘K`) salta a funzioni, selettori o
+    argomenti di aiuto anche quando il menu laterale è compresso.
+  - **Centro assistenza** (`?`, `H`, `F1` o `Ctrl+/`) propone guide filtrabili,
+    FAQ, scorciatoie e la modalità di aiuto al passaggio del mouse.
+  - **Diagramma del progetto** visualizza le connessioni; tieni premuto Maiusc
+    durante il download per salvare un JPG invece di un SVG e vedere gli avvisi
+    di compatibilità.
+  - **Confronto batterie** mostra come si comportano i pacchi compatibili e
+    evidenzia subito i rischi di sovraccarico.
+  - **Generatore di liste** produce tabelle per categoria con metadati, e-mail
+    della troupe e aggiunte basate sugli scenari pronte per la stampa.
+  - **Badge offline e Forza ricarica** indicano lo stato della connessione e
+    aggiornano i file in cache senza eliminare i progetti.
+- Un collegamento di salto e un indicatore offline mantengono il layout accessibile con tastiera e tocco; il badge appare ogni volta che il browser perde la connessione.
+- La barra di ricerca globale consente di saltare a funzioni, selettori di dispositivi o argomenti di aiuto; premi Invio per attivare il risultato evidenziato, usa / o Ctrl+K (⌘K su macOS) per focalizzarla subito (sugli schermi piccoli il menu laterale si apre in automatico) e premi Esc o × per cancellare la ricerca.
+- I controlli della barra superiore offrono cambio lingua, temi scuro e rosa e la finestra Impostazioni con colore accento, dimensione e famiglia del font, modalità ad alto contrasto e caricamento del logo, oltre agli strumenti di backup, ripristino e cancellazione cache.
+- Il pulsante di aiuto apre un dialogo ricercabile con sezioni guidate, scorciatoie da tastiera, FAQ e una modalità di suggerimenti al passaggio del mouse; si può aprire anche con ?, H, F1 o Ctrl+/ mentre digiti.
+- Il pulsante di ricarica forzata (🔄) cancella i file del service worker in cache così l’app offline si aggiorna senza perdere progetti o dispositivi.
+- Sugli schermi più piccoli un menu laterale a scomparsa replica ogni sezione principale per navigare rapidamente.
+
+### ♿ Personalizzazione e accessibilità
+- Le preferenze di tema includono modalità scura, accento rosa giocoso e un interruttore dedicato ad alto contrasto per migliorare la leggibilità.
+- Le modifiche al colore accento, alla dimensione base del font e alla famiglia tipografica si applicano all’istante e restano nel browser, ideali per rispettare il brand o esigenze di accessibilità.
+- Le scorciatoie integrate coprono ricerca globale (/ o Ctrl+K/⌘K), aiuto ( ?, H, F1, Ctrl+/ ), salvataggio (Invio o Ctrl+S/⌘S), modalità scura (D) e modalità rosa (P).
+- La modalità di aiuto al passaggio del mouse trasforma pulsanti, campi, menu e intestazioni in tooltip su richiesta, così chi è nuovo impara più velocemente.
+- Gli input con ricerca incrementale, i controlli con focus visibile e le icone a stella accanto ai selettori permettono di filtrare elenchi lunghi e fissare i preferiti in cima.
+- Carica un logo personalizzato per le stampe, configura i ruoli di monitoraggio
+  predefiniti e regola i preset dei requisiti di progetto affinché gli export
+  rispettino l’identità della produzione.
+- I pulsanti di duplicazione replicano subito le righe dei moduli e i preferiti
+  pinnati mantengono l’attrezzatura abituale in cima ai selettori, utile quando
+  il tempo sul set è limitato.
+
+### 📋 Lista attrezzatura
+Il generatore converte le tue scelte in una lista di carico categorizzata:
+
+- Clicca **Genera lista attrezzatura** per raccogliere l’equipaggiamento selezionato e i requisiti del progetto in una tabella.
+- La tabella si aggiorna automaticamente quando cambiano selezioni e requisiti.
+- Gli elementi sono raggruppati per categoria (camera, ottiche, alimentazione, monitoraggio, rigging, grip, accessori, consumabili) e i duplicati vengono uniti con la rispettiva quantità.
+- Cavi, rigging e accessori necessari per monitor, motori, gimbal e scenari meteo vengono aggiunti automaticamente.
+- Le selezioni degli scenari aggiungono l’attrezzatura correlata:
+  - *Handheld* + *Easyrig* inserisce una maniglia telescopica per un supporto stabile.
+  - *Gimbal* aggiunge il gimbal scelto, bracci articolati, spigot e paraluce o kit filtri.
+  - *Outdoor* fornisce spigot, ombrelli e coperture antipioggia CapIt.
+  - Gli scenari *Vehicle* e *Steadicam* includono staffe, bracci di isolamento e ventose quando necessari.
+- Le selezioni delle ottiche riportano diametro frontale, peso, dati dei rod e fuoco minimo, aggiungono supporti per lenti e adattatori matte box e avvisano sugli standard di rod incompatibili.
+- Le righe delle batterie rispecchiano i conteggi del calcolatore di potenza e includono piastre o dispositivi di *hotswap* quando richiesti.
+- Le preferenze di monitoraggio assegnano monitor predefiniti per ogni ruolo (regista, DoP, fuochista, ecc.) con set di cavi e ricevitori wireless.
+- Il modulo **Requisiti del progetto** alimenta la lista:
+  - **Nome del progetto**, **casa di produzione**, **noleggio** e **DoP** compaiono nell’intestazione delle specifiche stampate.
+  - Le voci **Troupe** raccolgono nomi, ruoli e indirizzi e-mail così i contatti viaggiano con il progetto.
+  - **Giorni di preparazione** e **giorni di ripresa** aggiungono note di pianificazione e, con scenari outdoor, suggeriscono attrezzatura per il meteo.
+  - Gli **scenari obbligatori** inseriscono rigging, gimbal e protezioni climatiche adeguati.
+  - **Impugnatura camera** ed **estensione mirino** inseriscono i componenti selezionati o i relativi supporti.
+  - Le opzioni di **matte box** e **filtri** aggiungono il sistema scelto con cassetti, adattatori a clamp o filtri necessari.
+  - Le configurazioni di **monitoraggio**, **distribuzione video** e **mirino** aggiungono monitor, cavi e overlay per ciascun ruolo.
+  - Le scelte dei **pulsanti personalizzati** e delle **preferenze treppiede** vengono elencate per riferimento rapido.
+- Gli elementi di ogni categoria sono ordinati alfabeticamente e mostrano un tooltip al passaggio del mouse.
+- La lista attrezzatura viene inclusa nelle anteprime stampabili e nei file di progetto condivisi.
+- Le liste vengono salvate automaticamente con il progetto e fanno parte sia dei file condivisi sia dei backup.
+- **Elimina lista attrezzatura** cancella la lista salvata e nasconde l’output.
+- I moduli della lista attrezzatura includono pulsanti a forchetta per duplicare al volo le voci inserite.
+
+### 📦 Categorie dei dispositivi
+- **Camera** (1)
+- **Monitor** (opzionale)
+- **Trasmettitore wireless** (opzionale)
+- **Motori FIZ** (0–4)
+- **Controller FIZ** (0–4)
+- **Sensore di distanza** (0–1)
+- **Piastra batteria** (solo sulle camere compatibili con V‑ o B‑Mount)
+- **Batteria V‑Mount** (0–1)
+
+### ⚙️ Calcoli di potenza
+- Consumo totale in watt
+- Corrente a 14,4 V e 12 V
+- Autonomia stimata in ore utilizzando la media ponderata dei feedback degli utenti
+- Numero di batterie necessario per un giorno di riprese di 10 h (inclusa la riserva)
+- Nota sulla temperatura per adattare l’autonomia in condizioni calde o fredde
+
+### 🔋 Controllo dell’erogazione della batteria
+- Avvisa se la corrente richiesta supera l’uscita della batteria (pin o D‑Tap)
+- Indica quando il carico si avvicina al limite (80 % di utilizzo)
+
+### 📊 Confronto batterie (opzionale)
+- Confronta le stime di autonomia fra tutte le batterie
+- Grafici a barre per un colpo d’occhio immediato
+
+### 🖼 Diagramma del progetto
+- Visualizza le connessioni di alimentazione e video dei dispositivi selezionati.
+- Avvisa quando i brand FIZ non sono compatibili.
+- Trascina i nodi per riordinare il layout, usa i pulsanti per zoomare ed esporta il diagramma in SVG o JPG.
+- Tieni premuto Shift mentre fai clic su Download per esportare uno snapshot JPG invece di un SVG.
+- Passa il mouse o tocca un dispositivo per vedere i dettagli nel popup.
+- Utilizza le icone [OpenMoji](https://openmoji.org/) quando la connessione è attiva e ripiega sugli emoji: 🔋 batteria, 🎥 camera, 🖥️ monitor, 📡 video, ⚙️ motore, 🎮 controller, 📐 distanza, 🎮 impugnatura e 🔌 piastra batteria.
+
+### 🧮 Ponderazione dei dati di autonomia
+- I feedback di autonomia inviati dagli utenti migliorano la stima finale.
+- Ogni voce viene corretta in base alla temperatura, passando da ×1 a 25 °C a:
+  - ×1,25 a 0 °C
+  - ×1,6 a −10 °C
+  - ×2 a −20 °C
+- Le impostazioni della camera influenzano il peso:
+  - Moltiplicatori di risoluzione: ≥12K ×3, ≥8K ×2, ≥4K ×1,5, ≥1080p ×1; risoluzioni inferiori scalate a 1080p.
+  - Il frame rate scala linearmente da 24 fps (es. 48 fps = ×2).
+  - Il Wi‑Fi attivo aggiunge il 10 %.
+  - Fattori codec: RAW/BRAW/ARRIRAW/R3D/CinemaDNG/Canon RAW/X‑OCN ×1; ProRes ×1,1; DNx/AVID ×1,2; All‑Intra ×1,3; H.264/AVC ×1,5; H.265/HEVC ×1,7.
+  - Le voci dei monitor sotto la luminosità specificata vengono pesate secondo il loro rapporto di luminosità.
+- Il peso finale riflette la quota di assorbimento di ciascun dispositivo, così i progetti simili contano di più.
+- La media ponderata viene applicata quando sono disponibili almeno tre voci.
+- Una dashboard ordina i contributi per peso e mostra la percentuale di ciascuno per un confronto immediato.
+
+### 🔍 Ricerca e filtri
+- Digita nei menu a discesa per trovare rapidamente un elemento.
+- Filtra le liste di dispositivi tramite un campo di ricerca.
+- Usa la barra di ricerca globale in alto per saltare a funzioni, dispositivi o argomenti di aiuto; premi Invio per navigare, / o Ctrl+K (⌘K su macOS) per focalizzarla al volo e Esc o × per cancellare.
+- Premi “/” o Ctrl+F (⌘F su macOS) per portare subito il focus sul campo di ricerca più vicino.
+- Clicca sulla stella accanto a qualsiasi selettore per fissare i preferiti in cima e sincronizzarli con i backup.
+
+### 🛠 Editor del database dispositivi
+- Aggiungi, modifica o elimina dispositivi in tutte le categorie.
+- Importa o esporta l’intero database in formato JSON.
+- Ripristina il database predefinito da `data.js`.
+
+### 🌓 Modalità scura
+- Attivala con il pulsante a forma di luna accanto al selettore della lingua.
+- La preferenza viene salvata nel browser.
+
+### 🦄 Modalità rosa
+- Clicca sull’icona dell’unicorno o premi **P** per attivare un accento rosa giocoso.
+- Funziona sia nel tema chiaro sia in quello scuro e resta attiva tra una visita e l’altra.
+
+### ⚫ Modalità ad alto contrasto
+- Attiva un tema ad alto contrasto per una migliore leggibilità.
+
+### 📝 Feedback di autonomia
+- Clicca su <strong>Invia feedback di autonomia</strong> sotto alla stima per aggiungere la tua misurazione.
+- Includi la temperatura per una ponderazione più accurata.
+- Le voci vengono salvate nel browser e migliorano le stime future.
+- Un cruscotto dedicato ordina i contributi in base al peso, mostra le
+  percentuali di contributo e mette in evidenza gli outlier per valutare
+  rapidamente i dati di campo.
+
+### ❓ Aiuto ricercabile
+- Aprilo tramite il pulsante <strong>?</strong> oppure con <kbd>?</kbd>, <kbd>H</kbd>, <kbd>F1</kbd> o <kbd>Ctrl+/</kbd>.
+- Usa il campo di ricerca per filtrare subito gli argomenti; la query viene azzerata alla chiusura.
+- Chiudi con <kbd>Esc</kbd> o cliccando all’esterno della finestra.
+
+---
+
+## ▶️ Come usarlo
+1. **Avvia l’app:** apri `index.html` in un browser moderno: non serve alcun server.
+2. **Esplora la barra superiore:** cambia lingua, alterna i temi scuro o rosa, apri Impostazioni per regolare accento e tipografia e avvia l’aiuto con ? o Ctrl+/.
+3. **Seleziona i dispositivi:** scegli l’attrezzatura per ogni categoria dai menu a discesa; digita per filtrare, clicca sulla stella per fissare i preferiti e lascia che gli scenari preconfigurati aggiungano automaticamente gli accessori.
+4. **Consulta i calcoli:** una volta selezionata la batteria vedrai consumo, corrente e autonomia; gli avvisi evidenziano eventuali superamenti dei limiti.
+5. **Salva e condividi i progetti:** assegna un nome e salva la configurazione, i backup automatici creano snapshot e il pulsante Condividi esporta un bundle JSON per la troupe.
+6. **Genera la lista attrezzatura:** premi **Genera lista attrezzatura** per trasformare i requisiti in una lista categorizzata con tooltip e accessori.
+7. **Gestisci i dati dei dispositivi:** clicca su “Modifica dati dispositivi…” per aprire l’editor, aggiornare i dispositivi, esportare/importare JSON o tornare ai valori predefiniti.
+8. **Invia feedback di autonomia:** usa “Invia feedback di autonomia” per registrare misurazioni reali e raffinare le medie ponderate.
+
+## 📱 Installare come app
+
+Il planner è una Progressive Web App e può essere installato direttamente dal browser:
+
+- **Chrome/Edge (desktop):** fai clic sull’icona di installazione nella barra degli indirizzi.
+- **Android:** apri il menu del browser e scegli *Aggiungi alla schermata Home*.
+- **iOS/iPadOS Safari:** tocca *Condividi* e seleziona *Aggiungi alla schermata Home*.
+
+Una volta installata, l’app si avvia dalla schermata Home, funziona offline e si aggiorna automaticamente.
+
+## 📡 Uso offline e archiviazione dati
+
+Servire l’app tramite HTTP(S) installa un service worker che memorizza in cache ogni file, così Cine Power Planner funziona completamente offline e si aggiorna in background. Progetti, feedback di autonomia e preferenze (lingua, tema, modalità rosa e liste attrezzatura salvate) vivono nel `localStorage` del browser. Cancellare i dati del sito elimina tutte le informazioni e nella finestra Impostazioni è disponibile anche il pulsante **Cancella cache locale** per lo stesso reset con un clic.
+L’intestazione mostra un badge offline non appena cade la connessione, e l’azione
+🔄 **Forza ricarica** aggiorna i file in cache senza toccare i progetti salvati.
+
+---
+
+## 🗂️ Struttura dei file
+```bash
+index.html       # Layout HTML principale
+style.css        # Stili e layout
+script.js        # Logica dell’applicazione
+data.js          # Elenco dispositivi predefinito
+storage.js       # Helper per LocalStorage
+README.*.md      # Documentazione in più lingue
+checkConsistency.js  # Verifica i campi obbligatori nei dati dei dispositivi
+normalizeData.js     # Pulisce le voci e uniforma i nomi dei connettori
+generateSchema.js    # Ricostruisce schema.json a partire da data.js
+unifyPorts.js        # Uniforma i nomi di porta legacy
+tests/               # Suite di test Jest
+```
+I font sono inclusi localmente tramite `fonts.css`, quindi una volta memorizzate le risorse l’app funziona interamente offline.
+
+## 🛠️ Sviluppo
+Richiede Node.js 18 o versione successiva.
+
+```bash
+npm install
+npm run lint     # esegue solo ESLint
+npm test         # esegue linting, controlli dati e test Jest
+```
+
+Dopo aver modificato i dati dei dispositivi, rigenera il database normalizzato:
+
+```bash
+npm run normalize
+npm run unify-ports
+npm run check-consistency
+npm run generate-schema
+```
+
+Aggiungi `--help` a uno qualsiasi degli script per visualizzare le opzioni disponibili.
+
+## 🤝 Contribuire
+Sono benvenuti contributi di ogni tipo! Apri una issue o invia una pull request su GitHub.
+Quando segnali dati errati, allegare backup dei progetti o misurazioni di
+autonomia aiuta a mantenere il catalogo preciso per tutti.

--- a/README.it.md
+++ b/README.it.md
@@ -1,252 +1,138 @@
-# 🎥 Cine Power Planner
+# Cine Power Planner
 
-Questo strumento basato sul browser aiuta a pianificare progetti camera professionali alimentati da batterie V‑Mount, B‑Mount o Gold-Mount. Calcola il **consumo energetico totale**, la **corrente assorbita** (a 14,4 V e 12 V) e l’**autonomia stimata della batteria**, verificando che il pacco possa erogare in sicurezza la potenza richiesta.
+![Icona di Cine Power Planner](icon.svg)
+
+Cine Power Planner è un’applicazione Web utilizzabile anche offline per pianificare rig di camera professionali alimentati da batterie V‑Mount, B‑Mount o Gold‑Mount. Calcola il consumo complessivo, verifica che ogni batteria possa erogare in sicurezza la corrente richiesta, stima autonomie realistiche a partire da dati di campo ponderati e mantiene insieme crew, scenari e liste attrezzatura così da non perdere informazioni tra i reparti.
 
 ---
 
-## 🌍 Lingue
+## Punti di forza
+
+### Configurazioni complesse senza tentativi alla cieca
+- Combina camere, piastre batteria, collegamenti wireless, monitor, motori e accessori visualizzando potenza totale, corrente a 14,4 V/12 V (e 33,6 V/21,6 V per B‑Mount) e runtime previsto.
+- Confronta le batterie compatibili affiancandole e ricevi avvisi quando l’assorbimento supera i limiti D‑Tap o pin.
+- Visualizza il rig con un diagramma interattivo che supporta trascinamento, zoom, export SVG/JPG e avvisi di compatibilità.
+
+### Tutti i reparti sulla stessa pagina
+- Salva più progetti con requisiti, contatti della crew, scenari di ripresa e note personalizzate.
+- Genera liste attrezzatura stampabili che raggruppano il kit per categoria, uniscono i duplicati, includono metadati tecnici e aggiungono accessori in base allo scenario.
+- Condividi pacchetti JSON che includono selezioni, feedback sulle autonomie, liste attrezzatura e dispositivi personalizzati per un ripristino completo.
+
+### Pronta a viaggiare e rispettosa della privacy
+- Funziona interamente nel browser: apri `index.html` direttamente oppure ospita il repository in HTTPS per attivare il service worker.
+- La cache offline conserva lingua, tema, preferiti e progetti ovunque senza inviare dati a server esterni.
+- Svuota la cache locale o usa il ricaricamento forzato per aggiornare gli asset in cache senza toccare i progetti salvati.
+
+### Su misura per il tuo team
+- Passa all’istante tra English, Deutsch, Español, Italiano e Français; l’app ricorda l’ultima lingua utilizzata.
+- Scegli temi scuro, rosa o ad alto contrasto, imposta un colore di accento, regola dimensione e famiglia del carattere in base al branding o alle esigenze di accessibilità.
+- Menu a discesa con ricerca, preferiti fissati e aiuto al passaggio del mouse mantengono produttiva la crew sul set.
+
+---
+
+## Avvio rapido
+
+1. Clona o scarica il repository.
+2. Apri `index.html` in un browser moderno (Chromium, Firefox o Safari). Non serve alcuna build.
+3. Facoltativo: servi la cartella via HTTPS per installare il service worker e ricevere aggiornamenti offline. Qualsiasi server statico va bene (`npx http-server -S` o simile).
+4. L’app salva i dati nel browser. Usa **Impostazioni → Backup** per esportare snapshot JSON prima di cambiare macchina.
+
+---
+
+## Flusso di lavoro tipico
+
+1. **Crea o carica un progetto.** Premi Invio o `Ctrl+S` (`⌘S` su macOS) per salvare rapidamente. Snapshot automatici ogni 10 minuti.
+2. **Seleziona camera, alimentazione e accessori.** I menu si filtrano mentre digiti e i preferiti restano fissati.
+3. **Controlla i risultati energetici.** Consulta watt, corrente, indicatori di sicurezza delle batterie e autonomie nel pannello di confronto.
+4. **Raccogli i requisiti.** Registra ruoli della crew, giorni di ripresa, scenari e note così che ogni export riporti il contesto corretto.
+5. **Genera gli output.** Produce liste attrezzatura, panoramiche stampabili e pacchetti progetto condivisi, quindi ripristinali più tardi con un solo upload.
+
+---
+
+## Elementi principali dell’interfaccia
+
+- **Ricerca globale** (`/` o `Ctrl+K`/`⌘K`) per saltare a funzioni, selettori o argomenti di aiuto anche con il menu laterale chiuso.
+- **Centro assistenza** (`?`, `H`, `F1` o `Ctrl+/`) con guide ricercabili, FAQ, scorciatoie e aiuto contestuale opzionale.
+- **Diagramma del progetto** che visualizza le connessioni; tieni premuto Maiusc al download per esportare un JPG invece di un SVG.
+- **Pannello di confronto batterie** che mostra le prestazioni di ogni pack compatibile e mette in evidenza i rischi di sovraccarico.
+- **Generatore di liste attrezzatura** che trasforma le selezioni in tabelle per categoria con metadati, email della crew e aggiunte guidate dagli scenari.
+- **Indicatore offline e ricarica forzata** per controllare la connettività e aggiornare gli asset in cache senza perdere progetti.
+
+---
+
+## Gestione dati ed export
+
+- Progetti, impostazioni, liste attrezzatura, preferiti e dispositivi personalizzati risiedono in `localStorage`; backup e ripristini mantengono tutto intatto.
+- La finestra Impostazioni offre promemoria orari per i backup, esportazioni manuali, ripristino con un clic e il pulsante **Cancella cache locale**.
+- I file progetto condivisi riuniscono selezioni, requisiti, feedback sulle autonomie, liste attrezzatura e dispositivi personalizzati per passaggi di consegne tra team.
+- Le anteprime stampabili includono nome progetto, dettagli di produzione, logo personalizzato opzionale e la lista attrezzatura generata.
+- Snapshot automatici in background consentono di tornare facilmente a uno stato precedente.
+
+---
+
+## Intelligenza su batterie e runtime
+
+- Calcola il consumo totale, il numero di batterie necessario per giornate da 10 ore e la corrente che ogni collegamento deve fornire.
+- Avvisa oltre l’80 % di utilizzo e blocca carichi non sicuri quando l’assorbimento supera la potenza continua o D‑Tap della batteria.
+- Le stime ponderate considerano temperatura, risoluzione, frame rate, codec, uso del Wi‑Fi, luminosità del monitor e quota di consumo di ogni dispositivo.
+- Una dashboard delle autonomie ordina i feedback per peso, mostra le percentuali di contributo e evidenzia gli outlier.
+- I feedback inviati dagli utenti raffinano le stime per i set reali.
+
+---
+
+## Personalizzazione e accessibilità
+
+- Passa tra temi scuro, rosa o ad alto contrasto e regola la tipografia senza ricaricare la pagina.
+- Carica un logo personalizzato per le stampe, imposta ruoli di monitoraggio predefiniti e configura requisiti di progetto standard.
+- Navigazione da tastiera, stati di focus visibili e link di salto garantiscono accessibilità e usabilità con screen reader.
+- Ricerca nei menu, preferiti fissati e pulsanti di duplicazione nelle liste accelerano l’inserimento ripetitivo dei dati.
+
+---
+
+## Scorciatoie da tastiera
+
+| Azione | Scorciatoia |
+| --- | --- |
+| Mettere a fuoco la ricerca globale | `/`, `Ctrl+K`, `⌘K` |
+| Aprire il dialogo di aiuto | `?`, `H`, `F1`, `Ctrl+/` |
+| Salvare il progetto | `Invio`, `Ctrl+S`, `⌘S` |
+| Attivare/disattivare il tema scuro | `D` |
+| Attivare/disattivare il tema rosa | `P` |
+| Ricarica forzata | Clic sull’icona 🔄 nell’intestazione |
+
+---
+
+## Sviluppo
+
+- Installa le dipendenze con `npm install` (utili per linting, test e script dati; nessun build step necessario).
+- Esegui `npm run lint` e `npm run test` prima del commit. Suite mirate disponibili tramite `npm run test:unit`, `npm run test:data`, `npm run test:dom` e `npm run test:script`.
+- Script utili:
+  - `npm run check-consistency` verifica l’allineamento dei dati.
+  - `npm run normalize` e `npm run unify-ports` mantengono ordinato il catalogo.
+  - `npm run generate-schema` aggiorna lo schema dei dispositivi.
+
+---
+
+## Traduzioni
+
+La documentazione è disponibile in più lingue e l’app rileva automaticamente quella del browser al primo avvio. Puoi cambiare in qualsiasi momento dal menu lingua in alto a destra:
+
 - 🇬🇧 [English](README.en.md)
 - 🇩🇪 [Deutsch](README.de.md)
 - 🇪🇸 [Español](README.es.md)
 - 🇮🇹 [Italiano](README.it.md)
 - 🇫🇷 [Français](README.fr.md)
 
-L’app usa automaticamente la lingua del browser al primo avvio e puoi cambiarla in alto a destra. La scelta viene ricordata per la visita successiva.
+Vuoi contribuire? Segui la [guida alle traduzioni](docs/translation-guide.md) per aggiungere nuove lingue all’interfaccia e alla documentazione.
 
 ---
 
-## 🆕 Novità
-- I controlli di accento e tipografia nelle Impostazioni ti permettono di modificare il colore accento, la dimensione base del font e la famiglia tipografica insieme ai temi scuro, rosa e ad alto contrasto.
-- Le scorciatoie da tastiera per la ricerca globale consentono di premere / o Ctrl+K (⌘K su macOS) per focalizzarla all’istante, anche quando si trova nel menu laterale mobile compresso.
-- Il pulsante di ricarica forzata svuota i file memorizzati dal service worker così l’app offline si aggiorna senza cancellare progetti o dispositivi salvati.
-- Le icone a stella in ogni selettore fissano in alto le videocamere, le batterie e gli accessori preferiti e li includono nei backup.
-- Il pulsante **Cancella cache locale** rimuove progetti e impostazioni memorizzati.
-- La lista attrezzatura e l’anteprima stampabile mostrano il nome del progetto per un riferimento rapido.
-- Carica un logo personalizzato da usare nelle stampe e nei backup.
-- I backup includono i preferiti e creano una copia automatica prima del ripristino.
-- Le voci della troupe dispongono ora di un campo e-mail.
-- Tema ad alto contrasto per una leggibilità migliore.
-- I moduli dei dispositivi compilano dinamicamente le categorie in base agli attributi dello schema.
-- Interfaccia ridisegnata con più contrasto e spaziatura per un’esperienza più pulita su qualsiasi dispositivo.
-- Condividere i progetti è più semplice: scarica un file JSON che raggruppa selezioni, requisiti, liste attrezzatura, feedback di autonomia e dispositivi personalizzati, poi importalo per ripristinare tutto.
-- Icone dedicate per gli scenari obbligatori per riconoscere subito i requisiti del progetto.
-- Diagramma del progetto interattivo che consente di trascinare i dispositivi, fare zoom, allineare alla griglia ed esportare in SVG o JPG.
-- Tema rosa giocoso che resta attivo tra una visita e l’altra.
-- Finestra di aiuto ricercabile con sezioni passo-passo e FAQ; aprila con ?, H, F1 o Ctrl+/.
-- Suggerimenti contestuali al passaggio del mouse su pulsanti, campi, menu a discesa e intestazioni.
-- Barra di ricerca globale per raggiungere rapidamente funzioni, selettori di dispositivi o argomenti di aiuto.
-- Supporto per videocamere con piastre batteria V-, B- o Gold-Mount.
-- Invia feedback di autonomia indicando anche la temperatura per affinare le stime.
-- Dashboard visiva per la ponderazione delle autonomie che mostra l’influenza delle impostazioni su ogni misurazione, ordinata per peso con percentuali precise.
-- Genera liste attrezzatura che riassumono l’equipaggiamento selezionato e i requisiti del progetto.
-- Salva i requisiti di progetto con ogni configurazione così la lista attrezzatura mantiene tutto il contesto.
-- Duplica all’istante le voci personalizzate dei moduli della lista attrezzatura grazie ai pulsanti a forchetta.
+## Contributi e supporto
+
+Sono ben accette segnalazioni di bug, proposte di funzionalità e correzioni dei dati. Apri una issue o invia una pull request con quanti più dettagli possibile. Se trovi autonomie errate o attrezzatura mancante, allega il file progetto o dati di esempio per mantenere affidabile il catalogo.
 
 ---
 
-## 🔧 Funzionalità
+## Licenza
 
-### ✅ Gestione dei progetti
-- Salva, carica e cancella più progetti camera (premi Invio o Ctrl+S/⌘S per salvare rapidamente; il pulsante Salva resta disattivato finché non inserisci un nome).
-- Vengono creati automaticamente snapshot ogni 10 minuti mentre il planner è aperto e dalla finestra Impostazioni puoi attivare esportazioni di backup orarie come promemoria.
-- Scarica un file JSON che raccoglie selezioni, requisiti, lista attrezzatura, feedback di autonomia e dispositivi personalizzati; importalo dal selettore Progetto condiviso per ripristinare tutto in un passaggio.
-- I dati sono archiviati localmente tramite `localStorage` e i preferiti vengono conservati nei backup; usa il pulsante **Cancella cache locale** nelle Impostazioni per eliminare progetti e modifiche ai dispositivi memorizzati.
-- Genera anteprime stampabili per ogni progetto salvato e aggiungi un logo personalizzato così esportazioni e backup rispettano l’identità della produzione.
-- Salva i requisiti di progetto insieme a ciascun progetto, così la lista attrezzatura mantiene il contesto completo.
-- Funziona completamente offline grazie al service worker installato: lingua, tema, dati dei dispositivi e preferiti persistono tra le sessioni.
-- Layout responsive che si adatta senza sforzo a desktop, tablet e smartphone.
-- Sulle videocamere compatibili scegli piastre **V‑Mount**, **B‑Mount** o **Gold-Mount**; l’elenco batterie si aggiorna automaticamente.
-
-### 🧭 Panoramica dell’interfaccia
-- Un collegamento di salto e un indicatore offline mantengono il layout accessibile con tastiera e tocco; il badge appare ogni volta che il browser perde la connessione.
-- La barra di ricerca globale consente di saltare a funzioni, selettori di dispositivi o argomenti di aiuto; premi Invio per attivare il risultato evidenziato, usa / o Ctrl+K (⌘K su macOS) per focalizzarla subito (sugli schermi piccoli il menu laterale si apre in automatico) e premi Esc o × per cancellare la ricerca.
-- I controlli della barra superiore offrono cambio lingua, temi scuro e rosa e la finestra Impostazioni con colore accento, dimensione e famiglia del font, modalità ad alto contrasto e caricamento del logo, oltre agli strumenti di backup, ripristino e cancellazione cache.
-- Il pulsante di aiuto apre un dialogo ricercabile con sezioni guidate, scorciatoie da tastiera, FAQ e una modalità di suggerimenti al passaggio del mouse; si può aprire anche con ?, H, F1 o Ctrl+/ mentre digiti.
-- Il pulsante di ricarica forzata (🔄) cancella i file del service worker in cache così l’app offline si aggiorna senza perdere progetti o dispositivi.
-- Sugli schermi più piccoli un menu laterale a scomparsa replica ogni sezione principale per navigare rapidamente.
-
-### ♿ Personalizzazione e accessibilità
-- Le preferenze di tema includono modalità scura, accento rosa giocoso e un interruttore dedicato ad alto contrasto per migliorare la leggibilità.
-- Le modifiche al colore accento, alla dimensione base del font e alla famiglia tipografica si applicano all’istante e restano nel browser, ideali per rispettare il brand o esigenze di accessibilità.
-- Le scorciatoie integrate coprono ricerca globale (/ o Ctrl+K/⌘K), aiuto ( ?, H, F1, Ctrl+/ ), salvataggio (Invio o Ctrl+S/⌘S), modalità scura (D) e modalità rosa (P).
-- La modalità di aiuto al passaggio del mouse trasforma pulsanti, campi, menu e intestazioni in tooltip su richiesta, così chi è nuovo impara più velocemente.
-- Gli input con ricerca incrementale, i controlli con focus visibile e le icone a stella accanto ai selettori permettono di filtrare elenchi lunghi e fissare i preferiti in cima.
-
-### 📋 Lista attrezzatura
-Il generatore converte le tue scelte in una lista di carico categorizzata:
-
-- Clicca **Genera lista attrezzatura** per raccogliere l’equipaggiamento selezionato e i requisiti del progetto in una tabella.
-- La tabella si aggiorna automaticamente quando cambiano selezioni e requisiti.
-- Gli elementi sono raggruppati per categoria (camera, ottiche, alimentazione, monitoraggio, rigging, grip, accessori, consumabili) e i duplicati vengono uniti con la rispettiva quantità.
-- Cavi, rigging e accessori necessari per monitor, motori, gimbal e scenari meteo vengono aggiunti automaticamente.
-- Le selezioni degli scenari aggiungono l’attrezzatura correlata:
-  - *Handheld* + *Easyrig* inserisce una maniglia telescopica per un supporto stabile.
-  - *Gimbal* aggiunge il gimbal scelto, bracci articolati, spigot e paraluce o kit filtri.
-  - *Outdoor* fornisce spigot, ombrelli e coperture antipioggia CapIt.
-  - Gli scenari *Vehicle* e *Steadicam* includono staffe, bracci di isolamento e ventose quando necessari.
-- Le selezioni delle ottiche riportano diametro frontale, peso, dati dei rod e fuoco minimo, aggiungono supporti per lenti e adattatori matte box e avvisano sugli standard di rod incompatibili.
-- Le righe delle batterie rispecchiano i conteggi del calcolatore di potenza e includono piastre o dispositivi di *hotswap* quando richiesti.
-- Le preferenze di monitoraggio assegnano monitor predefiniti per ogni ruolo (regista, DoP, fuochista, ecc.) con set di cavi e ricevitori wireless.
-- Il modulo **Requisiti del progetto** alimenta la lista:
-  - **Nome del progetto**, **casa di produzione**, **noleggio** e **DoP** compaiono nell’intestazione delle specifiche stampate.
-  - Le voci **Troupe** raccolgono nomi, ruoli e indirizzi e-mail così i contatti viaggiano con il progetto.
-  - **Giorni di preparazione** e **giorni di ripresa** aggiungono note di pianificazione e, con scenari outdoor, suggeriscono attrezzatura per il meteo.
-  - Gli **scenari obbligatori** inseriscono rigging, gimbal e protezioni climatiche adeguati.
-  - **Impugnatura camera** ed **estensione mirino** inseriscono i componenti selezionati o i relativi supporti.
-  - Le opzioni di **matte box** e **filtri** aggiungono il sistema scelto con cassetti, adattatori a clamp o filtri necessari.
-  - Le configurazioni di **monitoraggio**, **distribuzione video** e **mirino** aggiungono monitor, cavi e overlay per ciascun ruolo.
-  - Le scelte dei **pulsanti personalizzati** e delle **preferenze treppiede** vengono elencate per riferimento rapido.
-- Gli elementi di ogni categoria sono ordinati alfabeticamente e mostrano un tooltip al passaggio del mouse.
-- La lista attrezzatura viene inclusa nelle anteprime stampabili e nei file di progetto condivisi.
-- Le liste vengono salvate automaticamente con il progetto e fanno parte sia dei file condivisi sia dei backup.
-- **Elimina lista attrezzatura** cancella la lista salvata e nasconde l’output.
-- I moduli della lista attrezzatura includono pulsanti a forchetta per duplicare al volo le voci inserite.
-
-### 📦 Categorie dei dispositivi
-- **Camera** (1)
-- **Monitor** (opzionale)
-- **Trasmettitore wireless** (opzionale)
-- **Motori FIZ** (0–4)
-- **Controller FIZ** (0–4)
-- **Sensore di distanza** (0–1)
-- **Piastra batteria** (solo sulle camere compatibili con V‑ o B‑Mount)
-- **Batteria V‑Mount** (0–1)
-
-### ⚙️ Calcoli di potenza
-- Consumo totale in watt
-- Corrente a 14,4 V e 12 V
-- Autonomia stimata in ore utilizzando la media ponderata dei feedback degli utenti
-- Numero di batterie necessario per un giorno di riprese di 10 h (inclusa la riserva)
-- Nota sulla temperatura per adattare l’autonomia in condizioni calde o fredde
-
-### 🔋 Controllo dell’erogazione della batteria
-- Avvisa se la corrente richiesta supera l’uscita della batteria (pin o D‑Tap)
-- Indica quando il carico si avvicina al limite (80 % di utilizzo)
-
-### 📊 Confronto batterie (opzionale)
-- Confronta le stime di autonomia fra tutte le batterie
-- Grafici a barre per un colpo d’occhio immediato
-
-### 🖼 Diagramma del progetto
-- Visualizza le connessioni di alimentazione e video dei dispositivi selezionati.
-- Avvisa quando i brand FIZ non sono compatibili.
-- Trascina i nodi per riordinare il layout, usa i pulsanti per zoomare ed esporta il diagramma in SVG o JPG.
-- Tieni premuto Shift mentre fai clic su Download per esportare uno snapshot JPG invece di un SVG.
-- Passa il mouse o tocca un dispositivo per vedere i dettagli nel popup.
-- Utilizza le icone [OpenMoji](https://openmoji.org/) quando la connessione è attiva e ripiega sugli emoji: 🔋 batteria, 🎥 camera, 🖥️ monitor, 📡 video, ⚙️ motore, 🎮 controller, 📐 distanza, 🎮 impugnatura e 🔌 piastra batteria.
-
-### 🧮 Ponderazione dei dati di autonomia
-- I feedback di autonomia inviati dagli utenti migliorano la stima finale.
-- Ogni voce viene corretta in base alla temperatura, passando da ×1 a 25 °C a:
-  - ×1,25 a 0 °C
-  - ×1,6 a −10 °C
-  - ×2 a −20 °C
-- Le impostazioni della camera influenzano il peso:
-  - Moltiplicatori di risoluzione: ≥12K ×3, ≥8K ×2, ≥4K ×1,5, ≥1080p ×1; risoluzioni inferiori scalate a 1080p.
-  - Il frame rate scala linearmente da 24 fps (es. 48 fps = ×2).
-  - Il Wi‑Fi attivo aggiunge il 10 %.
-  - Fattori codec: RAW/BRAW/ARRIRAW/R3D/CinemaDNG/Canon RAW/X‑OCN ×1; ProRes ×1,1; DNx/AVID ×1,2; All‑Intra ×1,3; H.264/AVC ×1,5; H.265/HEVC ×1,7.
-  - Le voci dei monitor sotto la luminosità specificata vengono pesate secondo il loro rapporto di luminosità.
-- Il peso finale riflette la quota di assorbimento di ciascun dispositivo, così i progetti simili contano di più.
-- La media ponderata viene applicata quando sono disponibili almeno tre voci.
-- Una dashboard ordina i contributi per peso e mostra la percentuale di ciascuno per un confronto immediato.
-
-### 🔍 Ricerca e filtri
-- Digita nei menu a discesa per trovare rapidamente un elemento.
-- Filtra le liste di dispositivi tramite un campo di ricerca.
-- Usa la barra di ricerca globale in alto per saltare a funzioni, dispositivi o argomenti di aiuto; premi Invio per navigare, / o Ctrl+K (⌘K su macOS) per focalizzarla al volo e Esc o × per cancellare.
-- Premi “/” o Ctrl+F (⌘F su macOS) per portare subito il focus sul campo di ricerca più vicino.
-- Clicca sulla stella accanto a qualsiasi selettore per fissare i preferiti in cima e sincronizzarli con i backup.
-
-### 🛠 Editor del database dispositivi
-- Aggiungi, modifica o elimina dispositivi in tutte le categorie.
-- Importa o esporta l’intero database in formato JSON.
-- Ripristina il database predefinito da `data.js`.
-
-### 🌓 Modalità scura
-- Attivala con il pulsante a forma di luna accanto al selettore della lingua.
-- La preferenza viene salvata nel browser.
-
-### 🦄 Modalità rosa
-- Clicca sull’icona dell’unicorno o premi **P** per attivare un accento rosa giocoso.
-- Funziona sia nel tema chiaro sia in quello scuro e resta attiva tra una visita e l’altra.
-
-### ⚫ Modalità ad alto contrasto
-- Attiva un tema ad alto contrasto per una migliore leggibilità.
-
-### 📝 Feedback di autonomia
-- Clicca su <strong>Invia feedback di autonomia</strong> sotto alla stima per aggiungere la tua misurazione.
-- Includi la temperatura per una ponderazione più accurata.
-- Le voci vengono salvate nel browser e migliorano le stime future.
-
-### ❓ Aiuto ricercabile
-- Aprilo tramite il pulsante <strong>?</strong> oppure con <kbd>?</kbd>, <kbd>H</kbd>, <kbd>F1</kbd> o <kbd>Ctrl+/</kbd>.
-- Usa il campo di ricerca per filtrare subito gli argomenti; la query viene azzerata alla chiusura.
-- Chiudi con <kbd>Esc</kbd> o cliccando all’esterno della finestra.
-
----
-
-## ▶️ Come usarlo
-1. **Avvia l’app:** apri `index.html` in un browser moderno: non serve alcun server.
-2. **Esplora la barra superiore:** cambia lingua, alterna i temi scuro o rosa, apri Impostazioni per regolare accento e tipografia e avvia l’aiuto con ? o Ctrl+/.
-3. **Seleziona i dispositivi:** scegli l’attrezzatura per ogni categoria dai menu a discesa; digita per filtrare, clicca sulla stella per fissare i preferiti e lascia che gli scenari preconfigurati aggiungano automaticamente gli accessori.
-4. **Consulta i calcoli:** una volta selezionata la batteria vedrai consumo, corrente e autonomia; gli avvisi evidenziano eventuali superamenti dei limiti.
-5. **Salva e condividi i progetti:** assegna un nome e salva la configurazione, i backup automatici creano snapshot e il pulsante Condividi esporta un bundle JSON per la troupe.
-6. **Genera la lista attrezzatura:** premi **Genera lista attrezzatura** per trasformare i requisiti in una lista categorizzata con tooltip e accessori.
-7. **Gestisci i dati dei dispositivi:** clicca su “Modifica dati dispositivi…” per aprire l’editor, aggiornare i dispositivi, esportare/importare JSON o tornare ai valori predefiniti.
-8. **Invia feedback di autonomia:** usa “Invia feedback di autonomia” per registrare misurazioni reali e raffinare le medie ponderate.
-
-## 📱 Installare come app
-
-Il planner è una Progressive Web App e può essere installato direttamente dal browser:
-
-- **Chrome/Edge (desktop):** fai clic sull’icona di installazione nella barra degli indirizzi.
-- **Android:** apri il menu del browser e scegli *Aggiungi alla schermata Home*.
-- **iOS/iPadOS Safari:** tocca *Condividi* e seleziona *Aggiungi alla schermata Home*.
-
-Una volta installata, l’app si avvia dalla schermata Home, funziona offline e si aggiorna automaticamente.
-
-## 📡 Uso offline e archiviazione dati
-
-Servire l’app tramite HTTP(S) installa un service worker che memorizza in cache ogni file, così Cine Power Planner funziona completamente offline e si aggiorna in background. Progetti, feedback di autonomia e preferenze (lingua, tema, modalità rosa e liste attrezzatura salvate) vivono nel `localStorage` del browser. Cancellare i dati del sito elimina tutte le informazioni e nella finestra Impostazioni è disponibile anche il pulsante **Cancella cache locale** per lo stesso reset con un clic.
-
----
-
-## 🗂️ Struttura dei file
-```bash
-index.html       # Layout HTML principale
-style.css        # Stili e layout
-script.js        # Logica dell’applicazione
-data.js          # Elenco dispositivi predefinito
-storage.js       # Helper per LocalStorage
-README.*.md      # Documentazione in più lingue
-checkConsistency.js  # Verifica i campi obbligatori nei dati dei dispositivi
-normalizeData.js     # Pulisce le voci e uniforma i nomi dei connettori
-generateSchema.js    # Ricostruisce schema.json a partire da data.js
-unifyPorts.js        # Uniforma i nomi di porta legacy
-tests/               # Suite di test Jest
-```
-I font sono inclusi localmente tramite `fonts.css`, quindi una volta memorizzate le risorse l’app funziona interamente offline.
-
-## 🛠️ Sviluppo
-Richiede Node.js 18 o versione successiva.
-
-```bash
-npm install
-npm run lint     # esegue solo ESLint
-npm test         # esegue linting, controlli dati e test Jest
-```
-
-Dopo aver modificato i dati dei dispositivi, rigenera il database normalizzato:
-
-```bash
-npm run normalize
-npm run unify-ports
-npm run check-consistency
-npm run generate-schema
-```
-
-Aggiungi `--help` a uno qualsiasi degli script per visualizzare le opzioni disponibili.
-
-## 🤝 Contribuire
-Sono benvenuti contributi di ogni tipo! Apri una issue o invia una pull request su GitHub.
+Cine Power Planner è distribuito con licenza ISC.

--- a/README.md
+++ b/README.md
@@ -2,120 +2,110 @@
 
 ![Cine Power Planner icon](icon.svg)
 
-Cine Power Planner is an offline-capable web application for planning professional camera rigs that run on V‑Mount, B‑Mount or Gold‑Mount batteries. It calculates total power draw, checks that every pack can safely deliver the current you need, estimates realistic runtimes from weighted field data and keeps your crew, scenarios and gear lists together so nothing gets lost between departments.
+Cine Power Planner is a standalone web app for planning professional camera
+rigs powered by V‑Mount, B‑Mount or Gold‑Mount batteries. It calculates total
+power draw, checks that batteries can safely deliver the required output, and
+estimates how long your project will run. The tool runs entirely in the browser
+and even works offline.
 
----
+The planner was built for ACs, data wranglers and DoPs who need to keep complex
+digital cinema rigs running all day without guesswork. As you swap camera
+bodies, add accessories or adjust requirements, the power draw, required
+batteries and runtime feedback update instantly so you can react before you get
+to set.
+
+All planning, data entry and reporting stay on the machine in front of you.
+Language preferences, projects, custom devices, pinned favorites, runtime
+feedback and backups are stored in your browser, and service worker updates are
+explicit so productions can audit exactly what changes between versions. You
+can open the repository directly from disk for air‑gapped shoots or host it
+internally so crews across departments see the same trustworthy planner.
+
+**Why crews choose Cine Power Planner**
+
+- Model multi-mount rigs with precise draw calculations, weighted runtime
+  feedback and safety warnings when a battery cannot deliver the current you
+  need.
+- Keep production context together—projects store requirements, crew, scenarios
+  and even pinned favorites so printed gear lists and shared bundles carry the
+  whole picture.
+- Work the way you prefer with offline support, dark, pink and high-contrast
+  themes, typography controls and type-to-search shortcuts across the
+  interface.
+
+No build step is required—open `index.html` in your browser and start planning
+immediately. Serving the repository over HTTP(S) installs a service worker so
+that future visits work offline and pick up updates automatically.
 
 ## Highlights
 
-### Plan complex builds without guesswork
-- Combine cameras, battery plates, wireless links, monitors, motors and accessories while seeing total wattage, current draw at 14.4 V/12 V (and 33.6 V/21.6 V for B‑Mount) plus expected runtime.
-- Compare compatible batteries side-by-side and get warnings when draw exceeds D‑Tap or pin limits.
-- Visualize rigs with an interactive diagram that supports drag, zoom, SVG/JPG export and compatibility notices.
+- **Runs anywhere.** No accounts, servers or build steps—open `index.html` from
+  disk or host it behind the firewall your production already trusts.
+- **Designed for crews.** Projects keep requirements, runtime data, favorites
+  and backups together so camera, lighting and production teams share the same
+  context.
+- **Confidence by default.** Safety warnings, weighted runtime averages and a
+  comparison view make it easy to validate that planned batteries can deliver
+  the required current.
+- **Approachable customization.** Add custom devices, shareable project
+  bundles, localized UI strings and printable gear lists without leaving the
+  browser.
 
-### Keep every department aligned
-- Save multiple projects with requirements, crew contacts, shooting scenarios and custom notes.
-- Generate printable gear lists that group kit by category, merge duplicates, include technical metadata and reflect scenario-driven accessories.
-- Share JSON bundles that contain device selections, runtime feedback, gear lists and custom devices for an end-to-end restore.
+### Expanded highlights
 
-### Travel-ready and private
-- Works entirely in the browser—open `index.html` directly or host the repository over HTTPS to enable the service worker.
-- Offline caching keeps language, theme, favorites and projects available everywhere without sending data to external servers.
-- Clear the local cache or trigger a force reload to refresh cached assets without touching saved projects.
+- **Plan complex builds without guesswork.** Combine cameras, battery plates,
+  wireless links, monitors, motors and accessories while seeing total wattage,
+  current draw at 14.4 V/12 V (and 33.6 V/21.6 V for B‑Mount) plus realistic
+  runtimes drawn from weighted field data. The battery comparison panel flags
+  overloads before you pack the wrong kit.
+- **Keep every department aligned.** Save multiple projects with requirements,
+  crew contacts, shooting scenarios and custom notes. Generate printable gear
+  lists that group kit by category, merge duplicates, include technical
+  metadata and reflect scenario-driven accessories so lighting, grip and camera
+  departments stay synchronized.
+- **Stay productive anywhere.** Works entirely in the browser—open
+  `index.html` directly or serve it over HTTPS to enable the service worker.
+  Offline caching preserves language, theme, favorites and projects without
+  sending data to external servers and the **Force reload** button refreshes
+  cached assets without touching saved projects.
+- **Tailor it to your team.** Switch instantly between English, Deutsch,
+  Español, Italiano and Français, adjust font size and typeface, pick a custom
+  accent color, upload a print logo, and toggle dark, pink or high-contrast
+  themes. Type-to-search dropdowns, pinned favorites, fork buttons and hover
+  help keep busy crews productive on set.
 
-### Tailor it to your team
-- Switch instantly between English, Deutsch, Español, Italiano and Français; the planner remembers the last language used.
-- Choose dark, pink or high-contrast themes, set a custom accent color, adjust font size and pick the typeface that suits your stage or accessibility needs.
-- Type-to-search dropdowns, pinned favorites and hover help keep busy crews productive on set.
+## Table of Contents
 
----
-
-## Quick Start
-
-1. Clone or download the repository.
-2. Open `index.html` in any modern Chromium, Firefox or Safari browser. No build step is required.
-3. Optionally serve the folder over HTTPS to install the service worker for offline updates. Any static file server works (`npx http-server -S` or similar).
-4. The app stores data in your browser. Use **Settings → Backup** to export JSON snapshots before switching machines.
-
----
-
-## Typical Workflow
-
-1. **Create or load a project.** Press Enter or `Ctrl+S` (`⌘S` on macOS) to save quickly. Automatic snapshots run every 10 minutes.
-2. **Select your camera, power and accessories.** Dropdowns filter as you type and favorites stay pinned.
-3. **Review power results.** Check wattage, draw, battery safety indicators and runtimes in the comparison panel.
-4. **Capture requirements.** Record crew roles, shooting days, scenarios and notes so every export carries the right context.
-5. **Generate deliverables.** Produce gear lists, printable overviews and shared project bundles, then restore them later with a single upload.
-
----
-
-## Interface Essentials
-
-- **Global search** (`/` or `Ctrl+K`/`⌘K`) jumps to any feature, selector or help topic—even when the side menu is collapsed.
-- **Help center** (`?`, `H`, `F1` or `Ctrl+/`) surfaces searchable guides, FAQs, shortcuts and optional hover help.
-- **Project diagram** visualizes connections; hold Shift while downloading to export a JPG snapshot instead of SVG.
-- **Battery comparison panel** reveals how each compatible pack performs and highlights overload risks.
-- **Gear list generator** turns selections into categorized tables with metadata, crew emails and scenario-driven additions.
-- **Offline indicator & force reload** badges show connectivity status and let you refresh cached assets without losing projects.
-
----
-
-## Data & Export Management
-
-- Projects, settings, gear lists, favorites and custom devices live in `localStorage`; backups and restores keep everything intact.
-- The Settings dialog offers hourly backup reminders, manual backups, one-click restore and a **Clear Local Cache** button.
-- Shared project files bundle selections, requirements, runtime feedback, gear lists and custom devices for handoff between teams.
-- Printable overviews include the project name, production details, optional custom logo and the generated gear list.
-- Automatic snapshots run in the background so it is easy to roll back to an earlier state.
-
----
-
-## Battery & Runtime Intelligence
-
-- Calculates total consumption, required battery counts for 10-hour days and the current draw each connection must supply.
-- Warns at 80 % usage and blocks unsafe loads when draw exceeds a battery's continuous or D‑Tap rating.
-- Weighted runtime estimates factor in temperature, resolution, frame rate, codec, Wi‑Fi usage, monitor brightness and each device's share of the total draw.
-- A runtime dashboard orders feedback by weight, shows contribution percentages and highlights outliers.
-- Supports user-submitted feedback to refine estimates for real-world shoots.
-
----
-
-## Customization & Accessibility
-
-- Toggle dark, pink or high-contrast themes and adjust typography without reloading the page.
-- Upload a custom logo for printed overviews, set default monitoring roles and configure project requirement defaults.
-- Keyboard-friendly navigation, focus-visible controls and skip links support screen readers and on-set accessibility needs.
-- Type-to-search selectors, pinned favorites and fork buttons for gear list rows accelerate repetitive data entry.
-
----
-
-## Keyboard Shortcuts
-
-| Action | Shortcut |
-| --- | --- |
-| Focus global search | `/`, `Ctrl+K`, `⌘K` |
-| Open help dialog | `?`, `H`, `F1`, `Ctrl+/` |
-| Save project | `Enter`, `Ctrl+S`, `⌘S` |
-| Toggle dark theme | `D` |
-| Toggle pink theme | `P` |
-| Force reload | Click the 🔄 icon in the header |
-
----
-
-## Development
-
-- Install dependencies with `npm install` (used for linting, tests and data scripts—no build step is required).
-- Run `npm run lint` and `npm run test` before committing changes. Targeted test suites are available via `npm run test:unit`, `npm run test:data`, `npm run test:dom` and `npm run test:script`.
-- Utility scripts include:
-  - `npm run check-consistency` to validate device data alignment.
-  - `npm run normalize` and `npm run unify-ports` to keep the catalog tidy.
-  - `npm run generate-schema` to refresh the device schema.
-
----
+- [Highlights](#highlights)
+- [Translations](#translations)
+- [Recent Updates](#recent-updates)
+- [Features at a Glance](#features-at-a-glance)
+- [Quick Start](#quick-start)
+- [Example Workflow](#example-workflow)
+- [Key Concepts](#key-concepts)
+- [Interface Overview](#interface-overview)
+- [Customization and Accessibility](#customization-and-accessibility)
+- [Keyboard Shortcuts](#keyboard-shortcuts)
+- [Localization](#localization)
+- [Gear List](#gear-list)
+- [Runtime Data Weighting](#runtime-data-weighting)
+- [Install as an App](#install-as-an-app)
+- [Offline Use and Data Storage](#offline-use-and-data-storage)
+- [Backup and Recovery](#backup-and-recovery)
+- [Privacy and Data Ownership](#privacy-and-data-ownership)
+- [Browser Support](#browser-support)
+- [Development](#development)
+- [Device Data Workflow](#device-data-workflow)
+- [Troubleshooting](#troubleshooting)
+- [Feedback and Support](#feedback-and-support)
+- [Contributing](#contributing)
+- [Acknowledgements](#acknowledgements)
+- [License](#license)
 
 ## Translations
 
-Documentation is available in multiple languages, and the app automatically picks your browser language on first load. Switch anytime via the top-right language menu:
+Documentation is available in multiple languages. The app detects your browser
+language on first load, and you can switch languages in the top right corner:
 
 - 🇬🇧 [English](README.en.md)
 - 🇩🇪 [Deutsch](README.de.md)
@@ -123,16 +113,422 @@ Documentation is available in multiple languages, and the app automatically pick
 - 🇮🇹 [Italiano](README.it.md)
 - 🇫🇷 [Français](README.fr.md)
 
-Want to help? Follow the [translation guide](docs/translation-guide.md) to add new locales for both the interface and documentation.
+Contributions for additional languages are welcome. Follow the [translation guide](docs/translation-guide.md) for step-by-step instructions on localizing the interface, documentation and language switcher.
 
----
+## Recent Updates
 
-## Contributing & Support
+- **Accent and typography controls** – adjust the accent color, font size and typeface from the Settings dialog while dark, pink and high contrast themes remain available on every visit.
+- **Global search shortcuts** – press / or Ctrl+K (⌘K on macOS) to focus the feature search instantly, even when it lives inside the collapsed mobile side menu.
+- **Force reload button** – clear cached service worker files and refresh the offline app without deleting saved projects or devices.
+- **Pinned favorites** – star dropdown entries to keep go-to cameras, batteries and accessories at the top of each selector and include them in backups.
+- **Clear local cache** – wipe stored projects and settings with one click.
+- **Project name above gear list** – printed overviews and the gear list now show the project name.
+- **Custom print logo** – upload a logo that appears in printable overviews and backups.
+- **Favorites in backups** – favorites are saved and an automatic backup runs before restoring data.
+- **Crew email field** – record email addresses for each crew member.
+- **High contrast mode** – switch to a high contrast theme for improved readability.
+- **Dynamic device forms** – category fields populate automatically from the schema in new device forms.
+- **Refreshed interface design** – cleaner layout and improved contrast make the planner easier to use on desktop and mobile.
+- **Simplified project sharing** – download a single project file that bundles selections, requirements, gear lists, runtime feedback and custom devices, then load it to restore the full setup.
+- **Unique icons for required scenarios** – each required scenario now shows its own icon for quick recognition.
+- **Persistent diagram popups on touch** – tapping a node on touch devices keeps its popup visible until another node is selected.
+- **Interactive project diagram** – drag devices, zoom, snap nodes to a grid, and export layouts as SVG or JPG.
+- **Pink accent theme** – toggle a playful pink highlight that persists between visits or press **P** to switch quickly.
+- **Searchable help dialog and hover hints** – open with ?, H, F1 or Ctrl+/ (even while typing), filter topics instantly, press / or Ctrl+F to jump to the search box, browse the built-in FAQ, and hover over any button, field, dropdown or header for a quick explanation.
+- **Type-to-search dropdowns** – quickly narrow device lists by typing directly into any selector.
+- **Multi-mount support** – choose between V‑, B‑ or Gold‑Mount plates on supported cameras and the battery list updates automatically.
+- **User runtime feedback** – submit real-world runtimes with environment details to refine estimates.
+- **Visual runtime weighting dashboard** – see how temperature, resolution, frame rate and codec affect each runtime report, now sorted by weight with exact share percentages.
+- **Gear list generator** – compile selected gear and project requirements with one click.
+- **Quick project saving** – press Enter or Ctrl+S (⌘S on macOS) to save a project and the Save button stays disabled until a name is entered.
+- **Project requirement saving** – store project requirements with each project so gear lists retain full context.
+- **User entry duplication** – gear list forms use fork buttons to copy user fields instantly.
 
-Bug reports, feature ideas and data corrections are welcome. Open an issue or submit a pull request with as much detail as possible. If you discover incorrect runtimes or missing gear, include the project file or sample data so the catalog stays reliable.
+See the language-specific README files for full details.
 
----
+## Features at a Glance
+
+### Plan with confidence
+
+- Calculate total power consumption, current draw at 14.4 V (33.6 V for
+  B‑Mount) and 12 V (21.6 V for B‑Mount), and estimated battery runtime across
+  any combination of devices.
+- Combine user-submitted runtimes using weighted averages that account for
+  temperature, resolution, frame rate, codecs and each device’s share of total
+  draw.
+- Compare runtimes across all compatible batteries with the optional battery
+  comparison panel and warnings when a pack cannot safely supply the required
+  current.
+
+### Manage evolving projects
+
+- Save, auto-back up, share, restore and clear projects—requirements included—with
+  printable overviews and shareable JSON bundles that also include custom
+  devices and runtime feedback.
+- Customize the device database with your own gear, import or export the
+  catalog as JSON and revert to the bundled defaults at any time.
+
+### Communicate clearly
+
+- Visualize power and video connections with an interactive diagram: drag,
+  zoom, snap to grid and export as SVG or hold Shift to download a JPG
+  snapshot.
+- Generate rich gear lists that expand project requirements into categorized
+  packing tables with accessories, duplicates merged by quantity and tooltips
+  for weight and dimensions.
+
+### Stay productive anywhere
+
+- Jump to features, device selectors or help topics with the global search
+  field, star favorites to pin go-to devices and type directly inside dropdowns
+  to filter instantly.
+- Tailor the interface with language detection, dark or playful pink themes,
+  high contrast mode, accent color and typography controls.
+- Work completely offline thanks to the service worker, persistent storage and a
+  force reload button that refreshes cached assets without losing data.
+
+## Quick Start
+
+1. Download or clone this repository.
+2. Open `index.html` in a modern browser.
+3. (Optional) Serve the folder over HTTP to enable the service worker and
+   Progressive Web App features:
+   ```bash
+   npx http-server
+   # or
+   python -m http.server
+   ```
+   The planner then works fully offline and updates automatically.
+4. Create your first project, add devices from the dropdowns and generate a gear
+   list or printable overview to share with collaborators.
+
+## Example Workflow
+
+Use the planner end-to-end with the following workflow:
+
+1. **Create or load a project.** Use the project selector to load an existing setup or type a new project name and press Enter (or click **Save**) to start a fresh plan. The active project name appears above the gear list, printable overview and exports.
+2. **Add cameras, power and accessories.** Pick devices from the categorized dropdowns. Type-to-filter search boxes, pinned favorites and the global search shortcuts (/ or Ctrl+K / ⌘K) help you jump directly to gear, settings pages or help topics.
+3. **Check power draw and runtime.** Watch the power summary panel for current draw warnings, explore the battery comparison view to spot longer-lasting options and use the runtime dashboard to understand how temperature, codec, frame rate and other factors influence user feedback.
+4. **Capture project requirements.** Fill out project details, crew lists and required scenarios so the gear list and printable overview reflect the full production context. Fork buttons duplicate entries to speed up data entry.
+5. **Share or back up the plan.** Generate the gear list, export a planner backup or download a shareable project bundle before heading to set. Backups include custom devices, runtime feedback and pinned favorites.
+
+## Key Concepts
+
+Understanding the planner's vocabulary makes it easier to explore new features:
+
+### Projects
+
+- Saved plans collect device selections, project requirements, crew lists and
+  generated gear lists. The selector stores multiple projects and autosaves
+  every change so you can switch between productions without losing your place.
+- Shared project bundles export everything—device selections, runtime feedback,
+  favorites, gear lists and custom devices—so another machine can restore the
+  full context with a single upload.
+
+### Devices and accessories
+
+- Device dropdowns contain both bundled hardware and your own custom entries.
+  Category tabs match the files in `devices/`, making it simple to update or
+  audit the catalog in version control.
+- Favorites keep go-to cameras, batteries and accessories at the top of the
+  list. They appear in backups and follow the project when you export a bundle.
+
+### Runtime feedback
+
+- User-submitted runtimes are stored with environmental context. Weighted
+  averages factor in temperature, codec, resolution, frame rate and each
+  component's share of the total draw so estimates mirror real-world shoots.
+- The runtime dashboard orders entries by weight, shows contribution
+  percentages and highlights outliers so crews can evaluate feedback quickly.
+
+### Scenarios and gear lists
+
+- Required scenarios (e.g. Vehicle, Outdoor, Steadicam) expand into the
+  necessary rigging, weather protection and accessories. Generated gear lists
+  combine those presets with your device selections so printouts and shared
+  bundles capture the entire kit.
+
+### Backups and recoverability
+
+- Automatic snapshots, manual exports and the **Force reload** button let you
+  experiment without fear. Restores create a safety backup before overwriting
+  data, and the **Clear Local Cache** option removes everything when you need a
+  clean slate.
+
+## Interface Overview
+
+### Quick reference
+
+- **Global search** (`/` or `Ctrl+K`/`⌘K`) jumps to any feature, selector or help
+  topic—even when the side menu is collapsed.
+- **Help center** (`?`, `H`, `F1` or `Ctrl+/`) surfaces searchable guides, FAQs,
+  shortcuts and optional hover help that turns every button, field and header
+  into a tooltip.
+- **Project diagram** visualizes connections; hold Shift while downloading to
+  export a JPG snapshot instead of SVG and reveal compatibility notices inline.
+- **Battery comparison panel** reveals how each compatible pack performs and
+  highlights overload risks before you arrive on set.
+- **Gear list generator** turns selections into categorized tables with
+  metadata, crew emails and scenario-driven additions that print cleanly.
+- **Offline indicator and force reload** badges show connectivity status and let
+  you refresh cached assets without losing projects.
+
+### Top bar controls
+
+- A skip link, offline indicator and responsive branding keep the interface accessible across devices; the offline badge appears whenever the browser loses its connection.
+- The global search bar jumps to features, device selectors or help topics—press Enter to navigate to the highlighted result, use / or Ctrl+K (⌘K on macOS) to focus it from anywhere (the side menu opens automatically on small screens), and press Escape or × to clear the query.
+- Language, dark mode and pink mode buttons sit alongside the Settings dialog, which exposes accent color, font size, font family, high contrast and custom logo uploads plus backup, restore and Clear Local Cache tools.
+- The Help button opens a searchable dialog with step-by-step sections, keyboard shortcuts, FAQs and an optional hover-help mode; it can also be triggered with ?, H, F1 or Ctrl+/ even while typing.
+- The Force reload button (🔄) removes cached service worker files and refreshes the app without touching saved projects or device data.
+
+### Navigation and search
+
+- On smaller screens a collapsible side menu mirrors the main sections for quick navigation.
+- Every dropdown and editor list includes an inline search box and supports type-to-filter interactions; pressing / or Ctrl+F (⌘F on macOS) focuses the nearest search field.
+- Star icons beside selectors let you pin favorite devices so they stay at the top of the list and persist between sessions.
+
+## Customization and Accessibility
+
+- Theme preferences include dark mode, playful pink accents and a dedicated high contrast switch for improved readability.
+- Accent color, base font size and typeface can be customised in Settings; choices are applied immediately and remembered with other preferences.
+- A keyboard-friendly skip link, focus-visible controls, offline indicator and responsive layout improve navigation on desktops, tablets and phones.
+- Built-in keyboard shortcuts cover global search (/ or Ctrl+K/⌘K), help ( ?, H, F1, Ctrl+/ ), saving (Enter or Ctrl+S/⌘S), dark mode (D) and pink mode (P).
+- The hover-help toggle turns every button, field, dropdown and header into an on-demand tooltip so new users can learn the interface quickly.
+- Upload a custom logo for printed overviews, configure monitoring defaults and set preferred requirement presets so deliverables match the production company brand.
+- Fork buttons in gear list forms duplicate entries, and pinned favorites keep the most-used gear at the top of dropdowns for faster data entry.
+
+## Keyboard Shortcuts
+
+Keyboard navigation keeps the planner quick to operate on set and in prep. The following shortcuts work across desktop browsers unless otherwise noted:
+
+| Shortcut | Action | Notes |
+| --- | --- | --- |
+| `/`, `Ctrl+K`, `⌘K` | Focus the global search field. | Works even when the side navigation is collapsed; press `Esc` to clear the current query. |
+| `Enter`, `Ctrl+S`, `⌘S` | Save the active project. | The Save button stays disabled until a project name is entered. |
+| `?`, `H`, `F1`, `Ctrl+/` | Open the help dialog. | The dialog remains searchable while you type in other fields. |
+| `D` | Toggle dark mode. | Also available from **Settings → Themes**. |
+| `P` | Toggle the pink accent theme. | Works alongside light, dark or high-contrast modes. |
+| 🔄 button | Force reload cached assets. | Also accessible via **Settings → Force reload** without erasing projects. |
+
+## Localization
+
+The interface language loads automatically from the browser preference, and users can change it at any time from the language menu in the top bar or in **Settings**. To translate the planner into another language:
+
+1. Duplicate the nearest language file (for example `README.en.md`) as `README.<lang>.md` and translate the documentation.
+2. Add UI strings to `translations.js` by copying an existing language block (such as `en`) and translating each value. Most strings include tooltip text that appears in the help dialog and Settings panels, so keep formatting placeholders like `%s` intact.
+3. Provide translated static pages (privacy policy, imprint) where required by copying the relevant HTML files.
+4. Run `npm test` to ensure linting, data validations and Jest suites still pass before submitting a pull request.
+
+New locales can be previewed immediately in the browser by selecting the language from the menu; no build step is required.
+
+## Gear List
+
+The planner expands your selections into a detailed packing table:
+
+- Click **Generate Gear List** to compile chosen gear and project requirements into a categorized table.
+- The list refreshes automatically whenever device selections or project details change.
+- Entries are grouped by category (camera, lens, power, monitoring, rigging, grip, consumables, etc.) and duplicates are merged with a count.
+- Required cables, rigging and accessories are added automatically for monitors, motors, gimbals, weather scenarios and speciality setups.
+- Scenario selections inject matching gear (for example, *Handheld* + *Easyrig* adds a telescopic handle; *Gimbal* supplies the selected gimbal, friction arms and sunshades; *Outdoor* adds spigots, umbrellas and CapIt rain covers; *Vehicle* and *Steadicam* pack in mounts, isolation arms and suction gear where applicable).
+- Lens choices note front diameter, weight, minimum focus and rod requirements, and add lens supports and matte box components with warnings for incompatible rod standards.
+- Battery rows reflect counts from the power calculator and include a hotswap plate or the selected hotswap device when needed.
+- Monitoring preferences provide default monitors for each role and bundle cable sets for every screen.
+- The **Project Requirements** form feeds the list:
+  - **Project Name**, **Production Company**, **Rental House** and **DoP** appear in the heading of the printed requirements.
+  - **Crew** entries capture names, roles and email addresses so contact lists stay attached to each project.
+  - **Prep Days** and **Shooting Days** supply schedule notes and, when paired with outdoor scenarios, suggest weather gear.
+  - **Required Scenarios** append matching rigging, gimbals and weather protection.
+  - **Camera Handle** and **Viewfinder Extension** insert the chosen handle parts or extension brackets.
+  - **Matte Box** and **Filter** choices inject the selected system with any needed trays, clamp adapters or filters.
+  - **Monitoring Configuration**, **Video Distribution** and **Viewfinder** settings add monitors, cables and overlays for each role.
+  - **User Button** selections and **Tripod Preferences** are listed for quick reference.
+- Items are sorted alphabetically within their category and each exposes a tooltip on hover.
+- The gear list appears in printable overviews and shared project files so collaborators see the full context.
+- Gear lists save automatically with the project and are included in shared project files and backups.
+- **Delete Gear List** removes the saved list and hides the output.
+- Gear list forms use fork buttons to duplicate your entries instantly.
+
+## Runtime Data Weighting
+
+User-submitted battery runtimes are combined using a weighted average to better match your project:
+
+- Entries are adjusted for temperature, scaling from ×1 at 25 °C to ×1.25 at 0 °C, ×1.6 at −10 °C and ×2 at −20 °C.
+- Resolution multipliers: ≥12K ×3, ≥8K ×2, ≥4K ×1.5, ≥1080p ×1, lower scaled relative to 1080p.
+- Frame rate scales linearly from a base of 24 fps (e.g. 48 fps = ×2).
+- Wi‑Fi enabled adds 10 %.
+- Codec factors: RAW/BRAW/ARRIRAW/R3D/CinemaDNG/Canon RAW/X‑OCN ×1; ProRes ×1.1; DNx/AVID ×1.2; All‑Intra ×1.3; H.264/AVC ×1.5; H.265/HEVC ×1.7.
+- Monitor entries below the specified brightness are weighted by their brightness ratio.
+- The final weight reflects how much of the total power draw comes from the camera, monitor and other devices so that similar rigs count more.
+- A dedicated dashboard orders entries by weight and shows the share percentage for each runtime entry.
+
+## Install as an App
+
+Cine Power Planner is a Progressive Web App and can be installed for quick
+access:
+
+1. Open `index.html` in a supported browser.
+2. Use the browser's **Install** or **Add to Home Screen** option.
+   - **Chrome/Edge (desktop):** Click the install icon in the address bar.
+   - **Android:** Open the browser menu and choose *Add to Home screen*.
+   - **iOS Safari:** Tap the share icon and select *Add to Home Screen*.
+3. Launch the app from your applications list. The installed version works
+   offline and updates automatically.
+
+## Offline Use and Data Storage
+
+When served over HTTP(S), Cine Power Planner installs a service worker that caches all
+files so the planner runs entirely offline and pulls updates in the
+background. Projects, runtime submissions and preferences (language, theme,
+pink mode and saved gear lists) are stored locally via `localStorage` in your
+browser. Clearing the site's data in your browser removes all saved
+information, and the Settings dialog includes a **Clear Local Cache** button for a one-click reset when you need a fresh start.
+The header shows an offline indicator whenever the browser drops its
+connection, and the 🔄 **Force reload** action refreshes cached assets without
+touching saved data.
+See [Backup and Recovery](#backup-and-recovery) for tips on keeping your data safe.
+
+## Backup and Recovery
+
+Cine Power Planner automatically guards against data loss and gives you manual
+controls to export your work:
+
+- **Saved project snapshots:** The project selector keeps every setup you save,
+  and the app creates timestamped `auto-backup-…` entries every 10 minutes while
+  it is open. These snapshots appear at the bottom of the list so you can revert
+  to a previous state without overwriting the active project.
+- **Full planner backups:** Open **Settings → Backup & Restore** and press
+  **Backup** to download `planner-backup.json`. The file includes saved
+  projects, custom devices, session state, runtime feedback and favorites via
+  the internal `exportAllData()` routine. Restoring the file automatically saves
+  a safety copy of your current data before importing the new settings and warns
+  when the file was produced with a different app version.
+- **Clear Local Cache:** In **Settings → Backup & Restore**, wipe saved projects,
+  custom gear, favorites and runtime feedback with one click when you need to
+  start over.
+- **Regular reminders:** While the planner is running, an hourly background job
+  triggers the same backup export so you always have a recent download prompt as
+  a reminder to archive your data.
+
+## Privacy and Data Ownership
+
+Cine Power Planner intentionally keeps your data on the devices you control. The
+app runs entirely in the browser with no accounts, telemetry or background
+sync—projects, runtime submissions, favorites, custom devices, theme settings
+and backups stay in your local `localStorage` unless you choose to export them.
+Hosting the planner yourself (or loading it directly from disk) lets production
+teams work without personal information or gear lists leaving their own
+infrastructure.
+
+Because a service worker caches assets for offline use, the only runtime network
+requests come from optional resources such as the OpenMoji icon set when a
+connection is available. You can clear saved information at any time via
+**Settings → Clear Local Cache** or by deleting the site's data in your browser.
+Exports produce human-readable JSON so you can review exactly what will be
+shared before handing files to collaborators or clients.
+
+For added transparency, each service worker update is triggered by the
+repository contents—there are no background servers to push unreviewed code.
+Hourly backup reminders and the **Force reload** button give productions clear
+controls for how and when data leaves their machines.
+
+## Browser Support
+
+Cine Power Planner relies on modern web APIs and is tested in current versions of Chrome, Firefox, Edge and Safari. Older browsers may lack support for features like installation or offline caching. For the best experience, use a browser with up-to-date Progressive Web App (PWA) capabilities.
+
+## Development
+
+Set up a development environment with Node.js 18 or later. After cloning the repository, run `npm install` once, then use `npm test` to execute ESLint, data consistency checks and Jest tests together while you iterate on changes. See [CONTRIBUTING.md](CONTRIBUTING.md) for detailed guidelines on proposing updates and working with the dataset.
+
+### File Structure
+
+```
+index.html       # Main HTML layout
+style.css        # Styles and layout
+script.js        # Application logic
+devices/         # Default device lists by category
+storage.js       # LocalStorage helpers
+README.*.md      # Documentation in different languages
+checkConsistency.js  # Validates device data
+normalizeData.js     # Cleans and unifies device entries
+generateSchema.js    # Regenerates schema.json from data
+unifyPorts.js        # Harmonizes connector names
+tests/               # Jest test suite
+```
+
+### Install dependencies and run tests
+
+Requires Node.js 18 or later.
+
+```bash
+npm install
+npm run lint     # run ESLint alone
+npm test
+```
+
+`npm run lint` executes ESLint without running tests. The `npm test` command then runs ESLint, data consistency checks and a single Jest invocation that executes every project sequentially. Tests run with `--runInBand` and `maxWorkers=1` to minimise parallel memory usage while still failing fast when an assertion breaks.
+
+To run individual suites while iterating you can target specific Jest projects:
+
+```bash
+npm run test:unit   # module-level logic and storage helpers (1 GB heap cap)
+npm run test:data   # static dataset validations (1 GB heap cap)
+npm run test:dom    # lightweight DOM utilities (1.5 GB heap cap)
+npm run test:script # reduced smoke checks for script.js (3 GB heap cap)
+```
+
+## Device Data Workflow
+
+The device catalog that powers the planner lives under `devices/`. Each file
+groups related equipment (cameras, monitors, power, accessories, etc.) so
+changes are easy to review in Git history and within the app. When you edit
+these lists, run the helper scripts to clean, verify and rebuild the dataset
+before committing:
+
+```bash
+npm run normalize
+npm run unify-ports
+npm run check-consistency
+npm run generate-schema
+```
+
+`npm run normalize` applies various cleanup routines to unify connector names
+and expand shorthand entries. `npm run unify-ports` standardizes connector and
+port labels. `npm run check-consistency` confirms that required fields are
+present and raises an error if anything is missing. Finally,
+`npm run generate-schema` rebuilds `schema.json` from the current data so the
+interface reflects your updates.
+
+You can iterate faster with the data-focused Jest project when refining devices:
+
+```bash
+npm run test:data
+```
+
+Add `--help` to any of the helper commands for detailed usage (for example,
+`npm run normalize -- --help`). Review the generated JSON diffs to verify
+naming, connector standards and metadata before opening a pull request.
+
+## Troubleshooting
+
+- **Stuck on an old version?** Service workers aggressively cache assets. Click the in-app **Force reload** button, or open your browser's dev tools and perform a hard reload to clear stale files without deleting saved projects.
+- **Missing data after closing the tab?** Ensure the site has storage access. Private browsing modes or restrictive tracking protections can prevent `localStorage` from persisting backups, favorites and custom devices.
+- **Downloads are blocked?** The browser must be allowed to download multiple files for backups and shareable project bundles. Temporarily disable pop-up blockers or allow multiple downloads when prompted.
+- **Command-line scripts failing?** Confirm Node.js 18+ is installed, run `npm install` to fetch dependencies, and rerun the requested npm script. Memory errors usually mean a test suite exceeded its cap—rerun a narrower target such as `npm run test:unit`.
+
+## Feedback and Support
+
+If you run into problems, have questions, or want to suggest new features, please open an issue on GitHub. Community feedback helps improve the planner for everyone.
+When reporting data corrections, include relevant project exports or runtime
+samples so the catalog stays accurate for the next shoot.
+
+## Contributing
+
+Contributions are welcome! Please open an issue or submit a pull request on GitHub. Review [CONTRIBUTING.md](CONTRIBUTING.md) for expectations around dataset updates, translations and testing. Before submitting, run `npm test` to ensure that linting, data consistency checks, and unit tests all pass.
+
+## Acknowledgements
+
+ The planner uses the [OpenMoji](https://openmoji.org/) icon set when a network connection is available and relies on [lz-string](https://pieroxy.net/blog/pages/lz-string/index.html) to compactly store projects in URLs.
 
 ## License
 
-Cine Power Planner is released under the ISC License.
+Distributed under the ISC license. See `package.json` for details.

--- a/README.md
+++ b/README.md
@@ -2,80 +2,120 @@
 
 ![Cine Power Planner icon](icon.svg)
 
-Cine Power Planner is a standalone web app for planning professional camera
-rigs powered by V‑Mount, B‑Mount or Gold‑Mount batteries. It calculates total
-power draw, checks that batteries can safely deliver the required output, and
-estimates how long your project will run. The tool runs entirely in the browser
-and even works offline.
+Cine Power Planner is an offline-capable web application for planning professional camera rigs that run on V‑Mount, B‑Mount or Gold‑Mount batteries. It calculates total power draw, checks that every pack can safely deliver the current you need, estimates realistic runtimes from weighted field data and keeps your crew, scenarios and gear lists together so nothing gets lost between departments.
 
-The planner was built for ACs, data wranglers and DoPs who need to keep complex
-digital cinema rigs running all day without guesswork. As you swap camera
-bodies, add accessories or adjust requirements, the power draw, required
-batteries and runtime feedback update instantly so you can react before you get
-to set.
-
-**Why crews choose Cine Power Planner**
-
-- Model multi-mount rigs with precise draw calculations, weighted runtime
-  feedback and safety warnings when a battery cannot deliver the current you
-  need.
-- Keep production context together—projects store requirements, crew, scenarios
-  and even pinned favorites so printed gear lists and shared bundles carry the
-  whole picture.
-- Work the way you prefer with offline support, dark, pink and high-contrast
-  themes, typography controls and type-to-search shortcuts across the
-  interface.
-
-No build step is required—open `index.html` in your browser and start planning
-immediately. Serving the repository over HTTP(S) installs a service worker so
-that future visits work offline and pick up updates automatically.
+---
 
 ## Highlights
 
-- **Runs anywhere.** No accounts, servers or build steps—open `index.html` from
-  disk or host it behind the firewall your production already trusts.
-- **Designed for crews.** Projects keep requirements, runtime data, favorites
-  and backups together so camera, lighting and production teams share the same
-  context.
-- **Confidence by default.** Safety warnings, weighted runtime averages and a
-  comparison view make it easy to validate that planned batteries can deliver
-  the required current.
-- **Approachable customization.** Add custom devices, shareable project
-  bundles, localized UI strings and printable gear lists without leaving the
-  browser.
+### Plan complex builds without guesswork
+- Combine cameras, battery plates, wireless links, monitors, motors and accessories while seeing total wattage, current draw at 14.4 V/12 V (and 33.6 V/21.6 V for B‑Mount) plus expected runtime.
+- Compare compatible batteries side-by-side and get warnings when draw exceeds D‑Tap or pin limits.
+- Visualize rigs with an interactive diagram that supports drag, zoom, SVG/JPG export and compatibility notices.
 
-## Table of Contents
+### Keep every department aligned
+- Save multiple projects with requirements, crew contacts, shooting scenarios and custom notes.
+- Generate printable gear lists that group kit by category, merge duplicates, include technical metadata and reflect scenario-driven accessories.
+- Share JSON bundles that contain device selections, runtime feedback, gear lists and custom devices for an end-to-end restore.
 
-- [Highlights](#highlights)
-- [Translations](#translations)
-- [Recent Updates](#recent-updates)
-- [Features at a Glance](#features-at-a-glance)
-- [Quick Start](#quick-start)
-- [Example Workflow](#example-workflow)
-- [Key Concepts](#key-concepts)
-- [Interface Overview](#interface-overview)
-- [Customization and Accessibility](#customization-and-accessibility)
-- [Keyboard Shortcuts](#keyboard-shortcuts)
-- [Localization](#localization)
-- [Gear List](#gear-list)
-- [Runtime Data Weighting](#runtime-data-weighting)
-- [Install as an App](#install-as-an-app)
-- [Offline Use and Data Storage](#offline-use-and-data-storage)
-- [Backup and Recovery](#backup-and-recovery)
-- [Privacy and Data Ownership](#privacy-and-data-ownership)
-- [Browser Support](#browser-support)
-- [Development](#development)
-- [Device Data Workflow](#device-data-workflow)
-- [Troubleshooting](#troubleshooting)
-- [Feedback and Support](#feedback-and-support)
-- [Contributing](#contributing)
-- [Acknowledgements](#acknowledgements)
-- [License](#license)
+### Travel-ready and private
+- Works entirely in the browser—open `index.html` directly or host the repository over HTTPS to enable the service worker.
+- Offline caching keeps language, theme, favorites and projects available everywhere without sending data to external servers.
+- Clear the local cache or trigger a force reload to refresh cached assets without touching saved projects.
+
+### Tailor it to your team
+- Switch instantly between English, Deutsch, Español, Italiano and Français; the planner remembers the last language used.
+- Choose dark, pink or high-contrast themes, set a custom accent color, adjust font size and pick the typeface that suits your stage or accessibility needs.
+- Type-to-search dropdowns, pinned favorites and hover help keep busy crews productive on set.
+
+---
+
+## Quick Start
+
+1. Clone or download the repository.
+2. Open `index.html` in any modern Chromium, Firefox or Safari browser. No build step is required.
+3. Optionally serve the folder over HTTPS to install the service worker for offline updates. Any static file server works (`npx http-server -S` or similar).
+4. The app stores data in your browser. Use **Settings → Backup** to export JSON snapshots before switching machines.
+
+---
+
+## Typical Workflow
+
+1. **Create or load a project.** Press Enter or `Ctrl+S` (`⌘S` on macOS) to save quickly. Automatic snapshots run every 10 minutes.
+2. **Select your camera, power and accessories.** Dropdowns filter as you type and favorites stay pinned.
+3. **Review power results.** Check wattage, draw, battery safety indicators and runtimes in the comparison panel.
+4. **Capture requirements.** Record crew roles, shooting days, scenarios and notes so every export carries the right context.
+5. **Generate deliverables.** Produce gear lists, printable overviews and shared project bundles, then restore them later with a single upload.
+
+---
+
+## Interface Essentials
+
+- **Global search** (`/` or `Ctrl+K`/`⌘K`) jumps to any feature, selector or help topic—even when the side menu is collapsed.
+- **Help center** (`?`, `H`, `F1` or `Ctrl+/`) surfaces searchable guides, FAQs, shortcuts and optional hover help.
+- **Project diagram** visualizes connections; hold Shift while downloading to export a JPG snapshot instead of SVG.
+- **Battery comparison panel** reveals how each compatible pack performs and highlights overload risks.
+- **Gear list generator** turns selections into categorized tables with metadata, crew emails and scenario-driven additions.
+- **Offline indicator & force reload** badges show connectivity status and let you refresh cached assets without losing projects.
+
+---
+
+## Data & Export Management
+
+- Projects, settings, gear lists, favorites and custom devices live in `localStorage`; backups and restores keep everything intact.
+- The Settings dialog offers hourly backup reminders, manual backups, one-click restore and a **Clear Local Cache** button.
+- Shared project files bundle selections, requirements, runtime feedback, gear lists and custom devices for handoff between teams.
+- Printable overviews include the project name, production details, optional custom logo and the generated gear list.
+- Automatic snapshots run in the background so it is easy to roll back to an earlier state.
+
+---
+
+## Battery & Runtime Intelligence
+
+- Calculates total consumption, required battery counts for 10-hour days and the current draw each connection must supply.
+- Warns at 80 % usage and blocks unsafe loads when draw exceeds a battery's continuous or D‑Tap rating.
+- Weighted runtime estimates factor in temperature, resolution, frame rate, codec, Wi‑Fi usage, monitor brightness and each device's share of the total draw.
+- A runtime dashboard orders feedback by weight, shows contribution percentages and highlights outliers.
+- Supports user-submitted feedback to refine estimates for real-world shoots.
+
+---
+
+## Customization & Accessibility
+
+- Toggle dark, pink or high-contrast themes and adjust typography without reloading the page.
+- Upload a custom logo for printed overviews, set default monitoring roles and configure project requirement defaults.
+- Keyboard-friendly navigation, focus-visible controls and skip links support screen readers and on-set accessibility needs.
+- Type-to-search selectors, pinned favorites and fork buttons for gear list rows accelerate repetitive data entry.
+
+---
+
+## Keyboard Shortcuts
+
+| Action | Shortcut |
+| --- | --- |
+| Focus global search | `/`, `Ctrl+K`, `⌘K` |
+| Open help dialog | `?`, `H`, `F1`, `Ctrl+/` |
+| Save project | `Enter`, `Ctrl+S`, `⌘S` |
+| Toggle dark theme | `D` |
+| Toggle pink theme | `P` |
+| Force reload | Click the 🔄 icon in the header |
+
+---
+
+## Development
+
+- Install dependencies with `npm install` (used for linting, tests and data scripts—no build step is required).
+- Run `npm run lint` and `npm run test` before committing changes. Targeted test suites are available via `npm run test:unit`, `npm run test:data`, `npm run test:dom` and `npm run test:script`.
+- Utility scripts include:
+  - `npm run check-consistency` to validate device data alignment.
+  - `npm run normalize` and `npm run unify-ports` to keep the catalog tidy.
+  - `npm run generate-schema` to refresh the device schema.
+
+---
 
 ## Translations
 
-Documentation is available in multiple languages. The app detects your browser
-language on first load, and you can switch languages in the top right corner:
+Documentation is available in multiple languages, and the app automatically picks your browser language on first load. Switch anytime via the top-right language menu:
 
 - 🇬🇧 [English](README.en.md)
 - 🇩🇪 [Deutsch](README.de.md)
@@ -83,388 +123,16 @@ language on first load, and you can switch languages in the top right corner:
 - 🇮🇹 [Italiano](README.it.md)
 - 🇫🇷 [Français](README.fr.md)
 
-Contributions for additional languages are welcome. Follow the [translation guide](docs/translation-guide.md) for step-by-step instructions on localizing the interface, documentation and language switcher.
+Want to help? Follow the [translation guide](docs/translation-guide.md) to add new locales for both the interface and documentation.
 
-## Recent Updates
+---
 
-- **Accent and typography controls** – adjust the accent color, font size and typeface from the Settings dialog while dark, pink and high contrast themes remain available on every visit.
-- **Global search shortcuts** – press / or Ctrl+K (⌘K on macOS) to focus the feature search instantly, even when it lives inside the collapsed mobile side menu.
-- **Force reload button** – clear cached service worker files and refresh the offline app without deleting saved projects or devices.
-- **Pinned favorites** – star dropdown entries to keep go-to cameras, batteries and accessories at the top of each selector and include them in backups.
-- **Clear local cache** – wipe stored projects and settings with one click.
-- **Project name above gear list** – printed overviews and the gear list now show the project name.
-- **Custom print logo** – upload a logo that appears in printable overviews and backups.
-- **Favorites in backups** – favorites are saved and an automatic backup runs before restoring data.
-- **Crew email field** – record email addresses for each crew member.
-- **High contrast mode** – switch to a high contrast theme for improved readability.
-- **Dynamic device forms** – category fields populate automatically from the schema in new device forms.
-- **Refreshed interface design** – cleaner layout and improved contrast make the planner easier to use on desktop and mobile.
-- **Simplified project sharing** – download a single project file that bundles selections, requirements, gear lists, runtime feedback and custom devices, then load it to restore the full setup.
-- **Unique icons for required scenarios** – each required scenario now shows its own icon for quick recognition.
-- **Persistent diagram popups on touch** – tapping a node on touch devices keeps its popup visible until another node is selected.
-- **Interactive project diagram** – drag devices, zoom, snap nodes to a grid, and export layouts as SVG or JPG.
-- **Pink accent theme** – toggle a playful pink highlight that persists between visits or press **P** to switch quickly.
-- **Searchable help dialog and hover hints** – open with ?, H, F1 or Ctrl+/ (even while typing), filter topics instantly, press / or Ctrl+F to jump to the search box, browse the built-in FAQ, and hover over any button, field, dropdown or header for a quick explanation.
-- **Type-to-search dropdowns** – quickly narrow device lists by typing directly into any selector.
-- **Multi-mount support** – choose between V‑, B‑ or Gold‑Mount plates on supported cameras and the battery list updates automatically.
-- **User runtime feedback** – submit real-world runtimes with environment details to refine estimates.
-- **Visual runtime weighting dashboard** – see how temperature, resolution, frame rate and codec affect each runtime report, now sorted by weight with exact share percentages.
-- **Gear list generator** – compile selected gear and project requirements with one click.
-- **Quick project saving** – press Enter or Ctrl+S (⌘S on macOS) to save a project and the Save button stays disabled until a name is entered.
-- **Project requirement saving** – store project requirements with each project so gear lists retain full context.
-- **User entry duplication** – gear list forms use fork buttons to copy user fields instantly.
+## Contributing & Support
 
-See the language-specific README files for full details.
+Bug reports, feature ideas and data corrections are welcome. Open an issue or submit a pull request with as much detail as possible. If you discover incorrect runtimes or missing gear, include the project file or sample data so the catalog stays reliable.
 
-## Features at a Glance
-
-### Plan with confidence
-
-- Calculate total power consumption, current draw at 14.4 V (33.6 V for
-  B‑Mount) and 12 V (21.6 V for B‑Mount), and estimated battery runtime across
-  any combination of devices.
-- Combine user-submitted runtimes using weighted averages that account for
-  temperature, resolution, frame rate, codecs and each device’s share of total
-  draw.
-- Compare runtimes across all compatible batteries with the optional battery
-  comparison panel and warnings when a pack cannot safely supply the required
-  current.
-
-### Manage evolving projects
-
-- Save, auto-back up, share, restore and clear projects—requirements included—with
-  printable overviews and shareable JSON bundles that also include custom
-  devices and runtime feedback.
-- Customize the device database with your own gear, import or export the
-  catalog as JSON and revert to the bundled defaults at any time.
-
-### Communicate clearly
-
-- Visualize power and video connections with an interactive diagram: drag,
-  zoom, snap to grid and export as SVG or hold Shift to download a JPG
-  snapshot.
-- Generate rich gear lists that expand project requirements into categorized
-  packing tables with accessories, duplicates merged by quantity and tooltips
-  for weight and dimensions.
-
-### Stay productive anywhere
-
-- Jump to features, device selectors or help topics with the global search
-  field, star favorites to pin go-to devices and type directly inside dropdowns
-  to filter instantly.
-- Tailor the interface with language detection, dark or playful pink themes,
-  high contrast mode, accent color and typography controls.
-- Work completely offline thanks to the service worker, persistent storage and a
-  force reload button that refreshes cached assets without losing data.
-
-## Quick Start
-
-1. Download or clone this repository.
-2. Open `index.html` in a modern browser.
-3. (Optional) Serve the folder over HTTP to enable the service worker and
-   Progressive Web App features:
-   ```bash
-   npx http-server
-   # or
-   python -m http.server
-   ```
-   The planner then works fully offline and updates automatically.
-4. Create your first project, add devices from the dropdowns and generate a gear
-   list or printable overview to share with collaborators.
-
-## Example Workflow
-
-Use the planner end-to-end with the following workflow:
-
-1. **Create or load a project.** Use the project selector to load an existing setup or type a new project name and press Enter (or click **Save**) to start a fresh plan. The active project name appears above the gear list, printable overview and exports.
-2. **Add cameras, power and accessories.** Pick devices from the categorized dropdowns. Type-to-filter search boxes, pinned favorites and the global search shortcuts (/ or Ctrl+K / ⌘K) help you jump directly to gear, settings pages or help topics.
-3. **Check power draw and runtime.** Watch the power summary panel for current draw warnings, explore the battery comparison view to spot longer-lasting options and use the runtime dashboard to understand how temperature, codec, frame rate and other factors influence user feedback.
-4. **Capture project requirements.** Fill out project details, crew lists and required scenarios so the gear list and printable overview reflect the full production context. Fork buttons duplicate entries to speed up data entry.
-5. **Share or back up the plan.** Generate the gear list, export a planner backup or download a shareable project bundle before heading to set. Backups include custom devices, runtime feedback and pinned favorites.
-
-## Key Concepts
-
-Understanding the planner's vocabulary makes it easier to explore new features:
-
-### Projects
-
-- Saved plans collect device selections, project requirements, crew lists and
-  generated gear lists. The selector stores multiple projects and autosaves
-  every change so you can switch between productions without losing your place.
-
-### Devices and accessories
-
-- Device dropdowns contain both bundled hardware and your own custom entries.
-  Category tabs match the files in `devices/`, making it simple to update or
-  audit the catalog in version control.
-- Favorites keep go-to cameras, batteries and accessories at the top of the
-  list. They appear in backups and follow the project when you export a bundle.
-
-### Runtime feedback
-
-- User-submitted runtimes are stored with environmental context. Weighted
-  averages factor in temperature, codec, resolution, frame rate and each
-  component's share of the total draw so estimates mirror real-world shoots.
-
-### Scenarios and gear lists
-
-- Required scenarios (e.g. Vehicle, Outdoor, Steadicam) expand into the
-  necessary rigging, weather protection and accessories. Generated gear lists
-  combine those presets with your device selections so printouts and shared
-  bundles capture the entire kit.
-
-### Backups and recoverability
-
-- Automatic snapshots, manual exports and the **Force reload** button let you
-  experiment without fear. Restores create a safety backup before overwriting
-  data, and the **Clear Local Cache** option removes everything when you need a
-  clean slate.
-
-## Interface Overview
-
-### Top bar controls
-
-- A skip link, offline indicator and responsive branding keep the interface accessible across devices; the offline badge appears whenever the browser loses its connection.
-- The global search bar jumps to features, device selectors or help topics—press Enter to navigate to the highlighted result, use / or Ctrl+K (⌘K on macOS) to focus it from anywhere (the side menu opens automatically on small screens), and press Escape or × to clear the query.
-- Language, dark mode and pink mode buttons sit alongside the Settings dialog, which exposes accent color, font size, font family, high contrast and custom logo uploads plus backup, restore and Clear Local Cache tools.
-- The Help button opens a searchable dialog with step-by-step sections, keyboard shortcuts, FAQs and an optional hover-help mode; it can also be triggered with ?, H, F1 or Ctrl+/ even while typing.
-- The Force reload button (🔄) removes cached service worker files and refreshes the app without touching saved projects or device data.
-
-### Navigation and search
-
-- On smaller screens a collapsible side menu mirrors the main sections for quick navigation.
-- Every dropdown and editor list includes an inline search box and supports type-to-filter interactions; pressing / or Ctrl+F (⌘F on macOS) focuses the nearest search field.
-- Star icons beside selectors let you pin favorite devices so they stay at the top of the list and persist between sessions.
-
-## Customization and Accessibility
-
-- Theme preferences include dark mode, playful pink accents and a dedicated high contrast switch for improved readability.
-- Accent color, base font size and typeface can be customised in Settings; choices are applied immediately and remembered with other preferences.
-- A keyboard-friendly skip link, focus-visible controls, offline indicator and responsive layout improve navigation on desktops, tablets and phones.
-- Built-in keyboard shortcuts cover global search (/ or Ctrl+K/⌘K), help ( ?, H, F1, Ctrl+/ ), saving (Enter or Ctrl+S/⌘S), dark mode (D) and pink mode (P).
-- The hover-help toggle turns every button, field, dropdown and header into an on-demand tooltip so new users can learn the interface quickly.
-
-## Keyboard Shortcuts
-
-Keyboard navigation keeps the planner quick to operate on set and in prep. The following shortcuts work across desktop browsers unless otherwise noted:
-
-| Shortcut | Action | Notes |
-| --- | --- | --- |
-| `/`, `Ctrl+K`, `⌘K` | Focus the global search field. | Works even when the side navigation is collapsed; press `Esc` to clear the current query. |
-| `Enter`, `Ctrl+S`, `⌘S` | Save the active project. | The Save button stays disabled until a project name is entered. |
-| `?`, `H`, `F1`, `Ctrl+/` | Open the help dialog. | The dialog remains searchable while you type in other fields. |
-| `D` | Toggle dark mode. | Also available from **Settings → Themes**. |
-| `P` | Toggle the pink accent theme. | Works alongside light, dark or high-contrast modes. |
-
-## Localization
-
-The interface language loads automatically from the browser preference, and users can change it at any time from the language menu in the top bar or in **Settings**. To translate the planner into another language:
-
-1. Duplicate the nearest language file (for example `README.en.md`) as `README.<lang>.md` and translate the documentation.
-2. Add UI strings to `translations.js` by copying an existing language block (such as `en`) and translating each value. Most strings include tooltip text that appears in the help dialog and Settings panels, so keep formatting placeholders like `%s` intact.
-3. Provide translated static pages (privacy policy, imprint) where required by copying the relevant HTML files.
-4. Run `npm test` to ensure linting, data validations and Jest suites still pass before submitting a pull request.
-
-New locales can be previewed immediately in the browser by selecting the language from the menu; no build step is required.
-
-## Gear List
-
-The planner expands your selections into a detailed packing table:
-
-- Click **Generate Gear List** to compile chosen gear and project requirements into a categorized table.
-- The list refreshes automatically whenever device selections or project details change.
-- Entries are grouped by category (camera, lens, power, monitoring, rigging, grip, consumables, etc.) and duplicates are merged with a count.
-- Required cables, rigging and accessories are added automatically for monitors, motors, gimbals, weather scenarios and speciality setups.
-- Scenario selections inject matching gear (for example, *Handheld* + *Easyrig* adds a telescopic handle; *Gimbal* supplies the selected gimbal, friction arms and sunshades; *Outdoor* adds spigots, umbrellas and CapIt rain covers; *Vehicle* and *Steadicam* pack in mounts, isolation arms and suction gear where applicable).
-- Lens choices note front diameter, weight, minimum focus and rod requirements, and add lens supports and matte box components with warnings for incompatible rod standards.
-- Battery rows reflect counts from the power calculator and include a hotswap plate or the selected hotswap device when needed.
-- Monitoring preferences provide default monitors for each role and bundle cable sets for every screen.
-- The **Project Requirements** form feeds the list:
-  - **Project Name**, **Production Company**, **Rental House** and **DoP** appear in the heading of the printed requirements.
-  - **Crew** entries capture names, roles and email addresses so contact lists stay attached to each project.
-  - **Prep Days** and **Shooting Days** supply schedule notes and, when paired with outdoor scenarios, suggest weather gear.
-  - **Required Scenarios** append matching rigging, gimbals and weather protection.
-  - **Camera Handle** and **Viewfinder Extension** insert the chosen handle parts or extension brackets.
-  - **Matte Box** and **Filter** choices inject the selected system with any needed trays, clamp adapters or filters.
-  - **Monitoring Configuration**, **Video Distribution** and **Viewfinder** settings add monitors, cables and overlays for each role.
-  - **User Button** selections and **Tripod Preferences** are listed for quick reference.
-- Items are sorted alphabetically within their category and each exposes a tooltip on hover.
-- The gear list appears in printable overviews and shared project files so collaborators see the full context.
-- Gear lists save automatically with the project and are included in shared project files and backups.
-- **Delete Gear List** removes the saved list and hides the output.
-- Gear list forms use fork buttons to duplicate your entries instantly.
-
-## Runtime Data Weighting
-
-User-submitted battery runtimes are combined using a weighted average to better match your project:
-
-- Entries are adjusted for temperature, scaling from ×1 at 25 °C to ×1.25 at 0 °C, ×1.6 at −10 °C and ×2 at −20 °C.
-- Resolution multipliers: ≥12K ×3, ≥8K ×2, ≥4K ×1.5, ≥1080p ×1, lower scaled relative to 1080p.
-- Frame rate scales linearly from a base of 24 fps (e.g. 48 fps = ×2).
-- Wi‑Fi enabled adds 10 %.
-- Codec factors: RAW/BRAW/ARRIRAW/R3D/CinemaDNG/Canon RAW/X‑OCN ×1; ProRes ×1.1; DNx/AVID ×1.2; All‑Intra ×1.3; H.264/AVC ×1.5; H.265/HEVC ×1.7.
-- Monitor entries below the specified brightness are weighted by their brightness ratio.
-- The final weight reflects how much of the total power draw comes from the camera, monitor and other devices so that similar rigs count more.
-- A dedicated dashboard orders entries by weight and shows the share percentage for each runtime entry.
-
-## Install as an App
-
-Cine Power Planner is a Progressive Web App and can be installed for quick
-access:
-
-1. Open `index.html` in a supported browser.
-2. Use the browser's **Install** or **Add to Home Screen** option.
-   - **Chrome/Edge (desktop):** Click the install icon in the address bar.
-   - **Android:** Open the browser menu and choose *Add to Home screen*.
-   - **iOS Safari:** Tap the share icon and select *Add to Home Screen*.
-3. Launch the app from your applications list. The installed version works
-   offline and updates automatically.
-
-## Offline Use and Data Storage
-
-When served over HTTP(S), Cine Power Planner installs a service worker that caches all
-files so the planner runs entirely offline and pulls updates in the
-background. Projects, runtime submissions and preferences (language, theme,
-pink mode and saved gear lists) are stored locally via `localStorage` in your
-browser. Clearing the site's data in your browser removes all saved
-information, and the Settings dialog includes a **Clear Local Cache** button for a one-click reset when you need a fresh start.
-See [Backup and Recovery](#backup-and-recovery) for tips on keeping your data safe.
-
-## Backup and Recovery
-
-Cine Power Planner automatically guards against data loss and gives you manual
-controls to export your work:
-
-- **Saved project snapshots:** The project selector keeps every setup you save,
-  and the app creates timestamped `auto-backup-…` entries every 10 minutes while
-  it is open. These snapshots appear at the bottom of the list so you can revert
-  to a previous state without overwriting the active project.
-- **Full planner backups:** Open **Settings → Backup & Restore** and press
-  **Backup** to download `planner-backup.json`. The file includes saved
-  projects, custom devices, session state, runtime feedback and favorites via
-  the internal `exportAllData()` routine. Restoring the file automatically saves
-  a safety copy of your current data before importing the new settings and warns
-  when the file was produced with a different app version.
-- **Clear Local Cache:** In **Settings → Backup & Restore**, wipe saved projects,
-  custom gear, favorites and runtime feedback with one click when you need to
-  start over.
-- **Regular reminders:** While the planner is running, an hourly background job
-  triggers the same backup export so you always have a recent download prompt as
-  a reminder to archive your data.
-
-## Privacy and Data Ownership
-
-Cine Power Planner intentionally keeps your data on the devices you control. The
-app runs entirely in the browser with no accounts, telemetry or background
-sync—projects, runtime submissions, favorites, custom devices, theme settings
-and backups stay in your local `localStorage` unless you choose to export them.
-Hosting the planner yourself (or loading it directly from disk) lets production
-teams work without personal information or gear lists leaving their own
-infrastructure.
-
-Because a service worker caches assets for offline use, the only runtime network
-requests come from optional resources such as the OpenMoji icon set when a
-connection is available. You can clear saved information at any time via
-**Settings → Clear Local Cache** or by deleting the site's data in your browser.
-Exports produce human-readable JSON so you can review exactly what will be
-shared before handing files to collaborators or clients.
-
-## Browser Support
-
-Cine Power Planner relies on modern web APIs and is tested in current versions of Chrome, Firefox, Edge and Safari. Older browsers may lack support for features like installation or offline caching. For the best experience, use a browser with up-to-date Progressive Web App (PWA) capabilities.
-
-## Development
-
-Set up a development environment with Node.js 18 or later. After cloning the repository, run `npm install` once, then use `npm test` to execute ESLint, data consistency checks and Jest tests together while you iterate on changes. See [CONTRIBUTING.md](CONTRIBUTING.md) for detailed guidelines on proposing updates and working with the dataset.
-
-### File Structure
-
-```
-index.html       # Main HTML layout
-style.css        # Styles and layout
-script.js        # Application logic
-devices/         # Default device lists by category
-storage.js       # LocalStorage helpers
-README.*.md      # Documentation in different languages
-checkConsistency.js  # Validates device data
-normalizeData.js     # Cleans and unifies device entries
-generateSchema.js    # Regenerates schema.json from data
-unifyPorts.js        # Harmonizes connector names
-tests/               # Jest test suite
-```
-
-### Install dependencies and run tests
-
-Requires Node.js 18 or later.
-
-```bash
-npm install
-npm run lint     # run ESLint alone
-npm test
-```
-
-`npm run lint` executes ESLint without running tests. The `npm test` command then runs ESLint, data consistency checks and a single Jest invocation that executes every project sequentially. Tests run with `--runInBand` and `maxWorkers=1` to minimise parallel memory usage while still failing fast when an assertion breaks.
-
-To run individual suites while iterating you can target specific Jest projects:
-
-```bash
-npm run test:unit   # module-level logic and storage helpers (1 GB heap cap)
-npm run test:data   # static dataset validations (1 GB heap cap)
-npm run test:dom    # lightweight DOM utilities (1.5 GB heap cap)
-npm run test:script # reduced smoke checks for script.js (3 GB heap cap)
-```
-
-## Device Data Workflow
-
-The device catalog that powers the planner lives under `devices/`. Each file
-groups related equipment (cameras, monitors, power, accessories, etc.) so
-changes are easy to review in Git history and within the app. When you edit
-these lists, run the helper scripts to clean, verify and rebuild the dataset
-before committing:
-
-```bash
-npm run normalize
-npm run unify-ports
-npm run check-consistency
-npm run generate-schema
-```
-
-`npm run normalize` applies various cleanup routines to unify connector names
-and expand shorthand entries. `npm run unify-ports` standardizes connector and
-port labels. `npm run check-consistency` confirms that required fields are
-present and raises an error if anything is missing. Finally,
-`npm run generate-schema` rebuilds `schema.json` from the current data so the
-interface reflects your updates.
-
-You can iterate faster with the data-focused Jest project when refining devices:
-
-```bash
-npm run test:data
-```
-
-Add `--help` to any of the helper commands for detailed usage (for example,
-`npm run normalize -- --help`). Review the generated JSON diffs to verify
-naming, connector standards and metadata before opening a pull request.
-
-## Troubleshooting
-
-- **Stuck on an old version?** Service workers aggressively cache assets. Click the in-app **Force reload** button, or open your browser's dev tools and perform a hard reload to clear stale files without deleting saved projects.
-- **Missing data after closing the tab?** Ensure the site has storage access. Private browsing modes or restrictive tracking protections can prevent `localStorage` from persisting backups, favorites and custom devices.
-- **Downloads are blocked?** The browser must be allowed to download multiple files for backups and shareable project bundles. Temporarily disable pop-up blockers or allow multiple downloads when prompted.
-- **Command-line scripts failing?** Confirm Node.js 18+ is installed, run `npm install` to fetch dependencies, and rerun the requested npm script. Memory errors usually mean a test suite exceeded its cap—rerun a narrower target such as `npm run test:unit`.
-
-## Feedback and Support
-
-If you run into problems, have questions, or want to suggest new features, please open an issue on GitHub. Community feedback helps improve the planner for everyone.
-
-## Contributing
-
-Contributions are welcome! Please open an issue or submit a pull request on GitHub. Review [CONTRIBUTING.md](CONTRIBUTING.md) for expectations around dataset updates, translations and testing. Before submitting, run `npm test` to ensure that linting, data consistency checks, and unit tests all pass.
-
-## Acknowledgements
-
- The planner uses the [OpenMoji](https://openmoji.org/) icon set when a network connection is available and relies on [lz-string](https://pieroxy.net/blog/pages/lz-string/index.html) to compactly store projects in URLs.
+---
 
 ## License
 
-Distributed under the ISC license. See `package.json` for details.
+Cine Power Planner is released under the ISC License.


### PR DESCRIPTION
## Summary
- rewrite the primary README with a streamlined structure covering highlights, workflows, interface guidance, data management, customization, testing, translations and licensing details
- update the localized English, German, Spanish, French and Italian READMEs to mirror the new organization and refreshed content

## Testing
- not run (documentation only)

------
https://chatgpt.com/codex/tasks/task_e_68cd780744c4832080743bd87f2058e4