### PR TITLE
Refine overview and help icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -1007,7 +1007,23 @@
           id="featuresOverview"
           data-help-keywords="overview summary capabilities highlights offline offline-mode favorites favourites pinned search global keyboard shortcuts themes personalization backups tour"
         >
-          <h3><span class="help-icon icon-glyph" aria-hidden="true" data-icon-font="uicons">&#xF139;</span>Features at a Glance</h3>
+          <h3>
+            <span class="help-icon icon-glyph icon-svg" aria-hidden="true">
+              <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                <circle cx="12" cy="12" r="6.5" stroke-width="1.5" />
+                <circle cx="12" cy="12" r="1.5" stroke-width="1.5" />
+                <path d="M12 6.5v3" stroke-width="1.5" stroke-linecap="round" />
+                <path d="M12 14.5v3" stroke-width="1.5" stroke-linecap="round" />
+                <path d="M6.5 12h3" stroke-width="1.5" stroke-linecap="round" />
+                <path d="M14.5 12h3" stroke-width="1.5" stroke-linecap="round" />
+                <path d="M8.5 8.5 10.6 10.6" stroke-width="1.5" stroke-linecap="round" />
+                <path d="M13.4 13.4 15.5 15.5" stroke-width="1.5" stroke-linecap="round" />
+                <path d="M15.5 8.5 13.4 10.6" stroke-width="1.5" stroke-linecap="round" />
+                <path d="M10.6 13.4 8.5 15.5" stroke-width="1.5" stroke-linecap="round" />
+              </svg>
+            </span>
+            Features at a Glance
+          </h3>
           <ul>
             <li>Plan complete camera rigs and compute power draw and battery life.</li>
             <li>Save multiple projects, export or import them and print overviews.</li>
@@ -1063,7 +1079,18 @@
           id="gettingStarted"
           data-help-keywords="quickstart onboarding tutorial first steps workflow basics getting started new project guide"
         >
-          <h3><span class="help-icon icon-glyph" aria-hidden="true" data-icon-font="uicons">&#xEF93;</span>Getting Started</h3>
+          <h3>
+            <span class="help-icon icon-glyph icon-svg" aria-hidden="true">
+              <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                <path d="M6 16.5h5.25" stroke-width="1.5" stroke-linecap="round" />
+                <path d="M6.75 12.75 9.75 15.75" stroke-width="1.5" stroke-linecap="round" />
+                <path d="M9 14.5 16.5 7" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+                <path d="M16.5 7h-5.5" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+                <path d="M16.5 7v5.5" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+              </svg>
+            </span>
+            Getting Started
+          </h3>
           <ol>
             <li>
               Select a camera, monitor and other devices from the dropdown menus in the
@@ -1119,7 +1146,16 @@
           id="managingSetups"
           data-help-keywords="save saved projects load manage share backup restore export import delete rename factory reset clear project cache local storage browser reopen"
         >
-          <h3><span class="help-icon icon-glyph" aria-hidden="true" data-icon-font="uicons">&#xE852;</span>Managing Projects</h3>
+          <h3>
+            <span class="help-icon icon-glyph icon-svg" aria-hidden="true">
+              <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                <path d="M4.5 7.5h4.75L11 9.5h9.5v9.5H4.5Z" stroke-width="1.5" stroke-linejoin="round" />
+                <path d="M4.5 11h16" stroke-width="1.5" stroke-linecap="round" />
+                <path d="M8.25 13.75l1.75 2 4-4.75" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+              </svg>
+            </span>
+            Managing Projects
+          </h3>
           <ul>
             <li>
               Use
@@ -1229,7 +1265,20 @@
           id="settingsHelp"
           data-help-keywords="settings preferences customization customise personalize colour color font typeface accent high contrast theme backup restore"
         >
-          <h3><span class="help-icon icon-glyph" aria-hidden="true" data-icon-font="essential">&#xF211;</span>Settings &amp; Personalization</h3>
+          <h3>
+            <span class="help-icon icon-glyph icon-svg" aria-hidden="true">
+              <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                <rect x="5" y="5.5" width="14" height="14" rx="2" stroke-width="1.5" />
+                <path d="M8 9.5h8" stroke-width="1.5" stroke-linecap="round" />
+                <path d="M8 14h8" stroke-width="1.5" stroke-linecap="round" />
+                <path d="M8 18.5h8" stroke-width="1.5" stroke-linecap="round" />
+                <circle cx="12" cy="9.5" r="1.6" stroke-width="1.5" />
+                <circle cx="10.5" cy="14" r="1.6" stroke-width="1.5" />
+                <circle cx="13.5" cy="18.5" r="1.6" stroke-width="1.5" />
+              </svg>
+            </span>
+            Settings &amp; Personalization
+          </h3>
           <ul>
             <li>Switch languages instantly; the planner remembers your preference for next time.</li>
             <li>Tune the interface with dark mode, high contrast, pink accents and a custom accent color to match your production.</li>
