### PR TITLE
Update localized READMEs to match latest English content

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -1,8 +1,8 @@
 # 🎥 Cine Power Planner
 
-Dieses browserbasierte Werkzeug unterstützt dich bei der Planung professioneller Kamera-Setups mit V‑Mount-, B‑Mount- oder Gold-Mount-Akkus. Es berechnet den **Gesamtverbrauch**, die **Stromaufnahme** (bei 14,4 V und 12 V) sowie die **geschätzte Laufzeit** und prüft gleichzeitig, ob der Akku die benötigte Leistung zuverlässig liefern kann.
+Dieses browserbasierte Werkzeug hilft dir bei der Planung professioneller Kamera-Setups mit V‑Mount-, B‑Mount- oder Gold-Mount-Akkus. Es berechnet den **Gesamtverbrauch**, die **Stromaufnahme** (bei 14,4 V und 12 V) sowie die **geschätzte Laufzeit** und prüft gleichzeitig, ob der Akku die benötigte Leistung zuverlässig liefern kann.
 
-Alle Planungen, Eingaben und Exporte bleiben auf deinem Gerät. Spracheinstellungen, Projekte, eigene Geräte, Favoriten und Laufzeit-Feedback werden im Browser gespeichert, und Service-Worker-Updates kommen direkt aus diesem Repository. Du kannst den Planner offline von der lokalen Festplatte öffnen oder intern hosten, damit jede Abteilung dieselbe geprüfte Version nutzt.
+Sämtliche Planungen, Eingaben und Exporte bleiben auf deinem Gerät. Spracheinstellungen, Projekte, eigene Geräte, Favoriten und Laufzeit-Feedback werden im Browser gespeichert, und Service-Worker-Updates stammen direkt aus diesem Repository. Du kannst den Planner offline von der lokalen Festplatte öffnen oder intern hosten, damit jede Abteilung dieselbe geprüfte Version nutzt.
 
 ---
 
@@ -13,26 +13,26 @@ Alle Planungen, Eingaben und Exporte bleiben auf deinem Gerät. Spracheinstellun
 - 🇮🇹 [Italiano](README.it.md)
 - 🇫🇷 [Français](README.fr.md)
 
-Beim ersten Start übernimmt die App automatisch die Sprache deines Browsers. Über das Menü oben rechts kannst du jederzeit umschalten – die Auswahl wird für den nächsten Besuch gespeichert.
+Beim ersten Start übernimmt die Anwendung automatisch die Sprache deines Browsers. Über das Menü oben rechts kannst du jederzeit umschalten – die Auswahl bleibt für den nächsten Besuch erhalten.
 
 ---
 
 ## 🆕 Neueste Funktionen
-- Akzent- und Typografie-Regler in den Einstellungen lassen dich Akzentfarbe, Grundschriftgröße und Schriftfamilie sowie die Themes Dunkel, Pink und Hoher Kontrast einstellen.
-- Tastenkürzel für die globale Suche fokussieren das Feld sofort mit / oder Strg+K (⌘K auf macOS) – selbst wenn es im eingeklappten mobilen Seitenmenü steckt.
-- Die Aktion „Neu laden erzwingen" leert zwischengespeicherte Service-Worker-Dateien, damit sich die Offline-App aktualisiert, ohne Projekte oder Geräte zu löschen.
-- Sternsymbole in jeder Auswahl pinnen Lieblingskameras, ‑akkus und ‑zubehör oben an und nehmen sie in Backups auf.
+- Akzent- und Typografie-Regler in den Einstellungen erlauben dir Akzentfarbe, Grundschriftgröße und Schriftfamilie sowie die Themes Dunkel, Pink und Hoher Kontrast einstellen.
+- Tastenkürzel für die globale Suche setzen den Fokus sofort mit / oder Strg+K (⌘K auf macOS) – selbst wenn es im eingeklappten mobilen Seitenmenü steckt.
+- Die Aktion „Neu laden erzwingen" leert zwischengespeicherte Service-Worker-Dateien, damit sich die Offline-Anwendung aktualisiert, ohne Projekte oder Geräte zu löschen.
+- Sternsymbole neben jeder Auswahl pinnen Lieblingskameras, ‑akkus und ‑zubehör oben an und nehmen sie in Backups auf.
 - Der **Werkseinstellungen**-Workflow lädt automatisch eine Sicherung herunter, bevor gespeicherte Projekte, Geräte und Einstellungen gelöscht werden.
-- Geräteliste und druckbare Übersicht zeigen den Projektnamen als schnellen Referenzpunkt.
+- Geräteliste und druckbare Übersicht zeigen den Projektnamen als schnelle Referenz.
 - Lade ein eigenes Logo hoch, das in druckbaren Übersichten und Backups erscheint.
 - Backups enthalten Favoriten und erstellen vor jeder Wiederherstellung eine automatische Sicherung.
 - Crew-Einträge besitzen jetzt ein Feld für E-Mail-Adressen.
 - Neues High-Contrast-Theme für bessere Lesbarkeit.
-- Geräteformulare füllen Kategorien dynamisch anhand der Schema-Attribute aus.
-- Überarbeitetes Interface mit verbessertem Kontrast und großzügigerem Spacing für ein klares Erlebnis auf jedem Gerät.
-- Projekte lassen sich einfacher teilen: Lade eine JSON-Datei mit Auswahl, Anforderungen, Geräteliste, Laufzeit-Feedback und eigenen Geräten herunter und importiere sie anschließend, um alles wiederherzustellen.
+- Geräteformulare füllen die Kategorien dynamisch anhand der Schema-Attribute aus.
+- Überarbeitete Oberfläche mit verbessertem Kontrast und großzügigerem Spacing für ein klares Erlebnis auf jedem Gerät.
+- Projekt-Sharing wurde vereinfacht: Lade eine JSON-Datei mit Auswahl, Anforderungen, Geräteliste, Laufzeit-Feedback und eigenen Geräten herunter und importiere sie anschließend, um alles wiederherzustellen.
 - Eigene Symbole für verpflichtende Szenarien machen Projektanforderungen auf einen Blick sichtbar.
-- Interaktives Projekt-Diagramm zum Verschieben, Zoomen, Rastern und Exportieren als SVG oder JPG.
+- Interaktives Projekt-Diagramm zum Verschieben, Zoomen, Einrasten und Exportieren als SVG oder JPG.
 - Verspieltes pinkes Akzent-Theme, das zwischen Besuchen erhalten bleibt.
 - Durchsuchbarer Hilfedialog mit Schritt-für-Schritt-Bereichen und FAQ; öffne ihn mit ?, H, F1 oder Strg+/.
 - Kontextuelle Hover-Hilfe für Schaltflächen, Felder, Dropdowns und Überschriften.
@@ -56,10 +56,10 @@ Beim ersten Start übernimmt die App automatisch die Sprache deines Browsers. Ü
 - **Planner auf das Team zuschneiden.** Wechsle sofort zwischen Deutsch, Englisch, Spanisch, Italienisch und Französisch, passe Schriftgröße und -familie an, wähle eine eigene Akzentfarbe, lade ein Drucklogo hoch und schalte zwischen hellem, dunklem, pinkem oder kontrastreichem Theme. Tippen-zum-Suchen, angepinnte Favoriten, Duplizieren-Buttons und Hover-Hilfe sparen Zeit am Set.
 
 ### ✅ Projektverwaltung
-- Speichere, lade und lösche mehrere Kameraprojekte (Enter oder Strg+S/⌘S speichert schnell; der Button bleibt deaktiviert, bis ein Name eingetragen ist).
-- Alle zehn Minuten entstehen automatisch Schnappschüsse, solange der Planner geöffnet ist; im Einstellungsdialog lassen sich stündliche Backup-Exporte als Erinnerung aktivieren.
-- Lade eine JSON-Datei herunter, die Auswahl, Anforderungen, Geräteliste, Laufzeit-Feedback und eigene Geräte bündelt; über den Import-Picker stellst du alles in einem Schritt wieder her.
-- Daten liegen lokal im `localStorage`, Favoriten landen ebenfalls in Backups; die Option **Werkseinstellungen** erstellt vor dem Zurücksetzen automatisch eine Sicherung.
+- Speichere, lade und lösche mehrere Kameraprojekte (drücke Enter oder Strg+S/⌘S zum schnellen Speichern; der Button bleibt deaktiviert, bis ein Name eingetragen ist).
+- Alle zehn Minuten entstehen automatisch Sicherungsschnappschüsse, solange der Planner geöffnet ist; im Einstellungsdialog lassen sich stündliche Backup-Exporte als Erinnerung aktivieren.
+- Lade eine JSON-Datei herunter, die Auswahl, Anforderungen, Geräteliste, Laufzeit-Feedback und eigene Geräte bündelt; über den Import-Picker holst du alles in einem Schritt zurück.
+- Die Daten liegen lokal im `localStorage`, Favoriten landen ebenfalls in Backups; die Option **Werkseinstellungen** legt vor dem Zurücksetzen automatisch eine Sicherung ab.
 - Erstelle druckbare Übersichten für jedes gespeicherte Projekt und füge ein individuelles Logo hinzu, damit Exporte und Backups zum Produktionsbranding passen.
 - Projektanforderungen werden gemeinsam mit dem Projekt gespeichert, sodass Gerätelisten den kompletten Kontext behalten.
 - Funktioniert vollständig offline dank installiertem Service Worker – Sprache, Theme, Gerätedaten und Favoriten bleiben erhalten.
