### PR TITLE
Add pink mode toggle to settings dialog

### DIFF
--- a/index.html
+++ b/index.html
@@ -713,6 +713,10 @@
           <input type="checkbox" id="settingsDarkMode" />
         </div>
         <div class="form-row">
+          <label for="settingsPinkMode" id="settingsPinkModeLabel">Pink mode</label>
+          <input type="checkbox" id="settingsPinkMode" />
+        </div>
+        <div class="form-row">
           <label for="accentColorInput" id="accentColorLabel">Accent color</label>
           <input type="color" id="accentColorInput" value="#001589" />
         </div>

--- a/script.js
+++ b/script.js
@@ -2373,6 +2373,17 @@ function setLanguage(lang) {
       settingsDarkMode.setAttribute("aria-label", texts[lang].darkModeSetting);
     }
   }
+  const settingsPinkLabel = document.getElementById("settingsPinkModeLabel");
+  if (settingsPinkLabel) {
+    settingsPinkLabel.textContent = texts[lang].pinkModeSetting;
+    const pinkModeHelp =
+      texts[lang].settingsPinkModeHelp || texts[lang].pinkModeSetting;
+    settingsPinkLabel.setAttribute("data-help", pinkModeHelp);
+    if (settingsPinkMode) {
+      settingsPinkMode.setAttribute("data-help", pinkModeHelp);
+      settingsPinkMode.setAttribute("aria-label", texts[lang].pinkModeSetting);
+    }
+  }
   const accentLabel = document.getElementById("accentColorLabel");
   if (accentLabel) {
     accentLabel.textContent = texts[lang].accentColorSetting;
@@ -4264,6 +4275,7 @@ const settingsButton  = document.getElementById("settingsButton");
 const settingsDialog  = document.getElementById("settingsDialog");
 const settingsLanguage = document.getElementById("settingsLanguage");
 const settingsDarkMode = document.getElementById("settingsDarkMode");
+const settingsPinkMode = document.getElementById("settingsPinkMode");
 const accentColorInput = document.getElementById("accentColorInput");
 const settingsFontSize = document.getElementById("settingsFontSize");
 const settingsFontFamily = document.getElementById("settingsFontFamily");
@@ -15260,6 +15272,9 @@ function applyPinkMode(enabled) {
       pinkModeToggle.setAttribute("aria-pressed", "false");
     }
   }
+  if (settingsPinkMode) {
+    settingsPinkMode.checked = enabled;
+  }
 }
 
 let pinkModeEnabled = false;
@@ -15287,6 +15302,7 @@ if (settingsButton && settingsDialog) {
     prevAccentColor = accentColor;
     if (settingsLanguage) settingsLanguage.value = currentLang;
     if (settingsDarkMode) settingsDarkMode.checked = document.body.classList.contains('dark-mode');
+    if (settingsPinkMode) settingsPinkMode.checked = document.body.classList.contains('pink-mode');
     if (settingsHighContrast) settingsHighContrast.checked = document.body.classList.contains('high-contrast');
     if (settingsShowAutoBackups) settingsShowAutoBackups.checked = showAutoBackups;
     if (accentColorInput) {
@@ -15335,6 +15351,15 @@ if (settingsButton && settingsDialog) {
           localStorage.setItem('darkMode', enabled);
         } catch (e) {
           console.warn('Could not save dark mode preference', e);
+        }
+      }
+      if (settingsPinkMode) {
+        const enabled = settingsPinkMode.checked;
+        applyPinkMode(enabled);
+        try {
+          localStorage.setItem('pinkMode', enabled);
+        } catch (e) {
+          console.warn('Could not save pink mode preference', e);
         }
       }
       if (settingsHighContrast) {

--- a/tests/script/settings-theme.test.js
+++ b/tests/script/settings-theme.test.js
@@ -35,4 +35,31 @@ describe('settings dialog theme interactions', () => {
     expect(document.body.style.getPropertyValue('--accent-color')).toBe('');
     expect(document.body.style.getPropertyValue('--link-color')).toBe('');
   });
+
+  test('pink mode can be toggled from settings dialog', () => {
+    localStorage.setItem('pinkMode', 'false');
+
+    const { cleanup: clean } = setupScriptEnvironment();
+    cleanup = clean;
+
+    expect(document.body.classList.contains('pink-mode')).toBe(false);
+
+    const settingsButton = document.getElementById('settingsButton');
+    const settingsSave = document.getElementById('settingsSave');
+    const settingsPinkMode = document.getElementById('settingsPinkMode');
+
+    expect(settingsButton).toBeTruthy();
+    expect(settingsSave).toBeTruthy();
+    expect(settingsPinkMode).toBeTruthy();
+
+    settingsButton.click();
+
+    expect(settingsPinkMode.checked).toBe(false);
+
+    settingsPinkMode.checked = true;
+    settingsSave.click();
+
+    expect(document.body.classList.contains('pink-mode')).toBe(true);
+    expect(localStorage.getItem('pinkMode')).toBe('true');
+  });
 });

