### PR TITLE
Preserve pink mode accent when closing settings

### DIFF
--- a/script.js
+++ b/script.js
@@ -5964,6 +5964,20 @@ const applyAccentColor = (color) => {
   }
 };
 
+const clearAccentColorOverrides = () => {
+  const root = document.documentElement;
+  const rootStyle = root && root.style;
+  if (rootStyle) {
+    rootStyle.removeProperty('--accent-color');
+    rootStyle.removeProperty('--link-color');
+  }
+  if (document.body) {
+    const bodyStyle = document.body.style;
+    bodyStyle.removeProperty('--accent-color');
+    bodyStyle.removeProperty('--link-color');
+  }
+};
+
 try {
   const storedAccent = localStorage.getItem('accentColor');
   if (storedAccent) {
@@ -6224,6 +6238,10 @@ if (settingsFontFamily) {
 }
 
 const revertAccentColor = () => {
+  if (document.body && document.body.classList.contains('pink-mode')) {
+    clearAccentColorOverrides();
+    return;
+  }
   applyAccentColor(prevAccentColor);
 };
 
@@ -15204,10 +15222,7 @@ function applyHighContrast(enabled) {
     }
     document.documentElement.classList.remove("high-contrast");
     if (document.body && document.body.classList.contains('pink-mode')) {
-      document.documentElement.style.removeProperty('--accent-color');
-      document.documentElement.style.removeProperty('--link-color');
-      document.body.style.removeProperty('--accent-color');
-      document.body.style.removeProperty('--link-color');
+      clearAccentColorOverrides();
     } else {
       applyAccentColor(accentColor);
     }
@@ -15229,12 +15244,7 @@ function applyPinkMode(enabled) {
     if (accentColorInput) {
       accentColorInput.disabled = true;
     }
-    document.documentElement.style.removeProperty('--accent-color');
-    document.documentElement.style.removeProperty('--link-color');
-    if (document.body) {
-      document.body.style.removeProperty('--accent-color');
-      document.body.style.removeProperty('--link-color');
-    }
+    clearAccentColorOverrides();
     if (pinkModeToggle) {
       setToggleIcon(pinkModeToggle, ICON_GLYPHS.unicorn);
       pinkModeToggle.setAttribute("aria-pressed", "true");

--- a/tests/script/settings-theme.test.js
+++ b/tests/script/settings-theme.test.js
@@ -1,0 +1,38 @@
+const { setupScriptEnvironment } = require('../helpers/scriptEnvironment');
+
+describe('settings dialog theme interactions', () => {
+  let cleanup;
+
+  afterEach(() => {
+    if (typeof cleanup === 'function') {
+      cleanup();
+      cleanup = undefined;
+    }
+    localStorage.clear();
+  });
+
+  test('closing settings keeps pink mode accent overrides cleared', () => {
+    localStorage.setItem('pinkMode', 'true');
+    localStorage.setItem('accentColor', '#ff8800');
+
+    const { cleanup: clean } = setupScriptEnvironment();
+    cleanup = clean;
+
+    expect(document.body.classList.contains('pink-mode')).toBe(true);
+
+    const settingsButton = document.getElementById('settingsButton');
+    const settingsCancel = document.getElementById('settingsCancel');
+
+    expect(settingsButton).toBeTruthy();
+    expect(settingsCancel).toBeTruthy();
+
+    settingsButton.click();
+    settingsCancel.click();
+
+    expect(document.body.classList.contains('pink-mode')).toBe(true);
+    expect(document.documentElement.style.getPropertyValue('--accent-color')).toBe('');
+    expect(document.documentElement.style.getPropertyValue('--link-color')).toBe('');
+    expect(document.body.style.getPropertyValue('--accent-color')).toBe('');
+    expect(document.body.style.getPropertyValue('--link-color')).toBe('');
+  });
+});


### PR DESCRIPTION
## Summary
- avoid restoring the stored accent colour when the UI is in pink mode by clearing accent overrides instead
- reuse the new helper when leaving high contrast or enabling pink mode to keep the accent CSS variables consistent
- cover the regression with a jsdom test that simulates opening and cancelling the Settings dialog while pink mode is active

## Testing
- npm run test:script

------
https://chatgpt.com/codex/tasks/task_e_68cd80767c6c8320b2392762c6cf4d4c