### PR TITLE
Refactor typography scale into shared variables

### DIFF
--- a/fonts.css
+++ b/fonts.css
@@ -54,3 +54,36 @@
   font-display: swap;
   src: url('Ubuntu/Ubuntu-BoldItalic.ttf') format('truetype');
 }
+
+:root {
+  --font-family: 'Ubuntu', 'uicons-thin-straight', sans-serif;
+  --font-family-heading: 'Ubuntu', sans-serif;
+
+  --font-weight-light: 300;
+  --font-weight-regular: 400;
+  --font-weight-medium: 500;
+  --font-weight-semibold: 600;
+  --font-weight-bold: 700;
+
+  --font-size-2xs: 0.75em;
+  --font-size-xs: 0.8em;
+  --font-size-sm: 0.85em;
+  --font-size-md: 0.9em;
+  --font-size-base: 1em;
+  --font-size-root: 1rem;
+  --font-size-lg: 1.1em;
+  --font-size-xl: 1.2em;
+  --font-size-2xl: 1.4em;
+  --font-size-3xl: 1.5em;
+  --font-size-4xl: 1.8em;
+
+  --font-size-label: 0.95rem;
+  --font-size-label-sm: 0.85rem;
+  --font-size-meta: 0.9rem;
+  --font-size-tooltip: 0.8rem;
+  --font-size-print-base: 12pt;
+
+  --font-size-fixed-xs: 10px;
+  --font-size-fixed-sm: 12px;
+  --font-size-fixed-lg: 20px;
+}

--- a/overview-print.css
+++ b/overview-print.css
@@ -22,9 +22,9 @@ body.dark-mode {
   --power-color: #d33;
   --video-color: #369;
   --fiz-color: #090;
-  font-family: 'Ubuntu', sans-serif;
-  font-weight: 300;
-  font-size: 12pt;
+  font-family: var(--font-family-heading);
+  font-weight: var(--font-weight-light);
+  font-size: var(--font-size-print-base);
   -webkit-print-color-adjust: exact;
   print-color-adjust: exact;
   background: var(--surface-color);
@@ -54,7 +54,7 @@ body.dark-mode {
 }
 #overviewDialogContent #setupDiagram text {
   fill: var(--text-color);
-  font-family: 'Ubuntu', sans-serif;
+  font-family: var(--font-family-heading);
 }
 #overviewDialogContent #setupDiagram line,
 #overviewDialogContent #setupDiagram path.edge-path {
@@ -85,8 +85,8 @@ body.dark-mode {
 #overviewDialogContent h1,
 #overviewDialogContent h2,
 #overviewDialogContent h3 {
-  font-family: 'Ubuntu', sans-serif;
-  font-weight: 400;
+  font-family: var(--font-family-heading);
+  font-weight: var(--font-weight-regular);
   border-color: var(--text-color) !important;
   color: var(--text-color) !important;
 }
@@ -206,7 +206,7 @@ table, th, td {
 }
 #overviewDialogContent th {
   background-color: var(--control-bg) !important;
-  font-weight: 700;
+  font-weight: var(--font-weight-bold);
 }
 #overviewDialogContent tr {
   background-color: var(--surface-color) !important;
