### PR TITLE
Update camera icon rendering in setup diagram

### DIFF
--- a/index.html
+++ b/index.html
@@ -2611,7 +2611,7 @@
       </fieldset>
 
       <fieldset>
-        <legend><span class="legend-icon icon-glyph" aria-hidden="true" data-icon-font="film">&#xF12D;</span>Camera Project</legend>
+        <legend><span class="legend-icon icon-glyph" id="cameraProjectLegendIcon" aria-hidden="true"></span>Camera Project</legend>
         <div class="form-row"><label>Camera:<input type="text" id="fbCamera" name="fbCamera" readonly></label></div>
         <div class="form-row"><label>Battery Plate:<input type="text" id="fbBatteryPlate" name="fbBatteryPlate" readonly></label></div>
         <div class="form-row"><label>Lens Mount:<input list="mountOptions" id="fbLensMount" name="fbLensMount"></label></div>

--- a/overview-print.css
+++ b/overview-print.css
@@ -57,6 +57,27 @@ body.dark-mode {
   fill: var(--text-color);
   font-family: 'Ubuntu', sans-serif;
 }
+
+#overviewDialogContent #setupDiagram .node-icon-svg {
+  color: var(--text-color);
+}
+
+#overviewDialogContent #setupDiagram .node-icon-svg svg {
+  width: 24px;
+  height: 24px;
+  display: block;
+  stroke: var(--text-color);
+  stroke-width: 1.5px;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  fill: none;
+}
+
+#overviewDialogContent #setupDiagram .node-icon-svg svg .diagram-camera-icon__lens {
+  fill: var(--text-color);
+  fill-opacity: 0.2;
+  stroke: none;
+}
 #overviewDialogContent #setupDiagram line,
 #overviewDialogContent #setupDiagram path.edge-path {
   stroke: var(--control-text);
@@ -90,6 +111,18 @@ body.dark-mode {
   font-weight: var(--font-weight-regular);
   border-color: var(--text-color) !important;
   color: var(--text-color) !important;
+}
+
+#overviewDialogContent .icon-glyph.diagram-camera-icon svg {
+  stroke-width: 1.5px;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+#overviewDialogContent .icon-glyph.diagram-camera-icon svg .diagram-camera-icon__lens {
+  fill: currentColor;
+  fill-opacity: 0.2;
+  stroke: none;
 }
 
 #overviewDialogContent.logo-present {

--- a/style.css
+++ b/style.css
@@ -1585,6 +1585,25 @@ body.pink-mode .auto-gear-rule-title,
   fill: none;
 }
 
+.icon-glyph.diagram-camera-icon svg {
+  stroke-width: 1.5px;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.icon-glyph.diagram-camera-icon svg .diagram-camera-icon__lens {
+  fill: currentColor;
+  fill-opacity: 0.2;
+  stroke: none;
+}
+
+.dark-mode .icon-glyph.diagram-camera-icon svg .diagram-camera-icon__lens,
+html.dark-mode .icon-glyph.diagram-camera-icon svg .diagram-camera-icon__lens,
+body.high-contrast .icon-glyph.diagram-camera-icon svg .diagram-camera-icon__lens,
+html.high-contrast .icon-glyph.diagram-camera-icon svg .diagram-camera-icon__lens {
+  fill-opacity: 0.3;
+}
+
 @keyframes pink-mode-icon-pop {
   0% {
     transform: scale(0.85);
@@ -2795,6 +2814,42 @@ body.dark-mode.pink-mode #topBar #logo .logo-center {
 
 #setupDiagram .node-icon[data-icon-font='gadget'] {
   font-family: 'GadgetIcons', system-ui, sans-serif;
+}
+
+#setupDiagram .node-icon-svg {
+  color: #333;
+  pointer-events: none;
+}
+
+#setupDiagram .node-icon-svg svg {
+  width: 24px;
+  height: 24px;
+  display: block;
+  stroke: currentColor;
+  stroke-width: 1.5px;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  fill: none;
+}
+
+#setupDiagram .node-icon-svg svg .diagram-camera-icon__lens {
+  fill: currentColor;
+  fill-opacity: 0.2;
+  stroke: none;
+}
+
+.dark-mode #setupDiagram .node-icon-svg,
+html.dark-mode #setupDiagram .node-icon-svg,
+body.high-contrast #setupDiagram .node-icon-svg,
+html.high-contrast #setupDiagram .node-icon-svg {
+  color: var(--inverse-text-color);
+}
+
+.dark-mode #setupDiagram .node-icon-svg svg .diagram-camera-icon__lens,
+html.dark-mode #setupDiagram .node-icon-svg svg .diagram-camera-icon__lens,
+body.high-contrast #setupDiagram .node-icon-svg svg .diagram-camera-icon__lens,
+html.high-contrast #setupDiagram .node-icon-svg svg .diagram-camera-icon__lens {
+  fill-opacity: 0.3;
 }
 
 #setupDiagram .node-icon[data-icon-font='uicons'] {


### PR DESCRIPTION
## Summary
- replace the diagram camera glyph with an inline SVG and extend the renderer to position SVG icons
- add styling for the new camera icon across the app and printable overview
- show the updated camera symbol in the camera project legend and reuse the shared glyph helper

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cdcba0c88c8320b3224e71a265dbb6