### PR TITLE
Add magnet icon to grid snap toggle

### DIFF
--- a/script.js
+++ b/script.js
@@ -2801,7 +2801,7 @@ function setLanguage(lang) {
     downloadDiagramBtn.setAttribute("data-help", texts[lang].downloadDiagramHelp);
   }
   if (gridSnapToggleBtn) {
-    gridSnapToggleBtn.textContent = texts[lang].gridSnapToggle;
+    setButtonLabelWithIcon(gridSnapToggleBtn, texts[lang].gridSnapToggle, ICON_GLYPHS.magnet);
     gridSnapToggleBtn.setAttribute("title", texts[lang].gridSnapToggle);
     gridSnapToggleBtn.setAttribute("aria-label", texts[lang].gridSnapToggle);
     gridSnapToggleBtn.setAttribute("data-help", texts[lang].gridSnapToggleHelp);
@@ -3075,6 +3075,7 @@ const ICON_GLYPHS = Object.freeze({
   load: '\uE7B3',
   save: '\uE825',
   share: '\uF045',
+  magnet: '\uEB9E',
   timecode: '\uF1CD',
   audioIn: '\uEC2E',
   audioOut: '\uF44C',


### PR DESCRIPTION
## Summary
- render the snap-to-grid toggle with a reusable magnet icon glyph
- update icon constants to include the new magnet glyph

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cd99cb9cbc83209e2ed00e2ed316e0