### PR TITLE
Align settings dialog shell with help styling

### DIFF
--- a/style.css
+++ b/style.css
@@ -973,22 +973,16 @@ main.legal-content {
 .settings-content {
   background: var(--surface-color);
   border: 2px solid var(--accent-color);
-  padding: clamp(24px, 4vw, 48px);
+  padding: 20px;
   color: var(--text-color);
-  width: min(92vw, 520px);
-  max-height: 90vh;
+  width: min(90vw, 700px);
+  max-height: 80vh;
   overflow-y: auto;
   border-radius: var(--border-radius);
   box-shadow: 0 4px 20px rgba(0, 0, 0, 0.2);
   display: flex;
   flex-direction: column;
   gap: 20px;
-}
-
-@media (min-width: 900px) {
-  .settings-content {
-    width: min(78vw, 720px);
-  }
 }
 
 .settings-section {


### PR DESCRIPTION
## Summary
- align the settings dialog container padding, width and height with the help dialog to match its outlined appearance

## Testing
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68cdbdc749888320a121bff72fda4dfe