### PR TITLE
Limit migration storage alert to true storage failures

### DIFF
--- a/legacy/scripts/storage.js
+++ b/legacy/scripts/storage.js
@@ -326,7 +326,27 @@ if (typeof window !== 'undefined' && typeof navigator !== 'undefined') {
 function isPlainObject(val) {
   return val !== null && _typeof(val) === 'object' && !Array.isArray(val);
 }
-function alertStorageError() {
+function shouldDisplayStorageAlert(reason) {
+  if (!reason) {
+    return true;
+  }
+
+  if (reason === 'migration-read') {
+    if (typeof safeLocalStorageInfo !== 'undefined' && safeLocalStorageInfo) {
+      if (safeLocalStorageInfo.type && safeLocalStorageInfo.type !== 'memory') {
+        return false;
+      }
+    }
+  }
+
+  return true;
+}
+
+function alertStorageError(reason) {
+  if (!shouldDisplayStorageAlert(reason)) {
+    return;
+  }
+
   if (GLOBAL_SCOPE && typeof GLOBAL_SCOPE[STORAGE_ALERT_FLAG_NAME] === 'boolean') {
     storageErrorAlertShown = GLOBAL_SCOPE[STORAGE_ALERT_FLAG_NAME];
   }

--- a/src/scripts/storage.js
+++ b/src/scripts/storage.js
@@ -659,7 +659,27 @@ function isPlainObject(val) {
   return val !== null && typeof val === 'object' && !Array.isArray(val);
 }
 
-function alertStorageError() {
+function shouldDisplayStorageAlert(reason) {
+  if (!reason) {
+    return true;
+  }
+
+  if (reason === 'migration-read') {
+    if (typeof safeLocalStorageInfo !== 'undefined' && safeLocalStorageInfo) {
+      if (safeLocalStorageInfo.type && safeLocalStorageInfo.type !== 'memory') {
+        return false;
+      }
+    }
+  }
+
+  return true;
+}
+
+function alertStorageError(reason) {
+  if (!shouldDisplayStorageAlert(reason)) {
+    return;
+  }
+
   if (GLOBAL_SCOPE && typeof GLOBAL_SCOPE[STORAGE_ALERT_FLAG_NAME] === 'boolean') {
     storageErrorAlertShown = GLOBAL_SCOPE[STORAGE_ALERT_FLAG_NAME];
   }


### PR DESCRIPTION
## Summary
- avoid showing the storage emergency alert during migration reads when a compatible storage backend is still available
- mirror the suppression logic in the legacy bundle to keep behaviour in sync

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cf1672c9a48320a980fe04a7ef75fb