### PR TITLE
Backfill schema for media and video assist categories

### DIFF
--- a/assets/data/schema.json
+++ b/assets/data/schema.json
@@ -87,6 +87,7 @@
         "brand",
         "compatible",
         "diameterMm",
+        "dimensionsMm",
         "kNumber",
         "lengthMm",
         "rodStandard"
@@ -149,6 +150,8 @@
         "compatible",
         "diameterMm",
         "kNumber",
+        "model",
+        "note",
         "provenance",
         "sideFlags",
         "stages",
@@ -302,7 +305,6 @@
   },
   "iosVideo": {
     "attributes": [
-      "brand",
       "frequency",
       "latencyMs",
       "notes",
@@ -330,9 +332,18 @@
       "weight_g"
     ]
   },
-  "monitors": {
+  "media": {
     "attributes": [
       "brand",
+      "capacityGb",
+      "capacityTb",
+      "interface",
+      "kNumber",
+      "model"
+    ]
+  },
+  "monitors": {
+    "attributes": [
       "audioInput",
       "audioIo",
       "audioOutput",
@@ -351,13 +362,18 @@
   },
   "video": {
     "attributes": [
-      "brand",
       "frequency",
       "latencyMs",
       "power",
       "powerDrawWatts",
       "videoInputs",
       "videoOutputs"
+    ]
+  },
+  "videoAssist": {
+    "attributes": [
+      "brand",
+      "screenSizeInches"
     ]
   },
   "viewfinders": {
@@ -372,7 +388,6 @@
   },
   "wirelessReceivers": {
     "attributes": [
-      "brand",
       "frequency",
       "latencyMs",
       "power",

--- a/tools/generateSchema.js
+++ b/tools/generateSchema.js
@@ -47,6 +47,103 @@ function buildSchema(node) {
   return typeof node;
 }
 
+function getSchemaNode(schema, path) {
+  let node = schema;
+  for (const key of path) {
+    if (!node || typeof node !== 'object' || Array.isArray(node)) {
+      return undefined;
+    }
+    node = node[key];
+  }
+  return node;
+}
+
+function getAttributes(schema, path) {
+  const node = getSchemaNode(schema, path);
+  if (node && Array.isArray(node.attributes)) {
+    return node.attributes;
+  }
+  return [];
+}
+
+function setAttributes(schema, path, attrs) {
+  let node = schema;
+  for (let i = 0; i < path.length; i += 1) {
+    const key = path[i];
+    if (i === path.length - 1) {
+      node[key] = { attributes: attrs.slice().sort() };
+    } else {
+      if (!node[key] || typeof node[key] !== 'object' || Array.isArray(node[key]) || Array.isArray(node[key]?.attributes)) {
+        node[key] = {};
+      }
+      node = node[key];
+    }
+  }
+}
+
+function copyAttributes(schema, fromPath, toPath) {
+  const attrs = getAttributes(schema, fromPath);
+  if (attrs.length > 0) {
+    setAttributes(schema, toPath, attrs);
+  }
+}
+
+function unionAttributes(schema, sourcePaths, targetPath) {
+  const attrs = new Set();
+  for (const path of sourcePaths) {
+    for (const attr of getAttributes(schema, path)) {
+      attrs.add(attr);
+    }
+  }
+  if (attrs.size > 0) {
+    setAttributes(schema, targetPath, Array.from(attrs));
+  }
+}
+
+function sortSchema(node) {
+  if (!node || typeof node !== 'object' || Array.isArray(node)) {
+    return node;
+  }
+  const keys = Object.keys(node);
+  if (keys.length === 1 && Array.isArray(node.attributes)) {
+    return { attributes: node.attributes.slice().sort() };
+  }
+  const sorted = {};
+  for (const key of keys.sort()) {
+    sorted[key] = sortSchema(node[key]);
+  }
+  return sorted;
+}
+
+function augmentSchema(data, schema) {
+  const result = schema;
+
+  copyAttributes(result, ['lenses'], ['accessories', 'lenses']);
+
+  if (data && data.accessories && typeof data.accessories === 'object') {
+    for (const [category, value] of Object.entries(data)) {
+      if (
+        value === undefined &&
+        Object.prototype.hasOwnProperty.call(data.accessories, category)
+      ) {
+        copyAttributes(result, ['accessories', category], [category]);
+      }
+    }
+  }
+
+  const cablesNode = getSchemaNode(result, ['accessories', 'cables']);
+  if (cablesNode && typeof cablesNode === 'object' && !Array.isArray(cablesNode)) {
+    const sourcePaths = Object.keys(cablesNode)
+      .filter((key) => key !== 'cables')
+      .map((key) => ['accessories', 'cables', key]);
+    if (sourcePaths.length > 0) {
+      unionAttributes(result, sourcePaths, ['accessories', 'cables', 'cables']);
+    }
+  }
+
+  return sortSchema(result);
+}
+
 if (require.main === module) {
   const args = process.argv.slice(2);
   if (args.includes('--help') || args.includes('-h')) {
@@ -75,9 +172,9 @@ if (require.main === module) {
     );
     process.exit(0);
   }
-  const schema = buildSchema(devices);
+  const schema = augmentSchema(devices, buildSchema(devices));
   fs.writeFileSync(path.join(__dirname, '../assets/data/schema.json'), JSON.stringify(schema, null, 2));
   console.log('assets/data/schema.json generated');
 } else {
-  module.exports = { buildSchema, isDeviceObject, isDeviceMap };
+  module.exports = { buildSchema, isDeviceObject, isDeviceMap, augmentSchema };
 }


### PR DESCRIPTION
## Summary
- update the schema augmentation step to reuse accessory data when a top-level category is undefined, keeping aliases such as media and videoAssist populated
- regenerate `assets/data/schema.json` so media and video assist entries expose their attribute lists alongside the existing accessory data

## Testing
- npm run test:data

------
https://chatgpt.com/codex/tasks/task_e_68ce63329258832088fcbbd50f7e74ba