### PR TITLE
Align filter set typography with gear list

### DIFF
--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -4175,6 +4175,7 @@ body.dark-mode.pink-mode #gearListOutput h2,
   flex-direction: column;
   gap: 0.375rem;
   margin-top: 0.375rem;
+  line-height: var(--line-height-supporting);
 }
 
 #gearListFilterDetails.hidden {
@@ -4193,7 +4194,7 @@ body.dark-mode.pink-mode #gearListOutput h2,
 }
 
 #gearListFilterDetails .filter-detail-label {
-  font-weight: 600;
+  font-weight: var(--font-weight-regular);
   min-width: 0;
   margin-right: 0.25rem;
 }


### PR DESCRIPTION
## Summary
- align the filter set details typography with the standard gear list styling
- apply the gear list line height to the filter details container and reset the label weight

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cf0ce6f1688320961f0bbd469cae87