### PR TITLE
Ensure sidebar toggle initializes after load

### DIFF
--- a/src/scripts/script.js
+++ b/src/scripts/script.js
@@ -1277,11 +1277,21 @@ function setupResponsiveControls() {
   relocate();
 }
 
-if (typeof window !== 'undefined') {
-  document.addEventListener('DOMContentLoaded', () => {
-    setupSideMenu();
-    setupResponsiveControls();
-  });
+function initializeLayoutControls() {
+  setupSideMenu();
+  setupResponsiveControls();
+}
+
+if (typeof window !== 'undefined' && typeof document !== 'undefined') {
+  const runLayoutInitialization = () => {
+    initializeLayoutControls();
+  };
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', runLayoutInitialization, { once: true });
+  } else {
+    runLayoutInitialization();
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary
- ensure sidebar layout helpers run immediately when the DOM is already ready
- keep existing DOMContentLoaded path for browsers that finish parsing later

## Testing
- npm test --silent

------
https://chatgpt.com/codex/tasks/task_e_68ceea3a78f88320b9529d63cd731cc2