@@ -1271,7 +1320,17 @@
           id="autoBackupsHelp"
           data-help-keywords="auto backup automatic snapshot restore recovery safety hourly download full app backup notification show saved projects setting"
         >
-          <h3><span class="help-icon icon-glyph" aria-hidden="true" data-icon-font="uicons">&#xE825;</span>Automatic Backups</h3>
+          <h3>
+            <span class="help-icon icon-glyph icon-svg" aria-hidden="true">
+              <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                <path d="M12 4.5 18.5 7v5.5c0 3.8-2.8 7.1-6.5 7.9-3.7-.8-6.5-4.1-6.5-7.9V7Z" stroke-width="1.5" stroke-linejoin="round" />
+                <path d="M12 8.5v5.5" stroke-width="1.5" stroke-linecap="round" />
+                <path d="M9.5 12 12 14.5 14.5 12" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+                <path d="M8.5 17h7" stroke-width="1.5" stroke-linecap="round" />
+              </svg>
+            </span>
+            Automatic Backups
+          </h3>
           <ul>
             <li>The planner saves an auto backup every 10 minutes without interrupting your work. Entries are timestamped and stored alongside saved projects.</li>
             <li>Enable <strong>Show auto backups in project list</strong> in Settings → Backup &amp; Restore to temporarily reveal those snapshots in the <em>Saved Projects</em> dropdown.</li>
@@ -1294,7 +1353,19 @@
           id="projectRequirementsHelp"
           data-help-keywords="project requirements brief notes metadata crew schedule prep shoot forms multi-select documentation"
         >
-          <h3><span class="help-icon icon-glyph" aria-hidden="true" data-icon-font="uicons">&#xE469;</span>Project Requirements</h3>
+          <h3>
+            <span class="help-icon icon-glyph icon-svg" aria-hidden="true">
+              <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                <rect x="6" y="6.5" width="12" height="14" rx="2" stroke-width="1.5" />
+                <path d="M10 4h4" stroke-width="1.5" stroke-linecap="round" />
+                <path d="M9 6.5h6" stroke-width="1.5" stroke-linecap="round" />
+                <path d="M8.5 11h7.5" stroke-width="1.5" stroke-linecap="round" />
+                <path d="M8.5 14.5h7.5" stroke-width="1.5" stroke-linecap="round" />
+                <path d="M8.5 18h5" stroke-width="1.5" stroke-linecap="round" />
+              </svg>
+            </span>
+            Project Requirements
+          </h3>
           <ul>
             <li>Capture production details such as production company, rental house, DoP, crew roles with email contacts, shooting dates, resolutions, codecs and more for each project.</li>
             <li>Multi-select lists let you specify multiple scenarios, accessories or monitoring setups.</li>
@@ -1315,7 +1386,21 @@
           id="gearListHelp"
           data-help-keywords="gear list equipment inventory export print accessories scenarios quantity breakdown report"
         >
-          <h3><span class="help-icon icon-glyph" aria-hidden="true" data-icon-font="uicons">&#xE467;</span>Gear List</h3>
+          <h3>
+            <span class="help-icon icon-glyph icon-svg" aria-hidden="true">
+              <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                <rect x="6" y="5.5" width="12" height="14.5" rx="2" stroke-width="1.5" />
+                <path d="M8 7.5h8" stroke-width="1.5" stroke-linecap="round" />
+                <rect x="8" y="9" width="3" height="3" rx="0.6" stroke-width="1.5" />
+                <path d="M8.65 10.5l0.85 0.85 1.45-1.75" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+                <rect x="8" y="13.5" width="3" height="3" rx="0.6" stroke-width="1.5" />
+                <path d="M8.65 15l0.85 0.85 1.45-1.75" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+                <path d="M12.5 10.5h4.5" stroke-width="1.5" stroke-linecap="round" />
+                <path d="M12.5 15h4.5" stroke-width="1.5" stroke-linecap="round" />
+              </svg>
+            </span>
+            Gear List
+          </h3>
             <ul>
               <li>The <strong>Generate Gear List</strong> button expands every selected device and project detail into a rich table grouped by category and quantity.</li>
               <li>Any change to devices, lenses, batteries or project information rebuilds the list so it always reflects the current configuration.</li>
