### PR TITLE
Fix pink mode logo center transparency

### DIFF
--- a/style.css
+++ b/style.css
@@ -2378,7 +2378,7 @@ input[type="file"]:disabled::-webkit-file-upload-button {
   height: 32px;
 }
 
-body.dark-mode.pink-mode #topBar #logo .logo-center {
+body.pink-mode #topBar #logo .logo-center {
   fill: transparent !important;
 }
 


### PR DESCRIPTION
## Summary
- ensure the top bar logo center becomes transparent whenever pink mode is active so the accent shows correctly

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cde305faf88320bf184849158ae6cd