### PR TITLE
Fix help quick link icon spacing artifact

### DIFF
--- a/style.css
+++ b/style.css
@@ -1342,6 +1342,9 @@ body.pink-mode .auto-gear-rule-title,
   align-items: center;
   justify-content: flex-start;
   gap: 0.5em;
+  background: none;
+  border: none;
+  color: inherit;
   width: 100%;
   margin: 0;
   padding: 0 10px;


### PR DESCRIPTION
## Summary
- remove the default button styling from help quick links so the area between the icon and label no longer shows a striped rectangle

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cdb31e41648320a75dc68c59ba6b61