### PR TITLE
Ensure project dialog labels align left

### DIFF
--- a/style.css
+++ b/style.css
@@ -3632,6 +3632,28 @@ body.dark-mode.dark-accent-boost:not(.pink-mode) .settings-content.modal-surface
   margin: 0;
 }
 
+#projectDialog .form-row {
+  display: grid;
+  grid-template-columns: minmax(var(--form-label-min-width), var(--form-label-width)) minmax(0, 1fr);
+  align-items: center;
+  gap: var(--gap-size);
+}
+
+#projectDialog .form-row label {
+  flex: initial;
+  min-width: 0;
+}
+
+#projectDialog .form-row > :not(label) {
+  grid-column: 2;
+  justify-self: stretch;
+}
+
+#projectDialog .form-row > button,
+#projectDialog .form-row > .inline-form-button {
+  justify-self: start;
+}
+
 #projectDialog select[multiple] {
   height: auto;
 }


### PR DESCRIPTION
## Summary
- update Project Requirements dialog form rows to use a grid layout that keeps labels in the left column
- align non-label controls within the dialog so fields and selectors stay to the right of their labels

## Testing
- npm test -- --runTestsByPath tests/script/restoreSessionState.test.js

------
https://chatgpt.com/codex/tasks/task_e_68cde6a51bcc8320a0bbb236df2129ad