### PR TITLE
Reset gear list when deleting a project

### DIFF
--- a/src/scripts/script.js
+++ b/src/scripts/script.js
@@ -15002,20 +15002,47 @@ deleteSetupBtn.addEventListener("click", () => {
     }
     populateSetupSelect();
     setupNameInput.value = ""; // Clear setup name input
-    // Reset dropdowns to "None" or first option after deleting current setup
-    [cameraSelect, monitorSelect, videoSelect, cageSelect, distanceSelect, batterySelect, hotswapSelect].forEach(sel => {
-      const noneOption = Array.from(sel.options).find(opt => opt.value === "None");
-      if (noneOption) {
-        sel.value = "None";
-      } else {
-        sel.selectedIndex = 0;
+
+    let selectionResetHandled = false;
+    if (setupSelect) {
+      lastSetupName = '';
+      setupSelect.value = "";
+      setupSelect.dispatchEvent(new Event('change'));
+      selectionResetHandled = true;
+    }
+
+    if (!selectionResetHandled) {
+      if (gearListOutput) {
+        gearListOutput.innerHTML = '';
+        gearListOutput.classList.add('hidden');
       }
-    });
-    const sbSel = getSliderBowlSelect();
-    if (sbSel) sbSel.value = '';
-    motorSelects.forEach(sel => { if (sel.options.length) sel.value = "None"; });
-    controllerSelects.forEach(sel => { if (sel.options.length) sel.value = "None"; });
-    updateCalculations(); // Recalculate after deleting setup
+      if (projectRequirementsOutput) {
+        projectRequirementsOutput.innerHTML = '';
+        projectRequirementsOutput.classList.add('hidden');
+      }
+      currentProjectInfo = null;
+      if (projectForm) populateProjectForm({});
+      storeLoadedSetupState(null);
+      updateBatteryPlateVisibility();
+      updateBatteryOptions();
+      clearProjectAutoGearRules();
+      renderAutoGearRulesList();
+      updateAutoGearCatalogOptions();
+      // Reset dropdowns to "None" or first option after deleting current setup
+      [cameraSelect, monitorSelect, videoSelect, cageSelect, distanceSelect, batterySelect, hotswapSelect].forEach(sel => {
+        const noneOption = Array.from(sel.options).find(opt => opt.value === "None");
+        if (noneOption) {
+          sel.value = "None";
+        } else {
+          sel.selectedIndex = 0;
+        }
+      });
+      const sbSel = getSliderBowlSelect();
+      if (sbSel) sbSel.value = '';
+      motorSelects.forEach(sel => { if (sel.options.length) sel.value = "None"; });
+      controllerSelects.forEach(sel => { if (sel.options.length) sel.value = "None"; });
+      updateCalculations(); // Recalculate after deleting setup
+    }
     alert(texts[currentLang].alertSetupDeleted.replace("{name}", setupName));
   }
 });


### PR DESCRIPTION
## Summary
- trigger the setup change handler after deleting a project so the UI clears the gear list and requirements
- fall back to manually clearing stored project data when the setup selector is unavailable
- ensure supporting state such as project info, auto gear rules, and selects reset when a project is removed

## Testing
- npm run test:script

------
https://chatgpt.com/codex/tasks/task_e_68cf105c5f748320bb3e56bee3ff0519