### PR TITLE
Add icons to help quick links

### DIFF
--- a/script.js
+++ b/script.js
@@ -16160,9 +16160,21 @@ if (helpButton && helpDialog) {
       const button = document.createElement('button');
       button.type = 'button';
       button.className = 'help-quick-link';
-      button.textContent = label;
       button.dataset.targetId = id;
       button.setAttribute('aria-label', label);
+
+      const headingIcon = heading.querySelector('.help-icon.icon-glyph');
+      if (headingIcon) {
+        const icon = headingIcon.cloneNode(true);
+        icon.classList.remove('help-icon');
+        icon.classList.add('help-quick-link-icon');
+        button.appendChild(icon);
+      }
+
+      const labelSpan = document.createElement('span');
+      labelSpan.className = 'help-quick-link-label';
+      labelSpan.textContent = label;
+      button.appendChild(labelSpan);
       button.addEventListener('click', () => {
         if (section.hasAttribute('hidden')) return;
         if (helpQuickLinksList) {

--- a/style.css
+++ b/style.css
@@ -1254,6 +1254,35 @@ main.legal-content {
   white-space: normal;
 }
 
+.help-quick-link-icon {
+  --icon-color: var(--accent-color);
+  flex: 0 0 1.75em;
+  width: 1.75em;
+  height: 1.75em;
+  border-radius: 999px;
+  background-color: var(--panel-bg);
+  border: 1px solid var(--panel-border);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4);
+}
+
+.dark-mode .help-quick-link-icon,
+html.dark-mode .help-quick-link-icon {
+  box-shadow: inset 0 1px 0 rgba(0, 0, 0, 0.4);
+}
+
+.help-quick-link.active .help-quick-link-icon {
+  background-color: transparent;
+  border-color: transparent;
+  --icon-color: var(--inverse-text-color);
+  box-shadow: none;
+}
+
+.help-quick-link-label {
+  flex: 1 1 auto;
+  min-width: 0;
+  line-height: 1.3;
+}
+
 .help-quick-link:focus-visible {
   outline: 2px solid var(--accent-color);
   outline-offset: 2px;


### PR DESCRIPTION
## Summary
- clone each help section icon onto the generated quick link button and wrap the label for better structure
- style quick link icons with circular backgrounds and ensure active states inherit the correct colors

## Testing
- npm run test:dom

------
https://chatgpt.com/codex/tasks/task_e_68cd7dcf95208320ae4dd147e4cad541