@@ -78,7 +78,7 @@ Beim ersten Start übernimmt die App automatisch die Sprache deines Browsers. Ü
 - Die globale Suche springt zu Funktionen, Geräteselektoren oder Hilfethemen; drücke Enter für das markierte Ergebnis, / oder Strg+K (⌘K auf macOS) zum sofortigen Fokussieren (auf kleinen Displays öffnet sich das Seitenmenü automatisch) und Escape oder × zum Zurücksetzen.
 - Oben findest du Sprachumschaltung, Toggles für dunkles und pinkes Theme sowie den Einstellungsdialog mit Akzentfarbe, Schriftgröße, Schriftfamilie, High-Contrast-Schalter und Logo-Upload plus Backup-, Restore- und Werkseinstellungen-Tools, die vor dem Löschen eine Sicherung anlegen.
 - Die Hilfe-Schaltfläche öffnet einen durchsuchbaren Dialog mit Schritt-für-Schritt-Anleitungen, Tastenkürzeln, FAQ und optionalem Hover-Hilfemodus; erreichbar auch mit ?, H, F1 oder Strg+/ – selbst während der Eingabe.
-- Die Aktualisieren-Schaltfläche (🔄) löscht zwischengespeicherte Service-Worker-Dateien, damit sich die Offline-App erneuert, ohne Projekte oder Geräte zu verlieren.
+- Die Aktualisieren-Schaltfläche (🔄) löscht zwischengespeicherte Service-Worker-Dateien, damit sich die Offline-Anwendung erneuert, ohne Projekte oder Geräte zu verlieren.
 - Auf kleineren Bildschirmen spiegelt ein einklappbares Seitenmenü alle wichtigen Bereiche für schnellen Zugriff.
 
 ### ♿ Anpassung & Barrierefreiheit
@@ -91,21 +91,21 @@ Beim ersten Start übernimmt die App automatisch die Sprache deines Browsers. Ü
 - Gabel-Symbole duplizieren Formularzeilen sofort, und angepinnte Favoriten halten beliebte Geräte oben in der Liste – ideal für schnelle Eingaben am Set.
 
 ### 📋 Geräteliste
-Der Generator verwandelt deine Auswahl in eine kategorisierte Packliste:
+Der Generator verwandelt deine Auswahl in eine nach Kategorien sortierte Packliste:
 
 - Klicke auf **Geräteliste erstellen**, um ausgewähltes Equipment und Projektanforderungen in einer Tabelle zu bündeln.
 - Die Tabelle aktualisiert sich automatisch, sobald Geräteauswahl oder Anforderungen wechseln.
 - Einträge werden nach Kategorien gruppiert (Kamera, Optik, Strom, Monitoring, Rigging, Grip, Zubehör, Verbrauchsmaterial) und Duplikate zusammengeführt.
 - Benötigte Kabel, Rigging und Zubehör für Monitore, Motoren, Gimbals und Wetterszenarien werden automatisch ergänzt.
-- Szenario-Auswahlen fügen passendes Equipment hinzu:
+- Szenario-Auswahlen ergänzen passendes Equipment:
   - *Handheld* + *Easyrig* ergänzt einen teleskopischen Griff für stabilen Halt.
   - *Gimbal* fügt den gewählten Gimbal, Magic-Arms, Spigots sowie Sonnenblenden oder Filtersets hinzu.
   - *Outdoor* liefert Spigots, Schirme und CapIt-Regenhauben.
   - Die Szenarien *Vehicle* und *Steadicam* bringen Halterungen, Iso-Arme und Saugnäpfe mit, wo nötig.
-- Objektiv-Auswahlen enthalten Frontdurchmesser, Gewicht, Rod-Daten und Mindestfokus, ergänzen Linsensupports und Matte-Box-Adapter und warnen vor inkompatiblen Rod-Standards.
+- Objektiv-Auswahlen listen Frontdurchmesser, Gewicht, Rod-Daten und Mindestfokus, ergänzen Linsensupports und Matte-Box-Adapter und warnen vor inkompatiblen Rod-Standards.
 - Akkuzeilen spiegeln die Mengen aus dem Stromrechner und berücksichtigen Hotswap-Platten oder ausgewählte Hotswap-Geräte.
 - Monitoring-Präferenzen weisen Standardmonitore für jede Rolle (Regie, DoP, Fokus usw.) mit Kabelsets und Funkempfängern zu.
-- Das Formular **Projektanforderungen** speist die Liste:
+- Das Formular **Projektanforderungen** liefert die Daten für die Liste:
   - **Projektname**, **Produktion**, **Verleih** und **DoP** erscheinen in der Kopfzeile der gedruckten Anforderungen.
   - **Crew**-Einträge erfassen Namen, Rollen und E-Mail-Adressen, damit Kontaktdaten mit dem Projekt reisen.
   - **Prep-Tage** und **Drehtage** liefern Planungsnotizen und empfehlen bei Außenszenarien Wetter-Equipment.
@@ -114,9 +114,9 @@ Der Generator verwandelt deine Auswahl in eine kategorisierte Packliste:
   - Optionen für **Matte Box** und **Filter** ergänzen das gewünschte System samt nötiger Trays, Clamp-Adapter oder Filter.
   - Einstellungen für **Monitoring**, **Videoverteilung** und **Sucher** fügen Monitore, Kabel und Overlays für jede Rolle hinzu.
   - **User Buttons** und **Stativ-Präferenzen** werden für schnellen Zugriff aufgeführt.
-- Innerhalb der Kategorien sind Einträge alphabetisch sortiert und zeigen beim Hover Tooltips an.
+- Innerhalb der Kategorien sind die Einträge alphabetisch sortiert und zeigen beim Hover Tooltips an.
 - Die Geräteliste ist Teil der druckbaren Übersichten und der exportierten Projektdateien.
-- Gerätelisten werden automatisch mit dem Projekt gespeichert und in exportierte Dateien sowie Backups aufgenommen.
+- Gerätelisten werden automatisch mit dem Projekt gespeichert und sowohl in Exporten als auch in Backups abgelegt.
 - **Geräteliste löschen** entfernt die gespeicherte Liste und blendet die Ausgabe aus.
 - In den Formularen stehen Gabel-Schaltflächen bereit, um Benutzereinträge sofort zu duplizieren.
 
@@ -205,8 +205,8 @@ Der Generator verwandelt deine Auswahl in eine kategorisierte Packliste:
 
 ---
 
-## ▶️ So nutzt du die App
-1. **App starten:** Öffne `index.html` in einem modernen Browser – kein Server nötig.
+## ▶️ So nutzt du die Anwendung
+1. **Anwendung starten:** Öffne `index.html` in einem modernen Browser – kein Server nötig.
 2. **Top-Bar erkunden:** Sprache wechseln, Dunkel- oder Rosa-Theme umschalten, Einstellungen für Akzent und Typografie öffnen und den Hilfedialog mit ? oder Strg+/ starten.
 3. **Geräte auswählen:** Wähle über Dropdowns das Equipment je Kategorie; tippe zum Filtern, pinne Favoriten mit dem Stern und lass Szenario-Voreinstellungen Zubehör automatisch ergänzen.
 4. **Berechnungen ansehen:** Gesamtverbrauch, Strom und Laufzeit erscheinen, sobald ein Akku gewählt ist; Warnungen markieren überschrittene Grenzen.
@@ -215,19 +215,19 @@ Der Generator verwandelt deine Auswahl in eine kategorisierte Packliste:
 7. **Gerätedaten verwalten:** Über „Gerätedaten bearbeiten…" den Editor öffnen, Geräte anpassen, JSON exportieren/importieren oder auf Standardwerte zurücksetzen.
 8. **Laufzeit-Feedback senden:** Mit „Nutzer-Laufzeit-Feedback senden" Messwerte aus der Praxis erfassen und die Gewichtung verbessern.
 
-## 📱 Als App installieren
+## 📱 Als Anwendung installieren
 
-Der Planner ist eine Progressive Web App und lässt sich direkt aus dem Browser installieren:
+Der Planner ist eine Progressive-Web-App und lässt sich direkt aus dem Browser installieren:
 
 - **Chrome/Edge (Desktop):** Auf das Installationssymbol in der Adressleiste klicken.
 - **Android:** Browsermenü öffnen und *Zum Startbildschirm hinzufügen* wählen.
 - **iOS/iPadOS Safari:** Auf *Teilen* tippen und *Zum Home-Bildschirm* auswählen.
 
-Nach der Installation startet die App vom Startbildschirm, funktioniert offline und aktualisiert sich automatisch.
+Nach der Installation startet die Anwendung vom Startbildschirm, funktioniert offline und aktualisiert sich automatisch.
 
 ## 📡 Offline-Nutzung & Datenspeicherung
 
