### PR TITLE
Ensure favorite toggles inherit button color

### DIFF
--- a/style.css
+++ b/style.css
@@ -2031,6 +2031,7 @@ textarea:disabled {
   cursor: pointer;
   font-size: var(--font-size-base);
   color: var(--favorite-inactive-color);
+  --icon-color: currentColor;
   display: inline-flex;
   align-items: center;
   justify-content: center;


### PR DESCRIPTION
## Summary
- override the favorite toggle button icon color to follow the button text color
- keeps favorite icons consistent across themes, including pink mode

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cdcf1f987c8320b33d0518bf18f55c