### PR TITLE
Align user button icons

### DIFF
--- a/legacy/scripts/script.js
+++ b/legacy/scripts/script.js
@@ -4502,7 +4502,7 @@ var projectFieldIcons = {
   monitoringConfiguration: iconGlyph("\uF0D0", ICON_FONT_KEYS.UICONS),
   monitorUserButtons: iconGlyph("\uF0D1", ICON_FONT_KEYS.UICONS),
   cameraUserButtons: iconGlyph("\uF0D1", ICON_FONT_KEYS.UICONS),
-  viewfinderUserButtons: iconGlyph("\uF0D2", ICON_FONT_KEYS.UICONS)
+  viewfinderUserButtons: iconGlyph("\uF0D1", ICON_FONT_KEYS.UICONS)
 };
 function setButtonLabelWithIcon(button, label) {
   var glyph = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : ICON_GLYPHS.save;

--- a/src/scripts/script.js
+++ b/src/scripts/script.js
@@ -4951,7 +4951,7 @@ const projectFieldIcons = {
   monitoringConfiguration: iconGlyph('\uF0D0', ICON_FONT_KEYS.UICONS),
   monitorUserButtons: iconGlyph('\uF0D1', ICON_FONT_KEYS.UICONS),
   cameraUserButtons: iconGlyph('\uF0D1', ICON_FONT_KEYS.UICONS),
-  viewfinderUserButtons: iconGlyph('\uF0D2', ICON_FONT_KEYS.UICONS)
+  viewfinderUserButtons: iconGlyph('\uF0D1', ICON_FONT_KEYS.UICONS)
 };
 
 function setButtonLabelWithIcon(button, label, glyph = ICON_GLYPHS.save) {


### PR DESCRIPTION
## Summary
- align the user button field icons so the monitor, camera, and viewfinder sections share the same glyph

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cef87471788320be332a44daf5a723