### PR TITLE
Synchronize localized README files with English version

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -1,291 +1,299 @@
 # 🎥 Cine Power Planner
 
-Dieses browserbasierte Tool hilft bei der Planung professioneller Kamera-Projekte, die mit V‑Mount-, B‑Mount- oder Gold-Mount-Akkus betrieben werden. Es berechnet **Gesamtleistung**, **Stromaufnahme** (bei 14,4 V und 12 V) sowie die **geschätzte Akkulaufzeit** und prüft gleichzeitig, ob der Akku die benötigte Leistung sicher liefern kann.
+This browser based tool helps plan professional camera projects powered by V‑Mount, B‑Mount or Gold-Mount batteries. It calculates **total power consumption**, **current draw** (at 14.4 V and 12 V) and **estimated battery runtime** while checking that the battery can safely supply the required power.
 
-Alle Planungen, Eingaben und Exporte bleiben auf deinem Gerät. Spracheinstellungen, Projekte, eigene Geräte, Favoriten und Laufzeit-Feedback liegen im Browser, und Service-Worker-Updates stammen direkt aus diesem Repository. So kannst du die App offline von der Festplatte starten oder intern hosten, damit jede Abteilung dieselbe geprüfte Version nutzt.
+All planning, inputs and exports stay on the device in front of you. Language
+choice, projects, custom equipment, favorites and runtime feedback live in your
+browser, and service worker updates are driven directly by this repository. Run
+the planner offline from disk or host it internally so every department uses the
+same audited version.
 
 ---
 
-## 🌍 Sprachen
+## 🌍 Languages
 - 🇬🇧 [English](README.en.md)
 - 🇩🇪 [Deutsch](README.de.md)
 - 🇪🇸 [Español](README.es.md)
 - 🇮🇹 [Italiano](README.it.md)
 - 🇫🇷 [Français](README.fr.md)
 
-Die App übernimmt beim ersten Start automatisch die Sprache deines Browsers; über die rechte obere Ecke kannst du jederzeit umschalten. Die Auswahl wird für den nächsten Besuch gespeichert.
+The app automatically uses your browser language on first load, and you can switch the language in the top right corner. The choice is remembered for your next visit.
 
 ---
 
-## 🆕 Neueste Funktionen
-- Mit den Akzent- und Typografie-Reglern in den Einstellungen passt du Akzentfarbe, Grundschriftgröße und Schriftfamilie neben den dunklen, rosa und kontrastreichen Themes an.
-- Tastenkürzel für die globale Suche lassen dich / oder Strg+K (⌘K auf macOS) drücken, um sie sofort zu fokussieren – auch wenn sie im eingeklappten mobilen Seitenmenü liegt.
-- Die Schaltfläche „Neu laden erzwingen“ leert die zwischengespeicherten Service-Worker-Dateien, damit sich die Offline-App aktualisiert, ohne gespeicherte Projekte oder Geräte zu löschen.
-- Sternsymbole in jeder Auswahl heften Lieblingskameras, -akkus und -zubehör oben an und nehmen sie in Backups auf.
-- Der Workflow **Werkseinstellungen** lädt automatisch eine Sicherung herunter und entfernt danach gespeicherte Projekte, Geräte und Einstellungen.
-- Die Geräteliste und die druckbare Übersicht zeigen den Projektnamen für einen schnellen Überblick an.
-- Lade ein eigenes Logo hoch, das in druckbaren Übersichten und Backups erscheint.
-- Backups enthalten Favoriten und erstellen vor einer Wiederherstellung automatisch eine Sicherung.
-- Crew-Einträge besitzen jetzt ein Feld für E-Mail-Adressen.
-- Neues High-Contrast-Theme für bessere Lesbarkeit.
-- Geräteformulare füllen Kategorien dynamisch anhand der Schema-Attribute.
-- Überarbeitetes Interface mit verbessertem Kontrast und Abständen für ein aufgeräumtes Erlebnis auf allen Geräten.
-- Projekte lassen sich einfacher teilen: Lade eine JSON-Datei mit Auswahl, Anforderungen, Geräteliste, Laufzeit-Feedback und eigenen Geräten herunter und importiere sie, um alles wiederherzustellen.
-- Einzigartige Symbole für verpflichtende Szenarien helfen, Projektanforderungen auf einen Blick zu erkennen.
-- Interaktives Projekt-Diagramm zum Verschieben, Zoomen, am Raster ausrichten und als SVG oder JPG exportieren.
-- Verspieltes pinkes Akzent-Theme, das zwischen Besuchen erhalten bleibt.
-- Durchsuchbarer Hilfedialog mit Schritt-für-Schritt-Bereichen und FAQ; öffne ihn mit ?, H, F1 oder Strg+/.
-- Kontextuelle Hover-Hilfen für Schaltflächen, Felder, Dropdowns und Überschriften.
-- Globale Suchleiste zum Springen zu Funktionen, Geräteauswahlen oder Hilfethemen.
-- Unterstützung für Kameras mit V-, B- oder Gold-Mount-Akkuplatten.
-- Reiche Laufzeit-Feedback mitsamt Temperatur ein, um Schätzungen zu verbessern.
-- Visuelles Dashboard zur Gewichtung der Laufzeiten zeigt, wie Einstellungen jeden Eintrag beeinflussen, sortiert nach Gewicht mit exakten Prozentwerten.
-- Erstelle Gerätelisten, die ausgewählte Komponenten und Projektanforderungen zusammenfassen.
-- Speichere Projektanforderungen mit jedem Projekt, damit Gerätelisten den vollen Kontext behalten.
-- Dupliziere Benutzereinträge in den Gerätelistenvorlagen per Gabel-Symbol, um Felder sofort zu kopieren.
+## 🆕 Recent Features
+- Accent and typography controls in Settings let you adjust the accent color, base font size and typeface alongside dark, pink and high contrast themes.
+- Keyboard shortcuts for the global search let you press / or Ctrl+K (⌘K on macOS) to focus the feature search instantly, even when it sits inside the collapsed mobile side menu.
+- Force reload button clears cached service worker files so the offline app refreshes without deleting saved projects or devices.
+- Star icons in every selector pin favorite cameras, batteries and accessories to the top of the list and keep them in backups.
+- Factory reset workflow automatically downloads a backup before wiping stored projects, custom devices and settings.
+- Gear list and printable overview display the project name for quick reference.
+- Upload a custom logo for printed overviews and backups.
+- Backups include favorites and create an automatic backup before restore.
+- Crew list entries now feature an email field.
+- High contrast theme option for improved readability.
+- Device forms populate category fields dynamically based on schema attributes.
+- Revamped interface design with improved contrast and spacing for a cleaner experience on any device.
+- Simplified project sharing – download a JSON project file that bundles selections, requirements, gear lists, runtime feedback and custom devices, then load it to restore the full setup.
+- Unique icons for required scenarios to distinguish project requirements.
+- Interactive project diagram that lets you drag devices, zoom, snap nodes to a grid and export the layout as SVG or JPG.
+- Playful pink accent theme that persists between visits.
+- Searchable help dialog with step-by-step sections and a FAQ; open with ?, H, F1 or Ctrl+/.
+- Contextual hover help for buttons, fields, dropdowns and headers.
+- Global search bar to jump to features, device selectors or help topics.
+- Support for cameras with V-, B- or Gold-Mount battery plates.
+- Submit user runtime feedback with temperature for better estimates.
+- Visual runtime weighting dashboard to inspect how settings influence each report, now sorted by weight and showing exact share percentages.
+- Generate gear lists to compile selected gear and project requirements.
+- Save project requirements with each project so gear lists retain full context.
+- Duplicate user entries in gear list forms using fork buttons to copy fields instantly.
 
 ---
 
-## 🔧 Funktionen
+## 🔧 Features
 
-### ✨ Erweiterte Highlights
+### ✨ Expanded highlights
 
-- **Komplexe Rigs ohne Ratespiel.** Kombiniere Kameras, Batterieplatten,
-  Funkstrecken, Monitore, Motoren und Zubehör und sieh Gesamtleistung,
-  Stromaufnahme bei 14,4 V/12 V (bzw. 33,6 V/21,6 V bei B‑Mount) sowie
-  realistische Laufzeiten aus gewichteten Felddaten. Das Batterie-Vergleichspanel
-  warnt vor Überlastungen, bevor falsches Equipment eingepackt wird.
-- **Alle Abteilungen im Gleichklang.** Speichere mehrere Projekte mit
-  Anforderungen, Crew-Kontakten, Szenarien und Notizen. Druckbare
-  Gerätelisten gruppieren Equipment nach Kategorie, führen Duplikate zusammen,
-  zeigen technische Metadaten und berücksichtigen Szenario-Zubehör, damit
-  Kamera-, Licht- und Grip-Teams denselben Stand sehen.
-- **Produktiv überall.** Die App läuft komplett im Browser – öffne
-  `index.html` direkt oder liefere sie über HTTPS aus, um den Service Worker zu
-  aktivieren. Offline-Caching bewahrt Sprache, Themes, Favoriten und Projekte,
-  und die Aktion **Neu laden erzwingen** aktualisiert Assets ohne Datenverlust.
-- **Auf das Team zugeschnitten.** Wechsel sofort zwischen Deutsch, Englisch,
-  Spanisch, Italienisch und Französisch, passe Schriftgröße und Schriftart an,
-  wähle eine eigene Akzentfarbe, lade ein Drucklogo hoch und schalte zwischen
-  dunklem, rosa oder High-Contrast-Theme. Tippen-zum-Filtern, angepinnte
-  Favoriten, Gabel-Buttons und Hover-Hilfe sparen Zeit am Set.
+- **Build complex rigs without guesswork.** Combine cameras, battery plates,
+  wireless links, monitors, motors and accessories while tracking total draw at
+  14.4 V/12 V (and 33.6 V/21.6 V for B‑Mount) plus realistic runtimes from
+  weighted field data. The battery comparison panel flags overloads before the
+  wrong kit goes on the truck.
+- **Keep every department aligned.** Save multiple projects with requirements,
+  crew contacts, scenarios and notes. Printable gear lists group equipment by
+  category, merge duplicates, surface technical metadata and include
+  scenario-driven accessories so camera, lighting and grip teams stay synced.
+- **Work confidently anywhere.** Open `index.html` directly or serve the folder
+  over HTTPS to enable the service worker. Offline caching preserves language,
+  themes, favorites and projects, and **Force reload** refreshes cached assets
+  without touching stored data.
+- **Tailor the planner to your crew.** Switch instantly between English,
+  Deutsch, Español, Italiano and Français, adjust font size and typeface, pick a
+  custom accent color, upload a print logo and toggle dark, pink or
+  high-contrast themes. Type-to-search selectors, pinned favorites, fork buttons
+  and hover help keep on-set workflows fast.
 
-### ✅ Projektverwaltung
-- Speichere, lade und lösche mehrere Kamera-Projekte (drücke Enter oder Strg+S/⌘S zum schnellen Speichern; die Schaltfläche bleibt deaktiviert, bis ein Name eingegeben wurde).
-- Alle zehn Minuten entstehen automatisch Schnappschüsse, solange der Planner geöffnet ist; im Einstellungsdialog lassen sich stündliche Backup-Exporte als Erinnerung aktivieren.
-- Lade eine JSON-Datei herunter, die Auswahl, Anforderungen, Geräteliste, Laufzeit-Feedback und eigene Geräte bündelt; über den „Geteiltes Projekt“-Picker importierst du alles in einem Schritt.
-- Daten werden lokal über `localStorage` gespeichert, Favoriten landen ebenfalls in Backups; nutze die Option **Werkseinstellungen** in den Einstellungen, die vor dem Zurücksetzen automatisch eine Sicherung speichert.
-- Erstelle druckbare Übersichten für jedes gespeicherte Projekt und füge ein individuelles Logo hinzu, damit Exporte und Backups zum Produktionsbranding passen.
-- Projektanforderungen werden gemeinsam mit dem Projekt gespeichert, sodass Gerätelisten den gesamten Kontext behalten.
-- Funktioniert komplett offline dank installiertem Service Worker – Sprache, Theme, Gerätedaten und Favoriten bleiben erhalten.
-- Responsives Layout passt sich nahtlos an Desktop, Tablet und Smartphone an.
-- Wähle bei kompatiblen Kameras zwischen **V‑Mount**, **B‑Mount** oder **Gold-Mount**; die Akkuliste aktualisiert sich automatisch.
+### ✅ Project Management
+- Save, load and delete multiple camera projects (press Enter or Ctrl+S/⌘S to save quickly; the Save button stays disabled until a name is entered).
+- Automatic snapshots are created every 10 minutes while the planner is open, and the Settings dialog can trigger hourly backup exports as a reminder to archive data.
+- Download a JSON project file that bundles selections, requirements, gear lists, runtime feedback and custom devices; load it through the Import Project picker to restore everything in one step.
+- Data is stored locally via `localStorage` and favorites are preserved in backups; use the **Factory reset** option in Settings to capture a backup automatically before wiping cached projects and device edits.
+- Generate printable overviews for any saved project and add a custom logo so exports and backups match your production branding.
+- Save project requirements along with each project so gear lists retain full context.
+- Works fully offline with the installed service worker—language, theme, device data and favorites persist between sessions.
+- Responsive layout adapts seamlessly across desktops, tablets and phones.
+- Choose **V‑Mount**, **B‑Mount** or **Gold‑Mount** plates on supported cameras; the battery list adapts automatically.
 
-### 🧭 Interface-Überblick
-- **Kurzüberblick:**
-  - **Globale Suche** (`/` oder `Strg+K`/`⌘K`) springt zu Funktionen, Dropdowns
-    oder Hilfethemen – auch wenn das Seitenmenü eingeklappt ist.
-  - **Hilfecenter** (`?`, `H`, `F1` oder `Strg+/`) zeigt durchsuchbare Guides,
-    FAQ, Tastenkürzel und den optionalen Hover-Hilfemodus.
-  - **Projekt-Diagramm** visualisiert Verbindungen; mit gedrückter Umschalttaste
-    speicherst du statt SVG ein JPG und siehst Kompatibilitäts-Hinweise.
-  - **Batterievergleich** zeigt, wie kompatible Akkus performen und markiert
-    Überlastungen frühzeitig.
-  - **Gerätelisten-Generator** erstellt kategorisierte Tabellen mit Metadaten,
-    Crew-E-Mails und szenarioabhängigen Ergänzungen, die sich sauber drucken
-    lassen.
-  - **Offline-Badge & Neu laden erzwingen** zeigen den Verbindungsstatus an und
-    aktualisieren zwischengespeicherte Dateien, ohne Projekte zu löschen.
-- Ein Skip-Link und ein Offline-Indikator halten das Layout für Tastatur und Touch zugänglich; das Badge erscheint, sobald der Browser die Verbindung verliert.
-- Die globale Suchleiste springt zu Funktionen, Geräteauswahlen oder Hilfethemen; drücke Enter für das markierte Ergebnis, / oder Strg+K (⌘K auf macOS) zum sofortigen Fokussieren (auf kleinen Displays öffnet sich das Seitenmenü automatisch) und Escape oder × zum Zurücksetzen.
-- Oben findest du Sprachumschaltung, Toggles für dunkles und rosa Theme sowie den Einstellungsdialog mit Akzentfarbe, Schriftgröße, Schriftfamilie, High-Contrast-Schalter und Logo-Upload plus Backup-, Restore- und Werkseinstellungen-Werkzeuge, die vor dem Löschen eine Sicherung erstellen.
-- Die Hilfe-Schaltfläche öffnet einen durchsuchbaren Dialog mit Schritt-für-Schritt-Anleitungen, Tastenkürzeln, FAQ und optionalem Hover-Hilfemodus; du erreichst ihn auch mit ?, H, F1 oder Strg+/ – selbst während der Eingabe.
-- Die Schaltfläche zum Erzwingen einer Aktualisierung (🔄) löscht zwischengespeicherte Service-Worker-Dateien, damit sich die Offline-App erneuert, ohne Projekte oder Geräte zu verlieren.
-- Auf kleineren Bildschirmen spiegelt ein einklappbares Seitenmenü alle wichtigen Bereiche für schnellen Zugriff.
+### 🧭 Interface Overview
+- **Quick reference:**
+  - **Global search** (`/` or `Ctrl+K`/`⌘K`) jumps to features, selectors or help
+    topics even when the side drawer is collapsed.
+  - **Help center** (`?`, `H`, `F1` or `Ctrl+/`) surfaces searchable guides,
+    FAQs, shortcuts and the optional hover-help mode.
+  - **Project diagram** visualizes connections; hold Shift when downloading to
+    save a JPG snapshot instead of SVG while seeing compatibility notices.
+  - **Battery comparison** reveals how compatible packs perform and highlights
+    overload risks before call time.
+  - **Gear list generator** outputs categorized tables with metadata, crew
+    emails and scenario-driven accessories ready for print or PDF.
+  - **Offline badge & Force reload** show connectivity status and refresh cached
+    assets without clearing projects.
+- A skip link and offline indicator keep the layout accessible on keyboard and touch devices—the badge appears whenever the browser loses its connection.
+- The global search bar jumps to features, device selectors or help topics; press Enter to activate the highlighted result, use / or Ctrl+K (⌘K on macOS) to focus it from anywhere (the side menu opens automatically on small screens) and press Escape or tap × to clear the query.
+- Top bar controls provide language switching, dark and pink theme toggles plus a Settings dialog that exposes accent color, font size, font family, high contrast and custom logo uploads alongside backup, restore and Factory reset tools that back up data before wiping it.
+- The Help button opens a searchable dialog with step-by-step sections, keyboard shortcuts, FAQs and an optional hover-help mode; it can also be triggered with ?, H, F1 or Ctrl+/ even while typing.
+- The Force reload button (🔄) clears cached service worker files so the offline app updates without deleting saved projects or custom devices.
+- On smaller screens a collapsible side menu mirrors every major section for quick navigation.
 
-### ♿ Anpassung und Barrierefreiheit
-- Theme-Optionen umfassen Dunkelmodus, spielerische rosa Akzente und einen eigenen High-Contrast-Schalter für bessere Lesbarkeit.
-- Änderungen an Akzentfarbe, Grundschriftgröße und Schriftfamilie greifen sofort und bleiben im Browser gespeichert – ideal für Markenfarben oder Barrierefreiheit.
-- Eingebaute Tastenkürzel decken globale Suche (/ oder Strg+K/⌘K), Hilfe ( ?, H, F1, Strg+/ ), Speichern (Enter oder Strg+S/⌘S), Dunkelmodus (D) und Rosa-Modus (P) ab.
-- Der Hover-Hilfemodus macht jede Schaltfläche, jedes Feld, Dropdown und jede Überschrift zur Sofort-Hilfe – perfekt für neue Teammitglieder.
-- Tippen zum Filtern, sichtbare Fokusmarken und Sternsymbole neben Auswahllisten erleichtern das Durchsuchen langer Listen und das Fixieren von Favoriten.
-- Lade ein eigenes Logo für Ausdrucke hoch, konfiguriere Standard-Monitoring-Rollen und passe Vorgaben für Projektanforderungen an, damit Exporte zum Produktionsbranding passen.
-- Gabel-Symbole duplizieren Formularzeilen sofort und angepinnte Favoriten halten beliebte Geräte oben in der Liste – ideal für schnelle Eingaben am Set.
+### ♿ Customization & Accessibility
+- Theme preferences include dark mode, playful pink accents and a dedicated high contrast switch for improved readability.
+- Accent color, base font size and typeface changes apply instantly and persist in the browser, letting you match studio branding or accessibility needs.
+- Built-in keyboard shortcuts cover global search (/ or Ctrl+K/⌘K), help ( ?, H, F1, Ctrl+/ ), saving (Enter or Ctrl+S/⌘S), dark mode (D) and pink mode (P).
+- Hover-help mode turns every button, field, dropdown and header into an on-demand tooltip so new users can learn the interface quickly.
+- Type-to-search inputs, focus-visible controls and star icons beside selectors let you filter long lists quickly and pin favourite devices to the top.
+- Upload a custom logo for printouts, configure default monitoring roles and tweak project requirement presets so exports match your production branding.
+- Fork buttons duplicate gear list rows instantly, and pinned favourites keep go-to equipment at the top of selectors for faster data entry on set.
 
-### 📋 Geräteliste
-Der Generator verwandelt deine Auswahl in eine kategorisierte Packliste:
+### 📋 Gear List
+The generator turns your selections into a categorized packing list:
 
