### PR TITLE
Enhance help quick links with result counts

### DIFF
--- a/style.css
+++ b/style.css
@@ -1182,6 +1182,48 @@ main.legal-content {
   white-space: normal;
 }
 
+.help-quick-link-label {
+  flex: 1 1 auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25em;
+  min-width: 0;
+}
+
+.help-quick-link-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 1.75em;
+  padding: 0.15em 0.6em;
+  border-radius: 999px;
+  border: 1px solid var(--accent-color);
+  background: var(--surface-color);
+  background: color-mix(in srgb, var(--accent-color) 15%, var(--surface-color) 85%);
+  color: var(--accent-color);
+  font-weight: 600;
+  font-size: 0.85em;
+  line-height: 1.2;
+  font-variant-numeric: tabular-nums;
+  transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+
+.help-quick-link-count[hidden] {
+  display: none;
+}
+
+.help-quick-link.active .help-quick-link-count {
+  border-color: var(--inverse-text-color);
+  color: var(--inverse-text-color);
+  background: rgba(255, 255, 255, 0.2);
+  background: color-mix(in srgb, var(--inverse-text-color) 20%, transparent);
+}
+
+body.pink-mode .help-quick-link.active .help-quick-link-count {
+  border-color: var(--inverse-text-color);
+  color: var(--inverse-text-color);
+}
+
 .help-quick-link:focus-visible {
   outline: 2px solid var(--accent-color);
   outline-offset: 2px;

--- a/tests/dom/helpDialog.test.js
+++ b/tests/dom/helpDialog.test.js
@@ -84,6 +84,9 @@ describe('help dialog search behaviour', () => {
     expect(featuresItem).toBeTruthy();
     expect(powerItem).toBeTruthy();
     expect(troubleshootingItem).toBeTruthy();
+    const powerBadge = powerButton.querySelector('.help-quick-link-count');
+    expect(powerBadge).toBeTruthy();
+    expect(powerBadge.hasAttribute('hidden')).toBe(true);
 
     typeInHelpSearch('power calculator');
 
@@ -91,6 +94,9 @@ describe('help dialog search behaviour', () => {
     expect(powerItem.hasAttribute('hidden')).toBe(false);
     expect(featuresItem.hasAttribute('hidden')).toBe(true);
     expect(troubleshootingItem.hasAttribute('hidden')).toBe(true);
+    expect(powerButton.dataset.matchCount).toBe('1');
+    expect(powerBadge?.hasAttribute('hidden')).toBe(false);
+    expect(powerBadge?.textContent).toBe('1');
 
     typeInHelpSearch('no matching topic');
 
@@ -100,6 +106,8 @@ describe('help dialog search behaviour', () => {
 
     expect(helpQuickLinks.hasAttribute('hidden')).toBe(false);
     expect(featuresItem.hasAttribute('hidden')).toBe(false);
+    expect(powerButton.dataset.matchCount).toBeUndefined();
+    expect(powerBadge?.hasAttribute('hidden')).toBe(true);
   });
 
   test('clicking a quick link highlights the target section', () => {

--- a/translations.js
+++ b/translations.js
@@ -630,6 +630,8 @@ const texts = {
       "Jump directly to any section of the help dialog. Buttons only show topics that match the current search.",
     helpQuickLinkButtonHelp:
       "Scroll to the “%s” section in the help dialog.",
+    helpQuickLinkMatchCountOne: "%s match",
+    helpQuickLinkMatchCountOther: "%s matches",
     hoverHelpButtonLabel: "Hover for help",
     hoverHelpButtonHelp:
       "Activate hover help so moving the cursor over buttons, fields, dropdowns or headers reveals brief explanations.",
@@ -1288,6 +1290,8 @@ const texts = {
       "Vai direttamente a una sezione della guida. I pulsanti mostrano solo gli argomenti visibili alla ricerca corrente.",
     helpQuickLinkButtonHelp:
       "Scorri fino alla sezione “%s” nella finestra di aiuto.",
+    helpQuickLinkMatchCountOne: "%s corrispondenza",
+    helpQuickLinkMatchCountOther: "%s corrispondenze",
     hoverHelpButtonLabel: "Passa il mouse per aiuto",
     hoverHelpButtonHelp:
       "Attiva l'aiuto al passaggio del mouse così, spostando il cursore su pulsanti, campi, menu a discesa o intestazioni, vengono mostrate brevi spiegazioni.",
@@ -1954,6 +1958,8 @@ const texts = {
       "Ve directamente a una sección de la ayuda. Los botones solo muestran los temas que coinciden con la búsqueda actual.",
     helpQuickLinkButtonHelp:
       "Desplázate a la sección “%s” dentro del cuadro de ayuda.",
+    helpQuickLinkMatchCountOne: "%s coincidencia",
+    helpQuickLinkMatchCountOther: "%s coincidencias",
     hoverHelpButtonLabel: "Pasa el cursor para ayuda",
     hoverHelpButtonHelp:
       "Activa la ayuda al pasar el cursor para que al moverlo sobre botones, campos, menús desplegables o encabezados aparezcan breves explicaciones.",
@@ -2621,6 +2627,8 @@ const texts = {
       "Accédez directement à une section de l'aide. Les boutons n'affichent que les sujets correspondant à votre recherche actuelle.",
     helpQuickLinkButtonHelp:
       "Faites défiler jusqu'à la section « %s » dans la fenêtre d'aide.",
+    helpQuickLinkMatchCountOne: "%s résultat",
+    helpQuickLinkMatchCountOther: "%s résultats",
     hoverHelpButtonLabel: "Survoler pour obtenir de l'aide",
     hoverHelpButtonHelp:
       "Active l'aide au survol pour qu'en déplaçant le curseur sur les boutons, champs, menus déroulants ou en-têtes, des explications brèves apparaissent.",
@@ -3290,6 +3298,8 @@ const texts = {
       "Springe direkt zu einem Abschnitt im Hilfedialog. Die Schaltflächen zeigen nur Themen, die zur aktuellen Suche passen.",
     helpQuickLinkButtonHelp:
       "Zum Abschnitt „%s“ im Hilfedialog scrollen.",
+    helpQuickLinkMatchCountOne: "%s Treffer",
+    helpQuickLinkMatchCountOther: "%s Treffer",
     hoverHelpButtonLabel: "Für Hilfe darüberfahren",
     hoverHelpButtonHelp:
       "Aktiviere die Hover-Hilfe, damit beim Überfahren von Schaltflächen, Feldern, Dropdowns oder Überschriften kurze Erklärungen erscheinen.",


### PR DESCRIPTION
## Summary
- add badge counts and aria updates to help quick links so searches show how many topics match in each section
- surface the counts visually with new styling and translations while keeping quick link focus states accessible
- prefer feature results over device selections when relevance ties occur and extend dom tests for the new quick link badges

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd77f356bc8320a6ab3d11c1030b3d