### PR TITLE
Switch automatic gear backups to dropdown restore control

### DIFF
--- a/index.html
+++ b/index.html
@@ -859,7 +859,16 @@
         <div id="autoGearBackupsSection" class="auto-gear-backups">
           <h4 id="autoGearBackupsHeading">Automatic backups</h4>
           <p id="autoGearBackupsDescription" class="settings-hint"></p>
-          <ul id="autoGearBackupList" class="auto-gear-backup-list" aria-live="polite"></ul>
+          <div id="autoGearBackupControls" class="auto-gear-backup-controls" aria-live="polite">
+            <label for="autoGearBackupSelect" id="autoGearBackupSelectLabel">Choose a backup</label>
+            <div class="auto-gear-backup-row">
+              <select id="autoGearBackupSelect" class="auto-gear-backup-select" disabled>
+                <option value="">Select a backup to restore</option>
+              </select>
+              <button type="button" id="autoGearBackupRestore" disabled>Restore</button>
+            </div>
+            <p id="autoGearBackupEmpty" class="auto-gear-backup-empty" hidden>No automatic backups yet.</p>
+          </div>
         </div>
         <div id="autoGearEditor" class="auto-gear-editor" hidden>
           <div class="form-row">

--- a/style.css
+++ b/style.css
@@ -1118,27 +1118,20 @@ main.legal-content {
   gap: 8px;
 }
 
