### PR TITLE
Allow buttons to expand vertically when text wraps

### DIFF
--- a/src/styles/overview-print.css
+++ b/src/styles/overview-print.css
@@ -341,8 +341,8 @@ body:not(.light-mode) .gear-table .category-row td {
   color: var(--text-color) !important;
   border: none !important;
   min-width: var(--button-size) !important;
-  height: var(--button-size) !important;
   min-height: var(--button-size) !important;
+  height: auto !important;
 }
 
 .power-conn {

--- a/src/styles/overview.css
+++ b/src/styles/overview.css
@@ -158,8 +158,8 @@ th { background-color: var(--control-bg); font-weight: var(--font-weight-bold); 
 
 .diagram-controls button {
   min-width: var(--button-size);
-  height: var(--button-size);
   min-height: var(--button-size);
+  height: auto;
 }
 
 @media (max-width: 600px) {

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -440,8 +440,8 @@ main.legal-content {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  height: var(--button-size);
   min-height: var(--button-size);
+  height: auto;
   padding: 0 12px;
   border-radius: var(--border-radius);
   background-color: var(--control-bg);
@@ -849,7 +849,8 @@ main.legal-content {
 /* Ensure favorite star aligns with its select element without stretching */
 .select-wrapper .favorite-toggle {
   align-self: center;
-  height: var(--button-size);
+  min-height: var(--button-size);
+  height: auto;
   margin-top: 0;
   display: flex;
   align-items: center;
@@ -2218,8 +2219,8 @@ button {
   margin: 10px 5px 5px;
   cursor: pointer;
   font-size: var(--form-control-font-size);
-  height: var(--button-size);
   min-height: var(--button-size);
+  height: auto;
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -2727,8 +2728,8 @@ body.pink-mode #topBar #logo .logo-center {
 
 .diagram-controls button {
   min-width: var(--button-size);
-  height: var(--button-size);
   min-height: var(--button-size);
+  height: auto;
 }
 
 .diagram-controls button.active {


### PR DESCRIPTION
## Summary
- let core button styles auto-size vertically while maintaining the standard minimum height
- update diagram control buttons and link-style buttons to respect wrapped labels across the app and in printed views

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ce7d4c934c83209a2b7aee11b33e91