### PR TITLE
Restore double-gear motor icon

### DIFF
--- a/script.js
+++ b/script.js
@@ -3464,7 +3464,7 @@ const ICON_GLYPHS = Object.freeze({
   screen: iconGlyph('\uF11D', ICON_FONT_KEYS.GADGET),
   brightness: iconGlyph('\uE2B3', ICON_FONT_KEYS.UICONS),
   wifi: iconGlyph('\uF4AC', ICON_FONT_KEYS.UICONS),
-  gears: iconGlyph('\uF211', ICON_FONT_KEYS.ESSENTIAL),
+  gears: iconGlyph('\uF205', ICON_FONT_KEYS.ESSENTIAL),
   controller: iconGlyph('\uF117', ICON_FONT_KEYS.GADGET),
   distance: iconGlyph('\uEFB9', ICON_FONT_KEYS.UICONS),
   viewfinder: iconGlyph('\uF114', ICON_FONT_KEYS.FILM),


### PR DESCRIPTION
## Summary
- switch the motor icon glyph back to the double gear symbol

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cdd3d7c924832092e3c45a547f3e59