-Beim Ausliefern über HTTP(S) installiert sich ein Service Worker, der alle Dateien cached, sodass Cine Power Planner vollständig offline läuft und Updates im Hintergrund lädt. Projekte, Laufzeit-Einreichungen und Einstellungen (Sprache, Theme, Rosa-Modus, gespeicherte Gerätelisten) liegen im `localStorage` deines Browsers. Das Löschen der Seitendaten entfernt alle Informationen; im Einstellungsdialog gibt es dafür den Workflow **Werkseinstellungen**, der vor dem Leeren automatisch eine Sicherung speichert. Die Kopfzeile zeigt ein Offline-Badge, sobald die Verbindung wegfällt, und die Aktion 🔄 **Neu laden erzwingen** aktualisiert gecachte Assets, ohne Projekte anzutasten.
+Beim Ausliefern über HTTP(S) installiert sich ein Service Worker, der alle Dateien zwischenspeichert, sodass Cine Power Planner vollständig offline läuft und Updates im Hintergrund lädt. Projekte, Laufzeit-Einreichungen und Einstellungen (Sprache, Theme, Rosa-Modus, gespeicherte Gerätelisten) liegen im `localStorage` deines Browsers. Das Löschen der Seitendaten entfernt alle Informationen; im Einstellungsdialog gibt es dafür den Workflow **Werkseinstellungen**, der vor dem Leeren automatisch eine Sicherung speichert. Die Kopfzeile blendet ein Offline-Badge ein, sobald die Verbindung wegfällt, und die Aktion 🔄 **Neu laden erzwingen** aktualisiert gecachte Assets, ohne Projekte anzutasten.
 
 ---
 
@@ -273,4 +273,4 @@ Mit `--help` zeigen die Skripte weitere Optionen an.
 `npm run help` liefert eine kompakte Übersicht der Wartungsskripte und ihrer empfohlenen Reihenfolge.
 
 ## 🤝 Mitmachen
-Beiträge sind jederzeit willkommen! Eröffne gerne ein Issue oder sende einen Pull Request. Für Datenkorrekturen helfen Projekt-Backups oder Laufzeitbeispiele, damit der Gerätekatalog für alle verlässlich bleibt.
+Beiträge sind jederzeit willkommen! Eröffne gerne ein Issue oder sende einen Pull Request. Für Datenkorrekturen helfen angehängte Projekt-Backups oder Laufzeitbeispiele, damit der Gerätekatalog für alle verlässlich bleibt.

--- a/README.es.md
+++ b/README.es.md
@@ -1,8 +1,8 @@
 # 🎥 Cine Power Planner
 
-Esta herramienta en el navegador ayuda a planificar proyectos de cámara profesionales alimentados con baterías V‑Mount, B‑Mount o Gold-Mount. Calcula el **consumo total de energía**, la **corriente demandada** (a 14,4 V y 12 V) y la **autonomía estimada** mientras comprueba que la batería pueda suministrar con seguridad la potencia necesaria.
+Esta herramienta basada en navegador ayuda a planificar proyectos de cámara profesionales alimentados con baterías V‑Mount, B‑Mount o Gold-Mount. Calcula el **consumo total de energía**, la **corriente demandada** (a 14,4 V y 12 V) y la **autonomía estimada** mientras comprueba que la batería pueda suministrar con seguridad la potencia necesaria.
 
-Toda la planificación, los datos introducidos y las exportaciones permanecen en tu dispositivo. El idioma, los proyectos, el equipo personalizado, los favoritos y los comentarios de autonomía se guardan en tu navegador, y las actualizaciones del service worker provienen directamente de este repositorio. Ejecuta el planner sin conexión desde el disco o aloja la carpeta internamente para que cada departamento use la misma versión auditada.
+Toda la planificación, las entradas y las exportaciones permanecen en tu dispositivo. El idioma, los proyectos, el equipo personalizado, los favoritos y los comentarios de autonomía se guardan en tu navegador, y las actualizaciones del service worker provienen directamente de este repositorio. Ejecuta el planner sin conexión desde el disco o aloja la carpeta internamente para que cada departamento use la misma versión auditada.
 
 ---
 
@@ -13,23 +13,23 @@ Toda la planificación, los datos introducidos y las exportaciones permanecen en
 - 🇮🇹 [Italiano](README.it.md)
 - 🇫🇷 [Français](README.fr.md)
 
-La app adopta automáticamente el idioma de tu navegador en la primera visita y puedes cambiarlo desde la esquina superior derecha. La elección se recuerda para la siguiente sesión.
+La aplicación adopta automáticamente el idioma de tu navegador en la primera visita y puedes cambiarlo desde la esquina superior derecha. El ajuste se guarda para la siguiente sesión.
 
 ---
 
 ## 🆕 Novedades recientes
-- Los controles de acento y tipografía en Ajustes te permiten definir el color de acento, el tamaño base y la familia tipográfica junto con los temas oscuro, rosa y de alto contraste.
-- Los atajos de teclado para la búsqueda global enfocan el campo al instante con / o Ctrl+K (⌘K en macOS), incluso cuando está dentro del menú lateral móvil contraído.
-- El botón **Forzar recarga** vacía los archivos en caché del service worker para que la app sin conexión se actualice sin borrar proyectos ni dispositivos guardados.
-- Las estrellas en cada selector fijan cámaras, baterías y accesorios favoritos en la parte superior de la lista y los incluyen en las copias de seguridad.
+- Los controles de acento y tipografía en Ajustes permiten definir el color de acento, el tamaño base y la familia tipográfica junto con los temas oscuro, rosa y de alto contraste.
+- Los atajos de teclado de la búsqueda global enfocan el campo al instante con / o Ctrl+K (⌘K en macOS), incluso cuando está dentro del menú lateral móvil contraído.
+- El botón **Forzar recarga** vacía los archivos en caché del service worker para que la aplicación sin conexión se actualice sin borrar proyectos ni dispositivos guardados.
+- Las estrellas de cada selector fijan cámaras, baterías y accesorios favoritos en la parte superior de la lista y los incluyen en las copias de seguridad.
 - El flujo de **Restablecimiento de fábrica** descarga automáticamente una copia de seguridad antes de eliminar proyectos, dispositivos y ajustes almacenados.
 - La lista de equipo y la vista imprimible muestran el nombre del proyecto para consultarlo rápidamente.
 - Sube un logotipo personalizado para que aparezca en las vistas imprimibles y en las copias de seguridad.
 - Las copias de seguridad incluyen los favoritos y generan automáticamente una copia antes de restaurar.
-- Los registros del equipo cuentan ahora con un campo de correo electrónico.
+- Las fichas del equipo incluyen ahora un campo de correo electrónico.
 - Nuevo tema de alto contraste para mejorar la legibilidad.
 - Los formularios de dispositivos rellenan las categorías de forma dinámica según los atributos del esquema.
-- Interfaz rediseñada con mayor contraste y espacios más generosos para una experiencia más limpia en cualquier dispositivo.
+- Interfaz rediseñada con más contraste y espacios más generosos para una experiencia más limpia en cualquier dispositivo.
 - Compartir proyectos es más sencillo: descarga un archivo JSON con selecciones, requisitos, listas de equipo, comentarios de autonomía y dispositivos personalizados, e impórtalo para restaurarlo todo.
 - Iconos propios para los escenarios obligatorios que muestran de inmediato los requisitos del proyecto.
 - Diagrama de proyecto interactivo para arrastrar dispositivos, hacer zoom, alinear a la cuadrícula y exportar como SVG o JPG.
@@ -39,10 +39,10 @@ La app adopta automáticamente el idioma de tu navegador en la primera visita y 
 - Barra de búsqueda global para saltar a funciones, selectores de dispositivos o temas de ayuda.
 - Compatibilidad con cámaras con placas V‑, B‑ o Gold-Mount.
 - Envía comentarios de autonomía con temperatura para perfeccionar las estimaciones.
-- Panel visual de ponderación de autonomías que muestra cómo influyen los ajustes en cada medición, ordenado por peso con porcentajes precisos.
+- Panel visual que pondera las autonomías y muestra cómo influyen los ajustes en cada medición, ordenado por peso con porcentajes precisos.
 - Generador de listas de equipo que reúne el material seleccionado y los requisitos del proyecto.
 - Guarda los requisitos de proyecto con cada proyecto para conservar el contexto completo en las listas de equipo.
-- Duplica las entradas personalizadas en los formularios de la lista de equipo con los botones de bifurcación.
+- Duplica al instante las entradas personalizadas en los formularios de la lista de equipo con los botones en forma de horquilla.
 
 ---
 
@@ -50,19 +50,19 @@ La app adopta automáticamente el idioma de tu navegador en la primera visita y 
 
 ### ✨ Destacados ampliados
 
