### PR TITLE
Hide filter detail storage in form and render gear list controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -2556,7 +2556,7 @@
         <label for="filter" id="filterLabel">Filter:</label>
         <select id="filter" name="filter" multiple size="10"></select>
       </div>
-      <div class="form-row" id="filterDetails"></div>
+      <div class="form-row visually-hidden" id="filterDetails" aria-hidden="true"></div>
 
       <h3 id="monitoringHeading">Monitoring</h3>
       <div class="form-row">

--- a/script.js
+++ b/script.js
@@ -9077,7 +9077,7 @@ function checkSetupChanged() {
 const projectDialog = document.getElementById("projectDialog");
 const projectForm = document.getElementById("projectForm");
 const filterSelectElem = document.getElementById('filter');
-const filterDetailsContainer = document.getElementById('filterDetails');
+const filterDetailsStorage = document.getElementById('filterDetails');
 const matteboxSelect = document.getElementById('mattebox');
 const projectCancelBtn = document.getElementById("projectCancel");
 const feedbackDialog = document.getElementById("feedbackDialog");
@@ -17072,11 +17072,25 @@ function ensureGearListActions() {
             let shouldSync = false;
             if (target.matches('.filter-values-container input[type="checkbox"]')) {
                 const container = target.closest('.filter-values-container');
+                const storageId = container && container.getAttribute('data-storage-values');
                 const sel = container && container.querySelector('select');
-                if (sel) {
+                if (target.checked) {
+                    target.setAttribute('checked', '');
+                } else {
+                    target.removeAttribute('checked');
+                }
+                if (storageId) {
+                    syncGearListFilterValue(storageId, target.value, target.checked);
+                } else if (sel) {
                     const opt = Array.from(sel.options).find(opt => opt.value === target.value);
                     if (opt) opt.selected = target.checked;
                     sel.dispatchEvent(new Event('change'));
+                }
+                shouldSync = true;
+            } else if (target.matches('select[data-storage-id]')) {
+                const storageId = target.getAttribute('data-storage-id');
+                if (storageId) {
+                    syncGearListFilterSize(storageId, target.value);
                 }
                 shouldSync = true;
             } else if (target.id && target.id.startsWith('filter-size-')) {
@@ -19994,9 +20008,12 @@ function getFilterValueConfig(type) {
   }
 }
 
-function createFilterSizeSelect(type, selected = DEFAULT_FILTER_SIZE) {
+function createFilterSizeSelect(type, selected = DEFAULT_FILTER_SIZE, options = {}) {
+  const { includeId = true, idPrefix = 'filter-size-' } = options;
   const sel = document.createElement('select');
-  sel.id = `filter-size-${filterId(type)}`;
+  if (includeId) {
+    sel.id = `${idPrefix}${filterId(type)}`;
+  }
   let sizes = [DEFAULT_FILTER_SIZE, '4x4', '6x6', '95mm'];
   if (type === 'Rota-Pol') sizes = [DEFAULT_FILTER_SIZE, '6x6', '95mm'];
   sizes.forEach(s => {
@@ -20241,63 +20258,182 @@ function updateGearListFilterEntries(entries = []) {
   });
 }
 
+function getGearListFilterDetailsContainer() {
+  return gearListOutput ? gearListOutput.querySelector('#gearListFilterDetails') : null;
+}
+
+function filterTypeNeedsValueSelect(type) {
+  return type === 'Diopter'
+    || type === 'IRND'
+    || type === 'ND Grad HE'
+    || type === 'ND Grad SE'
+    || (type !== 'Clear' && type !== 'Pol' && type !== 'Rota-Pol');
+}
+
+function createFilterStorageValueSelect(type, selected) {
+  const select = document.createElement('select');
+  select.id = `filter-values-${filterId(type)}`;
+  select.multiple = true;
+  select.setAttribute('multiple', '');
+  select.hidden = true;
+  select.setAttribute('aria-hidden', 'true');
+  const { opts, defaults = [] } = getFilterValueConfig(type);
+  const chosen = Array.isArray(selected) && selected.length ? selected.slice() : defaults.slice();
+  opts.forEach(value => {
+    const opt = document.createElement('option');
+    opt.value = value;
+    opt.textContent = value;
+    if (chosen.includes(value)) {
+      opt.selected = true;
+      opt.setAttribute('selected', '');
+    }
+    select.appendChild(opt);
+  });
+  return select;
+}
+
+function renderFilterDetailsStorage(details) {
+  if (!filterDetailsStorage) return;
+  filterDetailsStorage.innerHTML = '';
+  if (!details.length) {
+    filterDetailsStorage.hidden = true;
+    return;
+  }
+  filterDetailsStorage.hidden = true;
+  details.forEach(detail => {
+    const { type, size, values, needsSize, needsValues } = detail;
+    if (needsSize) {
+      const sizeSelect = createFilterSizeSelect(type, size);
+      sizeSelect.hidden = true;
+      sizeSelect.setAttribute('aria-hidden', 'true');
+      sizeSelect.addEventListener('change', handleFilterDetailChange);
+      filterDetailsStorage.appendChild(sizeSelect);
+    }
+    if (needsValues) {
+      const valuesSelect = createFilterStorageValueSelect(type, values);
+      valuesSelect.addEventListener('change', handleFilterDetailChange);
+      filterDetailsStorage.appendChild(valuesSelect);
+    }
+  });
+}
+
+function renderGearListFilterDetails(details) {
+  const container = getGearListFilterDetailsContainer();
+  if (!container) return;
+  container.innerHTML = '';
+  if (!details.length) {
+    container.classList.add('hidden');
+    return;
+  }
+  container.classList.remove('hidden');
+  details.forEach(detail => {
+    const { type, label, size, values, needsSize, needsValues } = detail;
+    const row = document.createElement('div');
+    row.className = 'filter-detail';
+    const heading = document.createElement('div');
+    heading.className = 'filter-detail-label';
+    heading.textContent = label;
+    row.appendChild(heading);
+    const controls = document.createElement('div');
+    controls.className = 'filter-detail-controls';
+    if (needsSize) {
+      const sizeLabel = document.createElement('label');
+      sizeLabel.className = 'filter-detail-size';
+      const sizeText = document.createElement('span');
+      sizeText.className = 'filter-detail-sublabel';
+      sizeText.textContent = 'Size';
+      const sizeSelect = createFilterSizeSelect(type, size, { includeId: false });
+      sizeSelect.setAttribute('data-storage-id', `filter-size-${filterId(type)}`);
+      sizeLabel.append(sizeText, sizeSelect);
+      controls.appendChild(sizeLabel);
+    }
+    if (needsValues) {
+      const valuesWrap = document.createElement('div');
+      valuesWrap.className = 'filter-detail-values';
+      const valueLabel = document.createElement('span');
+      valueLabel.className = 'filter-detail-sublabel';
+      valueLabel.textContent = 'Strengths';
+      const optionsWrap = document.createElement('span');
+      optionsWrap.className = 'filter-values-container';
+      optionsWrap.setAttribute('data-storage-values', `filter-values-${filterId(type)}`);
+      const { opts, defaults = [] } = getFilterValueConfig(type);
+      const currentValues = Array.isArray(values) && values.length ? values : defaults;
+      opts.forEach(value => {
+        const lbl = document.createElement('label');
+        lbl.className = 'filter-value-option';
+        const cb = document.createElement('input');
+        cb.type = 'checkbox';
+        cb.value = value;
+        if (currentValues.includes(value)) {
+          cb.checked = true;
+          cb.setAttribute('checked', '');
+        }
+        lbl.append(cb, document.createTextNode(value));
+        optionsWrap.appendChild(lbl);
+      });
+      valuesWrap.append(valueLabel, optionsWrap);
+      controls.appendChild(valuesWrap);
+    }
+    row.appendChild(controls);
+    container.appendChild(row);
+  });
+}
+
+function syncGearListFilterSize(storageId, value) {
+  const storageSelect = document.getElementById(storageId);
+  if (!storageSelect) return;
+  if (storageSelect.value !== value) {
+    storageSelect.value = value;
+  }
+  storageSelect.dispatchEvent(new Event('change'));
+}
+
+function syncGearListFilterValue(storageId, value, isSelected) {
+  const storageSelect = document.getElementById(storageId);
+  if (!storageSelect) return;
+  let changed = false;
+  Array.from(storageSelect.options).forEach(opt => {
+    if (opt.value !== value) return;
+    if (opt.selected !== isSelected) {
+      opt.selected = isSelected;
+      changed = true;
+      if (isSelected) {
+        opt.setAttribute('selected', '');
+      } else {
+        opt.removeAttribute('selected');
+      }
+    }
+  });
+  if (changed) {
+    storageSelect.dispatchEvent(new Event('change'));
+  }
+}
+
 function renderFilterDetails() {
   if (!filterSelectElem) return;
-  const existingSelections = collectFilterSelections();
   const selected = Array.from(filterSelectElem.selectedOptions).map(o => o.value).filter(Boolean);
+  const existingSelections = collectFilterSelections();
   const existingTokens = existingSelections
     ? parseFilterTokens(existingSelections)
     : (currentProjectInfo && currentProjectInfo.filter ? parseFilterTokens(currentProjectInfo.filter) : []);
   const existingMap = new Map(existingTokens.map(token => [token.type, token]));
-  if (filterDetailsContainer) {
-    filterDetailsContainer.innerHTML = '';
-    if (!selected.length) {
-      filterDetailsContainer.classList.add('hidden');
-    } else {
-      filterDetailsContainer.classList.remove('hidden');
-      selected.forEach(type => {
-        const prev = existingMap.get(type) || {};
-        const row = document.createElement('div');
-        row.className = 'filter-detail';
-        const { label } = resolveFilterDisplayInfo(type, prev.size || DEFAULT_FILTER_SIZE);
-        const heading = document.createElement('div');
-        heading.className = 'filter-detail-label';
-        heading.textContent = label;
-        row.appendChild(heading);
-        const controls = document.createElement('div');
-        controls.className = 'filter-detail-controls';
-        if (type !== 'Diopter') {
-          const sizeLabel = document.createElement('label');
-          sizeLabel.className = 'filter-detail-size';
-          const sizeText = document.createElement('span');
-          sizeText.className = 'filter-detail-sublabel';
-          sizeText.textContent = 'Size';
-          const sizeSelect = createFilterSizeSelect(type, prev.size || DEFAULT_FILTER_SIZE);
-          sizeSelect.addEventListener('change', handleFilterDetailChange);
-          sizeLabel.append(sizeText, sizeSelect);
-          controls.appendChild(sizeLabel);
-        }
-        const needsValues = type === 'Diopter'
-          || type === 'IRND'
-          || type === 'ND Grad HE'
-          || type === 'ND Grad SE'
-          || (type !== 'Clear' && type !== 'Pol' && type !== 'Rota-Pol');
-        if (needsValues) {
-          const valuesWrap = document.createElement('div');
-          valuesWrap.className = 'filter-detail-values';
-          const valueLabel = document.createElement('span');
-          valueLabel.className = 'filter-detail-sublabel';
-          valueLabel.textContent = 'Strengths';
-          const { container, select } = createFilterValueSelect(type, prev.values);
-          select.addEventListener('change', handleFilterDetailChange);
-          valuesWrap.append(valueLabel, container);
-          controls.appendChild(valuesWrap);
-        }
-        row.appendChild(controls);
-        filterDetailsContainer.appendChild(row);
-      });
-    }
-  }
+  const details = selected.map(type => {
+    const prev = existingMap.get(type) || {};
+    const size = prev.size || DEFAULT_FILTER_SIZE;
+    const needsSize = type !== 'Diopter';
+    const needsValues = filterTypeNeedsValueSelect(type);
+    const { label } = resolveFilterDisplayInfo(type, size);
+    return {
+      type,
+      label,
+      size,
+      values: Array.isArray(prev.values) ? prev.values.slice() : undefined,
+      needsSize,
+      needsValues
+    };
+  });
+  renderFilterDetailsStorage(details);
+  renderGearListFilterDetails(details);
   if (matteboxSelect) {
     const needsSwing = selected.some(t => t === 'ND Grad HE' || t === 'ND Grad SE');
     if (needsSwing) matteboxSelect.value = 'Swing Away';
@@ -20359,7 +20495,7 @@ function applyFilterSelectionsToGearList(info = currentProjectInfo) {
 
 function buildFilterSelectHtml(filters = []) {
   const entries = buildFilterGearEntries(filters);
-  return entries.map(entry => {
+  const summaryHtml = entries.map(entry => {
     const attrs = [
       'class="gear-item"',
       `data-gear-name="${escapeHtml(entry.gearName)}"`,
@@ -20370,6 +20506,10 @@ function buildFilterSelectHtml(filters = []) {
     const text = formatFilterEntryText(entry);
     return `<span ${attrs.join(' ')}>${escapeHtml(text)}</span>`;
   }).join('<br>');
+  const detailsContainer = entries.length
+    ? '<div id="gearListFilterDetails" class="hidden" aria-live="polite"></div>'
+    : '';
+  return [summaryHtml, detailsContainer].filter(Boolean).join('<br>');
 }
 
 function collectFilterAccessories(filters = []) {

--- a/style.css
+++ b/style.css
@@ -3888,18 +3888,18 @@ body.dark-mode.dark-accent-boost:not(.pink-mode) .help-content {
   border-bottom: 1px solid var(--inverse-text-color);
 }
 
-#filterDetails {
+#gearListFilterDetails {
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
   margin-top: 0.5rem;
 }
 
-#filterDetails.hidden {
+#gearListFilterDetails.hidden {
   display: none;
 }
 
-#filterDetails .filter-detail {
+#gearListFilterDetails .filter-detail {
   display: flex;
   flex-wrap: wrap;
   gap: 0.5rem;
@@ -3910,53 +3910,53 @@ body.dark-mode.dark-accent-boost:not(.pink-mode) .help-content {
   background: var(--panel-bg);
 }
 
-#filterDetails .filter-detail-label {
+#gearListFilterDetails .filter-detail-label {
   font-weight: 600;
   min-width: 10rem;
 }
 
-#filterDetails .filter-detail-controls {
+#gearListFilterDetails .filter-detail-controls {
   display: flex;
   flex-wrap: wrap;
   gap: 0.5rem;
   align-items: center;
 }
 
-#filterDetails .filter-detail-size {
+#gearListFilterDetails .filter-detail-size {
   display: inline-flex;
   align-items: center;
   gap: 0.5rem;
   font-weight: 500;
 }
 
-#filterDetails .filter-detail-values {
+#gearListFilterDetails .filter-detail-values {
   display: flex;
   flex-wrap: wrap;
   gap: 0.25rem;
   align-items: center;
 }
 
-#filterDetails .filter-detail-sublabel {
+#gearListFilterDetails .filter-detail-sublabel {
   font-weight: 500;
 }
 
-#filterDetails .filter-detail-sublabel::after {
+#gearListFilterDetails .filter-detail-sublabel::after {
   content: ':';
 }
 
-#filterDetails .filter-values-container {
+#gearListFilterDetails .filter-values-container {
   display: inline-flex;
   flex-wrap: wrap;
   gap: 0.25rem;
 }
 
-#filterDetails .filter-value-option {
+#gearListFilterDetails .filter-value-option {
   display: inline-flex;
   align-items: center;
   gap: 0.25rem;
 }
 
-#filterDetails .filter-value-option input[type="checkbox"] {
+#gearListFilterDetails .filter-value-option input[type="checkbox"] {
   margin: 0;
   padding: 0;
 }


### PR DESCRIPTION
## Summary
- restore a hidden filter detail container inside the project requirements form so the data remains available for saves
- render filter size and strength controls inside the gear list while syncing them to the hidden storage selects
- update event handling and styles to support the new gear list filter detail container

## Testing
- npm run test:dom

------
https://chatgpt.com/codex/tasks/task_e_68cdd8761c888320823351345e2e5118