### PR TITLE
Update help dialog link and button styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -971,31 +971,31 @@
           </ul>
           <div class="help-link-group" aria-label="Jump to key features">
             <a
-              class="help-link help-chip"
+              class="help-link button-link"
               href="#setup-manager"
               data-help-target="#setupName"
               data-help-highlight="#setup-manager"
             >Project Overview</a>
             <a
-              class="help-link help-chip"
+              class="help-link button-link"
               href="#setup-config"
               data-help-target="#cameraSelect"
               data-help-highlight="#setup-config"
             >Configure Devices</a>
             <a
-              class="help-link help-chip"
+              class="help-link button-link"
               href="#results"
               data-help-target="#resultsHeading"
               data-help-highlight="#results"
             >Power Summary</a>
             <a
-              class="help-link help-chip"
+              class="help-link button-link"
               href="#setupDiagram"
               data-help-target="#setupDiagramHeading"
               data-help-highlight="#setupDiagram"
             >Project Diagram</a>
             <a
-              class="help-link help-chip"
+              class="help-link button-link"
               href="#device-manager"
               data-help-target="#deviceManagerHeading"
               data-help-highlight="#device-manager"
@@ -1182,29 +1182,29 @@
             <li>Use <strong>Backup</strong> to download a JSON snapshot of settings, projects, custom devices, favorites and runtime feedback; <strong>Restore</strong> loads a saved snapshot.</li>
           </ul>
           <div class="help-link-group" aria-label="Settings shortcuts">
-            <a class="help-link help-chip" href="#settingsButton" data-help-target="#settingsButton">Open Settings</a>
+            <a class="help-link button-link" href="#settingsButton" data-help-target="#settingsButton">Open Settings</a>
             <a
-              class="help-link help-chip"
+              class="help-link button-link"
               href="#settingsDialog"
               data-help-target="#accentColorInput"
             >Accent color</a>
             <a
-              class="help-link help-chip"
+              class="help-link button-link"
               href="#settingsDialog"
               data-help-target="#settingsLogo"
             >Upload logo</a>
             <a
-              class="help-link help-chip"
+              class="help-link button-link"
               href="#settingsDialog"
               data-help-target="#backupSettings"
             >Backup</a>
             <a
-              class="help-link help-chip"
+              class="help-link button-link"
               href="#settingsDialog"
               data-help-target="#restoreSettings"
             >Restore</a>
             <a
-              class="help-link help-chip"
+              class="help-link button-link"
               href="#settingsButton"
               data-help-target="#factoryResetButton"
             >Factory reset</a>
@@ -1223,14 +1223,14 @@
             <li>A full JSON export downloads automatically every hour with a name like “2024-05-12T14-00-00 full app backup.json” so you always have an offline safety copy.</li>
           </ul>
           <div class="help-link-group" aria-label="Automatic backup controls">
-            <a class="help-link help-chip" href="#settingsDialog" data-help-target="#settingsShowAutoBackups">Show auto backups setting</a>
+            <a class="help-link button-link" href="#settingsDialog" data-help-target="#settingsShowAutoBackups">Show auto backups setting</a>
             <a
-              class="help-link help-chip"
+              class="help-link button-link"
               href="#setup-manager"
               data-help-target="#setupSelect"
               data-help-highlight="#setup-manager"
             >Saved Projects</a>
-            <a class="help-link help-chip" href="#settingsDialog" data-help-target="#backupSettings">Download backup</a>
+            <a class="help-link button-link" href="#settingsDialog" data-help-target="#backupSettings">Download backup</a>
           </div>
         </section>
         <section
@@ -1247,7 +1247,7 @@
           </ul>
           <div class="help-link-group" aria-label="Project requirement tools">
             <a
-              class="help-link help-chip"
+              class="help-link button-link"
               href="#setup-manager"
               data-help-target="#generateGearListBtn"
               data-help-highlight="#setup-manager"
@@ -1302,18 +1302,18 @@
             </ul>
             <div class="help-link-group" aria-label="Gear list shortcuts">
               <a