-- **Diseña rigs complejos sin adivinar.** Combina cámaras, placas de batería, enlaces inalámbricos, monitores, motores y accesorios mientras controlas el consumo total a 14,4 V/12 V (y 33,6 V/21,6 V en B‑Mount) junto a autonomías realistas basadas en datos de campo ponderados. El panel de comparación de baterías avisa de sobrecargas antes de que el equipo salga al rodaje.
-- **Mantén alineados a todos los departamentos.** Guarda varios proyectos con requisitos, contactos del equipo, escenarios y notas. Las listas imprimibles agrupan el material por categoría, fusionan duplicados, muestran metadatos técnicos e incluyen accesorios condicionados por los escenarios para que cámara, iluminación y grip trabajen con el mismo contexto.
-- **Trabaja con confianza en cualquier lugar.** Abre `index.html` directamente o sirve la carpeta por HTTPS para activar el service worker. La caché sin conexión conserva idioma, temas, favoritos y proyectos, y **Forzar recarga** actualiza los recursos almacenados sin tocar tus datos.
-- **Adapta el planner a tu equipo.** Cambia al instante entre español, inglés, alemán, italiano y francés, ajusta el tamaño de la fuente y la tipografía, define un color de acento, sube un logotipo para impresión y alterna entre temas claro, oscuro, rosa o de alto contraste. Los selectores con búsqueda, los favoritos fijados, los botones de duplicar y las ayudas flotantes mantienen ágil el trabajo en set.
+- **Diseña rigs complejos sin adivinar.** Combina cámaras, placas de batería, enlaces inalámbricos, monitores, motores y accesorios mientras supervisas el consumo total a 14,4 V/12 V (y 33,6 V/21,6 V en B‑Mount) junto a autonomías realistas basadas en datos de campo ponderados. El panel de comparación de baterías avisa de sobrecargas antes de que el equipo salga al rodaje.
+- **Mantén coordinados a todos los departamentos.** Guarda varios proyectos con requisitos, contactos del equipo, escenarios y notas. Las listas imprimibles agrupan el material por categoría, fusionan duplicados, muestran metadatos técnicos e incluyen accesorios condicionados por los escenarios para que cámara, iluminación y grip trabajen con el mismo contexto.
+- **Trabaja con seguridad estés donde estés.** Abre `index.html` directamente o sirve la carpeta por HTTPS para activar el service worker. La caché sin conexión conserva idioma, temas, favoritos y proyectos, y **Forzar recarga** actualiza los recursos almacenados sin tocar tus datos.
+- **Ajusta el planner a tu equipo.** Cambia al instante entre español, inglés, alemán, italiano y francés, ajusta el tamaño de la fuente y la tipografía, define un color de acento, sube un logotipo para impresión y alterna entre temas claro, oscuro, rosa o de alto contraste. Los selectores con búsqueda, los favoritos fijados, los botones de duplicar y las ayudas flotantes mantienen ágil el trabajo en set.
 
 ### ✅ Gestión de proyectos
 - Guarda, carga y elimina múltiples proyectos (pulsa Enter o Ctrl+S/⌘S para guardar rápido; el botón Guardar permanece desactivado hasta introducir un nombre).
-- Se crean instantáneas automáticas cada 10 minutos mientras el planner está abierto, y el cuadro de Ajustes puede lanzar exportaciones de copias de seguridad cada hora como recordatorio.
-- Descarga un archivo JSON que incluye selecciones, requisitos, listas de equipo, comentarios de autonomía y dispositivos personalizados; impórtalo mediante el selector de proyectos para recuperarlo todo de una vez.
-- Los datos se almacenan localmente mediante `localStorage`, y los favoritos se conservan en las copias de seguridad; usa la opción **Restablecimiento de fábrica** para guardar automáticamente una copia antes de limpiar proyectos y dispositivos guardados.
-- Genera vistas imprimibles para cualquier proyecto y añade un logotipo personalizado para que exportaciones y copias coincidan con tu identidad de producción.
+- Se generan instantáneas automáticas cada 10 minutos mientras el planner está abierto, y el cuadro de Ajustes puede lanzar exportaciones de copias de seguridad cada hora como recordatorio.
+- Descarga un archivo JSON que reúne selecciones, requisitos, listas de equipo, comentarios de autonomía y dispositivos personalizados; impórtalo mediante el selector de proyectos para recuperarlo todo de una vez.
+- Los datos se guardan localmente mediante `localStorage`, y los favoritos se incluyen en las copias de seguridad; usa la opción **Restablecimiento de fábrica** para descargar automáticamente una copia antes de limpiar proyectos y dispositivos guardados.
+- Genera vistas imprimibles de cualquier proyecto y añade un logotipo personalizado para que exportaciones y copias coincidan con tu identidad de producción.
 - Los requisitos de proyecto se guardan junto a cada proyecto, de modo que la lista de equipo mantiene todo el contexto.
-- Funciona completamente sin conexión gracias al service worker: idioma, tema, datos de dispositivos y favoritos persisten entre sesiones.
+- Funciona íntegramente sin conexión gracias al service worker: idioma, tema, datos de dispositivos y favoritos persisten entre sesiones.
 - El diseño adaptable responde sin esfuerzo en ordenadores, tabletas y teléfonos.
 - En las cámaras compatibles puedes elegir placas **V‑Mount**, **B‑Mount** o **Gold-Mount**; la lista de baterías se actualiza automáticamente.
 
@@ -78,7 +78,7 @@ La app adopta automáticamente el idioma de tu navegador en la primera visita y 
 - La barra de búsqueda global salta a funciones, selectores de dispositivos o temas de ayuda; pulsa Enter para abrir el resultado destacado, usa / o Ctrl+K (⌘K en macOS) para enfocarla desde cualquier lugar (el menú lateral se abre automáticamente en pantallas pequeñas) y pulsa Escape o × para limpiar la consulta.
 - Los controles superiores permiten cambiar de idioma, alternar los temas oscuro y rosa y abrir Ajustes con opciones de color de acento, tamaño y familia tipográfica, modo de alto contraste y carga de logotipo, además de herramientas para copia de seguridad, restauración y Restablecimiento de fábrica que guardan una copia antes de borrar datos.
 - El botón de Ayuda abre un diálogo con búsqueda, secciones guiadas, atajos de teclado, FAQ y un modo de ayuda emergente opcional; también puedes abrirlo con ?, H, F1 o Ctrl+/ incluso mientras escribes.
-- El botón de recarga forzada (🔄) borra los archivos del service worker almacenados en caché para que la app sin conexión se actualice sin perder proyectos ni dispositivos.
+- El botón de recarga forzada (🔄) borra los archivos del service worker almacenados en caché para que la aplicación sin conexión se actualice sin perder proyectos ni dispositivos.
 - En pantallas pequeñas, un menú lateral plegable replica cada sección principal para navegar con rapidez.
 
 ### ♿ Personalización y accesibilidad
@@ -93,19 +93,19 @@ La app adopta automáticamente el idioma de tu navegador en la primera visita y 
 ### 📋 Lista de equipo
 El generador convierte tus selecciones en una lista de empaque categorizada:
 
-- Pulsa **Generar lista de equipo** para combinar el equipo elegido y los requisitos del proyecto en una tabla.
-- La tabla se actualiza automáticamente cuando cambian las selecciones o los requisitos.
+- Haz clic en **Generar lista de equipo** para combinar el equipo elegido y los requisitos del proyecto en una tabla.
+- La tabla se actualiza en cuanto cambian las selecciones o los requisitos.
 - Los elementos se agrupan por categoría (cámara, óptica, alimentación, monitorización, rigging, grip, accesorios, consumibles) y los duplicados se fusionan con sus cantidades.
 - Se añaden cables, rigging y accesorios necesarios para monitores, motores, gimbals y escenarios meteorológicos.
-- Las selecciones de escenarios añaden el equipo relacionado:
+- Las selecciones de escenarios agregan el equipo relacionado:
   - *Handheld* + *Easyrig* incorpora una empuñadura telescópica para un soporte estable.
   - *Gimbal* suma el gimbal seleccionado, brazos articulados, espigas y parasoles o kits de filtros.
   - *Outdoor* aporta espigas, paraguas y fundas de lluvia CapIt.
   - Los escenarios *Vehicle* y *Steadicam* incluyen montajes, brazos de aislamiento y ventosas cuando corresponde.
-- Las selecciones de óptica incluyen diámetro frontal, peso, datos de varillas y enfoque mínimo, añaden soportes de lente y adaptadores de matte box y avisan de estándares incompatibles.
+- Las selecciones de óptica aportan diámetro frontal, peso, datos de varillas y enfoque mínimo, añaden soportes de lente y adaptadores de matte box y avisan de estándares incompatibles.
 - Las filas de baterías reflejan los cálculos del módulo de potencia e incluyen placas o dispositivos de hotswap cuando son necesarios.
 - Las preferencias de monitorización asignan monitores predeterminados para cada rol (director, DoP, foco, etc.) con juegos de cables y receptores inalámbricos.
-- El formulario de **Requisitos del proyecto** alimenta la lista:
+- El formulario de **Requisitos del proyecto** nutre la lista:
   - **Nombre del proyecto**, **productora**, **casa de alquiler** y **DoP** aparecen en el encabezado de los requisitos impresos.
   - Las entradas de **equipo** recogen nombres, roles y correos electrónicos para que la información de contacto acompañe al proyecto.
   - **Días de preparación** y **días de rodaje** aportan notas de calendario y, combinados con escenarios exteriores, proponen equipo para la climatología.
@@ -114,9 +114,9 @@ El generador convierte tus selecciones en una lista de empaque categorizada:
   - Las opciones de **matte box** y **filtros** agregan el sistema elegido con bandejas, adaptadores de pinza o filtros necesarios.
   - Las configuraciones de **monitorización**, **distribución de vídeo** y **visor** añaden monitores, cables y overlays para cada rol.
   - Las selecciones de **botones de usuario** y **preferencias de trípode** se listan para referencia rápida.
-- Los elementos dentro de cada categoría se ordenan alfabéticamente y muestran descripciones emergentes al pasar el cursor.
+- Los elementos de cada categoría se ordenan alfabéticamente y muestran descripciones emergentes al pasar el cursor.
 - La lista de equipo se incluye en las vistas imprimibles y en los archivos de proyecto exportados.