-.auto-gear-backup-list {
-  list-style: none;
-  margin: 0;
-  padding: 0;
+.auto-gear-backup-controls {
   display: flex;
   flex-direction: column;
   gap: 8px;
 }
 
-.auto-gear-backup-item {
+.auto-gear-backup-row {
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-  padding: 8px 12px;
-  border: 1px solid var(--panel-border);
-  border-radius: var(--border-radius);
-  background: var(--surface-color);
+  gap: 8px;
+  flex-wrap: wrap;
 }
 
-.auto-gear-backup-meta {
+.auto-gear-backup-select {
   flex: 1;
   min-width: 0;
 }
@@ -1146,6 +1139,7 @@ main.legal-content {
 .auto-gear-backup-empty {
   font-style: italic;
   color: var(--muted-text-color, #666);
+  margin: 0;
 }
 
 .auto-gear-rule {

--- a/tests/script/autoGearRules.test.js
+++ b/tests/script/autoGearRules.test.js
@@ -363,8 +363,10 @@ describe('applyAutoGearRulesToTableHtml', () => {
       ])
     );
 
-    const backupButtons = document.querySelectorAll('#autoGearBackupList button[data-backup-id]');
-    expect(backupButtons.length).toBeGreaterThan(0);
+    const backupSelect = document.getElementById('autoGearBackupSelect');
+    expect(backupSelect).not.toBeNull();
+    const backupOptions = Array.from(backupSelect.options).filter(option => option.value);
+    expect(backupOptions.length).toBeGreaterThan(0);
 
     jest.useRealTimers();
   });
@@ -399,11 +401,17 @@ describe('applyAutoGearRulesToTableHtml', () => {
     editorName.value = 'Backup modified';
     document.getElementById('autoGearSaveRule').click();
 
-    const backupButton = document.querySelector('#autoGearBackupList button[data-backup-id]');
-    expect(backupButton).not.toBeNull();
+    const backupSelect = document.getElementById('autoGearBackupSelect');
+    const backupRestoreButton = document.getElementById('autoGearBackupRestore');
+    expect(backupSelect).not.toBeNull();
+    expect(backupRestoreButton).not.toBeNull();
+    const selectableOption = Array.from(backupSelect.options).find(option => option.value);
+    expect(selectableOption).toBeDefined();
+    backupSelect.value = selectableOption.value;
+    backupSelect.dispatchEvent(new Event('change'));
     const originalConfirm = window.confirm;
     window.confirm = jest.fn(() => true);
-    backupButton.click();
+    backupRestoreButton.click();
     window.confirm = originalConfirm;
 
     const storedRules = JSON.parse(localStorage.getItem(STORAGE_KEY));

--- a/translations.js
+++ b/translations.js
@@ -172,6 +172,8 @@ const texts = {
     autoGearBackupsHeading: "Automatic backups",
     autoGearBackupsDescription:
       "Backups save your rules every 10 minutes when changes occur. Restore a snapshot if something goes wrong.",
+    autoGearBackupSelectLabel: "Choose a backup",
+    autoGearBackupSelectPlaceholder: "Select a backup to restore",
     autoGearBackupEmpty: "No automatic backups yet.",
     autoGearBackupRestore: "Restore",
     autoGearBackupRestoreConfirm: "Replace your automatic gear rules with this backup?",
@@ -1304,6 +1306,8 @@ const texts = {
     autoGearBackupsHeading: "Backup automatici",
     autoGearBackupsDescription:
       "Viene salvato un backup ogni 10 minuti quando ci sono modifiche. Ripristina una versione se qualcosa va storto.",
+    autoGearBackupSelectLabel: "Scegli un backup",
+    autoGearBackupSelectPlaceholder: "Seleziona un backup da ripristinare",
     autoGearBackupEmpty: "Nessun backup automatico al momento.",
     autoGearBackupRestore: "Ripristina",
     autoGearBackupRestoreConfirm: "Sostituire le regole automatiche dell'equipaggiamento con questo backup?",
@@ -2041,6 +2045,8 @@ const texts = {
     autoGearBackupsHeading: "Copias de seguridad automáticas",
     autoGearBackupsDescription:
       "Se guarda una copia cada 10 minutos cuando hay cambios. Restaura una versión si algo salió mal.",
+    autoGearBackupSelectLabel: "Elige una copia de seguridad",
+    autoGearBackupSelectPlaceholder: "Selecciona una copia de seguridad para restaurar",
     autoGearBackupEmpty: "Aún no hay copias de seguridad automáticas.",
     autoGearBackupRestore: "Restaurar",
     autoGearBackupRestoreConfirm: "¿Reemplazar las reglas automáticas de equipo con esta copia de seguridad?",
@@ -2780,6 +2786,8 @@ const texts = {
     autoGearBackupsHeading: "Sauvegardes automatiques",
     autoGearBackupsDescription:
       "Une sauvegarde est créée toutes les 10 minutes en cas de changement. Restaurez une version si nécessaire.",
+    autoGearBackupSelectLabel: "Choisir une sauvegarde",
+    autoGearBackupSelectPlaceholder: "Sélectionnez une sauvegarde à restaurer",
     autoGearBackupEmpty: "Aucune sauvegarde automatique pour le moment.",
     autoGearBackupRestore: "Restaurer",
     autoGearBackupRestoreConfirm: "Remplacer les règles automatiques d’équipement par cette sauvegarde ?",
@@ -3522,6 +3530,8 @@ const texts = {
     autoGearBackupsHeading: "Automatische Sicherungen",
     autoGearBackupsDescription:
       "Alle 10 Minuten wird bei Änderungen eine Sicherung erstellt. Stelle eine Version wieder her, falls etwas schiefgeht.",
+    autoGearBackupSelectLabel: "Backup auswählen",
+    autoGearBackupSelectPlaceholder: "Wähle eine Sicherung zum Wiederherstellen",
     autoGearBackupEmpty: "Noch keine automatischen Sicherungen.",
     autoGearBackupRestore: "Wiederherstellen",
     autoGearBackupRestoreConfirm: "Automatische Gear-Regeln mit dieser Sicherung ersetzen?",


### PR DESCRIPTION
## Summary
- replace the automatic gear backup list with a dropdown-driven restore control and accessible label
- update scripts to populate the dropdown, manage button state, and add localized strings for every supported language

## Testing
- npm run test:script -- --runTestsByPath tests/script/autoGearRules.test.js

------
https://chatgpt.com/codex/tasks/task_e_68cdd24cc018832091b062c9788d08f6