### PR TITLE
Unify modal and popup styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -2351,8 +2351,14 @@
       </div>
     </div>
   </dialog>
-  <dialog id="shareDialog" aria-labelledby="shareDialogHeading">
-    <form id="shareForm" method="dialog">
+  <dialog
+    id="shareDialog"
+    class="app-modal"
+    role="dialog"
+    aria-modal="true"
+    aria-labelledby="shareDialogHeading"
+  >
+    <form id="shareForm" method="dialog" class="modal-surface share-dialog">
       <h3 id="shareDialogHeading">Export Project</h3>
       <p id="shareFilenameMessage">Enter a name for the exported project file (default: project).</p>
       <div class="form-row">
@@ -2732,8 +2738,14 @@
     </form>
   </dialog>
 
-  <dialog id="feedbackDialog" aria-labelledby="feedbackDialogHeading">
-    <form id="feedbackForm" method="dialog">
+  <dialog
+    id="feedbackDialog"
+    class="app-modal"
+    role="dialog"
+    aria-modal="true"
+    aria-labelledby="feedbackDialogHeading"
+  >
+    <form id="feedbackForm" method="dialog" class="modal-surface modal-surface-scrollable feedback-dialog">
       <h3 id="feedbackDialogHeading">User Runtime Feedback</h3>
 
       <fieldset>

--- a/src/scripts/script.js
+++ b/src/scripts/script.js
@@ -20229,7 +20229,7 @@ function copyTextToClipboardBestEffort(text) {
 
     try {
       textarea.focus();
-    } catch (focusError) {
+    } catch {
       // Ignore focus errors on platforms that disallow programmatic focus.
     }
 
@@ -20238,18 +20238,18 @@ function copyTextToClipboardBestEffort(text) {
       if (typeof textarea.setSelectionRange === 'function') {
         textarea.setSelectionRange(0, textarea.value.length);
       }
-    } catch (selectionError) {
+    } catch {
       // Ignore selection errors; execCommand may still succeed.
     }
 
     if (typeof document.execCommand === 'function') {
       try {
         document.execCommand('copy');
-      } catch (execError) {
+      } catch {
         // Ignore execCommand failures to avoid breaking the export flow.
       }
     }
-  } catch (error) {
+  } catch {
     // Ignore clipboard fallback errors.
   } finally {
     if (textarea && textarea.parentNode) {
@@ -20262,7 +20262,7 @@ function copyTextToClipboardBestEffort(text) {
     ) {
       try {
         previousActiveElement.focus();
-      } catch (focusRestoreError) {
+      } catch {
         // Ignore focus restoration errors.
       }
     }

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -664,21 +664,38 @@ main.legal-content {
   cursor: not-allowed;
 }
 
-#shareDialog form {
+.share-dialog {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: clamp(0.75rem, 2vw, 1rem);
+  width: min(90vw, 420px);
+  padding: clamp(1.25rem, 3vw, 1.75rem);
+  border-color: var(--panel-border);
+  box-shadow: var(--panel-shadow);
 }
 
-#shareDialog .form-row {
+.share-dialog h3 {
+  margin: 0;
+  font-size: calc(var(--font-size-relative-base) * var(--font-scale-xl));
+  font-weight: var(--font-weight-semibold);
+}
+
+.share-dialog p {
+  margin: 0;
+  color: var(--muted-text-color);
+  line-height: var(--line-height-supporting);
+}
+
+.share-dialog .form-row {
   align-items: center;
   gap: 0.75rem;
 }
 
-#shareDialog .dialog-actions {
+.dialog-actions {
   display: flex;
   justify-content: flex-end;
   gap: 0.75rem;
+  margin-top: clamp(0.75rem, 2vw, 1.25rem);
 }
 
 #setup-manager .share-import-row {
@@ -767,6 +784,21 @@ main.legal-content {
 
 #sharedImportDialog .dialog-actions button {
   min-width: clamp(96px, 20vw, 128px);
+}
+
+.feedback-dialog {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1rem, 3vw, 1.5rem);
+  width: min(95vw, 720px);
+  padding: clamp(1.25rem, 3vw, 2rem);
+  border-color: var(--panel-border);
+}
+
+.feedback-dialog h3 {
+  margin: 0;
+  font-size: calc(var(--font-size-relative-base) * var(--font-scale-xl));
+  font-weight: var(--font-weight-semibold);
 }
 
 #setup-manager #shareLinkMessage {
@@ -1008,19 +1040,6 @@ main.legal-content {
   padding: 20px;
   overflow-y: auto;
   -webkit-overflow-scrolling: touch;
-}
-
-#feedbackDialog {
-  border: 2px solid var(--accent-color);
-  border-radius: var(--border-radius);
-  padding: 20px;
-  width: min(90vw, 700px);
-  background: var(--surface-color);
-  color: var(--text-color);
-}
-
-#feedbackDialog::backdrop {
-  background: rgba(0, 0, 0, 0.6);
 }
 
 #feedbackForm fieldset {
