### PR TITLE
Fix PWA install guide dialog scrolling

### DIFF
--- a/index.html
+++ b/index.html
@@ -959,7 +959,7 @@
     aria-describedby="installGuideIntro"
     hidden
   >
-    <div class="modal-surface install-guide-content">
+    <div class="modal-surface modal-surface-scrollable install-guide-content">
       <h2 id="installGuideTitle">Install Cine Power Planner</h2>
       <p id="installGuideIntro">Add the planner to your Home Screen to use it like an app.</p>
       <ol id="installGuideSteps">
@@ -998,7 +998,7 @@
     aria-describedby="iosPwaHelpIntro"
     hidden
   >
-    <div class="modal-surface ios-pwa-help-content">
+    <div class="modal-surface modal-surface-scrollable ios-pwa-help-content">
       <h2 id="iosPwaHelpTitle">Keep your data when installing on iOS</h2>
       <p id="iosPwaHelpIntro">
         Safari keeps the browser tab and the installed app separate. To move your Cine Power Planner data into the app:

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -981,6 +981,7 @@ main.legal-content {
 .modal-surface-scrollable {
   max-height: 80vh;
   overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
 }
 
 #installGuideDialog {
@@ -992,6 +993,8 @@ main.legal-content {
   justify-content: center;
   z-index: 205;
   padding: 20px;
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
 }
 
 #iosPwaHelpDialog {
@@ -1003,6 +1006,8 @@ main.legal-content {
   justify-content: center;
   z-index: 210;
   padding: 20px;
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
 }
 
 #feedbackDialog {


### PR DESCRIPTION
## Summary
- make the PWA install guide and iOS help modals use the shared scrollable surface styling
- allow the modal overlays to scroll on touch devices for smaller viewports

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ce83e227148320b2abf3234eff6b8d