### PR TITLE
Refresh help content for storage dashboard and bundle sharing

### DIFF
--- a/index.html
+++ b/index.html
@@ -1157,6 +1157,7 @@
             <li>Automatic snapshots save the current project every 10 minutes and hourly full-app backups download timestamped JSON archives so you always have a recovery point.</li>
             <li>Force reload clears cached files and updates the app without deleting saved data.</li>
             <li>Cameras with both V- and B-Mount plates let you swap battery types; the list updates automatically.</li>
+            <li>Audit storage usage inside Settings → Data &amp; Storage to see project counts, auto backups, favorites, runtime notes, custom device categories and approximate backup size at a glance.</li>
           </ul>
           <div class="help-link-group" aria-label="Jump to key features">
             <a
@@ -1292,7 +1293,7 @@
                 data-help-target="#shareSetupBtn"
                 data-help-highlight="#setup-manager"
               ><strong>Export Project</strong></a>
-              downloads a JSON file containing your selections, project requirements, gear list, runtime feedback and any custom devices so you can back up or share the setup.
+              downloads a JSON bundle containing your selections, project requirements, gear list, runtime feedback, favorites, custom devices and—when enabled—your automatic gear rules so you can back up or share the setup offline.
             </li>
             <li>
               Open
@@ -1318,7 +1319,7 @@
                 data-help-target="#applySharedLinkBtn"
                 data-help-highlight="#setup-manager"
               ><strong>Import</strong></a>
-              to restore a shared configuration.
+              to restore a shared configuration. If the bundle includes automatic gear rules, decide whether to skip them, apply them only to the imported project or merge them into your global rules before the import finishes.
             </li>
             <li>
               Use
@@ -1444,6 +1445,23 @@
         </section>
         <section
           data-help-section
+          id="dataStorageHelp"
+          data-help-keywords="data storage dashboard usage totals backups summary favorites feedback devices size"
+        >
+          <h3><span class="help-icon icon-glyph" aria-hidden="true" data-icon-font="essential">&#xF10B;</span>Data &amp; Storage Dashboard</h3>
+          <ul>
+            <li>Open Settings → Data &amp; Storage to see how many saved projects, automatic backups, gear list snapshots, favorites and runtime feedback entries live on this device.</li>
+            <li>Review which custom device categories are in use and whether any unsaved session data is stored in the background.</li>
+            <li>The dashboard estimates backup size so you know how much space an export will occupy before downloading.</li>
+            <li>Use the panel as an audit log before resetting or archiving to ensure nothing important is left behind.</li>
+          </ul>
+          <div class="help-link-group" aria-label="Data and storage shortcuts">
+            <a class="help-link button-link" href="#settingsDialog" data-help-target="#dataHeading">Settings → Data &amp; Storage</a>
+            <a class="help-link button-link" href="#settingsDialog" data-help-target="#storageSummaryList">Storage summary</a>
+          </div>
+        </section>
+        <section
+          data-help-section
           id="projectRequirementsHelp"
           data-help-keywords="project requirements brief notes metadata crew schedule prep shoot forms multi-select documentation"
         >
@@ -1555,9 +1573,9 @@
               <strong>Remove these items</strong> hides entries the generator would normally include—match the item name and
               category shown in the gear list to target the right row.
             </li>
-            <li>
-              Rules live in Settings, are included in backups and apply to printable gear lists and exported project bundles.
-            </li>
+            <li>Save and recall complete rule sets with <strong>Save preset</strong> and <strong>Delete preset</strong>, or export/import them as JSON when you need to share automation offline.</li>
+            <li>Background snapshots capture every change; enable <strong>Show automatic backups</strong> to surface those copies in the Saved Projects menu for manual recovery.</li>
+            <li>Rules live in Settings, are included in backups and travel with exported project bundles when you choose to include them.</li>
           </ul>
           <div class="help-link-group" aria-label="Automatic gear rule controls">
             <a
@@ -1576,6 +1594,21 @@
               href="#settingsDialog"
               data-help-target="#autoGearRulesList"
             >Rules list</a>
+            <a
+              class="help-link button-link"
+              href="#settingsDialog"
+              data-help-target="#autoGearShowBackups"
+            >Automatic backups toggle</a>
+            <a
+              class="help-link button-link"
+              href="#settingsDialog"
+              data-help-target="#autoGearExport"
+            >Export rules</a>
+            <a
+              class="help-link button-link"
+              href="#settingsDialog"
+              data-help-target="#autoGearImport"
+            >Import rules</a>
           </div>
         </section>
         <section
