### PR TITLE
Scope auto gear styling to settings lists

### DIFF
--- a/style.css
+++ b/style.css
@@ -1274,7 +1274,7 @@ body.pink-mode .auto-gear-rule-title,
   gap: 8px;
 }
 
-.auto-gear-item {
+.auto-gear-item-list .auto-gear-item {
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -1285,7 +1285,7 @@ body.pink-mode .auto-gear-rule-title,
   background: var(--surface-color);
 }
 
-.auto-gear-item span {
+.auto-gear-item-list .auto-gear-item span {
   display: block;
 }
 


### PR DESCRIPTION
## Summary
- scope the auto gear item styling to the settings editor lists so automatically added gear entries render like normal gear items in the gear table

## Testing
- npm test -- autoGearRules

------
https://chatgpt.com/codex/tasks/task_e_68cdd9b3ee10832088d0128b6cc76abd