### PR TITLE
Add icon to runtime feedback button

### DIFF
--- a/index.html
+++ b/index.html
@@ -331,7 +331,9 @@
     <p id="dtapWarning" role="status" aria-live="polite" aria-describedby="batteryLabel"></p>
     <p id="hotswapWarning" role="status" aria-live="polite" aria-describedby="batteryHotswapLabel"></p>
     <div id="temperatureNote"></div>
-    <button id="runtimeFeedbackBtn" type="button">Submit User Runtime Feedback</button>
+    <button id="runtimeFeedbackBtn" type="button">
+      <span class="btn-icon icon-glyph" aria-hidden="true">&#xECF6;</span>Submit User Runtime Feedback
+    </button>
     <div id="feedbackTableContainer" class="hidden">
       <table id="userFeedbackTable" class="hidden"></table>
     </div>

--- a/script.js
+++ b/script.js
@@ -2071,6 +2071,7 @@ function setLanguage(lang) {
 
   runtimeFeedbackBtn.setAttribute("title", texts[lang].runtimeFeedbackBtn);
   runtimeFeedbackBtn.setAttribute("data-help", texts[lang].runtimeFeedbackBtnHelp);
+  setButtonLabelWithIcon(runtimeFeedbackBtn, texts[lang].runtimeFeedbackBtn, ICON_GLYPHS.note);
   // Update the "-- New Setup --" option text
   if (setupSelect.options.length > 0) {
     setupSelect.options[0].textContent = texts[lang].newSetupOption;
@@ -2164,9 +2165,6 @@ function setLanguage(lang) {
     "data-help",
     texts[lang].batteryCountHelp
   );
-
-  document.getElementById("runtimeFeedbackBtn").textContent =
-    texts[lang].runtimeFeedbackBtn;
 
   if (pinWarnElem)
     pinWarnElem.setAttribute("data-help", texts[lang].pinWarningHelp);


### PR DESCRIPTION
## Summary
- add an icon to the runtime feedback submission button so it matches other action buttons
- use the shared helper to apply the icon and localized label when updating the UI

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cd995b701883208d5a449a1b9c30ed