### PR TITLE
Align settings help icon with settings toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -1244,7 +1244,27 @@
           id="settingsHelp"
           data-help-keywords="settings preferences customization customise personalize colour color font typeface accent high contrast theme backup restore"
         >
-          <h3><span class="help-icon icon-glyph" aria-hidden="true" data-icon-font="essential">&#xF211;</span>Settings &amp; Personalization</h3>
+          <h3>
+            <span class="help-icon icon-glyph icon-svg" aria-hidden="true">
+              <svg viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                <path
+                  d="M9.593 3.94c.09-.542.559-.94 1.11-.94h2.594c.55 0 1.019.398 1.11.94l.213 1.281c.062.374.312.686.644.87.074.041.147.083.22.127.326.196.721.257 1.076.124l1.217-.456a1.125 1.125 0 0 1 1.369.491l1.297 2.246a1.125 1.125 0 0 1-.259 1.431l-1.004.826c-.293.241-.438.612-.431.991.001.042.002.084.002.127s0 .085-.002.127c-.007.379.138.75.431.991l1.004.827a1.125 1.125 0 0 1 .259 1.43l-1.297 2.247a1.125 1.125 0 0 1-1.369.49l-1.217-.455a1.35 1.35 0 0 0-1.076.124 5.58 5.58 0 0 1-.864.495 1.35 1.35 0 0 0-.644.87l-.213 1.281c-.09.542-.559.94-1.11.94H10.703a1.125 1.125 0 0 1-1.11-.94l-.214-1.281a1.35 1.35 0 0 0-.644-.87 5.446 5.446 0 0 1-.864-.495 1.35 1.35 0 0 0-1.076-.124l-1.217.455a1.125 1.125 0 0 1-1.369-.49L3.557 15.377a1.125 1.125 0 0 1 .259-1.431l1.004-.826c.292-.241.437-.613.43-.992a4.643 4.643 0 0 1-.002-.254c0-.042.001-.084.002-.127.007-.379-.138-.75-.43-.991l-1.005-.827A1.125 1.125 0 0 1 3.557 8.623l1.297-2.246a1.125 1.125 0 0 1 1.369-.491l1.217.456c.355.133.75.072 1.076-.124.073-.044.147-.086.22-.127.332-.183.582-.495.644-.87l.213-1.281Z"
+                  stroke="currentColor"
+                  stroke-width="1.5"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+                <path
+                  d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z"
+                  stroke="currentColor"
+                  stroke-width="1.5"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+              </svg>
+            </span>
+            Settings &amp; Personalization
+          </h3>
           <ul>
             <li>Switch languages instantly; the planner remembers your preference for next time.</li>
             <li>Tune the interface with dark mode, high contrast, pink accents and a custom accent color to match your production.</li>


### PR DESCRIPTION
## Summary
- switch the Settings & Personalization help section icon to the same gear SVG used by the main settings toggle for consistency

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cdc7df137c8320bb5a98b154f24734