### PR TITLE
Adjust auto gear rule title styling for accent theming

### DIFF
--- a/style.css
+++ b/style.css
@@ -1083,8 +1083,18 @@ main.legal-content {
 }
 
 .auto-gear-rule-title {
-  font-weight: 600;
+  font-weight: 500;
   margin: 0;
+}
+
+body.light-mode .auto-gear-rule-title,
+#overviewDialogContent:not(.dark-mode) .auto-gear-rule-title {
+  color: var(--accent-color);
+}
+
+body.pink-mode .auto-gear-rule-title,
+#overviewDialogContent.pink-mode .auto-gear-rule-title {
+  color: var(--accent-color);
 }
 
 .auto-gear-rule-meta {


### PR DESCRIPTION
## Summary
- lighten the weight of automatic gear rule titles for a softer presentation
- apply accent color to rule names in bright mode and all pink mode variants, including overview dialogs

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cdaeed94bc8320b3d1826b97b43333