### PR TITLE
Preserve custom accent colors when pink mode is active

### DIFF
--- a/legacy/scripts/static-theme.js
+++ b/legacy/scripts/static-theme.js
@@ -66,8 +66,11 @@
     root.classList.toggle('light-mode', !darkModeEnabled);
     body.classList.toggle('light-mode', !darkModeEnabled);
     updateThemeColor(darkModeEnabled);
-    var accentColor = safeGet('accentColor') || DEFAULT_ACCENT;
-    if (pinkModeEnabled) {
+    var storedAccent = safeGet('accentColor');
+    var accentColor = storedAccent || DEFAULT_ACCENT;
+    var hasCustomAccent = typeof storedAccent === 'string' && storedAccent.trim().toLowerCase() !== DEFAULT_ACCENT.toLowerCase();
+    var shouldPreserveAccent = hasCustomAccent || highContrastEnabled;
+    if (pinkModeEnabled && !shouldPreserveAccent) {
       root.style.removeProperty('--accent-color');
       root.style.removeProperty('--link-color');
       body.style.removeProperty('--accent-color');

--- a/src/scripts/script.js
+++ b/src/scripts/script.js
@@ -9426,6 +9426,10 @@ const DEFAULT_ACCENT_COLOR = '#001589';
 let accentColor = DEFAULT_ACCENT_COLOR;
 let prevAccentColor = accentColor;
 const HIGH_CONTRAST_ACCENT_COLOR = '#ffffff';
+const DEFAULT_ACCENT_NORMALIZED = DEFAULT_ACCENT_COLOR.toLowerCase();
+
+const normalizeAccentValue = value =>
+  typeof value === 'string' ? value.trim().toLowerCase() : '';
 
 const DARK_MODE_ACCENT_BOOST_CLASS = 'dark-accent-boost';
 const PINK_REFERENCE_COLOR = '#ff69b4';
@@ -9502,6 +9506,14 @@ const isHighContrastActive = () =>
   typeof document !== 'undefined' &&
   (document.documentElement.classList.contains('high-contrast') ||
     (document.body && document.body.classList.contains('high-contrast')));
+
+const hasCustomAccentSelection = () => {
+  const normalized = normalizeAccentValue(accentColor);
+  return normalized && normalized !== DEFAULT_ACCENT_NORMALIZED;
+};
+
+const shouldPreserveAccentInPinkMode = () =>
+  hasCustomAccentSelection() || isHighContrastActive();
 
 const applyAccentColor = (color) => {
   const highContrast = isHighContrastActive();
@@ -10183,7 +10195,11 @@ if (settingsFontFamily) {
 
 const revertAccentColor = () => {
   if (document.body && document.body.classList.contains('pink-mode')) {
-    clearAccentColorOverrides();
+    if (shouldPreserveAccentInPinkMode()) {
+      applyAccentColor(prevAccentColor);
+    } else {
+      clearAccentColorOverrides();
+    }
     return;
   }
   applyAccentColor(prevAccentColor);
@@ -19829,7 +19845,7 @@ function applyHighContrast(enabled) {
       document.body.classList.remove("high-contrast");
     }
     document.documentElement.classList.remove("high-contrast");
-    if (document.body && document.body.classList.contains('pink-mode')) {
+    if (document.body && document.body.classList.contains('pink-mode') && !hasCustomAccentSelection()) {
       clearAccentColorOverrides();
     } else {
       applyAccentColor(accentColor);
@@ -19916,12 +19932,17 @@ function startPinkModeIconRotation() {
 }
 
 function applyPinkMode(enabled) {
+  const preserveAccent = shouldPreserveAccentInPinkMode();
   if (enabled) {
     document.body.classList.add("pink-mode");
     if (accentColorInput) {
       accentColorInput.disabled = true;
     }
-    clearAccentColorOverrides();
+    if (preserveAccent) {
+      applyAccentColor(accentColor);
+    } else {
+      clearAccentColorOverrides();
+    }
     if (pinkModeToggle) {
       pinkModeToggle.setAttribute("aria-pressed", "true");
     }

--- a/src/scripts/static-theme.js
+++ b/src/scripts/static-theme.js
@@ -80,8 +80,13 @@
     body.classList.toggle('light-mode', !darkModeEnabled);
     updateThemeColor(darkModeEnabled);
 
-    var accentColor = safeGet('accentColor') || DEFAULT_ACCENT;
-    if (pinkModeEnabled) {
+    var storedAccent = safeGet('accentColor');
+    var accentColor = storedAccent || DEFAULT_ACCENT;
+    var hasCustomAccent =
+      typeof storedAccent === 'string' &&
+      storedAccent.trim().toLowerCase() !== DEFAULT_ACCENT.toLowerCase();
+    var shouldPreserveAccent = hasCustomAccent || highContrastEnabled;
+    if (pinkModeEnabled && !shouldPreserveAccent) {
       root.style.removeProperty('--accent-color');
       root.style.removeProperty('--link-color');
       body.style.removeProperty('--accent-color');

--- a/tests/script/settings-theme.test.js
+++ b/tests/script/settings-theme.test.js
@@ -11,7 +11,7 @@ describe('settings dialog theme interactions', () => {
     localStorage.clear();
   });
 
-  test('closing settings keeps pink mode accent overrides cleared', () => {
+  test('closing settings keeps custom accent overrides while pink mode stays active', () => {
     localStorage.setItem('pinkMode', 'true');
     localStorage.setItem('accentColor', '#ff8800');
 
@@ -30,6 +30,29 @@ describe('settings dialog theme interactions', () => {
     settingsCancel.click();
 
     expect(document.body.classList.contains('pink-mode')).toBe(true);
+    expect(document.documentElement.style.getPropertyValue('--accent-color')).toBe('#ff8800');
+    expect(document.documentElement.style.getPropertyValue('--link-color')).toBe('#ff8800');
+    expect(document.body.style.getPropertyValue('--accent-color')).toBe('#ff8800');
+    expect(document.body.style.getPropertyValue('--link-color')).toBe('#ff8800');
+  });
+
+  test('pink mode without custom accent continues to rely on theme defaults', () => {
+    localStorage.setItem('pinkMode', 'true');
+
+    const { cleanup: clean } = setupScriptEnvironment();
+    cleanup = clean;
+
+    expect(document.body.classList.contains('pink-mode')).toBe(true);
+
+    const settingsButton = document.getElementById('settingsButton');
+    const settingsCancel = document.getElementById('settingsCancel');
+
+    expect(settingsButton).toBeTruthy();
+    expect(settingsCancel).toBeTruthy();
+
+    settingsButton.click();
+    settingsCancel.click();
+
     expect(document.documentElement.style.getPropertyValue('--accent-color')).toBe('');
     expect(document.documentElement.style.getPropertyValue('--link-color')).toBe('');
     expect(document.body.style.getPropertyValue('--accent-color')).toBe('');

--- a/tests/script/static-theme.test.js
+++ b/tests/script/static-theme.test.js
@@ -117,4 +117,27 @@ describe('static theme preferences', () => {
     expect(body.style.getPropertyValue('--link-color')).toBe('#001589');
     expect(themeMeta.getAttribute('content')).toBe('#f9f9f9');
   });
+
+  test('retains stored custom accent when pink mode is enabled', () => {
+    localStorage.getItem.mockImplementation(key => {
+      if (key === 'pinkMode') {
+        return 'true';
+      }
+      if (key === 'accentColor') {
+        return '#ff8800';
+      }
+      return null;
+    });
+
+    loadStaticTheme();
+
+    const root = document.documentElement;
+    const body = document.body;
+
+    expect(body.classList.contains('pink-mode')).toBe(true);
+    expect(root.style.getPropertyValue('--accent-color')).toBe('#ff8800');
+    expect(root.style.getPropertyValue('--link-color')).toBe('#ff8800');
+    expect(body.style.getPropertyValue('--accent-color')).toBe('#ff8800');
+    expect(body.style.getPropertyValue('--link-color')).toBe('#ff8800');
+  });
 });


### PR DESCRIPTION
## Summary
- detect stored custom accents and keep inline accent overrides when pink mode or high contrast are enabled in both runtime scripts
- update the static theme bootstrapper to avoid clearing custom accent colors on initial load when pink mode is active
- expand tests to cover custom accent preservation and default behaviour when toggling pink mode

## Testing
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68cef249c1888320b654a77f0948d51b