### PR TITLE
Align share, load, and clear project actions

### DIFF
--- a/index.html
+++ b/index.html
@@ -198,67 +198,64 @@
       <span class="form-label-spacer" aria-hidden="true"></span>
       <div class="form-actions">
         <button id="shareSetupBtn"><span class="btn-icon icon-glyph" aria-hidden="true" data-icon-font="essential">&#xF219;</span>Share Project</button>
+        <div id="sharedLinkRow" class="share-import-group">
+          <label for="applySharedLinkBtn" id="sharedLinkLabel">Shared Project:</label>
+          <input
+            type="file"
+            id="sharedLinkInput"
+            accept=".json"
+            aria-hidden="true"
+            tabindex="-1"
+            class="visually-hidden"
+          />
+          <button id="applySharedLinkBtn">
+            <span class="btn-icon icon-glyph icon-svg" aria-hidden="true">
+              <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+                <path
+                  d="M12 3v9.75"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="1.5"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+                <polyline
+                  points="8.75 9.75 12 12.75 15.25 9.75"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="1.5"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+                <path
+                  d="M4.75 11.5H8.6L10.4 9h8.85L21 11.5"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="1.5"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+                <rect
+                  x="4.75"
+                  y="12.5"
+                  width="14.5"
+                  height="7.25"
+                  rx="1.75"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="1.5"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+              </svg>
+            </span>
+            Load
+          </button>
+        </div>
+        <button id="clearSetupBtn"><span class="btn-icon icon-glyph" aria-hidden="true" data-icon-font="essential">&#xF131;</span>Clear Current Project</button>
       </div>
     </div>
     <p id="shareLinkMessage" class="hidden" role="status" aria-live="polite"></p>
-    <div class="form-row" id="sharedLinkRow">
-      <label for="applySharedLinkBtn" id="sharedLinkLabel">Shared Project:</label>
-      <input
-        type="file"
-        id="sharedLinkInput"
-        accept=".json"
-        aria-hidden="true"
-        tabindex="-1"
-        class="visually-hidden"
-      />
-      <button id="applySharedLinkBtn">
-        <span class="btn-icon icon-glyph icon-svg" aria-hidden="true">
-          <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-            <path
-              d="M12 3v9.75"
-              fill="none"
-              stroke="currentColor"
-              stroke-width="1.5"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-            />
-            <polyline
-              points="8.75 9.75 12 12.75 15.25 9.75"
-              fill="none"
-              stroke="currentColor"
-              stroke-width="1.5"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-            />
-            <path
-              d="M4.75 11.5H8.6L10.4 9h8.85L21 11.5"
-              fill="none"
-              stroke="currentColor"
-              stroke-width="1.5"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-            />
-            <rect
-              x="4.75"
-              y="12.5"
-              width="14.5"
-              height="7.25"
-              rx="1.75"
-              fill="none"
-              stroke="currentColor"
-              stroke-width="1.5"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-            />
-          </svg>
-        </span>
-        Load
-      </button>
-    </div>
-    <div class="form-row form-row-actions">
-      <span class="form-label-spacer" aria-hidden="true"></span>
-      <button id="clearSetupBtn"><span class="btn-icon icon-glyph" aria-hidden="true" data-icon-font="essential">&#xF131;</span>Clear Current Project</button>
-    </div>
     <div class="form-row form-row-actions" role="group" aria-label="Project exports">
       <span class="form-label-spacer" aria-hidden="true"></span>
       <div class="form-actions">

--- a/style.css
+++ b/style.css
@@ -630,6 +630,21 @@ main.legal-content {
   margin: 0;
 }
 
+.share-import-group {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--gap-size);
+  flex: 1 1 0;
+  flex-wrap: wrap;
+  min-width: 0;
+}
+
+.share-import-group label {
+  flex: 0 1 auto;
+  white-space: nowrap;
+}
+
 
 .share-option {
   display: inline-flex;
@@ -728,11 +743,6 @@ main.legal-content {
   margin-left: calc(var(--form-label-width) + var(--gap-size));
 }
 
-#setup-manager #sharedLinkRow > button {
-  align-self: stretch;
-  margin: 0;
-}
-
 @media (max-width: 600px) {
   .form-row {
     flex-direction: column;
@@ -768,6 +778,22 @@ main.legal-content {
   }
   #setup-manager #shareLinkMessage {
     margin-left: 0;
+  }
+
+  .share-import-group {
+    width: 100%;
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .share-import-group label {
+    width: 100%;
+    white-space: normal;
+  }
+
+  .share-import-group button {
+    width: 100%;
+    align-self: stretch;
   }
 
   #setup-manager .share-import-row {
@@ -806,9 +832,6 @@ main.legal-content {
   flex: 0 0 auto;
 }
 
-#sharedLinkRow > button {
-  align-self: center;
-}
 .form-row > button:not(.clear-input-btn):not(.favorite-toggle) + button:not(.clear-input-btn):not(.favorite-toggle) {
   margin-left: 0;
 }
@@ -2122,8 +2145,10 @@ button {
     color 0.2s,
     transform 0.2s;
 }
-#sharedLinkRow > button {
-  margin: 0 5px 5px 5px;
+
+.share-import-group button {
+  margin: 0;
+  align-self: center;
 }
 button:hover {
   background-color: var(--control-hover-bg);
@@ -3424,14 +3449,26 @@ body.dark-mode.dark-accent-boost:not(.pink-mode) .help-content {
     width: 100%;
     margin: 5px 0 0 0;
   }
-  #sharedLinkRow > button {
-    align-self: stretch;
-    margin: 5px 0 0 0;
-  }
 
   .form-row > button + button {
     margin-left: 0;
     margin-top: 5px;
+  }
+
+  .share-import-group {
+    width: 100%;
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .share-import-group label {
+    width: 100%;
+    white-space: normal;
+  }
+
+  .share-import-group button {
+    width: 100%;
+    align-self: stretch;
   }
 
   .device-list-container {


### PR DESCRIPTION
## Summary
- show the share, load, and clear project actions together so the buttons align on a single row
- add layout rules for the shared project picker so it stays centered on desktop and stacks cleanly on narrow screens

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cdd12a1de48320a96e931e81aeccdf