### PR TITLE
Restore accent color headings in bright mode

### DIFF
--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -325,7 +325,7 @@ textarea:focus-visible {
 h1, h2, h3 {
   font-family: var(--font-family);
   font-weight: var(--font-weight-regular);
-  color: var(--text-color);
+  color: var(--accent-color);
 }
 h1 {
   font-size: calc(var(--font-size-relative-base) * var(--font-scale-display));
@@ -334,7 +334,7 @@ h1 {
 h2 {
   font-size: calc(var(--font-size-relative-base) * var(--font-scale-xxl));
   margin-top: 1.3em;
-  border-bottom: 1px solid var(--text-color);
+  border-bottom: 1px solid var(--accent-color);
 }
 
 body.pink-mode:not(.dark-mode) h1,


### PR DESCRIPTION
## Summary
- restore the accent color styling on page headings in bright mode so user-selected colors appear

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cef4b7e2388320adbbe8a13520855c