### PR TITLE
Improve offline persistence and refine search behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,8 +154,9 @@ See the language-specific README files for full details.
   to filter instantly.
 - Tailor the interface with language detection, dark or playful pink themes,
   high contrast mode, accent color and typography controls.
-- Work completely offline thanks to the service worker, persistent storage and a
-  force reload button that refreshes cached assets without losing data.
+- Work completely offline thanks to the service worker, persistent storage
+  requests and a force reload button that refreshes cached assets without
+  losing data.
 
 ## Quick Start
 
@@ -326,9 +327,10 @@ When served over HTTP(S), Cine Power Planner installs a service worker that cach
 files so the planner runs entirely offline and pulls updates in the
 background. Projects, runtime submissions and preferences (language, theme,
 pink mode and saved gear lists) are stored locally via `localStorage` in your
-browser. Clearing the site's data in your browser removes all saved
-information, and the Settings dialog includes a **Clear Local Cache** button for a one-click reset when you need a fresh start.
-See [Backup and Recovery](#backup-and-recovery) for tips on keeping your data safe.
+browser. Supporting browsers automatically grant [persistent storage](https://developer.mozilla.org/docs/Web/API/StorageManager/persist)
+through the StorageManager API when the planner loads, making it far less
+likely that offline backups or custom gear are evicted while you're on set.
+Clearing the site's data in your browser removes all saved information, and the Settings dialog includes a **Clear Local Cache** button for a one-click reset when you need a fresh start. See [Backup and Recovery](#backup-and-recovery) for tips on keeping your data safe.
 
 ## Backup and Recovery
 

--- a/script.js
+++ b/script.js
@@ -16367,11 +16367,13 @@ if (helpButton && helpDialog) {
       (isHelp || (!hasStrongNonHelp && helpScore > bestNonHelpScore));
 
     if (!isHelp && !preferHelp) {
+      const featureIsExact = featureMatch?.matchType === 'exactKey';
+      const deviceBeatsFeature =
+        (deviceStrong && !featureStrong) ||
+        (deviceStrong === featureStrong && deviceScore > featureScore);
       const shouldUseDevice =
         !!deviceMatch &&
-        (!featureMatch ||
-          (deviceStrong && !featureStrong) ||
-          (deviceStrong === featureStrong && deviceScore > featureScore));
+        (!featureMatch || (!featureIsExact && deviceBeatsFeature));
       if (shouldUseDevice) {
         const device = deviceMatch.value;
         if (device && device.select) {

--- a/tests/unit/persistentStorage.test.js
+++ b/tests/unit/persistentStorage.test.js
@@ -1,0 +1,77 @@
+describe('requestPersistentStorage helper', () => {
+  let originalNavigator;
+  let originalStorageManager;
+
+  beforeEach(() => {
+    jest.resetModules();
+    originalNavigator = global.navigator;
+    if (!originalNavigator) {
+      global.navigator = {};
+    }
+    originalStorageManager = global.navigator.storage;
+  });
+
+  afterEach(() => {
+    if (originalNavigator) {
+      originalNavigator.storage = originalStorageManager;
+      global.navigator = originalNavigator;
+    } else {
+      delete global.navigator;
+    }
+  });
+
+  test('resolves true without calling persist when already granted', async () => {
+    const persisted = jest.fn().mockResolvedValue(true);
+    const persist = jest.fn().mockResolvedValue(true);
+    global.navigator.storage = { persisted, persist };
+
+    const { requestPersistentStorage } = require('../../storage');
+
+    const result = await requestPersistentStorage();
+    expect(result).toBe(true);
+    expect(persisted).toHaveBeenCalledTimes(1);
+    expect(persist).not.toHaveBeenCalled();
+  });
+
+  test('attempts to persist once when permission is not yet granted', async () => {
+    const persisted = jest.fn().mockResolvedValue(false);
+    const persist = jest.fn().mockResolvedValue(true);
+    global.navigator.storage = { persisted, persist };
+
+    const { requestPersistentStorage } = require('../../storage');
+
+    const result = await requestPersistentStorage();
+    expect(result).toBe(true);
+    expect(persisted).toHaveBeenCalledTimes(1);
+    expect(persist).toHaveBeenCalledTimes(1);
+
+    const second = await requestPersistentStorage();
+    expect(second).toBe(true);
+    expect(persisted).toHaveBeenCalledTimes(1);
+    expect(persist).toHaveBeenCalledTimes(1);
+  });
+
+  test('logs a warning and resolves false when persistence is rejected', async () => {
+    const persisted = jest.fn().mockResolvedValue(false);
+    const rejection = new Error('denied');
+    const persist = jest.fn().mockRejectedValue(rejection);
+    global.navigator.storage = { persisted, persist };
+    const warnSpy = jest
+      .spyOn(console, 'warn')
+      .mockImplementation(() => {});
+
+    const { requestPersistentStorage } = require('../../storage');
+
+    const result = await requestPersistentStorage();
+    expect(result).toBe(false);
+    expect(persisted).toHaveBeenCalledTimes(1);
+    expect(persist).toHaveBeenCalledTimes(1);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Persistent storage request was rejected'),
+      rejection
+    );
+
+    warnSpy.mockRestore();
+  });
+});
+


### PR DESCRIPTION
## Summary
- request persistent storage through the StorageManager API when localStorage is available to strengthen offline data retention and export the helper
- add targeted Jest coverage for the persistence helper and update the offline usage docs to mention the new capability
- tweak the global feature search so exact feature matches win over equally strong device suggestions

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd7b7979148320862d7a60b3fba175