### PR TITLE
Update Managing Projects help link styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -1105,7 +1105,7 @@
               >Project Name</a>
               field and click
               <a
-                class="help-link"
+                class="help-link button-link"
                 href="#setup-manager"
                 data-help-target="#saveSetupBtn"
                 data-help-highlight="#setup-manager"
@@ -1124,7 +1124,7 @@
             <li>
               Use
               <a
-                class="help-link"
+                class="help-link button-link"
                 href="#setup-manager"
                 data-help-target="#saveSetupBtn"
                 data-help-highlight="#setup-manager"
@@ -1134,14 +1134,14 @@
             <li>
               Select a saved project from the
               <a
-                class="help-link"
+                class="help-link button-link"
                 href="#setup-manager"
                 data-help-target="#setupSelect"
                 data-help-highlight="#setup-manager"
               >Saved Projects</a>
               dropdown to load it instantly; adjust gear and click
               <a
-                class="help-link"
+                class="help-link button-link"
                 href="#setup-manager"
                 data-help-target="#saveSetupBtn"
                 data-help-highlight="#setup-manager"
@@ -1154,7 +1154,7 @@
             </li>
             <li>
               <a
-                class="help-link"
+                class="help-link button-link"
                 href="#setup-manager"
                 data-help-target="#shareSetupBtn"
                 data-help-highlight="#setup-manager"
@@ -1164,7 +1164,7 @@
             <li>
               Open
               <a
-                class="help-link"
+                class="help-link button-link"
                 href="#settingsButton"
                 data-help-target="#settingsButton"
               ><strong>Settings</strong></a>
@@ -1173,14 +1173,14 @@
             <li>
               Select a JSON file in the
               <a
-                class="help-link"
+                class="help-link button-link"
                 href="#setup-manager"
                 data-help-target="#sharedLinkInput"
                 data-help-highlight="#setup-manager"
               ><strong>Shared Project</strong></a>
               field and click
               <a
-                class="help-link"
+                class="help-link button-link"
                 href="#setup-manager"
                 data-help-target="#applySharedLinkBtn"
                 data-help-highlight="#setup-manager"
@@ -1190,14 +1190,14 @@
             <li>
               Use
               <a
-                class="help-link"
+                class="help-link button-link"
                 href="#setup-manager"
                 data-help-target="#deleteSetupBtn"
                 data-help-highlight="#setup-manager"
               ><strong>Delete</strong></a>
               to remove the saved entry or
               <a
-                class="help-link"
+                class="help-link button-link"
                 href="#setup-manager"
                 data-help-target="#clearSetupBtn"
                 data-help-highlight="#setup-manager"
@@ -1206,7 +1206,7 @@
             </li>
             <li>
               <a
-                class="help-link"
+                class="help-link button-link"
                 href="#setup-manager"
                 data-help-target="#generateOverviewBtn"
                 data-help-highlight="#setup-manager"
@@ -1216,7 +1216,7 @@
             <li>
               Need a clean slate? Choose
               <a
-                class="help-link"
+                class="help-link button-link"
                 href="#settingsButton"
                 data-help-target="#factoryResetButton"
               ><strong>Factory reset</strong></a>


### PR DESCRIPTION
## Summary
- add the button-link class to each Managing Projects help link so they match the rest of the help dialog styling

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cdbeffbd988320904a979e497c5b98