### PR TITLE
Ensure settings checkboxes remain square

### DIFF
--- a/style.css
+++ b/style.css
@@ -1655,6 +1655,7 @@ input[type="checkbox"] {
   width: 1.1em;
   height: 1.1em;
   min-width: 1.1em;
+  max-width: 1.1em;
   padding: 0;
   display: inline-grid;
   place-items: center;


### PR DESCRIPTION
## Summary
- limit the checkbox control width so settings toggles retain square dimensions

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cda800df7c8320ac7f5d0c74207b1b