### PR TITLE
Update cache version

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -1,5 +1,5 @@
 /* eslint-env serviceworker */
-const CACHE_NAME = 'cine-power-planner-v27';
+const CACHE_NAME = 'cine-power-planner-v28';
 const ASSETS = [
   './',
   './index.html',


### PR DESCRIPTION
## Summary
- bump the service worker cache name to v28 to force clients to refresh cached assets

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68ceebd96dfc83209b2f29dda96ee44d