@@ -265,7 +265,7 @@ body:not(.light-mode) .gear-table tbody {
 body:not(.light-mode) .gear-table .category-row td {
   border-top: 1px solid var(--accent-color);
   border-bottom: 1px solid var(--accent-color);
-  font-weight: 700;
+  font-weight: var(--font-weight-bold);
   color: var(--accent-color);
   break-after: avoid;
   page-break-after: avoid;
@@ -327,7 +327,7 @@ body:not(.light-mode) .gear-table .category-row td {
 }
 
 .warning {
-  font-weight: bold;
+  font-weight: var(--font-weight-bold);
 }
 
 #overviewDialogContent .device-category {

--- a/overview.css
+++ b/overview.css
@@ -7,15 +7,15 @@ select:focus-visible {
   outline: none;
 }
 
-body { font-family: 'Ubuntu', sans-serif; font-weight: 300; margin: 25px; color: var(--control-text); font-size: 0.9em; -webkit-print-color-adjust: exact; print-color-adjust: exact; }
+body { font-family: var(--font-family-heading); font-weight: var(--font-weight-light); margin: 25px; color: var(--control-text); font-size: var(--font-size-md); -webkit-print-color-adjust: exact; print-color-adjust: exact; }
 @media (max-width: 600px) {
   body { margin: 10px; }
   h2 { padding-bottom: 8px; }
 }
-h1, h2, h3 { font-family: 'Ubuntu', sans-serif; font-weight: 400; color: var(--accent-color); }
-h1 { font-size: 1.8em; margin-bottom: 0.2em; }
-h2 { font-size: 1.4em; margin-top: 1.3em; border-bottom: 2px solid var(--accent-color); padding-bottom: 5px; }
-h3 { font-size: 1.1em; margin-top: 1em; }
+h1, h2, h3 { font-family: var(--font-family-heading); font-weight: var(--font-weight-regular); color: var(--accent-color); }
+h1 { font-size: var(--font-size-4xl); margin-bottom: 0.2em; }
+h2 { font-size: var(--font-size-2xl); margin-top: 1.3em; border-bottom: 2px solid var(--accent-color); padding-bottom: 5px; }
+h3 { font-size: var(--font-size-lg); margin-top: 1em; }
 p { line-height: 1.4em; }
 ul { list-style: none; margin: 5px 0; padding-left: 0; }
 li { margin: 3px 0; }
@@ -25,9 +25,9 @@ table {
   margin-top: 5px;
   table-layout: fixed;
 }
-th, td { border: 1px solid var(--panel-border); padding: 8px; text-align: left; font-size: 0.9em; overflow: hidden; }
-th { background-color: var(--control-bg); font-weight: 700; }
-.warning { color: var(--danger-color); font-weight: bold; margin-top: 10px; }
+th, td { border: 1px solid var(--panel-border); padding: 8px; text-align: left; font-size: var(--font-size-md); overflow: hidden; }
+th { background-color: var(--control-bg); font-weight: var(--font-weight-bold); }
+.warning { color: var(--danger-color); font-weight: var(--font-weight-bold); margin-top: 10px; }
 
 .gear-table td {
   padding: 4px 0;
@@ -49,7 +49,7 @@ th { background-color: var(--control-bg); font-weight: 700; }
 .gear-table .category-row td {
   border-top: 1px solid var(--accent-color);
   border-bottom: 1px solid var(--accent-color);
-  font-weight: bold;
+  font-weight: var(--font-weight-bold);
   color: var(--accent-color);
   break-after: avoid;
   page-break-after: avoid;
@@ -57,7 +57,7 @@ th { background-color: var(--control-bg); font-weight: 700; }
 .print-btn,
 .back-btn {
   padding: 5px 10px;
-  font-size: 0.85em;
+  font-size: var(--font-size-sm);
   cursor: pointer;
   border-radius: var(--border-radius);
   border: none;
@@ -93,7 +93,7 @@ th { background-color: var(--control-bg); font-weight: 700; }
   border-radius: 6px;
   padding: 6px 10px;
   box-shadow: var(--panel-shadow);
-  font-size: 12px;
+  font-size: var(--font-size-fixed-sm);
 }
 .device-block strong { display: block; margin-bottom: 4px; }
 .device-category-container { display: flex; flex-wrap: wrap; gap: 10px; }
@@ -108,8 +108,8 @@ th { background-color: var(--control-bg); font-weight: 700; }
   box-shadow: var(--panel-shadow);
 }
 .device-category h3 {
-  font-family: 'Ubuntu', sans-serif;
-  font-weight: 400;
+  font-family: var(--font-family-heading);
+  font-weight: var(--font-weight-regular);
   margin-top: 0;
   margin-bottom: 5px;
   border-bottom: 1px solid var(--divider-color);
@@ -138,7 +138,7 @@ th { background-color: var(--control-bg); font-weight: 700; }
 }
 .category-icon { margin-right: 4px; }
 .connector-summary { margin-top: 5px; display: flex; flex-wrap: wrap; gap: 4px; }
-.connector-block { padding: 2px 4px; border-radius: 4px; margin: 2px 2px 0 0; font-size: 0.85em; }
+.connector-block { padding: 2px 4px; border-radius: 4px; margin: 2px 2px 0 0; font-size: var(--font-size-sm); }
 .info-box { margin-top: 5px; padding: 6px 10px; border-radius: 4px; }
 .power-conn { background-color: var(--power-conn-bg); }
 .fiz-conn { background-color: var(--fiz-conn-bg); }
@@ -175,7 +175,7 @@ th { background-color: var(--control-bg); font-weight: 700; }
   body { background-color: var(--background-color); color: var(--text-color); }
   h1, h2, h3 { color: var(--inverse-text-color); }
   h2 { border-bottom: 2px solid var(--inverse-text-color); }
-  th { background-color: var(--control-bg); font-weight: 700; }
+  th { background-color: var(--control-bg); font-weight: var(--font-weight-bold); }
   .print-btn, .back-btn { background: var(--control-bg); color: var(--text-color); }
   .device-category { background: var(--panel-bg); border-color: var(--panel-border); box-shadow: var(--panel-shadow); }
   .device-category h3 { border-bottom: 1px solid var(--inverse-text-color); color: var(--inverse-text-color); }

--- a/script.js
+++ b/script.js
@@ -7973,13 +7973,13 @@ const diagramCssLight = `
 .node-box{fill:#f0f0f0;stroke:none;}
 .node-box.first-fiz{stroke:none;}
 .first-fiz-highlight{stroke:url(#firstFizGrad);stroke-width:1px;fill:none;}
-.node-icon{font-size:20px;font-family:'uicons-thin-straight',system-ui,sans-serif;font-style:normal;}
+.node-icon{font-size:var(--font-size-fixed-lg);font-family:'uicons-thin-straight',system-ui,sans-serif;font-style:normal;}
 .conn{stroke:none;}
 .conn.red{fill:#d33;}
 .conn.blue{fill:#369;}
 .conn.green{fill:#090;}
 text{font-family:system-ui,sans-serif;}
-.edge-label{font-size:10px;}
+.edge-label{font-size:var(--font-size-fixed-xs);}
 line{stroke:#333;stroke-width:2px;}
 path.edge-path{stroke:#333;stroke-width:2px;fill:none;}
 path.power{stroke:#d33;}
@@ -7991,7 +7991,7 @@ const diagramCssDark = `
 .node-box{fill:#444;stroke:none;}
 .node-box.first-fiz{stroke:none;}
 .first-fiz-highlight{stroke:url(#firstFizGrad);}
-.node-icon{font-size:20px;font-family:'uicons-thin-straight',system-ui,sans-serif;font-style:normal;}
+.node-icon{font-size:var(--font-size-fixed-lg);font-family:'uicons-thin-straight',system-ui,sans-serif;font-style:normal;}
 text{fill:#fff;font-family:system-ui,sans-serif;}
 line{stroke:#fff;}
 path.edge-path{stroke:#fff;}
@@ -11317,11 +11317,11 @@ function renderSetupDiagram() {
 
     if (icon) {
       svg += `<text class="node-icon" x="${p.x}" y="${p.y - 10}" text-anchor="middle" dominant-baseline="middle">${icon}</text>`;
-      svg += `<text x="${p.x}" y="${p.y + 14}" text-anchor="middle" font-size="10">`;
+      svg += `<text x="${p.x}" y="${p.y + 14}" text-anchor="middle" font-size="var(--font-size-fixed-xs)">`;
       lines.forEach((line, i) => { svg += `<tspan x="${p.x}" dy="${i === 0 ? 0 : 12}">${escapeHtml(line)}</tspan>`; });
       svg += `</text>`;
     } else {
-      svg += `<text x="${p.x}" y="${p.y}" text-anchor="middle" dominant-baseline="middle" font-size="12">`;
+      svg += `<text x="${p.x}" y="${p.y}" text-anchor="middle" dominant-baseline="middle" font-size="var(--font-size-fixed-sm)">`;
       lines.forEach((line, i) => { svg += `<tspan x="${p.x}" dy="${i === 0 ? 0 : 12}">${escapeHtml(line)}</tspan>`; });
       svg += `</text>`;
     }

--- a/style.css
+++ b/style.css
@@ -104,11 +104,11 @@ body {
 
 body {
   font-family: var(--font-family);
-  font-weight: 300;
+  font-weight: var(--font-weight-light);
   margin: 0;
   background-color: var(--background-color);
   color: var(--text-color);
-  font-size: 1em;
+  font-size: var(--font-size-base);
 }
 
 main {
@@ -166,8 +166,8 @@ textarea {
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.18);
   letter-spacing: 0.03em;
   text-transform: uppercase;
-  font-size: 0.85rem;
-  font-weight: 500;
+  font-size: var(--font-size-label-sm);
+  font-weight: var(--font-weight-medium);
 }
 
 #installPromptBanner {
@@ -243,7 +243,7 @@ textarea:focus-visible {
 #dtapWarning,
 #compatWarning {
   color: var(--danger-color);
-  font-weight: bold;
+  font-weight: var(--font-weight-bold);
 }
 
 #exportOutput {
@@ -254,20 +254,20 @@ textarea:focus-visible {
 }
 h1, h2, h3 {
   font-family: var(--font-family);
-  font-weight: 400;
+  font-weight: var(--font-weight-regular);
   color: var(--accent-color);
 }
 h1 {
-  font-size: 1.8em;
+  font-size: var(--font-size-4xl);
   margin-bottom: 0.2em;
 }
 h2 {
-  font-size: 1.4em;
+  font-size: var(--font-size-2xl);
   margin-top: 1.3em;
   border-bottom: 2px solid var(--accent-color);
 }
 h3 {
-  font-size: 1.1em;
+  font-size: var(--font-size-lg);
   margin-top: 1em;
 }
 
@@ -283,7 +283,7 @@ p {
 
 a {
   color: var(--link-color);
-  font-weight: 400;
+  font-weight: var(--font-weight-regular);
   text-decoration: none;
 }
 
@@ -313,7 +313,7 @@ body.dark-mode a:visited,
 footer {
   text-align: center;
   padding: 20px 0;
-  font-size: 0.9em;
+  font-size: var(--font-size-md);
 }
 
 footer a {
@@ -361,7 +361,7 @@ main.legal-content {
 }
 
 .legal-language-nav a[aria-current="page"] {
-  font-weight: 600;
+  font-weight: var(--font-weight-semibold);
 }
 
 .legal-content h1 {
@@ -402,7 +402,7 @@ main.legal-content {
   border-radius: var(--border-radius);
   background-color: var(--control-bg);
   color: var(--control-text);
-  font-size: 0.85em;
+  font-size: var(--font-size-sm);
   text-decoration: none;
   transition: background-color 0.2s, color 0.2s, transform 0.2s;
 }
@@ -431,7 +431,7 @@ main.legal-content {
 .form-row label {
   flex: 0 0 var(--form-label-width);
   min-width: var(--form-label-min-width);
-  font-weight: 300;
+  font-weight: var(--font-weight-light);
 }
 .form-row select,
 .form-row input {
@@ -539,13 +539,13 @@ main.legal-content {
 }
 
 .schema-field-suffix {
-  font-size: 0.9em;
+  font-size: var(--font-size-md);
   color: var(--muted-text-color);
 }
 
 .schema-field-help {
   margin: 0;
-  font-size: 0.85em;
+  font-size: var(--font-size-sm);
   color: var(--muted-text-color);
   line-height: 1.4;
 }
@@ -592,7 +592,7 @@ main.legal-content {
   display: inline-flex;
   align-items: center;
   gap: 0.5rem;
-  font-size: 0.95rem;
+  font-size: var(--font-size-label);
   margin: 0;
 }
 
@@ -616,8 +616,8 @@ main.legal-content {
 }
 
 #setup-manager .share-import-options legend {
-  font-weight: 600;
-  font-size: 0.95rem;
+  font-weight: var(--font-weight-semibold);
+  font-size: var(--font-size-label);
   margin-bottom: 0.25rem;
 }
 
@@ -726,7 +726,7 @@ main.legal-content {
   flex-basis: 100%;
   margin: 0;
   margin-left: calc(var(--form-label-width) + var(--gap-size));
-  font-size: 0.75em;
+  font-size: var(--font-size-2xs);
   color: var(--control-text);
   opacity: 0.8;
 }
@@ -782,7 +782,7 @@ main.legal-content {
 }
 .field-with-label::before {
   content: attr(data-label);
-  font-size: 0.75em;
+  font-size: var(--font-size-2xs);
   color: var(--muted-text-color);
   margin-bottom: 2px;
 }
@@ -1083,7 +1083,7 @@ main.legal-content {
 }
 
 .auto-gear-rule-title {
-  font-weight: 500;
+  font-weight: var(--font-weight-medium);
   margin: 0;
 }
 
@@ -1099,7 +1099,7 @@ body.pink-mode .auto-gear-rule-title,
 
 .auto-gear-rule-meta {
   color: var(--muted-text-color, #666);
-  font-size: 0.9em;
+  font-size: var(--font-size-md);
 }
 
 .auto-gear-rule-items-label {
@@ -1113,7 +1113,7 @@ body.pink-mode .auto-gear-rule-title,
 }
 
 .auto-gear-rule-item {
-  font-size: 0.9em;
+  font-size: var(--font-size-md);
   line-height: 1.4;
   word-break: break-word;
 }
@@ -1218,12 +1218,12 @@ body.pink-mode .auto-gear-rule-title,
 }
 
 .storage-summary-label {
-  font-weight: 600;
+  font-weight: var(--font-weight-semibold);
 }
 
 .storage-summary-key {
   font-family: 'Courier New', Courier, monospace;
-  font-size: 0.75em;
+  font-size: var(--font-size-2xs);
   padding: 2px 6px;
   border-radius: 4px;
   background: var(--control-bg);
@@ -1232,14 +1232,14 @@ body.pink-mode .auto-gear-rule-title,
 
 .storage-summary-value {
   margin: 0;
-  font-weight: 500;
+  font-weight: var(--font-weight-medium);
 }
 
 .storage-summary-note,
 .storage-summary-description,
 .storage-summary-extra {
   margin: 0;
-  font-size: 0.85em;
+  font-size: var(--font-size-sm);
   color: var(--control-text);
   opacity: 0.85;
 }
@@ -1296,7 +1296,7 @@ body.pink-mode .auto-gear-rule-title,
   align-items: center;
   justify-content: center;
   line-height: 1;
-  font-size: 1rem;
+  font-size: var(--font-size-root);
   background: none;
   border: none;
   color: inherit;
@@ -1321,7 +1321,7 @@ body.pink-mode .auto-gear-rule-title,
 
 #helpQuickLinksHeading {
   margin: 0;
-  font-size: 1rem;
+  font-size: var(--font-size-root);
 }
 
 #helpQuickLinksList {
@@ -1355,7 +1355,7 @@ body.pink-mode .auto-gear-rule-title,
 .help-quick-link-icon {
   --icon-color: var(--accent-color);
   flex: 0 0 auto;
-  font-size: 1.1em;
+  font-size: var(--font-size-lg);
 }
 
 .help-quick-link.active .help-quick-link-icon {
@@ -1414,7 +1414,7 @@ body.pink-mode .auto-gear-rule-title,
   border-radius: var(--border-radius);
   background-color: var(--control-bg);
   color: var(--control-text);
-  font-size: 0.85em;
+  font-size: var(--font-size-sm);
   text-decoration: none;
   transition: background-color 0.2s, color 0.2s;
 }
@@ -1453,7 +1453,7 @@ body.pink-mode .auto-gear-rule-title,
 .icon-glyph {
   font-family: 'uicons-thin-straight';
   font-style: normal;
-  font-weight: 400;
+  font-weight: var(--font-weight-regular);
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -1462,8 +1462,8 @@ body.pink-mode .auto-gear-rule-title,
 }
 
 .icon-glyph.icon-text {
-  font-family: 'Ubuntu', sans-serif;
-  font-weight: 300;
+  font-family: var(--font-family-heading);
+  font-weight: var(--font-weight-light);
 }
 
 .icon-glyph.icon-svg {
@@ -1509,7 +1509,7 @@ body.pink-mode .auto-gear-rule-title,
 #helpSearchClear .icon-glyph,
 .clear-input-btn .icon-glyph,
 .controls button .icon-glyph {
-  font-size: 1.2em;
+  font-size: var(--font-size-xl);
 }
 
 .help-icon,
@@ -1524,7 +1524,7 @@ body.pink-mode .auto-gear-rule-title,
 }
 
 .favorite-icon.icon-glyph {
-  font-size: 1.1em;
+  font-size: var(--font-size-lg);
 }
 
 body.pink-mode button:hover,
@@ -1549,7 +1549,7 @@ body.pink-mode .favorite-toggle.favorited:active {
 .category-icon.icon-glyph,
 .scenario-icon.icon-glyph,
 .icon-box .icon.icon-glyph {
-  font-size: 1.1em;
+  font-size: var(--font-size-lg);
 }
 
 #hoverHelpTooltip {
@@ -1559,7 +1559,7 @@ body.pink-mode .favorite-toggle.favorited:active {
   color: var(--inverse-text-color);
   padding: 4px 8px;
   border-radius: 4px;
-  font-size: 0.8rem;
+  font-size: var(--font-size-tooltip);
   pointer-events: none;
   /* Allow longer hover help descriptions */
   max-width: 320px;
@@ -1612,7 +1612,7 @@ body.hover-help-active * {
 .device-category .list-filter {
   width: 100%;
   margin-bottom: 5px;
-  font-size: 0.9em;
+  font-size: var(--font-size-md);
 }
 
 /* Ensure form controls use consistent styling */
@@ -1620,7 +1620,7 @@ input,
 select,
 textarea {
   padding: 4px;
-  font-size: 1em;
+  font-size: var(--font-size-base);
   background-color: var(--control-bg);
   color: var(--control-text);
   border: none;
@@ -1637,7 +1637,7 @@ input[type="file"] {
   padding: 2px 4px;
   height: auto;
   min-height: var(--button-size);
-  font-size: 0.85em;
+  font-size: var(--font-size-sm);
   line-height: 1.2;
 }
 
@@ -1786,7 +1786,7 @@ textarea:disabled {
   background: transparent;
   border: none;
   cursor: pointer;
-  font-size: 1em;
+  font-size: var(--font-size-base);
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -1812,7 +1812,7 @@ textarea:disabled {
   border: none;
   outline: none;
   cursor: pointer;
-  font-size: 1rem;
+  font-size: var(--font-size-root);
   color: var(--favorite-inactive-color);
   display: inline-flex;
   align-items: center;
@@ -1863,7 +1863,7 @@ fieldset {
   box-sizing: border-box;
 }
 legend {
-  font-weight: 500;
+  font-weight: var(--font-weight-medium);
   color: var(--accent-color);
   padding: 0 5px;
 }
@@ -1893,7 +1893,7 @@ button {
   padding: 0 8px;
   margin: 10px 5px 5px;
   cursor: pointer;
-  font-size: 0.85em;
+  font-size: var(--font-size-sm);
   height: var(--button-size);
   min-height: var(--button-size);
   display: inline-flex;
@@ -1930,7 +1930,7 @@ input[type="file"]::-webkit-file-upload-button {
   padding: 0 8px;
   margin-right: 5px;
   cursor: pointer;
-  font-size: 0.8em;
+  font-size: var(--font-size-xs);
   height: 100%;
   min-height: var(--button-size);
   display: inline-flex;
@@ -1993,7 +1993,7 @@ input[type="file"]:disabled::-webkit-file-upload-button {
 
 .device-category h4 {
   font-family: var(--font-family);
-  font-weight: 400;
+  font-weight: var(--font-weight-regular);
   color: var(--accent-color);
   margin-top: 0;
   margin-bottom: 10px;
@@ -2010,7 +2010,7 @@ input[type="file"]:disabled::-webkit-file-upload-button {
 .device-ul li {
   border-bottom: 1px dashed var(--divider-color);
   padding: 5px 0;
-  font-size: 0.9em;
+  font-size: var(--font-size-md);
 }
 
 .device-summary {
@@ -2034,7 +2034,7 @@ input[type="file"]:disabled::-webkit-file-upload-button {
 
 .device-details {
   margin-left: 20px;
-  font-size: 0.85em;
+  font-size: var(--font-size-sm);
 }
 
 /* Arrange top-level device details in two columns */
@@ -2091,7 +2091,7 @@ input[type="file"]:disabled::-webkit-file-upload-button {
 }
 
 #topBar h1 {
-  font-size: 1.4em;
+  font-size: var(--font-size-2xl);
   margin: 0;
 }
 
@@ -2177,7 +2177,7 @@ body.dark-mode.pink-mode #topBar #logo .logo-center {
   background: none;
   border: none;
   cursor: pointer;
-  font-size: 1rem;
+  font-size: var(--font-size-root);
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -2199,7 +2199,7 @@ body.dark-mode.pink-mode #topBar #logo .logo-center {
 }
 
 .controls select {
-  font-size: 1em;
+  font-size: var(--font-size-base);
   padding: 2px 4px;
   text-align: center;
   text-align-last: center;
@@ -2233,7 +2233,7 @@ body.dark-mode.pink-mode #topBar #logo .logo-center {
 
 #helpButton {
   padding: 0 4px;
-  font-size: 1em;
+  font-size: var(--font-size-base);
 }
 
 /* Breakdown list */
@@ -2270,7 +2270,7 @@ body.dark-mode.pink-mode #topBar #logo .logo-center {
   align-items: center;
   justify-content: center;
   color: var(--inverse-text-color);
-  font-size: 0.75em;
+  font-size: var(--font-size-2xs);
   overflow: hidden;
 }
 
@@ -2315,7 +2315,7 @@ body.dark-mode.pink-mode #topBar #logo .logo-center {
   transform: translateX(-50%);
   background: var(--surface-color);
   color: var(--danger-color);
-  font-size: 0.75em;
+  font-size: var(--font-size-2xs);
   padding: 0 2px;
   white-space: nowrap;
 }
@@ -2327,7 +2327,7 @@ body.dark-mode.pink-mode #topBar #logo .logo-center {
 
 #maxPowerText {
   margin-top: 4px;
-  font-size: 0.9em;
+  font-size: var(--font-size-md);
 }
 
 /* Project diagram */
@@ -2350,7 +2350,7 @@ body.dark-mode.pink-mode #topBar #logo .logo-center {
 
 #diagramLegend {
   margin-top: 0.25em;
-  font-size: 12px;
+  font-size: var(--font-size-fixed-sm);
 }
 #diagramLegend span {
   margin: 0 6px;
@@ -2370,7 +2370,7 @@ body.dark-mode.pink-mode #topBar #logo .logo-center {
 
 #powerDiagramLegend {
   margin-top: 0.25em;
-  font-size: 12px;
+  font-size: var(--font-size-fixed-sm);
 }
 #powerDiagramLegend span {
   margin: 0 6px;
@@ -2435,7 +2435,7 @@ body.dark-mode.pink-mode #topBar #logo .logo-center {
 
 #diagramHint {
   margin-top: 0.25em;
-  font-size: 12px;
+  font-size: var(--font-size-fixed-sm);
   color: var(--muted-text-color);
 }
 
@@ -2446,7 +2446,7 @@ body.dark-mode.pink-mode #topBar #logo .logo-center {
   pointer-events: none;
   background: rgba(255, 255, 255, 0.95);
   border: 1px solid var(--control-text);
-  font-size: 12px;
+  font-size: var(--font-size-fixed-sm);
   padding: 6px 10px;
   border-radius: 6px;
   box-shadow: var(--panel-shadow);
@@ -2481,7 +2481,7 @@ body.dark-mode.pink-mode #topBar #logo .logo-center {
   border-radius: 3px;
   border: 1px solid;
   background-color: rgba(0,0,0,0.03);
-  font-size: 0.75em;
+  font-size: var(--font-size-2xs);
 }
 
 .scenario-box,
@@ -2493,7 +2493,7 @@ body.dark-mode.pink-mode #topBar #logo .logo-center {
   border-radius: 3px;
   border: 1px solid;
   background-color: rgba(0,0,0,0.03);
-  font-size: 0.75em;
+  font-size: var(--font-size-2xs);
 }
 
 .scenario-box .scenario-icon,
@@ -2506,7 +2506,7 @@ body.dark-mode.pink-mode #topBar #logo .logo-center {
   padding: 4px;
   border-radius: 3px;
   background: rgba(0,0,0,0.05);
-  font-size: 0.75em;
+  font-size: var(--font-size-2xs);
 }
 
 .lens-mount-box {
@@ -2516,8 +2516,8 @@ body.dark-mode.pink-mode #topBar #logo .logo-center {
 
 .info-label {
   width: 100%;
-  font-size: 0.75em;
-  font-weight: bold;
+  font-size: var(--font-size-2xs);
+  font-weight: var(--font-weight-bold);
   margin: 4px 2px 0;
 }
 
@@ -2525,7 +2525,7 @@ body.dark-mode.pink-mode #topBar #logo .logo-center {
   width: 100%;
   border-collapse: collapse;
   margin-top: 4px;
-  font-size: 0.8em;
+  font-size: var(--font-size-xs);
 }
 .port-table th {
   text-align: left;
@@ -2593,7 +2593,7 @@ body.dark-mode.pink-mode #topBar #logo .logo-center {
 }
 
 #setupDiagram .node-icon {
-  font-size: 20px;
+  font-size: var(--font-size-fixed-lg);
   font-family: 'uicons-thin-straight', system-ui, sans-serif;
   font-style: normal;
 }
@@ -2605,7 +2605,7 @@ body.dark-mode.pink-mode #topBar #logo .logo-center {
 #setupDiagram .conn.green { fill: var(--fiz-color); }
 
 #setupDiagram .edge-label {
-  font-size: 10px;
+  font-size: var(--font-size-fixed-xs);
   dominant-baseline: middle;
 }
 
@@ -2691,7 +2691,7 @@ body:not(.light-mode) #temperatureNote td {
   border: 1px solid var(--panel-border);
   padding: 8px;
   text-align: left;
-  font-size: 0.9em;
+  font-size: var(--font-size-md);
 }
 #batteryComparison th:nth-child(1),
 #batteryComparison td:nth-child(1) {
@@ -2795,12 +2795,12 @@ body.pink-mode #userFeedbackTable th {
 
 .weightingPercent {
   margin-left: 0.5em;
-  font-size: 0.9em;
+  font-size: var(--font-size-md);
 }
 
 .selectedBatteryRow {
     background-color: var(--selected-row-bg); /* Light blue background for selected row */
-    font-weight: bold;
+    font-weight: var(--font-weight-bold);
 }
 
 html.dark-mode,
@@ -3112,7 +3112,7 @@ body.dark-mode.dark-accent-boost:not(.pink-mode) .help-content {
 @media (max-width: 600px) {
   body {
     margin: 10px;
-    font-size: 0.85em;
+    font-size: var(--font-size-sm);
   }
 
   .controls select {
@@ -3258,12 +3258,12 @@ body.dark-mode.dark-accent-boost:not(.pink-mode) .help-content {
   box-shadow: var(--panel-shadow);
 }
 .requirement-box .req-icon {
-  font-size: 1.5em;
+  font-size: var(--font-size-3xl);
   display: block;
   margin-bottom: 5px;
 }
 .requirement-box .req-label {
-  font-weight: 700;
+  font-weight: var(--font-weight-bold);
   display: block;
 }
 .requirement-box .req-value {
@@ -3293,17 +3293,17 @@ body.dark-mode.dark-accent-boost:not(.pink-mode) .help-content {
   background: var(--surface-color);
   color: var(--control-text);
   font-family: var(--font-family);
-  font-weight: 300;
+  font-weight: var(--font-weight-light);
 }
 #overviewDialogContent h1,
 #overviewDialogContent h2,
 #overviewDialogContent h3 {
   font-family: var(--font-family);
-  font-weight: 400;
+  font-weight: var(--font-weight-regular);
   color: var(--accent-color);
 }
 #overviewDialogContent h1 {
-  font-size: 1.8em;
+  font-size: var(--font-size-4xl);
   margin-bottom: 0.2em;
 }
 
@@ -3311,13 +3311,13 @@ body.dark-mode.dark-accent-boost:not(.pink-mode) .help-content {
   display: none;
 }
 #overviewDialogContent h2 {
-  font-size: 1.4em;
+  font-size: var(--font-size-2xl);
   margin-top: 1.3em;
   border-bottom: 2px solid var(--accent-color);
   padding-bottom: 5px;
 }
 #overviewDialogContent h3 {
-  font-size: 1.1em;
+  font-size: var(--font-size-lg);
   margin-top: 1em;
 }
 #overviewDialogContent table {
@@ -3331,12 +3331,12 @@ body.dark-mode.dark-accent-boost:not(.pink-mode) .help-content {
   border: 1px solid var(--panel-border);
   padding: 8px;
   text-align: left;
-  font-size: 0.9em;
+  font-size: var(--font-size-md);
   overflow: hidden;
 }
 #overviewDialogContent th {
   background-color: var(--control-bg);
-  font-weight: 700;
+  font-weight: var(--font-weight-bold);
 }
 #overviewDialogContent tr:nth-child(even) {
   background-color: var(--panel-bg);
@@ -3347,7 +3347,7 @@ body.dark-mode.dark-accent-boost:not(.pink-mode) .help-content {
   border-radius: 6px;
   padding: 6px 10px;
   box-shadow: var(--panel-shadow);
-  font-size: 12px;
+  font-size: var(--font-size-fixed-sm);
 }
 #overviewDialogContent .device-block strong {
   display: block;
@@ -3370,7 +3370,7 @@ body.dark-mode.dark-accent-boost:not(.pink-mode) .help-content {
 }
 #overviewDialogContent .device-category h3 {
   font-family: var(--font-family);
-  font-weight: 400;
+  font-weight: var(--font-weight-regular);
   margin-top: 0;
   margin-bottom: 5px;
   border-bottom: 1px solid var(--divider-color);
@@ -3468,7 +3468,7 @@ body.dark-mode.dark-accent-boost:not(.pink-mode) .help-content {
 .gear-table .category-row td {
   border-top: 1px solid var(--accent-color);
   border-bottom: 1px solid var(--accent-color);
-  font-weight: bold;
+  font-weight: var(--font-weight-bold);
   color: var(--accent-color);
   break-after: avoid;
   page-break-after: avoid;
@@ -3513,7 +3513,7 @@ body.dark-mode.dark-accent-boost:not(.pink-mode) .help-content {
 #overviewDialogContent .gear-table .category-row td {
   border-top: 1px solid var(--accent-color);
   border-bottom: 1px solid var(--accent-color);
-  font-weight: bold;
+  font-weight: var(--font-weight-bold);
   color: var(--accent-color);
   break-after: avoid;
   page-break-after: avoid;
@@ -3664,7 +3664,7 @@ body.dark-mode.dark-accent-boost:not(.pink-mode) .help-content {
 #gearListActions .gear-list-autosave-note {
   flex-basis: 100%;
   margin: 0;
-  font-size: 0.9rem;
+  font-size: var(--font-size-meta);
   color: var(--muted-text-color);
 }
 
@@ -3710,7 +3710,7 @@ body.dark-mode.dark-accent-boost:not(.pink-mode) .help-content {
 #menuToggle {
   background: none;
   border: none;
-  font-size: 1.5em;
+  font-size: var(--font-size-3xl);
 }
 
 #sideMenu {
@@ -3751,7 +3751,7 @@ body.dark-mode.dark-accent-boost:not(.pink-mode) .help-content {
 #sideMenu a {
   color: var(--text-color);
   text-decoration: none;
-  font-size: 1.1em;
+  font-size: var(--font-size-lg);
   display: block;
   padding: 10px 0;
 }


### PR DESCRIPTION
## Summary
- define shared typography custom properties for font families, weights and size scale in `fonts.css`
- update `style.css`, `overview.css`, and `overview-print.css` to reference the shared tokens instead of hard-coded values
- align diagram export styling in `script.js` with the new global font-size variables

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cdb8fd13c483209f98a9150903ab45