### PR TITLE
Make logo accent follow pink mode

### DIFF
--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -118,7 +118,7 @@ body.pink-mode {
   --accent-color: #ff69b4;
   --link-color: #ff69b4;
   --icon-color: var(--accent-color);
-  --logo-accent-color: var(--brand-accent-color);
+  --logo-accent-color: var(--accent-color);
 }
 
 html {


### PR DESCRIPTION
## Summary
- update the pink mode CSS variables so the logo accent color switches to the pink accent

## Testing
- npm test -- --runTestsByPath tests/script/static-theme.test.js

------
https://chatgpt.com/codex/tasks/task_e_68cee30009d88320a80f8013376b22d9