@@ -2805,11 +2824,13 @@ body.pink-mode #topBar #logo .logo-center {
   display: none;
   position: absolute;
   pointer-events: none;
-  background: rgba(255, 255, 255, 0.95);
-  border: 1px solid var(--control-text);
+  background: var(--surface-color);
+  color: var(--text-color);
+  border: 1px solid var(--panel-border);
   font-size: var(--font-size-diagram-text);
-  padding: 6px 10px;
-  border-radius: 6px;
+  line-height: var(--line-height-supporting);
+  padding: clamp(0.5rem, 1vw, 0.75rem);
+  border-radius: var(--border-radius);
   box-shadow: var(--panel-shadow);
   z-index: 10;
   max-width: 320px;
@@ -3358,12 +3379,6 @@ body.dark-mode.pink-mode {
 .dark-mode #batteryComparison th { background-color: var(--control-bg); }
 .dark-mode .barContainer { background-color: var(--panel-bg); }
 .dark-mode .device-category h4 { color: var(--inverse-text-color); border-bottom: 1px solid var(--inverse-text-color); }
-.dark-mode .diagram-popup {
-  background: rgba(51, 51, 51, 0.95);
-  color: var(--inverse-text-color);
-  border-color: var(--border-strong-color);
-  box-shadow: var(--panel-shadow);
-}
 .dark-mode .connector-block,
 .dark-mode .info-box { background-color: rgba(255,255,255,0.1); }
 .dark-mode .scenario-box { background-color: rgba(255,255,255,0.1); }
@@ -3464,12 +3479,6 @@ body.dark-mode.dark-accent-boost:not(.pink-mode) .settings-content.modal-surface
   body:not(.light-mode) #batteryComparison th { background-color: var(--control-bg); }
   body:not(.light-mode) .barContainer { background-color: var(--panel-bg); }
   body:not(.light-mode) .device-category h4 { color: var(--inverse-text-color); border-bottom: 1px solid var(--inverse-text-color); }
-  body:not(.light-mode) .diagram-popup {
-    background: rgba(51, 51, 51, 0.95);
-    color: var(--inverse-text-color);
-    border-color: var(--border-strong-color);
-    box-shadow: var(--panel-shadow);
-  }
   body:not(.light-mode) .connector-block,
   body:not(.light-mode) .info-box { background-color: rgba(255,255,255,0.1); }
   body:not(.light-mode) .scenario-box { background-color: rgba(255,255,255,0.1); }


### PR DESCRIPTION
## Summary
- apply the shared modal surface styling to the share and feedback dialogs for consistent overlays
- refresh supporting CSS, including common dialog action spacing and diagram popup appearance
- tidy clipboard fallback handlers to satisfy linting without changing behaviour

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ce85e4ab788320a3d3136750352b25