@@ -2072,7 +2105,7 @@
                 data-help-target="#shareSetupBtn"
                 data-help-highlight="#setup-manager"
               ><em>Export Project</em></a>
-              to download a JSON file with your selections, project requirements, gear list, runtime feedback and any custom devices. Send the file to collaborators or keep it as a backup, then choose it in the
+              to download a Cine Power Planner project bundle (`.json`) containing your selections, project requirements, gear list, runtime feedback, favorites, custom devices and (if enabled) automatic gear rules. Send the bundle to collaborators or keep it as a backup, then choose it in the
               <a
                 class="help-link"
                 href="#setup-manager"
@@ -2086,7 +2119,7 @@
                 data-help-target="#applySharedLinkBtn"
                 data-help-highlight="#setup-manager"
               ><em>Import</em></a>
-              to restore it.
+              to restore it. When a bundle carries automatic gear rules you can choose whether to skip them, apply them only to the imported project or merge them into all projects before the import completes.
             </p>
           </details>
           <details

--- a/translations.js
+++ b/translations.js
@@ -734,11 +734,11 @@ const texts = {
     generateGearListHelp:
       "Build a categorized table that combines selected gear with project requirements. The list refreshes on every change, merges duplicate items with counts and auto-adds required cables, rigging, lens supports, matte box parts, battery counts with hotswap hardware, default monitors for each role and scenario-specific accessories. Entries are sorted alphabetically and include hover descriptions.",
     shareSetupHelp:
-      "Download a JSON file of the current project to share with others.",
+      "Download a Cine Power Planner project bundle (.json) with your selections, project requirements, gear list, runtime feedback, favorites, custom devices and optional automatic gear rules so you can share it offline.",
     applySharedLinkHelp:
-      "Load the configuration from the selected project file.",
+      "Load the configuration from the selected project bundle. If automatic gear rules are included you'll choose how to apply them before import finishes.",
     sharedLinkHelp:
-      "Choose a previously saved project JSON file to load.",
+      "Choose an exported Cine Power Planner project bundle (.json) to import.",
     cameraSelectHelp: "Choose the camera body that anchors your rig.",
     monitorSelectHelp: "Choose an on-board or wireless monitor to include.",
     videoSelectHelp: "Choose a transmitter/receiver pair or other wireless video link.",
@@ -1479,10 +1479,11 @@ const texts = {
     generateGearListHelp:
       "Genera una tabella categorizzata che combina l'attrezzatura selezionata con i requisiti del progetto. L'elenco si aggiorna a ogni modifica, unisce i duplicati con un conteggio e aggiunge automaticamente cavi, rigging, supporti lente, componenti matte box, conteggi batteria con hotswap, monitor predefiniti per ogni ruolo e accessori specifici per gli scenari. Gli elementi sono ordinati alfabeticamente e includono descrizioni al passaggio del mouse.",
     shareSetupHelp:
-      "Scarica un file JSON del progetto corrente per condividerlo.",
-    applySharedLinkHelp: "Carica la configurazione dal file di progetto selezionato.",
+      "Scarica un bundle di progetto Cine Power Planner (.json) con selezioni, requisiti, lista attrezzatura, feedback runtime, preferiti, dispositivi personalizzati e, se abilitate, le regole automatiche, per condividerlo offline.",
+    applySharedLinkHelp:
+      "Carica la configurazione dal bundle di progetto selezionato; se include regole automatiche potrai scegliere come applicarle prima del ripristino.",
     sharedLinkHelp:
-      "Seleziona un file JSON di progetto condiviso da caricare.",
+      "Seleziona un bundle di progetto Cine Power Planner (.json) esportato da caricare.",
     cameraSelectHelp: "Seleziona la fotocamera per la tua configurazione.",
     monitorSelectHelp: "Seleziona un monitor da includere.",
     videoSelectHelp: "Seleziona un sistema video wireless da includere.",
@@ -2235,10 +2236,11 @@ const texts = {
     generateGearListHelp:
       "Genera una tabla categorizada que combina el equipo seleccionado con los requisitos del proyecto. La lista se actualiza con cada cambio, fusiona duplicados con sus cantidades y añade automáticamente cables, rigging, soportes de lente, piezas de matte box, recuentos de baterías con hotswap, monitores predeterminados para cada rol y accesorios específicos de los escenarios. Los elementos se ordenan alfabéticamente e incluyen descripciones al pasar el cursor.",
     shareSetupHelp:
-      "Descarga un archivo JSON del proyecto actual para compartirlo.",
-    applySharedLinkHelp: "Carga la configuración desde el archivo de proyecto seleccionado.",
+      "Descarga un paquete de proyecto de Cine Power Planner (.json) con tus selecciones, requisitos, lista de equipo, comentarios de autonomía, favoritos, dispositivos personalizados y, si lo indicas, las reglas automáticas, para compartirlo sin conexión.",
+    applySharedLinkHelp:
+      "Carga la configuración desde el paquete de proyecto seleccionado; si incluye reglas automáticas podrás decidir cómo aplicarlas antes de completar la importación.",
     sharedLinkHelp:
-      "Selecciona un archivo JSON de proyecto compartido para cargarlo.",
+      "Selecciona un paquete de proyecto (.json) exportado de Cine Power Planner para importarlo.",
     cameraSelectHelp: "Selecciona la cámara para tu configuración.",
     monitorSelectHelp: "Selecciona un monitor para incluir.",
     videoSelectHelp: "Selecciona un sistema de video inalámbrico para incluir.",
@@ -2993,10 +2995,11 @@ const texts = {
     generateGearListHelp:
       "Génère un tableau catégorisé combinant le matériel sélectionné et les exigences du projet. La liste se met à jour à chaque changement, fusionne les doublons avec leur quantité et ajoute automatiquement câbles, rigging, supports d'objectif, éléments de matte box, nombre de batteries avec matériel de hotswap, moniteurs par rôle et accessoires spécifiques aux scénarios. Chaque entrée est triée alphabétiquement et offre une description au survol.",
     shareSetupHelp:
-      "Téléchargez un fichier JSON du projet actuel pour le partager.",
-    applySharedLinkHelp: "Chargez la configuration depuis le fichier projet sélectionné.",
+      "Téléchargez un bundle de projet Cine Power Planner (.json) contenant vos sélections, exigences, liste de matériel, retours d’autonomie, favoris, appareils personnalisés et, si activé, vos règles automatiques pour le partager hors ligne.",
+    applySharedLinkHelp:
+      "Chargez la configuration depuis le bundle de projet sélectionné ; si des règles automatiques sont incluses, vous déciderez comment les appliquer avant la fin de l’import.",
     sharedLinkHelp:
-      "Choisissez un fichier JSON de projet partagé à charger.",
+      "Choisissez un bundle de projet Cine Power Planner (.json) exporté à importer.",
     cameraSelectHelp: "Sélectionnez la caméra pour votre configuration.",
     monitorSelectHelp: "Sélectionnez un moniteur à inclure.",
     videoSelectHelp: "Sélectionnez un système vidéo sans fil à inclure.",
@@ -3753,10 +3756,11 @@ const texts = {
     generateGearListHelp:
       "Erstellt eine kategorisierte Tabelle aus ausgewähltem Equipment und Projektanforderungen. Die Liste aktualisiert sich bei jeder Änderung, fasst doppelte Einträge mit Anzahl zusammen und ergänzt automatisch benötigte Kabel, Rigging, Linsensupports, Matte-Box-Bauteile, Batteriezahlen mit Hotswap-Hardware, Standardmonitore pro Rolle sowie szenariospezifisches Zubehör. Alle Posten sind alphabetisch sortiert und zeigen beim Überfahren eine Beschreibung.",
     shareSetupHelp:
-      "Lädt eine JSON-Datei des aktuellen Projekts zum Teilen herunter.",
-    applySharedLinkHelp: "Lädt die Konfiguration aus der ausgewählten Projektdatei.",
+      "Lade ein Cine Power Planner Projektpaket (.json) mit deinen Auswahlen, Anforderungen, Gear-Liste, Laufzeit-Feedback, Favoriten, eigenen Geräten und – falls aktiviert – den automatischen Gear-Regeln herunter, um es offline zu teilen.",
+    applySharedLinkHelp:
+      "Lade die Konfiguration aus dem ausgewählten Projektpaket; wenn automatische Gear-Regeln enthalten sind, kannst du vor dem Import entscheiden, wie sie übernommen werden.",
     sharedLinkHelp:
-      "Wähle eine zuvor geteilte Projektdatei aus, um sie zu laden.",
+      "Wähle ein exportiertes Cine Power Planner Projektpaket (.json) zum Import aus.",
     cameraSelectHelp: "Wähle die Kamera für dein Setup.",
     monitorSelectHelp: "Wähle einen Monitor, der enthalten sein soll.",
     videoSelectHelp: "Wähle ein drahtloses Videosystem aus.",


### PR DESCRIPTION
## Summary
- highlight the Data & Storage dashboard and automatic gear backup tooling inside the help dialog
- document project bundle exports, auto gear import choices, and new quick links so guidance matches current features
- update tooltip translations across supported languages to describe bundle contents and optional automatic gear rules

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cdf3f4b714832084662c0994b07663