### PR TITLE
Ensure legacy gear lists remain visible after reload

### DIFF
--- a/script.js
+++ b/script.js
@@ -8782,13 +8782,54 @@ function splitGearListHtml(html) {
   const h3s = doc.querySelectorAll('h3');
   const reqHeading = h3s[0];
   const reqGrid = doc.querySelector('.requirements-grid');
-  const table = doc.querySelector('.gear-table');
-  ensureGearTableCategoryGrouping(table);
   const titleHtml = title ? title.outerHTML : '';
   const projectHtml = reqHeading && reqGrid ? titleHtml + reqHeading.outerHTML + reqGrid.outerHTML : '';
   const projectName = title ? title.textContent : '';
+  let table = doc.querySelector('.gear-table');
+  if (!table) {
+    const tables = Array.from(doc.querySelectorAll('table'));
+    if (tables.length === 1) {
+      table = tables[0];
+    } else if (tables.length > 1) {
+      const tableAfterGearHeading = tables.find(tbl => {
+        const prev = tbl.previousElementSibling;
+        return prev && prev.matches('h3') && /gear list/i.test(prev.textContent || '');
+      });
+      table = tableAfterGearHeading || tables[0];
+    }
+  }
   const gearHeadingHtml = projectName ? `<h2>Gear List: “${projectName}”</h2>` : '';
-  const gearHtml = table ? gearHeadingHtml + table.outerHTML : '';
+  let gearHtml = '';
+  if (table) {
+    ensureGearTableCategoryGrouping(table);
+    gearHtml = gearHeadingHtml + table.outerHTML;
+  }
+  if (!gearHtml) {
+    const bodyClone = doc.body ? doc.body.cloneNode(true) : null;
+    const bodyHtml = doc.body ? doc.body.innerHTML.trim() : '';
+    if (bodyClone) {
+      if (title) {
+        const cloneTitle = bodyClone.querySelector('h2');
+        if (cloneTitle) cloneTitle.remove();
+      }
+      if (reqHeading) {
+        const cloneHeading = bodyClone.querySelector('h3');
+        if (cloneHeading) cloneHeading.remove();
+      }
+      if (reqGrid) {
+        const cloneGrid = bodyClone.querySelector('.requirements-grid');
+        if (cloneGrid) cloneGrid.remove();
+      }
+      const fallbackHtml = bodyClone.innerHTML.trim();
+      if (fallbackHtml) {
+        gearHtml = fallbackHtml;
+      } else if (bodyHtml) {
+        gearHtml = bodyHtml;
+      }
+    } else if (bodyHtml) {
+      gearHtml = bodyHtml;
+    }
+  }
   return { projectHtml, gearHtml };
 }
 

--- a/tests/script/splitGearListHtml.test.js
+++ b/tests/script/splitGearListHtml.test.js
@@ -1,0 +1,43 @@
+const { setupScriptEnvironment } = require('../helpers/scriptEnvironment');
+
+describe('splitGearListHtml legacy compatibility', () => {
+  test('extracts tables without the modern gear-table class', () => {
+    const { cleanup } = setupScriptEnvironment({ readyState: 'loading' });
+    try {
+      const legacyHtml = `
+        <h2>Project One</h2>
+        <h3>Project Requirements</h3>
+        <div class="requirements-grid"><div class="requirement-box">Codec: ProRes</div></div>
+        <h3>Gear List</h3>
+        <table><tr><td>Legacy Item</td></tr></table>
+      `;
+      const { projectHtml, gearHtml } = global.splitGearListHtml(legacyHtml);
+      expect(projectHtml).toContain('requirements-grid');
+      expect(gearHtml).toContain('<table');
+      expect(gearHtml).toContain('Legacy Item');
+    } finally {
+      cleanup();
+    }
+  });
+
+  test('falls back to stored markup when no table is present', () => {
+    const { cleanup } = setupScriptEnvironment({ readyState: 'loading' });
+    try {
+      const legacyHtml = `
+        <h2>Project One</h2>
+        <h3>Project Requirements</h3>
+        <div class="requirements-grid"><div class="requirement-box">Codec: ProRes</div></div>
+        <h3>Gear List</h3>
+        <p>Legacy summary</p>
+        <ul><li>Legacy Item</li></ul>
+      `;
+      const { projectHtml, gearHtml } = global.splitGearListHtml(legacyHtml);
+      expect(projectHtml).toContain('requirements-grid');
+      expect(gearHtml).toContain('Legacy summary');
+      expect(gearHtml).toContain('<ul>');
+      expect(gearHtml).toContain('Legacy Item');
+    } finally {
+      cleanup();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- broaden `splitGearListHtml` to detect legacy tables and fallback to stored markup so saved gear lists stay visible after reload
- add script-level tests covering legacy gear list formats without the modern table markup

## Testing
- npm run test:script

------
https://chatgpt.com/codex/tasks/task_e_68cdddcfc1a0832099b6ea58001f7dff