### PR TITLE
Document factory reset workflow in README files

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -22,7 +22,7 @@ Die App übernimmt beim ersten Start automatisch die Sprache deines Browsers; ü
 - Tastenkürzel für die globale Suche lassen dich / oder Strg+K (⌘K auf macOS) drücken, um sie sofort zu fokussieren – auch wenn sie im eingeklappten mobilen Seitenmenü liegt.
 - Die Schaltfläche „Neu laden erzwingen“ leert die zwischengespeicherten Service-Worker-Dateien, damit sich die Offline-App aktualisiert, ohne gespeicherte Projekte oder Geräte zu löschen.
 - Sternsymbole in jeder Auswahl heften Lieblingskameras, -akkus und -zubehör oben an und nehmen sie in Backups auf.
-- Die Schaltfläche „Lokalen Cache löschen“ entfernt gespeicherte Projekte und Einstellungen.
+- Der Workflow **Werkseinstellungen** lädt automatisch eine Sicherung herunter und entfernt danach gespeicherte Projekte, Geräte und Einstellungen.
 - Die Geräteliste und die druckbare Übersicht zeigen den Projektnamen für einen schnellen Überblick an.
 - Lade ein eigenes Logo hoch, das in druckbaren Übersichten und Backups erscheint.
 - Backups enthalten Favoriten und erstellen vor einer Wiederherstellung automatisch eine Sicherung.
@@ -74,7 +74,7 @@ Die App übernimmt beim ersten Start automatisch die Sprache deines Browsers; ü
 - Speichere, lade und lösche mehrere Kamera-Projekte (drücke Enter oder Strg+S/⌘S zum schnellen Speichern; die Schaltfläche bleibt deaktiviert, bis ein Name eingegeben wurde).
 - Alle zehn Minuten entstehen automatisch Schnappschüsse, solange der Planner geöffnet ist; im Einstellungsdialog lassen sich stündliche Backup-Exporte als Erinnerung aktivieren.
 - Lade eine JSON-Datei herunter, die Auswahl, Anforderungen, Geräteliste, Laufzeit-Feedback und eigene Geräte bündelt; über den „Geteiltes Projekt“-Picker importierst du alles in einem Schritt.
-- Daten werden lokal über `localStorage` gespeichert, Favoriten landen ebenfalls in Backups; nutze die Schaltfläche **Lokalen Cache löschen** in den Einstellungen, um gespeicherte Projekte und Geräteanpassungen zu entfernen.
+- Daten werden lokal über `localStorage` gespeichert, Favoriten landen ebenfalls in Backups; nutze die Option **Werkseinstellungen** in den Einstellungen, die vor dem Zurücksetzen automatisch eine Sicherung speichert.
 - Erstelle druckbare Übersichten für jedes gespeicherte Projekt und füge ein individuelles Logo hinzu, damit Exporte und Backups zum Produktionsbranding passen.
 - Projektanforderungen werden gemeinsam mit dem Projekt gespeichert, sodass Gerätelisten den gesamten Kontext behalten.
 - Funktioniert komplett offline dank installiertem Service Worker – Sprache, Theme, Gerätedaten und Favoriten bleiben erhalten.
@@ -98,7 +98,7 @@ Die App übernimmt beim ersten Start automatisch die Sprache deines Browsers; ü
     aktualisieren zwischengespeicherte Dateien, ohne Projekte zu löschen.
 - Ein Skip-Link und ein Offline-Indikator halten das Layout für Tastatur und Touch zugänglich; das Badge erscheint, sobald der Browser die Verbindung verliert.
 - Die globale Suchleiste springt zu Funktionen, Geräteauswahlen oder Hilfethemen; drücke Enter für das markierte Ergebnis, / oder Strg+K (⌘K auf macOS) zum sofortigen Fokussieren (auf kleinen Displays öffnet sich das Seitenmenü automatisch) und Escape oder × zum Zurücksetzen.
