### PR TITLE
Adjust project requirement icon sizing

### DIFF
--- a/style.css
+++ b/style.css
@@ -3778,9 +3778,22 @@ body.dark-mode.dark-accent-boost:not(.pink-mode) .settings-content.modal-surface
   box-shadow: var(--panel-shadow);
 }
 .requirement-box .req-icon {
-  font-size: calc(var(--font-size-relative-base) * var(--font-scale-xxxl));
-  display: block;
+  --req-icon-size: calc(var(--font-size-relative-base) * var(--font-scale-xxxl));
+  font-size: var(--req-icon-size);
+  width: var(--req-icon-size);
+  height: var(--req-icon-size);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   margin: 0 auto 5px;
+  line-height: 1;
+  flex-shrink: 0;
+}
+
+.requirement-box .req-icon svg {
+  width: 100%;
+  height: 100%;
+  display: block;
 }
 .requirement-box .req-label {
   font-weight: var(--font-weight-bold);


### PR DESCRIPTION
## Summary
- standardize the layout box for project requirement icons in the overview
- ensure SVG and font-based glyphs scale to the same dimensions for consistent presentation

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cdf0cc00348320ad50c85558f4ea93