### PR TITLE
Update settings and help dialogs to shared modal design

### DIFF
--- a/index.html
+++ b/index.html
@@ -735,8 +735,8 @@
     <a id="privacyLink" href="datenschutz-en.html">Privacy Policy</a>
   </footer>
 
-  <div id="settingsDialog" role="dialog" aria-modal="true" aria-labelledby="settingsTitle" hidden>
-    <div class="settings-content">
+  <dialog id="settingsDialog" class="app-modal" role="dialog" aria-modal="true" aria-labelledby="settingsTitle" hidden>
+    <div class="modal-surface modal-surface-scrollable settings-content">
       <h2 id="settingsTitle">Settings</h2>
       <div class="settings-section general-settings">
         <div class="form-row">
@@ -916,7 +916,7 @@
         <button id="settingsCancel"><span class="btn-icon icon-glyph" aria-hidden="true" data-icon-font="essential">&#xF131;</span>Cancel</button>
       </div>
     </div>
-  </div>
+  </dialog>
 
   <div
     id="installGuideDialog"
@@ -926,7 +926,7 @@
     aria-describedby="installGuideIntro"
     hidden
   >
-    <div class="install-guide-content">
+    <div class="modal-surface install-guide-content">
       <h2 id="installGuideTitle">Install Cine Power Planner</h2>
       <p id="installGuideIntro">Add the planner to your Home Screen to use it like an app.</p>
       <ol id="installGuideSteps">
@@ -965,7 +965,7 @@
     aria-describedby="iosPwaHelpIntro"
     hidden
   >
-    <div class="ios-pwa-help-content">
+    <div class="modal-surface ios-pwa-help-content">
       <h2 id="iosPwaHelpTitle">Keep your data when installing on iOS</h2>
       <p id="iosPwaHelpIntro">
         Safari keeps the browser tab and the installed app separate. To move your Cine Power Planner data into the app:
@@ -986,8 +986,16 @@
     </div>
   </div>
 
-  <div id="helpDialog" role="dialog" aria-modal="true" aria-labelledby="helpTitle" tabindex="-1" hidden>
-    <div class="help-content">
+  <dialog
+    id="helpDialog"
+    class="app-modal"
+    role="dialog"
+    aria-modal="true"
+    aria-labelledby="helpTitle"
+    tabindex="-1"
+    hidden
+  >
+    <div class="modal-surface modal-surface-scrollable help-content">
       <button id="closeHelp">Close</button>
       <h2 id="helpTitle">How to use</h2>
       <div id="helpSearchContainer">
@@ -2269,7 +2277,7 @@
         </section>
       </div>
     </div>
-  </div>
+  </dialog>
   <dialog id="shareDialog" aria-labelledby="shareDialogHeading">
     <form id="shareForm" method="dialog">
       <h3 id="shareDialogHeading">Share Project</h3>

--- a/style.css
+++ b/style.css
@@ -878,15 +878,50 @@ main.legal-content {
   margin-bottom: 2px;
 }
 
-/* Help dialog */
-#helpDialog {
+#helpDialog[hidden] {
+  display: none;
+}
+#settingsDialog[hidden] {
+  display: none;
+}
+
+/* Global modal layout */
+.app-modal {
+  border: none;
+  padding: 0;
+  background: transparent;
+  color: inherit;
+  max-width: none;
+  width: 100vw;
+  height: 100vh;
+  margin: 0;
+}
+
+.app-modal::backdrop {
+  background: rgba(0, 0, 0, 0.6);
+}
+
+.app-modal[open] {
   position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.6);
   display: flex;
   align-items: center;
   justify-content: center;
+  padding: 20px;
   z-index: 200;
+}
+
+.modal-surface {
+  background: var(--surface-color);
+  color: var(--text-color);
+  border: 2px solid var(--accent-color);
+  border-radius: var(--border-radius);
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.2);
+}
+
+.modal-surface-scrollable {
+  max-height: 80vh;
+  overflow-y: auto;
 }
 
 #installGuideDialog {
@@ -909,16 +944,6 @@ main.legal-content {
   justify-content: center;
   z-index: 210;
   padding: 20px;
-}
-
-#settingsDialog {
-  position: fixed;
-  inset: 0;
-  background: rgba(0, 0, 0, 0.6);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 200;
 }
 
 #feedbackDialog {
@@ -951,10 +976,6 @@ main.legal-content {
   margin-top: 10px;
 }
 
-#helpDialog[hidden] {
-  display: none;
-}
-
 #installGuideDialog[hidden] {
   display: none;
 }
@@ -968,15 +989,8 @@ main.legal-content {
 }
 
 .help-content {
-  background: var(--surface-color);
-  border: 2px solid var(--accent-color);
   padding: 20px;
-  max-height: 80vh;
-  overflow-y: auto;
-  color: var(--text-color);
   width: min(90vw, 700px);
-  border-radius: var(--border-radius);
-  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.2);
 }
 
 .help-content h3 {
@@ -992,11 +1006,6 @@ main.legal-content {
 
 
 .install-guide-content {
-  background: var(--surface-color);
-  border: 2px solid var(--accent-color);
-  color: var(--text-color);
-  border-radius: var(--border-radius);
-  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.2);
   padding: clamp(20px, 4vw, 32px);
   width: min(520px, 100%);
   display: flex;
@@ -1031,11 +1040,6 @@ main.legal-content {
 
 
 .ios-pwa-help-content {
-  background: var(--surface-color);
-  border: 2px solid var(--accent-color);
-  color: var(--text-color);
-  border-radius: var(--border-radius);
-  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.2);
   padding: clamp(20px, 4vw, 32px);
   width: min(480px, 100%);
   display: flex;
@@ -1056,15 +1060,8 @@ main.legal-content {
 
 
 .settings-content {
-  background: var(--surface-color);
-  border: 2px solid var(--accent-color);
   padding: 20px;
-  color: var(--text-color);
   width: min(90vw, 700px);
-  max-height: 80vh;
-  overflow-y: auto;
-  border-radius: var(--border-radius);
-  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.2);
   display: flex;
   flex-direction: column;
   gap: 20px;


### PR DESCRIPTION
## Summary
- convert the settings and help overlays to use the shared modal `<dialog>` implementation and surface styling
- add reusable modal surface classes and apply them to the settings, help, install guide and iOS help layouts
- update dialog scripting to rely on shared helpers, ensure accessibility focus handling and close/cancel coverage

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cdcf902aac8320ab6f7edb7d992c5b