### PR TITLE
Add overview gear list deletion controls

### DIFF
--- a/src/styles/overview-print.css
+++ b/src/styles/overview-print.css
@@ -175,7 +175,8 @@ p {
 .print-btn,
 .back-btn,
 .favorite-toggle,
-.overview-actions {
+.overview-actions,
+.overview-gear-actions {
   display: none !important;
 }
 

--- a/src/styles/overview.css
+++ b/src/styles/overview.css
@@ -115,6 +115,33 @@ th { background-color: var(--control-bg); font-weight: var(--font-weight-bold); 
 .overview-actions .back-btn {
   margin: 0;
 }
+.overview-gear-actions {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+  margin: 10px 0 20px;
+}
+.overview-gear-actions .overview-delete-gear-btn {
+  background: var(--danger-color);
+  color: var(--inverse-text-color);
+  border: none;
+  border-radius: var(--border-radius);
+  padding: 0.6em 1.2em;
+  font-family: inherit;
+  font-size: calc(var(--font-size-relative-base) * var(--font-scale-sm));
+  cursor: pointer;
+  box-shadow: var(--panel-shadow);
+  transition: filter 0.2s ease, transform 0.1s ease;
+}
+.overview-gear-actions .overview-delete-gear-btn:hover,
+.overview-gear-actions .overview-delete-gear-btn:focus-visible {
+  filter: brightness(0.95);
+}
+.overview-gear-actions .overview-delete-gear-btn:active {
+  transform: translateY(1px);
+}
 .device-block-grid {
   display: grid;
   gap: 8px;
@@ -162,6 +189,12 @@ th { background-color: var(--control-bg); font-weight: var(--font-weight-bold); 
   }
   .overview-actions .print-btn,
   .overview-actions .back-btn {
+    width: 100%;
+  }
+  .overview-gear-actions {
+    justify-content: stretch;
+  }
+  .overview-gear-actions .overview-delete-gear-btn {
     width: 100%;
   }
   .device-category-container {

--- a/tests/dom/deleteGearList.test.js
+++ b/tests/dom/deleteGearList.test.js
@@ -62,6 +62,7 @@ describe('delete gear list action', () => {
 
     confirmSpy = jest.spyOn(window, 'confirm').mockReturnValue(true);
 
+    confirmSpy.mockClear();
     saveSetupsMock.mockClear();
     deleteProjectMock.mockClear();
     saveSessionStateMock.mockClear();
@@ -76,7 +77,13 @@ describe('delete gear list action', () => {
     const deleteBtn = document.getElementById('deleteGearListBtn');
     expect(deleteBtn).not.toBeNull();
 
+    const deletedEvents = [];
+    const deletedListener = (event) => deletedEvents.push(event);
+    document.addEventListener('gearlist:deleted', deletedListener);
+
     deleteBtn.click();
+
+    document.removeEventListener('gearlist:deleted', deletedListener);
 
     expect(confirmSpy).toHaveBeenCalledTimes(2);
     expect(deleteProjectMock).toHaveBeenCalledWith('Project One');
@@ -107,5 +114,27 @@ describe('delete gear list action', () => {
 
     expect(env.utils.getCurrentProjectInfo()).toBeNull();
     expect(saveSessionStateMock.mock.calls.some(([state]) => state.projectInfo === null)).toBe(true);
+
+    expect(deletedEvents.length).toBe(1);
+    expect(deletedEvents[0]).toBeDefined();
+    expect(deletedEvents[0].detail.projectName).toBe('Project One');
+    expect(typeof deletedEvents[0].detail.backupName).toBe('string');
+    expect(deletedEvents[0].detail.source).toBe('deleteCurrentGearList');
+  });
+
+  test('dispatching gearlist:delete-requested triggers gear list deletion', () => {
+    const deletedEvents = [];
+    const deletedListener = (event) => deletedEvents.push(event);
+    document.addEventListener('gearlist:deleted', deletedListener);
+
+    confirmSpy.mockClear();
+
+    document.dispatchEvent(new CustomEvent('gearlist:delete-requested', { detail: { source: 'test' } }));
+
+    document.removeEventListener('gearlist:deleted', deletedListener);
+
+    expect(confirmSpy).toHaveBeenCalledTimes(2);
+    expect(deletedEvents.length).toBe(1);
+    expect(deletedEvents[0].detail.projectName).toBe('Project One');
   });
 });


### PR DESCRIPTION
## Summary
- add a Delete Gear List action to the project overview and refresh the modal after removal
- expose deletion success via a gearlist:deleted event and guard document-level request handlers
- style and hide the overview delete control when printing and extend DOM tests to cover the new flows

## Testing
- npm run lint
- npm run test:dom

------
https://chatgpt.com/codex/tasks/task_e_68cf110ade248320a4a3502681fbcbd8