-- Oben findest du Sprachumschaltung, Toggles für dunkles und rosa Theme sowie den Einstellungsdialog mit Akzentfarbe, Schriftgröße, Schriftfamilie, High-Contrast-Schalter und Logo-Upload plus Backup-, Restore- und Cache-Löschen-Werkzeuge.
+- Oben findest du Sprachumschaltung, Toggles für dunkles und rosa Theme sowie den Einstellungsdialog mit Akzentfarbe, Schriftgröße, Schriftfamilie, High-Contrast-Schalter und Logo-Upload plus Backup-, Restore- und Werkseinstellungen-Werkzeuge, die vor dem Löschen eine Sicherung erstellen.
 - Die Hilfe-Schaltfläche öffnet einen durchsuchbaren Dialog mit Schritt-für-Schritt-Anleitungen, Tastenkürzeln, FAQ und optionalem Hover-Hilfemodus; du erreichst ihn auch mit ?, H, F1 oder Strg+/ – selbst während der Eingabe.
 - Die Schaltfläche zum Erzwingen einer Aktualisierung (🔄) löscht zwischengespeicherte Service-Worker-Dateien, damit sich die Offline-App erneuert, ohne Projekte oder Geräte zu verlieren.
 - Auf kleineren Bildschirmen spiegelt ein einklappbares Seitenmenü alle wichtigen Bereiche für schnellen Zugriff.
@@ -250,7 +250,7 @@ Nach der Installation startet die App vom Startbildschirm, funktioniert offline 
 
 ## 📡 Offline-Nutzung & Datenspeicherung
 
-Beim Ausliefern über HTTP(S) installiert sich ein Service Worker, der alle Dateien cached, sodass Cine Power Planner vollständig offline läuft und Updates im Hintergrund lädt. Projekte, Laufzeit-Einreichungen und Einstellungen (Sprache, Theme, Rosa-Modus, gespeicherte Gerätelisten) liegen im `localStorage` deines Browsers. Das Löschen der Seitendaten entfernt alle Informationen; im Einstellungsdialog gibt es dafür ebenfalls die Schaltfläche **Lokalen Cache löschen**.
+Beim Ausliefern über HTTP(S) installiert sich ein Service Worker, der alle Dateien cached, sodass Cine Power Planner vollständig offline läuft und Updates im Hintergrund lädt. Projekte, Laufzeit-Einreichungen und Einstellungen (Sprache, Theme, Rosa-Modus, gespeicherte Gerätelisten) liegen im `localStorage` deines Browsers. Das Löschen der Seitendaten entfernt alle Informationen; im Einstellungsdialog gibt es dafür ebenfalls den Workflow **Werkseinstellungen**, der vor dem Leeren automatisch eine Sicherung speichert.
 Die Kopfzeile zeigt ein Offline-Badge, sobald die Verbindung wegfällt, und die
 Aktion 🔄 **Neu laden erzwingen** aktualisiert gecachte Assets, ohne Projekte
 anzutasten.

--- a/README.en.md
+++ b/README.en.md
@@ -26,7 +26,7 @@ The app automatically uses your browser language on first load, and you can swit
 - Keyboard shortcuts for the global search let you press / or Ctrl+K (⌘K on macOS) to focus the feature search instantly, even when it sits inside the collapsed mobile side menu.
 - Force reload button clears cached service worker files so the offline app refreshes without deleting saved projects or devices.
 - Star icons in every selector pin favorite cameras, batteries and accessories to the top of the list and keep them in backups.
-- Clear local cache button wipes stored projects and settings.
+- Factory reset workflow automatically downloads a backup before wiping stored projects, custom devices and settings.
 - Gear list and printable overview display the project name for quick reference.
 - Upload a custom logo for printed overviews and backups.
 - Backups include favorites and create an automatic backup before restore.
@@ -77,7 +77,7 @@ The app automatically uses your browser language on first load, and you can swit
 - Save, load and delete multiple camera projects (press Enter or Ctrl+S/⌘S to save quickly; the Save button stays disabled until a name is entered).
 - Automatic snapshots are created every 10 minutes while the planner is open, and the Settings dialog can trigger hourly backup exports as a reminder to archive data.
 - Download a JSON project file that bundles selections, requirements, gear lists, runtime feedback and custom devices; load it through the Shared Project picker to restore everything in one step.
-- Data is stored locally via `localStorage` and favorites are preserved in backups; use the dedicated **Clear Local Cache** button in Settings if you need to wipe cached projects and device edits.
+- Data is stored locally via `localStorage` and favorites are preserved in backups; use the **Factory reset** option in Settings to capture a backup automatically before wiping cached projects and device edits.
 - Generate printable overviews for any saved project and add a custom logo so exports and backups match your production branding.
 - Save project requirements along with each project so gear lists retain full context.
 - Works fully offline with the installed service worker—language, theme, device data and favorites persist between sessions.
