### PR TITLE
Fix settings dialog button layout

### DIFF
--- a/style.css
+++ b/style.css
@@ -719,6 +719,7 @@ main.legal-content {
   align-self: center;
   margin-top: 0;
   white-space: nowrap;
+  flex: 0 0 auto;
 }
 
 #sharedLinkRow > button {
@@ -1257,6 +1258,12 @@ body.pink-mode .auto-gear-rule-title,
 .settings-content .button-row {
   display: flex;
   gap: 10px;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+#settingsDialog button {
+  flex-shrink: 0;
 }
 
 .settings-content .action-buttons {


### PR DESCRIPTION
## Summary
- prevent inline settings buttons from shrinking so their text stays fully visible
- allow settings dialog button rows to wrap while keeping button styling consistent with the main UI

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cdc20d2d6083208bc29ceeca4a4092