### PR TITLE
Use inline SVG icons for project export buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -228,10 +228,42 @@
       <span class="form-label-spacer" aria-hidden="true"></span>
       <div class="form-actions">
         <button id="generateOverviewBtn">
-          <span class="btn-icon icon-glyph" aria-hidden="true" data-icon-font="essential">&#xF13E;</span>Generate Overview
+          <span class="btn-icon icon-glyph icon-svg" aria-hidden="true">
+            <svg
+              viewBox="0 0 24 24"
+              aria-hidden="true"
+              focusable="false"
+              stroke-width="1.5"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <rect x="4.5" y="3.75" width="15" height="16.5" rx="2.25" />
+              <path d="M8.5 8h7" />
+              <path d="M8.5 11.5h7" />
+              <line x1="7.75" y1="16.75" x2="16.25" y2="16.75" />
+              <polyline points="8.75 16.75 11 13.75 13.25 15.5 16 12.5" />
+            </svg>
+          </span>
+          Generate Overview
         </button>
         <button id="generateGearListBtn" type="button">
-          <span class="btn-icon icon-glyph" aria-hidden="true" data-icon-font="essential">&#xF211;</span>Generate Gear List and Project Requirements
+          <span class="btn-icon icon-glyph icon-svg" aria-hidden="true">
+            <svg
+              viewBox="0 0 24 24"
+              aria-hidden="true"
+              focusable="false"
+              stroke-width="1.5"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <rect x="6.75" y="5.5" width="10.5" height="13.5" rx="2" />
+              <path d="M9.75 3.5h4.5" />
+              <path d="M9.5 9h6" />
+              <path d="M9.5 12.75l1.5 1.5 2.75-2.75" />
+              <path d="M9.5 16.25l1.5 1.5 2.75-2.75" />
+            </svg>
+          </span>
+          Generate Gear List and Project Requirements
         </button>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- replace the Generate Overview button glyph with a custom inline SVG that suggests a summarized report layout
- swap the Generate Gear List button glyph for an inline SVG checklist to clearly distinguish it from the overview action while honoring current theming

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cdc58ea8948320af759faf90431b5c