### PR TITLE
Hide gear list in overview when not generated

### DIFF
--- a/src/scripts/overview.js
+++ b/src/scripts/overview.js
@@ -261,6 +261,26 @@ function generatePrintableOverview() {
         : '';
     const batteryTableHtmlWithBreak = batteryTableHtml ? `<div class="page-break"></div>${batteryTableHtml}` : '';
 
+    // Only surface the gear list in the overview when the generator has
+    // produced visible output in the main interface.
+    const hasGeneratedGearList = (() => {
+        if (typeof document === 'undefined') return false;
+        const container = document.getElementById('gearListOutput');
+        if (!container) return false;
+        if (container.classList && container.classList.contains('hidden')) {
+            return false;
+        }
+        const trimmed = typeof container.innerHTML === 'string'
+            ? container.innerHTML.trim()
+            : '';
+        if (!trimmed) return false;
+        if (typeof container.querySelector === 'function') {
+            const table = container.querySelector('.gear-table');
+            if (table) return true;
+        }
+        return true;
+    })();
+
     let gearListCombined = getCurrentGearListHtml();
     if (!gearListCombined && currentProjectInfo) {
         gearListCombined = generateGearListHtml(currentProjectInfo);
@@ -274,7 +294,7 @@ function generatePrintableOverview() {
         if (parts.projectHtml) {
             projectSectionHtml = `<section id="projectRequirementsOutput" class="print-section project-requirements-section">${parts.projectHtml}</section>`;
         }
-        if (parts.gearHtml) {
+        if (parts.gearHtml && hasGeneratedGearList) {
             gearSectionHtml = `<section id="gearListOutput" class="gear-list-section">${parts.gearHtml}</section>`;
         }
     }


### PR DESCRIPTION
## Summary
- add detection to the printable overview to check if the gear list has actually been generated in the UI
- skip rendering the overview gear list section when no generated gear list is available while still keeping project requirements output

## Testing
- npm run test:script

------
https://chatgpt.com/codex/tasks/task_e_68cef16ce8f483208c707a88194fec2e