### PR TITLE
Adjust file input font sizing

### DIFF
--- a/style.css
+++ b/style.css
@@ -1633,7 +1633,9 @@ select {
 input[type="file"] {
   padding: 2px 4px;
   height: auto;
-  min-height: calc(var(--button-size) + 8px);
+  min-height: var(--button-size);
+  font-size: 0.85em;
+  line-height: 1.2;
 }
 
 .file-input-wrapper {
@@ -1925,7 +1927,7 @@ input[type="file"]::-webkit-file-upload-button {
   padding: 0 8px;
   margin-right: 5px;
   cursor: pointer;
-  font-size: 0.85em;
+  font-size: 0.8em;
   height: 100%;
   min-height: var(--button-size);
   display: inline-flex;


### PR DESCRIPTION
## Summary
- decrease the font size of file inputs and their selector buttons so the controls stay within the global button height
- align the minimum height of file inputs with the shared button size for consistent sizing

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cdb3828f4c8320bbc3dd458c50a13f