### PR TITLE
Centralize typography configuration

### DIFF
--- a/overview-print.css
+++ b/overview-print.css
@@ -23,8 +23,8 @@ body.dark-mode {
   --video-color: #369;
   --fiz-color: #090;
   font-family: 'Ubuntu', sans-serif;
-  font-weight: 300;
-  font-size: 12pt;
+  font-weight: var(--font-weight-light);
+  font-size: var(--font-size-base);
   line-height: var(--line-height-base, 1.6);
   -webkit-print-color-adjust: exact;
   print-color-adjust: exact;
@@ -87,7 +87,7 @@ body.dark-mode {
 #overviewDialogContent h2,
 #overviewDialogContent h3 {
   font-family: 'Ubuntu', sans-serif;
-  font-weight: 400;
+  font-weight: var(--font-weight-regular);
   border-color: var(--text-color) !important;
   color: var(--text-color) !important;
 }
@@ -208,7 +208,7 @@ table, th, td {
 }
 #overviewDialogContent th {
   background-color: var(--control-bg) !important;
-  font-weight: 700;
+  font-weight: var(--font-weight-bold);
 }
 #overviewDialogContent tr {
   background-color: var(--surface-color) !important;
@@ -267,7 +267,7 @@ body:not(.light-mode) .gear-table tbody {
 body:not(.light-mode) .gear-table .category-row td {
   border-top: 1px solid var(--accent-color);
   border-bottom: 1px solid var(--accent-color);
-  font-weight: 700;
+  font-weight: var(--font-weight-bold);
   color: var(--accent-color);
   break-after: avoid;
   page-break-after: avoid;
@@ -329,7 +329,7 @@ body:not(.light-mode) .gear-table .category-row td {
 }
 
 .warning {
-  font-weight: bold;
+  font-weight: var(--font-weight-bold);
 }
 
 #overviewDialogContent .device-category {

--- a/overview.css
+++ b/overview.css
@@ -7,15 +7,15 @@ select:focus-visible {
   outline: none;
 }
 
-body { font-family: 'Ubuntu', sans-serif; font-weight: 300; margin: 25px; color: var(--control-text); font-size: 0.9em; line-height: var(--line-height-base, 1.6); -webkit-print-color-adjust: exact; print-color-adjust: exact; }
+body { font-family: 'Ubuntu', sans-serif; font-weight: var(--font-weight-light); margin: 25px; color: var(--control-text); font-size: calc(var(--font-size-relative-base) * var(--font-scale-sm)); line-height: var(--line-height-base, 1.6); -webkit-print-color-adjust: exact; print-color-adjust: exact; }
 @media (max-width: 600px) {
   body { margin: 10px; }
   h2 { padding-bottom: 8px; }
 }
-h1, h2, h3 { font-family: 'Ubuntu', sans-serif; font-weight: 400; color: var(--accent-color); }
-h1 { font-size: 1.8em; margin-bottom: 0.2em; }
-h2 { font-size: 1.4em; margin-top: 1.3em; border-bottom: 2px solid var(--accent-color); padding-bottom: 5px; }
-h3 { font-size: 1.1em; margin-top: 1em; }
+h1, h2, h3 { font-family: 'Ubuntu', sans-serif; font-weight: var(--font-weight-regular); color: var(--accent-color); }
+h1 { font-size: calc(var(--font-size-relative-base) * var(--font-scale-display)); margin-bottom: 0.2em; }
+h2 { font-size: calc(var(--font-size-relative-base) * var(--font-scale-xxl)); margin-top: 1.3em; border-bottom: 2px solid var(--accent-color); padding-bottom: 5px; }
+h3 { font-size: calc(var(--font-size-relative-base) * var(--font-scale-lg)); margin-top: 1em; }
 p { line-height: var(--line-height-base, 1.6); }
 ul { list-style: none; margin: 5px 0; padding-left: 0; }
 li { margin: 3px 0; }
@@ -25,9 +25,9 @@ table {
   margin-top: 5px;
   table-layout: fixed;
 }
-th, td { border: 1px solid var(--panel-border); padding: 8px; text-align: left; font-size: 0.9em; overflow: hidden; }
-th { background-color: var(--control-bg); font-weight: 700; }
-.warning { color: var(--danger-color); font-weight: bold; margin-top: 10px; }
+th, td { border: 1px solid var(--panel-border); padding: 8px; text-align: left; font-size: calc(var(--font-size-relative-base) * var(--font-scale-sm)); overflow: hidden; }
+th { background-color: var(--control-bg); font-weight: var(--font-weight-bold); }
+.warning { color: var(--danger-color); font-weight: var(--font-weight-bold); margin-top: 10px; }
 
 .gear-table td {
   padding: 4px 0;
@@ -49,7 +49,7 @@ th { background-color: var(--control-bg); font-weight: 700; }
 .gear-table .category-row td {
   border-top: 1px solid var(--accent-color);
   border-bottom: 1px solid var(--accent-color);
-  font-weight: bold;
+  font-weight: var(--font-weight-bold);
   color: var(--accent-color);
   break-after: avoid;
   page-break-after: avoid;
@@ -57,7 +57,7 @@ th { background-color: var(--control-bg); font-weight: 700; }
 .print-btn,
 .back-btn {
   padding: 5px 10px;
-  font-size: 0.85em;
+  font-size: calc(var(--font-size-relative-base) * var(--font-scale-xs));
   cursor: pointer;
   border-radius: var(--border-radius);
   border: none;
@@ -93,7 +93,7 @@ th { background-color: var(--control-bg); font-weight: 700; }
   border-radius: 6px;
   padding: 6px 10px;
   box-shadow: var(--panel-shadow);
-  font-size: 12px;
+  font-size: calc(var(--font-size-base) * var(--font-scale-xxs));
 }
 .device-block strong { display: block; margin-bottom: 4px; }
 .device-category-container { display: flex; flex-wrap: wrap; gap: 10px; }
@@ -109,7 +109,7 @@ th { background-color: var(--control-bg); font-weight: 700; }
 }
 .device-category h3 {
   font-family: 'Ubuntu', sans-serif;
-  font-weight: 400;
+  font-weight: var(--font-weight-regular);
   margin-top: 0;
   margin-bottom: 5px;
   border-bottom: 1px solid var(--divider-color);
@@ -138,7 +138,7 @@ th { background-color: var(--control-bg); font-weight: 700; }
 }
 .category-icon { margin-right: 4px; }
 .connector-summary { margin-top: 5px; display: flex; flex-wrap: wrap; gap: 4px; }
-.connector-block { padding: 2px 4px; border-radius: 4px; margin: 2px 2px 0 0; font-size: 0.85em; }
+.connector-block { padding: 2px 4px; border-radius: 4px; margin: 2px 2px 0 0; font-size: calc(var(--font-size-relative-base) * var(--font-scale-xs)); }
 .info-box { margin-top: 5px; padding: 6px 10px; border-radius: 4px; }
 .power-conn { background-color: var(--power-conn-bg); }
 .fiz-conn { background-color: var(--fiz-conn-bg); }
@@ -175,7 +175,7 @@ th { background-color: var(--control-bg); font-weight: 700; }
   body { background-color: var(--background-color); color: var(--text-color); }
   h1, h2, h3 { color: var(--inverse-text-color); }
   h2 { border-bottom: 2px solid var(--inverse-text-color); }
-  th { background-color: var(--control-bg); font-weight: 700; }
+  th { background-color: var(--control-bg); font-weight: var(--font-weight-bold); }
   .print-btn, .back-btn { background: var(--control-bg); color: var(--text-color); }
   .device-category { background: var(--panel-bg); border-color: var(--panel-border); box-shadow: var(--panel-shadow); }
   .device-category h3 { border-bottom: 1px solid var(--inverse-text-color); color: var(--inverse-text-color); }

--- a/overview.js
+++ b/overview.js
@@ -100,10 +100,10 @@ function generatePrintableOverview() {
     // Get current warning messages with their colors
     let warningHtml = '';
     if (pinWarnElem.textContent.trim() !== '') {
-        warningHtml += `<p style="color: ${pinWarnElem.style.color}; font-weight: bold;">${pinWarnElem.textContent}</p>`;
+        warningHtml += `<p style="color: ${pinWarnElem.style.color}; font-weight: var(--font-weight-bold);">${pinWarnElem.textContent}</p>`;
     }
     if (dtapWarnElem.textContent.trim() !== '') {
-        warningHtml += `<p style="color: ${dtapWarnElem.style.color}; font-weight: bold;">${dtapWarnElem.textContent}</p>`;
+        warningHtml += `<p style="color: ${dtapWarnElem.style.color}; font-weight: var(--font-weight-bold);">${dtapWarnElem.textContent}</p>`;
     }
 
     const resultsSectionHtml = `

--- a/script.js
+++ b/script.js
@@ -8359,7 +8359,7 @@ const diagramCssLight = `
 .node-box{fill:#f0f0f0;stroke:none;}
 .node-box.first-fiz{stroke:none;}
 .first-fiz-highlight{stroke:url(#firstFizGrad);stroke-width:1px;fill:none;}
-.node-icon{font-size:20px;font-family:'UiconsThinStraight',system-ui,sans-serif;font-style:normal;}
+.node-icon{font-size:var(--font-size-diagram-icon, 20px);font-family:'UiconsThinStraight',system-ui,sans-serif;font-style:normal;}
 .node-icon[data-icon-font='essential']{font-family:'EssentialIcons',system-ui,sans-serif;}
 .node-icon[data-icon-font='film']{font-family:'FilmIndustryIcons',system-ui,sans-serif;}
 .node-icon[data-icon-font='gadget']{font-family:'GadgetIcons',system-ui,sans-serif;}
@@ -8368,7 +8368,7 @@ const diagramCssLight = `
 .conn.blue{fill:#369;}
 .conn.green{fill:#090;}
 text{font-family:system-ui,sans-serif;}
-.edge-label{font-size:10px;}
+.edge-label{font-size:var(--font-size-diagram-label, 10px);}
 line{stroke:#333;stroke-width:2px;}
 path.edge-path{stroke:#333;stroke-width:2px;fill:none;}
 path.power{stroke:#d33;}
@@ -8380,7 +8380,7 @@ const diagramCssDark = `
 .node-box{fill:#444;stroke:none;}
 .node-box.first-fiz{stroke:none;}
 .first-fiz-highlight{stroke:url(#firstFizGrad);}
-.node-icon{font-size:20px;font-family:'UiconsThinStraight',system-ui,sans-serif;font-style:normal;}
+.node-icon{font-size:var(--font-size-diagram-icon, 20px);font-family:'UiconsThinStraight',system-ui,sans-serif;font-style:normal;}
 .node-icon[data-icon-font='essential']{font-family:'EssentialIcons',system-ui,sans-serif;}
 .node-icon[data-icon-font='film']{font-family:'FilmIndustryIcons',system-ui,sans-serif;}
 .node-icon[data-icon-font='gadget']{font-family:'GadgetIcons',system-ui,sans-serif;}
@@ -11301,6 +11301,9 @@ function renderSetupDiagram() {
   const DEFAULT_NODE_W = 120;
   const nodeHeights = {};
   const nodeWidths = {};
+  const diagramLabelFontSize = 'var(--font-size-diagram-label, 10px)';
+  const diagramTextFontSize = 'var(--font-size-diagram-text, 12px)';
+
   nodes.forEach(id => {
     const label = pos[id].label || id;
     const lines = wrapLabel(label);
@@ -11714,11 +11717,11 @@ function renderSetupDiagram() {
         const fontAttr = ` data-icon-font="${resolvedIcon.font}"`;
         svg += `<text class="node-icon"${fontAttr} x="${p.x}" y="${p.y - 10}" text-anchor="middle" dominant-baseline="middle">${resolvedIcon.char}</text>`;
       }
-      svg += `<text x="${p.x}" y="${p.y + 14}" text-anchor="middle" font-size="10">`;
+      svg += `<text x="${p.x}" y="${p.y + 14}" text-anchor="middle" style="font-size: ${diagramLabelFontSize};">`;
       lines.forEach((line, i) => { svg += `<tspan x="${p.x}" dy="${i === 0 ? 0 : 12}">${escapeHtml(line)}</tspan>`; });
       svg += `</text>`;
     } else {
-      svg += `<text x="${p.x}" y="${p.y}" text-anchor="middle" dominant-baseline="middle" font-size="12">`;
+      svg += `<text x="${p.x}" y="${p.y}" text-anchor="middle" dominant-baseline="middle" style="font-size: ${diagramTextFontSize};">`;
       lines.forEach((line, i) => { svg += `<tspan x="${p.x}" dy="${i === 0 ? 0 : 12}">${escapeHtml(line)}</tspan>`; });
       svg += `</text>`;
     }

--- a/style.css
+++ b/style.css
@@ -27,6 +27,29 @@
   --form-label-min-width: 120px;
   --form-action-width: 110px;
   --font-family: 'Ubuntu', 'UiconsThinStraight', sans-serif;
+  /* Typography */
+  --font-size-base: 1rem;
+  --font-size-relative-base: 1em;
+  --font-scale-compact: 0.8;
+  --font-scale-xxs: 0.75;
+  --font-scale-xs: 0.85;
+  --font-scale-sm: 0.9;
+  --font-scale-md: 0.95;
+  --font-scale-lg: 1.1;
+  --font-scale-xl: 1.2;
+  --font-scale-xxl: 1.4;
+  --font-scale-xxxl: 1.5;
+  --font-scale-display: 1.8;
+  --font-scale-icon-lg: 1.25;
+  --font-scale-icon-sm: 0.625;
+  --font-weight-light: 300;
+  --font-weight-regular: 400;
+  --font-weight-medium: 500;
+  --font-weight-semibold: 600;
+  --font-weight-bold: 700;
+  --font-size-diagram-icon: calc(var(--font-size-base) * var(--font-scale-icon-lg));
+  --font-size-diagram-label: calc(var(--font-size-base) * var(--font-scale-icon-sm));
+  --font-size-diagram-text: calc(var(--font-size-base) * var(--font-scale-xxs));
   --diagram-node-fill: #f0f0f0;
   --power-color: #d33;
   --video-color: #369;
@@ -106,11 +129,11 @@ body {
 
 body {
   font-family: var(--font-family);
-  font-weight: 300;
+  font-weight: var(--font-weight-light);
   margin: 0;
   background-color: var(--background-color);
   color: var(--text-color);
-  font-size: 1em;
+  font-size: var(--font-size-relative-base);
   line-height: var(--line-height-base);
 }
 
@@ -169,8 +192,8 @@ textarea {
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.18);
   letter-spacing: 0.03em;
   text-transform: uppercase;
-  font-size: 0.85rem;
-  font-weight: 500;
+  font-size: calc(var(--font-size-base) * var(--font-scale-xs));
+  font-weight: var(--font-weight-medium);
 }
 
 #installPromptBanner {
@@ -246,7 +269,7 @@ textarea:focus-visible {
 #dtapWarning,
 #compatWarning {
   color: var(--danger-color);
-  font-weight: bold;
+  font-weight: var(--font-weight-bold);
 }
 
 #exportOutput {
@@ -257,20 +280,20 @@ textarea:focus-visible {
 }
 h1, h2, h3 {
   font-family: var(--font-family);
-  font-weight: 400;
+  font-weight: var(--font-weight-regular);
   color: var(--accent-color);
 }
 h1 {
-  font-size: 1.8em;
+  font-size: calc(var(--font-size-relative-base) * var(--font-scale-display));
   margin-bottom: 0.2em;
 }
 h2 {
-  font-size: 1.4em;
+  font-size: calc(var(--font-size-relative-base) * var(--font-scale-xxl));
   margin-top: 1.3em;
   border-bottom: 2px solid var(--accent-color);
 }
 h3 {
-  font-size: 1.1em;
+  font-size: calc(var(--font-size-relative-base) * var(--font-scale-lg));
   margin-top: 1em;
 }
 
@@ -286,7 +309,7 @@ p {
 
 a {
   color: var(--link-color);
-  font-weight: 400;
+  font-weight: var(--font-weight-regular);
   text-decoration: none;
 }
 
@@ -316,7 +339,7 @@ body.dark-mode a:visited,
 footer {
   text-align: center;
   padding: 20px 0;
-  font-size: 0.9em;
+  font-size: calc(var(--font-size-relative-base) * var(--font-scale-sm));
 }
 
 footer a {
@@ -364,7 +387,7 @@ main.legal-content {
 }
 
 .legal-language-nav a[aria-current="page"] {
-  font-weight: 600;
+  font-weight: var(--font-weight-semibold);
 }
 
 .legal-content h1 {
@@ -405,7 +428,7 @@ main.legal-content {
   border-radius: var(--border-radius);
   background-color: var(--control-bg);
   color: var(--control-text);
-  font-size: 0.85em;
+  font-size: calc(var(--font-size-relative-base) * var(--font-scale-xs));
   text-decoration: none;
   transition: background-color 0.2s, color 0.2s, transform 0.2s;
 }
@@ -434,7 +457,7 @@ main.legal-content {
 .form-row label {
   flex: 0 0 var(--form-label-width);
   min-width: var(--form-label-min-width);
-  font-weight: 300;
+  font-weight: var(--font-weight-light);
 }
 #setup-config .form-row label {
   line-height: 1.3;
@@ -545,13 +568,13 @@ main.legal-content {
 }
 
 .schema-field-suffix {
-  font-size: 0.9em;
+  font-size: calc(var(--font-size-relative-base) * var(--font-scale-sm));
   color: var(--muted-text-color);
 }
 
 .schema-field-help {
   margin: 0;
-  font-size: 0.85em;
+  font-size: calc(var(--font-size-relative-base) * var(--font-scale-xs));
   color: var(--muted-text-color);
   line-height: var(--line-height-supporting);
 }
@@ -598,7 +621,7 @@ main.legal-content {
   display: inline-flex;
   align-items: center;
   gap: 0.5rem;
-  font-size: 0.95rem;
+  font-size: calc(var(--font-size-base) * var(--font-scale-md));
   margin: 0;
 }
 
@@ -622,8 +645,8 @@ main.legal-content {
 }
 
 #setup-manager .share-import-options legend {
-  font-weight: 600;
-  font-size: 0.95rem;
+  font-weight: var(--font-weight-semibold);
+  font-size: calc(var(--font-size-base) * var(--font-scale-md));
   margin-bottom: 0.25rem;
 }
 
@@ -732,7 +755,7 @@ main.legal-content {
   flex-basis: 100%;
   margin: 0;
   margin-left: calc(var(--form-label-width) + var(--gap-size));
-  font-size: 0.75em;
+  font-size: calc(var(--font-size-relative-base) * var(--font-scale-xxs));
   color: var(--control-text);
   opacity: 0.8;
 }
@@ -788,7 +811,7 @@ main.legal-content {
 }
 .field-with-label::before {
   content: attr(data-label);
-  font-size: 0.75em;
+  font-size: calc(var(--font-size-relative-base) * var(--font-scale-xxs));
   color: var(--muted-text-color);
   margin-bottom: 2px;
 }
@@ -1089,7 +1112,7 @@ main.legal-content {
 }
 
 .auto-gear-rule-title {
-  font-weight: 500;
+  font-weight: var(--font-weight-medium);
   margin: 0;
 }
 
@@ -1105,7 +1128,7 @@ body.pink-mode .auto-gear-rule-title,
 
 .auto-gear-rule-meta {
   color: var(--muted-text-color, #666);
-  font-size: 0.9em;
+  font-size: calc(var(--font-size-relative-base) * var(--font-scale-sm));
 }
 
 .auto-gear-rule-items-label {
@@ -1119,7 +1142,7 @@ body.pink-mode .auto-gear-rule-title,
 }
 
 .auto-gear-rule-item {
-  font-size: 0.9em;
+  font-size: calc(var(--font-size-relative-base) * var(--font-scale-sm));
   line-height: var(--line-height-supporting);
   word-break: break-word;
 }
@@ -1224,12 +1247,12 @@ body.pink-mode .auto-gear-rule-title,
 }
 
 .storage-summary-label {
-  font-weight: 600;
+  font-weight: var(--font-weight-semibold);
 }
 
 .storage-summary-key {
   font-family: 'Courier New', Courier, monospace;
-  font-size: 0.75em;
+  font-size: calc(var(--font-size-relative-base) * var(--font-scale-xxs));
   padding: 2px 6px;
   border-radius: 4px;
   background: var(--control-bg);
@@ -1238,14 +1261,14 @@ body.pink-mode .auto-gear-rule-title,
 
 .storage-summary-value {
   margin: 0;
-  font-weight: 500;
+  font-weight: var(--font-weight-medium);
 }
 
 .storage-summary-note,
 .storage-summary-description,
 .storage-summary-extra {
   margin: 0;
-  font-size: 0.85em;
+  font-size: calc(var(--font-size-relative-base) * var(--font-scale-xs));
   color: var(--control-text);
   opacity: 0.85;
 }
@@ -1302,7 +1325,7 @@ body.pink-mode .auto-gear-rule-title,
   align-items: center;
   justify-content: center;
   line-height: 1;
-  font-size: 1rem;
+  font-size: var(--font-size-base);
   background: none;
   border: none;
   color: inherit;
@@ -1327,7 +1350,7 @@ body.pink-mode .auto-gear-rule-title,
 
 #helpQuickLinksHeading {
   margin: 0;
-  font-size: 1rem;
+  font-size: var(--font-size-base);
 }
 
 #helpQuickLinksList {
@@ -1361,7 +1384,7 @@ body.pink-mode .auto-gear-rule-title,
 .help-quick-link-icon {
   --icon-color: var(--accent-color);
   flex: 0 0 auto;
-  font-size: 1.1em;
+  font-size: calc(var(--font-size-relative-base) * var(--font-scale-lg));
 }
 
 .help-quick-link.active .help-quick-link-icon {
@@ -1420,7 +1443,7 @@ body.pink-mode .auto-gear-rule-title,
   border-radius: var(--border-radius);
   background-color: var(--control-bg);
   color: var(--control-text);
-  font-size: 0.85em;
+  font-size: calc(var(--font-size-relative-base) * var(--font-scale-xs));
   text-decoration: none;
   transition: background-color 0.2s, color 0.2s;
 }
@@ -1459,7 +1482,7 @@ body.pink-mode .auto-gear-rule-title,
 .icon-glyph {
   font-family: 'UiconsThinStraight';
   font-style: normal;
-  font-weight: 400;
+  font-weight: var(--font-weight-regular);
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -1485,7 +1508,7 @@ body.pink-mode .auto-gear-rule-title,
 
 .icon-glyph.icon-text {
   font-family: 'Ubuntu', sans-serif;
-  font-weight: 300;
+  font-weight: var(--font-weight-light);
 }
 
 .icon-glyph.icon-svg {
@@ -1586,7 +1609,7 @@ body.pink-mode .auto-gear-rule-title,
 #helpSearchClear .icon-glyph,
 .clear-input-btn .icon-glyph,
 .controls button .icon-glyph {
-  font-size: 1.2em;
+  font-size: calc(var(--font-size-relative-base) * var(--font-scale-xl));
 }
 
 .help-icon,
@@ -1601,7 +1624,7 @@ body.pink-mode .auto-gear-rule-title,
 }
 
 .favorite-icon.icon-glyph {
-  font-size: 0.95em;
+  font-size: calc(var(--font-size-relative-base) * var(--font-scale-md));
 }
 
 body.pink-mode button:hover,
@@ -1626,7 +1649,7 @@ body.pink-mode .favorite-toggle.favorited:active {
 .category-icon.icon-glyph,
 .scenario-icon.icon-glyph,
 .icon-box .icon.icon-glyph {
-  font-size: 1.1em;
+  font-size: calc(var(--font-size-relative-base) * var(--font-scale-lg));
 }
 
 #hoverHelpTooltip {
@@ -1636,7 +1659,7 @@ body.pink-mode .favorite-toggle.favorited:active {
   color: var(--inverse-text-color);
   padding: 4px 8px;
   border-radius: 4px;
-  font-size: 0.8rem;
+  font-size: calc(var(--font-size-base) * var(--font-scale-compact));
   pointer-events: none;
   /* Allow longer hover help descriptions */
   max-width: 320px;
@@ -1689,7 +1712,7 @@ body.hover-help-active * {
 .device-category .list-filter {
   width: 100%;
   margin-bottom: 5px;
-  font-size: 0.9em;
+  font-size: calc(var(--font-size-relative-base) * var(--font-scale-sm));
 }
 
 /* Ensure form controls use consistent styling */
@@ -1697,7 +1720,7 @@ input,
 select,
 textarea {
   padding: 4px;
-  font-size: 1em;
+  font-size: var(--font-size-relative-base);
   background-color: var(--control-bg);
   color: var(--control-text);
   border: none;
@@ -1714,7 +1737,7 @@ input[type="file"] {
   padding: 2px 4px;
   height: auto;
   min-height: var(--button-size);
-  font-size: 0.85em;
+  font-size: calc(var(--font-size-relative-base) * var(--font-scale-xs));
   line-height: 1.2;
 }
 
@@ -1863,7 +1886,7 @@ textarea:disabled {
   background: transparent;
   border: none;
   cursor: pointer;
-  font-size: 1em;
+  font-size: var(--font-size-relative-base);
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -1889,7 +1912,7 @@ textarea:disabled {
   border: none;
   outline: none;
   cursor: pointer;
-  font-size: 1rem;
+  font-size: var(--font-size-base);
   color: var(--favorite-inactive-color);
   display: inline-flex;
   align-items: center;
@@ -1940,7 +1963,7 @@ fieldset {
   box-sizing: border-box;
 }
 legend {
-  font-weight: 500;
+  font-weight: var(--font-weight-medium);
   color: var(--accent-color);
   padding: 0 5px;
 }
@@ -1970,7 +1993,7 @@ button {
   padding: 0 8px;
   margin: 10px 5px 5px;
   cursor: pointer;
-  font-size: 0.85em;
+  font-size: calc(var(--font-size-relative-base) * var(--font-scale-xs));
   height: var(--button-size);
   min-height: var(--button-size);
   display: inline-flex;
@@ -2007,7 +2030,7 @@ input[type="file"]::-webkit-file-upload-button {
   padding: 0 8px;
   margin-right: 5px;
   cursor: pointer;
-  font-size: 0.8em;
+  font-size: calc(var(--font-size-relative-base) * var(--font-scale-compact));
   height: 100%;
   min-height: var(--button-size);
   display: inline-flex;
@@ -2070,7 +2093,7 @@ input[type="file"]:disabled::-webkit-file-upload-button {
 
 .device-category h4 {
   font-family: var(--font-family);
-  font-weight: 400;
+  font-weight: var(--font-weight-regular);
   color: var(--accent-color);
   margin-top: 0;
   margin-bottom: 10px;
@@ -2087,7 +2110,7 @@ input[type="file"]:disabled::-webkit-file-upload-button {
 .device-ul li {
   border-bottom: 1px dashed var(--divider-color);
   padding: 5px 0;
-  font-size: 0.9em;
+  font-size: calc(var(--font-size-relative-base) * var(--font-scale-sm));
 }
 
 .device-summary {
@@ -2111,7 +2134,7 @@ input[type="file"]:disabled::-webkit-file-upload-button {
 
 .device-details {
   margin-left: 20px;
-  font-size: 0.85em;
+  font-size: calc(var(--font-size-relative-base) * var(--font-scale-xs));
 }
 
 /* Arrange top-level device details in two columns */
@@ -2168,7 +2191,7 @@ input[type="file"]:disabled::-webkit-file-upload-button {
 }
 
 #topBar h1 {
-  font-size: 1.4em;
+  font-size: calc(var(--font-size-relative-base) * var(--font-scale-xxl));
   margin: 0;
 }
 
@@ -2254,7 +2277,7 @@ body.dark-mode.pink-mode #topBar #logo .logo-center {
   background: none;
   border: none;
   cursor: pointer;
-  font-size: 1rem;
+  font-size: var(--font-size-base);
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -2276,7 +2299,7 @@ body.dark-mode.pink-mode #topBar #logo .logo-center {
 }
 
 .controls select {
-  font-size: 1em;
+  font-size: var(--font-size-relative-base);
   padding: 2px 4px;
   text-align: center;
   text-align-last: center;
@@ -2310,7 +2333,7 @@ body.dark-mode.pink-mode #topBar #logo .logo-center {
 
 #helpButton {
   padding: 0 4px;
-  font-size: 1em;
+  font-size: var(--font-size-relative-base);
 }
 
 /* Breakdown list */
@@ -2347,7 +2370,7 @@ body.dark-mode.pink-mode #topBar #logo .logo-center {
   align-items: center;
   justify-content: center;
   color: var(--inverse-text-color);
-  font-size: 0.75em;
+  font-size: calc(var(--font-size-relative-base) * var(--font-scale-xxs));
   overflow: hidden;
 }
 
@@ -2392,7 +2415,7 @@ body.dark-mode.pink-mode #topBar #logo .logo-center {
   transform: translateX(-50%);
   background: var(--surface-color);
   color: var(--danger-color);
-  font-size: 0.75em;
+  font-size: calc(var(--font-size-relative-base) * var(--font-scale-xxs));
   padding: 0 2px;
   white-space: nowrap;
 }
@@ -2404,7 +2427,7 @@ body.dark-mode.pink-mode #topBar #logo .logo-center {
 
 #maxPowerText {
   margin-top: 4px;
-  font-size: 0.9em;
+  font-size: calc(var(--font-size-relative-base) * var(--font-scale-sm));
 }
 
 /* Project diagram */
@@ -2427,7 +2450,7 @@ body.dark-mode.pink-mode #topBar #logo .logo-center {
 
 #diagramLegend {
   margin-top: 0.25em;
-  font-size: 12px;
+  font-size: var(--font-size-diagram-text);
 }
 #diagramLegend span {
   margin: 0 6px;
@@ -2447,7 +2470,7 @@ body.dark-mode.pink-mode #topBar #logo .logo-center {
 
 #powerDiagramLegend {
   margin-top: 0.25em;
-  font-size: 12px;
+  font-size: var(--font-size-diagram-text);
 }
 #powerDiagramLegend span {
   margin: 0 6px;
@@ -2512,7 +2535,7 @@ body.dark-mode.pink-mode #topBar #logo .logo-center {
 
 #diagramHint {
   margin-top: 0.25em;
-  font-size: 12px;
+  font-size: var(--font-size-diagram-text);
   color: var(--muted-text-color);
 }
 
@@ -2523,7 +2546,7 @@ body.dark-mode.pink-mode #topBar #logo .logo-center {
   pointer-events: none;
   background: rgba(255, 255, 255, 0.95);
   border: 1px solid var(--control-text);
-  font-size: 12px;
+  font-size: var(--font-size-diagram-text);
   padding: 6px 10px;
   border-radius: 6px;
   box-shadow: var(--panel-shadow);
@@ -2558,7 +2581,7 @@ body.dark-mode.pink-mode #topBar #logo .logo-center {
   border-radius: 3px;
   border: 1px solid;
   background-color: rgba(0,0,0,0.03);
-  font-size: 0.75em;
+  font-size: calc(var(--font-size-relative-base) * var(--font-scale-xxs));
 }
 
 .scenario-box,
@@ -2570,7 +2593,7 @@ body.dark-mode.pink-mode #topBar #logo .logo-center {
   border-radius: 3px;
   border: 1px solid;
   background-color: rgba(0,0,0,0.03);
-  font-size: 0.75em;
+  font-size: calc(var(--font-size-relative-base) * var(--font-scale-xxs));
 }
 
 .scenario-box .scenario-icon,
@@ -2583,7 +2606,7 @@ body.dark-mode.pink-mode #topBar #logo .logo-center {
   padding: 4px;
   border-radius: 3px;
   background: rgba(0,0,0,0.05);
-  font-size: 0.75em;
+  font-size: calc(var(--font-size-relative-base) * var(--font-scale-xxs));
 }
 
 .lens-mount-box {
@@ -2593,8 +2616,8 @@ body.dark-mode.pink-mode #topBar #logo .logo-center {
 
 .info-label {
   width: 100%;
-  font-size: 0.75em;
-  font-weight: bold;
+  font-size: calc(var(--font-size-relative-base) * var(--font-scale-xxs));
+  font-weight: var(--font-weight-bold);
   margin: 4px 2px 0;
 }
 
@@ -2602,7 +2625,7 @@ body.dark-mode.pink-mode #topBar #logo .logo-center {
   width: 100%;
   border-collapse: collapse;
   margin-top: 4px;
-  font-size: 0.8em;
+  font-size: calc(var(--font-size-relative-base) * var(--font-scale-compact));
 }
 .port-table th {
   text-align: left;
@@ -2670,7 +2693,7 @@ body.dark-mode.pink-mode #topBar #logo .logo-center {
 }
 
 #setupDiagram .node-icon {
-  font-size: 20px;
+  font-size: var(--font-size-diagram-icon);
   font-family: 'UiconsThinStraight', system-ui, sans-serif;
   font-style: normal;
 }
@@ -2698,7 +2721,7 @@ body.dark-mode.pink-mode #topBar #logo .logo-center {
 #setupDiagram .conn.green { fill: var(--fiz-color); }
 
 #setupDiagram .edge-label {
-  font-size: 10px;
+  font-size: var(--font-size-diagram-label);
   dominant-baseline: middle;
 }
 
@@ -2784,7 +2807,7 @@ body:not(.light-mode) #temperatureNote td {
   border: 1px solid var(--panel-border);
   padding: 8px;
   text-align: left;
-  font-size: 0.9em;
+  font-size: calc(var(--font-size-relative-base) * var(--font-scale-sm));
 }
 #batteryComparison th:nth-child(1),
 #batteryComparison td:nth-child(1) {
@@ -2888,12 +2911,12 @@ body.pink-mode #userFeedbackTable th {
 
 .weightingPercent {
   margin-left: 0.5em;
-  font-size: 0.9em;
+  font-size: calc(var(--font-size-relative-base) * var(--font-scale-sm));
 }
 
 .selectedBatteryRow {
     background-color: var(--selected-row-bg); /* Light blue background for selected row */
-    font-weight: bold;
+    font-weight: var(--font-weight-bold);
 }
 
 html.dark-mode,
@@ -3205,7 +3228,7 @@ body.dark-mode.dark-accent-boost:not(.pink-mode) .help-content {
 @media (max-width: 600px) {
   body {
     margin: 10px;
-    font-size: 0.85em;
+    font-size: calc(var(--font-size-relative-base) * var(--font-scale-xs));
   }
 
   .controls select {
@@ -3351,12 +3374,12 @@ body.dark-mode.dark-accent-boost:not(.pink-mode) .help-content {
   box-shadow: var(--panel-shadow);
 }
 .requirement-box .req-icon {
-  font-size: 1.5em;
+  font-size: calc(var(--font-size-relative-base) * var(--font-scale-xxxl));
   display: block;
   margin-bottom: 5px;
 }
 .requirement-box .req-label {
-  font-weight: 700;
+  font-weight: var(--font-weight-bold);
   display: block;
 }
 .requirement-box .req-value {
@@ -3386,17 +3409,17 @@ body.dark-mode.dark-accent-boost:not(.pink-mode) .help-content {
   background: var(--surface-color);
   color: var(--control-text);
   font-family: var(--font-family);
-  font-weight: 300;
+  font-weight: var(--font-weight-light);
 }
 #overviewDialogContent h1,
 #overviewDialogContent h2,
 #overviewDialogContent h3 {
   font-family: var(--font-family);
-  font-weight: 400;
+  font-weight: var(--font-weight-regular);
   color: var(--accent-color);
 }
 #overviewDialogContent h1 {
-  font-size: 1.8em;
+  font-size: calc(var(--font-size-relative-base) * var(--font-scale-display));
   margin-bottom: 0.2em;
 }
 
@@ -3404,13 +3427,13 @@ body.dark-mode.dark-accent-boost:not(.pink-mode) .help-content {
   display: none;
 }
 #overviewDialogContent h2 {
-  font-size: 1.4em;
+  font-size: calc(var(--font-size-relative-base) * var(--font-scale-xxl));
   margin-top: 1.3em;
   border-bottom: 2px solid var(--accent-color);
   padding-bottom: 5px;
 }
 #overviewDialogContent h3 {
-  font-size: 1.1em;
+  font-size: calc(var(--font-size-relative-base) * var(--font-scale-lg));
   margin-top: 1em;
 }
 #overviewDialogContent table {
@@ -3424,12 +3447,12 @@ body.dark-mode.dark-accent-boost:not(.pink-mode) .help-content {
   border: 1px solid var(--panel-border);
   padding: 8px;
   text-align: left;
-  font-size: 0.9em;
+  font-size: calc(var(--font-size-relative-base) * var(--font-scale-sm));
   overflow: hidden;
 }
 #overviewDialogContent th {
   background-color: var(--control-bg);
-  font-weight: 700;
+  font-weight: var(--font-weight-bold);
 }
 #overviewDialogContent tr:nth-child(even) {
   background-color: var(--panel-bg);
@@ -3440,7 +3463,7 @@ body.dark-mode.dark-accent-boost:not(.pink-mode) .help-content {
   border-radius: 6px;
   padding: 6px 10px;
   box-shadow: var(--panel-shadow);
-  font-size: 12px;
+  font-size: var(--font-size-diagram-text);
 }
 #overviewDialogContent .device-block strong {
   display: block;
@@ -3463,7 +3486,7 @@ body.dark-mode.dark-accent-boost:not(.pink-mode) .help-content {
 }
 #overviewDialogContent .device-category h3 {
   font-family: var(--font-family);
-  font-weight: 400;
+  font-weight: var(--font-weight-regular);
   margin-top: 0;
   margin-bottom: 5px;
   border-bottom: 1px solid var(--divider-color);
@@ -3561,7 +3584,7 @@ body.dark-mode.dark-accent-boost:not(.pink-mode) .help-content {
 .gear-table .category-row td {
   border-top: 1px solid var(--accent-color);
   border-bottom: 1px solid var(--accent-color);
-  font-weight: bold;
+  font-weight: var(--font-weight-bold);
   color: var(--accent-color);
   break-after: avoid;
   page-break-after: avoid;
@@ -3606,7 +3629,7 @@ body.dark-mode.dark-accent-boost:not(.pink-mode) .help-content {
 #overviewDialogContent .gear-table .category-row td {
   border-top: 1px solid var(--accent-color);
   border-bottom: 1px solid var(--accent-color);
-  font-weight: bold;
+  font-weight: var(--font-weight-bold);
   color: var(--accent-color);
   break-after: avoid;
   page-break-after: avoid;
@@ -3757,7 +3780,7 @@ body.dark-mode.dark-accent-boost:not(.pink-mode) .help-content {
 #gearListActions .gear-list-autosave-note {
   flex-basis: 100%;
   margin: 0;
-  font-size: 0.9rem;
+  font-size: calc(var(--font-size-base) * var(--font-scale-sm));
   color: var(--muted-text-color);
 }
 
@@ -3803,7 +3826,7 @@ body.dark-mode.dark-accent-boost:not(.pink-mode) .help-content {
 #menuToggle {
   background: none;
   border: none;
-  font-size: 1.5em;
+  font-size: calc(var(--font-size-relative-base) * var(--font-scale-xxxl));
 }
 
 #sideMenu {
@@ -3844,7 +3867,7 @@ body.dark-mode.dark-accent-boost:not(.pink-mode) .help-content {
 #sideMenu a {
   color: var(--text-color);
   text-decoration: none;
-  font-size: 1.1em;
+  font-size: calc(var(--font-size-relative-base) * var(--font-scale-lg));
   display: block;
   padding: 10px 0;
 }


### PR DESCRIPTION
## Summary
- introduce root-level font size scales and weight tokens in the main stylesheet and refactor UI typography to consume them
- apply the shared typography variables to overview and print styles so generated summaries stay consistent with global settings
- update diagram export styling and warning markup to reference the shared variables for icons, labels, and emphasis

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cdbe84a100832083269f1f925d2fc5