@@ -100,7 +100,7 @@ The app automatically uses your browser language on first load, and you can swit
     assets without clearing projects.
 - A skip link and offline indicator keep the layout accessible on keyboard and touch devices—the badge appears whenever the browser loses its connection.
 - The global search bar jumps to features, device selectors or help topics; press Enter to activate the highlighted result, use / or Ctrl+K (⌘K on macOS) to focus it from anywhere (the side menu opens automatically on small screens) and press Escape or tap × to clear the query.
-- Top bar controls provide language switching, dark and pink theme toggles plus a Settings dialog that exposes accent color, font size, font family, high contrast and custom logo uploads alongside backup, restore and Clear Local Cache tools.
+- Top bar controls provide language switching, dark and pink theme toggles plus a Settings dialog that exposes accent color, font size, font family, high contrast and custom logo uploads alongside backup, restore and Factory reset tools that back up data before wiping it.
 - The Help button opens a searchable dialog with step-by-step sections, keyboard shortcuts, FAQs and an optional hover-help mode; it can also be triggered with ?, H, F1 or Ctrl+/ even while typing.
 - The Force reload button (🔄) clears cached service worker files so the offline app updates without deleting saved projects or custom devices.
 - On smaller screens a collapsible side menu mirrors every major section for quick navigation.
@@ -259,7 +259,7 @@ so Cine Power Planner works fully offline and updates in the background. Project
 runtime submissions and preferences (language, theme, pink mode and saved gear
 lists) live in your browser's `localStorage`. Clearing the site's data in the
 browser removes all stored information, and the Settings dialog includes a
-**Clear Local Cache** button for the same one-click cleanup. The header shows an
+**Factory reset** workflow that saves a backup automatically before clearing everything. The header shows an
 offline badge whenever connectivity drops, and the 🔄 **Force reload** action
 refreshes cached assets without disturbing saved projects.
 

--- a/README.es.md
+++ b/README.es.md
@@ -27,7 +27,7 @@ La aplicación usa automáticamente el idioma de tu navegador en la primera visi
 - Los atajos de teclado para la búsqueda global te permiten pulsar / o Ctrl+K (⌘K en macOS) para enfocarla al instante, incluso cuando está dentro del menú lateral móvil.
 - El botón de recarga forzada borra los archivos en caché del *service worker* para que la aplicación sin conexión se actualice sin eliminar proyectos ni dispositivos guardados.
 - Los iconos de estrella en cada selector fijan las cámaras, baterías y accesorios favoritos en la parte superior de la lista y los conservan en las copias de seguridad.
-- El botón de borrar caché local elimina los proyectos y ajustes almacenados.
+- El flujo de **Restablecimiento de fábrica** descarga una copia de seguridad automáticamente antes de borrar los proyectos, ajustes y dispositivos guardados.
 - La lista de equipo y la vista imprimible muestran el nombre del proyecto para consultarlo rápidamente.
 - Sube un logotipo personalizado para que aparezca en las vistas imprimibles y en las copias de seguridad.
 - Las copias de seguridad incluyen los favoritos y crean una copia automática antes de restaurar.
@@ -80,7 +80,7 @@ La aplicación usa automáticamente el idioma de tu navegador en la primera visi
 - Guarda, carga y elimina múltiples proyectos de cámara (pulsa Enter o Ctrl+S/⌘S para guardar rápido; el botón Guardar permanece desactivado hasta introducir un nombre).
 - Se crean instantáneas automáticas cada 10 minutos mientras el planificador está abierto, y el diálogo de Ajustes puede programar exportaciones de copias de seguridad cada hora como recordatorio para archivar los datos.
 - Descarga un archivo JSON que agrupa selecciones, requisitos, listas de equipo, comentarios de autonomía y dispositivos personalizados; cárgalo mediante el selector de Proyecto compartido para restaurarlo todo de una vez.