-- Las listas de equipo se guardan automáticamente con el proyecto y forman parte de los archivos exportados y de las copias de seguridad.
+- Las listas de equipo se guardan automáticamente con el proyecto y se incluyen tanto en los archivos exportados como en las copias de seguridad.
 - **Eliminar lista de equipo** borra la lista guardada y oculta la salida.
 - Los formularios incluyen botones de bifurcación para duplicar entradas personalizadas al instante.
 
@@ -186,7 +186,7 @@ El generador convierte tus selecciones en una lista de empaque categorizada:
 - La preferencia se guarda en tu navegador
 
 ### 🦄 Modo rosa
-- Haz clic en el botón del unicornio (el modo rosa rota iconos cada 30 segundos con una animación suave y vuelve al caballo al salir) o pulsa **P** para activar un acento rosa lúdico
+- Haz clic en el botón del unicornio (el modo rosa rota iconos cada 30 segundos con una animación suave y vuelve al caballo cuando sales) o pulsa **P** para activar un acento rosa lúdico
 - Funciona en los temas claro y oscuro y persiste entre visitas
 
 ### ⚫ Modo de alto contraste
@@ -206,7 +206,7 @@ El generador convierte tus selecciones en una lista de empaque categorizada:
 ---
 
 ## ▶️ Cómo usarlo
-1. **Inicia la app:** abre `index.html` en cualquier navegador moderno; no necesita servidor.
+1. **Inicia la aplicación:** abre `index.html` en cualquier navegador moderno; no necesita servidor.
 2. **Explora la barra superior:** cambia de idioma, alterna los temas oscuro o rosa, abre Ajustes para modificar acento y tipografía y lanza la ayuda con ? o Ctrl+/.
 3. **Selecciona los dispositivos:** elige el equipo de cada categoría en los menús desplegables; escribe para filtrar, fija favoritos con la estrella y deja que los escenarios rellenen los accesorios automáticamente.
 4. **Consulta los cálculos:** verás consumo, corriente y autonomía en cuanto elijas una batería; las alertas señalan cuando se superan los límites.
@@ -215,19 +215,19 @@ El generador convierte tus selecciones en una lista de empaque categorizada:
 7. **Gestiona los datos de dispositivos:** haz clic en “Editar datos de dispositivos…” para abrir el editor, ajustar el catálogo, exportar/importar JSON o volver a los valores predeterminados.
 8. **Envía comentarios de autonomía:** usa “Enviar comentarios de autonomía” para registrar mediciones reales y refinar los promedios ponderados.
 
-## 📱 Instalar como app
+## 📱 Instalar como aplicación
 
-El planner es una Progressive Web App y puede instalarse directamente desde el navegador:
+El planner es una aplicación web progresiva y puede instalarse directamente desde el navegador:
 
 - **Chrome/Edge (escritorio):** haz clic en el icono de instalación de la barra de direcciones.
 - **Android:** abre el menú del navegador y elige *Añadir a pantalla de inicio*.
 - **iOS/iPadOS Safari:** toca *Compartir* y selecciona *Añadir a pantalla de inicio*.
 
-Una vez instalada, la app se abre desde la pantalla de inicio, funciona sin conexión y se actualiza automáticamente.
+Una vez instalada, la aplicación se abre desde la pantalla de inicio, funciona sin conexión y se actualiza automáticamente.
 
 ## 📡 Uso sin conexión y almacenamiento
 
-Servir la app mediante HTTP(S) instala un service worker que almacena en caché cada archivo, de modo que Cine Power Planner funciona completamente sin conexión y se actualiza en segundo plano. Los proyectos, los comentarios de autonomía y las preferencias (idioma, tema, modo rosa y listas guardadas) se almacenan en el `localStorage` del navegador. Borrar los datos del sitio elimina toda la información, y el cuadro de Ajustes incluye un flujo de **Restablecimiento de fábrica** que guarda automáticamente una copia antes de efectuar la limpieza. La cabecera muestra un indicador sin conexión cuando la red falla y la acción 🔄 **Forzar recarga** actualiza los recursos en caché sin tocar los proyectos guardados.
+Servir la aplicación mediante HTTP(S) instala un service worker que almacena en caché cada archivo, de modo que Cine Power Planner funciona completamente sin conexión y se actualiza en segundo plano. Los proyectos, los comentarios de autonomía y las preferencias (idioma, tema, modo rosa y listas guardadas) se almacenan en el `localStorage` del navegador. Borrar los datos del sitio elimina toda la información, y el cuadro de Ajustes incluye un flujo de **Restablecimiento de fábrica** que guarda automáticamente una copia antes de efectuar la limpieza. La cabecera muestra un indicador sin conexión cuando la red falla y la acción 🔄 **Forzar recarga** actualiza los recursos en caché sin tocar los proyectos guardados.
 
 ---
 
@@ -273,4 +273,4 @@ Añade `--help` a cualquiera de los scripts anteriores para ver las opciones dis
 Ejecuta `npm run help` para obtener un recordatorio rápido de los scripts de mantenimiento y del orden recomendado.
 
 ## 🤝 Contribuciones
-Las contribuciones son bienvenidas. Abre un issue o envía un pull request. Si informas de correcciones de datos, adjuntar copias de seguridad o mediciones de autonomía ayuda a mantener el catálogo fiable para todos.
+Las contribuciones son bienvenidas. Abre una incidencia o envía un pull request. Si informas de correcciones de datos, adjuntar copias de seguridad o mediciones de autonomía ayuda a mantener el catálogo fiable para todos.

--- a/README.fr.md
+++ b/README.fr.md
@@ -1,8 +1,8 @@
 # 🎥 Cine Power Planner
 
-Cet outil accessible dans le navigateur aide à planifier des projets caméra professionnels alimentés par des batteries V‑Mount, B‑Mount ou Gold-Mount. Il calcule la **consommation totale**, l’**intensité demandée** (à 14,4 V et 12 V) et l’**autonomie estimée**, tout en vérifiant que la batterie peut fournir la puissance requise en toute sécurité.
+Cet outil basé sur le navigateur aide à planifier des projets caméra professionnels alimentés par des batteries V‑Mount, B‑Mount ou Gold-Mount. Il calcule la **consommation totale**, l’**intensité demandée** (à 14,4 V et 12 V) et l’**autonomie estimée**, tout en vérifiant que la batterie peut fournir la puissance requise en toute sécurité.
 
-Toute la planification, les saisies et les exports restent sur votre appareil. La langue, les projets, les appareils personnalisés, les favoris et les retours d’autonomie sont stockés dans votre navigateur, et les mises à jour du service worker proviennent directement de ce dépôt. Lancez le planner hors ligne depuis le disque ou hébergez-le en interne pour que chaque département utilise la même version auditée.
+L’ensemble de la planification, des saisies et des exports reste sur votre appareil. La langue, les projets, les appareils personnalisés, les favoris et les retours d’autonomie sont stockés dans votre navigateur, et les mises à jour du service worker proviennent directement de ce dépôt. Lancez le planner hors ligne depuis le disque ou hébergez-le en interne pour que chaque département exploite la même version auditée.
 
 ---
 
@@ -13,15 +13,15 @@ Toute la planification, les saisies et les exports restent sur votre appareil. L
 - 🇮🇹 [Italiano](README.it.md)
 - 🇫🇷 [Français](README.fr.md)
 
-L’application adopte automatiquement la langue de votre navigateur lors de la première visite. Vous pouvez ensuite changer de langue à tout moment depuis l’angle supérieur droit ; le choix est mémorisé pour la prochaine session.
+L’application adopte automatiquement la langue de votre navigateur lors de la première visite. Vous pouvez ensuite changer de langue à tout moment depuis l’angle supérieur droit, et le choix est mémorisé pour la prochaine session.
 
 ---
 
 ## 🆕 Nouveautés
-- Les réglages d’accent et de typographie permettent d’ajuster couleur d’accent, taille de base et famille de police, aux côtés des thèmes sombre, rose et à fort contraste.
-- Les raccourcis clavier de la recherche globale focalisent le champ instantanément avec / ou Ctrl+K (⌘K sur macOS), même lorsqu’il se trouve dans le menu latéral replié.
+- Les réglages d’accent et de typographie dans Paramètres permettent d’ajuster couleur d’accent, taille de base et famille de police, aux côtés des thèmes sombre, rose et à fort contraste.
+- Les raccourcis clavier de la recherche globale placent le focus sur le champ instantanément avec / ou Ctrl+K (⌘K sur macOS), même lorsqu’il se trouve dans le menu latéral replié.
 - Le bouton **Forcer le rechargement** vide les fichiers mis en cache par le service worker afin de mettre à jour l’application hors ligne sans effacer projets ou appareils.
-- Les icônes en forme d’étoile épinglent caméras, batteries et accessoires favoris en haut des listes et les incluent dans les sauvegardes.
+- Les icônes en forme d’étoile fixent caméras, batteries et accessoires favoris en haut des listes et les incluent dans les sauvegardes.
 - Le flux de **Réinitialisation d’usine** télécharge automatiquement une sauvegarde avant de supprimer projets, appareils et paramètres stockés.
 - La liste de matériel et l’aperçu imprimable affichent le nom du projet pour une référence immédiate.
 - Importez un logo personnalisé pour les aperçus imprimables et les sauvegardes.
