### PR TITLE
Fix font size label typo

### DIFF
--- a/index.html
+++ b/index.html
@@ -775,7 +775,7 @@
             <option value="14">14px</option>
             <option value="16">16px</option>
             <option value="18">18px</option>
-            <option value="20">20px (Bitter)</option>
+            <option value="20">20px (Bigger)</option>
           </select>
         </div>
         <div class="form-row">


### PR DESCRIPTION
## Summary
- correct the 20px font size option label to read "20px (Bigger)"

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cdcb0b45808320a62633739b6f93cc