### PR TITLE
Adjust pink mode animated icons layout

### DIFF
--- a/style.css
+++ b/style.css
@@ -143,6 +143,7 @@ main {
   padding: calc(var(--page-padding) * var(--main-top-padding-multiplier))
     var(--page-padding)
     var(--page-padding);
+  position: relative;
 }
 
 section,
@@ -1576,17 +1577,17 @@ body.pink-mode .auto-gear-rule-title,
 }
 
 .pink-mode-animation-layer {
-  position: fixed;
+  position: absolute;
   inset: 0;
   pointer-events: none;
-  z-index: 25;
+  z-index: 2;
   overflow: visible;
 }
 
 .pink-mode-animation-instance {
   position: absolute;
-  top: var(--pink-mode-animation-y, 50vh);
-  left: var(--pink-mode-animation-x, 50vw);
+  top: var(--pink-mode-animation-y, 50%);
+  left: var(--pink-mode-animation-x, 50%);
   width: var(--pink-mode-animation-size, 120px);
   height: var(--pink-mode-animation-size, 120px);
   margin-top: calc(-0.5 * var(--pink-mode-animation-size, 120px));


### PR DESCRIPTION
## Summary
- anchor the pink mode animation layer inside the main content so animated icons scroll with the UI
- tune animation timing, sizing, and placement logic to keep icons smaller, within the interface, and prevent consecutive duplicates

## Testing
- npm run lint
- npm run test:script

------
https://chatgpt.com/codex/tasks/task_e_68cdc636dcc08320b0bade0e8efe08e6