### PR TITLE
Fix app icon cache refresh handling

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -123,7 +123,9 @@ if (typeof self !== 'undefined') {
 
     const isNavigationRequest = event.request.mode === 'navigate';
 
-    const isAppIconRequest = event.request.destination === 'image' && event.request.url.includes('/src/icons/');
+    const requestUrl = new URL(event.request.url);
+    const isSameOrigin = requestUrl.origin === self.location.origin;
+    const isAppIconRequest = isSameOrigin && requestUrl.pathname.includes('/src/icons/');
     if (isAppIconRequest) {
       event.respondWith((async () => {
         const cache = await caches.open(CACHE_NAME);

--- a/src/scripts/storage.js
+++ b/src/scripts/storage.js
@@ -569,7 +569,7 @@ if (GLOBAL_SCOPE && typeof GLOBAL_SCOPE === 'object') {
       configurable: true,
       get: getSafeLocalStorage,
     });
-  } catch (defineError) {
+  } catch {
     GLOBAL_SCOPE.SAFE_LOCAL_STORAGE = getSafeLocalStorage();
   }
 }


### PR DESCRIPTION
## Summary
- ensure the service worker refreshes cached app icons by checking the request URL instead of only the request destination
- silence an unused catch parameter warning while keeping the fallback assignment for SAFE_LOCAL_STORAGE

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cef0bab4e8832099e5d4f76fd3823a