### PR TITLE
Make help quick link icons white in dark mode

### DIFF
--- a/style.css
+++ b/style.css
@@ -1364,6 +1364,10 @@ body.pink-mode .auto-gear-rule-title,
   font-size: 1.1em;
 }
 
+.dark-mode .help-quick-link-icon {
+  --icon-color: var(--inverse-text-color);
+}
+
 .help-quick-link.active .help-quick-link-icon {
   --icon-color: var(--inverse-text-color);
 }


### PR DESCRIPTION
## Summary
- make the help quick link icons inherit the inverse text color in dark mode so they render white for the "Jump to a topic" section

## Testing
- npm run test:dom

------
https://chatgpt.com/codex/tasks/task_e_68cdbe5212c483208fd721b7f333a7b9