### PR TITLE
Adjust filter detail styling in gear list

### DIFF
--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -4157,8 +4157,8 @@ body.dark-mode.dark-accent-boost:not(.pink-mode) .settings-content.modal-surface
 #gearListFilterDetails {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
-  margin-top: 0.5rem;
+  gap: 0.375rem;
+  margin-top: 0.375rem;
 }
 
 #gearListFilterDetails.hidden {
@@ -4169,20 +4169,22 @@ body.dark-mode.dark-accent-boost:not(.pink-mode) .settings-content.modal-surface
   display: flex;
   flex-wrap: wrap;
   gap: 0.5rem;
-  align-items: center;
-  border: 1px solid var(--panel-border);
-  border-radius: var(--border-radius);
-  padding: 0.5rem;
-  background: var(--panel-bg);
+  align-items: flex-start;
+  padding: 0.125rem 0;
+  border: none;
+  border-radius: 0;
+  background: none;
 }
 
 #gearListFilterDetails .filter-detail-label {
   font-weight: 600;
-  min-width: 10rem;
+  min-width: 0;
+  margin-right: 0.25rem;
 }
 
 #gearListFilterDetails .filter-detail-controls {
   display: flex;
+  flex: 1 1 auto;
   flex-wrap: wrap;
   gap: 0.5rem;
   align-items: center;


### PR DESCRIPTION
## Summary
- remove the bordered panel treatment from gear list filter details so they blend with the surrounding items
- tweak spacing and label layout so filter controls align cleanly within the gear list rows

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cefee1805c8320ac7c9691e53e284a