### PR TITLE
Prompt for filename and auto gear inclusion on share

### DIFF
--- a/script.js
+++ b/script.js
@@ -3658,6 +3658,65 @@ const sharedLinkRow   = document.getElementById("sharedLinkRow");
 const sharedLinkInput = document.getElementById("sharedLinkInput");
 const shareLinkMessage = document.getElementById("shareLinkMessage");
 const shareIncludeAutoGearCheckbox = document.getElementById("shareIncludeAutoGear");
+
+function sanitizeShareFilename(name) {
+  if (!name) return '';
+  const trimmed = String(name).trim();
+  if (!trimmed) return '';
+  const sanitized = trimmed
+    .replace(/[\\/:*?"<>|]+/g, '_')
+    .replace(/\s+/g, ' ')
+    .replace(/^\.+/, '')
+    .replace(/\.+$/, '')
+    .trim();
+  return sanitized;
+}
+
+function ensureJsonExtension(filename) {
+  if (!filename) return '';
+  return /\.json$/i.test(filename) ? filename : `${filename}.json`;
+}
+
+function getDefaultShareFilename(setupName) {
+  const sanitized = sanitizeShareFilename(setupName);
+  return sanitized || 'project';
+}
+
+function promptForSharedFilename(setupName) {
+  const defaultName = getDefaultShareFilename(setupName);
+  const template = getLocalizedText('shareFilenamePrompt') || '';
+  const promptMessage = template.includes('{defaultName}')
+    ? template.replace('{defaultName}', defaultName)
+    : template || 'Enter a name for the shared project file:';
+  if (typeof window !== 'undefined' && typeof window.prompt === 'function') {
+    const response = window.prompt(promptMessage, defaultName);
+    if (response === null) {
+      return null;
+    }
+    const sanitized = sanitizeShareFilename(response);
+    if (!sanitized) {
+      const invalidMessage =
+        getLocalizedText('shareFilenameInvalid')
+        || 'Please enter a valid file name to continue.';
+      if (typeof window.alert === 'function') {
+        window.alert(invalidMessage);
+      }
+      return null;
+    }
+    return ensureJsonExtension(sanitized);
+  }
+  return ensureJsonExtension(defaultName);
+}
+
+function confirmAutoGearSelection(defaultInclude) {
+  const confirmMessage =
+    getLocalizedText('shareIncludeAutoGearConfirm')
+    || 'Include automatic gear rules in the shared file? Select OK to include them or Cancel to skip.';
+  if (typeof window !== 'undefined' && typeof window.confirm === 'function') {
+    return window.confirm(confirmMessage);
+  }
+  return !!defaultInclude;
+}
 const shareIncludeAutoGearText = document.getElementById("shareIncludeAutoGearText");
 const shareIncludeAutoGearLabelElem = document.getElementById("shareIncludeAutoGearLabel");
 const sharedImportOptions = document.getElementById("sharedImportOptions");
@@ -13053,6 +13112,23 @@ if (projectForm) {
 shareSetupBtn.addEventListener('click', () => {
   saveCurrentGearList();
   const setupName = getCurrentProjectName();
+  const shareFileName = promptForSharedFilename(setupName);
+  if (!shareFileName) {
+    return;
+  }
+  const rulesForShare = getAutoGearRules();
+  const hasAutoGearRules = Array.isArray(rulesForShare) && rulesForShare.length > 0;
+  let includeAutoGear = false;
+  if (hasAutoGearRules) {
+    includeAutoGear = confirmAutoGearSelection(
+      shareIncludeAutoGearCheckbox ? shareIncludeAutoGearCheckbox.checked : false
+    );
+    if (shareIncludeAutoGearCheckbox) {
+      shareIncludeAutoGearCheckbox.checked = includeAutoGear;
+    }
+  } else if (shareIncludeAutoGearCheckbox) {
+    shareIncludeAutoGearCheckbox.checked = false;
+  }
   const currentSetup = {
     setupName,
     camera: cameraSelect.value,
@@ -13097,18 +13173,15 @@ shareSetupBtn.addEventListener('click', () => {
   if (feedback.length) {
     currentSetup.feedback = feedback;
   }
-  if (shareIncludeAutoGearCheckbox && shareIncludeAutoGearCheckbox.checked) {
-    const rulesForShare = getAutoGearRules();
-    if (rulesForShare.length) {
-      currentSetup.autoGearRules = rulesForShare;
-    }
+  if (includeAutoGear && hasAutoGearRules) {
+    currentSetup.autoGearRules = rulesForShare;
   }
   const json = JSON.stringify(currentSetup, null, 2);
   const blob = new Blob([json], { type: 'application/json' });
   const url = URL.createObjectURL(blob);
   const a = document.createElement('a');
   a.href = url;
-  a.download = `${setupName || 'project'}.json`;
+  a.download = shareFileName;
   document.body.appendChild(a);
   a.click();
   document.body.removeChild(a);

--- a/translations.js
+++ b/translations.js
@@ -299,6 +299,11 @@ const texts = {
     shareSetupPrompt: "Project file ready to share.",
     shareLinkCopied: "Project file downloaded.",
     shareLinkTooLong: "Project data is too large to share.",
+    shareFilenamePrompt:
+      "Enter a name for the shared project file (default: {defaultName}).",
+    shareFilenameInvalid: "Please enter a valid file name to continue.",
+    shareIncludeAutoGearConfirm:
+      "Include automatic gear rules in the shared file? Select OK to include them or Cancel to skip.",
     shareIncludeAutoGearLabel: "Include automatic gear rules",
     shareIncludeAutoGearHelp: "Add your automatic gear rules to the shared project file.",
 
@@ -831,6 +836,11 @@ const texts = {
     shareSetupPrompt: "File di progetto pronto per la condivisione.",
     shareLinkCopied: "File di progetto scaricato.",
     shareLinkTooLong: "I dati del progetto sono troppo grandi da condividere.",
+    shareFilenamePrompt:
+      "Scegli un nome per il file di progetto condiviso (predefinito: {defaultName}).",
+    shareFilenameInvalid: "Inserisci un nome file valido per continuare.",
+    shareIncludeAutoGearConfirm:
+      "Vuoi includere le regole automatiche per l'attrezzatura nel file condiviso? Seleziona OK per includerle o Annulla per saltarle.",
     shareIncludeAutoGearLabel: "Includi le regole automatiche per l'attrezzatura",
     shareIncludeAutoGearHelp: "Aggiunge le tue regole automatiche per l'attrezzatura al file di progetto condiviso.",
     sharedLinkLabel: "Carica progetto condiviso:",
@@ -1543,6 +1553,11 @@ const texts = {
     shareSetupPrompt: "Archivo de proyecto listo para compartir.",
     shareLinkCopied: "Archivo de proyecto descargado.",
     shareLinkTooLong: "Los datos del proyecto son demasiado grandes para compartir.",
+    shareFilenamePrompt:
+      "Elige un nombre para el archivo de proyecto compartido (predeterminado: {defaultName}).",
+    shareFilenameInvalid: "Introduce un nombre de archivo válido para continuar.",
+    shareIncludeAutoGearConfirm:
+      "¿Quieres incluir las reglas automáticas de equipo en el archivo compartido? Selecciona Aceptar para incluirlas o Cancelar para omitirlas.",
     shareIncludeAutoGearLabel: "Incluir reglas automáticas de equipo",
     shareIncludeAutoGearHelp: "Agrega tus reglas automáticas de equipo al archivo de proyecto compartido.",
     sharedLinkLabel: "Cargar proyecto compartido:",
@@ -2269,6 +2284,11 @@ const texts = {
     shareSetupPrompt: "Fichier projet prêt à être partagé.",
     shareLinkCopied: "Fichier projet téléchargé.",
     shareLinkTooLong: "Les données du projet sont trop volumineuses pour être partagées.",
+    shareFilenamePrompt:
+      "Choisissez un nom pour le fichier projet partagé (par défaut : {defaultName}).",
+    shareFilenameInvalid: "Veuillez saisir un nom de fichier valide pour continuer.",
+    shareIncludeAutoGearConfirm:
+      "Souhaitez-vous inclure les règles automatiques d’équipement dans le fichier partagé ? Sélectionnez OK pour les inclure ou Annuler pour les ignorer.",
     shareIncludeAutoGearLabel: "Inclure les règles automatiques d’équipement",
     shareIncludeAutoGearHelp: "Ajoute vos règles automatiques d’équipement au fichier projet partagé.",
     sharedLinkLabel: "Charger un projet partagé :",
@@ -2997,6 +3017,11 @@ const texts = {
     shareSetupPrompt: "Projektdatei bereit zum Teilen.",
     shareLinkCopied: "Projektdatei heruntergeladen.",
     shareLinkTooLong: "Projektdaten sind zu groß zum Teilen.",
+    shareFilenamePrompt:
+      "Wähle einen Namen für die geteilte Projektdatei (Standard: {defaultName}).",
+    shareFilenameInvalid: "Bitte gib einen gültigen Dateinamen ein, um fortzufahren.",
+    shareIncludeAutoGearConfirm:
+      "Möchtest du die automatischen Gear-Regeln in die geteilte Datei aufnehmen? Wähle OK, um sie einzuschließen, oder Abbrechen, um sie auszulassen.",
     shareIncludeAutoGearLabel: "Automatische Gear-Regeln einschließen",
     shareIncludeAutoGearHelp: "Fügt deine automatischen Gear-Regeln zur geteilten Projektdatei hinzu.",
     sharedLinkLabel: "Geteiltes Projekt laden:",


### PR DESCRIPTION
## Summary
- prompt the user for a custom file name when sharing a project and sanitize the result
- confirm whether automatic gear rules should be included and respect the decision when exporting
- localize the new prompts and messages across supported languages

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cdb9a2edf08320a1bf896fa6544818