### PR TITLE
Ensure factory reset clears UI state

### DIFF
--- a/src/scripts/script.js
+++ b/src/scripts/script.js
@@ -20763,6 +20763,183 @@ if (restoreSettings && restoreSettingsInput) {
   });
 }
 
+function resetPlannerStateAfterFactoryReset() {
+  try {
+    if (typeof storeLoadedSetupState === 'function') {
+      storeLoadedSetupState(null);
+    }
+  } catch (error) {
+    console.warn('Failed to reset loaded setup state during factory reset', error);
+  }
+
+  try {
+    currentProjectInfo = null;
+  } catch (error) {
+    console.warn('Failed to clear in-memory project info during factory reset', error);
+  }
+
+  try {
+    if (typeof populateProjectForm === 'function') {
+      populateProjectForm({});
+    } else if (projectForm && typeof projectForm.reset === 'function') {
+      projectForm.reset();
+    }
+  } catch (error) {
+    console.warn('Failed to reset project form during factory reset', error);
+  }
+
+  try {
+    displayGearAndRequirements('');
+  } catch (error) {
+    console.warn('Failed to reset gear displays during factory reset', error);
+    if (gearListOutput) {
+      gearListOutput.innerHTML = '';
+      gearListOutput.classList.add('hidden');
+    }
+    if (projectRequirementsOutput) {
+      projectRequirementsOutput.innerHTML = '';
+      projectRequirementsOutput.classList.add('hidden');
+    }
+  }
+
+  const primarySelects = [
+    cameraSelect,
+    monitorSelect,
+    videoSelect,
+    cageSelect,
+    distanceSelect,
+    batterySelect,
+    hotswapSelect,
+    batteryPlateSelect,
+  ];
+  primarySelects.forEach(select => {
+    if (!select) return;
+    try {
+      const options = Array.from(select.options || []);
+      const noneOption = options.find(opt => opt.value === 'None');
+      if (noneOption) {
+        select.value = 'None';
+      } else if (options.length) {
+        select.selectedIndex = 0;
+      } else {
+        select.value = '';
+      }
+    } catch (selectError) {
+      console.warn('Failed to reset selector during factory reset', selectError);
+    }
+  });
+
+  try {
+    resetSelectsToNone(motorSelects);
+  } catch (error) {
+    console.warn('Failed to reset motor selections during factory reset', error);
+  }
+
+  try {
+    resetSelectsToNone(controllerSelects);
+  } catch (error) {
+    console.warn('Failed to reset controller selections during factory reset', error);
+  }
+
+  try {
+    const sliderSelect = getSliderBowlSelect();
+    if (sliderSelect) sliderSelect.value = '';
+  } catch (error) {
+    console.warn('Failed to reset slider bowl selection during factory reset', error);
+  }
+
+  try {
+    const easyrigSelect = getEasyrigSelect();
+    if (easyrigSelect) easyrigSelect.value = '';
+  } catch (error) {
+    console.warn('Failed to reset Easyrig selection during factory reset', error);
+  }
+
+  try {
+    if (setupNameInput) {
+      setupNameInput.value = '';
+    }
+  } catch (error) {
+    console.warn('Failed to clear setup name during factory reset', error);
+  }
+
+  try {
+    if (setupSelect) {
+      populateSetupSelect();
+      setupSelect.value = '';
+    }
+  } catch (error) {
+    console.warn('Failed to reset setup selector options during factory reset', error);
+  }
+
+  try {
+    syncAutoGearRulesFromStorage();
+  } catch (error) {
+    console.warn('Failed to sync automatic gear rules during factory reset', error);
+    try {
+      clearProjectAutoGearRules();
+    } catch (fallbackError) {
+      console.warn('Failed to clear project automatic gear rules during factory reset', fallbackError);
+    }
+  }
+
+  try {
+    renderAutoGearRulesList();
+  } catch (error) {
+    console.warn('Failed to render automatic gear rules during factory reset', error);
+  }
+
+  try {
+    updateAutoGearCatalogOptions();
+  } catch (error) {
+    console.warn('Failed to refresh automatic gear catalog during factory reset', error);
+  }
+
+  try {
+    updateBatteryPlateVisibility();
+  } catch (error) {
+    console.warn('Failed to reset battery plate visibility during factory reset', error);
+  }
+
+  try {
+    updateBatteryOptions();
+  } catch (error) {
+    console.warn('Failed to reset battery options during factory reset', error);
+  }
+
+  try {
+    if (typeof loadStoredLogoPreview === 'function') {
+      loadStoredLogoPreview();
+    }
+  } catch (error) {
+    console.warn('Failed to reset custom logo preview during factory reset', error);
+  }
+
+  try {
+    updateStorageSummary();
+  } catch (error) {
+    console.warn('Failed to update storage summary during factory reset', error);
+  }
+
+  try {
+    ensureGearListActions();
+  } catch (error) {
+    console.warn('Failed to ensure gear list actions during factory reset', error);
+  }
+
+  try {
+    checkSetupChanged();
+  } catch (error) {
+    console.warn('Failed to refresh setup state during factory reset', error);
+  }
+
+  try {
+    updateCalculations();
+  } catch (error) {
+    console.warn('Failed to update calculations during factory reset', error);
+  }
+}
+
 if (factoryResetButton) {
   factoryResetButton.addEventListener('click', () => {
     const langTexts = texts[currentLang] || texts.en || {};
@@ -20821,6 +20998,11 @@ if (factoryResetButton) {
         console.warn('Failed to stop pink mode animations during factory reset', animationError);
       }
       clearAllData();
+      try {
+        resetPlannerStateAfterFactoryReset();
+      } catch (resetError) {
+        console.warn('Failed to reset planner state after factory reset', resetError);
+      }
       try {
         darkModeEnabled = false;
         applyDarkMode(false);
@@ -23140,5 +23322,6 @@ if (typeof module !== "undefined" && module.exports) {
     confirmAutoGearSelection,
     configureSharedImportOptions,
     resolveSharedImportMode,
+    resetPlannerStateAfterFactoryReset,
   };
 }

--- a/tests/script/factoryReset.test.js
+++ b/tests/script/factoryReset.test.js
@@ -1,0 +1,106 @@
+const { loadApp } = require('./helpers/loadApp');
+
+describe('factory reset cleanup', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    localStorage.clear();
+    sessionStorage.clear();
+    jest.clearAllMocks();
+  });
+
+  test('resetPlannerStateAfterFactoryReset clears in-memory state and UI', () => {
+    const app = loadApp();
+    const {
+      resetPlannerStateAfterFactoryReset,
+      setCurrentProjectInfo,
+      getCurrentProjectInfo,
+      getAutoGearRules,
+      syncAutoGearRulesFromStorage,
+    } = app;
+
+    const setupSelect = document.getElementById('setupSelect');
+    const setupNameInput = document.getElementById('setupName');
+    const cameraSelect = document.getElementById('cameraSelect');
+    const gearListOutput = document.getElementById('gearListOutput');
+    const projectRequirementsOutput = document.getElementById('projectRequirementsOutput');
+    const projectNameInput = document.getElementById('projectName');
+
+    const customRules = [
+      {
+        id: 'rule-reset',
+        label: 'Custom Reset Rule',
+        scenarios: ['Handheld'],
+        add: [
+          { id: 'item-test', name: 'Focus Monitor Shade', category: 'Accessories', quantity: 1 },
+        ],
+        remove: [],
+      },
+    ];
+    syncAutoGearRulesFromStorage(customRules);
+    expect(getAutoGearRules().some((rule) => rule.label === 'Custom Reset Rule')).toBe(true);
+
+    setCurrentProjectInfo({ projectName: 'Active project' });
+    projectNameInput.value = 'Active project';
+
+    setupNameInput.value = 'Main setup';
+    const customOption = new Option('Main setup', 'Main setup');
+    setupSelect.appendChild(customOption);
+    setupSelect.value = 'Main setup';
+
+    const firstCamera = Array.from(cameraSelect.options).find(
+      (opt) => opt.value && opt.value !== 'None',
+    );
+    if (firstCamera) {
+      cameraSelect.value = firstCamera.value;
+    }
+
+    gearListOutput.innerHTML = '<div>Gear persists</div>';
+    gearListOutput.classList.remove('hidden');
+    projectRequirementsOutput.innerHTML = '<div>Requirements persist</div>';
+    projectRequirementsOutput.classList.remove('hidden');
+
+    localStorage.clear();
+    sessionStorage.clear();
+
+    resetPlannerStateAfterFactoryReset();
+
+    expect(getCurrentProjectInfo()).toBeNull();
+    expect(projectNameInput.value).toBe('');
+    expect(setupNameInput.value).toBe('');
+    expect(setupSelect.value).toBe('');
+    expect(Array.from(setupSelect.options).some((opt) => opt.value === 'Main setup')).toBe(false);
+
+    const hasNoneCamera = Array.from(cameraSelect.options).some((opt) => opt.value === 'None');
+    if (hasNoneCamera) {
+      expect(cameraSelect.value).toBe('None');
+    } else {
+      expect(cameraSelect.selectedIndex).toBe(0);
+    }
+
+    expect(gearListOutput.classList.contains('hidden')).toBe(true);
+    expect(gearListOutput.querySelector('.gear-table')).toBeNull();
+    expect(projectRequirementsOutput.classList.contains('hidden')).toBe(true);
+    expect(projectRequirementsOutput.querySelector('.requirement-box')).toBeNull();
+
+    const motorSelects = [
+      document.getElementById('motor1Select'),
+      document.getElementById('motor2Select'),
+      document.getElementById('motor3Select'),
+      document.getElementById('motor4Select'),
+    ];
+    motorSelects.forEach((select) => {
+      if (!select) return;
+      const noneOption = Array.from(select.options).find((opt) => opt.value === 'None');
+      if (noneOption) {
+        expect(select.value).toBe('None');
+      } else if (select.options.length) {
+        expect(select.selectedIndex).toBe(0);
+      } else {
+        expect(select.value).toBe('');
+      }
+    });
+
+    const rulesAfterReset = getAutoGearRules();
+    expect(rulesAfterReset.some((rule) => rule.label === 'Custom Reset Rule')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add a resetPlannerStateAfterFactoryReset helper that clears in-memory planner state, resets selectors, hides rendered outputs and refreshes derived UI when wiping the app
- call the helper during the factory reset workflow so projects, custom gear lists, previews and automatic gear data are removed alongside storage
- add a regression test covering the UI, automatic gear rule and project state cleanup performed after a factory reset

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cee7c259288320bdd0449af35fc562