-- Klicke auf **Geräteliste erstellen**, um ausgewähltes Equipment und Projektanforderungen in einer Tabelle zu bündeln.
-- Die Tabelle aktualisiert sich automatisch, sobald Geräteauswahl oder Anforderungen wechseln.
-- Elemente werden nach Kategorien gruppiert (Kamera, Optik, Strom, Monitoring, Rigging, Grip, Zubehör, Verbrauchsmaterial) und Duplikate zusammengeführt.
-- Benötigte Kabel, Rigging und Zubehör für Monitore, Motoren, Gimbals und Wetterszenarien werden automatisch ergänzt.
-- Szenario-Auswahlen fügen passendes Equipment hinzu:
-  - *Handheld* + *Easyrig* ergänzt einen teleskopischen Griff für stabilen Halt.
-  - *Gimbal* fügt das gewählte Gimbal, Magic-Arms, Spigots sowie Sonnenblenden oder Filtersets hinzu.
-  - *Outdoor* liefert Spigots, Schirme und CapIt-Regenhauben.
-  - Die Szenarien *Vehicle* und *Steadicam* bringen Halterungen, Iso-Arme und Saugnäpfe mit, wo nötig.
-- Objektiv-Auswahlen enthalten Frontdurchmesser, Gewicht, Rod-Daten und Mindestfokus, ergänzen Linsensupports und Matte-Box-Adapter und warnen vor inkompatiblen Rod-Standards.
-- Akkuzeilen spiegeln die Mengen aus dem Stromrechner und berücksichtigen Hotswap-Platten oder ausgewählte Hotswap-Geräte.
-- Monitoring-Präferenzen weisen Standardmonitore für jede Rolle (Regie, DoP, Fokus usw.) mit Kabelsets und Funkempfängern zu.
-- Das Formular **Projektanforderungen** speist die Liste:
-  - **Projektname**, **Produktion**, **Verleih** und **DoP** erscheinen in der Kopfzeile der gedruckten Anforderungen.
-  - **Crew**-Einträge erfassen Namen, Rollen und E-Mail-Adressen, damit Kontaktdaten mit dem Projekt reisen.
-  - **Prep-Tage** und **Drehtage** liefern Planungsnotizen und empfehlen bei Außenszenarien Wetter-Equipment.
-  - **Verpflichtende Szenarien** fügen passendes Rigging, Gimbals und Wetterschutz hinzu.
-  - **Kameragriff** und **Sucher-Erweiterung** tragen die gewählten Komponenten oder Verlängerungen ein.
-  - Optionen für **Matte Box** und **Filter** ergänzen das gewünschte System samt nötiger Trays, Clamp-Adapter oder Filter.
-  - Einstellungen für **Monitoring**, **Videoverteilung** und **Sucher** fügen Monitore, Kabel und Overlays für jede Rolle hinzu.
-  - **User Buttons** und **Stativ-Präferenzen** werden für schnellen Zugriff aufgeführt.
-- Innerhalb der Kategorien sind Einträge alphabetisch sortiert und zeigen beim Hover Tooltips an.
-- Die Geräteliste ist Teil der druckbaren Übersichten und der exportierten Projektdateien.
-- Gerätelisten werden automatisch mit dem Projekt gespeichert und in exportierte Dateien sowie Backups aufgenommen.
-- **Geräteliste löschen** entfernt die gespeicherte Liste und blendet die Ausgabe aus.
-- In den Formularen stehen Gabel-Schaltflächen bereit, um Benutzereinträge sofort zu duplizieren.
+- Click **Generate Gear List** to compile chosen gear and project requirements into a table.
+- The table updates automatically when device selections or requirements change.
+- Items are grouped by category (camera, lens, power, monitoring, rigging, grip, accessories, consumables) and duplicates are merged with counts.
+- Required cables, rigging and accessories are added for monitors, motors, gimbals and weather scenarios.
+- Scenario selections inject related gear:
+  - *Handheld* + *Easyrig* inserts a telescopic handle for stable support.
+  - *Gimbal* adds the selected gimbal, friction arms, spigots and sunshades or filter kits.
+  - *Outdoor* supplies spigots, umbrellas and CapIt rain covers.
+  - *Vehicle* and *Steadicam* scenarios pack in mounts, isolation arms and suction gear where applicable.
+- Lens selections append front diameter, weight, rod data and minimum focus, add lens supports and matte box adapters, and warn about incompatible rod standards.
+- Battery rows mirror counts from the power calculator and include hotswap plates or chosen hotswap devices when required.
+- Monitoring preferences assign default monitors for each role (Director, DoP, Focus, etc.) with cable sets and wireless receivers.
+- The **Project Requirements** form feeds the list:
+  - **Project Name**, **Production Company**, **Rental House** and **DoP** appear in the heading of the printed requirements.
+  - **Crew** entries capture names, roles and email addresses so contact info travels with the project.
+  - **Prep Days** and **Shooting Days** supply schedule notes and, when paired with outdoor scenarios, suggest weather gear.
+  - **Required Scenarios** append matching rigging, gimbals and weather protection.
+  - **Camera Handle** and **Viewfinder Extension** insert the chosen handle parts or extension brackets.
+  - **Matte Box** and **Filter** choices inject the selected system with any needed trays, clamp adapters or filters.
+  - **Monitoring Configuration**, **Video Distribution** and **Viewfinder** settings add monitors, cables and overlays for each role.
+  - **User Button** selections and **Tripod Preferences** are listed for quick reference.
+- Items inside each category are sorted alphabetically and display tooltips on hover.
+- The gear list is included in printable overviews and exported project files.
+- Gear lists save automatically with the project and are included in exported project files and backups.
+- **Delete Gear List** removes the saved list and hides the output.
+- Gear list forms provide fork buttons to duplicate user entries instantly.
 
-### 📦 Gerätekategorien
-- **Kamera** (1)
+### 📦 Device Categories
+- **Camera** (1)
 - **Monitor** (optional)
-- **Funk-Transmitter** (optional)
-- **FIZ-Motoren** (0–4)
-- **FIZ-Controller** (0–4)
-- **Distanzsensor** (0–1)
-- **Akkuplatte** (nur bei Kameras mit V‑ oder B‑Mount)
-- **V‑Mount-Akku** (0–1)
+- **Wireless Transmitter** (optional)
+- **FIZ Motors** (0–4)
+- **FIZ Controllers** (0–4)
+- **Distance Sensor** (0–1)
+- **Battery Plate** (only on cameras that accept V‑ or B‑Mount)
+- **V‑Mount Battery** (0–1)
 
-### ⚙️ Stromberechnung
-- Gesamtverbrauch in Watt
-- Stromstärke bei 14,4 V und 12 V
-- Geschätzte Akkulaufzeit in Stunden basierend auf gewichteten Community-Werten
-- Benötigte Akkumenge für einen 10-Stunden-Dreh (inkl. Reserve)
-- Temperaturhinweis zur Anpassung der Laufzeit bei Hitze oder Kälte
+### ⚙️ Power Calculations
+- Total consumption in watts
+- Current draw at 14.4 V and 12 V
+- Estimated battery runtime in hours using weighted user feedback
+- Required battery count for a 10 h shoot (incl. spare)
+- Temperature note to adjust runtime for hot or cold conditions
 
-### 🔋 Akkuausgang prüfen
-- Warnt, wenn die Stromaufnahme den Akku-Ausgang (Pin oder D‑Tap) übersteigt
-- Zeigt an, wenn der Verbrauch in die Nähe des Limits (80 %) rückt
+### 🔋 Battery Output Check
+- Warns if current draw exceeds the battery output (Pin or D‑Tap)
+- Indicates when draw is close to the limit (80 % usage)
 
-### 📊 Akkuvergleich (optional)
-- Vergleicht Laufzeitschätzungen aller Akkus
-- Balkendiagramme für einen schnellen Überblick
+### 📊 Battery Comparison (optional)
+- Compare runtime estimates across all batteries
+- Visual bar graph for quick reference
 
