### PR TITLE
Improve offline persistence and feature search

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,8 +184,9 @@ See the language-specific README files for full details.
   to filter instantly.
 - Tailor the interface with language detection, dark or playful pink themes,
   high contrast mode, accent color and typography controls.
-- Work completely offline thanks to the service worker, persistent storage and a
-  force reload button that refreshes cached assets without losing data.
+- Work completely offline thanks to the service worker, persistent storage
+  requested via the StorageManager API and a force reload button that refreshes
+  cached assets without losing data.
 
 ## Quick Start
 
@@ -380,8 +381,10 @@ When served over HTTP(S), Cine Power Planner installs a service worker that cach
 files so the planner runs entirely offline and pulls updates in the
 background. Projects, runtime submissions and preferences (language, theme,
 pink mode and saved gear lists) are stored locally via `localStorage` in your
-browser. Clearing the site's data in your browser removes all saved
-information, and the Settings dialog includes a **Clear Local Cache** button for a one-click reset when you need a fresh start.
+browser. The app proactively requests persistent storage through the
+`navigator.storage.persist()` API so browsers are less likely to evict saved
+data when disk space runs low. Clearing the site's data in your browser removes
+all saved information, and the Settings dialog includes a **Clear Local Cache** button for a one-click reset when you need a fresh start.
 The header shows an offline indicator whenever the browser drops its
 connection, and the 🔄 **Force reload** action refreshes cached assets without
 touching saved data.

--- a/tests/unit/persistentStorage.test.js
+++ b/tests/unit/persistentStorage.test.js
@@ -1,0 +1,80 @@
+const originalStorageDescriptor = Object.getOwnPropertyDescriptor(global.navigator, 'storage');
+
+const resetNavigatorStorage = () => {
+  if (originalStorageDescriptor) {
+    Object.defineProperty(global.navigator, 'storage', originalStorageDescriptor);
+  } else {
+    delete global.navigator.storage;
+  }
+};
+
+describe('requestPersistentStorage', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    resetNavigatorStorage();
+  });
+
+  afterEach(() => {
+    resetNavigatorStorage();
+  });
+
+  test('resolves true when storage is already persistent', async () => {
+    const persist = jest.fn().mockResolvedValue(true);
+    const persisted = jest.fn().mockResolvedValue(true);
+    Object.defineProperty(global.navigator, 'storage', {
+      configurable: true,
+      value: { persist, persisted }
+    });
+
+    const { requestPersistentStorage } = require('../../storage.js');
+
+    await expect(requestPersistentStorage()).resolves.toBe(true);
+    expect(persisted).toHaveBeenCalledTimes(1);
+    expect(persist).not.toHaveBeenCalled();
+  });
+
+  test('requests persistence when not yet granted', async () => {
+    const persist = jest.fn().mockResolvedValue(true);
+    const persisted = jest.fn().mockResolvedValue(false);
+    Object.defineProperty(global.navigator, 'storage', {
+      configurable: true,
+      value: { persist, persisted }
+    });
+
+    const { requestPersistentStorage } = require('../../storage.js');
+
+    await expect(requestPersistentStorage()).resolves.toBe(true);
+    expect(persisted).toHaveBeenCalledTimes(1);
+    expect(persist).toHaveBeenCalledTimes(1);
+
+    const again = requestPersistentStorage();
+    await expect(again).resolves.toBe(true);
+    expect(persist).toHaveBeenCalledTimes(1);
+  });
+
+  test('fails gracefully when StorageManager API is unavailable', async () => {
+    delete global.navigator.storage;
+
+    const { requestPersistentStorage } = require('../../storage.js');
+
+    await expect(requestPersistentStorage()).resolves.toBe(false);
+  });
+
+  test('handles errors from persist()', async () => {
+    const persist = jest.fn().mockRejectedValue(new Error('nope'));
+    const persisted = jest.fn().mockResolvedValue(false);
+    Object.defineProperty(global.navigator, 'storage', {
+      configurable: true,
+      value: { persist, persisted }
+    });
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const { requestPersistentStorage } = require('../../storage.js');
+
+    await expect(requestPersistentStorage()).resolves.toBe(false);
+    expect(persist).toHaveBeenCalledTimes(1);
+    expect(warnSpy).toHaveBeenCalled();
+
+    warnSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- request persistent storage via the StorageManager API to strengthen offline data retention and add coverage for the new helper
- refine the global feature search so exact feature matches outrank device suggestions and keep user-entered queries when the label only differs in casing
- document the persistent storage behaviour in the README and extend feature search tests for the new prioritisation rules

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd7e6357c48320be55dbd030ec1fbe