### PR TITLE
Update crew icon to new UIcons glyph

### DIFF
--- a/legacy/scripts/script.js
+++ b/legacy/scripts/script.js
@@ -4594,7 +4594,7 @@ var PINK_MODE_ICON_ANIMATION_RESET_DELAY = 450;
 var projectFieldIcons = {
   productionCompany: PRODUCTION_COMPANY_ICON,
   rentalHouse: RENTAL_HOUSE_ICON,
-  crew: iconGlyph("\uE638", ICON_FONT_KEYS.UICONS),
+  crew: iconGlyph("\uF404", ICON_FONT_KEYS.UICONS),
   prepDays: iconGlyph("\uE312", ICON_FONT_KEYS.UICONS),
   shootingDays: iconGlyph("\uE311", ICON_FONT_KEYS.UICONS),
   deliveryResolution: iconGlyph("\uE5BA", ICON_FONT_KEYS.UICONS),

--- a/src/scripts/script.js
+++ b/src/scripts/script.js
@@ -4978,7 +4978,7 @@ const PINK_MODE_ICON_ANIMATION_RESET_DELAY = 450;
 const projectFieldIcons = {
   productionCompany: PRODUCTION_COMPANY_ICON,
   rentalHouse: RENTAL_HOUSE_ICON,
-  crew: iconGlyph('\uE638', ICON_FONT_KEYS.UICONS),
+  crew: iconGlyph('\uF404', ICON_FONT_KEYS.UICONS),
   prepDays: iconGlyph('\uE312', ICON_FONT_KEYS.UICONS),
   shootingDays: iconGlyph('\uE311', ICON_FONT_KEYS.UICONS),
   deliveryResolution: iconGlyph('\uE5BA', ICON_FONT_KEYS.UICONS),


### PR DESCRIPTION
## Summary
- switch the crew field icon to the fi-ts-users glyph from the local UIcons set
- keep the legacy script bundle in sync with the updated icon codepoint

## Testing
- npm run test:script

------
https://chatgpt.com/codex/tasks/task_e_68cf0fd5f8988320b4f2b4d1c2d0ec3f