### PR TITLE
Adjust automatic gear mattebox select height

### DIFF
--- a/legacy/scripts/script.js
+++ b/legacy/scripts/script.js
@@ -6367,7 +6367,7 @@ function refreshAutoGearMatteboxOptions(selected) {
   var selectableOptions = Array.from(autoGearMatteboxSelect.options || []).filter(function (option) {
     return !option.disabled;
   });
-  var visibleCount = selectableOptions.length ? Math.min(4, Math.max(selectableOptions.length, 3)) : 1;
+  var visibleCount = selectableOptions.length ? Math.min(6, Math.max(selectableOptions.length, 4)) : 1;
   autoGearMatteboxSelect.size = visibleCount;
 }
 function populateAutoGearCategorySelect(select, currentValue) {

--- a/src/scripts/script.js
+++ b/src/scripts/script.js
@@ -6682,7 +6682,7 @@ function refreshAutoGearMatteboxOptions(selected) {
 
   const selectableOptions = Array.from(autoGearMatteboxSelect.options || []).filter(option => !option.disabled);
   const visibleCount = selectableOptions.length
-    ? Math.min(4, Math.max(selectableOptions.length, 3))
+    ? Math.min(6, Math.max(selectableOptions.length, 4))
     : 1;
   autoGearMatteboxSelect.size = visibleCount;
 }


### PR DESCRIPTION
## Summary
- Increase the automatic gear mattebox selector size so all mattebox options are visible without scrolling.
- Update the legacy bundle to keep the automatic gear mattebox sizing consistent.

## Testing
- npm run test:script

------
https://chatgpt.com/codex/tasks/task_e_68cf0de36800832091ad16f681be208b