--- a/translations.js
+++ b/translations.js
@@ -90,6 +90,9 @@ const texts = {
     darkModeSetting: "Dark mode",
     settingsDarkModeHelp:
       "Toggle dark mode from Settings while previewing the result instantly.",
+    pinkModeSetting: "Pink mode",
+    settingsPinkModeHelp:
+      "Enable the playful pink accent theme from Settings.",
     accentColorSetting: "Accent color",
     accentColorHelp:
       "Pick the accent color used for buttons, highlights and diagrams. The choice is saved with your settings.",
@@ -1156,6 +1159,9 @@ const texts = {
     darkModeSetting: "Modalità scura",
     settingsDarkModeHelp:
       "Attiva o disattiva il tema scuro dalle Impostazioni visualizzando subito il risultato.",
+    pinkModeSetting: "Modalità rosa",
+    settingsPinkModeHelp:
+      "Attiva il tema rosa giocoso dalle Impostazioni.",
     accentColorSetting: "Colore evidenza",
     accentColorHelp:
       "Seleziona il colore d'accento per pulsanti, evidenziazioni e diagramma. La scelta viene salvata.",
@@ -1841,6 +1847,9 @@ const texts = {
     darkModeSetting: "Modo oscuro",
     settingsDarkModeHelp:
       "Activa o desactiva el modo oscuro desde Ajustes viendo el resultado al momento.",
+    pinkModeSetting: "Modo rosa",
+    settingsPinkModeHelp:
+      "Activa el tema rosa divertido desde Ajustes.",
     accentColorSetting: "Color de acento",
     accentColorHelp:
       "Selecciona el color de acento usado en botones, destacados y diagramas. Se guarda con tus ajustes.",
@@ -2528,6 +2537,9 @@ const texts = {
     darkModeSetting: "Mode sombre",
     settingsDarkModeHelp:
       "Activez ou désactivez le mode sombre depuis Paramètres et voyez le résultat immédiatement.",
+    pinkModeSetting: "Mode rose",
+    settingsPinkModeHelp:
+      "Activez le thème rose ludique depuis Paramètres.",
     accentColorSetting: "Couleur d’accent",
     accentColorHelp:
       "Sélectionnez la couleur d’accent utilisée pour les boutons, les surlignages et le diagramme. Elle est enregistrée.",
@@ -3218,6 +3230,9 @@ const texts = {
     darkModeSetting: "Dunkelmodus",
     settingsDarkModeHelp:
       "Schalte den Dark Mode in den Einstellungen ein oder aus und sieh das Ergebnis sofort.",
+    pinkModeSetting: "Pinkmodus",
+    settingsPinkModeHelp:
+      "Aktiviere das verspielte Pink-Theme in den Einstellungen.",
     accentColorSetting: "Akzentfarbe",
     accentColorHelp:
       "Wähle die Akzentfarbe für Buttons, Hervorhebungen und Diagramm. Die Auswahl wird gespeichert.",


### PR DESCRIPTION
## Summary
- add a Pink mode checkbox to the Settings dialog alongside the existing dark mode toggle
- wire the new control into theme handling logic and localize its label/help across supported languages
- extend the theme settings Jest suite to verify pink mode can be saved via the dialog

## Testing
- npm run lint
- npm run test:script

------
https://chatgpt.com/codex/tasks/task_e_68cd983f851483209be228c8548ea3bb