### PR TITLE
Fix auto backup naming for unsaved setups

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -14139,8 +14139,14 @@ function autoBackup() {
     const pad = (n) => String(n).padStart(2, '0');
     const now = new Date();
     const baseName = `auto-backup-${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())}-${pad(now.getHours())}-${pad(now.getMinutes())}`;
-    const projectName = setupSelect.value ? `-${setupSelect.value}` : '';
-    const backupName = `${baseName}${projectName}`;
+    const activeNameRaw = setupSelect.value
+      || (setupNameInput && typeof setupNameInput.value === 'string'
+        ? setupNameInput.value.trim()
+        : '');
+    const normalizedName = activeNameRaw
+      ? activeNameRaw.replace(/\s+/g, ' ').trim()
+      : '';
+    const backupName = normalizedName ? `${baseName}-${normalizedName}` : baseName;
     const currentSetup = { ...getCurrentSetupState() };
     const gearListHtml = getCurrentGearListHtml();
     if (gearListHtml) {

--- a/tests/script/backupAutomation.test.js
+++ b/tests/script/backupAutomation.test.js
@@ -162,6 +162,32 @@ describe('automated backups', () => {
     expect(visibleValues).toContain(backupKey);
   });
 
+  test('auto backups include unsaved setup names from the input field', () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2024-05-06T12:30:00'));
+
+    const { autoBackup } = loadApp();
+
+    const setupsStore = {};
+    global.loadSetups.mockImplementation(() => setupsStore);
+    global.saveSetups.mockImplementation((next) => next);
+
+    const setupSelect = document.getElementById('setupSelect');
+    const setupNameInput = document.getElementById('setupName');
+    setupSelect.value = '';
+    setupNameInput.value = '  Fresh Concept  ';
+
+    const gearListOutput = document.getElementById('gearListOutput');
+    gearListOutput.classList.remove('hidden');
+    gearListOutput.innerHTML = '<h3>Gear List</h3><table class="gear-table"><tr><td>1x Alexa 35</td></tr></table>';
+
+    autoBackup();
+
+    const autoKeys = Object.keys(setupsStore).filter((name) => name.startsWith('auto-backup-'));
+    expect(autoKeys).toHaveLength(1);
+    expect(autoKeys[0]).toMatch(/-Fresh Concept$/);
+  });
+
   test('createSettingsBackup includes session storage snapshot', async () => {
     const { createSettingsBackup } = loadApp();
 


### PR DESCRIPTION
## Summary
- normalize auto backup identifiers to include the typed setup name when no saved setup is selected
- add a regression test covering auto backups created from an unsaved setup name

## Testing
- npm run lint
- npm run test:script -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68ce5c2b2e488320b39da6b44374ded0