-### 🖼 Projekt-Diagramm
-- Visualisiert Strom- und Videosignale der ausgewählten Geräte.
-- Warnt, wenn FIZ-Marken nicht kompatibel sind.
-- Ziehe Knoten, um das Layout neu zu ordnen, zoome mit den Schaltflächen und exportiere das Diagramm als SVG oder JPG.
-- Halte Shift gedrückt, während du auf Download klickst, um ein JPG statt eines SVG zu exportieren.
-- Fahre mit der Maus oder tippe auf Geräte, um Popover-Details zu sehen.
-- Nutzt [OpenMoji](https://openmoji.org/)-Icons, wenn eine Verbindung besteht, und greift sonst auf Emoji zurück: 🔋 Akku, 🎥 Kamera, 🖥️ Monitor, 📡 Video, ⚙️ Motor, 🎮 Controller, 📐 Distanz, 🎮 Griff und 🔌 Akkuplatte.
+### 🖼 Project Diagram
+- Visualize power and video connections for the selected devices
+- Warns when FIZ brands are incompatible
+- Drag nodes to rearrange the layout, zoom with the buttons and download the diagram as SVG or JPG
+- Hold Shift while clicking Download to export a JPG snapshot instead of SVG
+- Hover or tap devices to see popup details
+- Uses [OpenMoji](https://openmoji.org/) icons when online, falling back to emoji:
+  🔋 battery, 🎥 camera, 🖥️ monitor, 📡 video, ⚙️ motor,
+  🎮 controller, 📐 distance, 🎮 handle and 🔌 battery plate
 
-### 🧮 Gewichtung der Laufzeitdaten
-- Von Nutzenden gemeldete Laufzeiten verfeinern die Schätzung.
-- Jeder Eintrag wird temperaturabhängig skaliert – von ×1 bei 25 °C auf:
-  - ×1,25 bei 0 °C
-  - ×1,6 bei −10 °C
-  - ×2 bei −20 °C
-- Kameraeinstellungen beeinflussen das Gewicht:
-  - Auflösungsfaktoren: ≥12K ×3, ≥8K ×2, ≥4K ×1,5, ≥1080p ×1; niedrigere Werte werden auf 1080p skaliert.
-  - Bildrate skaliert linear ab 24 fps (z. B. 48 fps = ×2).
-  - Aktiviertes WLAN erhöht das Gewicht um 10 %.
-  - Codec-Faktoren: RAW/BRAW/ARRIRAW/R3D/CinemaDNG/Canon RAW/X‑OCN ×1; ProRes ×1,1; DNx/AVID ×1,2; All‑Intra ×1,3; H.264/AVC ×1,5; H.265/HEVC ×1,7.
-  - Monitor-Einträge unterhalb der angegebenen Helligkeit werden gemäß ihrem Helligkeitsverhältnis gewichtet.
-- Das Endgewicht spiegelt den Anteil jedes Geräts am Gesamtverbrauch wider, sodass passende Projekte stärker zählen.
-- Der gewichtete Durchschnitt kommt zum Einsatz, sobald mindestens drei Einträge verfügbar sind.
-- Ein Dashboard sortiert die Einträge nach Gewicht und zeigt den prozentualen Anteil für den schnellen Vergleich.
+### 🧮 Runtime data weighting
+- User-submitted battery runtimes refine the runtime estimate.
+- Each entry is adjusted for temperature, scaling from ×1 at 25 °C to:
+  - ×1.25 at 0 °C
+  - ×1.6 at −10 °C
+  - ×2 at −20 °C
+- Camera settings influence the weight:
+  - Resolution multipliers: ≥12K ×3, ≥8K ×2, ≥4K ×1.5, ≥1080p ×1, lower scaled to 1080p
+  - Frame rate scales linearly from 24 fps (e.g. 48 fps = ×2)
+  - Wi‑Fi enabled adds 10 %
+  - Codec factors: RAW/BRAW/ARRIRAW/R3D/CinemaDNG/Canon RAW/X‑OCN ×1; ProRes ×1.1; DNx/AVID ×1.2; All‑Intra ×1.3; H.264/AVC ×1.5; H.265/HEVC ×1.7
+  - Monitor entries below the specified brightness are weighted by their brightness ratio
+- The final weight reflects each device's share of the total power draw, so matching projects count more.
+- The weighted average is used once at least three entries are available.
+- A dashboard orders entries by weight and displays each one's share percentage for quick comparison.
 
-### 🔍 Suche & Filter
-- Tippe in Dropdowns, um Einträge schnell zu finden.
-- Filtere Gerätelisten über ein Suchfeld.
-- Nutze die globale Suche oben, um zu Funktionen, Geräten oder Hilfethemen zu springen; drücke Enter zum Navigieren, / oder Strg+K (⌘K auf macOS) zum sofortigen Fokussieren und Escape oder × zum Löschen.
-- Drücke „/“ oder Strg+F (⌘F auf macOS), um das nächstgelegene Suchfeld sofort zu fokussieren.
-- Klicke auf den Stern neben einer Auswahl, um Favoriten oben zu pinnen und in Backups mitzunehmen.
+### 🔍 Search & Filtering
+- Type inside dropdowns to quickly find entries
+- Filter device lists with a search box
+- Use the global search bar at the top to jump to features, devices or help topics; press Enter to navigate, use / or Ctrl+K (⌘K on macOS) to focus it instantly and press Escape or × to clear.
+- Press '/' or Ctrl+F (⌘F on macOS) to focus the nearest search box instantly.
+- Click the star beside any selector to pin favourites so they stay at the top of the list and sync with backups.
 
-### 🛠 Geräte-Datenbank-Editor
-- Geräte in allen Kategorien hinzufügen, bearbeiten oder löschen.
-- Gesamte Datenbank als JSON importieren oder exportieren.
-- Zur Standarddatenbank aus `assets/data/index.js` zurückkehren.
+### 🛠 Device Database Editor
+- Add, edit or delete devices in all categories
+- Import or export the full database as JSON
+- Revert to the default database from `assets/data/index.js`
 
-### 🌓 Dunkelmodus
-- Über die Mondschaltfläche neben dem Sprachmenü umschalten.
-- Die Einstellung wird im Browser gespeichert.
+### 🌓 Dark Mode
+- Toggle via the moon button next to the language selector.
+- Preference is stored in your browser.
 
-### 🦄 Rosa Modus
-- Auf den Einhorn-Button klicken (im aktiven Pinkmodus wechseln die Einhorn-Icons alle 30 Sekunden mit einer sanften Pop-Animation und beim Verlassen erscheint wieder das Pferd) oder **P** drücken, um den verspielten rosa Akzent zu aktivieren.
-- Funktioniert im hellen und dunklen Theme und bleibt zwischen Besuchen erhalten.
+### 🦄 Pink Mode
+- Click the unicorn button (pink mode cycles through unicorn icons every 30 seconds with a gentle pop animation and switches back to the horse icon when you leave the theme) or press **P** for a playful pink accent.
+- Works in both light and dark themes and persists between visits.
 
-### ⚫ High-Contrast-Modus
-- Aktiviert ein kontrastreiches Theme für bessere Lesbarkeit.
+### ⚫ High Contrast Mode
+- Toggle a high contrast theme for improved readability.
 
-### 📝 Laufzeit-Feedback
-- Klicke unter der Laufzeit auf <strong>Nutzer-Laufzeit-Feedback senden</strong>, um eigene Messungen hinzuzufügen.
-- Optional Temperatur eintragen, um die Gewichtung zu verfeinern.
-- Einträge werden im Browser gespeichert und verbessern künftige Schätzungen.
-- Ein Dashboard sortiert Beiträge nach Gewicht, zeigt prozentuale Anteile und
-  hebt Ausreißer hervor, damit Crews Feedback schneller bewerten können.
+### 📝 User Runtime Feedback
+- Click <strong>Submit User Runtime Feedback</strong> below the runtime to add your own measurement.
+- Optionally include temperature for more accurate weighting.
+- Entries are saved in your browser and improve future estimates.
+- A dashboard orders submissions by weight, shows contribution percentages and
+  highlights outliers so crews can review field data quickly.
 
-### ❓ Durchsuchbare Hilfe
-- Über die Schaltfläche <strong>?</strong> oder per <kbd>?</kbd>, <kbd>H</kbd>, <kbd>F1</kbd> oder <kbd>Strg+/</kbd> öffnen.
-- Mit dem Suchfeld Themen sofort filtern; die Eingabe wird beim Schließen zurückgesetzt.
-- Mit <kbd>Escape</kbd> oder Klick außerhalb des Dialogs schließen.
-
----
-
-## ▶️ So nutzt du die App
-1. **App starten:** Öffne `index.html` in einem modernen Browser – kein Server nötig.
-2. **Top-Bar erkunden:** Sprache wechseln, Dunkel- oder Rosa-Theme umschalten, Einstellungen für Akzent und Typografie öffnen und den Hilfedialog mit ? oder Strg+/ starten.
-3. **Geräte auswählen:** Wähle über Dropdowns das Equipment je Kategorie; tippe zum Filtern, pinne Favoriten mit dem Stern und lass Szenario-Voreinstellungen Zubehör automatisch ergänzen.
-4. **Berechnungen ansehen:** Gesamtverbrauch, Strom und Laufzeit erscheinen, sobald ein Akku gewählt ist; Warnungen markieren überschrittene Grenzen.
-5. **Projekte speichern & exportieren:** Benenne und speichere deine Konfiguration, Auto-Backups erstellen Schnappschüsse und die Schaltfläche „Projekt exportieren“ lädt ein JSON-Paket für das Team.
-6. **Geräteliste generieren:** Drücke **Geräteliste erstellen**, um Anforderungen in eine kategorisierte Packliste mit Tooltips und Zubehör zu verwandeln.
-7. **Gerätedaten verwalten:** Über „Gerätedaten bearbeiten…“ den Editor öffnen, Geräte anpassen, JSON exportieren/importieren oder auf Standardwerte zurücksetzen.
-8. **Laufzeit-Feedback senden:** Mit „Nutzer-Laufzeit-Feedback senden“ Messwerte aus der Praxis erfassen und die Gewichtung verbessern.
-
-## 📱 Als App installieren
-
-Der Planner ist eine Progressive Web App und lässt sich direkt aus dem Browser installieren:
-
-- **Chrome/Edge (Desktop):** Auf das Installationssymbol in der Adressleiste klicken.
-- **Android:** Browsermenü öffnen und *Zum Startbildschirm hinzufügen* wählen.
-- **iOS/iPadOS Safari:** Auf *Teilen* tippen und *Zum Home-Bildschirm* auswählen.
-
-Nach der Installation startet die App vom Startbildschirm, funktioniert offline und aktualisiert sich automatisch.
-
-## 📡 Offline-Nutzung & Datenspeicherung
-
-Beim Ausliefern über HTTP(S) installiert sich ein Service Worker, der alle Dateien cached, sodass Cine Power Planner vollständig offline läuft und Updates im Hintergrund lädt. Projekte, Laufzeit-Einreichungen und Einstellungen (Sprache, Theme, Rosa-Modus, gespeicherte Gerätelisten) liegen im `localStorage` deines Browsers. Das Löschen der Seitendaten entfernt alle Informationen; im Einstellungsdialog gibt es dafür ebenfalls den Workflow **Werkseinstellungen**, der vor dem Leeren automatisch eine Sicherung speichert.
-Die Kopfzeile zeigt ein Offline-Badge, sobald die Verbindung wegfällt, und die
-Aktion 🔄 **Neu laden erzwingen** aktualisiert gecachte Assets, ohne Projekte
-anzutasten.
+### ❓ Searchable Help
+- Open via the <strong>?</strong> button or press <kbd>?</kbd>, <kbd>H</kbd>, <kbd>F1</kbd> or <kbd>Ctrl+/</kbd>.
+- Use the search field to filter topics instantly; the query resets when the dialog closes.
+- Close with <kbd>Escape</kbd> or by clicking outside the dialog.
 
 ---
 
-## 🗂️ Verzeichnisstruktur
+## ▶️ How to Use
+1. **Launch App:** Open `index.html` in any modern browser – no server required.
+2. **Explore the Top Bar:** Switch language, toggle dark or pink themes, open Settings for accent and typography options, and start the searchable help dialog with ? or Ctrl+/.
+3. **Select Devices:** Choose gear from each category using the dropdowns—type to filter, click the star to pin favourites and let scenario presets fill in accessories automatically.
+4. **View Calculations:** See total draw, current and runtime once a battery is selected; warnings highlight when output limits are exceeded.
+5. **Save & Export Projects:** Name and save your configuration, auto-backups capture snapshots, and the Export button downloads a JSON bundle for collaborators while the Import button restores them.
+6. **Generate Gear Lists:** Press **Generate Gear List** to turn project requirements into a categorized packing list with tooltips and accessory packs.
+7. **Manage Device Data:** Click “Edit Device Data…” to open the database editor, modify devices, export/import JSON or revert to the defaults.
+8. **Submit Runtime Feedback:** Use “Submit User Runtime Feedback” to record field measurements and refine weighted estimates.
+
+## 📱 Install as an App
+
+The planner is a Progressive Web App and can be installed directly from your browser:
+
+- **Chrome/Edge (desktop):** Click the install icon in the address bar.
+- **Android:** Open the browser menu and choose *Add to Home Screen*.
+- **iOS/iPadOS Safari:** Tap the *Share* button and select *Add to Home Screen*.
+
+Once installed, the app launches from your home screen, works offline and updates itself automatically.
+
+## 📡 Offline Use & Data Storage
+
+Serving the app over HTTP(S) installs a service worker that caches every file
+so Cine Power Planner works fully offline and updates in the background. Projects,
+runtime submissions and preferences (language, theme, pink mode and saved gear
+lists) live in your browser's `localStorage`. Clearing the site's data in the
+browser removes all stored information, and the Settings dialog includes a
+**Factory reset** workflow that saves a backup automatically before clearing everything. The header shows an
+offline badge whenever connectivity drops, and the 🔄 **Force reload** action
+refreshes cached assets without disturbing saved projects.
+
+---
+
+## 🗂️ File Structure
 ```bash
-index.html                 # Zentrales HTML-Layout
-assets/css/style.css       # Styles und Layout
-assets/css/overview.css    # Gestaltung der Übersicht
-assets/css/overview-print.css # Druck-Styles für die Übersicht
-assets/js/script.js        # Anwendungslogik
-assets/js/storage.js       # Hilfsfunktionen für LocalStorage
-assets/js/static-theme.js  # Gemeinsame Theme-Logik für die Rechtstexte
-assets/data/index.js       # Standard-Geräteliste
-assets/data/devices/       # Gerätekataloge nach Kategorie
-assets/data/schema.json    # Generiertes Schema für Auswahllisten
-assets/vendor/             # Gebündelte Drittanbieter-Bibliotheken
-legal/                     # Offline-Rechtstexte
-tools/                     # Skripte zur Datenpflege
-tests/                     # Jest-Test-Suite
+index.html                 # Main HTML layout
+assets/css/style.css       # Core styles and layout
+assets/css/overview.css    # Printable overview styling
+assets/css/overview-print.css # Print overrides for the overview
+assets/js/script.js        # Application logic
+assets/js/storage.js       # LocalStorage helpers
+assets/js/static-theme.js  # Shared theme logic for legal pages
+assets/data/index.js       # Default device list
+assets/data/devices/       # Device catalogs by category
+assets/data/schema.json    # Generated schema for selectors
+assets/vendor/             # Bundled third-party libraries
+legal/                     # Offline legal documents
+tools/                     # Data maintenance scripts
+tests/                     # Jest test suite
 ```
-Schriftarten werden lokal über `fonts.css` eingebunden; sind die Assets einmal im Cache, funktioniert die Anwendung komplett offline.
+Fonts are bundled locally via `fonts.css`, so once the assets are cached the application works entirely offline.
 
-## 🛠️ Entwicklung
-Benötigt Node.js 18 oder neuer.
+## 🛠️ Development
+Requires Node.js 18 or later.
 
 ```bash
 npm install
-npm run lint     # führt nur ESLint aus
-npm test         # startet Linting, Datenprüfungen und Jest-Tests
+npm run lint     # run ESLint alone
+npm test         # runs linting, data checks and Jest tests
 ```
 
-Nach Änderungen an den Gerätedaten die normalisierte Datenbank neu erzeugen:
+After editing device data, regenerate the normalized database:
 
 ```bash
 npm run normalize
@@ -294,10 +302,11 @@ npm run check-consistency
 npm run generate-schema
 ```
 
-Mit `--help` zeigen die Skripte weitere Optionen an.
+Add `--help` to any of the above scripts for usage details.
 
-Mit `npm run help` erhältst du eine kurze Übersicht über die Wartungsskripte und ihre empfohlene Reihenfolge.
+Run `npm run help` whenever you need a quick reminder of the maintenance commands and their suggested order.
 
-## 🤝 Mitmachen
-Beiträge sind jederzeit willkommen! Eröffne gerne ein Issue oder sende einen Pull Request auf GitHub.
-Für Datenkorrekturen helfen Projekt-Backups oder Beispiel-Laufzeiten, damit die Gerätekataloge verlässlich bleiben.
+## 🤝 Contributing
+Contributions are welcome! Feel free to open an issue or submit a pull request on GitHub.
+When reporting data corrections, attaching project backups or runtime samples
+helps keep the catalog accurate for everyone.

--- a/README.es.md
+++ b/README.es.md
@@ -1,302 +1,299 @@
 # 🎥 Cine Power Planner
 
-Esta herramienta basada en el navegador ayuda a planificar proyectos de cámara profesionales alimentados con baterías V‑Mount, B‑Mount o Gold-Mount. Calcula el **consumo total de energía**, la **corriente demandada** (a 14,4 V y 12 V) y la **autonomía estimada de la batería**, al tiempo que comprueba que el paquete puede suministrar la potencia necesaria.
+This browser based tool helps plan professional camera projects powered by V‑Mount, B‑Mount or Gold-Mount batteries. It calculates **total power consumption**, **current draw** (at 14.4 V and 12 V) and **estimated battery runtime** while checking that the battery can safely supply the required power.
 
-Toda la planificación, los datos introducidos y las exportaciones permanecen en
-el dispositivo que tienes delante. El idioma, los proyectos, los equipos
-personalizados, los favoritos y los comentarios de autonomía viven en tu
-navegador, y las actualizaciones del service worker provienen directamente de
-este repositorio. Puedes ejecutar la app sin conexión desde el disco o alojarla
-internamente para que cada departamento trabaje con la misma versión auditada.
+All planning, inputs and exports stay on the device in front of you. Language
+choice, projects, custom equipment, favorites and runtime feedback live in your
+browser, and service worker updates are driven directly by this repository. Run
+the planner offline from disk or host it internally so every department uses the
+same audited version.
 
 ---
 
-## 🌍 Idiomas
+## 🌍 Languages
 - 🇬🇧 [English](README.en.md)
 - 🇩🇪 [Deutsch](README.de.md)
 - 🇪🇸 [Español](README.es.md)
 - 🇮🇹 [Italiano](README.it.md)
 - 🇫🇷 [Français](README.fr.md)
 
-La aplicación usa automáticamente el idioma de tu navegador en la primera visita y puedes cambiarlo desde la esquina superior derecha. La elección se recuerda para tu próxima sesión.
+The app automatically uses your browser language on first load, and you can switch the language in the top right corner. The choice is remembered for your next visit.
 
 ---
 
-## 🆕 Novedades recientes
-- Los controles de acento y tipografía en Ajustes te permiten modificar el color de acento, el tamaño base de la fuente y la tipografía, junto con los temas oscuro, rosa y de alto contraste.
-- Los atajos de teclado para la búsqueda global te permiten pulsar / o Ctrl+K (⌘K en macOS) para enfocarla al instante, incluso cuando está dentro del menú lateral móvil.
-- El botón de recarga forzada borra los archivos en caché del *service worker* para que la aplicación sin conexión se actualice sin eliminar proyectos ni dispositivos guardados.
-- Los iconos de estrella en cada selector fijan las cámaras, baterías y accesorios favoritos en la parte superior de la lista y los conservan en las copias de seguridad.
-- El flujo de **Restablecimiento de fábrica** descarga una copia de seguridad automáticamente antes de borrar los proyectos, ajustes y dispositivos guardados.
-- La lista de equipo y la vista imprimible muestran el nombre del proyecto para consultarlo rápidamente.
-- Sube un logotipo personalizado para que aparezca en las vistas imprimibles y en las copias de seguridad.
-- Las copias de seguridad incluyen los favoritos y crean una copia automática antes de restaurar.
-- Las entradas del equipo cuentan ahora con un campo de correo electrónico.
-- Opción de tema de alto contraste para mejorar la legibilidad.
-- Los formularios de dispositivos rellenan los campos de categoría dinámicamente según los atributos del esquema.
-- Rediseño de la interfaz con mejor contraste y espaciado para una experiencia más limpia en cualquier dispositivo.
-- Exportar proyectos es más sencillo: descarga un archivo JSON que agrupa selecciones, requisitos, listas de equipo, comentarios de autonomía y dispositivos personalizados, y vuelve a cargarlo mediante Importar para restaurarlo todo de una vez.
-- Iconos únicos para los escenarios obligatorios que ayudan a distinguir los requisitos del proyecto.
-- Diagrama de proyecto interactivo que permite arrastrar dispositivos, hacer zoom, ajustar nodos a la cuadrícula y exportar la disposición como SVG o JPG.
-- Tema rosa lúdico que se mantiene entre visitas.
-- Diálogo de ayuda con búsqueda y secciones paso a paso y un FAQ; ábrelo con ?, H, F1 o Ctrl+/.
-- Ayudas contextuales al pasar el cursor por botones, campos, menús y encabezados.
-- Barra de búsqueda global para saltar a funciones, selectores de dispositivos o temas de ayuda.
-- Compatibilidad con cámaras con placas de batería V-, B- o Gold-Mount.
-- Envía comentarios de autonomía con temperatura para mejorar las estimaciones.
-- Panel visual de ponderación de autonomías para inspeccionar cómo influyen los ajustes en cada informe, ahora ordenado por peso y con porcentajes exactos.
-- Genera listas de equipo para compilar el material seleccionado y los requisitos del proyecto.
-- Guarda los requisitos de proyecto con cada proyecto para que las listas de equipo conserven el contexto.
-- Duplica entradas de usuario en los formularios de la lista de equipo con los botones de bifurcar para copiar campos al instante.
+## 🆕 Recent Features
+- Accent and typography controls in Settings let you adjust the accent color, base font size and typeface alongside dark, pink and high contrast themes.
+- Keyboard shortcuts for the global search let you press / or Ctrl+K (⌘K on macOS) to focus the feature search instantly, even when it sits inside the collapsed mobile side menu.
+- Force reload button clears cached service worker files so the offline app refreshes without deleting saved projects or devices.
+- Star icons in every selector pin favorite cameras, batteries and accessories to the top of the list and keep them in backups.
+- Factory reset workflow automatically downloads a backup before wiping stored projects, custom devices and settings.
+- Gear list and printable overview display the project name for quick reference.
+- Upload a custom logo for printed overviews and backups.
+- Backups include favorites and create an automatic backup before restore.
+- Crew list entries now feature an email field.
+- High contrast theme option for improved readability.
+- Device forms populate category fields dynamically based on schema attributes.
+- Revamped interface design with improved contrast and spacing for a cleaner experience on any device.
+- Simplified project sharing – download a JSON project file that bundles selections, requirements, gear lists, runtime feedback and custom devices, then load it to restore the full setup.
+- Unique icons for required scenarios to distinguish project requirements.
+- Interactive project diagram that lets you drag devices, zoom, snap nodes to a grid and export the layout as SVG or JPG.
+- Playful pink accent theme that persists between visits.
+- Searchable help dialog with step-by-step sections and a FAQ; open with ?, H, F1 or Ctrl+/.
+- Contextual hover help for buttons, fields, dropdowns and headers.
+- Global search bar to jump to features, device selectors or help topics.
+- Support for cameras with V-, B- or Gold-Mount battery plates.
+- Submit user runtime feedback with temperature for better estimates.
+- Visual runtime weighting dashboard to inspect how settings influence each report, now sorted by weight and showing exact share percentages.
+- Generate gear lists to compile selected gear and project requirements.
+- Save project requirements with each project so gear lists retain full context.
+- Duplicate user entries in gear list forms using fork buttons to copy fields instantly.
 
 ---
 
-## 🔧 Funciones
+## 🔧 Features
 
-### ✨ Destacados ampliados
+### ✨ Expanded highlights
 
-- **Planifica rigs complejos sin conjeturas.** Combina cámaras, placas de
-  batería, enlaces inalámbricos, monitores, motores y accesorios mientras ves el
-  consumo total a 14,4 V/12 V (y 33,6 V/21,6 V para B‑Mount) junto a autonomías
-  realistas basadas en datos de campo ponderados. El panel de comparación de
-  baterías avisa de sobrecargas antes de que el equipo salga rumbo al rodaje.
-- **Mantén alineados a todos los departamentos.** Guarda varios proyectos con
-  requisitos, contactos del equipo, escenarios y notas. Las listas imprimibles
-  agrupan el material por categoría, fusionan duplicados, muestran metadatos
-  técnicos e incluyen accesorios condicionados por escenarios para que cámara,
-  iluminación y grip compartan el mismo contexto.
-- **Trabaja con confianza en cualquier lugar.** Abre `index.html` directamente o
-  sirve la carpeta por HTTPS para activar el service worker. La caché sin
-  conexión conserva idioma, temas, favoritos y proyectos, y **Forzar recarga**
-  actualiza los recursos almacenados sin tocar tus datos.
-- **Adapta el planner a tu equipo.** Cambia al instante entre español, inglés,
-  alemán, italiano y francés, ajusta el tamaño y la tipografía, define un color
-  de acento propio, sube un logotipo para impresión y alterna entre tema claro,
-  oscuro, rosa o de alto contraste. Los desplegables con búsqueda, favoritos
-  fijados, botones de bifurcación y ayudas flotantes mantienen ágil el trabajo en
-  set.
+- **Build complex rigs without guesswork.** Combine cameras, battery plates,
+  wireless links, monitors, motors and accessories while tracking total draw at
+  14.4 V/12 V (and 33.6 V/21.6 V for B‑Mount) plus realistic runtimes from
+  weighted field data. The battery comparison panel flags overloads before the
+  wrong kit goes on the truck.
+- **Keep every department aligned.** Save multiple projects with requirements,
+  crew contacts, scenarios and notes. Printable gear lists group equipment by
+  category, merge duplicates, surface technical metadata and include
+  scenario-driven accessories so camera, lighting and grip teams stay synced.
+- **Work confidently anywhere.** Open `index.html` directly or serve the folder
+  over HTTPS to enable the service worker. Offline caching preserves language,
+  themes, favorites and projects, and **Force reload** refreshes cached assets
+  without touching stored data.
+- **Tailor the planner to your crew.** Switch instantly between English,
+  Deutsch, Español, Italiano and Français, adjust font size and typeface, pick a
+  custom accent color, upload a print logo and toggle dark, pink or
+  high-contrast themes. Type-to-search selectors, pinned favorites, fork buttons
+  and hover help keep on-set workflows fast.
 
-### ✅ Gestión de proyectos
-- Guarda, carga y elimina múltiples proyectos de cámara (pulsa Enter o Ctrl+S/⌘S para guardar rápido; el botón Guardar permanece desactivado hasta introducir un nombre).
-- Se crean instantáneas automáticas cada 10 minutos mientras el planificador está abierto, y el diálogo de Ajustes puede programar exportaciones de copias de seguridad cada hora como recordatorio para archivar los datos.
-- Descarga un archivo JSON que agrupa selecciones, requisitos, listas de equipo, comentarios de autonomía y dispositivos personalizados; cárgalo mediante el selector de Importar proyecto para restaurarlo todo de una vez.
-- Los datos se almacenan localmente mediante `localStorage`, y los favoritos se conservan en las copias de seguridad; utiliza la opción de **Restablecimiento de fábrica** en Ajustes para guardar automáticamente una copia de seguridad antes de limpiar proyectos en caché y ediciones de dispositivos.
-- Genera vistas imprimibles para cualquier proyecto guardado y añade un logotipo personalizado para que las exportaciones y copias coincidan con la identidad de tu producción.
-- Guarda los requisitos de proyecto junto con cada proyecto para que las listas de equipo conserven el contexto completo.
-- Funciona totalmente sin conexión con el *service worker* instalado: idioma, tema, datos de dispositivos y favoritos persisten entre sesiones.
-- El diseño adaptable se ajusta sin esfuerzo a escritorios, tabletas y teléfonos.
-- En las cámaras compatibles elige placas **V‑Mount**, **B‑Mount** o **Gold-Mount**; la lista de baterías se adapta automáticamente.
+### ✅ Project Management
+- Save, load and delete multiple camera projects (press Enter or Ctrl+S/⌘S to save quickly; the Save button stays disabled until a name is entered).
+- Automatic snapshots are created every 10 minutes while the planner is open, and the Settings dialog can trigger hourly backup exports as a reminder to archive data.
+- Download a JSON project file that bundles selections, requirements, gear lists, runtime feedback and custom devices; load it through the Import Project picker to restore everything in one step.
+- Data is stored locally via `localStorage` and favorites are preserved in backups; use the **Factory reset** option in Settings to capture a backup automatically before wiping cached projects and device edits.
+- Generate printable overviews for any saved project and add a custom logo so exports and backups match your production branding.
+- Save project requirements along with each project so gear lists retain full context.
+- Works fully offline with the installed service worker—language, theme, device data and favorites persist between sessions.
+- Responsive layout adapts seamlessly across desktops, tablets and phones.
+- Choose **V‑Mount**, **B‑Mount** or **Gold‑Mount** plates on supported cameras; the battery list adapts automatically.
 
-### 🧭 Descripción de la interfaz
-- **Resumen rápido:**
-  - **Búsqueda global** (`/` o `Ctrl+K`/`⌘K`) salta a funciones, selectores o
-    temas de ayuda incluso cuando el menú lateral está contraído.
-  - **Centro de ayuda** (`?`, `H`, `F1` o `Ctrl+/`) ofrece guías filtrables,
-    preguntas frecuentes, accesos directos y el modo de ayuda flotante.
-  - **Diagrama del proyecto** visualiza conexiones; mantén pulsada Mayús al
-    descargar para guardar un JPG en lugar de SVG y ver avisos de
-    compatibilidad.
-  - **Comparador de baterías** muestra el rendimiento de cada pack compatible y
-    resalta riesgos de sobrecarga.
-  - **Generador de listas** crea tablas por categoría con metadatos, correos de
-    la crew y añadidos según escenario listos para imprimir.
-  - **Indicador sin conexión y Forzar recarga** reflejan el estado de la
-    conexión y renuevan archivos en caché sin borrar proyectos.
-- Un enlace de salto y un indicador sin conexión mantienen la interfaz accesible con teclado y pantallas táctiles: la insignia aparece cuando el navegador pierde la conexión.
-- La barra de búsqueda global salta a funciones, selectores de dispositivos o temas de ayuda; pulsa Enter para activar el resultado resaltado, usa / o Ctrl+K (⌘K en macOS) para enfocarla desde cualquier lugar (el menú lateral se abre automáticamente en pantallas pequeñas) y pulsa Escape o × para limpiar la consulta.
-- Los controles de la barra superior permiten cambiar el idioma, alternar los temas oscuro y rosa y abrir Ajustes con opciones de color de acento, tamaño y familia tipográfica, modo de alto contraste y carga de logotipo, además de herramientas para copia de seguridad, restauración y Restablecimiento de fábrica que guardan una copia antes de borrar los datos.
-- El botón de Ayuda abre un diálogo con búsqueda, secciones paso a paso, atajos de teclado, preguntas frecuentes y un modo de ayuda emergente opcional; también puede activarse con ?, H, F1 o Ctrl+/ incluso mientras escribes.
-- El botón de recarga forzada (🔄) borra los archivos del *service worker* en caché para que la aplicación sin conexión se actualice sin eliminar proyectos ni dispositivos guardados.
-- En pantallas pequeñas, un menú lateral plegable replica cada sección principal para navegar rápidamente.
+### 🧭 Interface Overview
+- **Quick reference:**
+  - **Global search** (`/` or `Ctrl+K`/`⌘K`) jumps to features, selectors or help
+    topics even when the side drawer is collapsed.
+  - **Help center** (`?`, `H`, `F1` or `Ctrl+/`) surfaces searchable guides,
+    FAQs, shortcuts and the optional hover-help mode.
+  - **Project diagram** visualizes connections; hold Shift when downloading to
+    save a JPG snapshot instead of SVG while seeing compatibility notices.
+  - **Battery comparison** reveals how compatible packs perform and highlights
+    overload risks before call time.
+  - **Gear list generator** outputs categorized tables with metadata, crew
+    emails and scenario-driven accessories ready for print or PDF.
+  - **Offline badge & Force reload** show connectivity status and refresh cached
+    assets without clearing projects.
+- A skip link and offline indicator keep the layout accessible on keyboard and touch devices—the badge appears whenever the browser loses its connection.
+- The global search bar jumps to features, device selectors or help topics; press Enter to activate the highlighted result, use / or Ctrl+K (⌘K on macOS) to focus it from anywhere (the side menu opens automatically on small screens) and press Escape or tap × to clear the query.
+- Top bar controls provide language switching, dark and pink theme toggles plus a Settings dialog that exposes accent color, font size, font family, high contrast and custom logo uploads alongside backup, restore and Factory reset tools that back up data before wiping it.
+- The Help button opens a searchable dialog with step-by-step sections, keyboard shortcuts, FAQs and an optional hover-help mode; it can also be triggered with ?, H, F1 or Ctrl+/ even while typing.
+- The Force reload button (🔄) clears cached service worker files so the offline app updates without deleting saved projects or custom devices.
+- On smaller screens a collapsible side menu mirrors every major section for quick navigation.
 
-### ♿ Personalización y accesibilidad
-- Las preferencias de tema incluyen modo oscuro, acentos rosas lúdicos y un interruptor dedicado de alto contraste para mejorar la legibilidad.
-- Los cambios en el color de acento, el tamaño base de la fuente y la tipografía se aplican al instante y persisten en el navegador, lo que te permite adaptarlo a la identidad del estudio o a necesidades de accesibilidad.
-- Los atajos de teclado integrados cubren la búsqueda global (/ o Ctrl+K/⌘K), la ayuda ( ?, H, F1, Ctrl+/ ), el guardado (Enter o Ctrl+S/⌘S), el modo oscuro (D) y el modo rosa (P).
-- El modo de ayuda al pasar el cursor convierte cada botón, campo, menú y encabezado en una descripción emergente bajo demanda para que las personas nuevas aprendan rápidamente.
-- Las entradas con búsqueda incremental, los controles visibles al enfocar y los iconos de estrella junto a los selectores permiten filtrar listas largas y fijar dispositivos favoritos en la parte superior.
-- Sube un logotipo para las impresiones, configura roles de monitorización por
-  defecto y ajusta los presets de requisitos del proyecto para que las
-  exportaciones respeten la identidad de la productora.
-- Los botones de bifurcación duplican filas de formularios de inmediato y los
-  favoritos fijados mantienen el equipo habitual en la parte alta de cada
-  selector, algo clave cuando el tiempo en set es limitado.
+### ♿ Customization & Accessibility
+- Theme preferences include dark mode, playful pink accents and a dedicated high contrast switch for improved readability.
+- Accent color, base font size and typeface changes apply instantly and persist in the browser, letting you match studio branding or accessibility needs.
+- Built-in keyboard shortcuts cover global search (/ or Ctrl+K/⌘K), help ( ?, H, F1, Ctrl+/ ), saving (Enter or Ctrl+S/⌘S), dark mode (D) and pink mode (P).
+- Hover-help mode turns every button, field, dropdown and header into an on-demand tooltip so new users can learn the interface quickly.
+- Type-to-search inputs, focus-visible controls and star icons beside selectors let you filter long lists quickly and pin favourite devices to the top.
+- Upload a custom logo for printouts, configure default monitoring roles and tweak project requirement presets so exports match your production branding.
+- Fork buttons duplicate gear list rows instantly, and pinned favourites keep go-to equipment at the top of selectors for faster data entry on set.
 
-### 📋 Lista de equipo
-El generador transforma tus selecciones en una lista de empaquetado categorizada:
+### 📋 Gear List
+The generator turns your selections into a categorized packing list:
 
-- Haz clic en **Generar lista de equipo** para compilar el material elegido y los requisitos del proyecto en una tabla.
-- La tabla se actualiza automáticamente cuando cambian las selecciones de dispositivos o los requisitos.
-- Los elementos se agrupan por categoría (cámara, óptica, alimentación, monitorización, rigging, grip, accesorios, consumibles) y los duplicados se combinan con sus cantidades.
-- Se añaden cables, rigging y accesorios necesarios para monitores, motores, gimbals y escenarios meteorológicos.
-- Las selecciones de escenarios añaden equipo relacionado:
-  - *Handheld* + *Easyrig* inserta una empuñadura telescópica para un soporte estable.
-  - *Gimbal* añade el gimbal seleccionado, brazos articulados, espigas y parasoles o kits de filtros.
-  - *Outdoor* aporta espigas, paraguas y fundas CapIt para lluvia.
-  - Los escenarios *Vehicle* y *Steadicam* incluyen monturas, brazos de aislamiento y ventosas cuando corresponde.
-- Las selecciones de óptica incluyen diámetro frontal, peso, datos de barras y enfoque mínimo, añaden soportes de lente y adaptadores de matte box, y avisan sobre estándares de barras incompatibles.
-- Las filas de baterías reflejan los recuentos del calculador de alimentación e incluyen placas de *hotswap* o dispositivos seleccionados cuando se necesitan.
-- Las preferencias de monitorización asignan monitores predeterminados para cada rol (Director, DoP, foco, etc.) con juegos de cables y receptores inalámbricos.
-- El formulario de **Requisitos del proyecto** alimenta la lista:
-  - **Nombre del proyecto**, **productora**, **casa de alquiler** y **DoP** aparecen en el encabezado de los requisitos impresos.
-  - Las entradas de **Equipo** recogen nombres, roles y direcciones de correo electrónico para que la información de contacto viaje con el proyecto.
-  - **Días de preparación** y **días de rodaje** aportan notas de planificación y, junto con escenarios exteriores, sugieren equipo para la climatología.
-  - Los **escenarios obligatorios** añaden rigging, gimbals y protección climática correspondiente.
-  - **Empuñadura de cámara** y **extensión de visor** insertan las piezas seleccionadas o los soportes de extensión.
-  - Las opciones de **matte box** y **filtros** agregan el sistema elegido con bandejas, adaptadores de pinza o filtros necesarios.
-  - Las configuraciones de **monitorización**, **distribución de vídeo** y **visor** añaden monitores, cables y superposiciones para cada rol.
-  - Las selecciones de **botones de usuario** y **preferencias de trípode** se listan para una referencia rápida.
-- Los elementos dentro de cada categoría se ordenan alfabéticamente y muestran descripciones al pasar el cursor.
-- La lista de equipo se incluye en las vistas imprimibles y en los archivos de proyectos exportados.
-- Las listas de equipo se guardan automáticamente con el proyecto y forman parte de los archivos exportados y de las copias de seguridad.
-- **Eliminar lista de equipo** borra la lista guardada y oculta la salida.
-- Los formularios de la lista de equipo incluyen botones de bifurcar para duplicar entradas de usuario al instante.
+- Click **Generate Gear List** to compile chosen gear and project requirements into a table.
+- The table updates automatically when device selections or requirements change.
+- Items are grouped by category (camera, lens, power, monitoring, rigging, grip, accessories, consumables) and duplicates are merged with counts.
+- Required cables, rigging and accessories are added for monitors, motors, gimbals and weather scenarios.
+- Scenario selections inject related gear:
+  - *Handheld* + *Easyrig* inserts a telescopic handle for stable support.
+  - *Gimbal* adds the selected gimbal, friction arms, spigots and sunshades or filter kits.
+  - *Outdoor* supplies spigots, umbrellas and CapIt rain covers.
+  - *Vehicle* and *Steadicam* scenarios pack in mounts, isolation arms and suction gear where applicable.
+- Lens selections append front diameter, weight, rod data and minimum focus, add lens supports and matte box adapters, and warn about incompatible rod standards.
+- Battery rows mirror counts from the power calculator and include hotswap plates or chosen hotswap devices when required.
+- Monitoring preferences assign default monitors for each role (Director, DoP, Focus, etc.) with cable sets and wireless receivers.
+- The **Project Requirements** form feeds the list:
+  - **Project Name**, **Production Company**, **Rental House** and **DoP** appear in the heading of the printed requirements.
+  - **Crew** entries capture names, roles and email addresses so contact info travels with the project.
+  - **Prep Days** and **Shooting Days** supply schedule notes and, when paired with outdoor scenarios, suggest weather gear.
+  - **Required Scenarios** append matching rigging, gimbals and weather protection.
+  - **Camera Handle** and **Viewfinder Extension** insert the chosen handle parts or extension brackets.
+  - **Matte Box** and **Filter** choices inject the selected system with any needed trays, clamp adapters or filters.
+  - **Monitoring Configuration**, **Video Distribution** and **Viewfinder** settings add monitors, cables and overlays for each role.
+  - **User Button** selections and **Tripod Preferences** are listed for quick reference.
+- Items inside each category are sorted alphabetically and display tooltips on hover.
+- The gear list is included in printable overviews and exported project files.
+- Gear lists save automatically with the project and are included in exported project files and backups.
+- **Delete Gear List** removes the saved list and hides the output.
+- Gear list forms provide fork buttons to duplicate user entries instantly.
 
-### 📦 Categorías de dispositivos
-- **Cámara** (1)
-- **Monitor** (opcional)
-- **Transmisor inalámbrico** (opcional)
-- **Motores FIZ** (0–4)
-- **Controladores FIZ** (0–4)
-- **Sensor de distancia** (0–1)
-- **Placa de batería** (solo en cámaras que aceptan V‑ o B‑Mount)
-- **Batería V‑Mount** (0–1)
+### 📦 Device Categories
+- **Camera** (1)
+- **Monitor** (optional)
+- **Wireless Transmitter** (optional)
+- **FIZ Motors** (0–4)
+- **FIZ Controllers** (0–4)
+- **Distance Sensor** (0–1)
+- **Battery Plate** (only on cameras that accept V‑ or B‑Mount)
+- **V‑Mount Battery** (0–1)
 
-### ⚙️ Cálculos de energía
-- Consumo total en vatios
-- Corriente demandada a 14,4 V y 12 V
-- Autonomía estimada de la batería en horas usando la media ponderada de los comentarios de personas usuarias
-- Número de baterías necesarias para un rodaje de 10 h (incluida la de repuesto)
-- Nota de temperatura para ajustar la autonomía en condiciones de calor o frío
+### ⚙️ Power Calculations
+- Total consumption in watts
+- Current draw at 14.4 V and 12 V
+- Estimated battery runtime in hours using weighted user feedback
+- Required battery count for a 10 h shoot (incl. spare)
+- Temperature note to adjust runtime for hot or cold conditions
 
-### 🔋 Comprobación de entrega de batería
-- Avisa si la corriente demandada supera la salida de la batería (pin o D‑Tap)
-- Indica cuando el consumo está cerca del límite (80 % de uso)
+### 🔋 Battery Output Check
+- Warns if current draw exceeds the battery output (Pin or D‑Tap)
+- Indicates when draw is close to the limit (80 % usage)
 
-### 📊 Comparación de baterías (opcional)
-- Compara estimaciones de autonomía entre todas las baterías
-- Gráficos de barras para consulta rápida
+### 📊 Battery Comparison (optional)
+- Compare runtime estimates across all batteries
+- Visual bar graph for quick reference
 
-### 🖼 Diagrama del proyecto
-- Visualiza las conexiones de alimentación y vídeo de los dispositivos seleccionados.
-- Advierte cuando las marcas FIZ son incompatibles.
-- Arrastra nodos para reorganizar el esquema, haz zoom con los botones y descarga el diagrama como SVG o JPG.
-- Mantén pulsado Shift al hacer clic en Descargar para exportar una instantánea JPG en lugar de SVG.
-- Pasa el cursor o toca los dispositivos para ver detalles emergentes.
-- Utiliza iconos de [OpenMoji](https://openmoji.org/) cuando hay conexión, con emoji como alternativa: 🔋 batería, 🎥 cámara, 🖥️ monitor, 📡 vídeo, ⚙️ motor, 🎮 controlador, 📐 distancia, 🎮 empuñadura y 🔌 placa de batería.
+### 🖼 Project Diagram
+- Visualize power and video connections for the selected devices
+- Warns when FIZ brands are incompatible
+- Drag nodes to rearrange the layout, zoom with the buttons and download the diagram as SVG or JPG
+- Hold Shift while clicking Download to export a JPG snapshot instead of SVG
+- Hover or tap devices to see popup details
+- Uses [OpenMoji](https://openmoji.org/) icons when online, falling back to emoji:
+  🔋 battery, 🎥 camera, 🖥️ monitor, 📡 video, ⚙️ motor,
+  🎮 controller, 📐 distance, 🎮 handle and 🔌 battery plate
 
-### 🧮 Ponderación de datos de autonomía
-- Los tiempos de batería aportados por la comunidad refinan la estimación de autonomía.
-- Cada registro se ajusta por temperatura, escalando desde ×1 a 25 °C hasta:
-  - ×1,25 a 0 °C
-  - ×1,6 a −10 °C
-  - ×2 a −20 °C
-- Los ajustes de cámara influyen en el peso:
-  - Multiplicadores de resolución: ≥12K ×3, ≥8K ×2, ≥4K ×1,5, ≥1080p ×1; resoluciones menores se escalan a 1080p.
-  - La frecuencia de cuadro escala linealmente desde 24 fps (por ejemplo, 48 fps = ×2).
-  - Wi‑Fi activado suma un 10 %.
-  - Factores de códec: RAW/BRAW/ARRIRAW/R3D/CinemaDNG/Canon RAW/X‑OCN ×1; ProRes ×1,1; DNx/AVID ×1,2; All‑Intra ×1,3; H.264/AVC ×1,5; H.265/HEVC ×1,7.
-  - Las entradas de monitores por debajo del brillo especificado se ponderan según su relación de brillo.
-- El peso final refleja la cuota de consumo de cada dispositivo, de modo que los proyectos equivalentes cuentan más.
-- Se usa la media ponderada cuando hay al menos tres entradas disponibles.
-- Un panel ordena los registros por peso y muestra el porcentaje que aporta cada uno para compararlos rápidamente.
+### 🧮 Runtime data weighting
+- User-submitted battery runtimes refine the runtime estimate.
+- Each entry is adjusted for temperature, scaling from ×1 at 25 °C to:
+  - ×1.25 at 0 °C
+  - ×1.6 at −10 °C
+  - ×2 at −20 °C
+- Camera settings influence the weight:
+  - Resolution multipliers: ≥12K ×3, ≥8K ×2, ≥4K ×1.5, ≥1080p ×1, lower scaled to 1080p
+  - Frame rate scales linearly from 24 fps (e.g. 48 fps = ×2)
+  - Wi‑Fi enabled adds 10 %
+  - Codec factors: RAW/BRAW/ARRIRAW/R3D/CinemaDNG/Canon RAW/X‑OCN ×1; ProRes ×1.1; DNx/AVID ×1.2; All‑Intra ×1.3; H.264/AVC ×1.5; H.265/HEVC ×1.7
+  - Monitor entries below the specified brightness are weighted by their brightness ratio
+- The final weight reflects each device's share of the total power draw, so matching projects count more.
+- The weighted average is used once at least three entries are available.
+- A dashboard orders entries by weight and displays each one's share percentage for quick comparison.
 
-### 🔍 Búsqueda y filtrado
-- Escribe dentro de los menús desplegables para encontrar entradas rápidamente.
-- Filtra las listas de dispositivos con un cuadro de búsqueda.
-- Utiliza la barra de búsqueda global en la parte superior para saltar a funciones, dispositivos o temas de ayuda; pulsa Enter para navegar, usa / o Ctrl+K (⌘K en macOS) para enfocarla al instante y pulsa Escape o × para limpiar.
-- Pulsa '/' o Ctrl+F (⌘F en macOS) para enfocar al instante el cuadro de búsqueda más cercano.
-- Haz clic en la estrella junto a cualquier selector para fijar favoritos, mantenerlos en la parte superior de la lista y sincronizarlos con las copias de seguridad.
+### 🔍 Search & Filtering
+- Type inside dropdowns to quickly find entries
+- Filter device lists with a search box
+- Use the global search bar at the top to jump to features, devices or help topics; press Enter to navigate, use / or Ctrl+K (⌘K on macOS) to focus it instantly and press Escape or × to clear.
+- Press '/' or Ctrl+F (⌘F on macOS) to focus the nearest search box instantly.
+- Click the star beside any selector to pin favourites so they stay at the top of the list and sync with backups.
 
-### 🛠 Editor de la base de datos de dispositivos
-- Añade, edita o elimina dispositivos en todas las categorías.
-- Importa o exporta la base de datos completa como JSON.
-- Vuelve a la base de datos predeterminada de `assets/data/index.js`.
+### 🛠 Device Database Editor
+- Add, edit or delete devices in all categories
+- Import or export the full database as JSON
+- Revert to the default database from `assets/data/index.js`
 
-### 🌓 Modo oscuro
-- Actívalo con el botón de la luna junto al selector de idioma.
-- La preferencia se guarda en tu navegador.
+### 🌓 Dark Mode
+- Toggle via the moon button next to the language selector.
+- Preference is stored in your browser.
 
-### 🦄 Modo rosa
-- Haz clic en el botón del unicornio (el modo rosa alterna iconos de unicornio cada 30 segundos con una suave animación emergente y vuelve al caballo cuando lo desactivas) o pulsa **P** para activar un acento rosa lúdico.
-- Funciona en los temas claro y oscuro y persiste entre visitas.
+### 🦄 Pink Mode
+- Click the unicorn button (pink mode cycles through unicorn icons every 30 seconds with a gentle pop animation and switches back to the horse icon when you leave the theme) or press **P** for a playful pink accent.
+- Works in both light and dark themes and persists between visits.
 
-### ⚫ Modo de alto contraste
-- Activa un tema de alto contraste para mejorar la legibilidad.
+### ⚫ High Contrast Mode
+- Toggle a high contrast theme for improved readability.
 
-### 📝 Comentarios de autonomía
-- Haz clic en <strong>Enviar comentarios de autonomía</strong> debajo de la autonomía para añadir tu propia medición.
-- Incluye la temperatura si quieres una ponderación más precisa.
-- Las entradas se guardan en tu navegador y mejoran las estimaciones futuras.
-- Un panel dedicado ordena los envíos según su peso, muestra porcentajes de
-  contribución y resalta valores atípicos para que el equipo evalúe los datos de
-  campo rápidamente.
+### 📝 User Runtime Feedback
+- Click <strong>Submit User Runtime Feedback</strong> below the runtime to add your own measurement.
+- Optionally include temperature for more accurate weighting.
+- Entries are saved in your browser and improve future estimates.
+- A dashboard orders submissions by weight, shows contribution percentages and
+  highlights outliers so crews can review field data quickly.
 
-### ❓ Ayuda con búsqueda
-- Ábrela mediante el botón <strong>?</strong> o pulsa <kbd>?</kbd>, <kbd>H</kbd>, <kbd>F1</kbd> o <kbd>Ctrl+/</kbd>.
-- Usa el campo de búsqueda para filtrar temas al instante; la consulta se restablece al cerrar el diálogo.
-- Cierra con <kbd>Escape</kbd> o haciendo clic fuera del diálogo.
+### ❓ Searchable Help
+- Open via the <strong>?</strong> button or press <kbd>?</kbd>, <kbd>H</kbd>, <kbd>F1</kbd> or <kbd>Ctrl+/</kbd>.
+- Use the search field to filter topics instantly; the query resets when the dialog closes.
+- Close with <kbd>Escape</kbd> or by clicking outside the dialog.
 
 ---
 
-## ▶️ Cómo usarlo
-1. **Inicia la aplicación:** abre `index.html` en cualquier navegador moderno; no necesita servidor.
-2. **Explora la barra superior:** cambia de idioma, alterna los temas oscuro o rosa, abre Ajustes para modificar acento y tipografías, y lanza el diálogo de ayuda con ? o Ctrl+/.
-3. **Selecciona los dispositivos:** elige el equipo de cada categoría con los menús desplegables; escribe para filtrar, haz clic en la estrella para fijar favoritos y deja que los escenarios preconfigurados rellenen los accesorios automáticamente.
-4. **Consulta los cálculos:** verás consumo total, corriente y autonomía cuando selecciones una batería; los avisos resaltan cuando se supera la entrega permitida.
-5. **Guarda y exporta proyectos:** pon nombre y guarda tu configuración, las copias automáticas capturan instantáneas y el botón Exportar descarga un paquete JSON para el equipo, mientras que Importar lo restaura.
-6. **Genera listas de equipo:** pulsa **Generar lista de equipo** para convertir los requisitos en una lista categorizada con descripciones y accesorios.
-7. **Gestiona los datos de dispositivos:** haz clic en “Editar datos de dispositivos…” para abrir el editor, modificar dispositivos, exportar/importar JSON o volver a los valores predeterminados.
-8. **Envía comentarios de autonomía:** usa “Enviar comentarios de autonomía” para registrar mediciones de campo y refinar las estimaciones ponderadas.
+## ▶️ How to Use
+1. **Launch App:** Open `index.html` in any modern browser – no server required.
+2. **Explore the Top Bar:** Switch language, toggle dark or pink themes, open Settings for accent and typography options, and start the searchable help dialog with ? or Ctrl+/.
+3. **Select Devices:** Choose gear from each category using the dropdowns—type to filter, click the star to pin favourites and let scenario presets fill in accessories automatically.
+4. **View Calculations:** See total draw, current and runtime once a battery is selected; warnings highlight when output limits are exceeded.
+5. **Save & Export Projects:** Name and save your configuration, auto-backups capture snapshots, and the Export button downloads a JSON bundle for collaborators while the Import button restores them.
+6. **Generate Gear Lists:** Press **Generate Gear List** to turn project requirements into a categorized packing list with tooltips and accessory packs.
+7. **Manage Device Data:** Click “Edit Device Data…” to open the database editor, modify devices, export/import JSON or revert to the defaults.
+8. **Submit Runtime Feedback:** Use “Submit User Runtime Feedback” to record field measurements and refine weighted estimates.
 
-## 📱 Instalar como aplicación
+## 📱 Install as an App
 
-El planificador es una aplicación web progresiva y puede instalarse directamente desde tu navegador:
+The planner is a Progressive Web App and can be installed directly from your browser:
 
-- **Chrome/Edge (escritorio):** haz clic en el icono de instalación de la barra de direcciones.
-- **Android:** abre el menú del navegador y elige *Añadir a la pantalla de inicio*.
-- **iOS/iPadOS Safari:** toca el botón *Compartir* y selecciona *Añadir a pantalla de inicio*.
+- **Chrome/Edge (desktop):** Click the install icon in the address bar.
+- **Android:** Open the browser menu and choose *Add to Home Screen*.
+- **iOS/iPadOS Safari:** Tap the *Share* button and select *Add to Home Screen*.
 
-Una vez instalada, la aplicación se abre desde tu pantalla de inicio, funciona sin conexión y se actualiza automáticamente.
+Once installed, the app launches from your home screen, works offline and updates itself automatically.
 
-## 📡 Uso sin conexión y almacenamiento de datos
+## 📡 Offline Use & Data Storage
 
-Servir la aplicación mediante HTTP(S) instala un *service worker* que almacena en caché cada archivo, de modo que Cine Power Planner funciona sin conexión y se actualiza en segundo plano. Los proyectos, los comentarios de autonomía y las preferencias (idioma, tema, modo rosa y listas de equipo guardadas) viven en el `localStorage` del navegador. Al borrar los datos del sitio en el navegador se elimina toda la información almacenada, y el diálogo de Ajustes incluye un flujo de **Restablecimiento de fábrica** que guarda automáticamente una copia antes de realizar la misma limpieza completa.
-La cabecera muestra un indicador sin conexión cuando se pierde la red, y la
-acción 🔄 **Forzar recarga** actualiza los recursos en caché sin afectar a los
-proyectos guardados.
+Serving the app over HTTP(S) installs a service worker that caches every file
+so Cine Power Planner works fully offline and updates in the background. Projects,
+runtime submissions and preferences (language, theme, pink mode and saved gear
+lists) live in your browser's `localStorage`. Clearing the site's data in the
+browser removes all stored information, and the Settings dialog includes a
+**Factory reset** workflow that saves a backup automatically before clearing everything. The header shows an
+offline badge whenever connectivity drops, and the 🔄 **Force reload** action
+refreshes cached assets without disturbing saved projects.
 
 ---
 
-## 🗂️ Estructura de archivos
+## 🗂️ File Structure
 ```bash
-index.html                 # Maquetación principal en HTML
-assets/css/style.css       # Estilos y diseño base
-assets/css/overview.css    # Estilos de la vista de resumen
-assets/css/overview-print.css # Ajustes de impresión para la vista general
-assets/js/script.js        # Lógica de la aplicación
-assets/js/storage.js       # Utilidades para LocalStorage
-assets/js/static-theme.js  # Lógica de tema compartida para las páginas legales
-assets/data/index.js       # Lista predeterminada de dispositivos
-assets/data/devices/       # Catálogos de dispositivos por categoría
-assets/data/schema.json    # Esquema generado para validaciones
-assets/vendor/             # Bibliotecas de terceros incluidas
-legal/                     # Páginas legales sin conexión
-tools/                     # Scripts de mantenimiento de datos
-tests/                     # Suite de pruebas de Jest
+index.html                 # Main HTML layout
+assets/css/style.css       # Core styles and layout
+assets/css/overview.css    # Printable overview styling
+assets/css/overview-print.css # Print overrides for the overview
+assets/js/script.js        # Application logic
+assets/js/storage.js       # LocalStorage helpers
+assets/js/static-theme.js  # Shared theme logic for legal pages
+assets/data/index.js       # Default device list
+assets/data/devices/       # Device catalogs by category
+assets/data/schema.json    # Generated schema for selectors
+assets/vendor/             # Bundled third-party libraries
+legal/                     # Offline legal documents
+tools/                     # Data maintenance scripts
+tests/                     # Jest test suite
 ```
-Las fuentes se incluyen localmente mediante `fonts.css`, así que una vez que los recursos están en caché la aplicación funciona completamente sin conexión.
+Fonts are bundled locally via `fonts.css`, so once the assets are cached the application works entirely offline.
 
-## 🛠️ Desarrollo
-Requiere Node.js 18 o posterior.
+## 🛠️ Development
+Requires Node.js 18 or later.
 
 ```bash
 npm install
-npm run lint     # ejecuta solo ESLint
-npm test         # ejecuta linting, comprobaciones de datos y pruebas de Jest
+npm run lint     # run ESLint alone
+npm test         # runs linting, data checks and Jest tests
 ```
 
-Después de editar los datos de dispositivos, regenera la base de datos normalizada:
+After editing device data, regenerate the normalized database:
 
 ```bash
 npm run normalize
@@ -305,11 +302,11 @@ npm run check-consistency
 npm run generate-schema
 ```
 
-Añade `--help` a cualquiera de los scripts anteriores para ver los detalles de uso.
+Add `--help` to any of the above scripts for usage details.
 
-Ejecuta `npm run help` cuando necesites un resumen rápido de los scripts de mantenimiento y su orden sugerido.
+Run `npm run help` whenever you need a quick reminder of the maintenance commands and their suggested order.
 
-## 🤝 Contribuciones
-¡Se agradecen las contribuciones! Puedes abrir un issue o enviar un *pull request* en GitHub.
-Si informas de datos incorrectos, adjuntar copias de seguridad de proyectos o
-mediciones de autonomía ayuda a mantener el catálogo fiable para todos.
+## 🤝 Contributing
+Contributions are welcome! Feel free to open an issue or submit a pull request on GitHub.
+When reporting data corrections, attaching project backups or runtime samples
+helps keep the catalog accurate for everyone.

--- a/README.fr.md
+++ b/README.fr.md
@@ -1,304 +1,299 @@
 # 🎥 Cine Power Planner
 
-Cet outil basé sur le navigateur aide à planifier des projets caméra professionnels alimentés par des batteries V‑Mount, B‑Mount ou Gold-Mount. Il calcule la **consommation totale**, l’**intensité demandée** (à 14,4 V et 12 V) et l’**autonomie estimée** tout en vérifiant que la batterie peut fournir la puissance requise en toute sécurité.
+This browser based tool helps plan professional camera projects powered by V‑Mount, B‑Mount or Gold-Mount batteries. It calculates **total power consumption**, **current draw** (at 14.4 V and 12 V) and **estimated battery runtime** while checking that the battery can safely supply the required power.
 
-Toute la planification, les saisies et les exports restent sur la machine sous
-vos yeux. La langue, les projets, les appareils personnalisés, les favoris et
-les retours d’autonomie sont stockés dans votre navigateur, et les mises à jour
-du service worker proviennent directement de ce dépôt. Vous pouvez lancer
-l’application hors ligne depuis le disque ou l’héberger en interne pour que
-tous les départements utilisent la même version vérifiée.
+All planning, inputs and exports stay on the device in front of you. Language
+choice, projects, custom equipment, favorites and runtime feedback live in your
+browser, and service worker updates are driven directly by this repository. Run
+the planner offline from disk or host it internally so every department uses the
+same audited version.
 
 ---
 
-## 🌍 Langues
+## 🌍 Languages
 - 🇬🇧 [English](README.en.md)
 - 🇩🇪 [Deutsch](README.de.md)
 - 🇪🇸 [Español](README.es.md)
 - 🇮🇹 [Italiano](README.it.md)
 - 🇫🇷 [Français](README.fr.md)
 
-L’application adopte automatiquement la langue de votre navigateur lors de la première visite et vous pouvez la modifier à tout moment en haut à droite. Le choix est mémorisé pour la prochaine session.
+The app automatically uses your browser language on first load, and you can switch the language in the top right corner. The choice is remembered for your next visit.
 
 ---
 
-## 🆕 Nouveautés
-- Les contrôles d’accent et de typographie dans Paramètres permettent d’ajuster la couleur d’accent, la taille de base de la police et la famille de caractères, en plus des thèmes sombre, rose et à fort contraste.
-- Les raccourcis clavier de la recherche globale permettent d’appuyer sur / ou Ctrl+K (⌘K sur macOS) pour la focaliser instantanément, même lorsqu’elle se trouve dans le menu latéral mobile replié.
-- Le bouton de rechargement forcé efface les fichiers mis en cache par le service worker afin que l’application hors ligne se mette à jour sans supprimer les projets ni les appareils enregistrés.
-- Les icônes étoilées dans chaque sélecteur épinglent les caméras, batteries et accessoires favoris en haut de la liste et les incluent dans les sauvegardes.
-- Le flux de **Réinitialisation d’usine** télécharge automatiquement une sauvegarde avant de supprimer les projets, appareils et paramètres stockés.
-- La liste de matériel et l’aperçu imprimable affichent le nom du projet pour une consultation rapide.
-- Importez un logo personnalisé pour les aperçus imprimables et les sauvegardes.
-- Les sauvegardes contiennent les favoris et créent une copie automatique avant toute restauration.
-- Les entrées d’équipe disposent désormais d’un champ e-mail.
-- Un thème à fort contraste améliore la lisibilité.
-- Les formulaires d’appareils remplissent les catégories dynamiquement selon le schéma.
-- Interface repensée avec plus de contraste et d’espacement pour une expérience plus claire sur tous les appareils.
-- L’export de projets est simplifié : téléchargez un fichier JSON qui regroupe sélections, exigences, listes de matériel, retours d’autonomie et appareils personnalisés, puis importez-le pour tout restaurer.
-- Des icônes uniques pour les scénarios requis facilitent l’identification des contraintes du projet.
-- Diagramme de projet interactif permettant de faire glisser les appareils, de zoomer, d’aligner sur la grille et d’exporter en SVG ou JPG.
-- Thème rose ludique persistant entre les visites.
-- Boîte d’aide avec recherche, sections pas à pas et FAQ ; ouvrez-la avec ?, H, F1 ou Ctrl+/.
-- Aides contextuelles au survol pour les boutons, champs, menus déroulants et en-têtes.
-- Barre de recherche globale pour accéder rapidement aux fonctionnalités, sélecteurs d’appareils ou rubriques d’aide.
-- Compatibilité avec les caméras dotées de plaques batterie V-, B- ou Gold-Mount.
-- Soumettez des retours d’autonomie accompagnés de la température pour affiner les estimations.
-- Tableau de pondération visuel pour analyser l’impact des réglages sur chaque mesure, trié par poids avec pourcentages précis.
-- Génération de listes de matériel regroupant les équipements choisis et les exigences du projet.
-- Sauvegarde des exigences de projet avec chaque configuration afin que la liste de matériel conserve tout le contexte.
-- Duplication instantanée des entrées utilisateur dans les formulaires de liste de matériel grâce aux boutons en forme de fourche.
+## 🆕 Recent Features
+- Accent and typography controls in Settings let you adjust the accent color, base font size and typeface alongside dark, pink and high contrast themes.
+- Keyboard shortcuts for the global search let you press / or Ctrl+K (⌘K on macOS) to focus the feature search instantly, even when it sits inside the collapsed mobile side menu.
+- Force reload button clears cached service worker files so the offline app refreshes without deleting saved projects or devices.
+- Star icons in every selector pin favorite cameras, batteries and accessories to the top of the list and keep them in backups.
+- Factory reset workflow automatically downloads a backup before wiping stored projects, custom devices and settings.
+- Gear list and printable overview display the project name for quick reference.
+- Upload a custom logo for printed overviews and backups.
+- Backups include favorites and create an automatic backup before restore.
+- Crew list entries now feature an email field.
+- High contrast theme option for improved readability.
+- Device forms populate category fields dynamically based on schema attributes.
+- Revamped interface design with improved contrast and spacing for a cleaner experience on any device.
+- Simplified project sharing – download a JSON project file that bundles selections, requirements, gear lists, runtime feedback and custom devices, then load it to restore the full setup.
+- Unique icons for required scenarios to distinguish project requirements.
+- Interactive project diagram that lets you drag devices, zoom, snap nodes to a grid and export the layout as SVG or JPG.
+- Playful pink accent theme that persists between visits.
+- Searchable help dialog with step-by-step sections and a FAQ; open with ?, H, F1 or Ctrl+/.
+- Contextual hover help for buttons, fields, dropdowns and headers.
+- Global search bar to jump to features, device selectors or help topics.
+- Support for cameras with V-, B- or Gold-Mount battery plates.
+- Submit user runtime feedback with temperature for better estimates.
+- Visual runtime weighting dashboard to inspect how settings influence each report, now sorted by weight and showing exact share percentages.
+- Generate gear lists to compile selected gear and project requirements.
+- Save project requirements with each project so gear lists retain full context.
+- Duplicate user entries in gear list forms using fork buttons to copy fields instantly.
 
 ---
 
-## 🔧 Fonctionnalités
+## 🔧 Features
 
-### ✨ Points forts supplémentaires
+### ✨ Expanded highlights
 
-- **Construisez des rigs complexes sans tâtonner.** Combinez caméras, plaques
-  batteries, liaisons sans fil, moniteurs, moteurs et accessoires tout en
-  visualisant la consommation totale à 14,4 V/12 V (et 33,6 V/21,6 V pour
-  B‑Mount) ainsi que des autonomies réalistes issues de données terrain
-  pondérées. Le panneau de comparaison des batteries signale les surcharges
-  avant de charger le mauvais matériel.
-- **Gardez chaque département aligné.** Enregistrez plusieurs projets avec
-  exigences, contacts d’équipe, scénarios et notes. Les listes imprimables
-  regroupent le matériel par catégorie, fusionnent les doublons, affichent les
-  métadonnées techniques et ajoutent les accessoires dictés par les scénarios
-  pour que caméra, lumière et machinerie partagent le même contexte.
-- **Travaillez sereinement partout.** Ouvrez `index.html` directement ou servez
-  le dossier en HTTPS pour activer le service worker. La mise en cache hors
-  ligne conserve langue, thèmes, favoris et projets, et **Forcer le rechargement**
-  actualise les fichiers sans toucher aux données.
-- **Adaptez l’outil à votre équipe.** Basculez instantanément entre français,
-  anglais, allemand, espagnol et italien, ajustez taille et police, choisissez
-  une couleur d’accent personnalisée, importez un logo d’impression et alternez
-  thème clair, sombre, rose ou à fort contraste. Les menus filtrables, favoris
-  épinglés, boutons de duplication et aides contextuelles gardent un rythme
-  rapide sur le plateau.
+- **Build complex rigs without guesswork.** Combine cameras, battery plates,
+  wireless links, monitors, motors and accessories while tracking total draw at
+  14.4 V/12 V (and 33.6 V/21.6 V for B‑Mount) plus realistic runtimes from
+  weighted field data. The battery comparison panel flags overloads before the
+  wrong kit goes on the truck.
+- **Keep every department aligned.** Save multiple projects with requirements,
+  crew contacts, scenarios and notes. Printable gear lists group equipment by
+  category, merge duplicates, surface technical metadata and include
+  scenario-driven accessories so camera, lighting and grip teams stay synced.
+- **Work confidently anywhere.** Open `index.html` directly or serve the folder
+  over HTTPS to enable the service worker. Offline caching preserves language,
+  themes, favorites and projects, and **Force reload** refreshes cached assets
+  without touching stored data.
+- **Tailor the planner to your crew.** Switch instantly between English,
+  Deutsch, Español, Italiano and Français, adjust font size and typeface, pick a
+  custom accent color, upload a print logo and toggle dark, pink or
+  high-contrast themes. Type-to-search selectors, pinned favorites, fork buttons
+  and hover help keep on-set workflows fast.
 
-### ✅ Gestion de projet
-- Enregistrez, chargez et supprimez plusieurs projets caméra (appuyez sur Entrée ou Ctrl+S/⌘S pour sauvegarder rapidement ; le bouton Enregistrer reste inactif tant qu’aucun nom n’est saisi).
-- Des instantanés automatiques sont créés toutes les 10 minutes tant que le planner est ouvert, et la boîte de dialogue Paramètres peut déclencher des exports de sauvegarde horaires pour penser à archiver vos données.
-- Téléchargez un fichier JSON qui regroupe sélections, exigences, liste de matériel, retours d’autonomie et appareils personnalisés ; chargez-le via le sélecteur Importer le projet pour tout restaurer en une étape.
-- Les données sont stockées localement via `localStorage` et les favoris sont inclus dans les sauvegardes ; utilisez l’option **Réinitialisation d’usine** dans Paramètres pour enregistrer automatiquement une sauvegarde avant de supprimer projets mis en cache et modifications d’appareils.
-- Générez des aperçus imprimables pour tout projet enregistré et ajoutez un logo personnalisé afin d’aligner exports et sauvegardes sur l’identité de votre production.
-- Enregistrez les exigences de projet avec chaque projet afin que la liste de matériel conserve tout le contexte.
-- Fonctionne entièrement hors ligne grâce au service worker installé : langue, thème, données d’appareils et favoris persistent entre les sessions.
-- Mise en page responsive qui s’adapte sans effort aux ordinateurs, tablettes et téléphones.
-- Sur les caméras compatibles, choisissez des plaques **V‑Mount**, **B‑Mount** ou **Gold-Mount** ; la liste de batteries se met à jour automatiquement.
+### ✅ Project Management
+- Save, load and delete multiple camera projects (press Enter or Ctrl+S/⌘S to save quickly; the Save button stays disabled until a name is entered).
+- Automatic snapshots are created every 10 minutes while the planner is open, and the Settings dialog can trigger hourly backup exports as a reminder to archive data.
+- Download a JSON project file that bundles selections, requirements, gear lists, runtime feedback and custom devices; load it through the Import Project picker to restore everything in one step.
+- Data is stored locally via `localStorage` and favorites are preserved in backups; use the **Factory reset** option in Settings to capture a backup automatically before wiping cached projects and device edits.
+- Generate printable overviews for any saved project and add a custom logo so exports and backups match your production branding.
+- Save project requirements along with each project so gear lists retain full context.
+- Works fully offline with the installed service worker—language, theme, device data and favorites persist between sessions.
+- Responsive layout adapts seamlessly across desktops, tablets and phones.
+- Choose **V‑Mount**, **B‑Mount** or **Gold‑Mount** plates on supported cameras; the battery list adapts automatically.
 
-### 🧭 Aperçu de l’interface
-- **Rappel express :**
-  - **Recherche globale** (`/` ou `Ctrl+K`/`⌘K`) rejoint fonctions, sélecteurs ou
-    rubriques d’aide même quand le menu latéral est replié.
-  - **Centre d’aide** (`?`, `H`, `F1` ou `Ctrl+/`) propose des guides filtrables,
-    une FAQ, des raccourcis et le mode d’aide contextuelle.
-  - **Diagramme de projet** visualise les connexions ; maintenez Maj en
-    téléchargeant pour obtenir un JPG au lieu d’un SVG et afficher les alertes de
-    compatibilité.
-  - **Comparateur de batteries** révèle les performances des packs compatibles
-    et signale les risques de surcharge.
-  - **Générateur de liste** produit des tableaux catégorisés avec métadonnées,
-    courriels de l’équipe et ajouts dépendant des scénarios prêts pour
-    l’impression.
-  - **Badge hors ligne et Forcer le rechargement** reflètent l’état de la
-    connexion et renouvellent les fichiers en cache sans effacer les projets.
-- Un lien d’évitement et un indicateur hors ligne maintiennent l’interface accessible au clavier et au tactile ; l’insigne apparaît dès que le navigateur perd la connexion.
-- La barre de recherche globale permet d’atteindre des fonctionnalités, sélecteurs d’appareils ou rubriques d’aide ; appuyez sur Entrée pour valider le résultat en surbrillance, utilisez / ou Ctrl+K (⌘K sur macOS) pour la focaliser instantanément (le menu latéral s’ouvre automatiquement sur les petits écrans) et appuyez sur Échap ou × pour effacer la requête.
-- Les commandes de la barre supérieure offrent le changement de langue, les thèmes sombre et rose, ainsi qu’une boîte de dialogue Paramètres avec la couleur d’accent, la taille et la famille de police, le mode à fort contraste et l’import de logo, ainsi que des outils de sauvegarde, restauration et Réinitialisation d’usine qui créent une sauvegarde avant l’effacement.
-- Le bouton Aide ouvre une boîte de dialogue recherchable avec des sections pas à pas, des raccourcis clavier, une FAQ et un mode aide contextuelle optionnel ; vous pouvez aussi l’ouvrir avec ?, H, F1 ou Ctrl+/ même en cours de saisie.
-- Le bouton de rechargement forcé (🔄) efface les fichiers du service worker en cache afin que l’application hors ligne se mette à jour sans supprimer projets ni appareils.
-- Sur les petits écrans, un menu latéral repliable reflète chaque section principale pour une navigation rapide.
+### 🧭 Interface Overview
+- **Quick reference:**
+  - **Global search** (`/` or `Ctrl+K`/`⌘K`) jumps to features, selectors or help
+    topics even when the side drawer is collapsed.
+  - **Help center** (`?`, `H`, `F1` or `Ctrl+/`) surfaces searchable guides,
+    FAQs, shortcuts and the optional hover-help mode.
+  - **Project diagram** visualizes connections; hold Shift when downloading to
+    save a JPG snapshot instead of SVG while seeing compatibility notices.
+  - **Battery comparison** reveals how compatible packs perform and highlights
+    overload risks before call time.
+  - **Gear list generator** outputs categorized tables with metadata, crew
+    emails and scenario-driven accessories ready for print or PDF.
+  - **Offline badge & Force reload** show connectivity status and refresh cached
+    assets without clearing projects.
+- A skip link and offline indicator keep the layout accessible on keyboard and touch devices—the badge appears whenever the browser loses its connection.
+- The global search bar jumps to features, device selectors or help topics; press Enter to activate the highlighted result, use / or Ctrl+K (⌘K on macOS) to focus it from anywhere (the side menu opens automatically on small screens) and press Escape or tap × to clear the query.
+- Top bar controls provide language switching, dark and pink theme toggles plus a Settings dialog that exposes accent color, font size, font family, high contrast and custom logo uploads alongside backup, restore and Factory reset tools that back up data before wiping it.
+- The Help button opens a searchable dialog with step-by-step sections, keyboard shortcuts, FAQs and an optional hover-help mode; it can also be triggered with ?, H, F1 or Ctrl+/ even while typing.
+- The Force reload button (🔄) clears cached service worker files so the offline app updates without deleting saved projects or custom devices.
+- On smaller screens a collapsible side menu mirrors every major section for quick navigation.
 
-### ♿ Personnalisation et accessibilité
-- Les thèmes incluent un mode sombre, un accent rose ludique et un interrupteur dédié à fort contraste pour une meilleure lisibilité.
-- Les changements de couleur d’accent, de taille de police et de typographie s’appliquent instantanément et restent enregistrés dans le navigateur, ce qui facilite l’adaptation à la charte graphique ou aux besoins d’accessibilité.
-- Les raccourcis intégrés couvrent la recherche globale (/ ou Ctrl+K/⌘K), l’aide ( ?, H, F1, Ctrl+/ ), l’enregistrement (Entrée ou Ctrl+S/⌘S), le mode sombre (D) et le mode rose (P).
-- Le mode aide au survol transforme chaque bouton, champ, menu et en-tête en infobulle à la demande pour accélérer l’apprentissage des nouveaux utilisateurs.
-- Les champs avec recherche incrémentale, les styles visibles au focus et les icônes étoilées à côté des sélecteurs facilitent le filtrage des longues listes et l’épinglage des favoris.
-- Importez un logo pour l’impression, définissez des rôles de monitoring par
-  défaut et ajustez les préréglages des exigences projet pour coller à la charte
-  de production.
-- Les boutons de duplication dupliquent instantanément les lignes des
-  formulaires et les favoris épinglés gardent le matériel essentiel en tête de
-  liste, idéal quand le temps est compté sur le plateau.
+### ♿ Customization & Accessibility
+- Theme preferences include dark mode, playful pink accents and a dedicated high contrast switch for improved readability.
+- Accent color, base font size and typeface changes apply instantly and persist in the browser, letting you match studio branding or accessibility needs.
+- Built-in keyboard shortcuts cover global search (/ or Ctrl+K/⌘K), help ( ?, H, F1, Ctrl+/ ), saving (Enter or Ctrl+S/⌘S), dark mode (D) and pink mode (P).
+- Hover-help mode turns every button, field, dropdown and header into an on-demand tooltip so new users can learn the interface quickly.
+- Type-to-search inputs, focus-visible controls and star icons beside selectors let you filter long lists quickly and pin favourite devices to the top.
+- Upload a custom logo for printouts, configure default monitoring roles and tweak project requirement presets so exports match your production branding.
+- Fork buttons duplicate gear list rows instantly, and pinned favourites keep go-to equipment at the top of selectors for faster data entry on set.
 
-### 📋 Liste de matériel
-Le générateur transforme vos sélections en une liste de préparation catégorisée :
+### 📋 Gear List
+The generator turns your selections into a categorized packing list:
 
-- Cliquez sur **Générer la liste de matériel** pour compiler l’équipement choisi et les exigences du projet dans un tableau.
-- Le tableau se met à jour automatiquement quand les sélections ou exigences changent.
-- Les éléments sont regroupés par catégorie (caméra, optique, alimentation, monitoring, rigging, grip, accessoires, consommables) et les doublons sont fusionnés avec leur quantité.
-- Les câbles, structures et accessoires requis pour les moniteurs, moteurs, gimbals et scénarios météo sont ajoutés automatiquement.
-- Les scénarios sélectionnés injectent le matériel associé :
-  - *Handheld* + *Easyrig* ajoute une poignée télescopique pour un soutien stable.
-  - *Gimbal* ajoute le gimbal choisi, des bras articulés, des spigots et des pare-soleil ou kits de filtres.
-  - *Outdoor* fournit des spigots, des parapluies et des housses de pluie CapIt.
-  - Les scénarios *Vehicle* et *Steadicam* ajoutent fixations, bras isolants et ventouses selon le cas.
-- Les sélections d’optique incluent diamètre frontal, poids, données de rods et mise au point minimale, ajoutent des supports d’objectif et adaptateurs de matte box, et avertissent des standards incompatibles.
-- Les lignes de batteries reflètent les quantités du calculateur d’alimentation et incluent des plaques ou appareils de *hotswap* si nécessaire.
-- Les préférences de monitoring attribuent des moniteurs par défaut pour chaque rôle (réalisateur, DoP, pointeur, etc.) avec jeux de câbles et récepteurs sans fil.
-- Le formulaire **Exigences du projet** alimente la liste :
-  - **Nom du projet**, **société de production**, **loueur** et **DoP** apparaissent dans l’en-tête des exigences imprimées.
-  - Les entrées de **l’équipe** capturent noms, rôles et adresses e-mail afin que les contacts suivent le projet.
-  - **Jours de préparation** et **jours de tournage** fournissent des notes de calendrier et, combinés à des scénarios extérieurs, suggèrent l’équipement météo.
-  - Les **scénarios requis** ajoutent rigging, gimbals et protections climatiques correspondants.
-  - **Poignée caméra** et **extension viseur** ajoutent les pièces ou supports sélectionnés.
-  - Les choix de **matte box** et de **filtres** ajoutent le système retenu avec plateaux, adaptateurs à collier ou filtres nécessaires.
-  - Les réglages de **monitoring**, **distribution vidéo** et **viseur** ajoutent moniteurs, câbles et incrustations pour chaque rôle.
-  - Les sélections de **boutons utilisateur** et **préférences de trépied** sont listées pour référence rapide.
-- Les éléments de chaque catégorie sont triés alphabétiquement et affichent une info-bulle au survol.
-- La liste de matériel figure dans les aperçus imprimables et dans les fichiers de projet exportés.
-- Les listes de matériel sont sauvegardées automatiquement avec le projet et incluses dans les fichiers exportés et les sauvegardes.
-- **Supprimer la liste de matériel** efface la liste enregistrée et masque la sortie.
-- Les formulaires de liste de matériel proposent des boutons en forme de fourche pour dupliquer instantanément les entrées utilisateur.
+- Click **Generate Gear List** to compile chosen gear and project requirements into a table.
+- The table updates automatically when device selections or requirements change.
+- Items are grouped by category (camera, lens, power, monitoring, rigging, grip, accessories, consumables) and duplicates are merged with counts.
+- Required cables, rigging and accessories are added for monitors, motors, gimbals and weather scenarios.
+- Scenario selections inject related gear:
+  - *Handheld* + *Easyrig* inserts a telescopic handle for stable support.
+  - *Gimbal* adds the selected gimbal, friction arms, spigots and sunshades or filter kits.
+  - *Outdoor* supplies spigots, umbrellas and CapIt rain covers.
+  - *Vehicle* and *Steadicam* scenarios pack in mounts, isolation arms and suction gear where applicable.
+- Lens selections append front diameter, weight, rod data and minimum focus, add lens supports and matte box adapters, and warn about incompatible rod standards.
+- Battery rows mirror counts from the power calculator and include hotswap plates or chosen hotswap devices when required.
+- Monitoring preferences assign default monitors for each role (Director, DoP, Focus, etc.) with cable sets and wireless receivers.
+- The **Project Requirements** form feeds the list:
+  - **Project Name**, **Production Company**, **Rental House** and **DoP** appear in the heading of the printed requirements.
+  - **Crew** entries capture names, roles and email addresses so contact info travels with the project.
+  - **Prep Days** and **Shooting Days** supply schedule notes and, when paired with outdoor scenarios, suggest weather gear.
+  - **Required Scenarios** append matching rigging, gimbals and weather protection.
+  - **Camera Handle** and **Viewfinder Extension** insert the chosen handle parts or extension brackets.
+  - **Matte Box** and **Filter** choices inject the selected system with any needed trays, clamp adapters or filters.
+  - **Monitoring Configuration**, **Video Distribution** and **Viewfinder** settings add monitors, cables and overlays for each role.
+  - **User Button** selections and **Tripod Preferences** are listed for quick reference.
+- Items inside each category are sorted alphabetically and display tooltips on hover.
+- The gear list is included in printable overviews and exported project files.
+- Gear lists save automatically with the project and are included in exported project files and backups.
+- **Delete Gear List** removes the saved list and hides the output.
+- Gear list forms provide fork buttons to duplicate user entries instantly.
 
-### 📦 Catégories d’appareils
-- **Caméra** (1)
-- **Moniteur** (optionnel)
-- **Transmetteur sans fil** (optionnel)
-- **Moteurs FIZ** (0–4)
-- **Contrôleurs FIZ** (0–4)
-- **Capteur de distance** (0–1)
-- **Plaque batterie** (uniquement sur les caméras compatibles V‑ ou B‑Mount)
-- **Batterie V‑Mount** (0–1)
+### 📦 Device Categories
+- **Camera** (1)
+- **Monitor** (optional)
+- **Wireless Transmitter** (optional)
+- **FIZ Motors** (0–4)
+- **FIZ Controllers** (0–4)
+- **Distance Sensor** (0–1)
+- **Battery Plate** (only on cameras that accept V‑ or B‑Mount)
+- **V‑Mount Battery** (0–1)
 
-### ⚙️ Calculs de puissance
-- Consommation totale en watts
-- Intensité à 14,4 V et 12 V
-- Autonomie estimée en heures via la moyenne pondérée des retours utilisateurs
-- Nombre de batteries nécessaires pour un tournage de 10 h (avec une de secours)
-- Note de température pour ajuster l’autonomie en conditions chaudes ou froides
+### ⚙️ Power Calculations
+- Total consumption in watts
+- Current draw at 14.4 V and 12 V
+- Estimated battery runtime in hours using weighted user feedback
+- Required battery count for a 10 h shoot (incl. spare)
+- Temperature note to adjust runtime for hot or cold conditions
 
-### 🔋 Vérification de la sortie batterie
-- Avertit si l’intensité dépasse la sortie de la batterie (pin ou D‑Tap)
-- Indique lorsque la consommation approche de la limite (80 % d’utilisation)
+### 🔋 Battery Output Check
+- Warns if current draw exceeds the battery output (Pin or D‑Tap)
+- Indicates when draw is close to the limit (80 % usage)
 
-### 📊 Comparaison des batteries (optionnel)
-- Compare les estimations d’autonomie de toutes les batteries
-- Graphiques à barres pour une lecture immédiate
+### 📊 Battery Comparison (optional)
+- Compare runtime estimates across all batteries
+- Visual bar graph for quick reference
 
-### 🖼 Diagramme du projet
-- Visualise les connexions d’alimentation et de vidéo des appareils sélectionnés.
-- Signale les marques FIZ incompatibles.
-- Faites glisser les nœuds pour réorganiser le schéma, zoomez avec les boutons et exportez le diagramme en SVG ou JPG.
-- Maintenez Shift enfoncé lors du clic sur Télécharger pour exporter une image JPG plutôt qu’un SVG.
-- Survolez ou touchez un appareil pour afficher sa fiche détaillée.
-- Utilise les icônes [OpenMoji](https://openmoji.org/) lorsqu’une connexion est disponible et se replie sur les emoji : 🔋 batterie, 🎥 caméra, 🖥️ moniteur, 📡 vidéo, ⚙️ moteur, 🎮 contrôleur, 📐 distance, 🎮 poignée et 🔌 plaque batterie.
+### 🖼 Project Diagram
+- Visualize power and video connections for the selected devices
+- Warns when FIZ brands are incompatible
+- Drag nodes to rearrange the layout, zoom with the buttons and download the diagram as SVG or JPG
+- Hold Shift while clicking Download to export a JPG snapshot instead of SVG
+- Hover or tap devices to see popup details
+- Uses [OpenMoji](https://openmoji.org/) icons when online, falling back to emoji:
+  🔋 battery, 🎥 camera, 🖥️ monitor, 📡 video, ⚙️ motor,
+  🎮 controller, 📐 distance, 🎮 handle and 🔌 battery plate
 
-### 🧮 Pondération des données d’autonomie
-- Les autonomies remontées par les utilisateurs affinent l’estimation.
-- Chaque saisie est ajustée en fonction de la température, en passant de ×1 à 25 °C à :
-  - ×1,25 à 0 °C
-  - ×1,6 à −10 °C
-  - ×2 à −20 °C
-- Les réglages caméra influencent la pondération :
-  - Multiplicateurs de résolution : ≥12K ×3, ≥8K ×2, ≥4K ×1,5, ≥1080p ×1 ; les résolutions inférieures sont ramenées à 1080p.
-  - La cadence est pondérée linéairement à partir de 24 i/s (ex. 48 i/s = ×2).
-  - Le Wi-Fi activé ajoute 10 %.
-  - Facteurs codecs : RAW/BRAW/ARRIRAW/R3D/CinemaDNG/Canon RAW/X‑OCN ×1 ; ProRes ×1,1 ; DNx/AVID ×1,2 ; All‑Intra ×1,3 ; H.264/AVC ×1,5 ; H.265/HEVC ×1,7.
-  - Les entrées moniteur en dessous de la luminosité spécifiée sont pondérées selon leur ratio de luminosité.
-- La pondération finale reflète la part de consommation de chaque appareil, de sorte que les projets similaires comptent davantage.
-- La moyenne pondérée est utilisée dès que trois entrées au minimum sont disponibles.
-- Un tableau de bord classe les mesures par poids et affiche le pourcentage associé pour comparer d’un coup d’œil.
+### 🧮 Runtime data weighting
+- User-submitted battery runtimes refine the runtime estimate.
+- Each entry is adjusted for temperature, scaling from ×1 at 25 °C to:
+  - ×1.25 at 0 °C
+  - ×1.6 at −10 °C
+  - ×2 at −20 °C
+- Camera settings influence the weight:
+  - Resolution multipliers: ≥12K ×3, ≥8K ×2, ≥4K ×1.5, ≥1080p ×1, lower scaled to 1080p
+  - Frame rate scales linearly from 24 fps (e.g. 48 fps = ×2)
+  - Wi‑Fi enabled adds 10 %
+  - Codec factors: RAW/BRAW/ARRIRAW/R3D/CinemaDNG/Canon RAW/X‑OCN ×1; ProRes ×1.1; DNx/AVID ×1.2; All‑Intra ×1.3; H.264/AVC ×1.5; H.265/HEVC ×1.7
+  - Monitor entries below the specified brightness are weighted by their brightness ratio
+- The final weight reflects each device's share of the total power draw, so matching projects count more.
+- The weighted average is used once at least three entries are available.
+- A dashboard orders entries by weight and displays each one's share percentage for quick comparison.
 
-### 🔍 Recherche et filtrage
-- Tapez dans les menus déroulants pour trouver rapidement une entrée.
-- Filtrez les listes d’appareils via un champ de recherche.
-- Utilisez la barre de recherche globale en haut pour rejoindre une fonctionnalité, un appareil ou un sujet d’aide ; appuyez sur Entrée pour naviguer, / ou Ctrl+K (⌘K sur macOS) pour la focaliser instantanément et Échap ou × pour effacer.
-- Appuyez sur « / » ou Ctrl+F (⌘F sur macOS) pour viser immédiatement le champ de recherche le plus proche.
-- Cliquez sur l’étoile à côté d’un sélecteur pour épingler vos favoris en haut de la liste et les synchroniser avec les sauvegardes.
+### 🔍 Search & Filtering
+- Type inside dropdowns to quickly find entries
+- Filter device lists with a search box
+- Use the global search bar at the top to jump to features, devices or help topics; press Enter to navigate, use / or Ctrl+K (⌘K on macOS) to focus it instantly and press Escape or × to clear.
+- Press '/' or Ctrl+F (⌘F on macOS) to focus the nearest search box instantly.
+- Click the star beside any selector to pin favourites so they stay at the top of the list and sync with backups.
 
-### 🛠 Éditeur de la base d’appareils
-- Ajoutez, modifiez ou supprimez des appareils dans toutes les catégories.
-- Importez ou exportez la base complète au format JSON.
-- Revenez à la base par défaut issue de `assets/data/index.js`.
+### 🛠 Device Database Editor
+- Add, edit or delete devices in all categories
+- Import or export the full database as JSON
+- Revert to the default database from `assets/data/index.js`
 
-### 🌓 Mode sombre
-- Activez-le via le bouton lune près du sélecteur de langue.
-- La préférence est mémorisée dans votre navigateur.
+### 🌓 Dark Mode
+- Toggle via the moon button next to the language selector.
+- Preference is stored in your browser.
 
-### 🦄 Mode rose
-- Cliquez sur le bouton licorne (le mode rose fait défiler des icônes de licorne toutes les 30 secondes avec une douce animation pop et revient au cheval lorsque vous quittez ce mode) ou appuyez sur **P** pour activer un accent rose ludique.
-- Fonctionne avec les thèmes clair et sombre et persiste entre les visites.
+### 🦄 Pink Mode
+- Click the unicorn button (pink mode cycles through unicorn icons every 30 seconds with a gentle pop animation and switches back to the horse icon when you leave the theme) or press **P** for a playful pink accent.
+- Works in both light and dark themes and persists between visits.
 
-### ⚫ Mode à fort contraste
-- Active un thème à contraste élevé pour améliorer la lisibilité.
+### ⚫ High Contrast Mode
+- Toggle a high contrast theme for improved readability.
 
-### 📝 Retours d’autonomie
-- Cliquez sur <strong>Soumettre un retour d’autonomie</strong> sous l’autonomie pour ajouter votre mesure.
-- Ajoutez la température pour une pondération plus précise.
-- Les entrées sont sauvegardées dans votre navigateur et affinent les estimations futures.
-- Un tableau de bord classe les retours selon leur poids, affiche les
-  pourcentages de contribution et met en évidence les valeurs atypiques pour que
-  l’équipe puisse analyser les données terrain en un clin d’œil.
+### 📝 User Runtime Feedback
+- Click <strong>Submit User Runtime Feedback</strong> below the runtime to add your own measurement.
+- Optionally include temperature for more accurate weighting.
+- Entries are saved in your browser and improve future estimates.
+- A dashboard orders submissions by weight, shows contribution percentages and
+  highlights outliers so crews can review field data quickly.
 
-### ❓ Aide avec recherche
-- Ouvrez-la via le bouton <strong>?</strong> ou avec <kbd>?</kbd>, <kbd>H</kbd>, <kbd>F1</kbd> ou <kbd>Ctrl+/</kbd>.
-- Utilisez le champ de recherche pour filtrer instantanément les sujets ; la requête est réinitialisée à la fermeture.
-- Fermez avec <kbd>Échap</kbd> ou en cliquant hors de la boîte de dialogue.
+### ❓ Searchable Help
+- Open via the <strong>?</strong> button or press <kbd>?</kbd>, <kbd>H</kbd>, <kbd>F1</kbd> or <kbd>Ctrl+/</kbd>.
+- Use the search field to filter topics instantly; the query resets when the dialog closes.
+- Close with <kbd>Escape</kbd> or by clicking outside the dialog.
 
 ---
 
-## ▶️ Mode d’emploi
-1. **Lancez l’application :** ouvrez `index.html` dans tout navigateur moderne – aucun serveur n’est requis.
-2. **Explorez la barre supérieure :** changez de langue, activez les thèmes sombre ou rose, ouvrez Paramètres pour régler l’accent et la typographie, et lancez l’aide avec ? ou Ctrl+/.
-3. **Sélectionnez les appareils :** choisissez l’équipement par catégorie via les menus déroulants ; saisissez pour filtrer, cliquez sur l’étoile pour épingler vos favoris et laissez les scénarios prédéfinis ajouter les accessoires automatiquement.
-4. **Consultez les calculs :** dès qu’une batterie est sélectionnée, la consommation, l’intensité et l’autonomie apparaissent ; des alertes signalent les limites dépassées.
-5. **Enregistrez et exportez les projets :** nommez et sauvegardez votre configuration, les sauvegardes automatiques capturent des instantanés et le bouton Exporter télécharge un bundle JSON pour vos partenaires tandis que le bouton Importer le restaure.
-6. **Générez la liste de matériel :** cliquez sur **Générer la liste de matériel** pour transformer les exigences en liste catégorisée avec infobulles et accessoires.
-7. **Gérez les données d’appareils :** choisissez « Modifier les données d’appareils… » pour ouvrir l’éditeur, ajuster les appareils, exporter/importer du JSON ou revenir aux valeurs par défaut.
-8. **Soumettez des retours d’autonomie :** utilisez « Soumettre un retour d’autonomie » pour enregistrer vos mesures terrain et enrichir la pondération.
+## ▶️ How to Use
+1. **Launch App:** Open `index.html` in any modern browser – no server required.
+2. **Explore the Top Bar:** Switch language, toggle dark or pink themes, open Settings for accent and typography options, and start the searchable help dialog with ? or Ctrl+/.
+3. **Select Devices:** Choose gear from each category using the dropdowns—type to filter, click the star to pin favourites and let scenario presets fill in accessories automatically.
+4. **View Calculations:** See total draw, current and runtime once a battery is selected; warnings highlight when output limits are exceeded.
+5. **Save & Export Projects:** Name and save your configuration, auto-backups capture snapshots, and the Export button downloads a JSON bundle for collaborators while the Import button restores them.
+6. **Generate Gear Lists:** Press **Generate Gear List** to turn project requirements into a categorized packing list with tooltips and accessory packs.
+7. **Manage Device Data:** Click “Edit Device Data…” to open the database editor, modify devices, export/import JSON or revert to the defaults.
+8. **Submit Runtime Feedback:** Use “Submit User Runtime Feedback” to record field measurements and refine weighted estimates.
 
-## 📱 Installer l’application
+## 📱 Install as an App
 
-Le planner est une application web progressive et peut être installée directement depuis le navigateur :
+The planner is a Progressive Web App and can be installed directly from your browser:
 
-- **Chrome/Edge (bureau) :** cliquez sur l’icône d’installation dans la barre d’adresse.
-- **Android :** ouvrez le menu du navigateur et choisissez *Ajouter à l’écran d’accueil*.
-- **iOS/iPadOS Safari :** touchez le bouton *Partager* puis *Ajouter à l’écran d’accueil*.
+- **Chrome/Edge (desktop):** Click the install icon in the address bar.
+- **Android:** Open the browser menu and choose *Add to Home Screen*.
+- **iOS/iPadOS Safari:** Tap the *Share* button and select *Add to Home Screen*.
 
-Une fois installée, l’application se lance depuis l’écran d’accueil, fonctionne hors ligne et se met à jour automatiquement.
+Once installed, the app launches from your home screen, works offline and updates itself automatically.
 
-## 📡 Utilisation hors ligne et stockage des données
+## 📡 Offline Use & Data Storage
 
-Servir l’application via HTTP(S) installe un service worker qui met chaque fichier en cache pour que Cine Power Planner fonctionne totalement hors ligne et se mette à jour en arrière-plan. Les projets, retours d’autonomie et préférences (langue, thème, mode rose et listes de matériel sauvegardées) sont stockés dans le `localStorage` du navigateur. Effacer les données du site supprime toutes les informations, et la boîte de dialogue Paramètres propose également un flux de **Réinitialisation d’usine** qui enregistre automatiquement une sauvegarde avant d’effectuer le même nettoyage complet.
-L’en-tête affiche un badge hors ligne dès que la connexion tombe, et l’action 🔄
-**Forcer le rechargement** actualise les fichiers mis en cache sans toucher aux
-projets enregistrés.
+Serving the app over HTTP(S) installs a service worker that caches every file
+so Cine Power Planner works fully offline and updates in the background. Projects,
+runtime submissions and preferences (language, theme, pink mode and saved gear
+lists) live in your browser's `localStorage`. Clearing the site's data in the
+browser removes all stored information, and the Settings dialog includes a
+**Factory reset** workflow that saves a backup automatically before clearing everything. The header shows an
+offline badge whenever connectivity drops, and the 🔄 **Force reload** action
+refreshes cached assets without disturbing saved projects.
 
 ---
 
-## 🗂️ Structure des fichiers
+## 🗂️ File Structure
 ```bash
-index.html                 # Mise en page HTML principale
-assets/css/style.css       # Styles et mise en page
-assets/css/overview.css    # Styles de l’aperçu imprimable
-assets/css/overview-print.css # Ajustements d’impression pour l’aperçu
-assets/js/script.js        # Logique applicative
-assets/js/storage.js       # Helpers LocalStorage
-assets/js/static-theme.js  # Logique de thème partagée pour les pages légales
-assets/data/index.js       # Liste d’appareils par défaut
-assets/data/devices/       # Catalogues d’appareils par catégorie
-assets/data/schema.json    # Schéma généré pour les sélecteurs
-assets/vendor/             # Bibliothèques tierces incluses
-legal/                     # Pages légales hors ligne
-tools/                     # Scripts de maintenance des données
-tests/                     # Suite de tests Jest
+index.html                 # Main HTML layout
+assets/css/style.css       # Core styles and layout
+assets/css/overview.css    # Printable overview styling
+assets/css/overview-print.css # Print overrides for the overview
+assets/js/script.js        # Application logic
+assets/js/storage.js       # LocalStorage helpers
+assets/js/static-theme.js  # Shared theme logic for legal pages
+assets/data/index.js       # Default device list
+assets/data/devices/       # Device catalogs by category
+assets/data/schema.json    # Generated schema for selectors
+assets/vendor/             # Bundled third-party libraries
+legal/                     # Offline legal documents
+tools/                     # Data maintenance scripts
+tests/                     # Jest test suite
 ```
-Les polices sont intégrées localement via `fonts.css`, ce qui permet à l’application de fonctionner entièrement hors ligne une fois les ressources en cache.
+Fonts are bundled locally via `fonts.css`, so once the assets are cached the application works entirely offline.
 
-## 🛠️ Développement
-Nécessite Node.js 18 ou version ultérieure.
+## 🛠️ Development
+Requires Node.js 18 or later.
 
 ```bash
 npm install
-npm run lint     # exécute uniquement ESLint
-npm test         # lance le linting, les vérifications de données et les tests Jest
+npm run lint     # run ESLint alone
+npm test         # runs linting, data checks and Jest tests
 ```
 
-Après modification des données d’appareils, régénérez la base normalisée :
+After editing device data, regenerate the normalized database:
 
 ```bash
 npm run normalize
@@ -307,11 +302,11 @@ npm run check-consistency
 npm run generate-schema
 ```
 
-Ajoutez `--help` à l’un de ces scripts pour afficher les options disponibles.
+Add `--help` to any of the above scripts for usage details.
 
-Exécutez `npm run help` pour afficher un résumé rapide des scripts de maintenance et de l’ordre recommandé.
+Run `npm run help` whenever you need a quick reminder of the maintenance commands and their suggested order.
 
-## 🤝 Contribuer
-Les contributions sont les bienvenues ! N’hésitez pas à ouvrir un ticket ou à proposer une pull request sur GitHub.
-Pour corriger des données, joindre des sauvegardes de projet ou des mesures
-d’autonomie aide à garder le catalogue fiable pour tout le monde.
+## 🤝 Contributing
+Contributions are welcome! Feel free to open an issue or submit a pull request on GitHub.
+When reporting data corrections, attaching project backups or runtime samples
+helps keep the catalog accurate for everyone.

--- a/README.it.md
+++ b/README.it.md
@@ -1,300 +1,299 @@
 # 🎥 Cine Power Planner
 
-Questo strumento basato sul browser aiuta a pianificare progetti camera professionali alimentati da batterie V‑Mount, B‑Mount o Gold-Mount. Calcola il **consumo energetico totale**, la **corrente assorbita** (a 14,4 V e 12 V) e l’**autonomia stimata della batteria**, verificando che il pacco possa erogare in sicurezza la potenza richiesta.
+This browser based tool helps plan professional camera projects powered by V‑Mount, B‑Mount or Gold-Mount batteries. It calculates **total power consumption**, **current draw** (at 14.4 V and 12 V) and **estimated battery runtime** while checking that the battery can safely supply the required power.
 
-Tutta la pianificazione, i dati inseriti e gli export restano sul dispositivo
-davanti a te. Lingua, progetti, dispositivi personalizzati, preferiti e feedback
-sulle autonomie sono salvati nel browser, e gli aggiornamenti del service worker
-arrivano direttamente da questo repository. Puoi avviare l’app offline dal
-disco oppure ospitarla internamente così che ogni reparto utilizzi la stessa
-versione verificata.
+All planning, inputs and exports stay on the device in front of you. Language
+choice, projects, custom equipment, favorites and runtime feedback live in your
+browser, and service worker updates are driven directly by this repository. Run
+the planner offline from disk or host it internally so every department uses the
+same audited version.
 
 ---
 
-## 🌍 Lingue
+## 🌍 Languages
 - 🇬🇧 [English](README.en.md)
 - 🇩🇪 [Deutsch](README.de.md)
 - 🇪🇸 [Español](README.es.md)
 - 🇮🇹 [Italiano](README.it.md)
 - 🇫🇷 [Français](README.fr.md)
 
-L’app usa automaticamente la lingua del browser al primo avvio e puoi cambiarla in alto a destra. La scelta viene ricordata per la visita successiva.
+The app automatically uses your browser language on first load, and you can switch the language in the top right corner. The choice is remembered for your next visit.
 
 ---
 
-## 🆕 Novità
-- I controlli di accento e tipografia nelle Impostazioni ti permettono di modificare il colore accento, la dimensione base del font e la famiglia tipografica insieme ai temi scuro, rosa e ad alto contrasto.
-- Le scorciatoie da tastiera per la ricerca globale consentono di premere / o Ctrl+K (⌘K su macOS) per focalizzarla all’istante, anche quando si trova nel menu laterale mobile compresso.
-- Il pulsante di ricarica forzata svuota i file memorizzati dal service worker così l’app offline si aggiorna senza cancellare progetti o dispositivi salvati.
-- Le icone a stella in ogni selettore fissano in alto le videocamere, le batterie e gli accessori preferiti e li includono nei backup.
-- Il flusso di **Ripristino di fabbrica** scarica automaticamente un backup prima di rimuovere progetti, dispositivi e impostazioni salvati.
-- La lista attrezzatura e l’anteprima stampabile mostrano il nome del progetto per un riferimento rapido.
-- Carica un logo personalizzato da usare nelle stampe e nei backup.
-- I backup includono i preferiti e creano una copia automatica prima del ripristino.
-- Le voci della troupe dispongono ora di un campo e-mail.
-- Tema ad alto contrasto per una leggibilità migliore.
-- I moduli dei dispositivi compilano dinamicamente le categorie in base agli attributi dello schema.
-- Interfaccia ridisegnata con più contrasto e spaziatura per un’esperienza più pulita su qualsiasi dispositivo.
-- Condividere i progetti è più semplice: scarica un file JSON che raggruppa selezioni, requisiti, liste attrezzatura, feedback di autonomia e dispositivi personalizzati, poi importalo per ripristinare tutto.
-- Icone dedicate per gli scenari obbligatori per riconoscere subito i requisiti del progetto.
-- Diagramma del progetto interattivo che consente di trascinare i dispositivi, fare zoom, allineare alla griglia ed esportare in SVG o JPG.
-- Tema rosa giocoso che resta attivo tra una visita e l’altra.
-- Finestra di aiuto ricercabile con sezioni passo-passo e FAQ; aprila con ?, H, F1 o Ctrl+/.
-- Suggerimenti contestuali al passaggio del mouse su pulsanti, campi, menu a discesa e intestazioni.
-- Barra di ricerca globale per raggiungere rapidamente funzioni, selettori di dispositivi o argomenti di aiuto.
-- Supporto per videocamere con piastre batteria V-, B- o Gold-Mount.
-- Invia feedback di autonomia indicando anche la temperatura per affinare le stime.
-- Dashboard visiva per la ponderazione delle autonomie che mostra l’influenza delle impostazioni su ogni misurazione, ordinata per peso con percentuali precise.
-- Genera liste attrezzatura che riassumono l’equipaggiamento selezionato e i requisiti del progetto.
-- Salva i requisiti di progetto con ogni configurazione così la lista attrezzatura mantiene tutto il contesto.
-- Duplica all’istante le voci personalizzate dei moduli della lista attrezzatura grazie ai pulsanti a forchetta.
+## 🆕 Recent Features
+- Accent and typography controls in Settings let you adjust the accent color, base font size and typeface alongside dark, pink and high contrast themes.
+- Keyboard shortcuts for the global search let you press / or Ctrl+K (⌘K on macOS) to focus the feature search instantly, even when it sits inside the collapsed mobile side menu.
+- Force reload button clears cached service worker files so the offline app refreshes without deleting saved projects or devices.
+- Star icons in every selector pin favorite cameras, batteries and accessories to the top of the list and keep them in backups.
+- Factory reset workflow automatically downloads a backup before wiping stored projects, custom devices and settings.
+- Gear list and printable overview display the project name for quick reference.
+- Upload a custom logo for printed overviews and backups.
+- Backups include favorites and create an automatic backup before restore.
+- Crew list entries now feature an email field.
+- High contrast theme option for improved readability.
+- Device forms populate category fields dynamically based on schema attributes.
+- Revamped interface design with improved contrast and spacing for a cleaner experience on any device.
+- Simplified project sharing – download a JSON project file that bundles selections, requirements, gear lists, runtime feedback and custom devices, then load it to restore the full setup.
+- Unique icons for required scenarios to distinguish project requirements.
+- Interactive project diagram that lets you drag devices, zoom, snap nodes to a grid and export the layout as SVG or JPG.
+- Playful pink accent theme that persists between visits.
+- Searchable help dialog with step-by-step sections and a FAQ; open with ?, H, F1 or Ctrl+/.
+- Contextual hover help for buttons, fields, dropdowns and headers.
+- Global search bar to jump to features, device selectors or help topics.
+- Support for cameras with V-, B- or Gold-Mount battery plates.
+- Submit user runtime feedback with temperature for better estimates.
+- Visual runtime weighting dashboard to inspect how settings influence each report, now sorted by weight and showing exact share percentages.
+- Generate gear lists to compile selected gear and project requirements.
+- Save project requirements with each project so gear lists retain full context.
+- Duplicate user entries in gear list forms using fork buttons to copy fields instantly.
 
 ---
 
-## 🔧 Funzionalità
+## 🔧 Features
 
-### ✨ Punti salienti aggiuntivi
+### ✨ Expanded highlights
 
-- **Progetta rig complessi senza tentativi.** Combina camere, piastre batteria,
-  link wireless, monitor, motori e accessori vedendo consumo totale a
-  14,4 V/12 V (e 33,6 V/21,6 V per B‑Mount) con autonomie realistiche basate su
-  dati di campo ponderati. Il pannello di confronto batterie segnala le
-  sovratensioni prima di preparare l’attrezzatura sbagliata.
-- **Mantieni allineati tutti i reparti.** Salva più progetti con requisiti,
-  contatti della troupe, scenari e note. Le liste stampabili raggruppano il
-  materiale per categoria, uniscono i duplicati, mostrano metadati tecnici e
-  includono accessori legati agli scenari così che camera, luce e grip condividano
-  lo stesso contesto.
-- **Lavora in tranquillità ovunque.** Apri `index.html` direttamente o servi la
-  cartella via HTTPS per attivare il service worker. La cache offline conserva
-  lingua, temi, preferiti e progetti, e **Forza ricarica** aggiorna gli asset
-  senza toccare i dati salvati.
-- **Adatta il planner alla tua troupe.** Passa subito tra italiano, inglese,
-  tedesco, spagnolo e francese, regola dimensione e font, scegli un colore
-  accento personalizzato, carica un logo per la stampa e alterna tema chiaro,
-  scuro, rosa o ad alto contrasto. I menu con ricerca, i preferiti fissati, i
-  pulsanti di duplicazione e le guide contestuali mantengono il ritmo sul set.
+- **Build complex rigs without guesswork.** Combine cameras, battery plates,
+  wireless links, monitors, motors and accessories while tracking total draw at
+  14.4 V/12 V (and 33.6 V/21.6 V for B‑Mount) plus realistic runtimes from
+  weighted field data. The battery comparison panel flags overloads before the
+  wrong kit goes on the truck.
+- **Keep every department aligned.** Save multiple projects with requirements,
+  crew contacts, scenarios and notes. Printable gear lists group equipment by
+  category, merge duplicates, surface technical metadata and include
+  scenario-driven accessories so camera, lighting and grip teams stay synced.
+- **Work confidently anywhere.** Open `index.html` directly or serve the folder
+  over HTTPS to enable the service worker. Offline caching preserves language,
+  themes, favorites and projects, and **Force reload** refreshes cached assets
+  without touching stored data.
+- **Tailor the planner to your crew.** Switch instantly between English,
+  Deutsch, Español, Italiano and Français, adjust font size and typeface, pick a
+  custom accent color, upload a print logo and toggle dark, pink or
+  high-contrast themes. Type-to-search selectors, pinned favorites, fork buttons
+  and hover help keep on-set workflows fast.
 
-### ✅ Gestione dei progetti
-- Salva, carica e cancella più progetti camera (premi Invio o Ctrl+S/⌘S per salvare rapidamente; il pulsante Salva resta disattivato finché non inserisci un nome).
-- Vengono creati automaticamente snapshot ogni 10 minuti mentre il planner è aperto e dalla finestra Impostazioni puoi attivare esportazioni di backup orarie come promemoria.
-- Scarica un file JSON che raccoglie selezioni, requisiti, lista attrezzatura, feedback di autonomia e dispositivi personalizzati; importalo dal selettore Importa progetto per ripristinare tutto in un passaggio.
-- I dati sono archiviati localmente tramite `localStorage` e i preferiti vengono conservati nei backup; usa l'opzione **Ripristino di fabbrica** nelle Impostazioni per salvare automaticamente un backup prima di eliminare progetti e modifiche ai dispositivi memorizzati.
-- Genera anteprime stampabili per ogni progetto salvato e aggiungi un logo personalizzato così esportazioni e backup rispettano l’identità della produzione.
-- Salva i requisiti di progetto insieme a ciascun progetto, così la lista attrezzatura mantiene il contesto completo.
-- Funziona completamente offline grazie al service worker installato: lingua, tema, dati dei dispositivi e preferiti persistono tra le sessioni.
-- Layout responsive che si adatta senza sforzo a desktop, tablet e smartphone.
-- Sulle videocamere compatibili scegli piastre **V‑Mount**, **B‑Mount** o **Gold-Mount**; l’elenco batterie si aggiorna automaticamente.
+### ✅ Project Management
+- Save, load and delete multiple camera projects (press Enter or Ctrl+S/⌘S to save quickly; the Save button stays disabled until a name is entered).
+- Automatic snapshots are created every 10 minutes while the planner is open, and the Settings dialog can trigger hourly backup exports as a reminder to archive data.
+- Download a JSON project file that bundles selections, requirements, gear lists, runtime feedback and custom devices; load it through the Import Project picker to restore everything in one step.
+- Data is stored locally via `localStorage` and favorites are preserved in backups; use the **Factory reset** option in Settings to capture a backup automatically before wiping cached projects and device edits.
+- Generate printable overviews for any saved project and add a custom logo so exports and backups match your production branding.
+- Save project requirements along with each project so gear lists retain full context.
+- Works fully offline with the installed service worker—language, theme, device data and favorites persist between sessions.
+- Responsive layout adapts seamlessly across desktops, tablets and phones.
+- Choose **V‑Mount**, **B‑Mount** or **Gold‑Mount** plates on supported cameras; the battery list adapts automatically.
 
-### 🧭 Panoramica dell’interfaccia
-- **Promemoria rapido:**
-  - **Ricerca globale** (`/` o `Ctrl+K`/`⌘K`) salta a funzioni, selettori o
-    argomenti di aiuto anche quando il menu laterale è compresso.
-  - **Centro assistenza** (`?`, `H`, `F1` o `Ctrl+/`) propone guide filtrabili,
-    FAQ, scorciatoie e la modalità di aiuto al passaggio del mouse.
-  - **Diagramma del progetto** visualizza le connessioni; tieni premuto Maiusc
-    durante il download per salvare un JPG invece di un SVG e vedere gli avvisi
-    di compatibilità.
-  - **Confronto batterie** mostra come si comportano i pacchi compatibili e
-    evidenzia subito i rischi di sovraccarico.
-  - **Generatore di liste** produce tabelle per categoria con metadati, e-mail
-    della troupe e aggiunte basate sugli scenari pronte per la stampa.
-  - **Badge offline e Forza ricarica** indicano lo stato della connessione e
-    aggiornano i file in cache senza eliminare i progetti.
-- Un collegamento di salto e un indicatore offline mantengono il layout accessibile con tastiera e tocco; il badge appare ogni volta che il browser perde la connessione.
-- La barra di ricerca globale consente di saltare a funzioni, selettori di dispositivi o argomenti di aiuto; premi Invio per attivare il risultato evidenziato, usa / o Ctrl+K (⌘K su macOS) per focalizzarla subito (sugli schermi piccoli il menu laterale si apre in automatico) e premi Esc o × per cancellare la ricerca.
-- I controlli della barra superiore offrono cambio lingua, temi scuro e rosa e la finestra Impostazioni con colore accento, dimensione e famiglia del font, modalità ad alto contrasto e caricamento del logo, oltre agli strumenti di backup, ripristino e Ripristino di fabbrica che salvano automaticamente un backup prima di cancellare i dati.
-- Il pulsante di aiuto apre un dialogo ricercabile con sezioni guidate, scorciatoie da tastiera, FAQ e una modalità di suggerimenti al passaggio del mouse; si può aprire anche con ?, H, F1 o Ctrl+/ mentre digiti.
-- Il pulsante di ricarica forzata (🔄) cancella i file del service worker in cache così l’app offline si aggiorna senza perdere progetti o dispositivi.
-- Sugli schermi più piccoli un menu laterale a scomparsa replica ogni sezione principale per navigare rapidamente.
+### 🧭 Interface Overview
+- **Quick reference:**
+  - **Global search** (`/` or `Ctrl+K`/`⌘K`) jumps to features, selectors or help
+    topics even when the side drawer is collapsed.
+  - **Help center** (`?`, `H`, `F1` or `Ctrl+/`) surfaces searchable guides,
+    FAQs, shortcuts and the optional hover-help mode.
+  - **Project diagram** visualizes connections; hold Shift when downloading to
+    save a JPG snapshot instead of SVG while seeing compatibility notices.
+  - **Battery comparison** reveals how compatible packs perform and highlights
+    overload risks before call time.
+  - **Gear list generator** outputs categorized tables with metadata, crew
+    emails and scenario-driven accessories ready for print or PDF.
+  - **Offline badge & Force reload** show connectivity status and refresh cached
+    assets without clearing projects.
+- A skip link and offline indicator keep the layout accessible on keyboard and touch devices—the badge appears whenever the browser loses its connection.
+- The global search bar jumps to features, device selectors or help topics; press Enter to activate the highlighted result, use / or Ctrl+K (⌘K on macOS) to focus it from anywhere (the side menu opens automatically on small screens) and press Escape or tap × to clear the query.
+- Top bar controls provide language switching, dark and pink theme toggles plus a Settings dialog that exposes accent color, font size, font family, high contrast and custom logo uploads alongside backup, restore and Factory reset tools that back up data before wiping it.
+- The Help button opens a searchable dialog with step-by-step sections, keyboard shortcuts, FAQs and an optional hover-help mode; it can also be triggered with ?, H, F1 or Ctrl+/ even while typing.
+- The Force reload button (🔄) clears cached service worker files so the offline app updates without deleting saved projects or custom devices.
+- On smaller screens a collapsible side menu mirrors every major section for quick navigation.
 
-### ♿ Personalizzazione e accessibilità
-- Le preferenze di tema includono modalità scura, accento rosa giocoso e un interruttore dedicato ad alto contrasto per migliorare la leggibilità.
-- Le modifiche al colore accento, alla dimensione base del font e alla famiglia tipografica si applicano all’istante e restano nel browser, ideali per rispettare il brand o esigenze di accessibilità.
-- Le scorciatoie integrate coprono ricerca globale (/ o Ctrl+K/⌘K), aiuto ( ?, H, F1, Ctrl+/ ), salvataggio (Invio o Ctrl+S/⌘S), modalità scura (D) e modalità rosa (P).
-- La modalità di aiuto al passaggio del mouse trasforma pulsanti, campi, menu e intestazioni in tooltip su richiesta, così chi è nuovo impara più velocemente.
-- Gli input con ricerca incrementale, i controlli con focus visibile e le icone a stella accanto ai selettori permettono di filtrare elenchi lunghi e fissare i preferiti in cima.
-- Carica un logo personalizzato per le stampe, configura i ruoli di monitoraggio
-  predefiniti e regola i preset dei requisiti di progetto affinché gli export
-  rispettino l’identità della produzione.
-- I pulsanti di duplicazione replicano subito le righe dei moduli e i preferiti
-  pinnati mantengono l’attrezzatura abituale in cima ai selettori, utile quando
-  il tempo sul set è limitato.
+### ♿ Customization & Accessibility
+- Theme preferences include dark mode, playful pink accents and a dedicated high contrast switch for improved readability.
+- Accent color, base font size and typeface changes apply instantly and persist in the browser, letting you match studio branding or accessibility needs.
+- Built-in keyboard shortcuts cover global search (/ or Ctrl+K/⌘K), help ( ?, H, F1, Ctrl+/ ), saving (Enter or Ctrl+S/⌘S), dark mode (D) and pink mode (P).
+- Hover-help mode turns every button, field, dropdown and header into an on-demand tooltip so new users can learn the interface quickly.
+- Type-to-search inputs, focus-visible controls and star icons beside selectors let you filter long lists quickly and pin favourite devices to the top.
+- Upload a custom logo for printouts, configure default monitoring roles and tweak project requirement presets so exports match your production branding.
+- Fork buttons duplicate gear list rows instantly, and pinned favourites keep go-to equipment at the top of selectors for faster data entry on set.
 
-### 📋 Lista attrezzatura
-Il generatore converte le tue scelte in una lista di carico categorizzata:
+### 📋 Gear List
+The generator turns your selections into a categorized packing list:
 
-- Clicca **Genera lista attrezzatura** per raccogliere l’equipaggiamento selezionato e i requisiti del progetto in una tabella.
-- La tabella si aggiorna automaticamente quando cambiano selezioni e requisiti.
-- Gli elementi sono raggruppati per categoria (camera, ottiche, alimentazione, monitoraggio, rigging, grip, accessori, consumabili) e i duplicati vengono uniti con la rispettiva quantità.
-- Cavi, rigging e accessori necessari per monitor, motori, gimbal e scenari meteo vengono aggiunti automaticamente.
-- Le selezioni degli scenari aggiungono l’attrezzatura correlata:
-  - *Handheld* + *Easyrig* inserisce una maniglia telescopica per un supporto stabile.
-  - *Gimbal* aggiunge il gimbal scelto, bracci articolati, spigot e paraluce o kit filtri.
-  - *Outdoor* fornisce spigot, ombrelli e coperture antipioggia CapIt.
-  - Gli scenari *Vehicle* e *Steadicam* includono staffe, bracci di isolamento e ventose quando necessari.
-- Le selezioni delle ottiche riportano diametro frontale, peso, dati dei rod e fuoco minimo, aggiungono supporti per lenti e adattatori matte box e avvisano sugli standard di rod incompatibili.
-- Le righe delle batterie rispecchiano i conteggi del calcolatore di potenza e includono piastre o dispositivi di *hotswap* quando richiesti.
-- Le preferenze di monitoraggio assegnano monitor predefiniti per ogni ruolo (regista, DoP, fuochista, ecc.) con set di cavi e ricevitori wireless.
-- Il modulo **Requisiti del progetto** alimenta la lista:
-  - **Nome del progetto**, **casa di produzione**, **noleggio** e **DoP** compaiono nell’intestazione delle specifiche stampate.
-  - Le voci **Troupe** raccolgono nomi, ruoli e indirizzi e-mail così i contatti viaggiano con il progetto.
-  - **Giorni di preparazione** e **giorni di ripresa** aggiungono note di pianificazione e, con scenari outdoor, suggeriscono attrezzatura per il meteo.
-  - Gli **scenari obbligatori** inseriscono rigging, gimbal e protezioni climatiche adeguati.
-  - **Impugnatura camera** ed **estensione mirino** inseriscono i componenti selezionati o i relativi supporti.
-  - Le opzioni di **matte box** e **filtri** aggiungono il sistema scelto con cassetti, adattatori a clamp o filtri necessari.
-  - Le configurazioni di **monitoraggio**, **distribuzione video** e **mirino** aggiungono monitor, cavi e overlay per ciascun ruolo.
-  - Le scelte dei **pulsanti personalizzati** e delle **preferenze treppiede** vengono elencate per riferimento rapido.
-- Gli elementi di ogni categoria sono ordinati alfabeticamente e mostrano un tooltip al passaggio del mouse.
-- La lista attrezzatura viene inclusa nelle anteprime stampabili e nei file di progetto esportati.
-- Le liste vengono salvate automaticamente con il progetto e fanno parte sia dei file esportati sia dei backup.
-- **Elimina lista attrezzatura** cancella la lista salvata e nasconde l’output.
-- I moduli della lista attrezzatura includono pulsanti a forchetta per duplicare al volo le voci inserite.
+- Click **Generate Gear List** to compile chosen gear and project requirements into a table.
+- The table updates automatically when device selections or requirements change.
+- Items are grouped by category (camera, lens, power, monitoring, rigging, grip, accessories, consumables) and duplicates are merged with counts.
+- Required cables, rigging and accessories are added for monitors, motors, gimbals and weather scenarios.
+- Scenario selections inject related gear:
+  - *Handheld* + *Easyrig* inserts a telescopic handle for stable support.
+  - *Gimbal* adds the selected gimbal, friction arms, spigots and sunshades or filter kits.
+  - *Outdoor* supplies spigots, umbrellas and CapIt rain covers.
+  - *Vehicle* and *Steadicam* scenarios pack in mounts, isolation arms and suction gear where applicable.
+- Lens selections append front diameter, weight, rod data and minimum focus, add lens supports and matte box adapters, and warn about incompatible rod standards.
+- Battery rows mirror counts from the power calculator and include hotswap plates or chosen hotswap devices when required.
+- Monitoring preferences assign default monitors for each role (Director, DoP, Focus, etc.) with cable sets and wireless receivers.
+- The **Project Requirements** form feeds the list:
+  - **Project Name**, **Production Company**, **Rental House** and **DoP** appear in the heading of the printed requirements.
+  - **Crew** entries capture names, roles and email addresses so contact info travels with the project.
+  - **Prep Days** and **Shooting Days** supply schedule notes and, when paired with outdoor scenarios, suggest weather gear.
+  - **Required Scenarios** append matching rigging, gimbals and weather protection.
+  - **Camera Handle** and **Viewfinder Extension** insert the chosen handle parts or extension brackets.
+  - **Matte Box** and **Filter** choices inject the selected system with any needed trays, clamp adapters or filters.
+  - **Monitoring Configuration**, **Video Distribution** and **Viewfinder** settings add monitors, cables and overlays for each role.
+  - **User Button** selections and **Tripod Preferences** are listed for quick reference.
+- Items inside each category are sorted alphabetically and display tooltips on hover.
+- The gear list is included in printable overviews and exported project files.
+- Gear lists save automatically with the project and are included in exported project files and backups.
+- **Delete Gear List** removes the saved list and hides the output.
+- Gear list forms provide fork buttons to duplicate user entries instantly.
 
-### 📦 Categorie dei dispositivi
+### 📦 Device Categories
 - **Camera** (1)
-- **Monitor** (opzionale)
-- **Trasmettitore wireless** (opzionale)
-- **Motori FIZ** (0–4)
-- **Controller FIZ** (0–4)
-- **Sensore di distanza** (0–1)
-- **Piastra batteria** (solo sulle camere compatibili con V‑ o B‑Mount)
-- **Batteria V‑Mount** (0–1)
+- **Monitor** (optional)
+- **Wireless Transmitter** (optional)
+- **FIZ Motors** (0–4)
+- **FIZ Controllers** (0–4)
+- **Distance Sensor** (0–1)
+- **Battery Plate** (only on cameras that accept V‑ or B‑Mount)
+- **V‑Mount Battery** (0–1)
 
-### ⚙️ Calcoli di potenza
-- Consumo totale in watt
-- Corrente a 14,4 V e 12 V
-- Autonomia stimata in ore utilizzando la media ponderata dei feedback degli utenti
-- Numero di batterie necessario per un giorno di riprese di 10 h (inclusa la riserva)
-- Nota sulla temperatura per adattare l’autonomia in condizioni calde o fredde
+### ⚙️ Power Calculations
+- Total consumption in watts
+- Current draw at 14.4 V and 12 V
+- Estimated battery runtime in hours using weighted user feedback
+- Required battery count for a 10 h shoot (incl. spare)
+- Temperature note to adjust runtime for hot or cold conditions
 
-### 🔋 Controllo dell’erogazione della batteria
-- Avvisa se la corrente richiesta supera l’uscita della batteria (pin o D‑Tap)
-- Indica quando il carico si avvicina al limite (80 % di utilizzo)
+### 🔋 Battery Output Check
+- Warns if current draw exceeds the battery output (Pin or D‑Tap)
+- Indicates when draw is close to the limit (80 % usage)
 
-### 📊 Confronto batterie (opzionale)
-- Confronta le stime di autonomia fra tutte le batterie
-- Grafici a barre per un colpo d’occhio immediato
+### 📊 Battery Comparison (optional)
+- Compare runtime estimates across all batteries
+- Visual bar graph for quick reference
 
-### 🖼 Diagramma del progetto
-- Visualizza le connessioni di alimentazione e video dei dispositivi selezionati.
-- Avvisa quando i brand FIZ non sono compatibili.
-- Trascina i nodi per riordinare il layout, usa i pulsanti per zoomare ed esporta il diagramma in SVG o JPG.
-- Tieni premuto Shift mentre fai clic su Download per esportare uno snapshot JPG invece di un SVG.
-- Passa il mouse o tocca un dispositivo per vedere i dettagli nel popup.
-- Utilizza le icone [OpenMoji](https://openmoji.org/) quando la connessione è attiva e ripiega sugli emoji: 🔋 batteria, 🎥 camera, 🖥️ monitor, 📡 video, ⚙️ motore, 🎮 controller, 📐 distanza, 🎮 impugnatura e 🔌 piastra batteria.
+### 🖼 Project Diagram
+- Visualize power and video connections for the selected devices
+- Warns when FIZ brands are incompatible
+- Drag nodes to rearrange the layout, zoom with the buttons and download the diagram as SVG or JPG
+- Hold Shift while clicking Download to export a JPG snapshot instead of SVG
+- Hover or tap devices to see popup details
+- Uses [OpenMoji](https://openmoji.org/) icons when online, falling back to emoji:
+  🔋 battery, 🎥 camera, 🖥️ monitor, 📡 video, ⚙️ motor,
+  🎮 controller, 📐 distance, 🎮 handle and 🔌 battery plate
 
-### 🧮 Ponderazione dei dati di autonomia
-- I feedback di autonomia inviati dagli utenti migliorano la stima finale.
-- Ogni voce viene corretta in base alla temperatura, passando da ×1 a 25 °C a:
-  - ×1,25 a 0 °C
-  - ×1,6 a −10 °C
-  - ×2 a −20 °C
-- Le impostazioni della camera influenzano il peso:
-  - Moltiplicatori di risoluzione: ≥12K ×3, ≥8K ×2, ≥4K ×1,5, ≥1080p ×1; risoluzioni inferiori scalate a 1080p.
-  - Il frame rate scala linearmente da 24 fps (es. 48 fps = ×2).
-  - Il Wi‑Fi attivo aggiunge il 10 %.
-  - Fattori codec: RAW/BRAW/ARRIRAW/R3D/CinemaDNG/Canon RAW/X‑OCN ×1; ProRes ×1,1; DNx/AVID ×1,2; All‑Intra ×1,3; H.264/AVC ×1,5; H.265/HEVC ×1,7.
-  - Le voci dei monitor sotto la luminosità specificata vengono pesate secondo il loro rapporto di luminosità.
-- Il peso finale riflette la quota di assorbimento di ciascun dispositivo, così i progetti simili contano di più.
-- La media ponderata viene applicata quando sono disponibili almeno tre voci.
-- Una dashboard ordina i contributi per peso e mostra la percentuale di ciascuno per un confronto immediato.
+### 🧮 Runtime data weighting
+- User-submitted battery runtimes refine the runtime estimate.
+- Each entry is adjusted for temperature, scaling from ×1 at 25 °C to:
+  - ×1.25 at 0 °C
+  - ×1.6 at −10 °C
+  - ×2 at −20 °C
+- Camera settings influence the weight:
+  - Resolution multipliers: ≥12K ×3, ≥8K ×2, ≥4K ×1.5, ≥1080p ×1, lower scaled to 1080p
+  - Frame rate scales linearly from 24 fps (e.g. 48 fps = ×2)
+  - Wi‑Fi enabled adds 10 %
+  - Codec factors: RAW/BRAW/ARRIRAW/R3D/CinemaDNG/Canon RAW/X‑OCN ×1; ProRes ×1.1; DNx/AVID ×1.2; All‑Intra ×1.3; H.264/AVC ×1.5; H.265/HEVC ×1.7
+  - Monitor entries below the specified brightness are weighted by their brightness ratio
+- The final weight reflects each device's share of the total power draw, so matching projects count more.
+- The weighted average is used once at least three entries are available.
+- A dashboard orders entries by weight and displays each one's share percentage for quick comparison.
 
-### 🔍 Ricerca e filtri
-- Digita nei menu a discesa per trovare rapidamente un elemento.
-- Filtra le liste di dispositivi tramite un campo di ricerca.
-- Usa la barra di ricerca globale in alto per saltare a funzioni, dispositivi o argomenti di aiuto; premi Invio per navigare, / o Ctrl+K (⌘K su macOS) per focalizzarla al volo e Esc o × per cancellare.
-- Premi “/” o Ctrl+F (⌘F su macOS) per portare subito il focus sul campo di ricerca più vicino.
-- Clicca sulla stella accanto a qualsiasi selettore per fissare i preferiti in cima e sincronizzarli con i backup.
+### 🔍 Search & Filtering
+- Type inside dropdowns to quickly find entries
+- Filter device lists with a search box
+- Use the global search bar at the top to jump to features, devices or help topics; press Enter to navigate, use / or Ctrl+K (⌘K on macOS) to focus it instantly and press Escape or × to clear.
+- Press '/' or Ctrl+F (⌘F on macOS) to focus the nearest search box instantly.
+- Click the star beside any selector to pin favourites so they stay at the top of the list and sync with backups.
 
-### 🛠 Editor del database dispositivi
-- Aggiungi, modifica o elimina dispositivi in tutte le categorie.
-- Importa o esporta l’intero database in formato JSON.
-- Ripristina il database predefinito da `assets/data/index.js`.
+### 🛠 Device Database Editor
+- Add, edit or delete devices in all categories
+- Import or export the full database as JSON
+- Revert to the default database from `assets/data/index.js`
 
-### 🌓 Modalità scura
-- Attivala con il pulsante a forma di luna accanto al selettore della lingua.
-- La preferenza viene salvata nel browser.
+### 🌓 Dark Mode
+- Toggle via the moon button next to the language selector.
+- Preference is stored in your browser.
 
-### 🦄 Modalità rosa
-- Clicca sul pulsante con l'unicorno (la modalità rosa fa ruotare le icone dell'unicorno ogni 30 secondi con una delicata animazione pop e torna al cavallo quando disattivi il tema) o premi **P** per attivare un accento rosa giocoso.
-- Funziona sia nel tema chiaro sia in quello scuro e resta attiva tra una visita e l’altra.
+### 🦄 Pink Mode
+- Click the unicorn button (pink mode cycles through unicorn icons every 30 seconds with a gentle pop animation and switches back to the horse icon when you leave the theme) or press **P** for a playful pink accent.
+- Works in both light and dark themes and persists between visits.
 
-### ⚫ Modalità ad alto contrasto
-- Attiva un tema ad alto contrasto per una migliore leggibilità.
+### ⚫ High Contrast Mode
+- Toggle a high contrast theme for improved readability.
 
-### 📝 Feedback di autonomia
-- Clicca su <strong>Invia feedback di autonomia</strong> sotto alla stima per aggiungere la tua misurazione.
-- Includi la temperatura per una ponderazione più accurata.
-- Le voci vengono salvate nel browser e migliorano le stime future.
-- Un cruscotto dedicato ordina i contributi in base al peso, mostra le
-  percentuali di contributo e mette in evidenza gli outlier per valutare
-  rapidamente i dati di campo.
+### 📝 User Runtime Feedback
+- Click <strong>Submit User Runtime Feedback</strong> below the runtime to add your own measurement.
+- Optionally include temperature for more accurate weighting.
+- Entries are saved in your browser and improve future estimates.
+- A dashboard orders submissions by weight, shows contribution percentages and
+  highlights outliers so crews can review field data quickly.
 
-### ❓ Aiuto ricercabile
-- Aprilo tramite il pulsante <strong>?</strong> oppure con <kbd>?</kbd>, <kbd>H</kbd>, <kbd>F1</kbd> o <kbd>Ctrl+/</kbd>.
-- Usa il campo di ricerca per filtrare subito gli argomenti; la query viene azzerata alla chiusura.
-- Chiudi con <kbd>Esc</kbd> o cliccando all’esterno della finestra.
-
----
-
-## ▶️ Come usarlo
-1. **Avvia l’app:** apri `index.html` in un browser moderno: non serve alcun server.
-2. **Esplora la barra superiore:** cambia lingua, alterna i temi scuro o rosa, apri Impostazioni per regolare accento e tipografia e avvia l’aiuto con ? o Ctrl+/.
-3. **Seleziona i dispositivi:** scegli l’attrezzatura per ogni categoria dai menu a discesa; digita per filtrare, clicca sulla stella per fissare i preferiti e lascia che gli scenari preconfigurati aggiungano automaticamente gli accessori.
-4. **Consulta i calcoli:** una volta selezionata la batteria vedrai consumo, corrente e autonomia; gli avvisi evidenziano eventuali superamenti dei limiti.
-5. **Salva ed esporta i progetti:** assegna un nome e salva la configurazione, i backup automatici creano snapshot e il pulsante Esporta scarica un bundle JSON per la troupe mentre Importa lo ripristina.
-6. **Genera la lista attrezzatura:** premi **Genera lista attrezzatura** per trasformare i requisiti in una lista categorizzata con tooltip e accessori.
-7. **Gestisci i dati dei dispositivi:** clicca su “Modifica dati dispositivi…” per aprire l’editor, aggiornare i dispositivi, esportare/importare JSON o tornare ai valori predefiniti.
-8. **Invia feedback di autonomia:** usa “Invia feedback di autonomia” per registrare misurazioni reali e raffinare le medie ponderate.
-
-## 📱 Installare come app
-
-Il planner è una Progressive Web App e può essere installato direttamente dal browser:
-
-- **Chrome/Edge (desktop):** fai clic sull’icona di installazione nella barra degli indirizzi.
-- **Android:** apri il menu del browser e scegli *Aggiungi alla schermata Home*.
-- **iOS/iPadOS Safari:** tocca *Condividi* e seleziona *Aggiungi alla schermata Home*.
-
-Una volta installata, l’app si avvia dalla schermata Home, funziona offline e si aggiorna automaticamente.
-
-## 📡 Uso offline e archiviazione dati
-
-Servire l’app tramite HTTP(S) installa un service worker che memorizza in cache ogni file, così Cine Power Planner funziona completamente offline e si aggiorna in background. Progetti, feedback di autonomia e preferenze (lingua, tema, modalità rosa e liste attrezzatura salvate) vivono nel `localStorage` del browser. Cancellare i dati del sito elimina tutte le informazioni e nella finestra Impostazioni è disponibile anche il flusso di **Ripristino di fabbrica**, che salva automaticamente un backup prima di eseguire lo stesso azzeramento completo.
-L’intestazione mostra un badge offline non appena cade la connessione, e l’azione
-🔄 **Forza ricarica** aggiorna i file in cache senza toccare i progetti salvati.
+### ❓ Searchable Help
+- Open via the <strong>?</strong> button or press <kbd>?</kbd>, <kbd>H</kbd>, <kbd>F1</kbd> or <kbd>Ctrl+/</kbd>.
+- Use the search field to filter topics instantly; the query resets when the dialog closes.
+- Close with <kbd>Escape</kbd> or by clicking outside the dialog.
 
 ---
 
-## 🗂️ Struttura dei file
+## ▶️ How to Use
+1. **Launch App:** Open `index.html` in any modern browser – no server required.
+2. **Explore the Top Bar:** Switch language, toggle dark or pink themes, open Settings for accent and typography options, and start the searchable help dialog with ? or Ctrl+/.
+3. **Select Devices:** Choose gear from each category using the dropdowns—type to filter, click the star to pin favourites and let scenario presets fill in accessories automatically.
+4. **View Calculations:** See total draw, current and runtime once a battery is selected; warnings highlight when output limits are exceeded.
+5. **Save & Export Projects:** Name and save your configuration, auto-backups capture snapshots, and the Export button downloads a JSON bundle for collaborators while the Import button restores them.
+6. **Generate Gear Lists:** Press **Generate Gear List** to turn project requirements into a categorized packing list with tooltips and accessory packs.
+7. **Manage Device Data:** Click “Edit Device Data…” to open the database editor, modify devices, export/import JSON or revert to the defaults.
+8. **Submit Runtime Feedback:** Use “Submit User Runtime Feedback” to record field measurements and refine weighted estimates.
+
+## 📱 Install as an App
+
+The planner is a Progressive Web App and can be installed directly from your browser:
+
+- **Chrome/Edge (desktop):** Click the install icon in the address bar.
+- **Android:** Open the browser menu and choose *Add to Home Screen*.
+- **iOS/iPadOS Safari:** Tap the *Share* button and select *Add to Home Screen*.
+
+Once installed, the app launches from your home screen, works offline and updates itself automatically.
+
+## 📡 Offline Use & Data Storage
+
+Serving the app over HTTP(S) installs a service worker that caches every file
+so Cine Power Planner works fully offline and updates in the background. Projects,
+runtime submissions and preferences (language, theme, pink mode and saved gear
+lists) live in your browser's `localStorage`. Clearing the site's data in the
+browser removes all stored information, and the Settings dialog includes a
+**Factory reset** workflow that saves a backup automatically before clearing everything. The header shows an
+offline badge whenever connectivity drops, and the 🔄 **Force reload** action
+refreshes cached assets without disturbing saved projects.
+
+---
+
+## 🗂️ File Structure
 ```bash
-index.html                 # Layout HTML principale
-assets/css/style.css       # Stili e layout
-assets/css/overview.css    # Stili della panoramica stampabile
-assets/css/overview-print.css # Regole di stampa per la panoramica
-assets/js/script.js        # Logica dell’applicazione
-assets/js/storage.js       # Helper per LocalStorage
-assets/js/static-theme.js  # Logica di tema condivisa per le pagine legali
-assets/data/index.js       # Elenco dispositivi predefinito
-assets/data/devices/       # Cataloghi dei dispositivi per categoria
-assets/data/schema.json    # Schema generato per i selettori
-assets/vendor/             # Librerie di terze parti incluse
-legal/                     # Pagine legali offline
-tools/                     # Script di manutenzione dei dati
-tests/                     # Suite di test Jest
+index.html                 # Main HTML layout
+assets/css/style.css       # Core styles and layout
+assets/css/overview.css    # Printable overview styling
+assets/css/overview-print.css # Print overrides for the overview
+assets/js/script.js        # Application logic
+assets/js/storage.js       # LocalStorage helpers
+assets/js/static-theme.js  # Shared theme logic for legal pages
+assets/data/index.js       # Default device list
+assets/data/devices/       # Device catalogs by category
+assets/data/schema.json    # Generated schema for selectors
+assets/vendor/             # Bundled third-party libraries
+legal/                     # Offline legal documents
+tools/                     # Data maintenance scripts
+tests/                     # Jest test suite
 ```
-I font sono inclusi localmente tramite `fonts.css`, quindi una volta memorizzate le risorse l’app funziona interamente offline.
+Fonts are bundled locally via `fonts.css`, so once the assets are cached the application works entirely offline.
 
-## 🛠️ Sviluppo
-Richiede Node.js 18 o versione successiva.
+## 🛠️ Development
+Requires Node.js 18 or later.
 
 ```bash
 npm install
-npm run lint     # esegue solo ESLint
-npm test         # esegue linting, controlli dati e test Jest
+npm run lint     # run ESLint alone
+npm test         # runs linting, data checks and Jest tests
 ```
 
-Dopo aver modificato i dati dei dispositivi, rigenera il database normalizzato:
+After editing device data, regenerate the normalized database:
 
 ```bash
 npm run normalize
@@ -303,11 +302,11 @@ npm run check-consistency
 npm run generate-schema
 ```
 
-Aggiungi `--help` a uno qualsiasi degli script per visualizzare le opzioni disponibili.
+Add `--help` to any of the above scripts for usage details.
 
-Esegui `npm run help` per ottenere rapidamente un riepilogo degli script di manutenzione e dell'ordine consigliato.
+Run `npm run help` whenever you need a quick reminder of the maintenance commands and their suggested order.
 
-## 🤝 Contribuire
-Sono benvenuti contributi di ogni tipo! Apri una issue o invia una pull request su GitHub.
-Quando segnali dati errati, allegare backup dei progetti o misurazioni di
-autonomia aiuta a mantenere il catalogo preciso per tutti.
+## 🤝 Contributing
+Contributions are welcome! Feel free to open an issue or submit a pull request on GitHub.
+When reporting data corrections, attaching project backups or runtime samples
+helps keep the catalog accurate for everyone.


### PR DESCRIPTION
## Summary
- replace the German, Spanish, French and Italian README files with the up-to-date English content so each localized README mirrors the canonical documentation

## Testing
- not run (docs only)

------
https://chatgpt.com/codex/tasks/task_e_68ce5f2f1070832088ccf5d63bafaa45