### PR TITLE
Align help quick link icons with help section sizing

### DIFF
--- a/style.css
+++ b/style.css
@@ -1460,7 +1460,11 @@ body.pink-mode .auto-gear-rule-title,
 .help-quick-link-icon {
   --icon-color: var(--accent-color);
   flex: 0 0 auto;
-  font-size: calc(var(--font-size-relative-base) * var(--font-scale-lg));
+  font-size: var(--icon-size-md);
+}
+
+.help-quick-link-icon.icon-glyph {
+  --icon-size: var(--icon-size-md);
 }
 
 .dark-mode .help-quick-link-icon {


### PR DESCRIPTION
## Summary
- use the shared medium icon size token for help quick link glyphs
- ensure cloned help section icons keep consistent sizing with their source headings

## Testing
- npm run test:dom

------
https://chatgpt.com/codex/tasks/task_e_68cdd9500f108320a157272ec2ab3a48