@@ -42,7 +42,7 @@ L’application adopte automatiquement la langue de votre navigateur lors de la 
 - Tableau de pondération visuel pour analyser l’impact des réglages sur chaque mesure, trié par poids avec pourcentages précis.
 - Générateur de liste de matériel qui agrège équipements choisis et exigences du projet.
 - Les exigences de projet sont sauvegardées avec chaque configuration pour conserver tout le contexte.
-- Les boutons en forme de fourche dupliquent instantanément les entrées personnalisées dans les formulaires de liste de matériel.
+- Les boutons en forme de fourche dupliquent désormais instantanément les entrées personnalisées dans les formulaires de liste de matériel.
 
 ---
 
@@ -56,14 +56,14 @@ L’application adopte automatiquement la langue de votre navigateur lors de la 
 - **Adaptez l’outil à votre équipe.** Basculez instantanément entre français, anglais, allemand, espagnol et italien, ajustez taille et police, choisissez une couleur d’accent personnalisée, importez un logo d’impression et alternez thème clair, sombre, rose ou à fort contraste. Menus filtrables, favoris épinglés, boutons de duplication et aides contextuelles gardent un rythme rapide sur le plateau.
 
 ### ✅ Gestion de projet
-- Enregistrez, chargez et supprimez plusieurs projets caméra (Entrée ou Ctrl+S/⌘S pour sauvegarder rapidement ; le bouton reste inactif tant qu’aucun nom n’est saisi).
-- Des instantanés automatiques sont créés toutes les 10 minutes tant que le planner est ouvert, et la boîte de dialogue Paramètres peut déclencher des exports de sauvegarde horaires en guise de rappel.
-- Téléchargez un fichier JSON regroupant sélections, exigences, liste de matériel, retours d’autonomie et appareils personnalisés ; importez-le via le sélecteur de projet pour tout restaurer d’un coup.
-- Les données sont stockées localement via `localStorage` et les favoris sont inclus dans les sauvegardes ; utilisez l’option **Réinitialisation d’usine** pour enregistrer automatiquement une copie avant d’effacer projets et modifications d’appareils.
+- Enregistrez, chargez et supprimez plusieurs projets caméra (appuyez sur Entrée ou Ctrl+S/⌘S pour sauvegarder rapidement ; le bouton reste inactif tant qu’aucun nom n’est saisi).
+- Des instantanés automatiques se créent toutes les 10 minutes tant que le planner est ouvert, et la boîte de dialogue Paramètres peut déclencher des exports de sauvegarde horaires en guise de rappel.
+- Téléchargez un fichier JSON qui regroupe sélections, exigences, liste de matériel, retours d’autonomie et appareils personnalisés ; importez-le via le sélecteur de projet pour tout restaurer d’un coup.
+- Les données se stockent localement via `localStorage` et les favoris sont inclus dans les sauvegardes ; utilisez l’option **Réinitialisation d’usine** pour enregistrer automatiquement une copie avant d’effacer projets et modifications d’appareils.
 - Générez des aperçus imprimables pour chaque projet et ajoutez un logo personnalisé afin d’aligner exports et sauvegardes sur l’identité de votre production.
 - Les exigences de projet sont enregistrées avec chaque projet afin que la liste de matériel conserve l’intégralité du contexte.
-- Fonctionne entièrement hors ligne grâce au service worker : langue, thème, données d’appareil et favoris persistent entre les sessions.
-- Mise en page responsive adaptée aux ordinateurs, tablettes et téléphones.
+- Fonctionne intégralement hors ligne grâce au service worker : langue, thème, données d’appareil et favoris persistent entre les sessions.
+- Mise en page responsive qui s’adapte aux ordinateurs, tablettes et téléphones.
 - Sur les caméras compatibles, choisissez des plaques **V‑Mount**, **B‑Mount** ou **Gold-Mount** ; la liste des batteries se met à jour automatiquement.
 
 ### 🧭 Aperçu de l’interface
@@ -91,19 +91,19 @@ L’application adopte automatiquement la langue de votre navigateur lors de la 
 - Les boutons de duplication dupliquent instantanément les lignes de formulaire, et les favoris épinglés maintiennent le matériel clé en tête de liste – pratique quand le temps est compté.
 
 ### 📋 Liste de matériel
-Le générateur transforme vos sélections en une liste de préparation catégorisée :
+Le générateur transforme vos sélections en une liste de préparation classée par catégorie :
 
 - Cliquez sur **Générer la liste de matériel** pour compiler équipement choisi et exigences du projet dans un tableau.
-- Le tableau se met à jour automatiquement lorsque sélections ou exigences évoluent.
+- Le tableau se met à jour dès que sélections ou exigences évoluent.
 - Les éléments sont regroupés par catégorie (caméra, optique, alimentation, monitoring, rigging, machinerie, accessoires, consommables) et les doublons sont fusionnés avec leur quantité.
 - Câbles, structures et accessoires requis pour moniteurs, moteurs, gimbals et scénarios météo sont ajoutés automatiquement.
-- Les scénarios sélectionnés injectent l’équipement associé :
+- Les scénarios sélectionnés ajoutent l’équipement associé :
   - *Handheld* + *Easyrig* ajoute une poignée télescopique pour un soutien stable.
   - *Gimbal* ajoute le gimbal choisi, des bras articulés, des spigots et des pare-soleil ou kits de filtres.
   - *Outdoor* fournit spigots, parapluies et housses de pluie CapIt.
   - Les scénarios *Vehicle* et *Steadicam* ajoutent fixations, bras isolants et ventouses selon le besoin.
 - Les sélections d’optique incluent diamètre frontal, poids, données de rods et mise au point minimale, ajoutent supports d’objectif et adaptateurs de matte box, et signalent les standards incompatibles.
-- Les lignes de batteries reflètent les quantités calculées et incluent plaques ou appareils de hotswap lorsque nécessaire.
+- Les lignes de batteries reprennent les quantités calculées et incluent plaques ou appareils de hotswap lorsque nécessaire.
 - Les préférences de monitoring attribuent des moniteurs par défaut pour chaque rôle (réalisateur, DoP, pointeur, etc.) avec jeux de câbles et récepteurs sans fil.
 - Le formulaire **Exigences du projet** alimente la liste :
   - **Nom du projet**, **société de production**, **loueur** et **DoP** apparaissent dans l’en-tête des exigences imprimées.
@@ -116,7 +116,7 @@ Le générateur transforme vos sélections en une liste de préparation catégor
   - Les sélections de **boutons utilisateur** et **préférences trépied** sont listées pour référence rapide.
 - Les éléments de chaque catégorie sont triés alphabétiquement et affichent une info-bulle au survol.
 - La liste de matériel est incluse dans les aperçus imprimables et les fichiers de projet exportés.
-- Les listes sont sauvegardées automatiquement avec le projet et incluses dans exports et sauvegardes.
+- Les listes sont enregistrées automatiquement avec le projet et incluses dans exports et sauvegardes.
 - **Supprimer la liste de matériel** efface la liste enregistrée et masque la sortie.
 - Les formulaires fournissent des boutons en forme de fourche pour dupliquer instantanément les entrées.
 
@@ -205,7 +205,7 @@ Le générateur transforme vos sélections en une liste de préparation catégor
 
 ---
 
-## ▶️ Mode d’emploi
+## ▶️ Guide d’utilisation
 1. **Lancez l’application :** ouvrez `index.html` dans un navigateur moderne – aucun serveur requis.
 2. **Explorez la barre supérieure :** changez de langue, activez les thèmes sombre ou rose, ouvrez Paramètres pour régler accent et typographie et lancez l’aide avec ? ou Ctrl+/.
 3. **Sélectionnez les appareils :** choisissez l’équipement par catégorie via les menus déroulants ; saisissez pour filtrer, épinglez vos favoris et laissez les scénarios préconfigurés ajouter automatiquement les accessoires.
@@ -217,7 +217,7 @@ Le générateur transforme vos sélections en une liste de préparation catégor
 
 ## 📱 Installer l’application
 
-Le planner est une Progressive Web App installable directement depuis le navigateur :
+Le planner est une application web progressive installable directement depuis le navigateur :
 
 - **Chrome/Edge (bureau) :** cliquez sur l’icône d’installation dans la barre d’adresse.
 - **Android :** ouvrez le menu du navigateur et choisissez *Ajouter à l’écran d’accueil*.
@@ -227,7 +227,7 @@ Une fois installée, l’application se lance depuis l’écran d’accueil, fon
 
 ## 📡 Utilisation hors ligne & stockage
 
-Servir l’application via HTTP(S) installe un service worker qui met chaque fichier en cache pour que Cine Power Planner fonctionne totalement hors ligne et se mette à jour en arrière-plan. Projets, retours d’autonomie et préférences (langue, thème, mode rose et listes enregistrées) sont stockés dans le `localStorage` du navigateur. Effacer les données du site supprime toutes les informations, et la boîte de dialogue Paramètres propose un flux de **Réinitialisation d’usine** qui sauvegarde automatiquement une copie avant le nettoyage complet. L’en-tête affiche un badge hors ligne dès que la connexion tombe, et l’action 🔄 **Forcer le rechargement** actualise les fichiers en cache sans toucher aux projets enregistrés.
+Servir l’application via HTTP(S) installe un service worker qui met en cache chaque fichier pour que Cine Power Planner fonctionne totalement hors ligne et se mette à jour en arrière-plan. Projets, retours d’autonomie et préférences (langue, thème, mode rose et listes enregistrées) sont stockés dans le `localStorage` du navigateur. Effacer les données du site supprime toutes les informations, et la boîte de dialogue Paramètres propose un flux de **Réinitialisation d’usine** qui sauvegarde automatiquement une copie avant le nettoyage complet. L’en-tête affiche un badge hors ligne dès que la connexion tombe, et l’action 🔄 **Forcer le rechargement** actualise les fichiers en cache sans toucher aux projets enregistrés.
 
 ---
 
