### PR TITLE
Adjust lens selector layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -2553,9 +2553,9 @@
         <section class="project-dialog-section" aria-labelledby="lensesHeading">
           <h3 id="lensesHeading" class="project-section-title">Lenses</h3>
           <div class="project-section-content">
-            <div class="form-row">
+            <div class="form-row lens-selector-row">
               <label for="lenses" id="lensesLabel">Lenses:</label>
-              <div class="select-wrapper">
+              <div class="select-wrapper lens-selector">
                 <select id="lenses" name="lenses" multiple size="10" aria-labelledby="lensesLabel"></select>
               </div>
             </div>

--- a/style.css
+++ b/style.css
@@ -3653,6 +3653,29 @@ body.dark-mode.dark-accent-boost:not(.pink-mode) .settings-content.modal-surface
   overflow-y: auto;
 }
 
+#projectDialog .lens-selector-row {
+  flex-wrap: nowrap;
+  align-items: flex-start;
+  gap: clamp(12px, 2vw, 16px);
+}
+
+#projectDialog .lens-selector-row label {
+  flex: 0 1 clamp(72px, 18vw, var(--form-label-width));
+  min-width: clamp(72px, 18vw, var(--form-label-width));
+  padding-top: 0.25rem;
+}
+
+#projectDialog .lens-selector {
+  flex: 1 1 clamp(320px, 60vw, 640px);
+  min-width: clamp(140px, 60vw, 640px);
+  max-width: 100%;
+}
+
+#projectDialog .lens-selector select {
+  width: 100%;
+  min-height: 15rem;
+}
+
 .project-dialog-footer {
   display: flex;
   justify-content: flex-end;


### PR DESCRIPTION
## Summary
- widen the lenses multi-select control with a dedicated layout wrapper
- align the lenses label to the left of the selector for improved readability

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cde65b72588320ac3e42017833e7cb