### PR TITLE
Increase base line spacing for readability

### DIFF
--- a/overview-print.css
+++ b/overview-print.css
@@ -25,6 +25,7 @@ body.dark-mode {
   font-family: 'Ubuntu', sans-serif;
   font-weight: 300;
   font-size: 12pt;
+  line-height: var(--line-height-base, 1.6);
   -webkit-print-color-adjust: exact;
   print-color-adjust: exact;
   background: var(--surface-color);
@@ -111,6 +112,7 @@ h1 {
 
 p {
   margin: 0.3em 0;
+  line-height: var(--line-height-base, 1.6);
 }
 
 #topBar,
@@ -229,7 +231,7 @@ body:not(.light-mode) .gear-table td {
   border-top: 1px solid var(--accent-color);
   border-bottom: 1px solid var(--accent-color);
   background: var(--panel-bg);
-  line-height: 1.4em;
+  line-height: var(--line-height-supporting, 1.5);
   break-inside: avoid;
   page-break-inside: avoid;
 }

--- a/overview.css
+++ b/overview.css
@@ -7,7 +7,7 @@ select:focus-visible {
   outline: none;
 }
 
-body { font-family: 'Ubuntu', sans-serif; font-weight: 300; margin: 25px; color: var(--control-text); font-size: 0.9em; -webkit-print-color-adjust: exact; print-color-adjust: exact; }
+body { font-family: 'Ubuntu', sans-serif; font-weight: 300; margin: 25px; color: var(--control-text); font-size: 0.9em; line-height: var(--line-height-base, 1.6); -webkit-print-color-adjust: exact; print-color-adjust: exact; }
 @media (max-width: 600px) {
   body { margin: 10px; }
   h2 { padding-bottom: 8px; }
@@ -16,7 +16,7 @@ h1, h2, h3 { font-family: 'Ubuntu', sans-serif; font-weight: 400; color: var(--a
 h1 { font-size: 1.8em; margin-bottom: 0.2em; }
 h2 { font-size: 1.4em; margin-top: 1.3em; border-bottom: 2px solid var(--accent-color); padding-bottom: 5px; }
 h3 { font-size: 1.1em; margin-top: 1em; }
-p { line-height: 1.4em; }
+p { line-height: var(--line-height-base, 1.6); }
 ul { list-style: none; margin: 5px 0; padding-left: 0; }
 li { margin: 3px 0; }
 table {
@@ -36,7 +36,7 @@ th { background-color: var(--control-bg); font-weight: 700; }
   border-top: 1px solid var(--accent-color);
   border-bottom: 1px solid var(--accent-color);
   background: var(--panel-bg);
-  line-height: 1.4em;
+  line-height: var(--line-height-supporting, 1.5);
   break-inside: avoid;
   page-break-inside: avoid;
 }

--- a/style.css
+++ b/style.css
@@ -49,6 +49,8 @@
   --offline-indicator-bg: #2f3437;
   --offline-indicator-text: #f5f7fa;
   --offline-indicator-border: rgba(245, 247, 250, 0.2);
+  --line-height-base: 1.6;
+  --line-height-supporting: 1.5;
   --status-error-bg: #fdd;
   --status-warning-bg: #ffd;
   --status-success-bg: #dfd;
@@ -109,6 +111,7 @@ body {
   background-color: var(--background-color);
   color: var(--text-color);
   font-size: 1em;
+  line-height: var(--line-height-base);
 }
 
 main {
@@ -273,7 +276,7 @@ h3 {
 
 /* Paragraph text */
 p {
-  line-height: 1.4em;
+  line-height: var(--line-height-base);
 }
 
 #tagline {
@@ -547,7 +550,7 @@ main.legal-content {
   margin: 0;
   font-size: 0.85em;
   color: var(--muted-text-color);
-  line-height: 1.4;
+  line-height: var(--line-height-supporting);
 }
 
 /* Keep controls aligned within Project Overview and Configure Devices */
@@ -1114,7 +1117,7 @@ body.pink-mode .auto-gear-rule-title,
 
 .auto-gear-rule-item {
   font-size: 0.9em;
-  line-height: 1.4;
+  line-height: var(--line-height-supporting);
   word-break: break-word;
 }
 
@@ -3135,7 +3138,7 @@ body.dark-mode.dark-accent-boost:not(.pink-mode) .help-content {
     margin-bottom: 4px;
   }
   #setup-config .form-row label {
-    line-height: 1.4;
+    line-height: var(--line-height-base);
   }
   .form-row select,
   .form-row input {
@@ -3444,7 +3447,7 @@ body.dark-mode.dark-accent-boost:not(.pink-mode) .help-content {
   border-top: 1px solid var(--accent-color);
   border-bottom: 1px solid var(--accent-color);
   background: var(--panel-bg);
-  line-height: 1.4em;
+  line-height: var(--line-height-supporting);
   break-inside: avoid;
   page-break-inside: avoid;
 }
@@ -3505,7 +3508,7 @@ body.dark-mode.dark-accent-boost:not(.pink-mode) .help-content {
   border-top: 1px solid var(--accent-color);
   border-bottom: 1px solid var(--accent-color);
   background: var(--panel-bg);
-  line-height: 1.4em;
+  line-height: var(--line-height-supporting);
   break-inside: avoid;
   page-break-inside: avoid;
 }


### PR DESCRIPTION
## Summary
- add shared variables for comfortable and supporting line heights and apply them to body text
- increase paragraph and helper text spacing across the app and mobile layouts
- update overview and print styles to use the new line-height defaults for consistent readability

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68cdb96a7a3c8320ac25693fa875adf5