-                class="help-link help-chip"
+                class="help-link button-link"
                 href="#setup-manager"
                 data-help-target="#generateGearListBtn"
                 data-help-highlight="#setup-manager"
               >Generate Gear List</a>
               <a
-                class="help-link help-chip"
+                class="help-link button-link"
                 href="#projectRequirementsOutput"
                 data-help-target="#projectRequirementsOutput"
               >Project Requirements output</a>
               <a
-                class="help-link help-chip"
+                class="help-link button-link"
                 href="#gearListOutput"
                 data-help-target="#gearListOutput"
               >Gear List output</a>
@@ -1352,18 +1352,18 @@
           </ul>
           <div class="help-link-group" aria-label="Automatic gear rule controls">
             <a
-              class="help-link help-chip"
+              class="help-link button-link"
               href="#settingsDialog"
               data-help-target="#autoGearHeading"
               data-help-highlight="#settingsDialog"
             >Settings → Automatic Gear Rules</a>
             <a
-              class="help-link help-chip"
+              class="help-link button-link"
               href="#settingsDialog"
               data-help-target="#autoGearAddRule"
             >Add rule</a>
             <a
-              class="help-link help-chip"
+              class="help-link button-link"
               href="#settingsDialog"
               data-help-target="#autoGearRulesList"
             >Rules list</a>
@@ -1384,25 +1384,25 @@
           </ul>
           <div class="help-link-group" aria-label="Power calculator controls">
             <a
-              class="help-link help-chip"
+              class="help-link button-link"
               href="#setup-config"
               data-help-target="#batterySelect"
               data-help-highlight="#setup-config"
             >Battery dropdown</a>
             <a
-              class="help-link help-chip"
+              class="help-link button-link"
               href="#results"
               data-help-target="#resultsHeading"
               data-help-highlight="#results"
             >Power Summary</a>
             <a
-              class="help-link help-chip"
+              class="help-link button-link"
               href="#setup-config"
               data-help-target="#batteryHotswapSelect"
               data-help-highlight="#setup-config"
             >Battery Hotswap</a>
             <a
-              class="help-link help-chip"
+              class="help-link button-link"
               href="#batteryComparison"
               data-help-target="#batteryComparisonHeading"
               data-help-highlight="#batteryComparison"
@@ -1438,7 +1438,7 @@
           </ul>
           <div class="help-link-group" aria-label="Power detail links">
             <a
-              class="help-link help-chip"
+              class="help-link button-link"
               href="#results"
               data-help-target="#resultsHeading"
               data-help-highlight="#results"
@@ -1458,13 +1458,13 @@
           </ul>
           <div class="help-link-group" aria-label="Runtime feedback tools">
             <a
-              class="help-link help-chip"
+              class="help-link button-link"
               href="#results"
               data-help-target="#runtimeFeedbackBtn"
               data-help-highlight="#results"
             >Submit feedback</a>
             <a
-              class="help-link help-chip"
+              class="help-link button-link"
               href="#feedbackDialog"
               data-help-target="#feedbackDialogHeading"
             >Feedback form</a>
@@ -1488,23 +1488,23 @@
           </ul>
           <div class="help-link-group" aria-label="Diagram controls">
             <a
-              class="help-link help-chip"
+              class="help-link button-link"
               href="#setupDiagram"
               data-help-target="#setupDiagramHeading"
               data-help-highlight="#setupDiagram"
             >View diagram</a>
             <a
-              class="help-link help-chip"
+              class="help-link button-link"
               href="#setupDiagram"
               data-help-target="#zoomIn"
             >Zoom in</a>
             <a
-              class="help-link help-chip"
+              class="help-link button-link"
               href="#setupDiagram"
               data-help-target="#resetView"
             >Reset view</a>
             <a
-              class="help-link help-chip"
+              class="help-link button-link"
               href="#setupDiagram"
               data-help-target="#gridSnapToggle"
             >Snap to Grid</a>
@@ -1523,23 +1523,23 @@
           </ul>
           <div class="help-link-group" aria-label="Device editor controls">
             <a
-              class="help-link help-chip"
+              class="help-link button-link"
               href="#device-manager"
               data-help-target="#toggleDeviceManager"
             >Edit Device Data…</a>
             <a
