### PR TITLE
Fix importing legacy project strings

### DIFF
--- a/storage.js
+++ b/storage.js
@@ -646,7 +646,8 @@ function createProjectImporter() {
   const defaultName = "Imported project";
 
   return (rawName, project, fallbackName = defaultName) => {
-    if (typeof project !== "string" && !isPlainObject(project)) return;
+    const normalizedProject = normalizeProject(project);
+    if (!normalizedProject) return;
 
     const candidates = [];
     if (typeof rawName === "string") {
@@ -669,13 +670,13 @@ function createProjectImporter() {
     if (candidates.includes("") && !normalizedNames.has("")) {
       usedNames.add("");
       normalizedNames.add("");
-      saveProject("", project);
+      saveProject("", normalizedProject);
       return;
     }
 
     const baseName = candidates.find((name) => name) || fallback;
     const uniqueName = generateUniqueName(baseName, usedNames, normalizedNames);
-    saveProject(uniqueName, project);
+    saveProject(uniqueName, normalizedProject);
   };
 }
 

--- a/tests/unit/storage.test.js
+++ b/tests/unit/storage.test.js
@@ -621,6 +621,18 @@ describe('export/import all data', () => {
     expect(unnamedEntry[1]).toEqual({ gearList: '<ul>Unnamed</ul>', projectInfo: null });
   });
 
+  test('importAllData handles legacy project string payload', () => {
+    const data = { project: '<section>Legacy</section>' };
+    importAllData(data);
+    expect(loadProject('')).toEqual({ gearList: '<section>Legacy</section>', projectInfo: null });
+  });
+
+  test('importAllData handles legacy project map entries stored as strings', () => {
+    const data = { project: { Legacy: '<div>Legacy</div>' } };
+    importAllData(data);
+    expect(loadProject('Legacy')).toEqual({ gearList: '<div>Legacy</div>', projectInfo: null });
+  });
+
   test('importAllData handles legacy single gearList', () => {
     const data = { gearList: '<p></p>' };
     importAllData(data);


### PR DESCRIPTION
## Summary
- normalize imported project payloads before saving so legacy string exports are preserved
- add unit coverage for legacy project strings in both direct and mapped imports

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cdb8e562548320b4346ec6fbd3b3da