### PR TITLE
Guard normalization storage rewrites

### DIFF
--- a/src/scripts/storage.js
+++ b/src/scripts/storage.js
@@ -535,8 +535,13 @@ function loadDeviceData() {
     changed = true;
   }
 
-  if (changed && SAFE_LOCAL_STORAGE) {
-    SAFE_LOCAL_STORAGE.setItem(DEVICE_STORAGE_KEY, JSON.stringify(data));
+  if (changed) {
+    saveJSONToStorage(
+      SAFE_LOCAL_STORAGE,
+      DEVICE_STORAGE_KEY,
+      data,
+      "Error updating device data in localStorage during normalization:",
+    );
   }
 
   console.log("Device data loaded from localStorage.");
@@ -609,8 +614,13 @@ function loadSetups() {
     },
   );
   const { data: setups, changed } = normalizeSetups(parsedData);
-  if (changed && SAFE_LOCAL_STORAGE) {
-    SAFE_LOCAL_STORAGE.setItem(SETUP_STORAGE_KEY, JSON.stringify(setups));
+  if (changed) {
+    saveJSONToStorage(
+      SAFE_LOCAL_STORAGE,
+      SETUP_STORAGE_KEY,
+      setups,
+      "Error updating setups in localStorage during normalization:",
+    );
   }
   return setups;
 }


### PR DESCRIPTION
## Summary
- wrap device normalization rewrites in the same guarded persistence path used by saveJSONToStorage
- apply the same storage guard to setup normalization rewrites and surface clear error messaging when updates fail

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ce715f215c8320b8a01ec7f5340584