### PR TITLE
Ensure missing primary storage restores from backup

### DIFF
--- a/src/scripts/storage.js
+++ b/src/scripts/storage.js
@@ -283,7 +283,10 @@ function loadJSONFromStorage(
     return primary.value;
   }
 
-  const shouldAttemptBackup = useBackup && (shouldAlert || restoreIfMissing);
+  const missingPrimary = !primary.ok && primary.reason === 'missing';
+
+  const shouldAttemptBackup =
+    useBackup && (shouldAlert || restoreIfMissing || missingPrimary);
 
   if (shouldAttemptBackup) {
     let backupRaw = null;
@@ -296,7 +299,7 @@ function loadJSONFromStorage(
 
     const backup = parseRawValue(backupRaw, 'backup');
     if (backup.ok) {
-      if (shouldAlert) {
+      if (shouldAlert || missingPrimary) {
         console.warn(`Recovered ${key} from backup copy.`);
       }
       if (backup.raw !== null && backup.raw !== undefined) {


### PR DESCRIPTION
## Summary
- attempt backup restoration whenever the primary JSON record is missing so saved data cannot be overwritten by defaults
- log backup recovery for missing primaries without surfacing user alerts to preserve the existing UX

## Testing
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68ce7112fc3c8320814c53b432e41972