### PR TITLE
Lighten project requirements selections in light mode

### DIFF
--- a/style.css
+++ b/style.css
@@ -1975,6 +1975,13 @@ select[multiple] option:checked {
   color: var(--inverse-text-color);
 }
 
+@supports (color: color-mix(in srgb, #000 50%, white)) {
+  body.light-mode:not(.high-contrast) #projectDialog select[multiple] option:checked {
+    background-color: color-mix(in srgb, var(--accent-color) 35%, white);
+    color: var(--accent-color);
+  }
+}
+
 html.high-contrast select[multiple] option:checked,
 body.high-contrast select[multiple] option:checked {
   color: #000;


### PR DESCRIPTION
## Summary
- lighten project requirement multi-select backgrounds in light mode while preserving dark mode styling
- keep high contrast mode unaffected by restricting the new styling to standard light mode only

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cdd067555c8320b01918c03b846c5b