### PR TITLE
Fix factory reset to clear legacy storage keys

### DIFF
--- a/tests/unit/storage.test.js
+++ b/tests/unit/storage.test.js
@@ -697,6 +697,20 @@ describe('clearAllData', () => {
     expect(localStorage.getItem(backupKeyFor(CUSTOM_LOGO_KEY))).toBeNull();
     expect(localStorage.getItem(backupKeyFor(CUSTOM_FONT_KEY))).toBeNull();
   });
+
+  test('removes legacy planner keys so migrations cannot restore cleared data', () => {
+    const legacySetupKey = 'cinePowerPlanner_setups';
+    const legacySessionKey = 'cinePowerPlanner_session';
+    localStorage.setItem(legacySetupKey, JSON.stringify({ Legacy: { foo: 'bar' } }));
+    localStorage.setItem(`${legacySetupKey}__backup`, JSON.stringify({ Legacy: { foo: 'bar' } }));
+    sessionStorage.setItem(legacySessionKey, JSON.stringify({ camera: 'Legacy Cam' }));
+
+    clearAllData();
+
+    expect(localStorage.getItem(legacySetupKey)).toBeNull();
+    expect(localStorage.getItem(`${legacySetupKey}__backup`)).toBeNull();
+    expect(sessionStorage.getItem(legacySessionKey)).toBeNull();
+  });
 });
 
 describe('export/import all data', () => {


### PR DESCRIPTION
## Summary
- ensure the factory reset routine clears legacy cinePowerPlanner_* keys across available storage implementations so old data cannot return after reset
- add a regression test covering legacy key removal during factory resets

## Testing
- npm run test:unit

------
https://chatgpt.com/codex/tasks/task_e_68cf14d10ddc8320a86179587dbef71d