### PR TITLE
Align app and cache versions

### DIFF
--- a/index.html
+++ b/index.html
@@ -916,7 +916,7 @@
       </section>
       <section class="settings-section" aria-labelledby="aboutHeading">
         <h3 id="aboutHeading">About &amp; Support</h3>
-        <p id="aboutVersion">Version 1.0.2</p>
+        <p id="aboutVersion">Version 1.0.3</p>
         <p><a href="https://github.com" id="supportLink" target="_blank">Support</a></p>
       </section>
       <div class="button-row action-buttons">

--- a/legacy/scripts/script.js
+++ b/legacy/scripts/script.js
@@ -60,7 +60,7 @@ if (typeof window !== 'undefined') {
     }
   }
 }
-var APP_VERSION = "1.0.2";
+var APP_VERSION = "1.0.3";
 var IOS_PWA_HELP_STORAGE_KEY = 'iosPwaHelpShown';
 var DEVICE_SCHEMA_PATH = 'src/data/schema.json';
 var DEVICE_SCHEMA_STORAGE_KEY = 'cameraPowerPlanner_schemaCache';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cine-power-planner",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cine-power-planner",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "license": "ISC",
       "dependencies": {
         "lottie-web": "^5.13.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cine-power-planner",
-  "version": "1.0.2",
-  "description": "Browser-based tool for planning professional camera setups powered by V-Mount or B-Mount batteries. It calculates total power consumption, current draw at 14.4\u202fV and 12\u202fV, and estimated battery runtime while checking that the battery can safely deliver the required power.",
+  "version": "1.0.3",
+  "description": "Browser-based tool for planning professional camera setups powered by V-Mount or B-Mount batteries. It calculates total power consumption, current draw at 14.4 V and 12 V, and estimated battery runtime while checking that the battery can safely deliver the required power.",
   "main": "src/data/index.js",
   "scripts": {
     "lint": "eslint .",

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,5 +1,5 @@
 /* eslint-env serviceworker */
-const CACHE_NAME = 'cine-power-planner-v28';
+const CACHE_NAME = 'cine-power-planner-v1.0.3';
 const ASSETS = [
   './',
   './index.html',

--- a/src/scripts/script.js
+++ b/src/scripts/script.js
@@ -40,7 +40,7 @@ if (typeof window !== 'undefined') {
   }
 }
 
-const APP_VERSION = "1.0.2";
+const APP_VERSION = "1.0.3";
 const IOS_PWA_HELP_STORAGE_KEY = 'iosPwaHelpShown';
 
 const DEVICE_SCHEMA_PATH = 'src/data/schema.json';

--- a/tests/unit/versionConsistency.test.js
+++ b/tests/unit/versionConsistency.test.js
@@ -1,0 +1,48 @@
+const fs = require('fs');
+const path = require('path');
+
+const rootDir = path.join(__dirname, '..', '..');
+
+const read = relativePath => fs.readFileSync(path.join(rootDir, relativePath), 'utf8');
+
+function extractVersion(regex, contents, source) {
+  const match = contents.match(regex);
+  if (!match) {
+    throw new Error(`Unable to find version in ${source}`);
+  }
+  return match[1];
+}
+
+describe('application version consistency', () => {
+  test('package version matches user-facing and cache versions', () => {
+    const { version } = require(path.join(rootDir, 'package.json'));
+
+    const appScriptVersion = extractVersion(
+      /const APP_VERSION = "([^"]+)";/,
+      read('src/scripts/script.js'),
+      'src/scripts/script.js',
+    );
+    expect(appScriptVersion).toBe(version);
+
+    const legacyScriptVersion = extractVersion(
+      /var APP_VERSION = "([^"]+)";/,
+      read('legacy/scripts/script.js'),
+      'legacy/scripts/script.js',
+    );
+    expect(legacyScriptVersion).toBe(version);
+
+    const htmlVersion = extractVersion(
+      /<p id="aboutVersion">Version ([^<]+)<\/p>/,
+      read('index.html'),
+      'index.html',
+    );
+    expect(htmlVersion).toBe(version);
+
+    const cacheVersion = extractVersion(
+      /const CACHE_NAME = ['"]cine-power-planner-v([^'"]+)['"];?/,
+      read('service-worker.js'),
+      'service-worker.js',
+    );
+    expect(cacheVersion).toBe(version);
+  });
+});


### PR DESCRIPTION
## Summary
- bump the application version to 1.0.3 and sync the user-facing label
- update the service worker cache name to track the same version number
- add a consistency test that fails if package, UI, and cache versions diverge

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ceec69ccf08320af7facf04dfa7537