### PR TITLE
Ensure gear list heading stays pink in pink mode

### DIFF
--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -4154,6 +4154,20 @@ body.dark-mode.dark-accent-boost:not(.pink-mode) .settings-content.modal-surface
   border-bottom: 1px solid var(--inverse-text-color);
 }
 
+body.dark-mode.pink-mode #gearListOutput h1,
+body.dark-mode.pink-mode #gearListOutput h2,
+body.dark-mode.pink-mode #gearListOutput h3,
+#gearListOutput.dark-mode.pink-mode h1,
+#gearListOutput.dark-mode.pink-mode h2,
+#gearListOutput.dark-mode.pink-mode h3 {
+  color: var(--accent-color);
+}
+
+body.dark-mode.pink-mode #gearListOutput h2,
+#gearListOutput.dark-mode.pink-mode h2 {
+  border-bottom: 1px solid var(--accent-color);
+}
+
 #gearListFilterDetails {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- allow pink mode to override the dark mode heading styles inside the gear list output
- ensure the gear list heading and divider use the active accent color when dark and pink modes are combined

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cefebf4efc83209032695d4150ab14