-- Los datos se almacenan localmente mediante `localStorage`, y los favoritos se conservan en las copias de seguridad; utiliza el botón **Borrar caché local** en Ajustes si necesitas limpiar proyectos en caché y ediciones de dispositivos.
+- Los datos se almacenan localmente mediante `localStorage`, y los favoritos se conservan en las copias de seguridad; utiliza la opción de **Restablecimiento de fábrica** en Ajustes para guardar automáticamente una copia de seguridad antes de limpiar proyectos en caché y ediciones de dispositivos.
 - Genera vistas imprimibles para cualquier proyecto guardado y añade un logotipo personalizado para que las exportaciones y copias coincidan con la identidad de tu producción.
 - Guarda los requisitos de proyecto junto con cada proyecto para que las listas de equipo conserven el contexto completo.
 - Funciona totalmente sin conexión con el *service worker* instalado: idioma, tema, datos de dispositivos y favoritos persisten entre sesiones.
@@ -104,7 +104,7 @@ La aplicación usa automáticamente el idioma de tu navegador en la primera visi
     conexión y renuevan archivos en caché sin borrar proyectos.
 - Un enlace de salto y un indicador sin conexión mantienen la interfaz accesible con teclado y pantallas táctiles: la insignia aparece cuando el navegador pierde la conexión.
 - La barra de búsqueda global salta a funciones, selectores de dispositivos o temas de ayuda; pulsa Enter para activar el resultado resaltado, usa / o Ctrl+K (⌘K en macOS) para enfocarla desde cualquier lugar (el menú lateral se abre automáticamente en pantallas pequeñas) y pulsa Escape o × para limpiar la consulta.
-- Los controles de la barra superior permiten cambiar el idioma, alternar los temas oscuro y rosa y abrir Ajustes con opciones de color de acento, tamaño y familia tipográfica, modo de alto contraste y carga de logotipo, además de herramientas para copia de seguridad, restauración y Borrar caché local.
+- Los controles de la barra superior permiten cambiar el idioma, alternar los temas oscuro y rosa y abrir Ajustes con opciones de color de acento, tamaño y familia tipográfica, modo de alto contraste y carga de logotipo, además de herramientas para copia de seguridad, restauración y Restablecimiento de fábrica que guardan una copia antes de borrar los datos.
 - El botón de Ayuda abre un diálogo con búsqueda, secciones paso a paso, atajos de teclado, preguntas frecuentes y un modo de ayuda emergente opcional; también puede activarse con ?, H, F1 o Ctrl+/ incluso mientras escribes.
 - El botón de recarga forzada (🔄) borra los archivos del *service worker* en caché para que la aplicación sin conexión se actualice sin eliminar proyectos ni dispositivos guardados.
 - En pantallas pequeñas, un menú lateral plegable replica cada sección principal para navegar rápidamente.
@@ -261,7 +261,7 @@ Una vez instalada, la aplicación se abre desde tu pantalla de inicio, funciona 
 
 ## 📡 Uso sin conexión y almacenamiento de datos
 
-Servir la aplicación mediante HTTP(S) instala un *service worker* que almacena en caché cada archivo, de modo que Cine Power Planner funciona sin conexión y se actualiza en segundo plano. Los proyectos, los comentarios de autonomía y las preferencias (idioma, tema, modo rosa y listas de equipo guardadas) viven en el `localStorage` del navegador. Al borrar los datos del sitio en el navegador se elimina toda la información almacenada, y el diálogo de Ajustes incluye un botón de **Borrar caché local** para la misma limpieza con un solo clic.
+Servir la aplicación mediante HTTP(S) instala un *service worker* que almacena en caché cada archivo, de modo que Cine Power Planner funciona sin conexión y se actualiza en segundo plano. Los proyectos, los comentarios de autonomía y las preferencias (idioma, tema, modo rosa y listas de equipo guardadas) viven en el `localStorage` del navegador. Al borrar los datos del sitio en el navegador se elimina toda la información almacenada, y el diálogo de Ajustes incluye un flujo de **Restablecimiento de fábrica** que guarda automáticamente una copia antes de realizar la misma limpieza completa.
 La cabecera muestra un indicador sin conexión cuando se pierde la red, y la
 acción 🔄 **Forzar recarga** actualiza los recursos en caché sin afectar a los
 proyectos guardados.