@@ -1380,7 +1465,21 @@
           id="autoGearRulesHelp"
           data-help-keywords="automatic gear rules auto add remove custom scenario requirements generator list automation"
         >
-          <h3><span class="help-icon icon-glyph" aria-hidden="true" data-icon-font="film">&#xF129;</span>Automatic Gear Rules</h3>
+          <h3>
+            <span class="help-icon icon-glyph icon-svg" aria-hidden="true">
+              <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                <circle cx="12" cy="8.5" r="2.2" stroke-width="1.5" />
+                <circle cx="7.5" cy="15.5" r="1.7" stroke-width="1.5" />
+                <circle cx="12" cy="15.5" r="1.7" stroke-width="1.5" />
+                <circle cx="16.5" cy="15.5" r="1.7" stroke-width="1.5" />
+                <path d="M12 10.7v1.8" stroke-width="1.5" stroke-linecap="round" />
+                <path d="M12 12.5 8.7 14.1" stroke-width="1.5" stroke-linecap="round" />
+                <path d="M12 12.5l3.3 1.6" stroke-width="1.5" stroke-linecap="round" />
+                <path d="M12 12.9v1.6" stroke-width="1.5" stroke-linecap="round" />
+              </svg>
+            </span>
+            Automatic Gear Rules
+          </h3>
           <ul>
             <li>
               Open <em>Settings → Automatic Gear Rules</em> to create custom additions or removals that run when specific
@@ -1430,7 +1529,18 @@
           id="powerCalculator"
           data-help-keywords="power calculator runtime estimator watt hours consumption battery life current warnings hotswap compare energy"
         >
-          <h3><span class="help-icon icon-glyph" aria-hidden="true" data-icon-font="essential">&#xF1F8;</span>Power Calculator</h3>
+          <h3>
+            <span class="help-icon icon-glyph icon-svg" aria-hidden="true">
+              <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                <path d="M6.5 15a5.5 5.5 0 0 1 11 0" stroke-width="1.5" stroke-linecap="round" />
+                <circle cx="12" cy="15" r="1.4" stroke-width="1.5" />
+                <path d="M12 9.5v3.8" stroke-width="1.5" stroke-linecap="round" />
+                <path d="M8.25 12.25 9.5 13.5" stroke-width="1.5" stroke-linecap="round" />
+                <path d="M15.75 12.25 14.5 13.5" stroke-width="1.5" stroke-linecap="round" />
+              </svg>
+            </span>
+            Power Calculator
+          </h3>
           <ul>
             <li>Select a battery to see estimated runtime, current draw and required batteries for a 10&nbsp;h shoot (incl. spare).</li>
             <li>A temperature note helps account for runtime changes in hot or cold conditions.</li>
@@ -1470,7 +1580,18 @@
           id="calculationDetails"
           data-help-keywords="calculation math formula codec weighting brightness wifi runtime details advanced explanation"
         >
-          <h3><span class="help-icon icon-glyph" aria-hidden="true" data-icon-font="essential">&#xF123;</span>Calculation Details</h3>
+          <h3>
+            <span class="help-icon icon-glyph icon-svg" aria-hidden="true">
+              <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                <rect x="4.5" y="9.5" width="3.5" height="6.5" rx="0.8" stroke-width="1.5" />
+                <rect x="9" y="7" width="3.5" height="9" rx="0.8" stroke-width="1.5" />
+                <rect x="13.5" y="11" width="3.5" height="5" rx="0.8" stroke-width="1.5" />
+                <circle cx="17.5" cy="15.5" r="3" stroke-width="1.5" />
+                <path d="M19.6 17.6 21.25 19.25" stroke-width="1.5" stroke-linecap="round" />
+              </svg>
+            </span>
+            Calculation Details
+          </h3>
           <ul>
             <li>Each device contributes its power draw in watts to <em>Total Consumption</em>.</li>
             <li>Current at 14.4 V (33.6 V for B‑Mount) and 12 V (21.6 V for B‑Mount) equals total watts divided by voltage.</li>
@@ -1506,7 +1627,20 @@
           id="runtimeFeedbackHelp"
           data-help-keywords="runtime feedback user measurements field data submit temperature weighting crowdsource"
         >
