### PR TITLE
Ensure full backups capture auto gear metadata

### DIFF
--- a/script.js
+++ b/script.js
@@ -19346,6 +19346,10 @@ const BACKUP_DATA_KEYS = [
   'gearList',
   'favorites',
   'autoGearRules',
+  'autoGearBackups',
+  'autoGearPresets',
+  'autoGearActivePresetId',
+  'autoGearShowBackups',
   'autoGearSeeded',
 ];
 

--- a/tests/script/autoGearRules.test.js
+++ b/tests/script/autoGearRules.test.js
@@ -528,6 +528,19 @@ describe('applyAutoGearRulesToTableHtml', () => {
       },
     ];
 
+    const legacyBackups = [
+      {
+        id: 'legacy-backup-1',
+        label: 'Legacy snapshot',
+        createdAt: '2023-10-15T08:30:00Z',
+        rules: legacyRules,
+      },
+    ];
+
+    const legacyPresets = [
+      { id: 'legacy-preset', label: 'Legacy bundle', rules: legacyRules },
+    ];
+
     const legacyData = {
       version: '0.9.0',
       storage: [
@@ -551,6 +564,11 @@ describe('applyAutoGearRulesToTableHtml', () => {
         Legacy: { name: 'Legacy', items: [] },
       },
       autoGearRules: legacyRules,
+      autoGearBackups: legacyBackups,
+      autoGearSeeded: true,
+      autoGearPresets: legacyPresets,
+      autoGearActivePresetId: 'legacy-preset',
+      autoGearShowBackups: true,
     };
 
     const fileContent = JSON.stringify(legacyData);
@@ -584,6 +602,11 @@ describe('applyAutoGearRulesToTableHtml', () => {
         expect.objectContaining({
           setups: legacyData.setups,
           autoGearRules: legacyData.autoGearRules,
+          autoGearBackups: legacyData.autoGearBackups,
+          autoGearSeeded: legacyData.autoGearSeeded,
+          autoGearPresets: legacyData.autoGearPresets,
+          autoGearActivePresetId: legacyData.autoGearActivePresetId,
+          autoGearShowBackups: legacyData.autoGearShowBackups,
         }),
       );
 


### PR DESCRIPTION
## Summary
- include automatic gear backups, presets, active preset ID, and visibility flags in the legacy backup fallback so older exports retain all metadata
- extend the legacy restore regression test to cover the additional automatic gear data fields

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cdf445d1248320bd0b8e3804cdd29d