### PR TITLE
Handle Steadicam D-Tap spare counts in gear list

### DIFF
--- a/legacy/scripts/script.js
+++ b/legacy/scripts/script.js
@@ -17367,6 +17367,8 @@ function generateGearListHtml() {
       riggingAcc.push('D-Tap Splitter');
       riggingAcc.push('D-Tap Extension 50 cm (Steadicam/Trinity)');
     }
+    riggingAcc.push('D-Tap Extension 50 cm (Spare)');
+    riggingAcc.push('D-Tap Extension 50 cm (Spare)');
   }
   var handleSelections = info.cameraHandle ? info.cameraHandle.split(',').map(function (r) {
     return r.trim();
@@ -17701,7 +17703,17 @@ function generateGearListHtml() {
               count = _ref105[1];
             return sum + count;
           }, 0);
-          if (_spareCount2 > 0) ctxParts.push("".concat(_spareCount2, "x Spare"));
+          if (_spareCount2 > 0) {
+            ctxParts.push("".concat(_spareCount2, "x Spare"));
+          } else if (base === 'D-Tap Extension 50 cm') {
+            var usedCount = _realEntries2.reduce(function (sum, _ref106) {
+              var _ref107 = _slicedToArray(_ref106, 2),
+                count = _ref107[1];
+              return sum + count;
+            }, 0);
+            var remaining = total - usedCount;
+            if (remaining > 0) ctxParts.push("".concat(remaining, "x Spare"));
+          }
         }
       }
       var ctxStr = ctxParts.length ? " (".concat(ctxParts.join(', '), ")") : '';

--- a/src/scripts/script.js
+++ b/src/scripts/script.js
@@ -17842,6 +17842,9 @@ function generateGearListHtml(info = {}) {
             riggingAcc.push('D-Tap Splitter');
             riggingAcc.push('D-Tap Extension 50 cm (Steadicam/Trinity)');
         }
+        for (let i = 0; i < 2; i++) {
+            riggingAcc.push('D-Tap Extension 50 cm (Spare)');
+        }
     }
     const handleSelections = info.cameraHandle
         ? info.cameraHandle.split(',').map(r => r.trim()).filter(Boolean)
@@ -18089,7 +18092,13 @@ function generateGearListHtml(info = {}) {
                         const spareCount = Object.entries(ctxCounts)
                             .filter(([c]) => c && c.toLowerCase() === 'spare')
                             .reduce((sum, [, count]) => sum + count, 0);
-                        if (spareCount > 0) ctxParts.push(`${spareCount}x Spare`);
+                        if (spareCount > 0) {
+                            ctxParts.push(`${spareCount}x Spare`);
+                        } else if (base === 'D-Tap Extension 50 cm') {
+                            const usedCount = realEntries.reduce((sum, [, count]) => sum + count, 0);
+                            const remaining = total - usedCount;
+                            if (remaining > 0) ctxParts.push(`${remaining}x Spare`);
+                        }
                     }
                 }
                 const ctxStr = ctxParts.length ? ` (${ctxParts.join(', ')})` : '';

--- a/tests/script/riggingAccessories.test.js
+++ b/tests/script/riggingAccessories.test.js
@@ -1,0 +1,36 @@
+const { setupScriptEnvironment } = require('../helpers/scriptEnvironment');
+
+describe('rigging accessory spares', () => {
+  let env;
+
+  afterEach(() => {
+    if (env && typeof env.cleanup === 'function') {
+      env.cleanup();
+    }
+    env = null;
+  });
+
+  const generateRiggingCellText = (info = {}) => {
+    env = setupScriptEnvironment();
+    const { generateGearListHtml } = env.utils;
+    const html = generateGearListHtml(info);
+    const container = document.createElement('div');
+    container.innerHTML = html;
+    const riggingGroup = Array.from(container.querySelectorAll('tbody.category-group')).find(group => {
+      const header = group.querySelector('.category-row td');
+      return header && header.textContent.trim() === 'Rigging';
+    });
+    if (!riggingGroup) {
+      return '';
+    }
+    const cell = riggingGroup.querySelector('tr:not(.category-row) td');
+    return cell ? cell.textContent : '';
+  };
+
+  test('steadi rigging includes spare D-Tap cables', () => {
+    const text = generateRiggingCellText({ requiredScenarios: 'Trinity' });
+    expect(text).toContain('4x D-Tap Extension 50 cm');
+    expect(text).toMatch(/4x D-Tap Extension 50 cm\s*\([^)]*2x Steadicam\/Trinity[^)]*\)/);
+    expect(text).toMatch(/4x D-Tap Extension 50 cm\s*\([^)]*2x Spare[^)]*\)/);
+  });
+});


### PR DESCRIPTION
## Summary
- ensure the gear list formatter infers spare D-Tap extensions for Steadicam/Trinity rigs when explicit spare contexts are missing
- mirror the spare inference logic in the legacy generator to keep both outputs aligned
- add a targeted test that confirms the Rigging section highlights spare cables for Steadicam/Trinity scenarios

## Testing
- npm run test:jest -- --testNamePattern=steadi
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cf02a84fb883209791990501690919