### PR TITLE
Prevent saving empty projects when no devices are selected

### DIFF
--- a/src/scripts/script.js
+++ b/src/scripts/script.js
@@ -10824,6 +10824,46 @@ function getCurrentSetupState() {
   return state;
 }
 
+function hasAnyDeviceSelection(state) {
+  if (!state) return false;
+  const isMeaningfulSelection = (value) => {
+    if (Array.isArray(value)) {
+      return value.some((item) => isMeaningfulSelection(item));
+    }
+    if (value == null) return false;
+    const normalized = typeof value === 'string' ? value.trim() : value;
+    if (!normalized) return false;
+    if (typeof normalized === 'string' && normalized.toLowerCase() === 'none') {
+      return false;
+    }
+    return true;
+  };
+
+  const primarySelections = [
+    state.camera,
+    state.monitor,
+    state.video,
+    state.cage,
+    state.batteryPlate,
+    state.battery,
+    state.batteryHotswap
+  ];
+
+  if (primarySelections.some((value) => isMeaningfulSelection(value))) {
+    return true;
+  }
+
+  if (isMeaningfulSelection(state.motors)) {
+    return true;
+  }
+
+  if (isMeaningfulSelection(state.controllers)) {
+    return true;
+  }
+
+  return false;
+}
+
 function checkSetupChanged() {
   if (!saveSetupBtn) return;
   const langTexts = texts[currentLang] || {};
@@ -14805,6 +14845,16 @@ saveSetupBtn.addEventListener("click", () => {
     return;
   }
   const currentSetup = { ...getCurrentSetupState() };
+  const langTexts = texts[currentLang] || {};
+  const fallbackTexts = texts.en || {};
+  if (!hasAnyDeviceSelection(currentSetup)) {
+    const message =
+      langTexts.alertSetupNeedsDevice ||
+      fallbackTexts.alertSetupNeedsDevice ||
+      'Please select at least one device before saving a project.';
+    alert(message);
+    return;
+  }
   const gearListHtml = getCurrentGearListHtml();
   if (gearListHtml) {
     currentSetup.gearList = gearListHtml;

--- a/src/scripts/translations.js
+++ b/src/scripts/translations.js
@@ -585,6 +585,7 @@ const texts = {
     noBatterySupports: "No battery can supply this load.",
 
     alertSetupName: "Please enter a name for the project.",
+    alertSetupNeedsDevice: "Please select at least one device before saving a project.",
     alertSetupSaved:
       "Project \"{name}\" saved in this browser. It stays available after closing or reopening tabs unless you clear the browser cache.",
     alertNoSetupSelected: "Please select a saved project to delete.",
@@ -1126,6 +1127,7 @@ const texts = {
     batteryCountTempLabel: "Batterie necessarie",
     noBatterySupports: "Nessuna batteria può fornire questo carico.",
     alertSetupName: "Immettere un nome per l'installazione.",
+    alertSetupNeedsDevice: "Seleziona almeno un dispositivo prima di salvare un progetto.",
     alertSetupSaved:
       "Setup \"{name}\" salvato nel browser. Rimane disponibile dopo aver chiuso o riaperto le schede finché non svuoti la cache del browser.",
     alertNoSetupSelected: "Selezionare una configurazione salvata da eliminare.",
@@ -1904,6 +1906,7 @@ const texts = {
     noBatterySupports: "Ninguna batería puede suministrar esta carga.",
 
     alertSetupName: "Ingresa un nombre para el proyecto.",
+    alertSetupNeedsDevice: "Selecciona al menos un dispositivo antes de guardar un proyecto.",
     alertSetupSaved:
       "Proyecto \"{name}\" guardado en este navegador. Permanece disponible al cerrar o volver a abrir pestañas mientras no borres la caché del navegador.",
     alertNoSetupSelected: "Selecciona un proyecto para eliminar.",
@@ -2685,6 +2688,7 @@ const texts = {
     noBatterySupports: "Aucune batterie ne peut fournir cette charge.",
 
     alertSetupName: "Veuillez saisir un nom pour la configuration.",
+    alertSetupNeedsDevice: "Veuillez sélectionner au moins un appareil avant d'enregistrer un projet.",
     alertSetupSaved:
       "Configuration \"{name}\" enregistrée dans ce navigateur. Elle reste disponible après avoir fermé ou rouvert des onglets tant que vous ne videz pas le cache du navigateur.",
     alertNoSetupSelected: "Sélectionnez une configuration à supprimer.",
@@ -3468,6 +3472,7 @@ const texts = {
     noBatterySupports: "Kein Akku kann diese Last liefern.",
 
     alertSetupName: "Bitte einen Namen für das Projekt eingeben.",
+    alertSetupNeedsDevice: "Bitte mindestens ein Gerät auswählen, bevor du ein Projekt speicherst.",
     alertSetupSaved:
       "Projekt \"{name}\" in diesem Browser gespeichert. Es bleibt verfügbar, wenn Sie Tabs oder den Browser schließen und erneut öffnen, solange Sie den Browsercache nicht löschen.",
     alertNoSetupSelected: "Wählen Sie ein gespeichertes Projekt zum Löschen aus.",


### PR DESCRIPTION
## Summary
- add a guard that prevents saving a project when no devices are selected
- localize the new validation alert across supported languages

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ceea771a748320ac3bb3ed96759844