### PR TITLE
Fix crew remove button alignment

### DIFF
--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -557,6 +557,8 @@ main.legal-content {
 
 .person-row button {
   flex: 0 0 auto;
+  margin: 0;
+  align-self: stretch;
 }
 
 #dynamicFields {
@@ -969,6 +971,10 @@ main.legal-content {
 }
 .period-row span {
   white-space: nowrap;
+}
+
+.period-row button {
+  margin: 0;
 }
 
 @media (max-width: 600px) {


### PR DESCRIPTION
## Summary
- remove default margins from crew and schedule remove buttons to align with adjacent selects and inputs
- stretch crew remove controls so their height matches the surrounding selectors for a consistent layout

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cef71236e0832082746e026ebcfbc4