### PR TITLE
Restore print overview category outlines without altering UI

### DIFF
--- a/src/scripts/overview.js
+++ b/src/scripts/overview.js
@@ -30,6 +30,17 @@ function generatePrintableOverview() {
     let deviceListHtml = '<div class="device-category-container">';
     const sections = {};
     const sectionOrder = [];
+    const printOutlineVarMap = {
+        category_cameras: '--camera-color',
+        category_monitors: '--monitor-color',
+        category_video: '--video-segment-color',
+        category_fiz_motors: '--motor-color',
+        category_fiz_controllers: '--controller-color',
+        category_fiz_distance: '--distance-color',
+        category_batteries: '--power-color',
+        category_batteryHotswaps: '--power-color',
+        category_viewfinders: '--monitor-color'
+    };
     const addToSection = (key, itemHtml) => {
         if (!sections[key]) {
             sections[key] = [];
@@ -73,18 +84,20 @@ function generatePrintableOverview() {
     processSelectForOverview(batterySelect, 'category_batteries', 'batteries'); // Handle battery separately for capacity
     processSelectForOverview(hotswapSelect, 'category_batteryHotswaps', 'batteryHotswaps');
 
-      sectionOrder.forEach(key => {
-          const heading = t[key] || key;
-          const icon = overviewSectionIcons[key] || '';
-          const iconHtml = icon && typeof iconMarkup === 'function'
+    sectionOrder.forEach(key => {
+        const heading = t[key] || key;
+        const icon = overviewSectionIcons[key] || '';
+        const iconHtml = icon && typeof iconMarkup === 'function'
             ? iconMarkup(icon, 'category-icon')
             : icon
-              ? `<span class="category-icon icon-glyph" data-icon-font="uicons" aria-hidden="true">${icon}</span>`
-              : '';
-          const gridClasses = (key === 'category_fiz_motors' || key === 'category_fiz_controllers') ? 'device-block-grid two-column' : 'device-block-grid single-column';
-        deviceListHtml += `<div class="device-category"><h3>${iconHtml}${heading}</h3><div class="${gridClasses}">${sections[key].join('')}</div></div>`;
-      });
-      deviceListHtml += '</div>';
+                ? `<span class="category-icon icon-glyph" data-icon-font="uicons" aria-hidden="true">${icon}</span>`
+                : '';
+        const gridClasses = (key === 'category_fiz_motors' || key === 'category_fiz_controllers') ? 'device-block-grid two-column' : 'device-block-grid single-column';
+        const colorVar = printOutlineVarMap[key];
+        const styleAttribute = colorVar ? ` style="--print-outline-color: var(${colorVar});"` : '';
+        deviceListHtml += `<div class="device-category"${styleAttribute}><h3>${iconHtml}${heading}</h3><div class="${gridClasses}">${sections[key].join('')}</div></div>`;
+    });
+    deviceListHtml += '</div>';
 
     const breakdownHtml = breakdownListElem.innerHTML;
     const batteryLifeUnitElem = document.getElementById("batteryLifeUnit");

--- a/src/styles/overview-print.css
+++ b/src/styles/overview-print.css
@@ -57,6 +57,12 @@ body.dark-mode {
   --panel-shadow: 0 2px 6px rgba(0, 0, 0, 0.05);
   --button-size: 24px;
   --diagram-node-fill: #f0f0f0;
+  --camera-color: #4caf50;
+  --monitor-color: #2196f3;
+  --video-segment-color: #ffc107;
+  --motor-color: #9c27b0;
+  --controller-color: #ff5722;
+  --distance-color: #795548;
   --power-color: #d33;
   --video-color: #369;
   --fiz-color: #090;
@@ -78,6 +84,12 @@ body.dark-mode {
   --control-bg: #f0f0f0;
   --control-text: #333;
   --diagram-node-fill: #f0f0f0;
+  --camera-color: #4caf50;
+  --monitor-color: #2196f3;
+  --video-segment-color: #ffc107;
+  --motor-color: #9c27b0;
+  --controller-color: #ff5722;
+  --distance-color: #795548;
   --power-color: #d33;
   --video-color: #369;
   --fiz-color: #090;
@@ -356,10 +368,14 @@ body:not(.light-mode) .gear-table .category-row td {
 }
 
 
-.device-block,
-.device-category {
+.device-block {
   border: 1px solid var(--text-color);
   box-shadow: var(--panel-shadow);
+}
+
+.device-category {
+  border: 1px solid var(--print-outline-color, var(--text-color));
+  box-shadow: var(--panel-shadow), 0 0 0 1px var(--print-outline-color, transparent);
 }
 
 #overviewDialogContent .barContainer {


### PR DESCRIPTION
## Summary
- add a category-to-color map when building the printable overview so each section exposes a print-only outline variable
- update the print stylesheet to define category palette fallbacks and draw outlines from the inline custom property
- revert the overview screen styles to their prior neutral outlines to keep the existing UI unchanged

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cef2cca370832084089987ca9b8484