### PR TITLE
Ensure mattebox defaults merge into automatic gear rules

### DIFF
--- a/src/scripts/script.js
+++ b/src/scripts/script.js
@@ -981,9 +981,28 @@ function buildDefaultMatteboxAutoGearRules() {
   ];
 }
 
+function ensureDefaultMatteboxAutoGearRules() {
+  const defaults = buildDefaultMatteboxAutoGearRules();
+  if (!defaults.length) return false;
+  const merged = mergeAutoGearRules(autoGearRules, defaults);
+  if (merged.length === autoGearRules.length) return false;
+  setAutoGearRules(merged);
+  return true;
+}
+
 function seedAutoGearRulesFromCurrentProject() {
-  if (autoGearRules.length) return;
-  if (hasSeededAutoGearDefaults()) return;
+  if (autoGearRules.length) {
+    const addedDefaults = ensureDefaultMatteboxAutoGearRules();
+    if (addedDefaults && !hasSeededAutoGearDefaults()) {
+      markAutoGearDefaultsSeeded();
+    }
+    return;
+  }
+  if (hasSeededAutoGearDefaults()) {
+    const addedDefaults = ensureDefaultMatteboxAutoGearRules();
+    if (addedDefaults) markAutoGearDefaultsSeeded();
+    return;
+  }
 
   const rules = [];
   const canGenerateRules = typeof generateGearListHtml === 'function'
@@ -1045,7 +1064,11 @@ function seedAutoGearRulesFromCurrentProject() {
   }
 
   buildDefaultMatteboxAutoGearRules().forEach(rule => rules.push(rule));
-  if (!rules.length) return;
+  if (!rules.length) {
+    const addedDefaults = ensureDefaultMatteboxAutoGearRules();
+    if (addedDefaults) markAutoGearDefaultsSeeded();
+    return;
+  }
   setAutoGearRules(rules);
   markAutoGearDefaultsSeeded();
 }

--- a/tests/script/autoGearRules.test.js
+++ b/tests/script/autoGearRules.test.js
@@ -268,6 +268,46 @@ describe('applyAutoGearRulesToTableHtml', () => {
     expect(entries[0].textContent).toContain('1x');
   });
 
+  test('seeds default mattebox rules when they are missing', () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify([
+        {
+          id: 'rule-existing',
+          label: 'Existing scenario rule',
+          scenarios: ['Outdoor'],
+          mattebox: [],
+          add: [
+            {
+              id: 'add-existing',
+              name: 'Rain Cover',
+              category: 'Miscellaneous',
+              quantity: 1,
+            },
+          ],
+          remove: [],
+        },
+      ])
+    );
+    localStorage.setItem('cameraPowerPlanner_autoGearSeeded', '1');
+
+    env = setupScriptEnvironment();
+    const { getAutoGearRules, setLanguage } = env.utils;
+
+    setLanguage('en');
+
+    const rules = getAutoGearRules();
+    const matteboxTriggers = rules
+      .filter(rule => Array.isArray(rule.mattebox) && rule.mattebox.length)
+      .map(rule => rule.mattebox.join(' + '));
+
+    expect(matteboxTriggers).toEqual(expect.arrayContaining([
+      'Swing Away',
+      'Rod based',
+      'Clamp On',
+    ]));
+  });
+
   test('saving a rule shows a confirmation notification', () => {
     env = setupScriptEnvironment();
 


### PR DESCRIPTION
## Summary
- add a guard that merges the built-in mattebox automatic gear rules into stored rules when missing
- adjust seeding to always inject mattebox defaults and extend the script test coverage for the behavior

## Testing
- npm test -- autoGearRules

------
https://chatgpt.com/codex/tasks/task_e_68cef5b569ec8320ab4dd36d0bc5b471