### PR TITLE
Prevent gear list categories splitting mid-page when printing

### DIFF
--- a/src/styles/overview-print.css
+++ b/src/styles/overview-print.css
@@ -314,6 +314,14 @@ body:not(.light-mode) .gear-table tbody {
   page-break-inside: avoid;
 }
 
+#overviewDialogContent .gear-table .category-row,
+#overviewDialogContent.dark-mode .gear-table .category-row,
+body:not(.light-mode) .gear-table .category-row {
+  break-after: avoid;
+  break-after: avoid-page;
+  page-break-after: avoid;
+}
+
 #overviewDialogContent .gear-table .gear-item {
   display: inline-flex;
   align-items: center;

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -4076,6 +4076,12 @@ body.dark-mode.dark-accent-boost:not(.pink-mode) .settings-content.modal-surface
   page-break-inside: avoid;
 }
 
+.gear-table .category-row {
+  break-after: avoid;
+  break-after: avoid-page;
+  page-break-after: avoid;
+}
+
 .gear-table .auto-gear-item {
   margin: 0;
   padding: 0;


### PR DESCRIPTION
## Summary
- ensure gear table category rows avoid page breaks so printing only splits before a new category
- mirror the same protection in the overview print stylesheet for consistent results when printing the overview dialog

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cef3adbf048320a98549d8ff8c13de