### PR TITLE
Refine status messaging styling and apply globally

### DIFF
--- a/index.html
+++ b/index.html
@@ -220,7 +220,7 @@
         <button id="clearSetupBtn"><span class="btn-icon icon-glyph" aria-hidden="true" data-icon-font="essential">&#xF131;</span>Clear Current Project</button>
       </div>
     </div>
-    <p id="shareLinkMessage" class="hidden" role="status" aria-live="polite"></p>
+    <p id="shareLinkMessage" class="hidden status-message" role="status" aria-live="polite"></p>
     <div class="form-row form-row-actions" role="group" aria-label="Project exports">
       <span class="form-label-spacer" aria-hidden="true"></span>
       <div class="form-actions">
@@ -363,16 +363,16 @@
     <div id="powerDiagram" class="hidden">
       <div id="powerDiagramBar" class="power-bar" role="img" aria-label="Power usage diagram"></div>
       <div id="powerDiagramLegend"></div>
-      <p id="maxPowerText"></p>
+      <p id="maxPowerText" class="status-message"></p>
     </div>
     <p><strong><span id="totalPowerLabel">Total Consumption:</span></strong> <span id="totalPower">0.0</span> W</p>
     <p><strong><span id="totalCurrent144Label">Total Current (at 14.4V):</span></strong> <span id="totalCurrent144">0.00</span> A</p>
     <p><strong><span id="totalCurrent12Label">Total Current (at 12V):</span></strong> <span id="totalCurrent12">0.00</span> A</p>
     <p><strong><span id="batteryLifeLabel">Runtime (estimated):</span></strong> <span id="batteryLife">0.00</span> <span id="batteryLifeUnit">hrs</span> <span id="runtimeAverageNote"></span></p>
     <p><strong><span id="batteryCountLabel">Batteries for 10h shoot (incl. spare):</span></strong> <span id="batteryCount">–</span></p>
-    <p id="pinWarning" role="status" aria-live="polite" aria-describedby="batteryLabel"></p>
-    <p id="dtapWarning" role="status" aria-live="polite" aria-describedby="batteryLabel"></p>
-    <p id="hotswapWarning" role="status" aria-live="polite" aria-describedby="batteryHotswapLabel"></p>
+    <p id="pinWarning" class="status-message" role="status" aria-live="polite" aria-describedby="batteryLabel"></p>
+    <p id="dtapWarning" class="status-message" role="status" aria-live="polite" aria-describedby="batteryLabel"></p>
+    <p id="hotswapWarning" class="status-message" role="status" aria-live="polite" aria-describedby="batteryHotswapLabel"></p>
     <div id="temperatureNote"></div>
     <button id="runtimeFeedbackBtn" type="button">
       <span class="btn-icon icon-glyph" aria-hidden="true" data-icon-font="essential">&#xF13E;</span>Submit User Runtime Feedback
@@ -384,7 +384,7 @@
 
   <section id="setupDiagram">
     <h2 id="setupDiagramHeading">Connection Diagram</h2>
-    <p id="compatWarning" role="status" aria-live="polite"></p>
+    <p id="compatWarning" class="status-message" role="status" aria-live="polite"></p>
     <p id="diagramDesc" class="visually-hidden">Visual representation of connected devices.</p>
     <div id="diagramArea" role="img" aria-label="Project diagram" aria-describedby="diagramDesc">
       <div id="diagramPopup" class="diagram-popup"></div>

