### PR TITLE
Remove external OpenMoji links from translated READMEs

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -173,7 +173,7 @@ Der Generator verwandelt deine Auswahl in eine kategorisierte Packliste:
 - Ziehe Knoten, um das Layout neu zu ordnen, zoome mit den Schaltflächen und exportiere das Diagramm als SVG oder JPG.
 - Halte Shift gedrückt, während du auf Download klickst, um ein JPG statt eines SVG zu exportieren.
 - Fahre mit der Maus oder tippe auf Geräte, um Popover-Details zu sehen.
-- Nutzt [OpenMoji](https://openmoji.org/)-Icons, wenn eine Verbindung besteht, und greift sonst auf Emoji zurück: 🔋 Akku, 🎥 Kamera, 🖥️ Monitor, 📡 Video, ⚙️ Motor, 🎮 Controller, 📐 Distanz, 🎮 Griff und 🔌 Akkuplatte.
+- Nutzt OpenMoji-Icons, wenn eine Verbindung besteht, und greift sonst auf Emoji zurück: 🔋 Akku, 🎥 Kamera, 🖥️ Monitor, 📡 Video, ⚙️ Motor, 🎮 Controller, 📐 Distanz, 🎮 Griff und 🔌 Akkuplatte.
 
 ### 🧮 Gewichtung der Laufzeitdaten
 - Von Nutzenden gemeldete Laufzeiten verfeinern die Schätzung.

--- a/README.es.md
+++ b/README.es.md
@@ -183,7 +183,7 @@ El generador transforma tus selecciones en una lista de empaquetado categorizada
 - Arrastra nodos para reorganizar el esquema, haz zoom con los botones y descarga el diagrama como SVG o JPG.
 - Mantén pulsado Shift al hacer clic en Descargar para exportar una instantánea JPG en lugar de SVG.
 - Pasa el cursor o toca los dispositivos para ver detalles emergentes.
-- Utiliza iconos de [OpenMoji](https://openmoji.org/) cuando hay conexión, con emoji como alternativa: 🔋 batería, 🎥 cámara, 🖥️ monitor, 📡 vídeo, ⚙️ motor, 🎮 controlador, 📐 distancia, 🎮 empuñadura y 🔌 placa de batería.
+- Utiliza iconos OpenMoji cuando hay conexión, con emoji como alternativa: 🔋 batería, 🎥 cámara, 🖥️ monitor, 📡 vídeo, ⚙️ motor, 🎮 controlador, 📐 distancia, 🎮 empuñadura y 🔌 placa de batería.
 
 ### 🧮 Ponderación de datos de autonomía
 - Los tiempos de batería aportados por la comunidad refinan la estimación de autonomía.

--- a/README.fr.md
+++ b/README.fr.md
@@ -185,7 +185,7 @@ Le générateur transforme vos sélections en une liste de préparation catégor
 - Faites glisser les nœuds pour réorganiser le schéma, zoomez avec les boutons et exportez le diagramme en SVG ou JPG.
 - Maintenez Shift enfoncé lors du clic sur Télécharger pour exporter une image JPG plutôt qu’un SVG.
 - Survolez ou touchez un appareil pour afficher sa fiche détaillée.
-- Utilise les icônes [OpenMoji](https://openmoji.org/) lorsqu’une connexion est disponible et se replie sur les emoji : 🔋 batterie, 🎥 caméra, 🖥️ moniteur, 📡 vidéo, ⚙️ moteur, 🎮 contrôleur, 📐 distance, 🎮 poignée et 🔌 plaque batterie.
+- Utilise les icônes OpenMoji lorsqu’une connexion est disponible et se replie sur les emoji : 🔋 batterie, 🎥 caméra, 🖥️ moniteur, 📡 vidéo, ⚙️ moteur, 🎮 contrôleur, 📐 distance, 🎮 poignée et 🔌 plaque batterie.
 
 ### 🧮 Pondération des données d’autonomie
 - Les autonomies remontées par les utilisateurs affinent l’estimation.

--- a/README.it.md
+++ b/README.it.md
@@ -182,7 +182,7 @@ Il generatore converte le tue scelte in una lista di carico categorizzata:
 - Trascina i nodi per riordinare il layout, usa i pulsanti per zoomare ed esporta il diagramma in SVG o JPG.
 - Tieni premuto Shift mentre fai clic su Download per esportare uno snapshot JPG invece di un SVG.
 - Passa il mouse o tocca un dispositivo per vedere i dettagli nel popup.
-- Utilizza le icone [OpenMoji](https://openmoji.org/) quando la connessione è attiva e ripiega sugli emoji: 🔋 batteria, 🎥 camera, 🖥️ monitor, 📡 video, ⚙️ motore, 🎮 controller, 📐 distanza, 🎮 impugnatura e 🔌 piastra batteria.
+- Utilizza le icone OpenMoji quando la connessione è attiva e ripiega sugli emoji: 🔋 batteria, 🎥 camera, 🖥️ monitor, 📡 video, ⚙️ motore, 🎮 controller, 📐 distanza, 🎮 impugnatura e 🔌 piastra batteria.
 
 ### 🧮 Ponderazione dei dati di autonomia
 - I feedback di autonomia inviati dagli utenti migliorano la stima finale.


### PR DESCRIPTION
## Summary
- remove external OpenMoji hyperlinks from the German, Spanish, French, and Italian READMEs to keep the documentation offline-friendly

## Testing
- not run (documentation-only change)

------
https://chatgpt.com/codex/tasks/task_e_68ce60a5664083209ff50e3a92297a28