### PR TITLE
Use Uicons summary icon for overview button

### DIFF
--- a/index.html
+++ b/index.html
@@ -225,22 +225,7 @@
       <span class="form-label-spacer" aria-hidden="true"></span>
       <div class="form-actions">
         <button id="generateOverviewBtn">
-          <span class="btn-icon icon-glyph icon-svg" aria-hidden="true">
-            <svg
-              viewBox="0 0 24 24"
-              aria-hidden="true"
-              focusable="false"
-              stroke-width="1.5"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-            >
-              <rect x="4.5" y="3.75" width="15" height="16.5" rx="2.25" />
-              <path d="M8.5 8h7" />
-              <path d="M8.5 11.5h7" />
-              <line x1="7.75" y1="16.75" x2="16.25" y2="16.75" />
-              <polyline points="8.75 16.75 11 13.75 13.25 15.5 16 12.5" />
-            </svg>
-          </span>
+          <span class="btn-icon icon-glyph" aria-hidden="true" data-icon-font="uicons">&#xF1F5;</span>
           Generate Overview
         </button>
         <button id="generateGearListBtn" type="button">

--- a/legacy/scripts/script.js
+++ b/legacy/scripts/script.js
@@ -3382,7 +3382,7 @@ function setLanguage(lang) {
       updateHelpQuickLinksForLanguage(lang);
     }
   }
-  setButtonLabelWithIcon(document.getElementById("generateOverviewBtn"), texts[lang].generateOverviewBtn, ICON_GLYPHS.note);
+  setButtonLabelWithIcon(document.getElementById("generateOverviewBtn"), texts[lang].generateOverviewBtn, ICON_GLYPHS.overview);
   setButtonLabelWithIcon(document.getElementById("generateGearListBtn"), texts[lang].generateGearListBtn, ICON_GLYPHS.gears);
   setButtonLabelWithIcon(document.getElementById("shareSetupBtn"), texts[lang].shareSetupBtn, ICON_GLYPHS.fileExport);
   var exportRevert = document.getElementById("exportAndRevertBtn");
@@ -3785,6 +3785,7 @@ var ICON_GLYPHS = Object.freeze({
   audioIn: iconGlyph("\uF1C3", ICON_FONT_KEYS.ESSENTIAL),
   audioOut: iconGlyph("\uF22F", ICON_FONT_KEYS.ESSENTIAL),
   note: iconGlyph("\uF13E", ICON_FONT_KEYS.ESSENTIAL),
+  overview: iconGlyph("\uF1F5", ICON_FONT_KEYS.UICONS),
   feedback: Object.freeze({
     markup: FEEDBACK_ICON_SVG,
     className: 'icon-svg'

--- a/src/scripts/script.js
+++ b/src/scripts/script.js
@@ -3522,7 +3522,7 @@ function setLanguage(lang) {
   setButtonLabelWithIcon(
     document.getElementById("generateOverviewBtn"),
     texts[lang].generateOverviewBtn,
-    ICON_GLYPHS.note
+    ICON_GLYPHS.overview
   );
   setButtonLabelWithIcon(
     document.getElementById("generateGearListBtn"),
@@ -4126,6 +4126,7 @@ const ICON_GLYPHS = Object.freeze({
   audioIn: iconGlyph('\uF1C3', ICON_FONT_KEYS.ESSENTIAL),
   audioOut: iconGlyph('\uF22F', ICON_FONT_KEYS.ESSENTIAL),
   note: iconGlyph('\uF13E', ICON_FONT_KEYS.ESSENTIAL),
+  overview: iconGlyph('\uF1F5', ICON_FONT_KEYS.UICONS),
   feedback: Object.freeze({ markup: FEEDBACK_ICON_SVG, className: 'icon-svg' }),
   resetView: Object.freeze({ markup: RESET_VIEW_ICON_SVG, className: 'icon-svg' }),
   pin: iconGlyph('\uF1EF', ICON_FONT_KEYS.ESSENTIAL),


### PR DESCRIPTION
## Summary
- replace the Generate Overview button SVG with the local Uicons summary-check glyph for consistent styling
- expose a reusable overview glyph in the icon map and use it when wiring button labels in both modern and legacy scripts

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ce9c27a5e48320a6e769fd973a7323