### PR TITLE
Fix print warning text color

### DIFF
--- a/src/styles/overview-print.css
+++ b/src/styles/overview-print.css
@@ -60,6 +60,8 @@ body.dark-mode {
   --power-color: #d33;
   --video-color: #369;
   --fiz-color: #090;
+  --status-warning-bg: #ffe066;
+  --status-warning-text-color: #000;
   font-family: 'Ubuntu', sans-serif;
   font-weight: var(--font-weight-light);
   font-size: var(--font-size-base);
@@ -77,6 +79,8 @@ body.dark-mode {
   --panel-border: #ddd;
   --control-bg: #f0f0f0;
   --control-text: #333;
+  --status-warning-bg: #ffe066;
+  --status-warning-text-color: #000;
   --diagram-node-fill: #f0f0f0;
   --power-color: #d33;
   --video-color: #369;


### PR DESCRIPTION
## Summary
- ensure print stylesheet overrides warning colors so text remains readable when printing in dark mode

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cef31bdc7c832081d31ddefc8623ef