--- a/README.fr.md
+++ b/README.fr.md
@@ -27,7 +27,7 @@ L’application adopte automatiquement la langue de votre navigateur lors de la 
 - Les raccourcis clavier de la recherche globale permettent d’appuyer sur / ou Ctrl+K (⌘K sur macOS) pour la focaliser instantanément, même lorsqu’elle se trouve dans le menu latéral mobile replié.
 - Le bouton de rechargement forcé efface les fichiers mis en cache par le service worker afin que l’application hors ligne se mette à jour sans supprimer les projets ni les appareils enregistrés.
 - Les icônes étoilées dans chaque sélecteur épinglent les caméras, batteries et accessoires favoris en haut de la liste et les incluent dans les sauvegardes.
-- Le bouton **Effacer le cache local** supprime les projets et paramètres stockés.
+- Le flux de **Réinitialisation d’usine** télécharge automatiquement une sauvegarde avant de supprimer les projets, appareils et paramètres stockés.
 - La liste de matériel et l’aperçu imprimable affichent le nom du projet pour une consultation rapide.
 - Importez un logo personnalisé pour les aperçus imprimables et les sauvegardes.
 - Les sauvegardes contiennent les favoris et créent une copie automatique avant toute restauration.
@@ -81,7 +81,7 @@ L’application adopte automatiquement la langue de votre navigateur lors de la 
 - Enregistrez, chargez et supprimez plusieurs projets caméra (appuyez sur Entrée ou Ctrl+S/⌘S pour sauvegarder rapidement ; le bouton Enregistrer reste inactif tant qu’aucun nom n’est saisi).
 - Des instantanés automatiques sont créés toutes les 10 minutes tant que le planner est ouvert, et la boîte de dialogue Paramètres peut déclencher des exports de sauvegarde horaires pour penser à archiver vos données.
 - Téléchargez un fichier JSON qui regroupe sélections, exigences, liste de matériel, retours d’autonomie et appareils personnalisés ; chargez-le via le sélecteur Projet partagé pour tout restaurer en une étape.
-- Les données sont stockées localement via `localStorage` et les favoris sont inclus dans les sauvegardes ; utilisez le bouton **Effacer le cache local** dans Paramètres pour supprimer projets mis en cache et modifications d’appareils.
+- Les données sont stockées localement via `localStorage` et les favoris sont inclus dans les sauvegardes ; utilisez l’option **Réinitialisation d’usine** dans Paramètres pour enregistrer automatiquement une sauvegarde avant de supprimer projets mis en cache et modifications d’appareils.
 - Générez des aperçus imprimables pour tout projet enregistré et ajoutez un logo personnalisé afin d’aligner exports et sauvegardes sur l’identité de votre production.
 - Enregistrez les exigences de projet avec chaque projet afin que la liste de matériel conserve tout le contexte.
 - Fonctionne entièrement hors ligne grâce au service worker installé : langue, thème, données d’appareils et favoris persistent entre les sessions.
@@ -106,7 +106,7 @@ L’application adopte automatiquement la langue de votre navigateur lors de la 
     connexion et renouvellent les fichiers en cache sans effacer les projets.
 - Un lien d’évitement et un indicateur hors ligne maintiennent l’interface accessible au clavier et au tactile ; l’insigne apparaît dès que le navigateur perd la connexion.
 - La barre de recherche globale permet d’atteindre des fonctionnalités, sélecteurs d’appareils ou rubriques d’aide ; appuyez sur Entrée pour valider le résultat en surbrillance, utilisez / ou Ctrl+K (⌘K sur macOS) pour la focaliser instantanément (le menu latéral s’ouvre automatiquement sur les petits écrans) et appuyez sur Échap ou × pour effacer la requête.
-- Les commandes de la barre supérieure offrent le changement de langue, les thèmes sombre et rose, ainsi qu’une boîte de dialogue Paramètres avec la couleur d’accent, la taille et la famille de police, le mode à fort contraste et l’import de logo, ainsi que des outils de sauvegarde, restauration et nettoyage du cache local.
+- Les commandes de la barre supérieure offrent le changement de langue, les thèmes sombre et rose, ainsi qu’une boîte de dialogue Paramètres avec la couleur d’accent, la taille et la famille de police, le mode à fort contraste et l’import de logo, ainsi que des outils de sauvegarde, restauration et Réinitialisation d’usine qui créent une sauvegarde avant l’effacement.
 - Le bouton Aide ouvre une boîte de dialogue recherchable avec des sections pas à pas, des raccourcis clavier, une FAQ et un mode aide contextuelle optionnel ; vous pouvez aussi l’ouvrir avec ?, H, F1 ou Ctrl+/ même en cours de saisie.
 - Le bouton de rechargement forcé (🔄) efface les fichiers du service worker en cache afin que l’application hors ligne se mette à jour sans supprimer projets ni appareils.
 - Sur les petits écrans, un menu latéral repliable reflète chaque section principale pour une navigation rapide.
