### PR TITLE
Align overview dialog with active theme

### DIFF
--- a/src/scripts/overview.js
+++ b/src/scripts/overview.js
@@ -311,13 +311,19 @@ function generatePrintableOverview() {
     overviewDialog.innerHTML = overviewHtml;
     const content = overviewDialog.querySelector('#overviewDialogContent');
 
-    // Match current theme for on-screen overview; print stylesheet will override
-    if (document.body.classList.contains('dark-mode')) {
-        content.classList.add('dark-mode');
-    }
-    if (document.body.classList.contains('pink-mode')) {
-        content.classList.add('pink-mode');
-    }
+    const applyThemeClasses = (target) => {
+        if (!target || typeof document === 'undefined') return;
+        const themeClasses = ['dark-mode', 'light-mode', 'pink-mode', 'dark-accent-boost', 'high-contrast'];
+        const activeClasses = new Set([
+            ...(document.documentElement ? Array.from(document.documentElement.classList) : []),
+            ...(document.body ? Array.from(document.body.classList) : []),
+        ]);
+        themeClasses.forEach(themeClass => {
+            target.classList.toggle(themeClass, activeClasses.has(themeClass));
+        });
+    };
+
+    applyThemeClasses(content);
 
     const closeBtn = overviewDialog.querySelector('#closeOverviewBtn');
     if (closeBtn) {


### PR DESCRIPTION
## Summary
- copy the active theme classes from the document root and body onto the overview dialog so it inherits dark, pink, and accent boost palettes

## Testing
- npm run test:script

------
https://chatgpt.com/codex/tasks/task_e_68cef28ad7e88320a0fec2cb6f4de02d