### PR TITLE
Fix missing camera icon in setup diagram

### DIFF
--- a/script.js
+++ b/script.js
@@ -3687,8 +3687,10 @@ function positionSvgMarkup(markup, centerX, centerY, size = 24) {
       .replace(/\s+y\s*=\s*"[^"]*"/gi, '')
       .trim();
     const additions = [];
-    if (!/\bwidth\s*=/.test(attrText)) additions.push(`width="${width}"`);
-    if (!/\bheight\s*=/.test(attrText)) additions.push(`height="${height}"`);
+    const hasWidth = /(?:^|\s)width\s*=/i.test(attrText);
+    const hasHeight = /(?:^|\s)height\s*=/i.test(attrText);
+    if (!hasWidth) additions.push(`width="${width}"`);
+    if (!hasHeight) additions.push(`height="${height}"`);
     additions.push(`x="-${formatSvgCoordinate(half)}"`);
     additions.push(`y="-${formatSvgCoordinate(half)}"`);
     attrText = [attrText, ...additions].filter(Boolean).join(' ').trim();

--- a/tests/dom/utils.test.js
+++ b/tests/dom/utils.test.js
@@ -79,6 +79,21 @@ describe('utility function tests', () => {
     expect(labels.some(l => /Serial/.test(l))).toBe(true);
   });
 
+  test('renderSetupDiagram adds camera SVG icon with explicit sizing', () => {
+    const { renderSetupDiagram } = utils;
+    devices.cameras.CamIcon = { powerDrawWatts: 15 };
+    addOpt('cameraSelect', 'CamIcon');
+    renderSetupDiagram();
+    const cameraIcon = document.querySelector(
+      '#setupDiagram .diagram-node[data-node="camera"] .node-icon-svg svg'
+    );
+    expect(cameraIcon).not.toBeNull();
+    expect(cameraIcon.getAttribute('width')).toBe('24');
+    expect(cameraIcon.getAttribute('height')).toBe('24');
+    expect(cameraIcon.getAttribute('x')).toBe('-12');
+    expect(cameraIcon.getAttribute('y')).toBe('-12');
+  });
+
   test('normalizePowerPortType handles case-insensitive mappings', () => {
     const { normalizePowerPortType } = utils;
     expect(normalizePowerPortType('dc input')).toEqual(['DC IN']);


### PR DESCRIPTION
## Summary
- avoid mis-detecting existing width/height attributes when positioning inline SVG markup so the camera node keeps its explicit size
- add a DOM test to confirm the setup diagram renders the camera icon with the expected dimensions

## Testing
- npm run lint
- npm run check-consistency
- npm run test:jest -- --runTestsByPath tests/dom/utils.test.js
- npm run test:jest

------
https://chatgpt.com/codex/tasks/task_e_68cdeeb9461c8320ad1940fee16b9971