### PR TITLE
Enhance bright accent handling in themes

### DIFF
--- a/style.css
+++ b/style.css
@@ -281,7 +281,7 @@ textarea:focus-visible {
 h1, h2, h3 {
   font-family: var(--font-family);
   font-weight: var(--font-weight-regular);
-  color: var(--accent-color);
+  color: var(--text-color);
 }
 h1 {
   font-size: calc(var(--font-size-relative-base) * var(--font-scale-display));
@@ -290,6 +290,16 @@ h1 {
 h2 {
   font-size: calc(var(--font-size-relative-base) * var(--font-scale-xxl));
   margin-top: 1.3em;
+  border-bottom: 2px solid var(--text-color);
+}
+
+body.pink-mode:not(.dark-mode) h1,
+body.pink-mode:not(.dark-mode) h2,
+body.pink-mode:not(.dark-mode) h3 {
+  color: var(--accent-color);
+}
+
+body.pink-mode:not(.dark-mode) h2 {
   border-bottom: 2px solid var(--accent-color);
 }
 h3 {

--- a/tests/script/dark-accent-boost.test.js
+++ b/tests/script/dark-accent-boost.test.js
@@ -23,6 +23,18 @@ describe('dark accent boost for bright custom colors', () => {
     expect(document.body.classList.contains('dark-accent-boost')).toBe(true);
   });
 
+  test('enables boost for bright custom accents in dark mode', () => {
+    localStorage.setItem('accentColor', '#ffee58');
+    localStorage.setItem('darkMode', 'true');
+
+    const { cleanup: clean } = setupScriptEnvironment();
+    cleanup = clean;
+
+    expect(document.body.classList.contains('dark-mode')).toBe(true);
+    expect(document.body.classList.contains('pink-mode')).toBe(false);
+    expect(document.body.classList.contains('dark-accent-boost')).toBe(true);
+  });
+
   test('removes boost when accent color changes to a darker tone', () => {
     localStorage.setItem('accentColor', '#ff6ab5');
     localStorage.setItem('darkMode', 'true');
@@ -50,6 +62,17 @@ describe('dark accent boost for bright custom colors', () => {
     expect(darkModeToggle).toBeTruthy();
 
     darkModeToggle.click();
+
+    expect(document.body.classList.contains('dark-mode')).toBe(false);
+    expect(document.body.classList.contains('dark-accent-boost')).toBe(false);
+  });
+
+  test('does not enable boost in light mode even with bright accent colors', () => {
+    localStorage.setItem('accentColor', '#ffee58');
+    localStorage.setItem('darkMode', 'false');
+
+    const { cleanup: clean } = setupScriptEnvironment();
+    cleanup = clean;
 
     expect(document.body.classList.contains('dark-mode')).toBe(false);
     expect(document.body.classList.contains('dark-accent-boost')).toBe(false);


### PR DESCRIPTION
## Summary
- expand the dark-mode accent boost to cover bright high-luminance custom accents
- adjust light-mode heading colors to use the primary text color while keeping pink mode accents
- add regression tests covering bright accent handling across dark and light modes

## Testing
- npm run test:script

------
https://chatgpt.com/codex/tasks/task_e_68cdc515fbe88320bcf463bc2e6176c7