-          <h3><span class="help-icon icon-glyph" aria-hidden="true" data-icon-font="essential">&#xF13E;</span>User Runtime Feedback</h3>
+          <h3>
+            <span class="help-icon icon-glyph icon-svg" aria-hidden="true">
+              <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                <path d="M5.5 8h13a2 2 0 0 1 2 2v5a2 2 0 0 1-2 2H12l-3.5 3v-3H5.5a2 2 0 0 1-2-2v-5a2 2 0 0 1 2-2Z" stroke-width="1.5" stroke-linejoin="round" />
+                <path d="M8.5 12h4.5" stroke-width="1.5" stroke-linecap="round" />
+                <path d="M8.5 14.5h6" stroke-width="1.5" stroke-linecap="round" />
+                <path d="M15.5 9.5v1.4" stroke-width="1.5" stroke-linecap="round" />
+                <path d="M15.5 10.2h1.4" stroke-width="1.5" stroke-linecap="round" />
+                <path d="M14.95 9.7 16.3 11" stroke-width="1.5" stroke-linecap="round" />
+                <path d="M16.05 9.7 14.7 11" stroke-width="1.5" stroke-linecap="round" />
+              </svg>
+            </span>
+            User Runtime Feedback
+          </h3>
           <ul>
             <li>Click <strong>Submit User Runtime Feedback</strong> below the runtime to add your own measurement.</li>
             <li>Include temperature for more accurate weighting.</li>
@@ -1531,7 +1665,21 @@
           id="setupDiagramHelp"
           data-help-keywords="diagram layout connections map wiring visualize nodes drag zoom pan svg jpg export reset snap grid"
         >
-          <h3><span class="help-icon icon-glyph" aria-hidden="true" data-icon-font="uicons">&#xEF8C;</span>Project Diagram</h3>
+          <h3>
+            <span class="help-icon icon-glyph icon-svg" aria-hidden="true">
+              <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                <circle cx="7.5" cy="9" r="2.1" stroke-width="1.5" />
+                <circle cx="16.5" cy="9" r="2.1" stroke-width="1.5" />
+                <circle cx="12" cy="15.5" r="2.2" stroke-width="1.5" />
+                <circle cx="18" cy="16.5" r="1.8" stroke-width="1.5" />
+                <path d="M9.6 9h4.8" stroke-width="1.5" stroke-linecap="round" />
+                <path d="M8.4 10.7 10.8 13" stroke-width="1.5" stroke-linecap="round" />
+                <path d="M15.6 10.7 13.2 13" stroke-width="1.5" stroke-linecap="round" />
+                <path d="M13.8 16 17 16.8" stroke-width="1.5" stroke-linecap="round" />
+              </svg>
+            </span>
+            Project Diagram
+          </h3>
           <ul>
             <li>Visualizes power and video connections between selected devices.</li>
             <li>Drag nodes to rearrange the layout; use +/– buttons to zoom.</li>
@@ -1571,7 +1719,18 @@
           id="deviceEditorHelp"
           data-help-keywords="device editor database custom gear add edit modify remove import export revert data management"
         >
-          <h3><span class="help-icon icon-glyph" aria-hidden="true" data-icon-font="uicons">&#xF2DF;</span>Device Database Editor</h3>
+          <h3>
+            <span class="help-icon icon-glyph icon-svg" aria-hidden="true">
+              <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                <rect x="5.5" y="5.5" width="8.5" height="11.5" rx="2" stroke-width="1.5" />
+                <path d="M5.5 9.5h8.5" stroke-width="1.5" stroke-linecap="round" />
+                <path d="M5.5 13h8.5" stroke-width="1.5" stroke-linecap="round" />
+                <path d="M16.5 8.5 19.5 11.5l-4.5 4.5-2.5.5.5-2.5Z" stroke-width="1.5" stroke-linejoin="round" />
+                <path d="M18.3 9.7 16.2 11.8" stroke-width="1.5" stroke-linecap="round" />
+              </svg>
+            </span>
+            Device Database Editor
+          </h3>
           <ul>
             <li>Open with <em>Edit Device Data…</em> to add, modify or remove devices.</li>
             <li>Changes are stored locally; use <em>Export</em> and <em>Import</em> to share databases.</li>
@@ -1606,7 +1765,17 @@
           id="deviceCategoriesHelp"
           data-help-keywords="device categories slots limits optional required types selection count overview"
         >
