### PR TITLE
Use cinema camera Uicon glyph

### DIFF
--- a/legacy/scripts/script.js
+++ b/legacy/scripts/script.js
@@ -3769,7 +3769,7 @@ var ICON_GLYPHS = Object.freeze({
   controller: iconGlyph("\uF117", ICON_FONT_KEYS.GADGET),
   distance: iconGlyph("\uEFB9", ICON_FONT_KEYS.UICONS),
   viewfinder: iconGlyph("\uF114", ICON_FONT_KEYS.FILM),
-  camera: iconGlyph("\uF12D", ICON_FONT_KEYS.FILM),
+  camera: iconGlyph("\uE333", ICON_FONT_KEYS.UICONS),
   trash: iconGlyph("\uF254", ICON_FONT_KEYS.ESSENTIAL),
   reload: iconGlyph("\uF202", ICON_FONT_KEYS.ESSENTIAL),
   load: Object.freeze({

--- a/src/scripts/script.js
+++ b/src/scripts/script.js
@@ -4113,7 +4113,7 @@ const ICON_GLYPHS = Object.freeze({
   controller: iconGlyph('\uF117', ICON_FONT_KEYS.GADGET),
   distance: iconGlyph('\uEFB9', ICON_FONT_KEYS.UICONS),
   viewfinder: iconGlyph('\uF114', ICON_FONT_KEYS.FILM),
-  camera: iconGlyph('\uF12D', ICON_FONT_KEYS.FILM),
+  camera: iconGlyph('\uE333', ICON_FONT_KEYS.UICONS),
   trash: iconGlyph('\uF254', ICON_FONT_KEYS.ESSENTIAL),
   reload: iconGlyph('\uF202', ICON_FONT_KEYS.ESSENTIAL),
   load: Object.freeze({ markup: LOAD_ICON_SVG, className: 'icon-svg' }),


### PR DESCRIPTION
## Summary
- replace the generic film-font camera glyph with the cinema camera icon from the bundled Uicons set
- mirror the same glyph update in the legacy script bundle to keep parity

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ce9c7f3934832099969158340ca38b