### PR TITLE
Implement shared project load dialog for gear rules

### DIFF
--- a/index.html
+++ b/index.html
@@ -210,33 +210,15 @@
     </div>
     <p id="shareLinkMessage" class="hidden" role="status" aria-live="polite"></p>
     <div class="form-row" id="sharedLinkRow">
-      <label for="sharedLinkInput" id="sharedLinkLabel">Shared Project:</label>
-      <input type="file" id="sharedLinkInput" accept=".json" aria-labelledby="sharedLinkLabel" />
+      <label for="applySharedLinkBtn" id="sharedLinkLabel">Shared Project:</label>
+      <input
+        type="file"
+        id="sharedLinkInput"
+        accept=".json"
+        aria-labelledby="sharedLinkLabel"
+        class="visually-hidden"
+      />
       <button id="applySharedLinkBtn"><span class="btn-icon icon-glyph" aria-hidden="true">&#xE7B3;</span>Load</button>
-    </div>
-    <div class="form-row share-import-row">
-      <span class="form-label-spacer" aria-hidden="true"></span>
-      <fieldset id="sharedImportOptions" class="share-import-options">
-        <legend id="sharedImportLegend">Automatic gear rules</legend>
-        <select
-          id="sharedImportModeSelect"
-          class="share-import-mode-select"
-          name="sharedImportMode"
-          multiple
-          size="3"
-          aria-labelledby="sharedImportLegend"
-        >
-          <option id="sharedImportModeNoneOption" value="none" selected>
-            Don't import automatic gear rules
-          </option>
-          <option id="sharedImportModeProjectOption" value="project" disabled>
-            Use shared rules for this project only
-          </option>
-          <option id="sharedImportModeGlobalOption" value="global" disabled>
-            Add shared rules to all projects
-          </option>
-        </select>
-      </fieldset>
     </div>
     <div class="form-row form-row-actions">
       <span class="form-label-spacer" aria-hidden="true"></span>
@@ -946,6 +928,32 @@
       </section>
       <div class="button-row install-guide-actions">
         <button id="installGuideClose" type="button">Close</button>
+      </div>
+    </div>
+  </div>
+
+  <div
+    id="sharedRulesDialog"
+    role="dialog"
+    aria-modal="true"
+    aria-labelledby="sharedRulesDialogTitle"
+    aria-describedby="sharedRulesDialogMessage"
+    hidden
+  >
+    <div class="shared-rules-dialog">
+      <h2 id="sharedRulesDialogTitle">Automatic gear rules</h2>
+      <p id="sharedRulesDialogMessage">
+        This project includes automatic gear rules. How should they be handled?
+      </p>
+      <label for="sharedRulesDialogSelect" id="sharedRulesDialogSelectLabel">Automatic gear rules</label>
+      <select id="sharedRulesDialogSelect" aria-labelledby="sharedRulesDialogSelectLabel">
+        <option id="sharedRulesDialogNoneOption" value="none">Don't import automatic gear rules</option>
+        <option id="sharedRulesDialogProjectOption" value="project">Use shared rules for this project only</option>
+        <option id="sharedRulesDialogGlobalOption" value="global">Add shared rules to all projects</option>
+      </select>
+      <div class="button-row shared-rules-dialog-actions">
+        <button id="sharedRulesDialogCancel">Cancel</button>
+        <button id="sharedRulesDialogApply">Apply</button>
       </div>
     </div>
   </div>

--- a/script.js
+++ b/script.js
@@ -2121,56 +2121,72 @@ function setLanguage(lang) {
     }
   }
 