-              class="help-link help-chip"
+              class="help-link button-link"
               href="#device-manager"
               data-help-target="#deviceManagerHeading"
               data-help-highlight="#device-manager"
             >Device Library</a>
             <a
-              class="help-link help-chip"
+              class="help-link button-link"
               href="#device-manager"
               data-help-target="#exportDataBtn"
             >Export database</a>
             <a
-              class="help-link help-chip"
+              class="help-link button-link"
               href="#device-manager"
               data-help-target="#importDataBtn"
             >Import database</a>
@@ -1564,7 +1564,7 @@
           <p>The number in parentheses shows how many of that type you can select.</p>
           <div class="help-link-group" aria-label="Device selection">
             <a
-              class="help-link help-chip"
+              class="help-link button-link"
               href="#setup-config"
               data-help-target="#cameraSelect"
               data-help-highlight="#setup-config"
@@ -1587,17 +1587,17 @@
           </ul>
           <div class="help-link-group" aria-label="Search controls">
             <a
-              class="help-link help-chip"
+              class="help-link button-link"
               href="#topBar"
               data-help-target="#featureSearch"
             >Global search</a>
             <a
-              class="help-link help-chip"
+              class="help-link button-link"
               href="#helpDialog"
               data-help-target="#helpSearch"
             >Help search</a>
             <a
-              class="help-link help-chip"
+              class="help-link button-link"
               href="#setup-config"
               data-help-target="#cameraSelect"
               data-help-highlight="#setup-config"
@@ -1619,9 +1619,9 @@
             <li>Close the dialog with <kbd>Escape</kbd> or by clicking outside.</li>
           </ul>
           <div class="help-link-group" aria-label="Help dialog controls">
-            <a class="help-link help-chip" href="#helpButton" data-help-target="#helpButton">Help button</a>
-            <a class="help-link help-chip" href="#helpDialog" data-help-target="#helpSearch">Help search</a>
-            <a class="help-link help-chip" href="#helpDialog" data-help-target="#helpSearchClear">Clear search</a>
+            <a class="help-link button-link" href="#helpButton" data-help-target="#helpButton">Help button</a>
+            <a class="help-link button-link" href="#helpDialog" data-help-target="#helpSearch">Help search</a>
+            <a class="help-link button-link" href="#helpDialog" data-help-target="#helpSearchClear">Clear search</a>
           </div>
         </section>
         <section
@@ -1670,19 +1670,19 @@
             </li>
           </ul>
           <div class="help-link-group" aria-label="Troubleshooting tools">
-            <a class="help-link help-chip" href="#reloadButton" data-help-target="#reloadButton"><em>Force reload</em></a>
+            <a class="help-link button-link" href="#reloadButton" data-help-target="#reloadButton"><em>Force reload</em></a>
             <a
-              class="help-link help-chip"
+              class="help-link button-link"
               href="#settingsDialog"
               data-help-target="#settingsShowAutoBackups"
             >Auto backups</a>
             <a
-              class="help-link help-chip"
+              class="help-link button-link"
               href="#settingsDialog"
               data-help-target="#factoryResetButton"
             >Factory reset</a>
             <a
-              class="help-link help-chip"
+              class="help-link button-link"
               href="#device-manager"
               data-help-target="#exportAndRevertBtn"
             >Export &amp; Revert</a>
@@ -1700,7 +1700,7 @@
             <li>Click anywhere or press <kbd>Escape</kbd> to exit.</li>
           </ul>
           <div class="help-link-group" aria-label="Hover help control">
-            <a class="help-link help-chip" href="#helpDialog" data-help-target="#hoverHelpButton">Hover for help button</a>
+            <a class="help-link button-link" href="#helpDialog" data-help-target="#hoverHelpButton">Hover for help button</a>
           </div>
         </section>
         <section
@@ -1714,8 +1714,8 @@
             <li>Your choice is remembered for the next visit.</li>
           </ul>
           <div class="help-link-group" aria-label="Language controls">