@@ -273,4 +273,4 @@ Ajoutez `--help` à l’un de ces scripts pour afficher les options disponibles.
 Exécutez `npm run help` pour obtenir un rappel rapide des scripts de maintenance et de l’ordre recommandé.
 
 ## 🤝 Contribuer
-Les contributions sont les bienvenues ! Ouvrez un ticket ou proposez une pull request. Lors de corrections de données, joindre des sauvegardes de projet ou des mesures d’autonomie aide à maintenir un catalogue fiable pour tous.
+Les contributions sont les bienvenues ! Ouvrez un ticket ou proposez une pull request. Lors de corrections de données, joignez des sauvegardes de projet ou des mesures d’autonomie pour aider à maintenir un catalogue fiable pour tous.

--- a/README.it.md
+++ b/README.it.md
@@ -1,8 +1,8 @@
 # 🎥 Cine Power Planner
 
-Questo strumento basato sul browser aiuta a pianificare progetti camera professionali alimentati da batterie V‑Mount, B‑Mount o Gold-Mount. Calcola il **consumo totale**, la **corrente assorbita** (a 14,4 V e 12 V) e l’**autonomia stimata**, verificando che il pacco batteria possa erogare in sicurezza la potenza richiesta.
+Questo strumento basato sul browser ti aiuta a pianificare progetti camera professionali alimentati da batterie V‑Mount, B‑Mount o Gold-Mount. Calcola il **consumo totale**, la **corrente assorbita** (a 14,4 V e 12 V) e l’**autonomia stimata**, verificando che il pacco batteria possa erogare in sicurezza la potenza richiesta.
 
-Tutta la pianificazione, i dati inseriti e gli export restano sul dispositivo davanti a te. Lingua, progetti, dispositivi personalizzati, preferiti e feedback sulle autonomie vivono nel browser, e gli aggiornamenti del service worker arrivano direttamente da questo repository. Avvia il planner offline dal disco o ospitalo internamente così che ogni reparto utilizzi la stessa versione verificata.
+Tutta la pianificazione, gli input e gli export restano sul dispositivo davanti a te. Lingua, progetti, dispositivi personalizzati, preferiti e feedback sulle autonomie vivono nel browser, e gli aggiornamenti del service worker arrivano direttamente da questo repository. Avvia il planner offline dal disco o ospitalo internamente così che ogni reparto utilizzi la stessa versione verificata.
 
 ---
 
@@ -13,23 +13,23 @@ Tutta la pianificazione, i dati inseriti e gli export restano sul dispositivo da
 - 🇮🇹 [Italiano](README.it.md)
 - 🇫🇷 [Français](README.fr.md)
 
-Al primo avvio l’app adotta la lingua del browser; puoi cambiarla dall’angolo in alto a destra e la scelta verrà ricordata per la visita successiva.
+Al primo avvio l’applicazione adotta la lingua del browser; puoi cambiarla dall’angolo in alto a destra e la scelta viene ricordata per la visita successiva.
 
 ---
 
 ## 🆕 Novità
-- I controlli di accento e tipografia nelle Impostazioni permettono di regolare colore, dimensione base e famiglia del font insieme ai temi scuro, rosa e ad alto contrasto.
-- Le scorciatoie per la ricerca globale mettono a fuoco il campo all’istante con / o Ctrl+K (⌘K su macOS), anche quando è nascosto nel menu laterale compresso.
-- Il pulsante **Forza ricarica** cancella i file del service worker in cache per aggiornare l’app offline senza eliminare progetti o dispositivi salvati.
-- Le icone a stella in ogni selettore fissano videocamere, batterie e accessori preferiti in cima alla lista e li includono nei backup.
+- I controlli di accento e tipografia nelle Impostazioni consentono di regolare colore, dimensione base e famiglia del font insieme ai temi scuro, rosa e ad alto contrasto.
+- Le scorciatoie della ricerca globale portano il focus sul campo all’istante con / o Ctrl+K (⌘K su macOS), anche quando è nascosto nel menu laterale compresso.
+- Il pulsante **Forza ricarica** cancella i file del service worker in cache per aggiornare l’applicazione offline senza eliminare progetti o dispositivi salvati.
+- Le icone a stella di ogni selettore fissano videocamere, batterie e accessori preferiti in cima alla lista e li includono nei backup.
 - Il flusso di **Ripristino di fabbrica** scarica automaticamente una copia di sicurezza prima di rimuovere progetti, dispositivi e impostazioni memorizzati.
 - La lista attrezzatura e l’anteprima stampabile mostrano il nome del progetto per un riferimento veloce.
 - Puoi caricare un logo personalizzato che apparirà nelle stampe e nei backup.
 - I backup includono i preferiti e creano automaticamente una copia prima del ripristino.
-- Le schede della troupe includono ora un campo e-mail.
+- Le schede della troupe includono ora un campo e-mail dedicato.
 - Nuovo tema ad alto contrasto per migliorare la leggibilità.
 - I moduli dei dispositivi compilano le categorie in modo dinamico partendo dallo schema.
-- Interfaccia ridisegnata con più contrasto e spaziatura per un’esperienza più pulita su qualsiasi dispositivo.
+- Interfaccia ridisegnata con contrasto maggiore e spaziature più generose per un’esperienza più pulita su qualsiasi dispositivo.
 - Condividere i progetti è più semplice: scarica un file JSON con selezioni, requisiti, lista attrezzatura, feedback di autonomia e dispositivi personalizzati, quindi importalo per ripristinare tutto.
 - Icone dedicate per gli scenari obbligatori evidenziano subito i requisiti del progetto.
 - Diagramma del progetto interattivo per trascinare i dispositivi, fare zoom, allineare alla griglia ed esportare in SVG o JPG.
@@ -57,13 +57,13 @@ Al primo avvio l’app adotta la lingua del browser; puoi cambiarla dall’angol
 
 ### ✅ Gestione dei progetti
 - Salva, carica e cancella più progetti (premi Invio o Ctrl+S/⌘S per salvare rapidamente; il pulsante rimane disattivato finché non inserisci un nome).
-- Vengono creati automaticamente snapshot ogni 10 minuti mentre il planner è aperto, e nelle Impostazioni puoi attivare export orari di backup come promemoria.
-- Scarica un file JSON che raccoglie selezioni, requisiti, lista attrezzatura, feedback di autonomia e dispositivi personalizzati; importalo dal selettore per ripristinare tutto in un passo.
-- I dati sono archiviati localmente tramite `localStorage` e i preferiti vengono inclusi nei backup; l’opzione **Ripristino di fabbrica** salva automaticamente una copia prima di cancellare progetti e modifiche ai dispositivi.
+- Vengono creati snapshot automatici ogni 10 minuti mentre il planner è aperto, e nelle Impostazioni puoi attivare export orari di backup come promemoria.
+- Scarica un file JSON che raggruppa selezioni, requisiti, lista attrezzatura, feedback di autonomia e dispositivi personalizzati; importalo dal selettore per ripristinare tutto in un passo.
+- I dati si salvano localmente tramite `localStorage` e i preferiti vengono inclusi nei backup; l’opzione **Ripristino di fabbrica** scarica automaticamente una copia prima di cancellare progetti e modifiche ai dispositivi.
 - Genera anteprime stampabili per ogni progetto e aggiungi un logo personalizzato così esportazioni e backup rispettano l’identità della produzione.
 - I requisiti di progetto vengono salvati con il progetto, così la lista attrezzatura conserva il contesto completo.
-- Funziona completamente offline grazie al service worker: lingua, tema, dati dei dispositivi e preferiti persistono tra le sessioni.
-- Layout responsive che si adatta a desktop, tablet e smartphone.
+- Funziona interamente offline grazie al service worker: lingua, tema, dati dei dispositivi e preferiti persistono tra le sessioni.
+- Il layout responsive si adatta a desktop, tablet e smartphone.
 - Sulle videocamere compatibili puoi scegliere piastre **V‑Mount**, **B‑Mount** o **Gold-Mount**; l’elenco delle batterie si aggiorna automaticamente.
 
 ### 🧭 Panoramica dell’interfaccia
@@ -78,7 +78,7 @@ Al primo avvio l’app adotta la lingua del browser; puoi cambiarla dall’angol
 - La barra di ricerca globale consente di raggiungere funzioni, selettori o argomenti di aiuto; premi Invio per aprire il risultato evidenziato, usa / o Ctrl+K (⌘K su macOS) per focalizzarla subito (su schermi piccoli il menu laterale si apre automaticamente) e premi Esc o × per cancellare la ricerca.
 - I controlli della barra superiore offrono cambio lingua, temi scuro e rosa e la finestra Impostazioni con colore accento, dimensione e famiglia del font, modalità ad alto contrasto e caricamento del logo, oltre agli strumenti di backup, ripristino e Ripristino di fabbrica che salvano una copia prima di cancellare i dati.
 - Il pulsante di aiuto apre un dialogo ricercabile con sezioni guidate, scorciatoie da tastiera, FAQ e una modalità di suggerimenti al passaggio del mouse; lo puoi aprire anche con ?, H, F1 o Ctrl+/ mentre digiti.
