### PR TITLE
Clarify help guidance for scenarios and runtime feedback

### DIFF
--- a/index.html
+++ b/index.html
@@ -1373,6 +1373,7 @@
             <li>Capture production details such as production company, rental house, DoP, crew roles with email contacts, shooting dates, resolutions, codecs and more for each project.</li>
             <li>Multi-select lists let you specify multiple scenarios, accessories or monitoring setups.</li>
             <li>Use the + buttons to add crew entries or prep/shoot ranges, and tap the − buttons to remove items as plans change.</li>
+            <li>A live summary under <strong>Required Scenarios</strong> displays icon-labelled chips for every selection so you can confirm which accessory packs will trigger; choosing <strong>Dolly</strong> unlocks <strong>Remote Head</strong> and automatically surfaces default monitor options to keep downstream lists complete.</li>
             <li>The information is saved with the project and included in printed overviews and gear lists.</li>
           </ul>
           <div class="help-link-group" aria-label="Project requirement tools">
@@ -1620,6 +1621,7 @@
           <ul>
             <li>Click <strong>Submit User Runtime Feedback</strong> below the runtime to add your own measurement.</li>
             <li>Include temperature for more accurate weighting.</li>
+            <li>Use <strong>Use Current Location</strong> to capture an approximate position in the log—everything stays stored on this device for offline reference.</li>
             <li>Your entries are stored locally and refine the runtime estimate.</li>
           </ul>
           <div class="help-link-group" aria-label="Runtime feedback tools">


### PR DESCRIPTION
## Summary
- expand the Project Requirements help section with details about the new scenario summary chips and dolly-triggered defaults
- document the Use Current Location option in the runtime feedback help so users know it remains offline

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ce8fc568c883208bbc37b0063afb88