-          <h3><span class="help-icon icon-glyph" aria-hidden="true" data-icon-font="uicons">&#xE84A;</span>Device Categories</h3>
+          <h3>
+            <span class="help-icon icon-glyph icon-svg" aria-hidden="true">
+              <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                <rect x="6" y="6" width="5.5" height="5.5" rx="1" stroke-width="1.5" />
+                <rect x="12.5" y="6" width="5.5" height="5.5" rx="1" stroke-width="1.5" />
+                <rect x="6" y="12.5" width="5.5" height="5.5" rx="1" stroke-width="1.5" />
+                <rect x="12.5" y="12.5" width="5.5" height="5.5" rx="1" stroke-width="1.5" />
+              </svg>
+            </span>
+            Device Categories
+          </h3>
           <ul>
             <li><strong>Camera</strong> (1)</li>
             <li><strong>Monitor</strong> (optional)</li>
@@ -1632,7 +1801,19 @@
           id="searchFiltering"
           data-help-keywords="search filter filtering favourites favorites quick find slash ctrl+f ctrl+k global search star pinned clear query"
         >
-          <h3><span class="help-icon icon-glyph" aria-hidden="true" data-icon-font="uicons">&#xF016;</span>Search &amp; Filtering</h3>
+          <h3>
+            <span class="help-icon icon-glyph icon-svg" aria-hidden="true">
+              <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                <circle cx="10" cy="10" r="4.2" stroke-width="1.5" />
+                <path d="M12.9 12.9 17.5 17.5" stroke-width="1.5" stroke-linecap="round" />
+                <path d="M7.5 8.5h5" stroke-width="1.5" stroke-linecap="round" />
+                <path d="M7.5 11.5h5" stroke-width="1.5" stroke-linecap="round" />
+                <path d="M9.5 7.5v2" stroke-width="1.5" stroke-linecap="round" />
+                <path d="M11 10.5v2" stroke-width="1.5" stroke-linecap="round" />
+              </svg>
+            </span>
+            Search &amp; Filtering
+          </h3>
           <ul>
             <li>Every dropdown and list can be filtered via its search box.</li>
             <li>The help dialog itself is searchable using the field at the top.</li>
@@ -1665,7 +1846,23 @@
           id="helpDialogHelp"
           data-help-keywords="help dialog window modal question mark f1 instructions search toggle open close clear focus"
         >
-          <h3><span class="help-icon icon-glyph" aria-hidden="true" data-icon-font="uicons">&#xEEFB;</span>Help Dialog</h3>
+          <h3>
+            <span class="help-icon icon-glyph icon-svg" aria-hidden="true">
+              <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                <circle cx="12" cy="12" r="6.5" stroke-width="1.5" />
+                <circle cx="12" cy="12" r="3" stroke-width="1.5" />
+                <path d="M12 5.5v2.3" stroke-width="1.5" stroke-linecap="round" />
+                <path d="M12 16.2v2.3" stroke-width="1.5" stroke-linecap="round" />
+                <path d="M5.5 12h2.3" stroke-width="1.5" stroke-linecap="round" />
+                <path d="M16.2 12h2.3" stroke-width="1.5" stroke-linecap="round" />
+                <path d="M7.7 7.7 9.3 9.3" stroke-width="1.5" stroke-linecap="round" />
+                <path d="M14.7 14.7 16.3 16.3" stroke-width="1.5" stroke-linecap="round" />
+                <path d="M7.7 16.3 9.3 14.7" stroke-width="1.5" stroke-linecap="round" />
+                <path d="M14.7 9.3 16.3 7.7" stroke-width="1.5" stroke-linecap="round" />
+              </svg>
+            </span>
+            Help Dialog
+          </h3>
           <ul>
             <li>Open with the <strong>?</strong> button or press <kbd>?</kbd>, <kbd>H</kbd>, <kbd>F1</kbd> or <kbd>Ctrl</kbd>+<kbd>/</kbd> (<kbd>⌘</kbd>+<kbd>/</kbd> on macOS); shortcuts work even while typing.</li>
             <li>Type keywords or alternate spellings to filter topics; the search resets automatically whenever you close the dialog.</li>
@@ -1685,7 +1882,18 @@
           id="troubleshootingHelp"
           data-help-keywords="troubleshooting recovery issue problem stuck blank update reload cache backup restore revert factory reset missing gear lost data"
         >