@@ -263,7 +263,7 @@ Une fois installée, l’application se lance depuis l’écran d’accueil, fon
 
 ## 📡 Utilisation hors ligne et stockage des données
 
-Servir l’application via HTTP(S) installe un service worker qui met chaque fichier en cache pour que Cine Power Planner fonctionne totalement hors ligne et se mette à jour en arrière-plan. Les projets, retours d’autonomie et préférences (langue, thème, mode rose et listes de matériel sauvegardées) sont stockés dans le `localStorage` du navigateur. Effacer les données du site supprime toutes les informations, et la boîte de dialogue Paramètres propose également un bouton **Effacer le cache local** pour le même nettoyage en un clic.
+Servir l’application via HTTP(S) installe un service worker qui met chaque fichier en cache pour que Cine Power Planner fonctionne totalement hors ligne et se mette à jour en arrière-plan. Les projets, retours d’autonomie et préférences (langue, thème, mode rose et listes de matériel sauvegardées) sont stockés dans le `localStorage` du navigateur. Effacer les données du site supprime toutes les informations, et la boîte de dialogue Paramètres propose également un flux de **Réinitialisation d’usine** qui enregistre automatiquement une sauvegarde avant d’effectuer le même nettoyage complet.
 L’en-tête affiche un badge hors ligne dès que la connexion tombe, et l’action 🔄
 **Forcer le rechargement** actualise les fichiers mis en cache sans toucher aux
 projets enregistrés.

--- a/README.it.md
+++ b/README.it.md
@@ -27,7 +27,7 @@ L’app usa automaticamente la lingua del browser al primo avvio e puoi cambiarl
 - Le scorciatoie da tastiera per la ricerca globale consentono di premere / o Ctrl+K (⌘K su macOS) per focalizzarla all’istante, anche quando si trova nel menu laterale mobile compresso.
 - Il pulsante di ricarica forzata svuota i file memorizzati dal service worker così l’app offline si aggiorna senza cancellare progetti o dispositivi salvati.
 - Le icone a stella in ogni selettore fissano in alto le videocamere, le batterie e gli accessori preferiti e li includono nei backup.
-- Il pulsante **Cancella cache locale** rimuove progetti e impostazioni memorizzati.
+- Il flusso di **Ripristino di fabbrica** scarica automaticamente un backup prima di rimuovere progetti, dispositivi e impostazioni salvati.
 - La lista attrezzatura e l’anteprima stampabile mostrano il nome del progetto per un riferimento rapido.
 - Carica un logo personalizzato da usare nelle stampe e nei backup.
 - I backup includono i preferiti e creano una copia automatica prima del ripristino.
@@ -79,7 +79,7 @@ L’app usa automaticamente la lingua del browser al primo avvio e puoi cambiarl
 - Salva, carica e cancella più progetti camera (premi Invio o Ctrl+S/⌘S per salvare rapidamente; il pulsante Salva resta disattivato finché non inserisci un nome).
 - Vengono creati automaticamente snapshot ogni 10 minuti mentre il planner è aperto e dalla finestra Impostazioni puoi attivare esportazioni di backup orarie come promemoria.
 - Scarica un file JSON che raccoglie selezioni, requisiti, lista attrezzatura, feedback di autonomia e dispositivi personalizzati; importalo dal selettore Progetto condiviso per ripristinare tutto in un passaggio.
