### PR TITLE
Adjust logo palette for pink mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,7 +44,7 @@
           <style>
             .logo-background { fill: var(--logo-background-color, var(--accent-color)); }
             .cls-1 { fill: var(--logo-accent-color, var(--accent-color)); }
-            .cls-2 { fill: #fff; }
+            .cls-2 { fill: var(--logo-center-color, #fff); }
           </style>
         </defs>
         <rect class="logo-background" width="1024" height="1024" rx="128" ry="128" />

--- a/legal/datenschutz-en.html
+++ b/legal/datenschutz-en.html
@@ -24,7 +24,7 @@
           <style>
             .logo-background { fill: var(--logo-background-color, var(--accent-color)); }
             .cls-1 { fill: var(--logo-accent-color, var(--accent-color)); }
-            .cls-2 { fill: #fff; }
+            .cls-2 { fill: var(--logo-center-color, #fff); }
           </style>
         </defs>
         <rect class="cls-1 logo-background" width="1024" height="1024" rx="128" ry="128" />

--- a/legal/datenschutz-es.html
+++ b/legal/datenschutz-es.html
@@ -24,7 +24,7 @@
           <style>
             .logo-background { fill: var(--logo-background-color, var(--accent-color)); }
             .cls-1 { fill: var(--logo-accent-color, var(--accent-color)); }
-            .cls-2 { fill: #fff; }
+            .cls-2 { fill: var(--logo-center-color, #fff); }
           </style>
         </defs>
         <rect class="cls-1 logo-background" width="1024" height="1024" rx="128" ry="128" />

--- a/legal/datenschutz-fr.html
+++ b/legal/datenschutz-fr.html
@@ -24,7 +24,7 @@
           <style>
             .logo-background { fill: var(--logo-background-color, var(--accent-color)); }
             .cls-1 { fill: var(--logo-accent-color, var(--accent-color)); }
-            .cls-2 { fill: #fff; }
+            .cls-2 { fill: var(--logo-center-color, #fff); }
           </style>
         </defs>
         <rect class="cls-1 logo-background" width="1024" height="1024" rx="128" ry="128" />

--- a/legal/datenschutz-it.html
+++ b/legal/datenschutz-it.html
@@ -24,7 +24,7 @@
           <style>
             .logo-background { fill: var(--logo-background-color, var(--accent-color)); }
             .cls-1 { fill: var(--logo-accent-color, var(--accent-color)); }
-            .cls-2 { fill: #fff; }
+            .cls-2 { fill: var(--logo-center-color, #fff); }
           </style>
         </defs>
         <rect class="cls-1 logo-background" width="1024" height="1024" rx="128" ry="128" />

--- a/legal/datenschutz.html
+++ b/legal/datenschutz.html
@@ -24,7 +24,7 @@
           <style>
             .logo-background { fill: var(--logo-background-color, var(--accent-color)); }
             .cls-1 { fill: var(--logo-accent-color, var(--accent-color)); }
-            .cls-2 { fill: #fff; }
+            .cls-2 { fill: var(--logo-center-color, #fff); }
           </style>
         </defs>
         <rect class="cls-1 logo-background" width="1024" height="1024" rx="128" ry="128" />

--- a/legal/impressum-en.html
+++ b/legal/impressum-en.html
@@ -24,7 +24,7 @@
           <style>
             .logo-background { fill: var(--logo-background-color, var(--accent-color)); }
             .cls-1 { fill: var(--logo-accent-color, var(--accent-color)); }
-            .cls-2 { fill: #fff; }
+            .cls-2 { fill: var(--logo-center-color, #fff); }
           </style>
         </defs>
         <rect class="cls-1 logo-background" width="1024" height="1024" rx="128" ry="128" />

--- a/legal/impressum-es.html
+++ b/legal/impressum-es.html
@@ -24,7 +24,7 @@
           <style>
             .logo-background { fill: var(--logo-background-color, var(--accent-color)); }
             .cls-1 { fill: var(--logo-accent-color, var(--accent-color)); }
-            .cls-2 { fill: #fff; }
+            .cls-2 { fill: var(--logo-center-color, #fff); }
           </style>
         </defs>
         <rect class="cls-1 logo-background" width="1024" height="1024" rx="128" ry="128" />

--- a/legal/impressum-fr.html
+++ b/legal/impressum-fr.html
@@ -24,7 +24,7 @@
           <style>
             .logo-background { fill: var(--logo-background-color, var(--accent-color)); }
             .cls-1 { fill: var(--logo-accent-color, var(--accent-color)); }
-            .cls-2 { fill: #fff; }
+            .cls-2 { fill: var(--logo-center-color, #fff); }
           </style>
         </defs>
         <rect class="cls-1 logo-background" width="1024" height="1024" rx="128" ry="128" />

--- a/legal/impressum-it.html
+++ b/legal/impressum-it.html
@@ -24,7 +24,7 @@
           <style>
             .logo-background { fill: var(--logo-background-color, var(--accent-color)); }
             .cls-1 { fill: var(--logo-accent-color, var(--accent-color)); }
-            .cls-2 { fill: #fff; }
+            .cls-2 { fill: var(--logo-center-color, #fff); }
           </style>
         </defs>
         <rect class="cls-1 logo-background" width="1024" height="1024" rx="128" ry="128" />

--- a/legal/impressum.html
+++ b/legal/impressum.html
@@ -24,7 +24,7 @@
           <style>
             .logo-background { fill: var(--logo-background-color, var(--accent-color)); }
             .cls-1 { fill: var(--logo-accent-color, var(--accent-color)); }
-            .cls-2 { fill: #fff; }
+            .cls-2 { fill: var(--logo-center-color, #fff); }
           </style>
         </defs>
         <rect class="cls-1 logo-background" width="1024" height="1024" rx="128" ry="128" />

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -6,6 +6,7 @@
   --accent-color: var(--brand-accent-color);
   --logo-background-color: var(--accent-color);
   --logo-accent-color: var(--brand-accent-color);
+  --logo-center-color: #ffffff;
   --link-color: var(--accent-color);
   --background-color: #f9f9f9;
   --surface-color: #ffffff;
@@ -118,8 +119,12 @@ body.pink-mode {
   --accent-color: #ff69b4;
   --link-color: #ff69b4;
   --icon-color: var(--accent-color);
-  --logo-accent-color: var(--accent-color);
-  --logo-background-color: var(--brand-accent-color);
+  --logo-accent-color: #ff3b9d;
+  --logo-accent-color: color-mix(in srgb, var(--accent-color) 90%, #a50058);
+  --logo-background-color: #ff9dd0;
+  --logo-background-color: color-mix(in srgb, var(--accent-color) 45%, white);
+  --logo-center-color: #fff3fa;
+  --logo-center-color: color-mix(in srgb, var(--accent-color) 15%, white);
 }
 
 html {
@@ -2518,7 +2523,7 @@ input[type="file"]:disabled::-webkit-file-upload-button {
 }
 
 body.pink-mode #topBar #logo .logo-center {
-  fill: #fff !important;
+  fill: var(--logo-center-color) !important;
 }
 
 #topBar .feature-search {


### PR DESCRIPTION
## Summary
- add a dedicated `--logo-center-color` CSS variable so the logo palette can adapt per theme
- refresh the pink mode palette to supply softer pink background and accent tones for the logo
- update every inline SVG logo reference to consume the new variable so legal pages and the app stay consistent

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cf01ca56cc8320bf7c6db63a375c72