### PR TITLE
Fix duplicate icons in help quick links

### DIFF
--- a/script.js
+++ b/script.js
@@ -18066,7 +18066,20 @@ if (helpButton && helpDialog) {
       if (!id) return;
       const heading = section.querySelector('h3');
       if (!heading) return;
-      const label = heading.textContent.trim();
+      const headingIcon = heading.querySelector('.help-icon.icon-glyph');
+      let label = heading.textContent || '';
+      if (headingIcon) {
+        const iconText = headingIcon.textContent || '';
+        if (iconText) {
+          const iconIndex = label.indexOf(iconText);
+          if (iconIndex > -1) {
+            label =
+              label.slice(0, iconIndex) +
+              label.slice(iconIndex + iconText.length);
+          }
+        }
+      }
+      label = label.trim();
       if (!label) return;
       const li = document.createElement('li');
       const button = document.createElement('button');
@@ -18075,7 +18088,6 @@ if (helpButton && helpDialog) {
       button.dataset.targetId = id;
       button.setAttribute('aria-label', label);
 
-      const headingIcon = heading.querySelector('.help-icon.icon-glyph');
       if (headingIcon) {
         const icon = headingIcon.cloneNode(true);
         icon.classList.remove('help-icon');


### PR DESCRIPTION
## Summary
- ensure quick link labels strip heading glyphs before building buttons so each topic shows a single icon

## Testing
- npm run test:dom

------
https://chatgpt.com/codex/tasks/task_e_68cdbe01ac54832088b25bafecb8e6ba