### PR TITLE
Unify popup layout and toast styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -951,15 +951,14 @@
     </div>
   </dialog>
 
-  <div
+  <dialog
     id="installGuideDialog"
-    role="dialog"
+    class="app-modal"
     aria-modal="true"
     aria-labelledby="installGuideTitle"
     aria-describedby="installGuideIntro"
-    hidden
   >
-    <div class="modal-surface install-guide-content">
+    <div class="modal-surface modal-content install-guide-content">
       <h2 id="installGuideTitle">Install Cine Power Planner</h2>
       <p id="installGuideIntro">Add the planner to your Home Screen to use it like an app.</p>
       <ol id="installGuideSteps">
@@ -984,21 +983,20 @@
           devices.
         </p>
       </section>
-      <div class="button-row install-guide-actions">
+      <div class="button-row modal-actions install-guide-actions">
         <button id="installGuideClose" type="button">Close</button>
       </div>
     </div>
-  </div>
+  </dialog>
 
-  <div
+  <dialog
     id="iosPwaHelpDialog"
-    role="dialog"
+    class="app-modal"
     aria-modal="true"
     aria-labelledby="iosPwaHelpTitle"
     aria-describedby="iosPwaHelpIntro"
-    hidden
   >
-    <div class="modal-surface ios-pwa-help-content">
+    <div class="modal-surface modal-content ios-pwa-help-content">
       <h2 id="iosPwaHelpTitle">Keep your data when installing on iOS</h2>
       <p id="iosPwaHelpIntro">
         Safari keeps the browser tab and the installed app separate. To move your Cine Power Planner data into the app:
@@ -1013,11 +1011,11 @@
         After restoring once, all changes stay inside the installed app. Keep the backup if you plan to reinstall or switch
         devices.
       </p>
-      <div class="button-row ios-pwa-help-actions">
+      <div class="button-row modal-actions ios-pwa-help-actions">
         <button id="iosPwaHelpClose">Got it</button>
       </div>
     </div>
-  </div>
+  </dialog>
 
   <dialog
     id="helpDialog"
@@ -2351,8 +2349,8 @@
       </div>
     </div>
   </dialog>
-  <dialog id="shareDialog" aria-labelledby="shareDialogHeading">
-    <form id="shareForm" method="dialog">
+  <dialog id="shareDialog" class="app-modal" aria-labelledby="shareDialogHeading" aria-modal="true">
+    <form id="shareForm" method="dialog" class="modal-surface modal-content share-dialog-form">
       <h3 id="shareDialogHeading">Export Project</h3>
       <p id="shareFilenameMessage">Enter a name for the exported project file (default: project).</p>
       <div class="form-row">
@@ -2363,7 +2361,7 @@
         <input type="checkbox" id="shareIncludeAutoGear" />
         <span id="shareIncludeAutoGearText">Include automatic gear rules</span>
       </label>
-      <div class="dialog-actions">
+      <div class="button-row modal-actions">
         <button type="button" id="shareCancelBtn">Cancel</button>
         <button type="submit" id="shareConfirmBtn">Download</button>
       </div>
@@ -2371,7 +2369,7 @@
   </dialog>
 
   <dialog id="sharedImportDialog" class="app-modal" aria-labelledby="sharedImportDialogHeading" aria-modal="true">
-    <form id="sharedImportForm" method="dialog" class="modal-surface share-import-dialog">
+    <form id="sharedImportForm" method="dialog" class="modal-surface modal-content share-import-dialog">
       <h3 id="sharedImportDialogHeading">Automatic gear rules</h3>
       <p id="sharedImportDialogMessage">Choose how to apply the shared automatic gear rules from this project.</p>
       <fieldset id="sharedImportOptions" class="share-import-options">
@@ -2395,7 +2393,7 @@
           </option>
         </select>
       </fieldset>
-      <div class="dialog-actions">
+      <div class="button-row modal-actions">
         <button type="button" id="sharedImportCancelBtn">Cancel</button>
         <button type="submit" id="sharedImportConfirmBtn">Apply</button>
       </div>
@@ -2732,8 +2730,8 @@
     </form>
   </dialog>
 
-  <dialog id="feedbackDialog" aria-labelledby="feedbackDialogHeading">
-    <form id="feedbackForm" method="dialog">
+  <dialog id="feedbackDialog" class="app-modal" aria-labelledby="feedbackDialogHeading" aria-modal="true">
+    <form id="feedbackForm" method="dialog" class="modal-surface modal-surface-scrollable modal-content feedback-dialog-form">
       <h3 id="feedbackDialogHeading">User Runtime Feedback</h3>
 
       <fieldset>