-- I dati sono archiviati localmente tramite `localStorage` e i preferiti vengono conservati nei backup; usa il pulsante **Cancella cache locale** nelle Impostazioni per eliminare progetti e modifiche ai dispositivi memorizzati.
+- I dati sono archiviati localmente tramite `localStorage` e i preferiti vengono conservati nei backup; usa l'opzione **Ripristino di fabbrica** nelle Impostazioni per salvare automaticamente un backup prima di eliminare progetti e modifiche ai dispositivi memorizzati.
 - Genera anteprime stampabili per ogni progetto salvato e aggiungi un logo personalizzato così esportazioni e backup rispettano l’identità della produzione.
 - Salva i requisiti di progetto insieme a ciascun progetto, così la lista attrezzatura mantiene il contesto completo.
 - Funziona completamente offline grazie al service worker installato: lingua, tema, dati dei dispositivi e preferiti persistono tra le sessioni.
@@ -103,7 +103,7 @@ L’app usa automaticamente la lingua del browser al primo avvio e puoi cambiarl
     aggiornano i file in cache senza eliminare i progetti.
 - Un collegamento di salto e un indicatore offline mantengono il layout accessibile con tastiera e tocco; il badge appare ogni volta che il browser perde la connessione.
 - La barra di ricerca globale consente di saltare a funzioni, selettori di dispositivi o argomenti di aiuto; premi Invio per attivare il risultato evidenziato, usa / o Ctrl+K (⌘K su macOS) per focalizzarla subito (sugli schermi piccoli il menu laterale si apre in automatico) e premi Esc o × per cancellare la ricerca.
-- I controlli della barra superiore offrono cambio lingua, temi scuro e rosa e la finestra Impostazioni con colore accento, dimensione e famiglia del font, modalità ad alto contrasto e caricamento del logo, oltre agli strumenti di backup, ripristino e cancellazione cache.
+- I controlli della barra superiore offrono cambio lingua, temi scuro e rosa e la finestra Impostazioni con colore accento, dimensione e famiglia del font, modalità ad alto contrasto e caricamento del logo, oltre agli strumenti di backup, ripristino e Ripristino di fabbrica che salvano automaticamente un backup prima di cancellare i dati.
 - Il pulsante di aiuto apre un dialogo ricercabile con sezioni guidate, scorciatoie da tastiera, FAQ e una modalità di suggerimenti al passaggio del mouse; si può aprire anche con ?, H, F1 o Ctrl+/ mentre digiti.
 - Il pulsante di ricarica forzata (🔄) cancella i file del service worker in cache così l’app offline si aggiorna senza perdere progetti o dispositivi.
 - Sugli schermi più piccoli un menu laterale a scomparsa replica ogni sezione principale per navigare rapidamente.
@@ -260,7 +260,7 @@ Una volta installata, l’app si avvia dalla schermata Home, funziona offline e 
 
 ## 📡 Uso offline e archiviazione dati
 
