### PR TITLE
Use Uicons glyph for gear list button

### DIFF
--- a/index.html
+++ b/index.html
@@ -229,22 +229,7 @@
           Generate Overview
         </button>
         <button id="generateGearListBtn" type="button">
-          <span class="btn-icon icon-glyph icon-svg" aria-hidden="true">
-            <svg
-              viewBox="0 0 24 24"
-              aria-hidden="true"
-              focusable="false"
-              stroke-width="1.5"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-            >
-              <rect x="6.75" y="5.5" width="10.5" height="13.5" rx="2" />
-              <path d="M9.75 3.5h4.5" />
-              <path d="M9.5 9h6" />
-              <path d="M9.5 12.75l1.5 1.5 2.75-2.75" />
-              <path d="M9.5 16.25l1.5 1.5 2.75-2.75" />
-            </svg>
-          </span>
+          <span class="btn-icon icon-glyph" aria-hidden="true" data-icon-font="uicons">&#xE467;</span>
           Generate Gear List and Project Requirements
         </button>
       </div>

--- a/src/scripts/script.js
+++ b/src/scripts/script.js
@@ -3612,7 +3612,7 @@ function setLanguage(lang) {
   setButtonLabelWithIcon(
     document.getElementById("generateGearListBtn"),
     texts[lang].generateGearListBtn,
-    ICON_GLYPHS.gears
+    ICON_GLYPHS.gearList
   );
   setButtonLabelWithIcon(
     document.getElementById("shareSetupBtn"),
@@ -4174,6 +4174,7 @@ const ICON_GLYPHS = Object.freeze({
   audioOut: iconGlyph('\uF22F', ICON_FONT_KEYS.ESSENTIAL),
   note: iconGlyph('\uF13E', ICON_FONT_KEYS.ESSENTIAL),
   overview: iconGlyph('\uF1F5', ICON_FONT_KEYS.UICONS),
+  gearList: iconGlyph('\uE467', ICON_FONT_KEYS.UICONS),
   feedback: Object.freeze({ markup: FEEDBACK_ICON_SVG, className: 'icon-svg' }),
   resetView: Object.freeze({ markup: RESET_VIEW_ICON_SVG, className: 'icon-svg' }),
   pin: iconGlyph('\uF1EF', ICON_FONT_KEYS.ESSENTIAL),
@@ -20965,6 +20966,7 @@ async function clearCachesAndReload() {
         const { location } = window;
         const hasReplace = location && typeof location.replace === 'function';
         const hasReload = location && typeof location.reload === 'function';
+        let navigationTriggered = false;
         if (hasReplace) {
           const paramName = 'forceReload';
           const timestamp = Date.now().toString(36);
@@ -20985,9 +20987,9 @@ async function clearCachesAndReload() {
             href += '?' + paramName + '=' + timestamp;
           }
           location.replace(href + hash);
-          return;
+          navigationTriggered = true;
         }
-        if (hasReload) {
+        if (!navigationTriggered && hasReload) {
           location.reload();
         }
       }


### PR DESCRIPTION
## Summary
- replace the inline SVG on the Generate Gear List button with a local Uicons glyph and keep the label translation-ready
- add a dedicated gear list glyph mapping so other gear-related icons remain unchanged
- clean up the cache reload helper to avoid returning inside finally blocks while preserving reload behaviour

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cee57fdd548320a155d8d27db415d8