### PR TITLE
Guard normalization rewrites with safe storage

### DIFF
--- a/assets/js/storage.js
+++ b/assets/js/storage.js
@@ -535,8 +535,13 @@ function loadDeviceData() {
     changed = true;
   }
 
-  if (changed && SAFE_LOCAL_STORAGE) {
-    SAFE_LOCAL_STORAGE.setItem(DEVICE_STORAGE_KEY, JSON.stringify(data));
+  if (changed) {
+    saveJSONToStorage(
+      SAFE_LOCAL_STORAGE,
+      DEVICE_STORAGE_KEY,
+      data,
+      "Error saving normalized device data to localStorage:",
+    );
   }
 
   console.log("Device data loaded from localStorage.");
@@ -609,8 +614,13 @@ function loadSetups() {
     },
   );
   const { data: setups, changed } = normalizeSetups(parsedData);
-  if (changed && SAFE_LOCAL_STORAGE) {
-    SAFE_LOCAL_STORAGE.setItem(SETUP_STORAGE_KEY, JSON.stringify(setups));
+  if (changed) {
+    saveJSONToStorage(
+      SAFE_LOCAL_STORAGE,
+      SETUP_STORAGE_KEY,
+      setups,
+      "Error saving normalized setup data to localStorage:",
+    );
   }
   return setups;
 }


### PR DESCRIPTION
## Summary
- wrap normalized device data rewrites with saveJSONToStorage to handle persistence failures
- guard normalized setup storage writes with the same helper to avoid quota errors mid-load

## Testing
- npm run test:unit

------
https://chatgpt.com/codex/tasks/task_e_68ce6ec9d3048320add9799f4dde8311