### PR TITLE
Adjust configure device label spacing

### DIFF
--- a/style.css
+++ b/style.css
@@ -433,6 +433,9 @@ main.legal-content {
   min-width: var(--form-label-min-width);
   font-weight: 300;
 }
+#setup-config .form-row label {
+  line-height: 1.3;
+}
 .form-row select,
 .form-row input {
   flex: 1;


### PR DESCRIPTION
## Summary
- increase the line height for Configure Devices form labels to improve readability when labels wrap

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cdb9453a54832089c7df066d64da3d