### PR TITLE
Remove redundant cancel control from project requirements

### DIFF
--- a/index.html
+++ b/index.html
@@ -2389,9 +2389,6 @@
     <form id="projectForm" method="dialog" class="modal-surface modal-surface-scrollable project-dialog">
       <div class="project-dialog-header">
         <h2 id="projectDialogHeading">Project Requirements</h2>
-        <button type="button" id="projectDialogClose" class="project-dialog-close" aria-label="Cancel">
-          <span class="icon-glyph" aria-hidden="true" data-icon-font="essential">&#xF131;</span>
-        </button>
       </div>
       <div class="project-dialog-body">
         <section class="project-dialog-section project-dialog-section-basic">


### PR DESCRIPTION
## Summary
- remove the extra cancel button from the Project Requirements dialog header
- rely on the footer cancel action for consistent dismissal behavior

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cf109620648320b31da5704f1aade8