### PR TITLE
Use Uicons for project requirements overview icons

### DIFF
--- a/legacy/scripts/script.js
+++ b/legacy/scripts/script.js
@@ -3730,23 +3730,8 @@ function glyphText(glyph) {
 var FEEDBACK_ICON_SVG = "\n  <svg viewBox=\"0 0 24 24\" xmlns=\"http://www.w3.org/2000/svg\" aria-hidden=\"true\">\n    <path\n      d=\"M5 4.5H19Q21.5 4.5 21.5 7V13Q21.5 15.5 19 15.5H15.5L12 19 8.5 15.5H5Q2.5 15.5 2.5 13V7Q2.5 4.5 5 4.5Z\"\n      fill=\"none\"\n      stroke=\"currentColor\"\n      stroke-width=\"1.5\"\n      stroke-linecap=\"round\"\n      stroke-linejoin=\"round\"\n    />\n    <path\n      d=\"M8.5 10.5 10.5 12.5 14.5 8.5\"\n      fill=\"none\"\n      stroke=\"currentColor\"\n      stroke-width=\"1.5\"\n      stroke-linecap=\"round\"\n      stroke-linejoin=\"round\"\n    />\n  </svg>\n".trim();
 var LOAD_ICON_SVG = "\n  <svg viewBox=\"0 0 24 24\" xmlns=\"http://www.w3.org/2000/svg\" aria-hidden=\"true\">\n    <path\n      d=\"M12 3v9.75\"\n      fill=\"none\"\n      stroke=\"currentColor\"\n      stroke-width=\"1.5\"\n      stroke-linecap=\"round\"\n      stroke-linejoin=\"round\"\n    />\n    <polyline\n      points=\"8.75 9.75 12 12.75 15.25 9.75\"\n      fill=\"none\"\n      stroke=\"currentColor\"\n      stroke-width=\"1.5\"\n      stroke-linecap=\"round\"\n      stroke-linejoin=\"round\"\n    />\n    <path\n      d=\"M4.75 11.5H8.6L10.4 9h8.85L21 11.5\"\n      fill=\"none\"\n      stroke=\"currentColor\"\n      stroke-width=\"1.5\"\n      stroke-linecap=\"round\"\n      stroke-linejoin=\"round\"\n    />\n    <rect\n      x=\"4.75\"\n      y=\"12.5\"\n      width=\"14.5\"\n      height=\"7.25\"\n      rx=\"1.75\"\n      fill=\"none\"\n      stroke=\"currentColor\"\n      stroke-width=\"1.5\"\n      stroke-linecap=\"round\"\n      stroke-linejoin=\"round\"\n    />\n  </svg>\n".trim();
 var RESET_VIEW_ICON_SVG = "\n  <svg viewBox=\"0 0 24 24\" xmlns=\"http://www.w3.org/2000/svg\" aria-hidden=\"true\">\n    <g\n      fill=\"none\"\n      stroke=\"currentColor\"\n      stroke-width=\"1.5\"\n      stroke-linecap=\"round\"\n      stroke-linejoin=\"round\"\n    >\n      <line x1=\"12\" y1=\"4.75\" x2=\"12\" y2=\"9.75\" />\n      <polyline points=\"10.75 8.5 12 9.75 13.25 8.5\" />\n      <line x1=\"12\" y1=\"19.25\" x2=\"12\" y2=\"14.25\" />\n      <polyline points=\"10.75 15.5 12 14.25 13.25 15.5\" />\n      <line x1=\"4.75\" y1=\"12\" x2=\"9.75\" y2=\"12\" />\n      <polyline points=\"8.5 10.75 9.75 12 8.5 13.25\" />\n      <line x1=\"19.25\" y1=\"12\" x2=\"14.25\" y2=\"12\" />\n      <polyline points=\"15.5 10.75 14.25 12 15.5 13.25\" />\n    </g>\n    <circle cx=\"12\" cy=\"12\" r=\"1.35\" fill=\"currentColor\" />\n  </svg>\n".trim();
-var ASPECT_RATIO_ICON_SVG = "\n  <svg viewBox=\"0 0 24 24\" xmlns=\"http://www.w3.org/2000/svg\" aria-hidden=\"true\">\n    <g\n      fill=\"none\"\n      stroke=\"currentColor\"\n      stroke-width=\"1.5\"\n      stroke-linecap=\"round\"\n      stroke-linejoin=\"round\"\n    >\n      <rect x=\"3.5\" y=\"6\" width=\"17\" height=\"12\" rx=\"2\" ry=\"2\" />\n      <line x1=\"8\" y1=\"12\" x2=\"16\" y2=\"12\" />\n      <polyline points=\"9 10.75 8 12 9 13.25\" />\n      <polyline points=\"15 10.75 16 12 15 13.25\" />\n      <line x1=\"12\" y1=\"9\" x2=\"12\" y2=\"15\" />\n      <polyline points=\"10.75 10 12 9 13.25 10\" />\n      <polyline points=\"10.75 14 12 15 13.25 14\" />\n    </g>\n  </svg>\n".trim();
-var REQUIRED_SCENARIOS_ICON_SVG = "\n  <svg viewBox=\"0 0 24 24\" xmlns=\"http://www.w3.org/2000/svg\" aria-hidden=\"true\">\n    <g\n      fill=\"none\"\n      stroke=\"currentColor\"\n      stroke-width=\"1.5\"\n      stroke-linecap=\"round\"\n      stroke-linejoin=\"round\"\n    >\n      <path d=\"M8.5 4.5V3.25A1.25 1.25 0 0 1 9.75 2h4.5a1.25 1.25 0 0 1 1.25 1.25V4.5\" />\n      <rect x=\"5.25\" y=\"4.5\" width=\"13.5\" height=\"15.5\" rx=\"2\" ry=\"2\" />\n      <rect x=\"8.25\" y=\"8.75\" width=\"3\" height=\"3\" rx=\"0.5\" ry=\"0.5\" />\n      <rect x=\"8.25\" y=\"13.75\" width=\"3\" height=\"3\" rx=\"0.5\" ry=\"0.5\" />\n      <polyline points=\"9 10.25 9.85 11.05 11 9.75\" />\n      <polyline points=\"9 15.25 9.85 16.05 11 14.75\" />\n      <line x1=\"12.75\" y1=\"10.25\" x2=\"16.5\" y2=\"10.25\" />\n      <line x1=\"12.75\" y1=\"15.25\" x2=\"16.5\" y2=\"15.25\" />\n    </g>\n  </svg>\n".trim();
-var MONITORING_SUPPORT_ICON_SVG = "\n  <svg viewBox=\"0 0 24 24\" xmlns=\"http://www.w3.org/2000/svg\" aria-hidden=\"true\">\n    <g\n      fill=\"none\"\n      stroke=\"currentColor\"\n      stroke-width=\"1.5\"\n      stroke-linecap=\"round\"\n      stroke-linejoin=\"round\"\n    >\n      <rect x=\"4.25\" y=\"5.5\" width=\"15.5\" height=\"9.5\" rx=\"1.75\" ry=\"1.75\" />\n      <path d=\"M9 15.25 7.1 19.5\" />\n      <path d=\"M15 15.25 16.9 19.5\" />\n      <line x1=\"9.75\" y1=\"19.5\" x2=\"14.25\" y2=\"19.5\" />\n      <line x1=\"12\" y1=\"15\" x2=\"12\" y2=\"19.5\" />\n    </g>\n  </svg>\n".trim();
 var PRODUCTION_COMPANY_ICON = iconGlyph('\uE2D5', ICON_FONT_KEYS.UICONS);
 var RENTAL_HOUSE_ICON = iconGlyph('\uEA09', ICON_FONT_KEYS.UICONS);
-var ASPECT_RATIO_ICON = Object.freeze({
-  markup: ASPECT_RATIO_ICON_SVG,
-  className: 'icon-svg'
-});
-var REQUIRED_SCENARIOS_ICON = Object.freeze({
-  markup: REQUIRED_SCENARIOS_ICON_SVG,
-  className: 'icon-svg'
-});
-var MONITORING_SUPPORT_ICON = Object.freeze({
-  markup: MONITORING_SUPPORT_ICON_SVG,
-  className: 'icon-svg'
-});
 var STAR_ICON_SVG = "\n  <svg viewBox=\"0 0 24 24\" xmlns=\"http://www.w3.org/2000/svg\">\n    <path d=\"M12 17.25 6.545 20.2 7.9 13.975 3 9.45l6.272-.7L12 3l2.728 5.75L21 9.45l-4.9 4.525 1.355 6.225Z\" />\n  </svg>\n".trim();
 var ICON_GLYPHS = Object.freeze({
   batteryBolt: iconGlyph("\uE1A6", ICON_FONT_KEYS.UICONS),
@@ -4445,25 +4430,25 @@ var PINK_MODE_ICON_ANIMATION_RESET_DELAY = 450;
 var projectFieldIcons = {
   productionCompany: PRODUCTION_COMPANY_ICON,
   rentalHouse: RENTAL_HOUSE_ICON,
-  crew: iconGlyph("\uF102", ICON_FONT_KEYS.FILM),
-  prepDays: iconGlyph("\uF126", ICON_FONT_KEYS.ESSENTIAL),
-  shootingDays: iconGlyph("\uF10C", ICON_FONT_KEYS.FILM),
-  deliveryResolution: ICON_GLYPHS.screen,
-  recordingResolution: ICON_GLYPHS.camera,
-  aspectRatio: ASPECT_RATIO_ICON,
-  codec: iconGlyph("\uF107", ICON_FONT_KEYS.GADGET),
-  baseFrameRate: ICON_GLYPHS.timecode,
-  sensorMode: iconGlyph("\uF110", ICON_FONT_KEYS.GADGET),
-  requiredScenarios: REQUIRED_SCENARIOS_ICON,
-  lenses: iconGlyph("\uF117", ICON_FONT_KEYS.FILM),
-  cameraHandle: ICON_GLYPHS.gears,
-  viewfinderExtension: iconGlyph("\uF12E", ICON_FONT_KEYS.FILM),
+  crew: iconGlyph("\uF258", ICON_FONT_KEYS.UICONS),
+  prepDays: iconGlyph("\uE312", ICON_FONT_KEYS.UICONS),
+  shootingDays: iconGlyph("\uE311", ICON_FONT_KEYS.UICONS),
+  deliveryResolution: iconGlyph("\uEFFC", ICON_FONT_KEYS.UICONS),
+  recordingResolution: iconGlyph("\uE333", ICON_FONT_KEYS.UICONS),
+  aspectRatio: iconGlyph("\uE86E", ICON_FONT_KEYS.UICONS),
+  codec: iconGlyph("\uE7A1", ICON_FONT_KEYS.UICONS),
+  baseFrameRate: iconGlyph("\uE484", ICON_FONT_KEYS.UICONS),
+  sensorMode: iconGlyph("\uF034", ICON_FONT_KEYS.UICONS),
+  requiredScenarios: iconGlyph("\uE46A", ICON_FONT_KEYS.UICONS),
+  lenses: iconGlyph("\uE0A3", ICON_FONT_KEYS.UICONS),
+  cameraHandle: iconGlyph("\uE93B", ICON_FONT_KEYS.UICONS),
+  viewfinderExtension: iconGlyph("\uE338", ICON_FONT_KEYS.UICONS),
   gimbal: iconGlyph("\uEA9C", ICON_FONT_KEYS.UICONS),
-  monitoringSupport: MONITORING_SUPPORT_ICON,
-  monitoringConfiguration: ICON_GLYPHS.sliders,
-  monitorUserButtons: ICON_GLYPHS.sliders,
-  cameraUserButtons: ICON_GLYPHS.sliders,
-  viewfinderUserButtons: ICON_GLYPHS.sliders
+  monitoringSupport: iconGlyph("\uE5BA", ICON_FONT_KEYS.UICONS),
+  monitoringConfiguration: iconGlyph("\uF0D0", ICON_FONT_KEYS.UICONS),
+  monitorUserButtons: iconGlyph("\uEA5A", ICON_FONT_KEYS.UICONS),
+  cameraUserButtons: iconGlyph("\uEF14", ICON_FONT_KEYS.UICONS),
+  viewfinderUserButtons: iconGlyph("\uF2BD", ICON_FONT_KEYS.UICONS)
 };
 function setButtonLabelWithIcon(button, label) {
   var glyph = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : ICON_GLYPHS.save;
@@ -20364,7 +20349,7 @@ function clearCachesAndReload() {
 }
 function _clearCachesAndReload() {
   _clearCachesAndReload = _asyncToGenerator(_regenerator().m(function _callee11() {
-    var registrations, _navigator, serviceWorker, regs, reg, readyReg, keys, _window, location, hasReplace, hasReload, paramName, timestamp, href, hash, hashIndex, pattern, replacement, _t11, _t12, _t13, _t14;
+    var registrations, _navigator, serviceWorker, regs, reg, readyReg, keys, _window, location, hasReplace, hasReload, replaced, paramName, timestamp, href, hash, hashIndex, pattern, replacement, _t11, _t12, _t13, _t14;
     return _regenerator().w(function (_context11) {
       while (1) switch (_context11.p = _context11.n) {
         case 0:
@@ -20481,34 +20466,34 @@ function _clearCachesAndReload() {
           _window = window, location = _window.location;
           hasReplace = location && typeof location.replace === 'function';
           hasReload = location && typeof location.reload === 'function';
-          if (!hasReplace) {
-            _context11.n = 18;
-            break;
+          replaced = false;
+          if (hasReplace) {
+            paramName = 'forceReload';
+            timestamp = Date.now().toString(36);
+            href = location.href || '';
+            hash = '';
+            hashIndex = href.indexOf('#');
+            if (hashIndex !== -1) {
+              hash = href.slice(hashIndex);
+              href = href.slice(0, hashIndex);
+            }
+            pattern = new RegExp('([?&])' + paramName + '=[^&]*');
+            replacement = '$1' + paramName + '=' + timestamp;
+            if (pattern.test(href)) {
+              href = href.replace(pattern, replacement);
+            } else if (href.indexOf('?') !== -1) {
+              href += '&' + paramName + '=' + timestamp;
+            } else if (href) {
+              href += '?' + paramName + '=' + timestamp;
+            }
+            location.replace(href + hash);
+            replaced = true;
           }
-          paramName = 'forceReload';
-          timestamp = Date.now().toString(36);
-          href = location.href || '';
-          hash = '';
-          hashIndex = href.indexOf('#');
-          if (hashIndex !== -1) {
-            hash = href.slice(hashIndex);
-            href = href.slice(0, hashIndex);
-          }
-          pattern = new RegExp('([?&])' + paramName + '=[^&]*');
-          replacement = '$1' + paramName + '=' + timestamp;
-          if (pattern.test(href)) {
-            href = href.replace(pattern, replacement);
-          } else if (href.indexOf('?') !== -1) {
-            href += '&' + paramName + '=' + timestamp;
-          } else if (href) {
-            href += '?' + paramName + '=' + timestamp;
-          }
-          location.replace(href + hash);
-          return _context11.a(2);
-        case 18:
-          if (hasReload) {
+          if (!replaced && hasReload) {
             location.reload();
           }
+          _context11.n = 21;
+          break;
         case 19:
           _context11.n = 21;
           break;

--- a/src/scripts/script.js
+++ b/src/scripts/script.js
@@ -4076,70 +4076,8 @@ const RESET_VIEW_ICON_SVG = `
   </svg>
 `.trim();
 
-const ASPECT_RATIO_ICON_SVG = `
-  <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-    <g
-      fill="none"
-      stroke="currentColor"
-      stroke-width="1.5"
-      stroke-linecap="round"
-      stroke-linejoin="round"
-    >
-      <rect x="3.5" y="6" width="17" height="12" rx="2" ry="2" />
-      <line x1="8" y1="12" x2="16" y2="12" />
-      <polyline points="9 10.75 8 12 9 13.25" />
-      <polyline points="15 10.75 16 12 15 13.25" />
-      <line x1="12" y1="9" x2="12" y2="15" />
-      <polyline points="10.75 10 12 9 13.25 10" />
-      <polyline points="10.75 14 12 15 13.25 14" />
-    </g>
-  </svg>
-`.trim();
-
-const REQUIRED_SCENARIOS_ICON_SVG = `
-  <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-    <g
-      fill="none"
-      stroke="currentColor"
-      stroke-width="1.5"
-      stroke-linecap="round"
-      stroke-linejoin="round"
-    >
-      <path d="M8.5 4.5V3.25A1.25 1.25 0 0 1 9.75 2h4.5a1.25 1.25 0 0 1 1.25 1.25V4.5" />
-      <rect x="5.25" y="4.5" width="13.5" height="15.5" rx="2" ry="2" />
-      <rect x="8.25" y="8.75" width="3" height="3" rx="0.5" ry="0.5" />
-      <rect x="8.25" y="13.75" width="3" height="3" rx="0.5" ry="0.5" />
-      <polyline points="9 10.25 9.85 11.05 11 9.75" />
-      <polyline points="9 15.25 9.85 16.05 11 14.75" />
-      <line x1="12.75" y1="10.25" x2="16.5" y2="10.25" />
-      <line x1="12.75" y1="15.25" x2="16.5" y2="15.25" />
-    </g>
-  </svg>
-`.trim();
-
-const MONITORING_SUPPORT_ICON_SVG = `
-  <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-    <g
-      fill="none"
-      stroke="currentColor"
-      stroke-width="1.5"
-      stroke-linecap="round"
-      stroke-linejoin="round"
-    >
-      <rect x="4.25" y="5.5" width="15.5" height="9.5" rx="1.75" ry="1.75" />
-      <path d="M9 15.25 7.1 19.5" />
-      <path d="M15 15.25 16.9 19.5" />
-      <line x1="9.75" y1="19.5" x2="14.25" y2="19.5" />
-      <line x1="12" y1="15" x2="12" y2="19.5" />
-    </g>
-  </svg>
-`.trim();
-
 const PRODUCTION_COMPANY_ICON = iconGlyph('\uE2D5', ICON_FONT_KEYS.UICONS);
 const RENTAL_HOUSE_ICON = iconGlyph('\uEA09', ICON_FONT_KEYS.UICONS);
-const ASPECT_RATIO_ICON = Object.freeze({ markup: ASPECT_RATIO_ICON_SVG, className: 'icon-svg' });
-const REQUIRED_SCENARIOS_ICON = Object.freeze({ markup: REQUIRED_SCENARIOS_ICON_SVG, className: 'icon-svg' });
-const MONITORING_SUPPORT_ICON = Object.freeze({ markup: MONITORING_SUPPORT_ICON_SVG, className: 'icon-svg' });
 
 const STAR_ICON_SVG = `
   <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
@@ -4925,25 +4863,25 @@ const PINK_MODE_ICON_ANIMATION_RESET_DELAY = 450;
 const projectFieldIcons = {
   productionCompany: PRODUCTION_COMPANY_ICON,
   rentalHouse: RENTAL_HOUSE_ICON,
-  crew: iconGlyph('\uF102', ICON_FONT_KEYS.FILM),
-  prepDays: iconGlyph('\uF126', ICON_FONT_KEYS.ESSENTIAL),
-  shootingDays: iconGlyph('\uF10C', ICON_FONT_KEYS.FILM),
-  deliveryResolution: ICON_GLYPHS.screen,
-  recordingResolution: ICON_GLYPHS.camera,
-  aspectRatio: ASPECT_RATIO_ICON,
-  codec: iconGlyph('\uF107', ICON_FONT_KEYS.GADGET),
-  baseFrameRate: ICON_GLYPHS.timecode,
-  sensorMode: iconGlyph('\uF110', ICON_FONT_KEYS.GADGET),
-  requiredScenarios: REQUIRED_SCENARIOS_ICON,
-  lenses: iconGlyph('\uF117', ICON_FONT_KEYS.FILM),
-  cameraHandle: ICON_GLYPHS.gears,
-  viewfinderExtension: iconGlyph('\uF12E', ICON_FONT_KEYS.FILM),
+  crew: iconGlyph('\uF258', ICON_FONT_KEYS.UICONS),
+  prepDays: iconGlyph('\uE312', ICON_FONT_KEYS.UICONS),
+  shootingDays: iconGlyph('\uE311', ICON_FONT_KEYS.UICONS),
+  deliveryResolution: iconGlyph('\uEFFC', ICON_FONT_KEYS.UICONS),
+  recordingResolution: iconGlyph('\uE333', ICON_FONT_KEYS.UICONS),
+  aspectRatio: iconGlyph('\uE86E', ICON_FONT_KEYS.UICONS),
+  codec: iconGlyph('\uE7A1', ICON_FONT_KEYS.UICONS),
+  baseFrameRate: iconGlyph('\uE484', ICON_FONT_KEYS.UICONS),
+  sensorMode: iconGlyph('\uF034', ICON_FONT_KEYS.UICONS),
+  requiredScenarios: iconGlyph('\uE46A', ICON_FONT_KEYS.UICONS),
+  lenses: iconGlyph('\uE0A3', ICON_FONT_KEYS.UICONS),
+  cameraHandle: iconGlyph('\uE93B', ICON_FONT_KEYS.UICONS),
+  viewfinderExtension: iconGlyph('\uE338', ICON_FONT_KEYS.UICONS),
   gimbal: iconGlyph('\uEA9C', ICON_FONT_KEYS.UICONS),
-  monitoringSupport: MONITORING_SUPPORT_ICON,
-  monitoringConfiguration: ICON_GLYPHS.sliders,
-  monitorUserButtons: ICON_GLYPHS.sliders,
-  cameraUserButtons: ICON_GLYPHS.sliders,
-  viewfinderUserButtons: ICON_GLYPHS.sliders
+  monitoringSupport: iconGlyph('\uE5BA', ICON_FONT_KEYS.UICONS),
+  monitoringConfiguration: iconGlyph('\uF0D0', ICON_FONT_KEYS.UICONS),
+  monitorUserButtons: iconGlyph('\uEA5A', ICON_FONT_KEYS.UICONS),
+  cameraUserButtons: iconGlyph('\uEF14', ICON_FONT_KEYS.UICONS),
+  viewfinderUserButtons: iconGlyph('\uF2BD', ICON_FONT_KEYS.UICONS)
 };
 
 function setButtonLabelWithIcon(button, label, glyph = ICON_GLYPHS.save) {
@@ -20965,6 +20903,7 @@ async function clearCachesAndReload() {
         const { location } = window;
         const hasReplace = location && typeof location.replace === 'function';
         const hasReload = location && typeof location.reload === 'function';
+        let replaced = false;
         if (hasReplace) {
           const paramName = 'forceReload';
           const timestamp = Date.now().toString(36);
@@ -20985,9 +20924,9 @@ async function clearCachesAndReload() {
             href += '?' + paramName + '=' + timestamp;
           }
           location.replace(href + hash);
-          return;
+          replaced = true;
         }
-        if (hasReload) {
+        if (!replaced && hasReload) {
           location.reload();
         }
       }


### PR DESCRIPTION
## Summary
- replace the project requirements icon map with Uicons glyphs so the overview uses the local icon font only
- mirror the icon changes and reload fallback tweak in the legacy bundle to keep the generated build aligned

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cee5c04f508320b3ff4ee74b137ec7