### PR TITLE
Update reset view button icon

### DIFF
--- a/index.html
+++ b/index.html
@@ -389,7 +389,10 @@
     <div class="diagram-controls">
       <button id="zoomOut" type="button" title="Zoom out" aria-label="Zoom out">-</button>
       <button id="zoomIn" type="button" title="Zoom in" aria-label="Zoom in">+</button>
-      <button id="resetView" type="button"><span class="btn-icon icon-glyph" aria-hidden="true" data-icon-font="essential">&#xF202;</span>Reset View</button>
+      <button id="resetView" type="button">
+        <span class="btn-icon icon-glyph" aria-hidden="true" data-icon-font="film">&#xF114;</span>
+        Reset View
+      </button>
       <button id="gridSnapToggle" type="button" aria-pressed="false">Snap to Grid</button>
     </div>
     <p id="diagramHint" class="diagram-hint"></p>

--- a/script.js
+++ b/script.js
@@ -3054,7 +3054,7 @@ function setLanguage(lang) {
     gridSnapToggleBtn.setAttribute("aria-pressed", gridSnap ? "true" : "false");
   }
   if (resetViewBtn) {
-    setButtonLabelWithIcon(resetViewBtn, texts[lang].resetViewBtn, ICON_GLYPHS.reload);
+    setButtonLabelWithIcon(resetViewBtn, texts[lang].resetViewBtn, ICON_GLYPHS.resetView);
     resetViewBtn.setAttribute("title", texts[lang].resetViewBtn);
     resetViewBtn.setAttribute("aria-label", texts[lang].resetViewBtn);
     resetViewBtn.setAttribute("data-help", texts[lang].resetViewHelp);
@@ -3432,6 +3432,7 @@ const ICON_GLYPHS = Object.freeze({
   audioOut: iconGlyph('\uF22F', ICON_FONT_KEYS.ESSENTIAL),
   note: iconGlyph('\uF13E', ICON_FONT_KEYS.ESSENTIAL),
   feedback: Object.freeze({ markup: FEEDBACK_ICON_SVG }),
+  resetView: iconGlyph('\uF114', ICON_FONT_KEYS.FILM),
   pin: iconGlyph('\uF1EF', ICON_FONT_KEYS.ESSENTIAL),
   sun: iconGlyph('\uF1F7', ICON_FONT_KEYS.UICONS),
   moon: iconGlyph('\uEC7E', ICON_FONT_KEYS.UICONS),


### PR DESCRIPTION
## Summary
- show the Reset View control with the film icon font's viewfinder glyph for a more consistent in-app style
- keep the `ICON_GLYPHS.resetView` mapping so language changes continue to refresh the control correctly

## Testing
- npm test -- --runTestsByPath tests/unit/storageFallback.test.js

------
https://chatgpt.com/codex/tasks/task_e_68cdcfaef90c83209246e13b23411c6c