### PR TITLE
Fix legacy backup value serialization

### DIFF
--- a/src/scripts/script.js
+++ b/src/scripts/script.js
@@ -19853,6 +19853,14 @@ function isPlainObject(value) {
 function normalizeStoredValue(value) {
   if (typeof value === 'string') return value;
   if (value === undefined || value === null) return '';
+  if (typeof value === 'object') {
+    try {
+      return JSON.stringify(value);
+    } catch (error) {
+      console.warn('Failed to serialize stored value for backup compatibility', error);
+      return '';
+    }
+  }
   try {
     return String(value);
   } catch (error) {
@@ -22427,6 +22435,7 @@ if (typeof module !== "undefined" && module.exports) {
     autoBackup,
     createSettingsBackup,
     captureStorageSnapshot,
+    extractBackupSections,
     searchKey,
     searchTokens,
     findBestSearchMatch,

--- a/tests/script/backupCompatibility.test.js
+++ b/tests/script/backupCompatibility.test.js
@@ -1,0 +1,29 @@
+const { loadApp } = require('./helpers/loadApp');
+
+describe('backup compatibility utilities', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    localStorage.clear();
+    sessionStorage.clear();
+    jest.clearAllMocks();
+  });
+
+  test('extractBackupSections preserves object values as JSON strings', () => {
+    const { extractBackupSections } = loadApp();
+
+    const legacyBackup = {
+      settings: {
+        cameraPowerPlanner_setups: { name: 'Main Setup', items: ['Camera A'] },
+        darkMode: true,
+      },
+    };
+
+    const sections = extractBackupSections(legacyBackup);
+
+    expect(sections.settings.cameraPowerPlanner_setups).toBe(
+      JSON.stringify({ name: 'Main Setup', items: ['Camera A'] }),
+    );
+    expect(sections.settings.darkMode).toBe('true');
+  });
+});
+

--- a/tests/script/helpers/loadApp.js
+++ b/tests/script/helpers/loadApp.js
@@ -1,0 +1,67 @@
+const fs = require('fs');
+const path = require('path');
+
+function ensureTestDom() {
+  if (typeof window.matchMedia !== 'function') {
+    window.matchMedia = () => ({
+      matches: false,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      addListener: () => {},
+      removeListener: () => {},
+    });
+  }
+
+  if (!Element.prototype.scrollIntoView) {
+    Element.prototype.scrollIntoView = () => {};
+  }
+}
+
+function loadApp() {
+  jest.resetModules();
+  ensureTestDom();
+
+  const template = fs.readFileSync(
+    path.join(__dirname, '../../../index.html'),
+    'utf8',
+  );
+  const bodyMatch = template.match(/<body[^>]*>([\s\S]*)<\/body>/i);
+  const bodyHtml = bodyMatch ? bodyMatch[1] : '';
+  document.body.innerHTML = bodyHtml.replace(/<script[\s\S]*?<\/script>/gi, '');
+
+  const { texts, categoryNames, gearItems } = require('../../../src/scripts/translations.js');
+  const devicesData = require('../../../src/data');
+
+  window.texts = texts;
+  global.texts = texts;
+  window.categoryNames = categoryNames;
+  global.categoryNames = categoryNames;
+  window.gearItems = gearItems;
+  global.gearItems = gearItems;
+  window.devices = JSON.parse(JSON.stringify(devicesData));
+  global.devices = window.devices;
+
+  global.loadDeviceData = jest.fn(() => null);
+  global.saveDeviceData = jest.fn();
+  global.loadSetups = jest.fn(() => ({}));
+  global.saveSetups = jest.fn();
+  global.loadSessionState = jest.fn(() => null);
+  global.saveSessionState = jest.fn();
+  global.loadProject = jest.fn(() => ({}));
+  global.saveProject = jest.fn();
+  global.deleteProject = jest.fn();
+  global.loadFavorites = jest.fn(() => ({}));
+  global.saveFavorites = jest.fn();
+  global.exportAllData = jest.fn(() => ({ exported: true }));
+  global.importAllData = jest.fn();
+  global.clearAllData = jest.fn();
+  global.showNotification = jest.fn();
+
+  return require('../../../src/scripts/script.js');
+}
+
+module.exports = {
+  loadApp,
+  ensureTestDom,
+};
+


### PR DESCRIPTION
## Summary
- ensure legacy backup values that arrive as objects are JSON serialised so their data is preserved
- expose `extractBackupSections` for Node-based tests
- add a script helper to load the app in tests and a regression test that verifies object values survive backup extraction

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ce8ff2df1c83208794c96f46ea839d