-          <h3><span class="help-icon icon-glyph" aria-hidden="true" data-icon-font="uicons">&#xF2DF;</span>Troubleshooting &amp; Recovery</h3>
+          <h3>
+            <span class="help-icon icon-glyph icon-svg" aria-hidden="true">
+              <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                <path d="M8 6.5 10.5 9" stroke-width="1.5" stroke-linecap="round" />
+                <path d="M10.5 9 5 14.5l3 3 5.5-5.5" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+                <path d="M10.5 9 12.2 7.3l2.5 2.5-1.7 1.7" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+                <path d="M15.5 7.5h3v3" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+                <path d="M14.5 18.5a5 5 0 1 1 3.5-8.5" stroke-width="1.5" stroke-linecap="round" />
+              </svg>
+            </span>
+            Troubleshooting &amp; Recovery
+          </h3>
           <ul>
             <li>
               If the interface looks stuck or outdated, click
@@ -1749,7 +1957,16 @@
           id="hoverHelp"
           data-help-keywords="hover help tooltips hints guidance cursor descriptions overlay tips"
         >
-          <h3><span class="help-icon icon-glyph" aria-hidden="true" data-icon-font="uicons">&#xE597;</span>Hover Help</h3>
+          <h3>
+            <span class="help-icon icon-glyph icon-svg" aria-hidden="true">
+              <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                <path d="M6.5 5.5 11.5 16l1.5-3 3 1.5Z" stroke-width="1.5" stroke-linejoin="round" />
+                <rect x="12.5" y="6.5" width="5.5" height="3.5" rx="0.8" stroke-width="1.5" />
+                <path d="M12.5 8.25h-2" stroke-width="1.5" stroke-linecap="round" />
+              </svg>
+            </span>
+            Hover Help
+          </h3>
           <ul>
             <li>Activate tooltip mode with <strong>Hover for help</strong> in the help dialog.</li>
             <li>Move the cursor over buttons, fields, dropdowns or headers to see brief explanations.</li>
@@ -1764,7 +1981,20 @@
           id="languageHelp"
           data-help-keywords="language translation locale localisation english german spanish french italian switch change"
         >
-          <h3><span class="help-icon icon-glyph" aria-hidden="true" data-icon-font="uicons">&#xEAE7;</span>Language</h3>
+          <h3>
+            <span class="help-icon icon-glyph icon-svg" aria-hidden="true">
+              <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                <circle cx="10" cy="12" r="4.5" stroke-width="1.5" />
+                <path d="M10 7.5v9" stroke-width="1.5" stroke-linecap="round" />
+                <path d="M5.5 12h9" stroke-width="1.5" stroke-linecap="round" />
+                <path d="M6.5 9.5h7" stroke-width="1.5" stroke-linecap="round" />
+                <path d="M6.5 14.5h7" stroke-width="1.5" stroke-linecap="round" />
+                <path d="M15 7.5a2.2 2.2 0 0 1 2.2 2.2c0 1.6-2.2 4.6-2.2 4.6s-2.2-3-2.2-4.6A2.2 2.2 0 0 1 15 7.5Z" stroke-width="1.5" stroke-linejoin="round" />
+                <circle cx="15" cy="9.6" r="0.9" stroke-width="1.5" />
+              </svg>
+            </span>
+            Language
+          </h3>
           <ul>
             <li>Use the dropdown in the top right to switch languages.</li>
             <li>Your choice is remembered for the next visit.</li>
@@ -1836,7 +2066,17 @@
           id="shortcuts"
           data-help-keywords="keyboard shortcuts hotkeys key commands quick reference controls"
         >
-          <h3><span class="help-icon icon-glyph" aria-hidden="true" data-icon-font="uicons">&#xEAB8;</span>Keyboard Shortcuts</h3>
+          <h3>
+            <span class="help-icon icon-glyph icon-svg" aria-hidden="true">
+              <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                <rect x="5.5" y="8" width="13" height="8.5" rx="2" stroke-width="1.5" />
+                <path d="M8.5 12h6.5" stroke-width="1.5" stroke-linecap="round" />
+                <path d="M9 10.5h5" stroke-width="1.5" stroke-linecap="round" />
+                <path d="M9 13.5h3" stroke-width="1.5" stroke-linecap="round" />
+              </svg>
+            </span>
+            Keyboard Shortcuts
+          </h3>
           <ul>
             <li><kbd>?</kbd>, <kbd>H</kbd>, <kbd>F1</kbd> or <kbd>Ctrl</kbd>+<kbd>/</kbd> – toggle help</li>
             <li><kbd>Ctrl</kbd>+<kbd>K</kbd> (<kbd>⌘</kbd>+<kbd>K</kbd>) – focus the global search field</li>