-            <a class="help-link help-chip" href="#languageSelect" data-help-target="#languageSelect">Header language menu</a>
-            <a class="help-link help-chip" href="#settingsDialog" data-help-target="#settingsLanguage">Settings language</a>
+            <a class="help-link button-link" href="#languageSelect" data-help-target="#languageSelect">Header language menu</a>
+            <a class="help-link button-link" href="#settingsDialog" data-help-target="#settingsLanguage">Settings language</a>
           </div>
         </section>
         <section
@@ -1729,7 +1729,7 @@
             <li>The setting persists between visits.</li>
           </ul>
           <div class="help-link-group" aria-label="Theme controls">
-            <a class="help-link help-chip" href="#darkModeToggle" data-help-target="#darkModeToggle">Dark mode toggle</a>
+            <a class="help-link button-link" href="#darkModeToggle" data-help-target="#darkModeToggle">Dark mode toggle</a>
           </div>
         </section>
         <section
@@ -1744,7 +1744,7 @@
             <li>Press <kbd>P</kbd> to toggle pink mode.</li>
           </ul>
           <div class="help-link-group" aria-label="Theme controls">
-            <a class="help-link help-chip" href="#pinkModeToggle" data-help-target="#pinkModeToggle">Pink mode toggle</a>
+            <a class="help-link button-link" href="#pinkModeToggle" data-help-target="#pinkModeToggle">Pink mode toggle</a>
           </div>
         </section>
         <section

--- a/style.css
+++ b/style.css
@@ -1282,8 +1282,8 @@ main.legal-content {
   margin-top: 0.75rem;
 }
 
-.help-link,
-.help-link:visited {
+.help-link-group .button-link,
+.help-link-group .button-link:visited {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -1292,57 +1292,26 @@ main.legal-content {
   border-radius: var(--border-radius);
   background-color: var(--control-bg);
   color: var(--control-text);
+  font-size: 0.85em;
   text-decoration: none;
-  font-family: inherit;
-  font-weight: inherit;
-  font-size: 1em;
-  line-height: 1;
-  transition: background-color 0.2s, color 0.2s, transform 0.2s;
+  transition: background-color 0.2s, color 0.2s;
 }
 
-.help-link:hover {
-  background-color: var(--accent-color);
-  color: var(--inverse-text-color);
-  transform: translateY(-2px);
+.help-link-group .button-link:hover {
+  background-color: var(--control-hover-bg);
+  color: var(--control-text);
+  transform: none;
 }
 
-.help-link:active {
-  background-color: var(--accent-color);
-  color: var(--inverse-text-color);
-  filter: brightness(0.9);
-  transform: translateY(0);
+.help-link-group .button-link:active {
+  background-color: var(--control-active-bg);
+  color: var(--control-text);
+  filter: none;
+  transform: none;
 }
 
-.help-link:focus-visible {
+.help-link-group .button-link:focus-visible {
   outline: 2px solid var(--accent-color);
-  outline-offset: 2px;
-}
-
-.help-chip {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 0.25rem;
-  padding: 0.45rem 0.75rem;
-  border-radius: var(--border-radius);
-  border: 1px solid var(--accent-color);
-  background: none;
-  line-height: 1.3;
-  min-height: 2.5rem;
-  text-align: center;
-  text-decoration: none;
-  transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
-  white-space: normal;
-}
-
-.help-chip:hover,
-.help-chip:focus {
-  background: var(--accent-color);
-  color: var(--inverse-text-color);
-}
-
-.help-chip:focus-visible {
-  outline: 2px solid var(--inverse-text-color);
   outline-offset: 2px;
 }
 
@@ -1414,8 +1383,6 @@ body.pink-mode button:active,
 body.pink-mode button:focus-visible,
 body.pink-mode .button-link:hover,
 body.pink-mode .button-link:active,
-body.pink-mode .help-link:hover,
-body.pink-mode .help-link:active,
 body.pink-mode .help-quick-link.active,
 body.pink-mode .favorite-toggle.favorited,
 body.pink-mode .favorite-toggle:hover,


### PR DESCRIPTION
## Summary
- convert help dialog action links to use the shared button style instead of custom chips
- retarget the CSS so inline help references fall back to text links while grouped actions inherit the global button states

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cd7c7af74483208c885cd880bbcec8