### PR TITLE
Use Uicons download/upload glyphs for import/export

### DIFF
--- a/index.html
+++ b/index.html
@@ -198,49 +198,7 @@
       <span class="form-label-spacer" aria-hidden="true"></span>
       <div class="form-actions">
         <button id="shareSetupBtn">
-          <span class="btn-icon icon-glyph icon-svg" aria-hidden="true">
-            <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-              <line
-                x1="12"
-                y1="6.75"
-                x2="12"
-                y2="16.25"
-                fill="none"
-                stroke="currentColor"
-                stroke-width="1.5"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-              />
-              <polyline
-                points="8.75 12.75 12 16.25 15.25 12.75"
-                fill="none"
-                stroke="currentColor"
-                stroke-width="1.5"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-              />
-              <path
-                d="M4.75 14.5H8.6L10.4 17h8.85L21 14.5"
-                fill="none"
-                stroke="currentColor"
-                stroke-width="1.5"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-              />
-              <rect
-                x="4.75"
-                y="12.5"
-                width="14.5"
-                height="7.25"
-                rx="1.75"
-                fill="none"
-                stroke="currentColor"
-                stroke-width="1.5"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-              />
-            </svg>
-          </span>
+          <span class="btn-icon icon-glyph" aria-hidden="true" data-icon-font="uicons">&#xF423;</span>
           Export Project
         </button>
         <div id="sharedLinkRow" class="share-import-group">
@@ -254,49 +212,7 @@
             class="visually-hidden"
           />
           <button id="applySharedLinkBtn">
-            <span class="btn-icon icon-glyph icon-svg" aria-hidden="true">
-              <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-                <line
-                  x1="12"
-                  y1="6.75"
-                  x2="12"
-                  y2="16.25"
-                  fill="none"
-                  stroke="currentColor"
-                  stroke-width="1.5"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                />
-                <polyline
-                  points="8.75 10.25 12 6.75 15.25 10.25"
-                  fill="none"
-                  stroke="currentColor"
-                  stroke-width="1.5"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                />
-                <path
-                  d="M4.75 14.5H8.6L10.4 17h8.85L21 14.5"
-                  fill="none"
-                  stroke="currentColor"
-                  stroke-width="1.5"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                />
-                <rect
-                  x="4.75"
-                  y="12.5"
-                  width="14.5"
-                  height="7.25"
-                  rx="1.75"
-                  fill="none"
-                  stroke="currentColor"
-                  stroke-width="1.5"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                />
-              </svg>
-            </span>
+            <span class="btn-icon icon-glyph" aria-hidden="true" data-icon-font="uicons">&#xF425;</span>
             Import Project
           </button>
         </div>
@@ -807,8 +723,8 @@
     </div>
     <button id="addDeviceBtn">Add</button>
     <button id="cancelEditBtn" class="hidden"><span class="btn-icon icon-glyph" aria-hidden="true" data-icon-font="essential">&#xF131;</span>Cancel</button>
-      <button id="exportDataBtn">Export Database</button>
-      <button id="importDataBtn">Import Database</button>
+      <button id="exportDataBtn"><span class="btn-icon icon-glyph" aria-hidden="true" data-icon-font="uicons">&#xF423;</span>Export Database</button>
+      <button id="importDataBtn"><span class="btn-icon icon-glyph" aria-hidden="true" data-icon-font="uicons">&#xF425;</span>Import Database</button>
       <input type="file" id="importFileInput" accept=".json" class="hidden" />
       <button id="exportAndRevertBtn">Export and Revert to default Database</button>
     </div>

--- a/src/scripts/script.js
+++ b/src/scripts/script.js
@@ -2300,7 +2300,7 @@ function setLanguage(lang) {
   setButtonLabelWithIcon(
     applySharedLinkBtn,
     texts[lang].loadSharedLinkBtn,
-    ICON_GLYPHS.load
+    ICON_GLYPHS.fileImport
   );
 
   // Descriptive hover help for setup management controls
@@ -2662,9 +2662,9 @@ function setLanguage(lang) {
   }
   setButtonLabelWithIcon(cancelEditBtn, texts[lang].cancelEditBtn, ICON_GLYPHS.circleX);
   cancelEditBtn.setAttribute('data-help', texts[lang].cancelEditBtnHelp);
-  exportBtn.textContent = texts[lang].exportDataBtn;
+  setButtonLabelWithIcon(exportBtn, texts[lang].exportDataBtn, ICON_GLYPHS.fileExport);
   exportBtn.setAttribute('data-help', texts[lang].exportDataBtnHelp);
-  importDataBtn.textContent = texts[lang].importDataBtn; // New translation for import button
+  setButtonLabelWithIcon(importDataBtn, texts[lang].importDataBtn, ICON_GLYPHS.fileImport);
   importDataBtn.setAttribute('data-help', texts[lang].importDataBtnHelp);
   // Placeholders for inputs
   setupNameInput.placeholder = texts[lang].setupNameLabel.replace(":", "");
@@ -3360,7 +3360,7 @@ function setLanguage(lang) {
   setButtonLabelWithIcon(
     document.getElementById("shareSetupBtn"),
     texts[lang].shareSetupBtn,
-    ICON_GLYPHS.share
+    ICON_GLYPHS.fileExport
   );
   const exportRevert = document.getElementById("exportAndRevertBtn");
   if (exportRevert) {
@@ -3945,6 +3945,8 @@ const ICON_GLYPHS = Object.freeze({
   trash: iconGlyph('\uF254', ICON_FONT_KEYS.ESSENTIAL),
   reload: iconGlyph('\uF202', ICON_FONT_KEYS.ESSENTIAL),
   load: Object.freeze({ markup: LOAD_ICON_SVG, className: 'icon-svg' }),
+  fileExport: iconGlyph('\uF423', ICON_FONT_KEYS.UICONS),
+  fileImport: iconGlyph('\uF425', ICON_FONT_KEYS.UICONS),
   save: iconGlyph('\uF207', ICON_FONT_KEYS.ESSENTIAL),
   share: iconGlyph('\uF219', ICON_FONT_KEYS.ESSENTIAL),
   magnet: iconGlyph('\uF1B5', ICON_FONT_KEYS.ESSENTIAL),


### PR DESCRIPTION
## Summary
- swap the export and import buttons in the share panel over to the Uicons file-export and file-import glyphs
- add the same matching icons to the device database export/import controls and reuse the helper so text updates stay consistent

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ce743f69a8832093687213b1e1e01f