### PR TITLE
Fix gear list restoration when renamed without saving

### DIFF
--- a/script.js
+++ b/script.js
@@ -17435,8 +17435,23 @@ function restoreSessionState() {
   }
   if (gearListOutput || projectRequirementsOutput) {
     const projectName = getCurrentProjectName();
-    const storedProject = typeof loadProject === 'function' ? loadProject(projectName) : null;
-    if (storedProject && (storedProject.gearList || storedProject.projectInfo)) {
+    const fetchStoredProject = name =>
+      typeof loadProject === 'function' && typeof name === 'string'
+        ? loadProject(name)
+        : null;
+    const hasProjectPayload = project =>
+      project && (project.gearList || project.projectInfo);
+    let storedProject = fetchStoredProject(projectName);
+    if (!hasProjectPayload(storedProject) && state) {
+      const fallbackName = typeof state.setupSelect === 'string' ? state.setupSelect.trim() : '';
+      if (fallbackName && fallbackName !== projectName) {
+        const fallbackProject = fetchStoredProject(fallbackName);
+        if (hasProjectPayload(fallbackProject)) {
+          storedProject = fallbackProject;
+        }
+      }
+    }
+    if (hasProjectPayload(storedProject)) {
       const mergedInfo = {
         ...(storedProject.projectInfo || {}),
         ...(currentProjectInfo || {})


### PR DESCRIPTION
## Summary
- update the session restore logic to fall back to the previously selected setup when the current project name has no stored data so saved gear lists stay visible after reloads
- add a regression test that covers the rename fallback scenario for restoreSessionState

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cdd8d8d028832091bb97118af222a6