### PR TITLE
Normalize project requirement icon sizing

### DIFF
--- a/src/scripts/script.js
+++ b/src/scripts/script.js
@@ -16324,19 +16324,44 @@ function summarizeByType(list) {
     }, {});
 }
 
-function iconMarkup(glyph, className = 'info-icon') {
+function iconMarkup(glyph, classNameOrOptions = 'info-icon', options = null) {
   if (!glyph) return '';
+  let opts = {};
+  let resolvedClassName = 'info-icon';
+  if (typeof classNameOrOptions === 'string' || classNameOrOptions === null) {
+    resolvedClassName = classNameOrOptions || '';
+    if (options && typeof options === 'object') {
+      opts = options;
+    }
+  } else if (classNameOrOptions && typeof classNameOrOptions === 'object') {
+    opts = classNameOrOptions;
+    resolvedClassName = classNameOrOptions.className || 'info-icon';
+  }
+  if (typeof opts.className === 'string') {
+    resolvedClassName = opts.className;
+  }
+  const styleParts = [];
+  if (typeof opts.size === 'string' && opts.size.trim()) {
+    styleParts.push(`--icon-size: ${opts.size.trim()}`);
+  }
+  if (typeof opts.scale === 'string' && opts.scale.trim()) {
+    styleParts.push(`--icon-scale: ${opts.scale.trim()}`);
+  }
+  if (typeof opts.style === 'string' && opts.style.trim()) {
+    styleParts.push(opts.style.trim());
+  }
+  const styleAttr = styleParts.length ? ` style="${styleParts.join(';')}"` : '';
   const resolved = resolveIconGlyph(glyph);
   const classes = ['icon-glyph'];
-  if (className) classes.unshift(className);
+  if (resolvedClassName) classes.unshift(resolvedClassName);
   if (resolved.markup) {
     if (resolved.className) classes.push(resolved.className);
     const markup = ensureSvgHasAriaHidden(resolved.markup);
-    return `<span class="${classes.join(' ')}" aria-hidden="true">${markup}</span>`;
+    return `<span class="${classes.join(' ')}"${styleAttr} aria-hidden="true">${markup}</span>`;
   }
   const char = resolved.char || '';
   if (!char) return '';
-  return `<span class="${classes.join(' ')}" data-icon-font="${resolved.font}" aria-hidden="true">${char}</span>`;
+  return `<span class="${classes.join(' ')}"${styleAttr} data-icon-font="${resolved.font}" aria-hidden="true">${char}</span>`;
 }
 
 function applyIconGlyph(element, glyph) {
@@ -17737,7 +17762,10 @@ function generateGearListHtml(info = {}) {
         infoEntries.map(([k, v]) => {
             const value = escapeHtml(v).replace(/\n/g, '<br>');
             const label = projectLabels[k] || k;
-            const iconHtml = iconMarkup(projectFieldIcons[k], 'req-icon');
+            const iconHtml = iconMarkup(projectFieldIcons[k], {
+                className: 'req-icon',
+                size: 'var(--req-icon-size)'
+            });
             return `<div class="requirement-box" data-field="${k}">${iconHtml}<span class="req-label">${escapeHtml(label)}</span><span class="req-value">${value}</span></div>`;
         }).join('') + '</div>' : '';
     const requirementsHeading = projectFormTexts.heading || 'Project Requirements';

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -3859,9 +3859,14 @@ body.dark-mode.dark-accent-boost:not(.pink-mode) .settings-content.modal-surface
 }
 .requirement-box .req-icon {
   --req-icon-size: calc(var(--font-size-relative-base) * var(--font-scale-xxxl));
-  font-size: var(--req-icon-size);
-  width: var(--req-icon-size);
-  height: var(--req-icon-size);
+  --icon-size: var(--req-icon-size);
+  font-size: var(--icon-size);
+  width: var(--icon-size);
+  height: var(--icon-size);
+  min-width: var(--icon-size);
+  min-height: var(--icon-size);
+  max-width: var(--icon-size);
+  max-height: var(--icon-size);
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -3871,8 +3876,10 @@ body.dark-mode.dark-accent-boost:not(.pink-mode) .settings-content.modal-surface
 }
 
 .requirement-box .req-icon svg {
-  width: 100%;
-  height: 100%;
+  width: var(--icon-size);
+  height: var(--icon-size);
+  max-width: 100%;
+  max-height: 100%;
   display: block;
 }
 .requirement-box .req-label {


### PR DESCRIPTION
## Summary
- allow `iconMarkup` to accept sizing options and use them when rendering project requirement icons
- enforce consistent dimensions for requirement overview icons so SVG and font glyphs appear uniform

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ce9ce600208320b1fbb020601221e4