### PR TITLE
Fix auto gear item styling in gear list

### DIFF
--- a/src/styles/overview-print.css
+++ b/src/styles/overview-print.css
@@ -322,6 +322,17 @@ body:not(.light-mode) .gear-table tbody {
   white-space: nowrap;
 }
 
+#overviewDialogContent .gear-table .auto-gear-item,
+#overviewDialogContent.dark-mode .gear-table .auto-gear-item,
+body:not(.light-mode) .gear-table .auto-gear-item {
+  margin: 0;
+  padding: 0;
+  border: none;
+  border-radius: 0;
+  background: none;
+  box-shadow: none;
+}
+
 #overviewDialogContent .gear-table .gear-item select {
   width: auto;
   min-width: 0;

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -4075,6 +4075,15 @@ body.dark-mode.dark-accent-boost:not(.pink-mode) .settings-content.modal-surface
   page-break-inside: avoid;
 }
 
+.gear-table .auto-gear-item {
+  margin: 0;
+  padding: 0;
+  border: none;
+  border-radius: 0;
+  background: none;
+  box-shadow: none;
+}
+
 #gearListOutput .cage-select-wrapper {
   display: inline-flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- reset the gear table styling for auto gear entries so they render like standard gear rows
- mirror the styling override in the overview print stylesheet to keep automatic additions consistent when printing

## Testing
- npm run lint *(fails: existing `no-unsafe-finally` violation in src/scripts/script.js)*
- npm run test:jest -- --runTestsByPath tests/script/autoGearRules.test.js


------
https://chatgpt.com/codex/tasks/task_e_68cee64127c08320b7ba6cbea98eae7f