### PR TITLE
Use Uicons for project requirements overview

### DIFF
--- a/legacy/scripts/script.js
+++ b/legacy/scripts/script.js
@@ -3730,23 +3730,11 @@ function glyphText(glyph) {
 var FEEDBACK_ICON_SVG = "\n  <svg viewBox=\"0 0 24 24\" xmlns=\"http://www.w3.org/2000/svg\" aria-hidden=\"true\">\n    <path\n      d=\"M5 4.5H19Q21.5 4.5 21.5 7V13Q21.5 15.5 19 15.5H15.5L12 19 8.5 15.5H5Q2.5 15.5 2.5 13V7Q2.5 4.5 5 4.5Z\"\n      fill=\"none\"\n      stroke=\"currentColor\"\n      stroke-width=\"1.5\"\n      stroke-linecap=\"round\"\n      stroke-linejoin=\"round\"\n    />\n    <path\n      d=\"M8.5 10.5 10.5 12.5 14.5 8.5\"\n      fill=\"none\"\n      stroke=\"currentColor\"\n      stroke-width=\"1.5\"\n      stroke-linecap=\"round\"\n      stroke-linejoin=\"round\"\n    />\n  </svg>\n".trim();
 var LOAD_ICON_SVG = "\n  <svg viewBox=\"0 0 24 24\" xmlns=\"http://www.w3.org/2000/svg\" aria-hidden=\"true\">\n    <path\n      d=\"M12 3v9.75\"\n      fill=\"none\"\n      stroke=\"currentColor\"\n      stroke-width=\"1.5\"\n      stroke-linecap=\"round\"\n      stroke-linejoin=\"round\"\n    />\n    <polyline\n      points=\"8.75 9.75 12 12.75 15.25 9.75\"\n      fill=\"none\"\n      stroke=\"currentColor\"\n      stroke-width=\"1.5\"\n      stroke-linecap=\"round\"\n      stroke-linejoin=\"round\"\n    />\n    <path\n      d=\"M4.75 11.5H8.6L10.4 9h8.85L21 11.5\"\n      fill=\"none\"\n      stroke=\"currentColor\"\n      stroke-width=\"1.5\"\n      stroke-linecap=\"round\"\n      stroke-linejoin=\"round\"\n    />\n    <rect\n      x=\"4.75\"\n      y=\"12.5\"\n      width=\"14.5\"\n      height=\"7.25\"\n      rx=\"1.75\"\n      fill=\"none\"\n      stroke=\"currentColor\"\n      stroke-width=\"1.5\"\n      stroke-linecap=\"round\"\n      stroke-linejoin=\"round\"\n    />\n  </svg>\n".trim();
 var RESET_VIEW_ICON_SVG = "\n  <svg viewBox=\"0 0 24 24\" xmlns=\"http://www.w3.org/2000/svg\" aria-hidden=\"true\">\n    <g\n      fill=\"none\"\n      stroke=\"currentColor\"\n      stroke-width=\"1.5\"\n      stroke-linecap=\"round\"\n      stroke-linejoin=\"round\"\n    >\n      <line x1=\"12\" y1=\"4.75\" x2=\"12\" y2=\"9.75\" />\n      <polyline points=\"10.75 8.5 12 9.75 13.25 8.5\" />\n      <line x1=\"12\" y1=\"19.25\" x2=\"12\" y2=\"14.25\" />\n      <polyline points=\"10.75 15.5 12 14.25 13.25 15.5\" />\n      <line x1=\"4.75\" y1=\"12\" x2=\"9.75\" y2=\"12\" />\n      <polyline points=\"8.5 10.75 9.75 12 8.5 13.25\" />\n      <line x1=\"19.25\" y1=\"12\" x2=\"14.25\" y2=\"12\" />\n      <polyline points=\"15.5 10.75 14.25 12 15.5 13.25\" />\n    </g>\n    <circle cx=\"12\" cy=\"12\" r=\"1.35\" fill=\"currentColor\" />\n  </svg>\n".trim();
-var ASPECT_RATIO_ICON_SVG = "\n  <svg viewBox=\"0 0 24 24\" xmlns=\"http://www.w3.org/2000/svg\" aria-hidden=\"true\">\n    <g\n      fill=\"none\"\n      stroke=\"currentColor\"\n      stroke-width=\"1.5\"\n      stroke-linecap=\"round\"\n      stroke-linejoin=\"round\"\n    >\n      <rect x=\"3.5\" y=\"6\" width=\"17\" height=\"12\" rx=\"2\" ry=\"2\" />\n      <line x1=\"8\" y1=\"12\" x2=\"16\" y2=\"12\" />\n      <polyline points=\"9 10.75 8 12 9 13.25\" />\n      <polyline points=\"15 10.75 16 12 15 13.25\" />\n      <line x1=\"12\" y1=\"9\" x2=\"12\" y2=\"15\" />\n      <polyline points=\"10.75 10 12 9 13.25 10\" />\n      <polyline points=\"10.75 14 12 15 13.25 14\" />\n    </g>\n  </svg>\n".trim();
-var REQUIRED_SCENARIOS_ICON_SVG = "\n  <svg viewBox=\"0 0 24 24\" xmlns=\"http://www.w3.org/2000/svg\" aria-hidden=\"true\">\n    <g\n      fill=\"none\"\n      stroke=\"currentColor\"\n      stroke-width=\"1.5\"\n      stroke-linecap=\"round\"\n      stroke-linejoin=\"round\"\n    >\n      <path d=\"M8.5 4.5V3.25A1.25 1.25 0 0 1 9.75 2h4.5a1.25 1.25 0 0 1 1.25 1.25V4.5\" />\n      <rect x=\"5.25\" y=\"4.5\" width=\"13.5\" height=\"15.5\" rx=\"2\" ry=\"2\" />\n      <rect x=\"8.25\" y=\"8.75\" width=\"3\" height=\"3\" rx=\"0.5\" ry=\"0.5\" />\n      <rect x=\"8.25\" y=\"13.75\" width=\"3\" height=\"3\" rx=\"0.5\" ry=\"0.5\" />\n      <polyline points=\"9 10.25 9.85 11.05 11 9.75\" />\n      <polyline points=\"9 15.25 9.85 16.05 11 14.75\" />\n      <line x1=\"12.75\" y1=\"10.25\" x2=\"16.5\" y2=\"10.25\" />\n      <line x1=\"12.75\" y1=\"15.25\" x2=\"16.5\" y2=\"15.25\" />\n    </g>\n  </svg>\n".trim();
-var MONITORING_SUPPORT_ICON_SVG = "\n  <svg viewBox=\"0 0 24 24\" xmlns=\"http://www.w3.org/2000/svg\" aria-hidden=\"true\">\n    <g\n      fill=\"none\"\n      stroke=\"currentColor\"\n      stroke-width=\"1.5\"\n      stroke-linecap=\"round\"\n      stroke-linejoin=\"round\"\n    >\n      <rect x=\"4.25\" y=\"5.5\" width=\"15.5\" height=\"9.5\" rx=\"1.75\" ry=\"1.75\" />\n      <path d=\"M9 15.25 7.1 19.5\" />\n      <path d=\"M15 15.25 16.9 19.5\" />\n      <line x1=\"9.75\" y1=\"19.5\" x2=\"14.25\" y2=\"19.5\" />\n      <line x1=\"12\" y1=\"15\" x2=\"12\" y2=\"19.5\" />\n    </g>\n  </svg>\n".trim();
 var PRODUCTION_COMPANY_ICON = iconGlyph('\uE2D5', ICON_FONT_KEYS.UICONS);
 var RENTAL_HOUSE_ICON = iconGlyph('\uEA09', ICON_FONT_KEYS.UICONS);
-var ASPECT_RATIO_ICON = Object.freeze({
-  markup: ASPECT_RATIO_ICON_SVG,
-  className: 'icon-svg'
-});
-var REQUIRED_SCENARIOS_ICON = Object.freeze({
-  markup: REQUIRED_SCENARIOS_ICON_SVG,
-  className: 'icon-svg'
-});
-var MONITORING_SUPPORT_ICON = Object.freeze({
-  markup: MONITORING_SUPPORT_ICON_SVG,
-  className: 'icon-svg'
-});
+var ASPECT_RATIO_ICON = iconGlyph('\uE71D', ICON_FONT_KEYS.UICONS);
+var REQUIRED_SCENARIOS_ICON = iconGlyph('\uF4D4', ICON_FONT_KEYS.UICONS);
+var MONITORING_SUPPORT_ICON = iconGlyph('\uEF0F', ICON_FONT_KEYS.UICONS);
 var STAR_ICON_SVG = "\n  <svg viewBox=\"0 0 24 24\" xmlns=\"http://www.w3.org/2000/svg\">\n    <path d=\"M12 17.25 6.545 20.2 7.9 13.975 3 9.45l6.272-.7L12 3l2.728 5.75L21 9.45l-4.9 4.525 1.355 6.225Z\" />\n  </svg>\n".trim();
 var ICON_GLYPHS = Object.freeze({
   batteryBolt: iconGlyph("\uE1A6", ICON_FONT_KEYS.UICONS),
@@ -4445,25 +4433,25 @@ var PINK_MODE_ICON_ANIMATION_RESET_DELAY = 450;
 var projectFieldIcons = {
   productionCompany: PRODUCTION_COMPANY_ICON,
   rentalHouse: RENTAL_HOUSE_ICON,
-  crew: iconGlyph("\uF102", ICON_FONT_KEYS.FILM),
-  prepDays: iconGlyph("\uF126", ICON_FONT_KEYS.ESSENTIAL),
-  shootingDays: iconGlyph("\uF10C", ICON_FONT_KEYS.FILM),
-  deliveryResolution: ICON_GLYPHS.screen,
+  crew: iconGlyph("\uE638", ICON_FONT_KEYS.UICONS),
+  prepDays: iconGlyph("\uE312", ICON_FONT_KEYS.UICONS),
+  shootingDays: iconGlyph("\uE311", ICON_FONT_KEYS.UICONS),
+  deliveryResolution: iconGlyph("\uE5BA", ICON_FONT_KEYS.UICONS),
   recordingResolution: ICON_GLYPHS.camera,
   aspectRatio: ASPECT_RATIO_ICON,
-  codec: iconGlyph("\uF107", ICON_FONT_KEYS.GADGET),
-  baseFrameRate: ICON_GLYPHS.timecode,
-  sensorMode: iconGlyph("\uF110", ICON_FONT_KEYS.GADGET),
+  codec: iconGlyph("\uE7C9", ICON_FONT_KEYS.UICONS),
+  baseFrameRate: iconGlyph("\uE46F", ICON_FONT_KEYS.UICONS),
+  sensorMode: iconGlyph("\uF034", ICON_FONT_KEYS.UICONS),
   requiredScenarios: REQUIRED_SCENARIOS_ICON,
-  lenses: iconGlyph("\uF117", ICON_FONT_KEYS.FILM),
-  cameraHandle: ICON_GLYPHS.gears,
-  viewfinderExtension: iconGlyph("\uF12E", ICON_FONT_KEYS.FILM),
+  lenses: iconGlyph("\uE0A3", ICON_FONT_KEYS.UICONS),
+  cameraHandle: iconGlyph("\uF2DC", ICON_FONT_KEYS.UICONS),
+  viewfinderExtension: iconGlyph("\uE338", ICON_FONT_KEYS.UICONS),
   gimbal: iconGlyph("\uEA9C", ICON_FONT_KEYS.UICONS),
   monitoringSupport: MONITORING_SUPPORT_ICON,
-  monitoringConfiguration: ICON_GLYPHS.sliders,
-  monitorUserButtons: ICON_GLYPHS.sliders,
-  cameraUserButtons: ICON_GLYPHS.sliders,
-  viewfinderUserButtons: ICON_GLYPHS.sliders
+  monitoringConfiguration: iconGlyph("\uF0D0", ICON_FONT_KEYS.UICONS),
+  monitorUserButtons: iconGlyph("\uF0D1", ICON_FONT_KEYS.UICONS),
+  cameraUserButtons: iconGlyph("\uF0D1", ICON_FONT_KEYS.UICONS),
+  viewfinderUserButtons: iconGlyph("\uF0D2", ICON_FONT_KEYS.UICONS)
 };
 function setButtonLabelWithIcon(button, label) {
   var glyph = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : ICON_GLYPHS.save;

--- a/src/scripts/script.js
+++ b/src/scripts/script.js
@@ -4095,70 +4095,11 @@ const RESET_VIEW_ICON_SVG = `
   </svg>
 `.trim();
 
-const ASPECT_RATIO_ICON_SVG = `
-  <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-    <g
-      fill="none"
-      stroke="currentColor"
-      stroke-width="1.5"
-      stroke-linecap="round"
-      stroke-linejoin="round"
-    >
-      <rect x="3.5" y="6" width="17" height="12" rx="2" ry="2" />
-      <line x1="8" y1="12" x2="16" y2="12" />
-      <polyline points="9 10.75 8 12 9 13.25" />
-      <polyline points="15 10.75 16 12 15 13.25" />
-      <line x1="12" y1="9" x2="12" y2="15" />
-      <polyline points="10.75 10 12 9 13.25 10" />
-      <polyline points="10.75 14 12 15 13.25 14" />
-    </g>
-  </svg>
-`.trim();
-
-const REQUIRED_SCENARIOS_ICON_SVG = `
-  <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-    <g
-      fill="none"
-      stroke="currentColor"
-      stroke-width="1.5"
-      stroke-linecap="round"
-      stroke-linejoin="round"
-    >
-      <path d="M8.5 4.5V3.25A1.25 1.25 0 0 1 9.75 2h4.5a1.25 1.25 0 0 1 1.25 1.25V4.5" />
-      <rect x="5.25" y="4.5" width="13.5" height="15.5" rx="2" ry="2" />
-      <rect x="8.25" y="8.75" width="3" height="3" rx="0.5" ry="0.5" />
-      <rect x="8.25" y="13.75" width="3" height="3" rx="0.5" ry="0.5" />
-      <polyline points="9 10.25 9.85 11.05 11 9.75" />
-      <polyline points="9 15.25 9.85 16.05 11 14.75" />
-      <line x1="12.75" y1="10.25" x2="16.5" y2="10.25" />
-      <line x1="12.75" y1="15.25" x2="16.5" y2="15.25" />
-    </g>
-  </svg>
-`.trim();
-
-const MONITORING_SUPPORT_ICON_SVG = `
-  <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-    <g
-      fill="none"
-      stroke="currentColor"
-      stroke-width="1.5"
-      stroke-linecap="round"
-      stroke-linejoin="round"
-    >
-      <rect x="4.25" y="5.5" width="15.5" height="9.5" rx="1.75" ry="1.75" />
-      <path d="M9 15.25 7.1 19.5" />
-      <path d="M15 15.25 16.9 19.5" />
-      <line x1="9.75" y1="19.5" x2="14.25" y2="19.5" />
-      <line x1="12" y1="15" x2="12" y2="19.5" />
-    </g>
-  </svg>
-`.trim();
-
 const PRODUCTION_COMPANY_ICON = iconGlyph('\uE2D5', ICON_FONT_KEYS.UICONS);
 const RENTAL_HOUSE_ICON = iconGlyph('\uEA09', ICON_FONT_KEYS.UICONS);
-const ASPECT_RATIO_ICON = Object.freeze({ markup: ASPECT_RATIO_ICON_SVG, className: 'icon-svg' });
-const REQUIRED_SCENARIOS_ICON = Object.freeze({ markup: REQUIRED_SCENARIOS_ICON_SVG, className: 'icon-svg' });
-const MONITORING_SUPPORT_ICON = Object.freeze({ markup: MONITORING_SUPPORT_ICON_SVG, className: 'icon-svg' });
+const ASPECT_RATIO_ICON = iconGlyph('\uE71D', ICON_FONT_KEYS.UICONS);
+const REQUIRED_SCENARIOS_ICON = iconGlyph('\uF4D4', ICON_FONT_KEYS.UICONS);
+const MONITORING_SUPPORT_ICON = iconGlyph('\uEF0F', ICON_FONT_KEYS.UICONS);
 
 const STAR_ICON_SVG = `
   <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
@@ -4945,25 +4886,25 @@ const PINK_MODE_ICON_ANIMATION_RESET_DELAY = 450;
 const projectFieldIcons = {
   productionCompany: PRODUCTION_COMPANY_ICON,
   rentalHouse: RENTAL_HOUSE_ICON,
-  crew: iconGlyph('\uF102', ICON_FONT_KEYS.FILM),
-  prepDays: iconGlyph('\uF126', ICON_FONT_KEYS.ESSENTIAL),
-  shootingDays: iconGlyph('\uF10C', ICON_FONT_KEYS.FILM),
-  deliveryResolution: ICON_GLYPHS.screen,
+  crew: iconGlyph('\uE638', ICON_FONT_KEYS.UICONS),
+  prepDays: iconGlyph('\uE312', ICON_FONT_KEYS.UICONS),
+  shootingDays: iconGlyph('\uE311', ICON_FONT_KEYS.UICONS),
+  deliveryResolution: iconGlyph('\uE5BA', ICON_FONT_KEYS.UICONS),
   recordingResolution: ICON_GLYPHS.camera,
   aspectRatio: ASPECT_RATIO_ICON,
-  codec: iconGlyph('\uF107', ICON_FONT_KEYS.GADGET),
-  baseFrameRate: ICON_GLYPHS.timecode,
-  sensorMode: iconGlyph('\uF110', ICON_FONT_KEYS.GADGET),
+  codec: iconGlyph('\uE7C9', ICON_FONT_KEYS.UICONS),
+  baseFrameRate: iconGlyph('\uE46F', ICON_FONT_KEYS.UICONS),
+  sensorMode: iconGlyph('\uF034', ICON_FONT_KEYS.UICONS),
   requiredScenarios: REQUIRED_SCENARIOS_ICON,
-  lenses: iconGlyph('\uF117', ICON_FONT_KEYS.FILM),
-  cameraHandle: ICON_GLYPHS.gears,
-  viewfinderExtension: iconGlyph('\uF12E', ICON_FONT_KEYS.FILM),
+  lenses: iconGlyph('\uE0A3', ICON_FONT_KEYS.UICONS),
+  cameraHandle: iconGlyph('\uF2DC', ICON_FONT_KEYS.UICONS),
+  viewfinderExtension: iconGlyph('\uE338', ICON_FONT_KEYS.UICONS),
   gimbal: iconGlyph('\uEA9C', ICON_FONT_KEYS.UICONS),
   monitoringSupport: MONITORING_SUPPORT_ICON,
-  monitoringConfiguration: ICON_GLYPHS.sliders,
-  monitorUserButtons: ICON_GLYPHS.sliders,
-  cameraUserButtons: ICON_GLYPHS.sliders,
-  viewfinderUserButtons: ICON_GLYPHS.sliders
+  monitoringConfiguration: iconGlyph('\uF0D0', ICON_FONT_KEYS.UICONS),
+  monitorUserButtons: iconGlyph('\uF0D1', ICON_FONT_KEYS.UICONS),
+  cameraUserButtons: iconGlyph('\uF0D1', ICON_FONT_KEYS.UICONS),
+  viewfinderUserButtons: iconGlyph('\uF0D2', ICON_FONT_KEYS.UICONS)
 };
 
 function setButtonLabelWithIcon(button, label, glyph = ICON_GLYPHS.save) {


### PR DESCRIPTION
## Summary
- replace the project requirements icons with Uicons glyphs in the main script so the overview uses the bundled font
- mirror the Uicons-only mapping in the legacy script to keep both builds aligned

## Testing
- npm run test:script

------
https://chatgpt.com/codex/tasks/task_e_68cee9830e3483208130c7ee8ac4d76c