### PR TITLE
Adjust diagram fill for pink mode

### DIFF
--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -119,6 +119,7 @@ body.pink-mode {
   --link-color: #ff69b4;
   --icon-color: var(--accent-color);
   --logo-accent-color: var(--accent-color);
+  --diagram-node-fill: #ffe4f2;
 }
 
 html {
@@ -3401,6 +3402,7 @@ body.dark-mode.dark-accent-boost:not(.pink-mode) h2 {
 
 body.dark-mode.pink-mode {
   --link-color: var(--inverse-text-color);
+  --diagram-node-fill: #4a1530;
 }
 .dark-mode section,
 .dark-mode .device-category,


### PR DESCRIPTION
## Summary
- update the pink theme CSS variables so setup diagram nodes use a playful pink fill in light mode
- darken the diagram node fill for the dark + pink theme combination to preserve contrast

## Testing
- npm test -- --runTestsByPath tests/script/settings-theme.test.js

------
https://chatgpt.com/codex/tasks/task_e_68cee81cebc883209a1816d64a88de66