### PR TITLE
Fix CSP warning and avoid custom font key redeclaration

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
   <meta name="theme-color" content="#f9f9f9" />
   <meta name="application-name" content="Cine Power Planner" />
   <meta name="apple-mobile-web-app-title" content="Cine Power Planner" />
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; connect-src 'self'; img-src 'self' data:; script-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self' data:; manifest-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none';" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; connect-src 'self'; img-src 'self' data:; script-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self' data:; manifest-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self';" />
   <meta name="referrer" content="no-referrer" />
   <meta name="color-scheme" content="light dark" />
   <title>Cine Power Planner</title>

--- a/src/scripts/script.js
+++ b/src/scripts/script.js
@@ -1,5 +1,5 @@
 // script.js – Main logic for the Cine Power Planner app
-/* global texts, categoryNames, gearItems, loadSessionState, saveSessionState, loadProject, saveProject, deleteProject, registerDevice, loadFavorites, saveFavorites, exportAllData, importAllData, clearAllData, loadAutoGearRules, saveAutoGearRules, loadAutoGearBackups, saveAutoGearBackups, loadAutoGearSeedFlag, saveAutoGearSeedFlag, loadAutoGearPresets, saveAutoGearPresets, loadAutoGearActivePresetId, saveAutoGearActivePresetId, loadAutoGearBackupVisibility, saveAutoGearBackupVisibility, AUTO_GEAR_RULES_STORAGE_KEY, AUTO_GEAR_SEEDED_STORAGE_KEY, AUTO_GEAR_BACKUPS_STORAGE_KEY, AUTO_GEAR_PRESETS_STORAGE_KEY, AUTO_GEAR_ACTIVE_PRESET_STORAGE_KEY, AUTO_GEAR_BACKUP_VISIBILITY_STORAGE_KEY, SAFE_LOCAL_STORAGE, getSafeLocalStorage */
+/* global texts, categoryNames, gearItems, loadSessionState, saveSessionState, loadProject, saveProject, deleteProject, registerDevice, loadFavorites, saveFavorites, exportAllData, importAllData, clearAllData, loadAutoGearRules, saveAutoGearRules, loadAutoGearBackups, saveAutoGearBackups, loadAutoGearSeedFlag, saveAutoGearSeedFlag, loadAutoGearPresets, saveAutoGearPresets, loadAutoGearActivePresetId, saveAutoGearActivePresetId, loadAutoGearBackupVisibility, saveAutoGearBackupVisibility, AUTO_GEAR_RULES_STORAGE_KEY, AUTO_GEAR_SEEDED_STORAGE_KEY, AUTO_GEAR_BACKUPS_STORAGE_KEY, AUTO_GEAR_PRESETS_STORAGE_KEY, AUTO_GEAR_ACTIVE_PRESET_STORAGE_KEY, AUTO_GEAR_BACKUP_VISIBILITY_STORAGE_KEY, SAFE_LOCAL_STORAGE, getSafeLocalStorage, CUSTOM_FONT_STORAGE_KEY */
 
 // Use `var` here instead of `let` because `index.html` loads the lz-string
 // library from a CDN which defines a global `LZString` variable. Using `let`
@@ -8931,7 +8931,10 @@ if (uiScaleRoot) {
   }
 }
 
-const CUSTOM_FONT_STORAGE_KEY = 'cameraPowerPlanner_customFonts';
+const CUSTOM_FONT_STORAGE_KEY_NAME =
+  typeof CUSTOM_FONT_STORAGE_KEY !== 'undefined'
+    ? CUSTOM_FONT_STORAGE_KEY
+    : 'cameraPowerPlanner_customFonts';
 const customFontEntries = new Map();
 
 const SUPPORTED_FONT_TYPES = new Set([
@@ -8950,7 +8953,7 @@ const SUPPORTED_FONT_EXTENSIONS = ['.ttf', '.otf', '.ttc', '.woff', '.woff2'];
 function loadCustomFontMetadataFromStorage() {
   if (typeof localStorage === 'undefined') return [];
   try {
-    const raw = localStorage.getItem(CUSTOM_FONT_STORAGE_KEY);
+    const raw = localStorage.getItem(CUSTOM_FONT_STORAGE_KEY_NAME);
     if (!raw) return [];
     const parsed = JSON.parse(raw);
     if (!Array.isArray(parsed)) return [];
@@ -8975,7 +8978,7 @@ function persistCustomFontsToStorage() {
       name: entry.name,
       data: entry.data
     }));
-    localStorage.setItem(CUSTOM_FONT_STORAGE_KEY, JSON.stringify(payload));
+    localStorage.setItem(CUSTOM_FONT_STORAGE_KEY_NAME, JSON.stringify(payload));
     return true;
   } catch (error) {
     console.warn('Could not save custom fonts', error);


### PR DESCRIPTION
## Summary
- reuse the storage-defined custom font key in script.js to avoid redeclaring the constant and prevent runtime syntax errors
- remove the unsupported frame-ancestors directive from the meta-based CSP to eliminate the browser warning

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ce764a856c8320a7c62983e865e02b