### PR TITLE
Use safe storage for export/import helpers

### DIFF
--- a/tests/unit/storageFallback.test.js
+++ b/tests/unit/storageFallback.test.js
@@ -1,4 +1,6 @@
 const FAVORITES_KEY = 'cameraPowerPlanner_favorites';
+const CUSTOM_FONT_KEY = 'cameraPowerPlanner_customFonts';
+const CUSTOM_LOGO_KEY = 'customLogo';
 
 describe('SAFE_LOCAL_STORAGE fallback behaviour', () => {
   let originalLocalStorageDescriptor;
@@ -53,6 +55,38 @@ describe('SAFE_LOCAL_STORAGE fallback behaviour', () => {
     );
     expect(global.localStorage.getItem(FAVORITES_KEY)).toBeNull();
     expect(loadFavorites()).toEqual({ cameraSelect: ['Alexa Mini'] });
+  });
+
+  test('export/import helpers rely on SAFE_LOCAL_STORAGE fallback', () => {
+    const { importAllData, exportAllData } = storageModule;
+    const session = global.sessionStorage;
+
+    const fonts = [
+      { id: 'font-1', name: 'Planner Sans', data: 'data:font/plain;base64,AAA' },
+    ];
+
+    importAllData({
+      preferences: {
+        darkMode: true,
+        accentColor: '#123456',
+      },
+      customLogo: 'data:image/png;base64,logo',
+      customFonts: fonts,
+    });
+
+    expect(session.getItem('darkMode')).toBe('true');
+    expect(session.getItem('accentColor')).toBe('#123456');
+    expect(session.getItem(CUSTOM_LOGO_KEY)).toBe('data:image/png;base64,logo');
+    expect(session.getItem(CUSTOM_FONT_KEY)).toBe(JSON.stringify(fonts));
+    expect(global.localStorage.getItem('darkMode')).toBeNull();
+
+    const exported = exportAllData();
+    expect(exported.preferences).toMatchObject({
+      darkMode: true,
+      accentColor: '#123456',
+    });
+    expect(exported.customLogo).toBe('data:image/png;base64,logo');
+    expect(exported.customFonts).toEqual(fonts);
   });
 });
 


### PR DESCRIPTION
## Summary
- update the export/import helpers to read from and write to SAFE_LOCAL_STORAGE so backups respect the storage fallback
- keep backup key handling intact when using the safe storage abstraction and adjust related warnings
- extend the SAFE_LOCAL_STORAGE fallback unit suite to cover export/import flows

## Testing
- npm run test:unit

------
https://chatgpt.com/codex/tasks/task_e_68ce6e9e83cc8320b6374487acfaf19b