### PR TITLE
Adjust pink mode logo colors to use accent

### DIFF
--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -119,12 +119,9 @@ body.pink-mode {
   --accent-color: #ff69b4;
   --link-color: #ff69b4;
   --icon-color: var(--accent-color);
-  --logo-accent-color: #ff3b9d;
-  --logo-accent-color: color-mix(in srgb, var(--accent-color) 90%, #a50058);
-  --logo-background-color: #ff9dd0;
-  --logo-background-color: color-mix(in srgb, var(--accent-color) 45%, white);
-  --logo-center-color: #fff3fa;
-  --logo-center-color: color-mix(in srgb, var(--accent-color) 15%, white);
+  --logo-accent-color: var(--accent-color);
+  --logo-background-color: var(--accent-color);
+  --logo-center-color: #ffffff;
 }
 
 html {


### PR DESCRIPTION
## Summary
- update the pink mode logo variables to use the standard accent color instead of desaturated mixes

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cf064e73988320b862436c0a184893