### PR TITLE
Ensure factory reset clears preferences and projects

### DIFF
--- a/src/scripts/script.js
+++ b/src/scripts/script.js
@@ -20230,6 +20230,7 @@ function copyTextToClipboardBestEffort(text) {
     try {
       textarea.focus();
     } catch (focusError) {
+      void focusError;
       // Ignore focus errors on platforms that disallow programmatic focus.
     }
 
@@ -20239,6 +20240,7 @@ function copyTextToClipboardBestEffort(text) {
         textarea.setSelectionRange(0, textarea.value.length);
       }
     } catch (selectionError) {
+      void selectionError;
       // Ignore selection errors; execCommand may still succeed.
     }
 
@@ -20246,10 +20248,12 @@ function copyTextToClipboardBestEffort(text) {
       try {
         document.execCommand('copy');
       } catch (execError) {
+        void execError;
         // Ignore execCommand failures to avoid breaking the export flow.
       }
     }
   } catch (error) {
+    void error;
     // Ignore clipboard fallback errors.
   } finally {
     if (textarea && textarea.parentNode) {
@@ -20263,6 +20267,7 @@ function copyTextToClipboardBestEffort(text) {
       try {
         previousActiveElement.focus();
       } catch (focusRestoreError) {
+        void focusRestoreError;
         // Ignore focus restoration errors.
       }
     }

--- a/src/scripts/storage.js
+++ b/src/scripts/storage.js
@@ -63,6 +63,17 @@ const AUTO_GEAR_PRESETS_STORAGE_KEY = 'cameraPowerPlanner_autoGearPresets';
 const AUTO_GEAR_ACTIVE_PRESET_STORAGE_KEY = 'cameraPowerPlanner_autoGearActivePreset';
 const AUTO_GEAR_BACKUP_VISIBILITY_STORAGE_KEY = 'cameraPowerPlanner_autoGearShowBackups';
 
+const PREFERENCE_STORAGE_KEYS = Object.freeze([
+  'darkMode',
+  'pinkMode',
+  'highContrast',
+  'showAutoBackups',
+  'accentColor',
+  'fontSize',
+  'fontFamily',
+  'language',
+]);
+
 const STORAGE_BACKUP_SUFFIX = '__backup';
 const RAW_STORAGE_BACKUP_KEYS = new Set([
   getCustomFontStorageKeyName(),
@@ -1308,6 +1319,9 @@ function clearAllData() {
   if (typeof sessionStorage !== 'undefined') {
     deleteFromStorage(sessionStorage, SESSION_STATE_KEY, msg);
   }
+  PREFERENCE_STORAGE_KEYS.forEach((key) => {
+    deleteFromStorage(SAFE_LOCAL_STORAGE, key, msg, { disableBackup: true });
+  });
   console.log("All planner data cleared from storage.");
 }
 

--- a/tests/unit/storage.test.js
+++ b/tests/unit/storage.test.js
@@ -582,6 +582,14 @@ describe('clearAllData', () => {
       backupKeyFor(CUSTOM_FONT_KEY),
       JSON.stringify([{ id: 'font-1', name: 'My Font', data: 'data:font/woff;base64,BBBB' }]),
     );
+    localStorage.setItem('darkMode', 'true');
+    localStorage.setItem('pinkMode', 'true');
+    localStorage.setItem('highContrast', 'true');
+    localStorage.setItem('showAutoBackups', 'true');
+    localStorage.setItem('accentColor', '#00ff00');
+    localStorage.setItem('fontSize', '18');
+    localStorage.setItem('fontFamily', "'My Font', sans-serif");
+    localStorage.setItem('language', 'de');
     clearAllData();
     expect(localStorage.getItem(DEVICE_KEY)).toBeNull();
     expect(localStorage.getItem(SETUP_KEY)).toBeNull();
@@ -598,6 +606,14 @@ describe('clearAllData', () => {
     expect(localStorage.getItem(SCHEMA_CACHE_KEY)).toBeNull();
     expect(localStorage.getItem(CUSTOM_LOGO_KEY)).toBeNull();
     expect(localStorage.getItem(CUSTOM_FONT_KEY)).toBeNull();
+    expect(localStorage.getItem('darkMode')).toBeNull();
+    expect(localStorage.getItem('pinkMode')).toBeNull();
+    expect(localStorage.getItem('highContrast')).toBeNull();
+    expect(localStorage.getItem('showAutoBackups')).toBeNull();
+    expect(localStorage.getItem('accentColor')).toBeNull();
+    expect(localStorage.getItem('fontSize')).toBeNull();
+    expect(localStorage.getItem('fontFamily')).toBeNull();
+    expect(localStorage.getItem('language')).toBeNull();
 
     expect(localStorage.getItem(backupKeyFor(DEVICE_KEY))).toBeNull();
     expect(localStorage.getItem(backupKeyFor(SETUP_KEY))).toBeNull();


### PR DESCRIPTION
## Summary
- ensure factory reset removes theme preferences and other saved settings
- add regression coverage verifying preference keys are cleared
- quiet eslint no-unused-vars warnings for intentionally ignored errors

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ce86db83c0832092a45812d05b917d