### PR TITLE
Hide diagram controls in printable overview

### DIFF
--- a/legacy/scripts/overview.js
+++ b/legacy/scripts/overview.js
@@ -262,10 +262,9 @@ function generatePrintableOverview() {
     diagramAreaHtml = areaClone.outerHTML;
   }
   var diagramLegendHtml = diagramLegend ? diagramLegend.outerHTML : '';
-  var diagramControlsHtml = document.querySelector('.diagram-controls') ? document.querySelector('.diagram-controls').outerHTML : '';
   var diagramHintHtml = diagramHint ? diagramHint.outerHTML : '';
   var diagramDescHtml = document.getElementById('diagramDesc') ? document.getElementById('diagramDesc').outerHTML : '';
-  var diagramSectionHtml = diagramAreaHtml ? "<section id=\"setupDiagram\" class=\"diagram-section print-section\"><h2>".concat(t.setupDiagramHeading, "</h2>").concat(diagramDescHtml).concat(diagramAreaHtml).concat(diagramLegendHtml).concat(diagramControlsHtml).concat(diagramHintHtml, "</section>") : '';
+  var diagramSectionHtml = diagramAreaHtml ? "<section id=\"setupDiagram\" class=\"diagram-section print-section\"><h2>".concat(t.setupDiagramHeading, "</h2>").concat(diagramDescHtml).concat(diagramAreaHtml).concat(diagramLegendHtml).concat(diagramHintHtml, "</section>") : '';
   var batteryTableHtmlWithBreak = batteryTableHtml ? "<div class=\"page-break\"></div>".concat(batteryTableHtml) : '';
   var gearListCombined = getCurrentGearListHtml();
   if (!gearListCombined && currentProjectInfo) {

--- a/src/scripts/overview.js
+++ b/src/scripts/overview.js
@@ -253,11 +253,10 @@ function generatePrintableOverview() {
       diagramAreaHtml = areaClone.outerHTML;
     }
     const diagramLegendHtml = diagramLegend ? diagramLegend.outerHTML : '';
-    const diagramControlsHtml = document.querySelector('.diagram-controls') ? document.querySelector('.diagram-controls').outerHTML : '';
     const diagramHintHtml = diagramHint ? diagramHint.outerHTML : '';
     const diagramDescHtml = document.getElementById('diagramDesc') ? document.getElementById('diagramDesc').outerHTML : '';
     const diagramSectionHtml = diagramAreaHtml
-        ? `<section id="setupDiagram" class="diagram-section print-section"><h2>${t.setupDiagramHeading}</h2>${diagramDescHtml}${diagramAreaHtml}${diagramLegendHtml}${diagramControlsHtml}${diagramHintHtml}</section>`
+        ? `<section id="setupDiagram" class="diagram-section print-section"><h2>${t.setupDiagramHeading}</h2>${diagramDescHtml}${diagramAreaHtml}${diagramLegendHtml}${diagramHintHtml}</section>`
         : '';
     const batteryTableHtmlWithBreak = batteryTableHtml ? `<div class="page-break"></div>${batteryTableHtml}` : '';
 


### PR DESCRIPTION
## Summary
- stop cloning the interactive diagram controls into the printable overview so they no longer appear in printouts
- mirror the same change in the legacy overview generator to keep the fallback export consistent

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cef382b7c083209ce860d095ec45f9