-- Il pulsante di ricarica forzata (🔄) elimina i file del service worker in cache così l’app offline si aggiorna senza perdere progetti o dispositivi.
+- Il pulsante di ricarica forzata (🔄) elimina i file del service worker in cache così l’applicazione offline si aggiorna senza perdere progetti o dispositivi.
 - Su schermi piccoli un menu laterale a scomparsa replica ogni sezione principale per navigare rapidamente.
 
 ### ♿ Personalizzazione e accessibilità
@@ -91,10 +91,10 @@ Al primo avvio l’app adotta la lingua del browser; puoi cambiarla dall’angol
 - I pulsanti a forchetta duplicano le righe dei moduli all’istante e i preferiti fissati mantengono l’attrezzatura abituale in cima alle liste, utile quando il tempo è limitato.
 
 ### 📋 Lista attrezzatura
-Il generatore trasforma le tue scelte in una lista di carico suddivisa per categorie:
+Il generatore trasforma le tue scelte in una lista di carico ordinata per categorie:
 
 - Clicca su **Genera lista attrezzatura** per raccogliere l’equipaggiamento selezionato e i requisiti del progetto in una tabella.
-- La tabella si aggiorna automaticamente quando cambiano selezioni o requisiti.
+- La tabella si aggiorna non appena cambiano selezioni o requisiti.
 - Gli elementi sono raggruppati per categoria (camera, ottiche, alimentazione, monitoraggio, rigging, grip, accessori, consumabili) e i duplicati sono uniti con la quantità corretta.
 - Cavi, rigging e accessori necessari per monitor, motori, gimbal e scenari meteo vengono aggiunti automaticamente.
 - Gli scenari selezionati aggiungono l’attrezzatura correlata:
@@ -102,8 +102,8 @@ Il generatore trasforma le tue scelte in una lista di carico suddivisa per categ
   - *Gimbal* aggiunge il gimbal scelto, bracci articolati, spigot e paraluce o kit filtri.
   - *Outdoor* fornisce spigot, ombrelli e coperture antipioggia CapIt.
   - Gli scenari *Vehicle* e *Steadicam* includono staffe, bracci di isolamento e ventose quando necessari.
-- Le selezioni delle ottiche riportano diametro frontale, peso, dati dei rod e fuoco minimo, aggiungono supporti per lenti e adattatori matte box e segnalano standard incompatibili.
-- Le righe delle batterie riflettono i conteggi del calcolatore di potenza e includono piastre o dispositivi di hotswap quando richiesti.
+- Le selezioni delle ottiche riportano diametro frontale, peso, dati dei rod e fuoco minimo, aggiungono i supporti per lenti e gli adattatori matte box e segnalano eventuali standard incompatibili.
+- Le righe delle batterie riprendono i conteggi del calcolatore di potenza e includono piastre o dispositivi di hotswap quando richiesti.
 - Le preferenze di monitoraggio assegnano monitor predefiniti a ogni ruolo (regista, DoP, fuochista, ecc.) con set di cavi e ricevitori wireless.
 - Il modulo **Requisiti del progetto** alimenta la lista:
   - **Nome del progetto**, **casa di produzione**, **noleggio** e **DoP** compaiono nell’intestazione delle specifiche stampate.
@@ -116,7 +116,7 @@ Il generatore trasforma le tue scelte in una lista di carico suddivisa per categ
   - Le scelte dei **pulsanti personalizzati** e delle **preferenze treppiede** vengono elencate per riferimento rapido.
 - All’interno di ogni categoria gli elementi sono ordinati alfabeticamente e mostrano un tooltip al passaggio del mouse.
 - La lista attrezzatura è inclusa nelle anteprime stampabili e nei file di progetto esportati.
-- Le liste vengono salvate automaticamente con il progetto e fanno parte sia degli export sia dei backup.
+- Le liste vengono salvate automaticamente insieme al progetto e sono incluse sia negli export sia nei backup.
 - **Elimina lista attrezzatura** cancella la lista salvata e nasconde l’output.
 - I moduli includono pulsanti a forchetta per duplicare le voci inserite al volo.
 
@@ -206,7 +206,7 @@ Il generatore trasforma le tue scelte in una lista di carico suddivisa per categ
 ---
 
 ## ▶️ Come usarlo
-1. **Avvia l’app:** apri `index.html` in un browser moderno; non serve alcun server.
+1. **Avvia l’applicazione:** apri `index.html` in un browser moderno; non serve alcun server.
 2. **Esplora la barra superiore:** cambia lingua, alterna i temi scuro o rosa, apri Impostazioni per regolare accento e tipografia e lancia l’aiuto con ? o Ctrl+/.
 3. **Seleziona i dispositivi:** scegli l’attrezzatura per ogni categoria dai menu; digita per filtrare, fissa i preferiti con la stella e lascia che gli scenari compilino gli accessori.
 4. **Consulta i calcoli:** dopo aver scelto una batteria vedrai consumo, corrente e autonomia; gli avvisi evidenziano eventuali superamenti dei limiti.
@@ -215,19 +215,19 @@ Il generatore trasforma le tue scelte in una lista di carico suddivisa per categ
 7. **Gestisci i dati dei dispositivi:** clicca su “Modifica dati dispositivi…” per aprire l’editor, aggiornare il catalogo, esportare/importare JSON o tornare ai valori predefiniti.
 8. **Invia feedback di autonomia:** usa “Invia feedback di autonomia” per registrare misurazioni reali e perfezionare le medie ponderate.
 
-## 📱 Installare come app
+## 📱 Installare come applicazione
 
-Il planner è una Progressive Web App installabile direttamente dal browser:
+Il planner è un’applicazione web progressiva installabile direttamente dal browser:
 
 - **Chrome/Edge (desktop):** fai clic sull’icona di installazione nella barra degli indirizzi.
 - **Android:** apri il menu del browser e scegli *Aggiungi alla schermata Home*.
 - **iOS/iPadOS Safari:** tocca *Condividi* e seleziona *Aggiungi alla schermata Home*.
 
-Una volta installata, l’app si avvia dalla schermata Home, funziona offline e si aggiorna automaticamente.
+Una volta installata, l’applicazione si avvia dalla schermata Home, funziona offline e si aggiorna automaticamente.
 
 ## 📡 Uso offline e archiviazione
 
-Servire l’app via HTTP(S) installa un service worker che memorizza in cache ogni file, così Cine Power Planner funziona completamente offline e si aggiorna in background. Progetti, feedback di autonomia e preferenze (lingua, tema, modalità rosa e liste salvate) risiedono nel `localStorage` del browser. Cancellare i dati del sito elimina tutte le informazioni e il menu Impostazioni offre un flusso di **Ripristino di fabbrica** che salva automaticamente un backup prima della stessa pulizia completa. L’intestazione mostra un badge offline quando la connessione cade e l’azione 🔄 **Forza ricarica** aggiorna i file in cache senza toccare i progetti.
+Servire l’applicazione via HTTP(S) installa un service worker che memorizza in cache ogni file, così Cine Power Planner funziona completamente offline e si aggiorna in background. Progetti, feedback di autonomia e preferenze (lingua, tema, modalità rosa e liste salvate) risiedono nel `localStorage` del browser. Cancellare i dati del sito elimina tutte le informazioni e il menu Impostazioni offre un flusso di **Ripristino di fabbrica** che salva automaticamente un backup prima della stessa pulizia completa. L’intestazione mostra un badge offline quando la connessione cade e l’azione 🔄 **Forza ricarica** aggiorna i file in cache senza toccare i progetti.
 
 ---
 
@@ -248,7 +248,7 @@ legal/                     # Pagine legali offline
 tools/                     # Script di manutenzione dei dati
 tests/                     # Suite di test Jest
 ```
-I font sono inclusi localmente tramite `fonts.css`; una volta in cache, l’app funziona interamente offline.
+I font sono inclusi localmente tramite `fonts.css`; una volta in cache, l’applicazione funziona interamente offline.
 
 ## 🛠️ Sviluppo
 Richiede Node.js 18 o successivo.
@@ -273,4 +273,4 @@ Aggiungi `--help` a uno qualsiasi degli script per visualizzare le opzioni dispo
 Esegui `npm run help` per un riepilogo rapido dei comandi di manutenzione e dell’ordine consigliato.
 
 ## 🤝 Contribuire
-Contributi di ogni tipo sono benvenuti! Apri una issue o invia una pull request. Per correzioni sui dati, allegare backup di progetto o misure di autonomia aiuta a mantenere un catalogo accurato per tutti.
+Contributi di ogni tipo sono benvenuti! Apri una issue o invia una pull request. Per correzioni sui dati, allega backup di progetto o misure di autonomia per mantenere un catalogo accurato per tutti.


### PR DESCRIPTION
## Summary
- align the Spanish README with the current English introduction, feature highlights, and project workflow details
- mirror the latest English terminology and instructions across the German, French, and Italian READMEs so every locale documents the same capabilities

## Testing
- not run (documentation updates only)

------
https://chatgpt.com/codex/tasks/task_e_68ce65f2c1808320b70435457243fcf2