### PR TITLE
Fix duplicate custom font storage key declaration

### DIFF
--- a/src/scripts/script.js
+++ b/src/scripts/script.js
@@ -1,5 +1,5 @@
 // script.js – Main logic for the Cine Power Planner app
-/* global texts, categoryNames, gearItems, loadSessionState, saveSessionState, loadProject, saveProject, deleteProject, registerDevice, loadFavorites, saveFavorites, exportAllData, importAllData, clearAllData, loadAutoGearRules, saveAutoGearRules, loadAutoGearBackups, saveAutoGearBackups, loadAutoGearSeedFlag, saveAutoGearSeedFlag, loadAutoGearPresets, saveAutoGearPresets, loadAutoGearActivePresetId, saveAutoGearActivePresetId, loadAutoGearBackupVisibility, saveAutoGearBackupVisibility, AUTO_GEAR_RULES_STORAGE_KEY, AUTO_GEAR_SEEDED_STORAGE_KEY, AUTO_GEAR_BACKUPS_STORAGE_KEY, AUTO_GEAR_PRESETS_STORAGE_KEY, AUTO_GEAR_ACTIVE_PRESET_STORAGE_KEY, AUTO_GEAR_BACKUP_VISIBILITY_STORAGE_KEY, SAFE_LOCAL_STORAGE, getSafeLocalStorage, CUSTOM_FONT_STORAGE_KEY */
+/* global texts, categoryNames, gearItems, loadSessionState, saveSessionState, loadProject, saveProject, deleteProject, registerDevice, loadFavorites, saveFavorites, exportAllData, importAllData, clearAllData, loadAutoGearRules, saveAutoGearRules, loadAutoGearBackups, saveAutoGearBackups, loadAutoGearSeedFlag, saveAutoGearSeedFlag, loadAutoGearPresets, saveAutoGearPresets, loadAutoGearActivePresetId, saveAutoGearActivePresetId, loadAutoGearBackupVisibility, saveAutoGearBackupVisibility, AUTO_GEAR_RULES_STORAGE_KEY, AUTO_GEAR_SEEDED_STORAGE_KEY, AUTO_GEAR_BACKUPS_STORAGE_KEY, AUTO_GEAR_PRESETS_STORAGE_KEY, AUTO_GEAR_ACTIVE_PRESET_STORAGE_KEY, AUTO_GEAR_BACKUP_VISIBILITY_STORAGE_KEY, SAFE_LOCAL_STORAGE, getSafeLocalStorage, CUSTOM_FONT_STORAGE_KEY, CUSTOM_FONT_STORAGE_KEY_NAME */
 
 // Use `var` here instead of `let` because `index.html` loads the lz-string
 // library from a CDN which defines a global `LZString` variable. Using `let`
@@ -8933,10 +8933,12 @@ if (uiScaleRoot) {
   }
 }
 
-const CUSTOM_FONT_STORAGE_KEY_NAME =
-  typeof CUSTOM_FONT_STORAGE_KEY !== 'undefined'
-    ? CUSTOM_FONT_STORAGE_KEY
-    : 'cameraPowerPlanner_customFonts';
+const customFontStorageKeyName =
+  typeof CUSTOM_FONT_STORAGE_KEY_NAME !== 'undefined'
+    ? CUSTOM_FONT_STORAGE_KEY_NAME
+    : typeof CUSTOM_FONT_STORAGE_KEY !== 'undefined'
+      ? CUSTOM_FONT_STORAGE_KEY
+      : 'cameraPowerPlanner_customFonts';
 const customFontEntries = new Map();
 
 const SUPPORTED_FONT_TYPES = new Set([
@@ -8955,7 +8957,7 @@ const SUPPORTED_FONT_EXTENSIONS = ['.ttf', '.otf', '.ttc', '.woff', '.woff2'];
 function loadCustomFontMetadataFromStorage() {
   if (typeof localStorage === 'undefined') return [];
   try {
-    const raw = localStorage.getItem(CUSTOM_FONT_STORAGE_KEY_NAME);
+    const raw = localStorage.getItem(customFontStorageKeyName);
     if (!raw) return [];
     const parsed = JSON.parse(raw);
     if (!Array.isArray(parsed)) return [];
@@ -8980,7 +8982,7 @@ function persistCustomFontsToStorage() {
       name: entry.name,
       data: entry.data
     }));
-    localStorage.setItem(CUSTOM_FONT_STORAGE_KEY_NAME, JSON.stringify(payload));
+    localStorage.setItem(customFontStorageKeyName, JSON.stringify(payload));
     return true;
   } catch (error) {
     console.warn('Could not save custom fonts', error);


### PR DESCRIPTION
## Summary
- avoid re-declaring the custom font storage key in the UI script by reusing the global fallback
- mark the global constant for linting to keep references recognized

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ce7d1eb4f08320b41fb150c6c82a8f