### PR TITLE
Remove white background bubble from help quick links

### DIFF
--- a/style.css
+++ b/style.css
@@ -1326,25 +1326,12 @@ main.legal-content {
 
 .help-quick-link-icon {
   --icon-color: var(--accent-color);
-  flex: 0 0 1.75em;
-  width: 1.75em;
-  height: 1.75em;
-  border-radius: 999px;
-  background-color: var(--panel-bg);
-  border: 1px solid var(--panel-border);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4);
-}
-
-.dark-mode .help-quick-link-icon,
-html.dark-mode .help-quick-link-icon {
-  box-shadow: inset 0 1px 0 rgba(0, 0, 0, 0.4);
+  flex: 0 0 auto;
+  font-size: 1.1em;
 }
 
 .help-quick-link.active .help-quick-link-icon {
-  background-color: transparent;
-  border-color: transparent;
   --icon-color: var(--inverse-text-color);
-  box-shadow: none;
 }
 
 .help-quick-link-label {


### PR DESCRIPTION
## Summary
- remove the white background circle from help quick link icons so only the glyph remains
- retain the active-state color swap for readability

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cda944966883209daf9e8d771c6d53