### PR TITLE
Use gear icon for FIZ motor connectors

### DIFF
--- a/legacy/scripts/script.js
+++ b/legacy/scripts/script.js
@@ -16041,7 +16041,7 @@ function generateConnectorSummary(device) {
     dir: 'In'
   }, {
     items: device.fizConnectors,
-    icon: ICON_GLYPHS.sliders,
+    icon: ICON_GLYPHS.gears,
     cls: 'fiz-conn',
     label: 'FIZ Port'
   }, {

--- a/src/scripts/script.js
+++ b/src/scripts/script.js
@@ -16382,7 +16382,7 @@ function generateConnectorSummary(device) {
     const connectors = [
         { items: device.power?.powerDistributionOutputs, icon: ICON_GLYPHS.bolt, cls: 'power-conn', label: 'Power', dir: 'Out' },
         { items: powerInputTypes(device).map(t => ({ type: t })), icon: ICON_GLYPHS.plug, cls: 'power-conn', label: 'Power', dir: 'In' },
-        { items: device.fizConnectors, icon: ICON_GLYPHS.sliders, cls: 'fiz-conn', label: 'FIZ Port' },
+        { items: device.fizConnectors, icon: ICON_GLYPHS.gears, cls: 'fiz-conn', label: 'FIZ Port' },
         { items: device.video?.inputs || device.videoInputs, icon: ICON_GLYPHS.screen, cls: 'video-conn', label: 'Video', dir: 'In' },
         { items: device.video?.outputs || device.videoOutputs, icon: ICON_GLYPHS.screen, cls: 'video-conn', label: 'Video', dir: 'Out' },
         { items: device.timecode, icon: ICON_GLYPHS.timecode, cls: 'neutral-conn', label: 'Timecode' },


### PR DESCRIPTION
## Summary
- update the connector summary to render the FIZ entry with the gear glyph
- mirror the glyph change in the legacy bundle to keep the UI consistent

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ce9c9717288320931d4edde7eadfc9