### PR TITLE
Auto-save pink mode settings when toggled

### DIFF
--- a/script.js
+++ b/script.js
@@ -16481,7 +16481,13 @@ function applyPinkMode(enabled) {
   }
 }
 
+function isPinkModeActive() {
+  return !!(document.body && document.body.classList.contains('pink-mode'));
+}
+
 let pinkModeEnabled = false;
+
+let settingsInitialPinkMode = isPinkModeActive();
 
 function persistPinkModePreference(enabled) {
   pinkModeEnabled = !!enabled;
@@ -16493,12 +16499,23 @@ function persistPinkModePreference(enabled) {
   }
 }
 
+function rememberSettingsPinkModeBaseline() {
+  settingsInitialPinkMode = isPinkModeActive();
+}
+
+function revertSettingsPinkModeIfNeeded() {
+  if (isPinkModeActive() !== settingsInitialPinkMode) {
+    persistPinkModePreference(settingsInitialPinkMode);
+  }
+}
+
 try {
   pinkModeEnabled = localStorage.getItem('pinkMode') === 'true';
 } catch (e) {
   console.warn('Could not load pink mode preference', e);
 }
 applyPinkMode(pinkModeEnabled);
+rememberSettingsPinkModeBaseline();
 
 if (pinkModeToggle) {
   pinkModeToggle.addEventListener("click", () => {
@@ -16515,6 +16532,7 @@ if (settingsPinkMode) {
 if (settingsButton && settingsDialog) {
   settingsButton.addEventListener('click', () => {
     prevAccentColor = accentColor;
+    rememberSettingsPinkModeBaseline();
     if (settingsLanguage) settingsLanguage.value = currentLang;
     if (settingsDarkMode) settingsDarkMode.checked = document.body.classList.contains('dark-mode');
     if (settingsPinkMode) settingsPinkMode.checked = document.body.classList.contains('pink-mode');
@@ -16546,6 +16564,8 @@ if (settingsButton && settingsDialog) {
 
   if (settingsCancel) {
     settingsCancel.addEventListener('click', () => {
+      revertSettingsPinkModeIfNeeded();
+      rememberSettingsPinkModeBaseline();
       revertAccentColor();
       if (settingsLogo) settingsLogo.value = '';
       if (settingsLogoPreview) loadStoredLogoPreview();
@@ -16656,12 +16676,15 @@ if (settingsButton && settingsDialog) {
         }
       }
       closeAutoGearEditor();
+      rememberSettingsPinkModeBaseline();
       settingsDialog.setAttribute('hidden', '');
     });
   }
 
   settingsDialog.addEventListener('click', e => {
     if (e.target === settingsDialog) {
+      revertSettingsPinkModeIfNeeded();
+      rememberSettingsPinkModeBaseline();
       revertAccentColor();
       if (settingsLogo) settingsLogo.value = '';
       if (settingsLogoPreview) loadStoredLogoPreview();
@@ -18111,6 +18134,8 @@ if (helpButton && helpDialog) {
     } else if (
       e.key === 'Escape' && settingsDialog && !settingsDialog.hasAttribute('hidden')
     ) {
+      revertSettingsPinkModeIfNeeded();
+      rememberSettingsPinkModeBaseline();
       revertAccentColor();
       settingsDialog.setAttribute('hidden', '');
     } else if (

--- a/script.js
+++ b/script.js
@@ -16482,22 +16482,33 @@ function applyPinkMode(enabled) {
 }
 
 let pinkModeEnabled = false;
+
+function persistPinkModePreference(enabled) {
+  pinkModeEnabled = !!enabled;
+  applyPinkMode(pinkModeEnabled);
+  try {
+    localStorage.setItem('pinkMode', pinkModeEnabled);
+  } catch (e) {
+    console.warn('Could not save pink mode preference', e);
+  }
+}
+
 try {
-  pinkModeEnabled = localStorage.getItem("pinkMode") === "true";
+  pinkModeEnabled = localStorage.getItem('pinkMode') === 'true';
 } catch (e) {
-  console.warn("Could not load pink mode preference", e);
+  console.warn('Could not load pink mode preference', e);
 }
 applyPinkMode(pinkModeEnabled);
 
 if (pinkModeToggle) {
   pinkModeToggle.addEventListener("click", () => {
-    pinkModeEnabled = !document.body.classList.contains("pink-mode");
-    applyPinkMode(pinkModeEnabled);
-    try {
-      localStorage.setItem("pinkMode", pinkModeEnabled);
-    } catch (e) {
-      console.warn("Could not save pink mode preference", e);
-    }
+    persistPinkModePreference(!document.body.classList.contains('pink-mode'));
+  });
+}
+
+if (settingsPinkMode) {
+  settingsPinkMode.addEventListener('change', () => {
+    persistPinkModePreference(settingsPinkMode.checked);
   });
 }
 
@@ -16558,13 +16569,7 @@ if (settingsButton && settingsDialog) {
         }
       }
       if (settingsPinkMode) {
-        const enabled = settingsPinkMode.checked;
-        applyPinkMode(enabled);
-        try {
-          localStorage.setItem('pinkMode', enabled);
-        } catch (e) {
-          console.warn('Could not save pink mode preference', e);
-        }
+        persistPinkModePreference(settingsPinkMode.checked);
       }
       if (settingsHighContrast) {
         const enabled = settingsHighContrast.checked;
@@ -18153,13 +18158,7 @@ if (helpButton && helpDialog) {
         saveSetupBtn.click();
       }
     } else if (e.key.toLowerCase() === 'p' && !isTextField) {
-      pinkModeEnabled = !document.body.classList.contains('pink-mode');
-      applyPinkMode(pinkModeEnabled);
-      try {
-        localStorage.setItem('pinkMode', pinkModeEnabled);
-      } catch (err) {
-        console.warn('Could not save pink mode preference', err);
-      }
+      persistPinkModePreference(!document.body.classList.contains('pink-mode'));
     }
   });
 

--- a/tests/script/settings-theme.test.js
+++ b/tests/script/settings-theme.test.js
@@ -62,4 +62,33 @@ describe('settings dialog theme interactions', () => {
     expect(document.body.classList.contains('pink-mode')).toBe(true);
     expect(localStorage.getItem('pinkMode')).toBe('true');
   });
+
+  test('pink mode toggles auto-save from settings dialog', () => {
+    localStorage.setItem('pinkMode', 'false');
+
+    const { cleanup: clean } = setupScriptEnvironment();
+    cleanup = clean;
+
+    const settingsButton = document.getElementById('settingsButton');
+    const settingsPinkMode = document.getElementById('settingsPinkMode');
+
+    expect(settingsButton).toBeTruthy();
+    expect(settingsPinkMode).toBeTruthy();
+
+    settingsButton.click();
+
+    expect(settingsPinkMode.checked).toBe(false);
+
+    settingsPinkMode.checked = true;
+    settingsPinkMode.dispatchEvent(new Event('change', { bubbles: true }));
+
+    expect(document.body.classList.contains('pink-mode')).toBe(true);
+    expect(localStorage.getItem('pinkMode')).toBe('true');
+
+    settingsPinkMode.checked = false;
+    settingsPinkMode.dispatchEvent(new Event('change', { bubbles: true }));
+
+    expect(document.body.classList.contains('pink-mode')).toBe(false);
+    expect(localStorage.getItem('pinkMode')).toBe('false');
+  });
 });

--- a/tests/script/settings-theme.test.js
+++ b/tests/script/settings-theme.test.js
@@ -91,4 +91,60 @@ describe('settings dialog theme interactions', () => {
     expect(document.body.classList.contains('pink-mode')).toBe(false);
     expect(localStorage.getItem('pinkMode')).toBe('false');
   });
+
+  test('pink mode auto-save can be reverted by cancelling settings', () => {
+    localStorage.setItem('pinkMode', 'false');
+
+    const { cleanup: clean } = setupScriptEnvironment();
+    cleanup = clean;
+
+    const settingsButton = document.getElementById('settingsButton');
+    const settingsPinkMode = document.getElementById('settingsPinkMode');
+    const settingsCancel = document.getElementById('settingsCancel');
+
+    expect(settingsButton).toBeTruthy();
+    expect(settingsPinkMode).toBeTruthy();
+    expect(settingsCancel).toBeTruthy();
+
+    settingsButton.click();
+
+    expect(settingsPinkMode.checked).toBe(false);
+
+    settingsPinkMode.checked = true;
+    settingsPinkMode.dispatchEvent(new Event('change', { bubbles: true }));
+
+    expect(document.body.classList.contains('pink-mode')).toBe(true);
+    expect(localStorage.getItem('pinkMode')).toBe('true');
+
+    settingsCancel.click();
+
+    expect(document.body.classList.contains('pink-mode')).toBe(false);
+    expect(localStorage.getItem('pinkMode')).toBe('false');
+  });
+
+  test('pink mode auto-save can be reverted when closing with escape', () => {
+    localStorage.setItem('pinkMode', 'false');
+
+    const { cleanup: clean } = setupScriptEnvironment();
+    cleanup = clean;
+
+    const settingsButton = document.getElementById('settingsButton');
+    const settingsPinkMode = document.getElementById('settingsPinkMode');
+
+    expect(settingsButton).toBeTruthy();
+    expect(settingsPinkMode).toBeTruthy();
+
+    settingsButton.click();
+
+    settingsPinkMode.checked = true;
+    settingsPinkMode.dispatchEvent(new Event('change', { bubbles: true }));
+
+    expect(document.body.classList.contains('pink-mode')).toBe(true);
+    expect(localStorage.getItem('pinkMode')).toBe('true');
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+
+    expect(document.body.classList.contains('pink-mode')).toBe(false);
+    expect(localStorage.getItem('pinkMode')).toBe('false');
+  });
 });


### PR DESCRIPTION
## Summary
- centralize pink mode persistence so all toggles store the preference consistently
- automatically save the pink mode setting when the checkbox in the Settings dialog changes
- add regression coverage for the new auto-save behavior

## Testing
- npm run test:script

------
https://chatgpt.com/codex/tasks/task_e_68cdb4448a9883209da0c27d08b658a7