--- a/legacy/scripts/overview.js
+++ b/legacy/scripts/overview.js
@@ -87,13 +87,56 @@ function generatePrintableOverview() {
   var breakdownHtml = breakdownListElem.innerHTML;
   var batteryLifeUnitElem = document.getElementById("batteryLifeUnit");
   var resultsHtml = "\n        <ul id=\"breakdownList\">".concat(breakdownHtml, "</ul>\n        <p><strong>").concat(t.totalPowerLabel, "</strong> ").concat(totalPowerElem.textContent, " W</p>\n        <p><strong>").concat(t.totalCurrent144Label, "</strong> ").concat(totalCurrent144Elem.textContent, " A</p>\n        <p><strong>").concat(t.totalCurrent12Label, "</strong> ").concat(totalCurrent12Elem.textContent, " A</p>\n        <p><strong>").concat(t.batteryLifeLabel, "</strong> ").concat(batteryLifeElem.textContent, " ").concat(batteryLifeUnitElem ? batteryLifeUnitElem.textContent : '', "</p>\n        <p><strong>").concat(t.batteryCountLabel, "</strong> ").concat(batteryCountElem.textContent, "</p>\n    ");
-  var warningHtml = '';
-  if (pinWarnElem.textContent.trim() !== '') {
-    warningHtml += "<p style=\"color: ".concat(pinWarnElem.style.color, "; font-weight: var(--font-weight-bold);\">").concat(pinWarnElem.textContent, "</p>");
+  var severityClassMap = {
+    danger: 'status-message--danger',
+    warning: 'status-message--warning',
+    success: 'status-message--success',
+    info: 'status-message--info'
+  };
+  var severityClassList = [];
+  for (var level in severityClassMap) {
+    if (Object.prototype.hasOwnProperty.call(severityClassMap, level)) {
+      severityClassList.push(severityClassMap[level]);
+    }
   }
-  if (dtapWarnElem.textContent.trim() !== '') {
-    warningHtml += "<p style=\"color: ".concat(dtapWarnElem.style.color, "; font-weight: var(--font-weight-bold);\">").concat(dtapWarnElem.textContent, "</p>");
-  }
+  var extractSeverityClass = function extractSeverityClass(element) {
+    if (!element) return '';
+    var datasetLevel = element.dataset ? element.dataset.statusLevel : element.getAttribute && element.getAttribute('data-status-level');
+    if (datasetLevel && severityClassMap[datasetLevel]) {
+      return severityClassMap[datasetLevel];
+    }
+    if (element.classList) {
+      for (var i = 0; i < severityClassList.length; i++) {
+        if (element.classList.contains(severityClassList[i])) {
+          return severityClassList[i];
+        }
+      }
+    }
+    if (typeof element.getAttribute === 'function') {
+      var classAttr = element.getAttribute('class') || '';
+      if (classAttr) {
+        var classParts = classAttr.split(/\s+/);
+        for (var _i3 = 0; _i3 < severityClassList.length; _i3++) {
+          if (classParts.indexOf(severityClassList[_i3]) !== -1) {
+            return severityClassList[_i3];
+          }
+        }
+      }
+    }
+    return '';
+  };
+  var buildStatusMarkup = function buildStatusMarkup(element) {
+    if (!element || element.textContent.trim() === '') {
+      return '';
+    }
+    var classes = ['status-message'];
+    var severityClass = extractSeverityClass(element);
+    if (severityClass) {
+      classes.push(severityClass);
+    }
+    return "<p class=\"".concat(classes.join(' '), "\">").concat(escapeHtmlSafe(element.textContent), "</p>");
+  };
+  var warningHtml = buildStatusMarkup(pinWarnElem) + buildStatusMarkup(dtapWarnElem);
   var resultsSectionHtml = "\n        <section id=\"resultsSection\" class=\"results-section print-section\">\n            <h2>".concat(t.resultsHeading, "</h2>\n            <div class=\"results-body\">\n                ").concat(resultsHtml, "\n                ").concat(warningHtml ? "<div class=\"results-warnings\">".concat(warningHtml, "</div>") : '', "\n            </div>\n        </section>\n    ");
   var batteryTableHtml = '';
   var totalWatt = parseFloat(totalPowerElem.textContent);

--- a/src/scripts/overview.js
+++ b/src/scripts/overview.js
@@ -98,13 +98,41 @@ function generatePrintableOverview() {
     `;
 
     // Get current warning messages with their colors
-    let warningHtml = '';
-    if (pinWarnElem.textContent.trim() !== '') {
-        warningHtml += `<p style="color: ${pinWarnElem.style.color}; font-weight: var(--font-weight-bold);">${pinWarnElem.textContent}</p>`;
-    }
-    if (dtapWarnElem.textContent.trim() !== '') {
-        warningHtml += `<p style="color: ${dtapWarnElem.style.color}; font-weight: var(--font-weight-bold);">${dtapWarnElem.textContent}</p>`;
-    }
+    const severityClassMap = {
+        danger: 'status-message--danger',
+        warning: 'status-message--warning',
+        success: 'status-message--success',
+        info: 'status-message--info'
+    };
+    const extractSeverityClass = (element) => {
+        if (!element) return '';
+        const datasetLevel = element.dataset ? element.dataset.statusLevel : element.getAttribute && element.getAttribute('data-status-level');
+        if (datasetLevel && severityClassMap[datasetLevel]) {
+            return severityClassMap[datasetLevel];
+        }
+        if (element.classList) {
+            return Object.values(severityClassMap).find(cls => element.classList.contains(cls)) || '';
+        }
+        const classAttr = typeof element.getAttribute === 'function' ? element.getAttribute('class') : '';
+        if (classAttr) {
+            const classes = classAttr.split(/\s+/);
+            return Object.values(severityClassMap).find(cls => classes.includes(cls)) || '';
+        }
+        return '';
+    };
+    const buildStatusMarkup = (element) => {
+        if (!element || element.textContent.trim() === '') {
+            return '';
+        }
+        const classes = ['status-message'];
+        const severityClass = extractSeverityClass(element);
+        if (severityClass) {
+            classes.push(severityClass);
+        }
+        return `<p class="${classes.join(' ')}">${escapeHtmlSafe(element.textContent)}</p>`;
+    };
+
+    const warningHtml = buildStatusMarkup(pinWarnElem) + buildStatusMarkup(dtapWarnElem);
 
     const resultsSectionHtml = `
         <section id="resultsSection" class="results-section print-section">

--- a/src/styles/overview-print.css
+++ b/src/styles/overview-print.css
@@ -7,6 +7,44 @@ select:focus-visible {
   outline: none;
 }
 
+.status-message {
+  margin-top: 0.6em;
+}
+
+.status-message:empty {
+  display: none;
+}
+
+.status-message--info,
+.status-message--success,
+.status-message--warning,
+.status-message--danger {
+  padding: 0.45em 0.7em;
+  border-radius: var(--border-radius);
+  border: 1px solid var(--status-border-color);
+  background-color: var(--panel-bg);
+  display: block;
+}
+
+.status-message--info {
+  color: var(--text-color);
+}
+
+.status-message--success {
+  background-color: var(--status-success-bg);
+  color: var(--status-success-text-color);
+}
+
+.status-message--warning {
+  background-color: var(--status-warning-bg);
+  color: var(--status-warning-text-color);
+}
+
+.status-message--danger {
+  background-color: var(--status-error-bg);
+  color: var(--status-error-text-color);
+}
+
 @page {
   size: A4;
   margin: 1cm;

--- a/src/styles/overview.css
+++ b/src/styles/overview.css
@@ -7,6 +7,44 @@ select:focus-visible {
   outline: none;
 }
 
+.status-message {
+  margin-top: 0.6em;
+}
+
+.status-message:empty {
+  display: none;
+}
+
+.status-message--info,
+.status-message--success,
+.status-message--warning,
+.status-message--danger {
+  padding: 0.45em 0.7em;
+  border-radius: var(--border-radius);
+  border: 1px solid var(--status-border-color);
+  background-color: var(--panel-bg);
+  display: block;
+}
+
+.status-message--info {
+  color: var(--text-color);
+}
+
+.status-message--success {
+  background-color: var(--status-success-bg);
+  color: var(--status-success-text-color);
+}
+
+.status-message--warning {
+  background-color: var(--status-warning-bg);
+  color: var(--status-warning-text-color);
+}
+
+.status-message--danger {
+  background-color: var(--status-error-bg);
+  color: var(--status-error-text-color);
+}
+
 body { font-family: 'Ubuntu', sans-serif; font-weight: var(--font-weight-light); margin: 25px; color: var(--control-text); font-size: calc(var(--font-size-relative-base) * var(--font-scale-sm)); line-height: var(--line-height-base, 1.6); -webkit-print-color-adjust: exact; print-color-adjust: exact; }
 @media (max-width: 600px) {
   body { margin: 10px; }

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -249,6 +249,44 @@ textarea {
   display: none !important;
 }
 
+.status-message {
+  margin-top: 0.75em;
+}
+
+.status-message:empty {
+  display: none;
+}
+
+.status-message--info,
+.status-message--success,
+.status-message--warning,
+.status-message--danger {
+  padding: 0.5em 0.75em;
+  border-radius: var(--border-radius);
+  border: 1px solid var(--status-border-color);
+  background-color: var(--panel-bg);
+  display: block;
+}
+
+.status-message--info {
+  color: var(--text-color);
+}
+
+.status-message--success {
+  background-color: var(--status-success-bg);
+  color: var(--status-success-text-color);
+}
+
+.status-message--warning {
+  background-color: var(--status-warning-bg);
+  color: var(--status-warning-text-color);
+}
+
+.status-message--danger {
+  background-color: var(--status-error-bg);
+  color: var(--status-error-text-color);
+}
+
 /* Improve keyboard accessibility by clearly showing focus outlines for links, inputs, and textareas */
 button:focus,
 a:focus,
@@ -275,13 +313,6 @@ textarea:focus-visible {
 
 .flex-1 {
   flex: 1;
-}
-
-#pinWarning,
-#dtapWarning,
-#compatWarning {
-  color: var(--danger-color);
-  font-weight: var(--font-weight-bold);
 }
 
 #exportOutput {


### PR DESCRIPTION
## Summary
- add reusable status-message styling and apply it to runtime warnings, compatibility notices, and the power limit indicator
- introduce a status helper in the modern and legacy scripts to centralise severity handling instead of inline colour changes
- propagate the new severity classes into printable overview markup so summary exports mirror the in-app visual hierarchy

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ce8fe11b508320b364a4f8674721db