### PR TITLE
Fix runtime feedback icon proportions

### DIFF
--- a/script.js
+++ b/script.js
@@ -3636,7 +3636,7 @@ const ICON_GLYPHS = Object.freeze({
   audioIn: iconGlyph('\uF1C3', ICON_FONT_KEYS.ESSENTIAL),
   audioOut: iconGlyph('\uF22F', ICON_FONT_KEYS.ESSENTIAL),
   note: iconGlyph('\uF13E', ICON_FONT_KEYS.ESSENTIAL),
-  feedback: Object.freeze({ markup: FEEDBACK_ICON_SVG }),
+  feedback: Object.freeze({ markup: FEEDBACK_ICON_SVG, className: 'icon-svg' }),
   resetView: Object.freeze({ markup: RESET_VIEW_ICON_SVG, className: 'icon-svg' }),
   pin: iconGlyph('\uF1EF', ICON_FONT_KEYS.ESSENTIAL),
   sun: iconGlyph('\uF1F7', ICON_FONT_KEYS.UICONS),


### PR DESCRIPTION
## Summary
- ensure the runtime feedback button uses the shared SVG icon sizing class to avoid horizontal stretching

## Testing
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68cde1b77df88320a471b343b069d705