### PR TITLE
Improve feature search ranking heuristics

### DIFF
--- a/tests/script/featureSearch.test.js
+++ b/tests/script/featureSearch.test.js
@@ -430,4 +430,30 @@ describe('global feature search helpers', () => {
 
     expect(result?.value?.label).toContain('Monitor');
   });
+
+  test('findBestSearchMatch prefers the most specific key subset match', () => {
+    const entries = new Map();
+    entries.set(
+      searchKey('Battery Summary'),
+      {
+        label: 'Battery Summary',
+        tokens: searchTokens('Battery Summary')
+      }
+    );
+    entries.set(
+      searchKey('Battery Summary Chart'),
+      {
+        label: 'Battery Summary Chart',
+        tokens: searchTokens('Battery Summary Chart')
+      }
+    );
+
+    const result = findBestSearchMatch(
+      entries,
+      searchKey('Battery Summary Chart View'),
+      searchTokens('Battery Summary Chart View')
+    );
+
+    expect(result?.value?.label).toBe('Battery Summary Chart');
+  });
 });


### PR DESCRIPTION
## Summary
- refine feature search ranking to evaluate all key prefixes, key subset, and partial matches before picking the best candidate
- break token-score ties by preferring closer key lengths for steadier results
- add a regression test ensuring the search chooses the most specific key subset match

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cdf4c58bc483208313d85b2383f5b3