### PR TITLE
Darken pink mode logo accent

### DIFF
--- a/src/scripts/static-theme.js
+++ b/src/scripts/static-theme.js
@@ -34,6 +34,8 @@
     } else {
       root.style.setProperty('--link-color', color);
     }
+    root.style.setProperty('--logo-background-color', accentValue);
+    root.style.setProperty('--logo-accent-color', accentValue);
 
     if (body) {
       body.style.setProperty('--accent-color', accentValue);
@@ -42,6 +44,8 @@
       } else {
         body.style.setProperty('--link-color', color);
       }
+      body.style.setProperty('--logo-background-color', accentValue);
+      body.style.setProperty('--logo-accent-color', accentValue);
     }
   }
 
@@ -91,6 +95,10 @@
       root.style.removeProperty('--link-color');
       body.style.removeProperty('--accent-color');
       body.style.removeProperty('--link-color');
+      root.style.removeProperty('--logo-background-color');
+      root.style.removeProperty('--logo-accent-color');
+      body.style.removeProperty('--logo-background-color');
+      body.style.removeProperty('--logo-accent-color');
     } else {
       applyAccent(accentColor, root, body);
     }

--- a/src/scripts/storage.js
+++ b/src/scripts/storage.js
@@ -1,5 +1,5 @@
 // storage.js - Handles reading from and writing to localStorage.
-/* global texts, currentLang */
+/* global texts, currentLang, SAFE_LOCAL_STORAGE */
 
 const GLOBAL_SCOPE =
   typeof globalThis !== 'undefined'

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -119,8 +119,8 @@ body.pink-mode {
   --accent-color: #ff69b4;
   --link-color: #ff69b4;
   --icon-color: var(--accent-color);
-  --logo-accent-color: var(--accent-color);
-  --logo-background-color: var(--accent-color);
+  --logo-accent-color: #f255a8;
+  --logo-background-color: #f255a8;
   --logo-center-color: #ffffff;
 }
 


### PR DESCRIPTION
## Summary
- update the pink mode logo accent and background color to a richer #f255a8 shade
- extend static theme initialization to propagate accent-driven logo colors and clear overrides when relying on pink defaults
- declare the SAFE_LOCAL_STORAGE global so linting continues to pass

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cf186848108320b292f3d14eac9b81