@@ -1852,7 +2092,16 @@
           id="faq"
           data-help-keywords="faq questions answers troubleshooting tips"
         >
-          <h3><span class="help-icon icon-glyph" aria-hidden="true" data-icon-font="uicons">&#xEEFB;</span>FAQ</h3>
+          <h3>
+            <span class="help-icon icon-glyph icon-svg" aria-hidden="true">
+              <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                <path d="M5.5 8h13v8H12l-3 3v-3H5.5Z" stroke-width="1.5" stroke-linejoin="round" />
+                <path d="M12.5 10.2a1.9 1.9 0 0 1 3.5.9c0 1.1-.9 1.5-1.7 2-0.6 0.4-1.1 0.7-1.1 1.5v0.3" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+                <path d="M14.3 15.8v0.2" stroke-width="1.5" stroke-linecap="round" />
+              </svg>
+            </span>
+            FAQ
+          </h3>
           <details
             class="faq-item"
             data-help-keywords="save project saved projects ctrl+s enter autosave rename update"

--- a/script.js
+++ b/script.js
@@ -3282,6 +3282,13 @@ function glyphText(glyph) {
   return resolved.char || '';
 }
 
+function svgIconGlyph(markup) {
+  if (typeof markup !== 'string') {
+    return Object.freeze({ markup: '', className: 'icon-svg' });
+  }
+  return Object.freeze({ markup: markup.trim(), className: 'icon-svg' });
+}
+
 const ICON_GLYPHS = Object.freeze({
   batteryBolt: iconGlyph('\uE1A6', ICON_FONT_KEYS.UICONS),
   batteryFull: iconGlyph('\uE1A9', ICON_FONT_KEYS.UICONS),
@@ -8414,17 +8421,104 @@ const diagramIcons = {
   distance: ICON_GLYPHS.distance
 };
 
+const overviewIconGlyphs = Object.freeze({
+  batteries: svgIconGlyph(`
+    <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+      <rect x="3.25" y="6.25" width="7.5" height="11.5" rx="1.5" ry="1.5" stroke-width="1.5" />
+      <rect x="13.25" y="6.25" width="7.5" height="11.5" rx="1.5" ry="1.5" stroke-width="1.5" />
+      <path d="M6.5 4.75h2.5" stroke-width="1.5" stroke-linecap="round" />
+      <path d="M16.5 4.75h2.5" stroke-width="1.5" stroke-linecap="round" />
+      <path d="M8.75 6.25v-1.5" stroke-width="1.5" stroke-linecap="round" />
+      <path d="M18.75 6.25v-1.5" stroke-width="1.5" stroke-linecap="round" />
+    </svg>
+  `),
+  hotswaps: svgIconGlyph(`
+    <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+      <rect x="3.75" y="6" width="7" height="11" rx="1.5" ry="1.5" stroke-width="1.5" />
+      <rect x="13.25" y="7" width="7" height="11" rx="1.5" ry="1.5" stroke-width="1.5" />
+      <path d="M10.75 11.5h4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+      <path d="M14.75 11.5 13 9.75" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+      <path d="M14.75 11.5 13 13.25" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+    </svg>
+  `),
+  cameras: svgIconGlyph(`
+    <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+      <rect x="3.5" y="7" width="11.5" height="10" rx="2" stroke-width="1.5" />
+      <path d="M15 9.5 20.5 7v10L15 15.5" stroke-width="1.5" stroke-linejoin="round" />
+      <circle cx="9.25" cy="12" r="2.75" stroke-width="1.5" />
+      <path d="M6.5 7V5.5h4.75l1.75 1.75" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+      <path d="M5.75 16.5h2.5" stroke-width="1.5" stroke-linecap="round" />
+    </svg>
+  `),
+  viewfinders: svgIconGlyph(`
+    <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+      <rect x="3.75" y="8" width="11" height="7.5" rx="1.8" stroke-width="1.5" />
+      <path d="M14.75 9.5 20.25 12l-5.5 2.5V9.5Z" stroke-width="1.5" stroke-linejoin="round" />
+      <path d="M7 6h4.5" stroke-width="1.5" stroke-linecap="round" />
+      <path d="M6 11.75h2" stroke-width="1.5" stroke-linecap="round" />
+    </svg>
+  `),
+  monitors: svgIconGlyph(`
+    <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+      <rect x="3.5" y="5" width="17" height="12" rx="2" stroke-width="1.5" />
+      <path d="M8 9h8" stroke-width="1.5" stroke-linecap="round" />
+      <path d="M12 17v3" stroke-width="1.5" stroke-linecap="round" />
+      <path d="M8.5 20h7" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+    </svg>
+  `),
+  video: svgIconGlyph(`
+    <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+      <rect x="7.5" y="7" width="9" height="10" rx="1.5" stroke-width="1.5" />
+      <path d="M12 4v3" stroke-width="1.5" stroke-linecap="round" />
+      <path d="M9.5 5 7.5 3" stroke-width="1.5" stroke-linecap="round" />
+      <path d="M14.5 5 16.5 3" stroke-width="1.5" stroke-linecap="round" />
+      <path d="M18.5 8.5a5 5 0 0 1 0 7" stroke-width="1.5" stroke-linecap="round" />
+      <path d="M17 9.75a3.25 3.25 0 0 1 0 4.5" stroke-width="1.5" stroke-linecap="round" />
+      <circle cx="12" cy="12" r="1.75" stroke-width="1.5" />
+    </svg>
+  `),
+  motors: svgIconGlyph(`
+    <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+      <rect x="5.75" y="5" width="6.5" height="14" rx="1.75" stroke-width="1.5" />
+      <path d="M12.25 12h1.5" stroke-width="1.5" stroke-linecap="round" />
+      <circle cx="16.5" cy="12" r="2.75" stroke-width="1.5" />
+      <path d="M16.5 9.25v5.5" stroke-width="1.5" stroke-linecap="round" />
+      <path d="M13.75 12h5.5" stroke-width="1.5" stroke-linecap="round" />
+      <path d="M14.55 10.7 18.45 14.6" stroke-width="1.5" stroke-linecap="round" />
+      <path d="M18.45 10.7 14.55 14.6" stroke-width="1.5" stroke-linecap="round" />
+    </svg>
+  `),
+  controllers: svgIconGlyph(`
+    <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+      <rect x="6.75" y="4.5" width="10.5" height="15" rx="2.5" stroke-width="1.5" />
+      <circle cx="12" cy="11.75" r="3" stroke-width="1.5" />
+      <path d="M9 7.5h6" stroke-width="1.5" stroke-linecap="round" />
+      <path d="M9.25 9.5h2.25" stroke-width="1.5" stroke-linecap="round" />
+      <path d="M9.25 15.5h5.5" stroke-width="1.5" stroke-linecap="round" />
+    </svg>
+  `),
+  distance: svgIconGlyph(`
+    <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+      <rect x="5.75" y="6" width="8" height="12" rx="2" stroke-width="1.5" />
+      <circle cx="9.75" cy="12" r="2.25" stroke-width="1.5" />
+      <path d="M13.75 9.5c1.5 1 1.5 4 0 5" stroke-width="1.5" stroke-linecap="round" />
+      <path d="M15.75 8.5c2 1.3 2 6.2 0 7.5" stroke-width="1.5" stroke-linecap="round" />
+    </svg>
+  `)
+});
+
 // Map overview section keys to diagram icons
 /* exported overviewSectionIcons */
 const overviewSectionIcons = {
-  category_batteries: diagramIcons.battery,
-  category_cameras: diagramIcons.camera,
-  category_viewfinders: diagramIcons.viewfinder,
-  category_monitors: diagramIcons.monitor,
-  category_video: diagramIcons.video,
-  category_fiz_motors: diagramIcons.motors,
-  category_fiz_controllers: diagramIcons.controllers,
-  category_fiz_distance: diagramIcons.distance
+  category_batteries: overviewIconGlyphs.batteries,
+  category_batteryHotswaps: overviewIconGlyphs.hotswaps,
+  category_cameras: overviewIconGlyphs.cameras,
+  category_viewfinders: overviewIconGlyphs.viewfinders,
+  category_monitors: overviewIconGlyphs.monitors,
+  category_video: overviewIconGlyphs.video,
+  category_fiz_motors: overviewIconGlyphs.motors,
+  category_fiz_controllers: overviewIconGlyphs.controllers,
+  category_fiz_distance: overviewIconGlyphs.distance
 };
 
 // Load an image and optionally strip a solid background using Canvas


### PR DESCRIPTION
## Summary
- add a helper for SVG glyphs and dedicated overview icons for batteries, cameras, monitors, video links, FIZ hardware, distance sensors and battery hotswaps
- refresh help dialog headings to use inline SVG artwork tailored to each topic while keeping existing accessibility styling

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68cdbcb75c048320bed7bd30d1b33510