@@ -2780,7 +2778,7 @@
         <div class="form-row"><label>Batteries Used per Day:<input type="number" id="fbBatteriesPerDay" name="fbBatteriesPerDay"></label></div>
       </fieldset>
 
-      <div class="form-row button-row">
+      <div class="button-row modal-actions">
         <button type="submit" id="fbSubmit">Save &amp; Submit</button>
         <button type="button" id="fbCancel"><span class="btn-icon icon-glyph" aria-hidden="true" data-icon-font="essential">&#xF131;</span>Cancel</button>
       </div>
@@ -2834,7 +2832,7 @@
       <option value="120"></option>
     </datalist>
   </dialog>
-  <dialog id="overviewDialog"></dialog>
+  <dialog id="overviewDialog" class="app-modal" aria-modal="true"></dialog>
   <script src="src/scripts/globalthis-polyfill.js"></script>
   <script src="src/data/devices/index.js"></script>
   <script src="src/data/devices/cameras.js"></script>

--- a/src/scripts/overview.js
+++ b/src/scripts/overview.js
@@ -256,8 +256,12 @@ function generatePrintableOverview() {
 
     const logoHtml = customLogo ? `<img id="printLogo" src="${customLogo}" alt="Logo" />` : '';
     const contentClass = customLogo ? 'logo-present' : '';
+    const surfaceClasses = ['modal-surface', 'modal-surface-scrollable', 'modal-content', 'overview-dialog-surface'];
+    if (contentClass) {
+        surfaceClasses.push(contentClass);
+    }
     const overviewHtml = `
-        <div id="overviewDialogContent" class="${contentClass}">
+        <div id="overviewDialogContent" class="${surfaceClasses.join(' ')}">
             <div class="overview-actions">
                 <button id="closeOverviewBtn" class="back-btn">${t.backToAppBtn}</button>
                 <button id="printOverviewBtn" class="print-btn">${t.printBtn}</button>

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -664,20 +664,29 @@ main.legal-content {
   cursor: not-allowed;
 }
 
-#shareDialog form {
+.feedback-dialog-form {
+  width: min(90vw, 720px);
+  max-width: 720px;
+  border-color: var(--panel-border);
+  gap: clamp(1rem, 2.5vw, 1.5rem);
+}
+
+.overview-dialog-surface {
+  width: min(90vw, 960px);
+  max-width: 960px;
+  gap: clamp(1.25rem, 3vw, 2rem);
+}
+
+.share-dialog-form {
   display: flex;
   flex-direction: column;
   gap: 1rem;
+  border-color: var(--panel-border);
+  width: min(90vw, 420px);
 }
 
-#shareDialog .form-row {
+.share-dialog-form .form-row {
   align-items: center;
-  gap: 0.75rem;
-}
-
-#shareDialog .dialog-actions {
-  display: flex;
-  justify-content: flex-end;
   gap: 0.75rem;
 }
 
@@ -707,29 +716,25 @@ main.legal-content {
   min-height: 6.5rem;
 }
 
-#sharedImportDialog .share-import-dialog {
+.share-import-dialog {
   width: min(90vw, 420px);
-  display: flex;
-  flex-direction: column;
-  gap: clamp(1rem, 2.5vw, 1.5rem);
-  padding: clamp(1.25rem, 3vw, 1.75rem);
   border-color: var(--panel-border);
   box-shadow: var(--panel-shadow);
 }
 
-#sharedImportDialog .share-import-dialog h3 {
+.share-import-dialog h3 {
   margin: 0;
   font-size: calc(var(--font-size-relative-base) * var(--font-scale-xl));
   font-weight: var(--font-weight-semibold);
 }
 
-#sharedImportDialog .share-import-dialog p {
+.share-import-dialog p {
   margin: 0;
   color: var(--muted-text-color);
   line-height: 1.5;
 }
 
-#sharedImportDialog .share-import-options {
+.share-import-dialog .share-import-options {
   border: 1px solid var(--panel-border);
   border-radius: var(--border-radius);
   padding: 0.75rem;
@@ -739,14 +744,14 @@ main.legal-content {
   background-color: var(--panel-bg);
 }
 
-#sharedImportDialog .share-import-options legend {
+.share-import-dialog .share-import-options legend {
   font-weight: var(--font-weight-semibold);
   font-size: calc(var(--font-size-relative-base) * var(--font-scale-md));
   margin-bottom: 0.25rem;
   color: var(--text-color);
 }
 
-#sharedImportDialog .share-import-mode-select {
+.share-import-dialog .share-import-mode-select {
   width: 100%;
   min-height: 6.5rem;
   border: 1px solid var(--control-border);
@@ -755,17 +760,11 @@ main.legal-content {
   color: var(--control-text);
 }
 
-#sharedImportDialog .share-import-mode-select option {
+.share-import-dialog .share-import-mode-select option {
   padding: 0.5rem 0.75rem;
 }
 
-#sharedImportDialog .dialog-actions {
-  display: flex;
-  justify-content: flex-end;
-  gap: 0.75rem;
-}
-
-#sharedImportDialog .dialog-actions button {
+.share-import-dialog .modal-actions button {
   min-width: clamp(96px, 20vw, 128px);
 }
 
@@ -973,6 +972,22 @@ main.legal-content {
   box-shadow: 0 4px 20px rgba(0, 0, 0, 0.2);
 }
 
+.modal-content {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1rem, 2.5vw, 1.5rem);
+  padding: clamp(1.25rem, 3vw, 1.75rem);
+  width: min(90vw, 520px);
+  max-width: 520px;
+}
+
+.modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
 .help-content.modal-surface,
 .settings-content.modal-surface {
   border: 2px solid var(--panel-border);
@@ -983,39 +998,65 @@ main.legal-content {
   overflow-y: auto;
 }
 
-#installGuideDialog {
+.app-toast-container {
   position: fixed;
-  inset: 0;
-  background: rgba(0, 0, 0, 0.6);
+  top: clamp(1rem, 2vw, 1.5rem);
+  right: clamp(1rem, 2vw, 1.5rem);
   display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 205;
-  padding: 20px;
+  flex-direction: column;
+  gap: 0.75rem;
+  z-index: 10000;
+  pointer-events: none;
 }
 
-#iosPwaHelpDialog {
-  position: fixed;
-  inset: 0;
-  background: rgba(0, 0, 0, 0.6);
-  display: flex;
+.app-toast {
+  display: inline-flex;
   align-items: center;
-  justify-content: center;
-  z-index: 210;
-  padding: 20px;
-}
-
-#feedbackDialog {
-  border: 2px solid var(--accent-color);
+  gap: 0.5rem;
+  padding: 0.75rem 1.25rem;
   border-radius: var(--border-radius);
-  padding: 20px;
-  width: min(90vw, 700px);
+  border: 1px solid var(--panel-border);
   background: var(--surface-color);
   color: var(--text-color);
+  box-shadow: 0 0.75rem 2.5rem rgba(0, 0, 0, 0.14);
+  pointer-events: auto;
+  min-width: 220px;
 }
 
-#feedbackDialog::backdrop {
-  background: rgba(0, 0, 0, 0.6);
+.app-toast__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.2rem;
+  color: inherit;
+}
+
+.app-toast__icon::before {
+  content: attr(data-icon);
+}
+
+.app-toast__message {
+  flex: 1;
+  line-height: 1.4;
+}
+
+.app-toast--success {
+  background: var(--status-success-bg);
+  color: var(--status-success-text-color);
+}
+
+.app-toast--error {
+  background: var(--status-error-bg);
+  color: var(--status-error-text-color);
+}
+
+.app-toast--warning {
+  background: var(--status-warning-bg);
+  color: var(--status-warning-text-color);
+}
+
+.app-toast--info {
+  background: var(--panel-bg);
 }
 
 #feedbackForm fieldset {
@@ -1033,14 +1074,6 @@ main.legal-content {
   justify-content: flex-end;
   gap: 10px;
   margin-top: 10px;
-}
-
-#installGuideDialog[hidden] {
-  display: none;
-}
-
-#iosPwaHelpDialog[hidden] {
-  display: none;
 }
 
 #settingsDialog[hidden] {


### PR DESCRIPTION
## Summary
- Standardize modal markup for the install guide, sharing, shared import, feedback, and overview dialogs so they reuse the shared modal surface helpers.
- Update the install and iOS help overlays to use the dialog helpers for consistent focus handling and close behaviour.
- Refresh modal CSS and toast notifications with reusable classes and accessible styling to present a unified popup design.

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ce811871388320b40f1921f78fc1a7