### PR TITLE
Limit storage alert to fallback failures

### DIFF
--- a/src/scripts/storage.js
+++ b/src/scripts/storage.js
@@ -664,6 +664,15 @@ function alertStorageError(reason) {
     return;
   }
 
+  const storageType =
+    safeLocalStorageInfo && typeof safeLocalStorageInfo === 'object'
+      ? safeLocalStorageInfo.type
+      : null;
+
+  if (!storageType || storageType === 'local') {
+    return;
+  }
+
   if (GLOBAL_SCOPE && typeof GLOBAL_SCOPE[STORAGE_ALERT_FLAG_NAME] === 'boolean') {
     storageErrorAlertShown = GLOBAL_SCOPE[STORAGE_ALERT_FLAG_NAME];
   }


### PR DESCRIPTION
## Summary
- require the modern storage alert to run only when safe storage has fallen back away from localStorage
- mirror the same gating in the legacy bundle by tracking which storage backend is active
- update the storage alert unit tests to reflect the new behavior and ensure the alert still fires when fallback reads fail

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cf11c1bb348320a43d37141b536a9b