### PR TITLE
Handle quota errors when verifying localStorage

### DIFF
--- a/legacy/scripts/storage.js
+++ b/legacy/scripts/storage.js
@@ -40,6 +40,34 @@ var AUTO_GEAR_ACTIVE_PRESET_STORAGE_KEY = 'cameraPowerPlanner_autoGearActivePres
 var AUTO_GEAR_BACKUP_VISIBILITY_STORAGE_KEY = 'cameraPowerPlanner_autoGearShowBackups';
 var STORAGE_BACKUP_SUFFIX = '__backup';
 var RAW_STORAGE_BACKUP_KEYS = new Set([CUSTOM_FONT_STORAGE_KEY_NAME, CUSTOM_LOGO_STORAGE_KEY]);
+var PRIMARY_STORAGE_KEYS = [
+  DEVICE_STORAGE_KEY,
+  SETUP_STORAGE_KEY,
+  SESSION_STATE_KEY,
+  FEEDBACK_STORAGE_KEY,
+  PROJECT_STORAGE_KEY,
+  FAVORITES_STORAGE_KEY,
+  DEVICE_SCHEMA_CACHE_KEY,
+  AUTO_GEAR_RULES_STORAGE_KEY,
+  AUTO_GEAR_SEEDED_STORAGE_KEY,
+  AUTO_GEAR_BACKUPS_STORAGE_KEY,
+  AUTO_GEAR_PRESETS_STORAGE_KEY,
+  AUTO_GEAR_ACTIVE_PRESET_STORAGE_KEY,
+  AUTO_GEAR_BACKUP_VISIBILITY_STORAGE_KEY
+];
+var SIMPLE_STORAGE_KEYS = [
+  CUSTOM_LOGO_STORAGE_KEY,
+  CUSTOM_FONT_STORAGE_KEY_NAME,
+  'darkMode',
+  'pinkMode',
+  'highContrast',
+  'showAutoBackups',
+  'accentColor',
+  'fontSize',
+  'fontFamily',
+  'language',
+  'iosPwaHelpShown'
+];
 var STORAGE_ALERT_FLAG_NAME = '__cameraPowerPlannerStorageAlertShown';
 var storageErrorAlertShown = false;
 if (GLOBAL_SCOPE) {
@@ -55,12 +83,94 @@ var ACCESSORY_COLLECTION_KEYS = ['chargers', 'cages', 'powerPlates', 'cameraSupp
 var getStorageManager = function getStorageManager() {
   return typeof navigator !== 'undefined' && navigator && _typeof(navigator.storage) === 'object' ? navigator.storage : null;
 };
+var QUOTA_ERROR_NAMES = new Set(['QuotaExceededError', 'NS_ERROR_DOM_QUOTA_REACHED']);
+var QUOTA_ERROR_CODES = new Set([22, 1014]);
+var QUOTA_ERROR_NUMBERS = new Set([22, 1014]);
+var isQuotaExceededError = function isQuotaExceededError(error) {
+  if (!error || 'object' !== _typeof(error)) {
+    return false;
+  }
+  if (typeof error.code === 'number' && QUOTA_ERROR_CODES.has(error.code)) {
+    return true;
+  }
+  if (typeof error.number === 'number' && QUOTA_ERROR_NUMBERS.has(error.number)) {
+    return true;
+  }
+  if (typeof error.name === 'string' && QUOTA_ERROR_NAMES.has(error.name)) {
+    return true;
+  }
+  return false;
+};
+var hasStoredEntries = function hasStoredEntries(storage) {
+  if (!storage) return false;
+  try {
+    if (typeof storage.length === 'number' && storage.length > 0) {
+      return true;
+    }
+  } catch (lengthError) {
+    console.warn('Unable to read storage length after quota error', lengthError);
+  }
+  if (typeof storage.getItem === 'function') {
+    try {
+      for (var i = 0; i < PRIMARY_STORAGE_KEYS.length; i += 1) {
+        var key = PRIMARY_STORAGE_KEYS[i];
+        if (storage.getItem(key) !== null) {
+          return true;
+        }
+        var backupKey = key + STORAGE_BACKUP_SUFFIX;
+        if (storage.getItem(backupKey) !== null) {
+          return true;
+        }
+      }
+      for (var j = 0; j < SIMPLE_STORAGE_KEYS.length; j += 1) {
+        var simpleKey = SIMPLE_STORAGE_KEYS[j];
+        if (storage.getItem(simpleKey) !== null) {
+          return true;
+        }
+        if (RAW_STORAGE_BACKUP_KEYS.has(simpleKey)) {
+          var simpleBackupKey = simpleKey + STORAGE_BACKUP_SUFFIX;
+          if (storage.getItem(simpleBackupKey) !== null) {
+            return true;
+          }
+        }
+      }
+    } catch (inspectionError) {
+      console.warn('Unable to inspect known storage keys after quota error', inspectionError);
+    }
+  }
+  if (typeof storage.key === 'function') {
+    try {
+      var length = typeof storage.length === 'number' ? storage.length : 0;
+      for (var index = 0; index < length; index += 1) {
+        var candidate = storage.key(index);
+        if (typeof candidate === 'string' && candidate) {
+          return true;
+        }
+      }
+    } catch (iterationError) {
+      console.warn('Unable to iterate storage keys after quota error', iterationError);
+    }
+  }
+  return false;
+};
 var SAFE_LOCAL_STORAGE = function () {
   var TEST_KEY = '__storage_test__';
   var verifyStorage = function verifyStorage(storage) {
     if (!storage) return null;
-    storage.setItem(TEST_KEY, '1');
-    storage.removeItem(TEST_KEY);
+    try {
+      storage.setItem(TEST_KEY, '1');
+    } catch (error) {
+      if (isQuotaExceededError(error) && hasStoredEntries(storage)) {
+        console.warn('localStorage quota exceeded. Existing planner data will remain available but new saves may fail.', error);
+        return storage;
+      }
+      throw error;
+    }
+    try {
+      storage.removeItem(TEST_KEY);
+    } catch (cleanupError) {
+      console.warn('Unable to clean up storage test key', cleanupError);
+    }
     return storage;
   };
   if (typeof window !== 'undefined') {

--- a/src/scripts/storage.js
+++ b/src/scripts/storage.js
@@ -69,6 +69,36 @@ const RAW_STORAGE_BACKUP_KEYS = new Set([
   CUSTOM_LOGO_STORAGE_KEY,
 ]);
 
+const PRIMARY_STORAGE_KEYS = [
+  DEVICE_STORAGE_KEY,
+  SETUP_STORAGE_KEY,
+  SESSION_STATE_KEY,
+  FEEDBACK_STORAGE_KEY,
+  PROJECT_STORAGE_KEY,
+  FAVORITES_STORAGE_KEY,
+  DEVICE_SCHEMA_CACHE_KEY,
+  AUTO_GEAR_RULES_STORAGE_KEY,
+  AUTO_GEAR_SEEDED_STORAGE_KEY,
+  AUTO_GEAR_BACKUPS_STORAGE_KEY,
+  AUTO_GEAR_PRESETS_STORAGE_KEY,
+  AUTO_GEAR_ACTIVE_PRESET_STORAGE_KEY,
+  AUTO_GEAR_BACKUP_VISIBILITY_STORAGE_KEY,
+];
+
+const SIMPLE_STORAGE_KEYS = [
+  CUSTOM_LOGO_STORAGE_KEY,
+  getCustomFontStorageKeyName(),
+  'darkMode',
+  'pinkMode',
+  'highContrast',
+  'showAutoBackups',
+  'accentColor',
+  'fontSize',
+  'fontFamily',
+  'language',
+  'iosPwaHelpShown',
+];
+
 const STORAGE_ALERT_FLAG_NAME = '__cameraPowerPlannerStorageAlertShown';
 
 let storageErrorAlertShown = false;
@@ -133,10 +163,108 @@ const getStorageManager = () =>
 const SAFE_LOCAL_STORAGE = (() => {
   const TEST_KEY = '__storage_test__';
 
+  const QUOTA_ERROR_NAMES = new Set([
+    'QuotaExceededError',
+    'NS_ERROR_DOM_QUOTA_REACHED',
+  ]);
+  const QUOTA_ERROR_CODES = new Set([22, 1014]);
+  const QUOTA_ERROR_NUMBERS = new Set([22, 1014]);
+
+  const isQuotaExceededError = (error) => {
+    if (!error || typeof error !== 'object') {
+      return false;
+    }
+    if (typeof error.code === 'number' && QUOTA_ERROR_CODES.has(error.code)) {
+      return true;
+    }
+    if (typeof error.number === 'number' && QUOTA_ERROR_NUMBERS.has(error.number)) {
+      return true;
+    }
+    if (typeof error.name === 'string' && QUOTA_ERROR_NAMES.has(error.name)) {
+      return true;
+    }
+    return false;
+  };
+
+  const hasStoredEntries = (storage) => {
+    if (!storage) return false;
+
+    try {
+      if (typeof storage.length === 'number' && storage.length > 0) {
+        return true;
+      }
+    } catch (lengthError) {
+      console.warn('Unable to read storage length after quota error', lengthError);
+    }
+
+    if (typeof storage.getItem === 'function') {
+      try {
+        for (let i = 0; i < PRIMARY_STORAGE_KEYS.length; i += 1) {
+          const key = PRIMARY_STORAGE_KEYS[i];
+          if (storage.getItem(key) !== null) {
+            return true;
+          }
+          const backupKey = `${key}${STORAGE_BACKUP_SUFFIX}`;
+          if (storage.getItem(backupKey) !== null) {
+            return true;
+          }
+        }
+
+        for (let i = 0; i < SIMPLE_STORAGE_KEYS.length; i += 1) {
+          const key = SIMPLE_STORAGE_KEYS[i];
+          if (storage.getItem(key) !== null) {
+            return true;
+          }
+          if (RAW_STORAGE_BACKUP_KEYS.has(key)) {
+            const backupKey = `${key}${STORAGE_BACKUP_SUFFIX}`;
+            if (storage.getItem(backupKey) !== null) {
+              return true;
+            }
+          }
+        }
+      } catch (inspectionError) {
+        console.warn('Unable to inspect known storage keys after quota error', inspectionError);
+      }
+    }
+
+    if (typeof storage.key === 'function') {
+      try {
+        const length = typeof storage.length === 'number' ? storage.length : 0;
+        for (let index = 0; index < length; index += 1) {
+          const candidate = storage.key(index);
+          if (typeof candidate === 'string' && candidate) {
+            return true;
+          }
+        }
+      } catch (iterationError) {
+        console.warn('Unable to iterate storage keys after quota error', iterationError);
+      }
+    }
+
+    return false;
+  };
+
   const verifyStorage = (storage) => {
     if (!storage) return null;
-    storage.setItem(TEST_KEY, '1');
-    storage.removeItem(TEST_KEY);
+    try {
+      storage.setItem(TEST_KEY, '1');
+    } catch (error) {
+      if (isQuotaExceededError(error) && hasStoredEntries(storage)) {
+        console.warn(
+          'localStorage quota exceeded. Existing planner data will remain available but new saves may fail.',
+          error,
+        );
+        return storage;
+      }
+      throw error;
+    }
+
+    try {
+      storage.removeItem(TEST_KEY);
+    } catch (cleanupError) {
+      console.warn('Unable to clean up storage test key', cleanupError);
+    }
+
     return storage;
   };
 

--- a/tests/unit/storageFallback.test.js
+++ b/tests/unit/storageFallback.test.js
@@ -1,5 +1,38 @@
 const FAVORITES_KEY = 'cameraPowerPlanner_favorites';
 
+const createQuotaStorage = (initialData = {}) => {
+  const store = { ...initialData };
+  const quotaError = () => {
+    const error = new Error('Quota exceeded');
+    error.name = 'QuotaExceededError';
+    error.code = 22;
+    error.number = 22;
+    return error;
+  };
+
+  return {
+    get length() {
+      return Object.keys(store).length;
+    },
+    key: jest.fn((index) => {
+      const keys = Object.keys(store);
+      return index >= 0 && index < keys.length ? keys[index] : null;
+    }),
+    getItem: jest.fn((key) =>
+      Object.prototype.hasOwnProperty.call(store, key) ? store[key] : null,
+    ),
+    setItem: jest.fn(() => {
+      throw quotaError();
+    }),
+    removeItem: jest.fn((key) => {
+      delete store[key];
+    }),
+    clear: jest.fn(() => {
+      Object.keys(store).forEach((key) => delete store[key]);
+    }),
+  };
+};
+
 describe('SAFE_LOCAL_STORAGE fallback behaviour', () => {
   let originalLocalStorageDescriptor;
   let storageModule;
@@ -53,6 +86,165 @@ describe('SAFE_LOCAL_STORAGE fallback behaviour', () => {
     );
     expect(global.localStorage.getItem(FAVORITES_KEY)).toBeNull();
     expect(loadFavorites()).toEqual({ cameraSelect: ['Alexa Mini'] });
+  });
+});
+
+describe('SAFE_LOCAL_STORAGE quota handling', () => {
+  let originalWindow;
+  let originalLocalStorageDescriptor;
+  let originalSessionStorageDescriptor;
+  let originalGlobalLocalStorage;
+  let originalGlobalSessionStorage;
+  let consoleWarnSpy;
+
+  beforeEach(() => {
+    jest.resetModules();
+
+    originalWindow = typeof global.window === 'undefined' ? undefined : global.window;
+    if (!global.window) {
+      global.window = {};
+    }
+
+    originalLocalStorageDescriptor = Object.getOwnPropertyDescriptor(global.window, 'localStorage');
+    originalSessionStorageDescriptor = Object.getOwnPropertyDescriptor(global.window, 'sessionStorage');
+
+    originalGlobalLocalStorage = global.localStorage;
+    originalGlobalSessionStorage = global.sessionStorage;
+
+    const session = originalGlobalSessionStorage || global.sessionStorage;
+    if (!session) {
+      const memoryStore = {};
+      const sessionMock = {
+        get length() {
+          return Object.keys(memoryStore).length;
+        },
+        key: jest.fn((index) => {
+          const keys = Object.keys(memoryStore);
+          return index >= 0 && index < keys.length ? keys[index] : null;
+        }),
+        getItem: jest.fn((key) =>
+          Object.prototype.hasOwnProperty.call(memoryStore, key) ? memoryStore[key] : null,
+        ),
+        setItem: jest.fn((key, value) => {
+          memoryStore[key] = String(value);
+        }),
+        removeItem: jest.fn((key) => {
+          delete memoryStore[key];
+        }),
+        clear: jest.fn(() => {
+          Object.keys(memoryStore).forEach((key) => delete memoryStore[key]);
+        }),
+      };
+      global.sessionStorage = sessionMock;
+    }
+
+    const activeSession = global.sessionStorage;
+    if (typeof activeSession.clear === 'function') {
+      activeSession.clear();
+    }
+    if (activeSession.getItem && activeSession.getItem.mockClear) {
+      activeSession.getItem.mockClear();
+    }
+    if (activeSession.setItem && activeSession.setItem.mockClear) {
+      activeSession.setItem.mockClear();
+    }
+    if (activeSession.removeItem && activeSession.removeItem.mockClear) {
+      activeSession.removeItem.mockClear();
+    }
+    if (activeSession.key && activeSession.key.mockClear) {
+      activeSession.key.mockClear();
+    }
+
+    Object.defineProperty(global.window, 'sessionStorage', {
+      configurable: true,
+      value: activeSession,
+    });
+
+    consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleWarnSpy.mockRestore();
+    jest.resetModules();
+
+    if (originalLocalStorageDescriptor) {
+      Object.defineProperty(global.window, 'localStorage', originalLocalStorageDescriptor);
+    } else if (global.window) {
+      delete global.window.localStorage;
+    }
+
+    if (originalSessionStorageDescriptor) {
+      Object.defineProperty(global.window, 'sessionStorage', originalSessionStorageDescriptor);
+    } else if (global.window) {
+      delete global.window.sessionStorage;
+    }
+
+    if (originalWindow === undefined) {
+      delete global.window;
+    } else {
+      global.window = originalWindow;
+    }
+
+    if (originalGlobalLocalStorage !== undefined) {
+      global.localStorage = originalGlobalLocalStorage;
+    } else {
+      delete global.localStorage;
+    }
+
+    if (originalGlobalSessionStorage !== undefined) {
+      global.sessionStorage = originalGlobalSessionStorage;
+    } else {
+      delete global.sessionStorage;
+    }
+  });
+
+  test('retains localStorage when quota errors occur but stored entries exist', () => {
+    const quotaStorage = createQuotaStorage({
+      [FAVORITES_KEY]: JSON.stringify({ cameraSelect: ['Alexa Mini'] }),
+    });
+
+    Object.defineProperty(global.window, 'localStorage', {
+      configurable: true,
+      value: quotaStorage,
+    });
+    global.localStorage = quotaStorage;
+
+    const { getSafeLocalStorage, loadFavorites } = require('../../src/scripts/storage');
+
+    expect(getSafeLocalStorage()).toBe(quotaStorage);
+    expect(loadFavorites()).toEqual({ cameraSelect: ['Alexa Mini'] });
+
+    const quotaWarning = consoleWarnSpy.mock.calls.find(
+      ([message]) => typeof message === 'string' && message.includes('localStorage quota exceeded')
+    );
+    expect(quotaWarning).toBeDefined();
+    expect(quotaStorage.setItem).toHaveBeenCalledTimes(1);
+    expect(quotaStorage.setItem.mock.calls[0][0]).toBe('__storage_test__');
+  });
+
+  test('falls back to sessionStorage when quota errors occur without stored entries', () => {
+    const quotaStorage = createQuotaStorage();
+
+    Object.defineProperty(global.window, 'localStorage', {
+      configurable: true,
+      value: quotaStorage,
+    });
+    global.localStorage = quotaStorage;
+
+    const { getSafeLocalStorage, saveFavorites } = require('../../src/scripts/storage');
+
+    expect(getSafeLocalStorage()).toBe(global.sessionStorage);
+
+    saveFavorites({ cameraSelect: ['Alexa Mini'] });
+
+    const sessionCalls = global.sessionStorage.setItem.mock.calls;
+    expect(sessionCalls[0][0]).toBe('__storage_test__');
+    expect(sessionCalls).toEqual(expect.arrayContaining([
+      [FAVORITES_KEY, JSON.stringify({ cameraSelect: ['Alexa Mini'] })],
+      [`${FAVORITES_KEY}__backup`, JSON.stringify({ cameraSelect: ['Alexa Mini'] })],
+    ]));
+    expect(quotaStorage.setItem).toHaveBeenCalledTimes(1);
+    expect(quotaStorage.setItem.mock.calls[0][0]).toBe('__storage_test__');
   });
 });
 


### PR DESCRIPTION
## Summary
- guard localStorage verification against quota errors so existing planner data remains accessible before falling back
- mirror the enhanced quota handling logic in the legacy storage bundle
- add regression coverage to confirm SAFE_LOCAL_STORAGE keeps existing data on quota failures and still falls back when empty

## Testing
- npm run lint
- npm run test:jest -- --runTestsByPath tests/unit/storageFallback.test.js

------
https://chatgpt.com/codex/tasks/task_e_68ce90055a6483209765e0db869d7361