-Servire l’app tramite HTTP(S) installa un service worker che memorizza in cache ogni file, così Cine Power Planner funziona completamente offline e si aggiorna in background. Progetti, feedback di autonomia e preferenze (lingua, tema, modalità rosa e liste attrezzatura salvate) vivono nel `localStorage` del browser. Cancellare i dati del sito elimina tutte le informazioni e nella finestra Impostazioni è disponibile anche il pulsante **Cancella cache locale** per lo stesso reset con un clic.
+Servire l’app tramite HTTP(S) installa un service worker che memorizza in cache ogni file, così Cine Power Planner funziona completamente offline e si aggiorna in background. Progetti, feedback di autonomia e preferenze (lingua, tema, modalità rosa e liste attrezzatura salvate) vivono nel `localStorage` del browser. Cancellare i dati del sito elimina tutte le informazioni e nella finestra Impostazioni è disponibile anche il flusso di **Ripristino di fabbrica**, che salva automaticamente un backup prima di eseguire lo stesso azzeramento completo.
 L’intestazione mostra un badge offline non appena cade la connessione, e l’azione
 🔄 **Forza ricarica** aggiorna i file in cache senza toccare i progetti salvati.
 

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Contributions for additional languages are welcome. Follow the [translation guid
 - **Global search shortcuts** – press / or Ctrl+K (⌘K on macOS) to focus the feature search instantly, even when it lives inside the collapsed mobile side menu.
 - **Force reload button** – clear cached service worker files and refresh the offline app without deleting saved projects or devices.
 - **Pinned favorites** – star dropdown entries to keep go-to cameras, batteries and accessories at the top of each selector and include them in backups.
-- **Clear local cache** – wipe stored projects and settings with one click.
+- **Factory reset button** – download a backup automatically before wiping saved projects, custom devices and settings in one step.
 - **Project name above gear list** – printed overviews and the gear list now show the project name.
 - **Custom print logo** – upload a logo that appears in printable overviews and backups.
 - **Favorites in backups** – favorites are saved and an automatic backup runs before restoring data.
@@ -252,8 +252,8 @@ Understanding the planner's vocabulary makes it easier to explore new features:
 
 - Automatic snapshots, manual exports and the **Force reload** button let you
   experiment without fear. Restores create a safety backup before overwriting
-  data, and the **Clear Local Cache** option removes everything when you need a
-  clean slate.
+  data, and the **Factory reset** option downloads a backup before wiping
+  everything when you need a clean slate.
 
 ## Interface Overview
 
@@ -277,7 +277,7 @@ Understanding the planner's vocabulary makes it easier to explore new features:
 
 - A skip link, offline indicator and responsive branding keep the interface accessible across devices; the offline badge appears whenever the browser loses its connection.
 - The global search bar jumps to features, device selectors or help topics—press Enter to navigate to the highlighted result, use / or Ctrl+K (⌘K on macOS) to focus it from anywhere (the side menu opens automatically on small screens), and press Escape or × to clear the query.
-- Language, dark mode and pink mode buttons sit alongside the Settings dialog, which exposes accent color, font size, font family, high contrast and custom logo uploads plus backup, restore and Clear Local Cache tools.
+- Language, dark mode and pink mode buttons sit alongside the Settings dialog, which exposes accent color, font size, font family, high contrast and custom logo uploads plus backup, restore and Factory reset tools that capture a backup before wiping planner data.
 - The Help button opens a searchable dialog with step-by-step sections, keyboard shortcuts, FAQs and an optional hover-help mode; it can also be triggered with ?, H, F1 or Ctrl+/ even while typing.
 - The Force reload button (🔄) removes cached service worker files and refreshes the app without touching saved projects or device data.
 
@@ -381,7 +381,8 @@ files so the planner runs entirely offline and pulls updates in the
 background. Projects, runtime submissions and preferences (language, theme,
 pink mode and saved gear lists) are stored locally via `localStorage` in your
 browser. Clearing the site's data in your browser removes all saved
-information, and the Settings dialog includes a **Clear Local Cache** button for a one-click reset when you need a fresh start.
+information, and the Settings dialog includes a **Factory reset** workflow that
+downloads a backup before clearing everything when you need a fresh start.
 The header shows an offline indicator whenever the browser drops its
 connection, and the 🔄 **Force reload** action refreshes cached assets without
 touching saved data.
@@ -402,9 +403,9 @@ controls to export your work:
   the internal `exportAllData()` routine. Restoring the file automatically saves
   a safety copy of your current data before importing the new settings and warns
   when the file was produced with a different app version.
-- **Clear Local Cache:** In **Settings → Backup & Restore**, wipe saved projects,
-  custom gear, favorites and runtime feedback with one click when you need to
-  start over.
+- **Factory reset:** Open **Settings → Backup & Restore → Factory reset** to
+  download a backup automatically and then wipe saved projects, custom gear,
+  favorites and runtime feedback when you need to start over.
 - **Regular reminders:** While the planner is running, an hourly background job
   triggers the same backup export so you always have a recent download prompt as
   a reminder to archive your data.
@@ -422,7 +423,7 @@ infrastructure.
 Because a service worker caches assets for offline use, the only runtime network
 requests come from optional resources such as the OpenMoji icon set when a
 connection is available. You can clear saved information at any time via
-**Settings → Clear Local Cache** or by deleting the site's data in your browser.
+**Settings → Factory reset** or by deleting the site's data in your browser.
 Exports produce human-readable JSON so you can review exactly what will be
 shared before handing files to collaborators or clients.
 


### PR DESCRIPTION
## Summary
- update the main README to describe the Factory reset workflow instead of the removed Clear Local Cache button
- refresh the English, Spanish, German, French and Italian READMEs so they all explain that Factory reset saves a backup before wiping data

## Testing
- not run (documentation-only changes)

------
https://chatgpt.com/codex/tasks/task_e_68cd7d4211f88320b2b8a9923f880ed4