### PR TITLE
Fix favorite star icons to use currentColor fill

### DIFF
--- a/legacy/scripts/script.js
+++ b/legacy/scripts/script.js
@@ -3757,7 +3757,7 @@ var RENTAL_HOUSE_ICON = iconGlyph('\uEA09', ICON_FONT_KEYS.UICONS);
 var ASPECT_RATIO_ICON = iconGlyph('\uE71D', ICON_FONT_KEYS.UICONS);
 var REQUIRED_SCENARIOS_ICON = iconGlyph('\uF4D4', ICON_FONT_KEYS.UICONS);
 var MONITORING_SUPPORT_ICON = iconGlyph('\uEF0F', ICON_FONT_KEYS.UICONS);
-var STAR_ICON_SVG = "\n  <svg viewBox=\"0 0 24 24\" xmlns=\"http://www.w3.org/2000/svg\">\n    <path d=\"M12 17.25 6.545 20.2 7.9 13.975 3 9.45l6.272-.7L12 3l2.728 5.75L21 9.45l-4.9 4.525 1.355 6.225Z\" />\n  </svg>\n".trim();
+var STAR_ICON_SVG = "\n  <svg viewBox=\"0 0 24 24\" xmlns=\"http://www.w3.org/2000/svg\">\n    <path d=\"M12 17.25 6.545 20.2 7.9 13.975 3 9.45l6.272-.7L12 3l2.728 5.75L21 9.45l-4.9 4.525 1.355 6.225Z\" fill=\"currentColor\" stroke=\"currentColor\" stroke-width=\"0\" />\n  </svg>\n".trim();
 var ICON_GLYPHS = Object.freeze({
   batteryBolt: iconGlyph("\uE1A6", ICON_FONT_KEYS.UICONS),
   batteryFull: iconGlyph("\uE1A9", ICON_FONT_KEYS.UICONS),

--- a/src/scripts/script.js
+++ b/src/scripts/script.js
@@ -4133,7 +4133,12 @@ const MONITORING_SUPPORT_ICON = iconGlyph('\uEF0F', ICON_FONT_KEYS.UICONS);
 
 const STAR_ICON_SVG = `
   <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-    <path d="M12 17.25 6.545 20.2 7.9 13.975 3 9.45l6.272-.7L12 3l2.728 5.75L21 9.45l-4.9 4.525 1.355 6.225Z" />
+    <path
+      d="M12 17.25 6.545 20.2 7.9 13.975 3 9.45l6.272-.7L12 3l2.728 5.75L21 9.45l-4.9 4.525 1.355 6.225Z"
+      fill="currentColor"
+      stroke="currentColor"
+      stroke-width="0"
+    />
   </svg>
 `.trim();
 


### PR DESCRIPTION
## Summary
- ensure the favorite star SVG explicitly fills with currentColor so the toggle icons stay consistent across themes
- update the legacy bundle to use the same star markup for offline builds

## Testing
- npm run test:script

------
https://chatgpt.com/codex/tasks/task_e_68cef12db7188320be5fb2933621b2d6