### PR TITLE
Align FAQ icon with help toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -1835,7 +1835,9 @@
           id="faq"
           data-help-keywords="faq questions answers troubleshooting tips"
         >
-          <h3><span class="help-icon icon-glyph" aria-hidden="true" data-icon-font="uicons">&#xEEFB;</span>FAQ</h3>
+          <h3>
+            <span class="help-icon icon-glyph icon-text" aria-hidden="true" data-icon-font="uicons">?</span>FAQ
+          </h3>
           <details
             class="faq-item"
             data-help-keywords="save project saved projects ctrl+s enter autosave rename update"


### PR DESCRIPTION
## Summary
- replace the FAQ heading icon in the help dialog with the question mark glyph used by the help toggle so the quick link icon matches

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cdc76255188320860d63c189e8393c