### PR TITLE
Avoid redeclaring custom font storage key

### DIFF
--- a/src/scripts/script.js
+++ b/src/scripts/script.js
@@ -8933,7 +8933,10 @@ if (uiScaleRoot) {
   }
 }
 
-const CUSTOM_FONT_STORAGE_KEY_NAME =
+// Mirror the storage key defined in storage.js without redeclaring the same
+// identifier so browsers don't throw "Identifier has already been declared"
+// when both scripts load in the same page.
+const CUSTOM_FONT_STORAGE_KEY_NAME_LOCAL =
   typeof CUSTOM_FONT_STORAGE_KEY !== 'undefined'
     ? CUSTOM_FONT_STORAGE_KEY
     : 'cameraPowerPlanner_customFonts';
@@ -8955,7 +8958,7 @@ const SUPPORTED_FONT_EXTENSIONS = ['.ttf', '.otf', '.ttc', '.woff', '.woff2'];
 function loadCustomFontMetadataFromStorage() {
   if (typeof localStorage === 'undefined') return [];
   try {
-    const raw = localStorage.getItem(CUSTOM_FONT_STORAGE_KEY_NAME);
+    const raw = localStorage.getItem(CUSTOM_FONT_STORAGE_KEY_NAME_LOCAL);
     if (!raw) return [];
     const parsed = JSON.parse(raw);
     if (!Array.isArray(parsed)) return [];
@@ -8980,7 +8983,7 @@ function persistCustomFontsToStorage() {
       name: entry.name,
       data: entry.data
     }));
-    localStorage.setItem(CUSTOM_FONT_STORAGE_KEY_NAME, JSON.stringify(payload));
+    localStorage.setItem(CUSTOM_FONT_STORAGE_KEY_NAME_LOCAL, JSON.stringify(payload));
     return true;
   } catch (error) {
     console.warn('Could not save custom fonts', error);


### PR DESCRIPTION
## Summary
- use a locally scoped constant name in script.js for the custom font storage key so it no longer conflicts with storage.js
- update the custom font persistence helpers to use the new identifier and document why it exists

## Testing
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68ce7d6a7bd4832084e81debecd6ddff