-  let sharedImportLegendText = sharedImportLegend ? sharedImportLegend.textContent : '';
-  if (sharedImportLegend) {
-    const legend = texts[lang].sharedImportAutoGearLabel
-      || texts.en?.sharedImportAutoGearLabel
-      || sharedImportLegend.textContent;
-    sharedImportLegend.textContent = legend;
-    sharedImportLegendText = legend;
-    if (sharedImportOptions) {
-      sharedImportOptions.setAttribute('data-help', legend);
-    }
+  const sharedRulesLabel = texts[lang].sharedImportAutoGearLabel
+    || texts.en?.sharedImportAutoGearLabel
+    || (sharedRulesDialogTitle ? sharedRulesDialogTitle.textContent : '');
+  if (sharedRulesDialogTitle && sharedRulesLabel) {
+    sharedRulesDialogTitle.textContent = sharedRulesLabel;
   }
-  if (sharedImportModeSelect && sharedImportLegendText) {
-    sharedImportModeSelect.setAttribute('aria-label', sharedImportLegendText);
-    sharedImportModeSelect.setAttribute('data-help', sharedImportLegendText);
+  if (sharedRulesDialogSelectLabel && sharedRulesLabel) {
+    sharedRulesDialogSelectLabel.textContent = sharedRulesLabel;
+    sharedRulesDialogSelectLabel.setAttribute('data-help', sharedRulesLabel);
   }
-  if (sharedImportModeNoneOption) {
+  if (sharedRulesDialogSelect && sharedRulesLabel) {
+    sharedRulesDialogSelect.setAttribute('aria-label', sharedRulesLabel);
+    sharedRulesDialogSelect.setAttribute('data-help', sharedRulesLabel);
+  }
+  if (sharedRulesDialogMessage) {
+    const message = texts[lang].sharedImportAutoGearDialogMessage
+      || texts.en?.sharedImportAutoGearDialogMessage
+      || sharedRulesDialogMessage.textContent;
+    sharedRulesDialogMessage.textContent = message;
+  }
+  if (sharedRulesDialogNoneOption) {
     const label = texts[lang].sharedImportAutoGearNone
       || texts.en?.sharedImportAutoGearNone
-      || sharedImportModeNoneOption.textContent;
-    sharedImportModeNoneOption.textContent = label;
+      || sharedRulesDialogNoneOption.textContent;
+    sharedRulesDialogNoneOption.textContent = label;
     const help = texts[lang].sharedImportAutoGearNoneHelp
       || texts.en?.sharedImportAutoGearNoneHelp
       || label;
-    sharedImportModeNoneOption.setAttribute('data-help', help);
-    sharedImportModeNoneOption.setAttribute('title', help);
-    sharedImportModeNoneOption.setAttribute('aria-label', label);
+    sharedRulesDialogNoneOption.setAttribute('data-help', help);
+    sharedRulesDialogNoneOption.setAttribute('title', help);
   }
-  if (sharedImportModeProjectOption) {
+  if (sharedRulesDialogProjectOption) {
     const label = texts[lang].sharedImportAutoGearProject
       || texts.en?.sharedImportAutoGearProject
-      || sharedImportModeProjectOption.textContent;
-    sharedImportModeProjectOption.textContent = label;
+      || sharedRulesDialogProjectOption.textContent;
+    sharedRulesDialogProjectOption.textContent = label;
     const help = texts[lang].sharedImportAutoGearProjectHelp
       || texts.en?.sharedImportAutoGearProjectHelp
       || label;
-    sharedImportModeProjectOption.setAttribute('data-help', help);
-    sharedImportModeProjectOption.setAttribute('title', help);
-    sharedImportModeProjectOption.setAttribute('aria-label', label);
+    sharedRulesDialogProjectOption.setAttribute('data-help', help);
+    sharedRulesDialogProjectOption.setAttribute('title', help);
   }
-  if (sharedImportModeGlobalOption) {
+  if (sharedRulesDialogGlobalOption) {
     const label = texts[lang].sharedImportAutoGearGlobal
       || texts.en?.sharedImportAutoGearGlobal
-      || sharedImportModeGlobalOption.textContent;
-    sharedImportModeGlobalOption.textContent = label;
+      || sharedRulesDialogGlobalOption.textContent;
+    sharedRulesDialogGlobalOption.textContent = label;
     const help = texts[lang].sharedImportAutoGearGlobalHelp
       || texts.en?.sharedImportAutoGearGlobalHelp
       || label;
-    sharedImportModeGlobalOption.setAttribute('data-help', help);
-    sharedImportModeGlobalOption.setAttribute('title', help);
-    sharedImportModeGlobalOption.setAttribute('aria-label', label);
+    sharedRulesDialogGlobalOption.setAttribute('data-help', help);
+    sharedRulesDialogGlobalOption.setAttribute('title', help);
+  }
+  if (sharedRulesDialogApply) {
+    const label = texts[lang].sharedImportAutoGearDialogApply
+      || texts.en?.sharedImportAutoGearDialogApply
+      || sharedRulesDialogApply.textContent;
+    setButtonLabelWithIcon(sharedRulesDialogApply, label, ICON_GLYPHS.save);
+    sharedRulesDialogApply.setAttribute('data-help', label);
+  }
+  if (sharedRulesDialogCancel) {
+    const label = texts[lang].sharedImportAutoGearDialogCancel
+      || texts.en?.sharedImportAutoGearDialogCancel
+      || sharedRulesDialogCancel.textContent;
+    setButtonLabelWithIcon(sharedRulesDialogCancel, label, ICON_GLYPHS.circleX);
+    sharedRulesDialogCancel.setAttribute('data-help', label);
   }
 
   applySharedLinkBtn.setAttribute("title", texts[lang].loadSharedLinkBtn);
@@ -3660,18 +3676,16 @@ const shareLinkMessage = document.getElementById("shareLinkMessage");
 const shareIncludeAutoGearCheckbox = document.getElementById("shareIncludeAutoGear");
 const shareIncludeAutoGearText = document.getElementById("shareIncludeAutoGearText");
 const shareIncludeAutoGearLabelElem = document.getElementById("shareIncludeAutoGearLabel");
-const sharedImportOptions = document.getElementById("sharedImportOptions");
-const sharedImportLegend = document.getElementById("sharedImportLegend");
-const sharedImportModeSelect = document.getElementById("sharedImportModeSelect");
-const sharedImportModeNoneOption = document.getElementById("sharedImportModeNoneOption");
-const sharedImportModeProjectOption = document.getElementById("sharedImportModeProjectOption");
-const sharedImportModeGlobalOption = document.getElementById("sharedImportModeGlobalOption");
-if (sharedImportModeSelect) {
-  Array.from(sharedImportModeSelect.options || []).forEach(option => {
-    if (option.value === "none") return;
-    option.disabled = true;
-  });
-}
+const sharedRulesDialog = document.getElementById("sharedRulesDialog");
+const sharedRulesDialogTitle = document.getElementById("sharedRulesDialogTitle");
+const sharedRulesDialogMessage = document.getElementById("sharedRulesDialogMessage");
+const sharedRulesDialogSelectLabel = document.getElementById("sharedRulesDialogSelectLabel");
+const sharedRulesDialogSelect = document.getElementById("sharedRulesDialogSelect");
+const sharedRulesDialogApply = document.getElementById("sharedRulesDialogApply");
+const sharedRulesDialogCancel = document.getElementById("sharedRulesDialogCancel");
+const sharedRulesDialogNoneOption = document.getElementById("sharedRulesDialogNoneOption");
+const sharedRulesDialogProjectOption = document.getElementById("sharedRulesDialogProjectOption");
+const sharedRulesDialogGlobalOption = document.getElementById("sharedRulesDialogGlobalOption");
 let lastSetupName = setupSelect ? setupSelect.value : '';
 const applySharedLinkBtn = document.getElementById("applySharedLinkBtn");
 const sharedKeyMap = {
@@ -3697,6 +3711,10 @@ const sharedKeyMap = {
 
 let lastSharedSetupData = null;
 let lastSharedAutoGearRules = null;
+let lastSharedImportMode = null;
+let sharedRulesDialogResolver = null;
+let sharedRulesDialogRejecter = null;
+let lastActiveBeforeSharedRules = null;
 
 function cloneSharedImportValue(value) {
   if (value == null) return null;
@@ -3705,6 +3723,33 @@ function cloneSharedImportValue(value) {
   } catch (error) {
     console.warn('Failed to clone shared import value', error);
     return null;
+  }
+}
+
+function autoGearRulesMatch(first, second) {
+  const normalize = list => (Array.isArray(list)
+    ? list.map(normalizeAutoGearRule).filter(Boolean)
+    : []);
+  const a = normalize(first);
+  const b = normalize(second);
+  if (a.length !== b.length) {
+    return false;
+  }
+  const signaturesA = a.map(autoGearRuleSignature).sort();
+  const signaturesB = b.map(autoGearRuleSignature).sort();
+  return signaturesA.every((signature, index) => signature === signaturesB[index]);
+}
+
+function shouldPromptForSharedRules(sharedRules) {
+  if (!Array.isArray(sharedRules) || !sharedRules.length) {
+    return false;
+  }
+  try {
+    const currentRules = getAutoGearRules();
+    return !autoGearRulesMatch(sharedRules, currentRules);
+  } catch (error) {
+    console.warn('Failed to compare automatic gear rules', error);
+    return true;
   }
 }
 
@@ -3718,12 +3763,12 @@ function clearStoredSharedImportData() {
   lastSharedAutoGearRules = null;
 }
 
-function reapplySharedImportSelection() {
+function reapplySharedImportSelection(modeOverride) {
   if (lastSharedSetupData === null) return;
   const storedData = cloneSharedImportValue(lastSharedSetupData);
   if (!storedData) return;
   const storedRules = cloneSharedImportValue(lastSharedAutoGearRules);
-  const mode = resolveSharedImportMode(storedRules);
+  const mode = resolveSharedImportMode(storedRules, modeOverride);
   applySharedSetup(storedData, {
     autoGearMode: mode,
     sharedAutoGearRules: storedRules,
@@ -3731,31 +3776,69 @@ function reapplySharedImportSelection() {
   updateCalculations();
 }
 
-function resolveSharedImportMode(sharedRules) {
+function resolveSharedImportMode(sharedRules, explicitMode) {
   const hasRules = Array.isArray(sharedRules) && sharedRules.length > 0;
-  if (!sharedImportModeSelect) {
-    return hasRules ? 'project' : 'none';
-  }
-  const selectedValues = Array.from(sharedImportModeSelect.selectedOptions || [])
-    .map(option => option.value)
-    .filter(value => value === 'none' || value === 'project' || value === 'global');
   if (!hasRules) {
     return 'none';
   }
-  let modes = Array.from(new Set(selectedValues));
-  if (!modes.length) {
-    return 'project';
+  const preferred = [explicitMode, lastSharedImportMode].find(mode => (
+    mode === 'none' || mode === 'project' || mode === 'global'
+  ));
+  if (preferred) {
+    return preferred;
   }
-  if (modes.length > 1 && modes.includes('none')) {
-    modes = modes.filter(value => value !== 'none');
+  return 'project';
+}
+
+function closeSharedRulesDialog(restoreFocus = true) {
+  if (!sharedRulesDialog) return;
+  sharedRulesDialog.setAttribute('hidden', '');
+  sharedRulesDialogResolver = null;
+  sharedRulesDialogRejecter = null;
+  if (restoreFocus && lastActiveBeforeSharedRules && typeof lastActiveBeforeSharedRules.focus === 'function') {
+    lastActiveBeforeSharedRules.focus();
   }
-  if (!modes.length) {
-    return 'project';
+  lastActiveBeforeSharedRules = null;
+}
+
+function openSharedRulesDialog(defaultMode = 'project') {
+  if (!sharedRulesDialog) {
+    return Promise.resolve(defaultMode);
   }
-  if (modes.length === 1) {
-    return modes[0];
+  const allowed = ['none', 'project', 'global'];
+  const selection = allowed.includes(defaultMode) ? defaultMode : 'project';
+  if (sharedRulesDialogSelect) {
+    sharedRulesDialogSelect.value = selection;
   }
-  return modes;
+  sharedRulesDialog.removeAttribute('hidden');
+  lastActiveBeforeSharedRules = document.activeElement;
+  const focusTarget = sharedRulesDialogSelect || sharedRulesDialog.querySelector('button, [href], [tabindex]:not([tabindex="-1"])');
+  if (focusTarget && typeof focusTarget.focus === 'function') {
+    focusTarget.focus();
+  }
+  return new Promise((resolve, reject) => {
+    sharedRulesDialogResolver = resolve;
+    sharedRulesDialogRejecter = reject;
+  });
+}
+
+function confirmSharedRulesDialogSelection() {
+  const allowed = ['none', 'project', 'global'];
+  const selected = sharedRulesDialogSelect ? sharedRulesDialogSelect.value : 'project';
+  const mode = allowed.includes(selected) ? selected : 'project';
+  const resolver = sharedRulesDialogResolver;
+  closeSharedRulesDialog();
+  if (typeof resolver === 'function') {
+    resolver(mode);
+  }
+}
+
+function cancelSharedRulesDialogSelection() {
+  const rejecter = sharedRulesDialogRejecter;
+  closeSharedRulesDialog();
+  if (typeof rejecter === 'function') {
+    rejecter(new Error('cancelled'));
+  }
 }
 
 function encodeSharedSetup(setup) {
@@ -5647,6 +5730,10 @@ if (iosPwaHelpDialog) {
 document.addEventListener('keydown', event => {
   if (event.key !== 'Escape' && event.key !== 'Esc') return;
   let handled = false;
+  if (sharedRulesDialog && !sharedRulesDialog.hasAttribute('hidden')) {
+    cancelSharedRulesDialogSelection();
+    handled = true;
+  }
   if (iosPwaHelpDialog && !iosPwaHelpDialog.hasAttribute('hidden')) {
     closeIosPwaHelp(true);
     handled = true;
@@ -13122,7 +13209,18 @@ shareSetupBtn.addEventListener('click', () => {
 
 if (applySharedLinkBtn && sharedLinkInput) {
   applySharedLinkBtn.addEventListener('click', () => {
-    const file = sharedLinkInput.files[0];
+    try {
+      sharedLinkInput.value = '';
+    } catch (error) {
+      console.warn('Failed to reset shared project input', error);
+    }
+    if (typeof sharedLinkInput.click === 'function') {
+      sharedLinkInput.click();
+    }
+  });
+
+  sharedLinkInput.addEventListener('change', () => {
+    const file = (sharedLinkInput.files && sharedLinkInput.files[0]) || null;
     if (!file) return;
     const reader = new FileReader();
     reader.onload = () => {
@@ -13130,41 +13228,73 @@ if (applySharedLinkBtn && sharedLinkInput) {
         const data = JSON.parse(reader.result);
         const sharedRules = Array.isArray(data.autoGearRules) ? data.autoGearRules : null;
         storeSharedImportData(data, sharedRules);
-        if (sharedImportModeSelect) {
-          const hasRules = Array.isArray(sharedRules) && sharedRules.length > 0;
-          Array.from(sharedImportModeSelect.options || []).forEach(option => {
-            if (option.value === 'none') {
-              option.disabled = false;
-              if (!hasRules) {
-                option.selected = true;
-              }
-            } else {
-              option.disabled = !hasRules;
-              if (!hasRules) {
-                option.selected = false;
-              }
+        const hasRules = Array.isArray(sharedRules) && sharedRules.length > 0;
+        const handleModeSelection = mode => {
+          reapplySharedImportSelection(mode);
+        };
+        if (hasRules && shouldPromptForSharedRules(sharedRules)) {
+          const defaultMode = resolveSharedImportMode(sharedRules, lastSharedImportMode);
+          openSharedRulesDialog(defaultMode).then(mode => {
+            lastSharedImportMode = mode;
+            handleModeSelection(mode);
+          }).catch(() => {
+            clearStoredSharedImportData();
+          }).finally(() => {
+            try {
+              sharedLinkInput.value = '';
+            } catch (error) {
+              console.warn('Failed to reset shared project input after dialog', error);
             }
           });
-          if (!hasRules && !sharedImportModeSelect.selectedOptions.length) {
-            sharedImportModeSelect.selectedIndex = 0;
+        } else {
+          handleModeSelection(hasRules ? 'none' : 'none');
+          try {
+            sharedLinkInput.value = '';
+          } catch (error) {
+            console.warn('Failed to reset shared project input after load', error);
           }
         }
-        const mode = resolveSharedImportMode(sharedRules);
-        applySharedSetup(data, { autoGearMode: mode, sharedAutoGearRules: sharedRules });
-        updateCalculations();
-      } catch {
+      } catch (error) {
+        console.warn('Failed to load shared project', error);
         clearStoredSharedImportData();
         alert(texts[currentLang].invalidSharedLink);
+        try {
+          sharedLinkInput.value = '';
+        } catch (err) {
+          console.warn('Failed to reset shared project input after error', err);
+        }
+      }
+    };
+    reader.onerror = () => {
+      clearStoredSharedImportData();
+      alert(texts[currentLang].invalidSharedLink);
+      try {
+        sharedLinkInput.value = '';
+      } catch (error) {
+        console.warn('Failed to reset shared project input after read error', error);
       }
     };
     reader.readAsText(file);
   });
 }
 
-if (sharedImportModeSelect) {
-  sharedImportModeSelect.addEventListener('change', () => {
-    if (lastSharedSetupData === null) return;
-    reapplySharedImportSelection();
+if (sharedRulesDialogApply) {
+  sharedRulesDialogApply.addEventListener('click', () => {
+    confirmSharedRulesDialogSelection();
+  });
+}
+
+if (sharedRulesDialogCancel) {
+  sharedRulesDialogCancel.addEventListener('click', () => {
+    cancelSharedRulesDialogSelection();
+  });
+}
+
+if (sharedRulesDialog) {
+  sharedRulesDialog.addEventListener('click', event => {
+    if (event.target === sharedRulesDialog) {
+      cancelSharedRulesDialogSelection();
+    }
   });
 }
 

--- a/style.css
+++ b/style.css
@@ -600,32 +600,6 @@ main.legal-content {
   margin: 0;
 }
 
-#setup-manager .share-import-row {
-  align-items: flex-start;
-}
-
-#setup-manager .share-import-options {
-  flex: 1;
-  border: 1px solid var(--panel-border);
-  border-radius: var(--border-radius);
-  padding: 0.75rem;
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-  background-color: var(--surface-color);
-}
-
-#setup-manager .share-import-options legend {
-  font-weight: 600;
-  font-size: 0.95rem;
-  margin-bottom: 0.25rem;
-}
-
-#setup-manager .share-import-mode-select {
-  width: 100%;
-  min-height: 6.5rem;
-}
-
 #setup-manager #shareLinkMessage {
   margin-left: calc(var(--form-label-width) + var(--gap-size));
 }
@@ -678,14 +652,6 @@ main.legal-content {
 
   #setup-manager .share-option {
     justify-content: flex-start;
-  }
-
-  #setup-manager .share-import-row {
-    flex-direction: column;
-  }
-
-  #setup-manager .share-import-options {
-    width: 100%;
   }
 
   .settings-hint {
@@ -870,6 +836,46 @@ main.legal-content {
 
 #iosPwaHelpDialog[hidden] {
   display: none;
+}
+
+#sharedRulesDialog {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 210;
+}
+
+#sharedRulesDialog[hidden] {
+  display: none;
+}
+
+.shared-rules-dialog {
+  background: var(--surface-color);
+  border: 2px solid var(--accent-color);
+  border-radius: var(--border-radius);
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.2);
+  color: var(--text-color);
+  width: min(460px, 90vw);
+  padding: clamp(20px, 4vw, 28px);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.shared-rules-dialog label {
+  font-weight: 600;
+}
+
+.shared-rules-dialog select {
+  width: 100%;
+}
+
+.shared-rules-dialog-actions {
+  justify-content: flex-end;
+  gap: 0.75rem;
 }
 
 #settingsDialog[hidden] {

--- a/tests/script/autoGearRules.test.js
+++ b/tests/script/autoGearRules.test.js
@@ -230,14 +230,14 @@ describe('applyAutoGearRulesToTableHtml', () => {
     );
   });
 
-  test('changing the shared import mode reapplies shared rules', () => {
+  test('prompting for shared automatic gear rules applies the selected mode', async () => {
     env = setupScriptEnvironment();
     env.utils.syncAutoGearRulesFromStorage([]);
 
-    const applySharedLinkBtn = document.getElementById('applySharedLinkBtn');
     const sharedLinkInput = document.getElementById('sharedLinkInput');
-    const sharedImportModeSelect = document.getElementById('sharedImportModeSelect');
-    const sharedImportModeGlobalOption = document.getElementById('sharedImportModeGlobalOption');
+    const sharedRulesDialog = document.getElementById('sharedRulesDialog');
+    const sharedRulesDialogSelect = document.getElementById('sharedRulesDialogSelect');
+    const sharedRulesDialogApply = document.getElementById('sharedRulesDialogApply');
 
     const sharedRule = {
       id: 'shared-rule',
@@ -270,22 +270,27 @@ describe('applyAutoGearRulesToTableHtml', () => {
 
     window.FileReader = FileReaderStub;
 
-    applySharedLinkBtn.click();
+    sharedLinkInput.dispatchEvent(new Event('change', { bubbles: true }));
 
-    expect(sharedImportModeGlobalOption.disabled).toBe(false);
+    await Promise.resolve();
+
+    expect(sharedRulesDialog).not.toBeNull();
+    expect(sharedRulesDialog.hasAttribute('hidden')).toBe(false);
+
     const storedBeforeChange = localStorage.getItem('cameraPowerPlanner_autoGearRules');
     expect(storedBeforeChange).not.toBeNull();
     expect(JSON.parse(storedBeforeChange)).toEqual([]);
 
-    Array.from(sharedImportModeSelect.options).forEach(option => {
-      option.selected = option.value === 'global';
-    });
+    sharedRulesDialogSelect.value = 'global';
+    sharedRulesDialogApply.click();
 
-    sharedImportModeSelect.dispatchEvent(new Event('change', { bubbles: true }));
+    await Promise.resolve();
+    await Promise.resolve();
 
     const stored = JSON.parse(localStorage.getItem('cameraPowerPlanner_autoGearRules'));
     expect(stored).toHaveLength(1);
     expect(stored[0].label).toBe('Shared grip tweak');
+    expect(sharedRulesDialog.hasAttribute('hidden')).toBe(true);
   });
 
   test('rule editor accepts multiple additions at once', () => {

--- a/translations.js
+++ b/translations.js
@@ -312,6 +312,10 @@ const texts = {
     sharedImportAutoGearProjectHelp: "Apply the shared automatic gear rules to this project without affecting others.",
     sharedImportAutoGearGlobal: "Add shared rules to all projects",
     sharedImportAutoGearGlobalHelp: "Merge the shared automatic gear rules into your global collection.",
+    sharedImportAutoGearDialogMessage:
+      "This project includes automatic gear rules. How should they be handled?",
+    sharedImportAutoGearDialogApply: "Apply",
+    sharedImportAutoGearDialogCancel: "Cancel",
 
     cameraLabel: "Camera:",
     monitorLabel: "Monitor:",
@@ -843,6 +847,10 @@ const texts = {
     sharedImportAutoGearProjectHelp: "Applica le regole automatiche condivise solo a questo progetto.",
     sharedImportAutoGearGlobal: "Aggiungi le regole condivise a tutti i progetti",
     sharedImportAutoGearGlobalHelp: "Unisci le regole automatiche condivise alla raccolta globale.",
+    sharedImportAutoGearDialogMessage:
+      "Questo progetto include regole automatiche per l'attrezzatura. Come vuoi gestirle?",
+    sharedImportAutoGearDialogApply: "Applica",
+    sharedImportAutoGearDialogCancel: "Annulla",
     cameraLabel: "Telecamera:",
     monitorLabel: "Monitor:",
     videoLabel: "Trasmettitore wireless:",
@@ -1555,6 +1563,10 @@ const texts = {
     sharedImportAutoGearProjectHelp: "Aplica las reglas automáticas compartidas a este proyecto sin afectar a los demás.",
     sharedImportAutoGearGlobal: "Añadir las reglas compartidas a todos los proyectos",
     sharedImportAutoGearGlobalHelp: "Incorpora las reglas automáticas compartidas a tu colección global.",
+    sharedImportAutoGearDialogMessage:
+      "Este proyecto incluye reglas automáticas de equipo. ¿Cómo deseas gestionarlas?",
+    sharedImportAutoGearDialogApply: "Aplicar",
+    sharedImportAutoGearDialogCancel: "Cancelar",
 
     cameraLabel: "Cámara:",
     monitorLabel: "Monitor:",
@@ -2281,6 +2293,10 @@ const texts = {
     sharedImportAutoGearProjectHelp: "Applique les règles automatiques partagées à ce projet sans toucher aux autres.",
     sharedImportAutoGearGlobal: "Ajouter les règles partagées à tous les projets",
     sharedImportAutoGearGlobalHelp: "Ajoute les règles automatiques partagées à votre collection globale.",
+    sharedImportAutoGearDialogMessage:
+      "Ce projet contient des règles automatiques d’équipement. Comment souhaitez-vous les appliquer ?",
+    sharedImportAutoGearDialogApply: "Appliquer",
+    sharedImportAutoGearDialogCancel: "Annuler",
 
     cameraLabel: "Caméra:",
     monitorLabel: "Moniteur:",
@@ -3009,6 +3025,10 @@ const texts = {
     sharedImportAutoGearProjectHelp: "Wendet die geteilten automatischen Gear-Regeln nur auf dieses Projekt an.",
     sharedImportAutoGearGlobal: "Geteilte Regeln zu allen Projekten hinzufügen",
     sharedImportAutoGearGlobalHelp: "Fügt die geteilten automatischen Gear-Regeln deiner globalen Sammlung hinzu.",
+    sharedImportAutoGearDialogMessage:
+      "Diese Projektdatei enthält automatische Gear-Regeln. Wie sollen sie übernommen werden?",
+    sharedImportAutoGearDialogApply: "Übernehmen",
+    sharedImportAutoGearDialogCancel: "Abbrechen",
 
     cameraLabel: "Kamera:",
     monitorLabel: "Monitor:",


### PR DESCRIPTION
## Summary
- trigger the shared project load from the Load button and hide the file picker field
- add a modal selector that lets users choose how imported automatic gear rules are applied
- style the new dialog, localize its content, and update the shared project import test to cover the new workflow

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cdb85d76548320a473d3efff06a707