### PR TITLE
Align script tests with aggregated UI preference storage

### DIFF
--- a/src/scripts/overview.js
+++ b/src/scripts/overview.js
@@ -1,4 +1,4 @@
-/* global currentLang, texts, devices, escapeHtml, generateConnectorSummary, cameraSelect, monitorSelect, videoSelect, distanceSelect, motorSelects, controllerSelects, batterySelect, hotswapSelect, overviewSectionIcons, breakdownListElem, totalPowerElem, totalCurrent144Elem, totalCurrent12Elem, batteryLifeElem, batteryCountElem, pinWarnElem, dtapWarnElem, getSelectedPlate, supportsBMountCamera, supportsGoldMountCamera, getCurrentGearListHtml, currentProjectInfo, generateGearListHtml, setupDiagramContainer, diagramLegend, diagramHint, getDiagramCss, openDialog, closeDialog, splitGearListHtml, getCssVariableValue, iconMarkup */
+/* global currentLang, texts, devices, escapeHtml, generateConnectorSummary, cameraSelect, monitorSelect, videoSelect, distanceSelect, motorSelects, controllerSelects, batterySelect, hotswapSelect, overviewSectionIcons, breakdownListElem, totalPowerElem, totalCurrent144Elem, totalCurrent12Elem, batteryLifeElem, batteryCountElem, pinWarnElem, dtapWarnElem, getSelectedPlate, supportsBMountCamera, supportsGoldMountCamera, getCurrentGearListHtml, currentProjectInfo, generateGearListHtml, setupDiagramContainer, diagramLegend, diagramHint, getDiagramCss, openDialog, closeDialog, splitGearListHtml, getCssVariableValue, iconMarkup, getUiPreference */
 
 const getCssVarValue = (typeof getCssVariableValue === 'function'
     ? getCssVariableValue
@@ -25,7 +25,7 @@ function generatePrintableOverview() {
     const locale = localeMap[lang] || 'en-US';
     const dateTimeString = now.toLocaleDateString(locale) + ' ' + now.toLocaleTimeString();
     const t = (typeof texts === 'object' && texts) ? (texts[lang] || texts.en || {}) : {};
-    const customLogo = typeof localStorage !== 'undefined' ? localStorage.getItem('customLogo') : null;
+    const customLogo = typeof getUiPreference === 'function' ? getUiPreference('customLogo') : null;
 
     let deviceListHtml = '<div class="device-category-container">';
     const sections = {};

--- a/tests/script/autoGearRules.test.js
+++ b/tests/script/autoGearRules.test.js
@@ -1,3 +1,4 @@
+/* global getUiPreference */
 const { setupScriptEnvironment } = require('../helpers/scriptEnvironment');
 
 const STORAGE_KEY = 'cameraPowerPlanner_autoGearRules';
@@ -774,8 +775,8 @@ describe('applyAutoGearRulesToTableHtml', () => {
     try {
       restoreInput.dispatchEvent(new Event('change'));
 
-      expect(localStorage.getItem('language')).toBe('es');
-      expect(localStorage.getItem('darkMode')).toBe('true');
+      expect(getUiPreference('language')).toBe('es');
+      expect(getUiPreference('darkMode')).toBe('true');
       expect(sessionStorage.getItem('cameraPowerPlanner_session')).toBe(
         JSON.stringify({ activeSetup: 'Legacy' }),
       );

--- a/tests/script/backupAutomation.test.js
+++ b/tests/script/backupAutomation.test.js
@@ -1,6 +1,8 @@
 const fs = require('fs');
 const path = require('path');
 
+const { createUiPreferenceStubs } = require('../helpers/scriptEnvironment');
+
 defaultDeviceSetup();
 
 function defaultDeviceSetup() {
@@ -60,6 +62,16 @@ const loadApp = () => {
   global.importAllData = jest.fn();
   global.clearAllData = jest.fn();
   global.showNotification = jest.fn();
+
+  const uiPreferenceStubs = createUiPreferenceStubs();
+  window.getUiPreference = uiPreferenceStubs.getUiPreference;
+  window.setUiPreference = uiPreferenceStubs.setUiPreference;
+  window.removeUiPreference = uiPreferenceStubs.removeUiPreference;
+  window.clearUiPreferences = uiPreferenceStubs.clearUiPreferences;
+  global.getUiPreference = window.getUiPreference;
+  global.setUiPreference = window.setUiPreference;
+  global.removeUiPreference = window.removeUiPreference;
+  global.clearUiPreferences = window.clearUiPreferences;
 
   return require('../../src/scripts/script.js');
 };

--- a/tests/script/dark-accent-boost.test.js
+++ b/tests/script/dark-accent-boost.test.js
@@ -1,4 +1,13 @@
-const { setupScriptEnvironment } = require('../helpers/scriptEnvironment');
+const {
+  setupScriptEnvironment,
+  UI_PREFERENCES_STORAGE_KEY,
+} = require('../helpers/scriptEnvironment');
+
+function seedUiPreferences(preferences) {
+  const payload = JSON.stringify(preferences);
+  localStorage.setItem(UI_PREFERENCES_STORAGE_KEY, payload);
+  localStorage.setItem(`${UI_PREFERENCES_STORAGE_KEY}__backup`, payload);
+}
 
 describe('dark accent boost for bright custom colors', () => {
   let cleanup;
@@ -12,8 +21,10 @@ describe('dark accent boost for bright custom colors', () => {
   });
 
   test('enables boost when custom accent brightness is similar to pink in dark mode', () => {
-    localStorage.setItem('accentColor', '#ff6ab5');
-    localStorage.setItem('darkMode', 'true');
+    seedUiPreferences({
+      accentColor: '#ff6ab5',
+      darkMode: 'true',
+    });
 
     const { cleanup: clean } = setupScriptEnvironment();
     cleanup = clean;
@@ -24,8 +35,10 @@ describe('dark accent boost for bright custom colors', () => {
   });
 
   test('enables boost for bright custom accents in dark mode', () => {
-    localStorage.setItem('accentColor', '#ffee58');
-    localStorage.setItem('darkMode', 'true');
+    seedUiPreferences({
+      accentColor: '#ffee58',
+      darkMode: 'true',
+    });
 
     const { cleanup: clean } = setupScriptEnvironment();
     cleanup = clean;
@@ -36,8 +49,10 @@ describe('dark accent boost for bright custom colors', () => {
   });
 
   test('removes boost when accent color changes to a darker tone', () => {
-    localStorage.setItem('accentColor', '#ff6ab5');
-    localStorage.setItem('darkMode', 'true');
+    seedUiPreferences({
+      accentColor: '#ff6ab5',
+      darkMode: 'true',
+    });
 
     const { cleanup: clean } = setupScriptEnvironment();
     cleanup = clean;
@@ -52,8 +67,10 @@ describe('dark accent boost for bright custom colors', () => {
   });
 
   test('removes boost when leaving dark mode', () => {
-    localStorage.setItem('accentColor', '#ff6ab5');
-    localStorage.setItem('darkMode', 'true');
+    seedUiPreferences({
+      accentColor: '#ff6ab5',
+      darkMode: 'true',
+    });
 
     const { cleanup: clean } = setupScriptEnvironment();
     cleanup = clean;
@@ -68,8 +85,10 @@ describe('dark accent boost for bright custom colors', () => {
   });
 
   test('does not enable boost in light mode even with bright accent colors', () => {
-    localStorage.setItem('accentColor', '#ffee58');
-    localStorage.setItem('darkMode', 'false');
+    seedUiPreferences({
+      accentColor: '#ffee58',
+      darkMode: 'false',
+    });
 
     const { cleanup: clean } = setupScriptEnvironment();
     cleanup = clean;

--- a/tests/script/featureSearch.test.js
+++ b/tests/script/featureSearch.test.js
@@ -1,6 +1,8 @@
 const fs = require('fs');
 const path = require('path');
 
+const { createUiPreferenceStubs } = require('../helpers/scriptEnvironment');
+
 const loadScript = () => {
   jest.resetModules();
 
@@ -52,6 +54,16 @@ const loadScript = () => {
   global.saveFavorites = jest.fn();
   global.exportAllData = jest.fn();
   global.importAllData = jest.fn();
+
+  const uiPreferenceStubs = createUiPreferenceStubs();
+  window.getUiPreference = uiPreferenceStubs.getUiPreference;
+  window.setUiPreference = uiPreferenceStubs.setUiPreference;
+  window.removeUiPreference = uiPreferenceStubs.removeUiPreference;
+  window.clearUiPreferences = uiPreferenceStubs.clearUiPreferences;
+  global.getUiPreference = window.getUiPreference;
+  global.setUiPreference = window.setUiPreference;
+  global.removeUiPreference = window.removeUiPreference;
+  global.clearUiPreferences = window.clearUiPreferences;
 
   return require('../../src/scripts/script.js');
 };

--- a/tests/script/helpers/loadApp.js
+++ b/tests/script/helpers/loadApp.js
@@ -1,6 +1,8 @@
 const fs = require('fs');
 const path = require('path');
 
+const { createUiPreferenceStubs } = require('../../helpers/scriptEnvironment');
+
 function ensureTestDom() {
   if (typeof window.matchMedia !== 'function') {
     window.matchMedia = () => ({
@@ -56,6 +58,16 @@ function loadApp() {
   global.importAllData = jest.fn();
   global.clearAllData = jest.fn();
   global.showNotification = jest.fn();
+
+  const uiPreferenceStubs = createUiPreferenceStubs();
+  window.getUiPreference = uiPreferenceStubs.getUiPreference;
+  window.setUiPreference = uiPreferenceStubs.setUiPreference;
+  window.removeUiPreference = uiPreferenceStubs.removeUiPreference;
+  window.clearUiPreferences = uiPreferenceStubs.clearUiPreferences;
+  global.getUiPreference = window.getUiPreference;
+  global.setUiPreference = window.setUiPreference;
+  global.removeUiPreference = window.removeUiPreference;
+  global.clearUiPreferences = window.clearUiPreferences;
 
   return require('../../../src/scripts/script.js');
 }

--- a/tests/script/settings-theme.test.js
+++ b/tests/script/settings-theme.test.js
@@ -1,22 +1,36 @@
-const { setupScriptEnvironment } = require('../helpers/scriptEnvironment');
+const {
+  setupScriptEnvironment,
+  UI_PREFERENCES_STORAGE_KEY,
+} = require('../helpers/scriptEnvironment');
+
+function seedUiPreferences(preferences) {
+  const payload = JSON.stringify(preferences);
+  localStorage.setItem(UI_PREFERENCES_STORAGE_KEY, payload);
+  localStorage.setItem(`${UI_PREFERENCES_STORAGE_KEY}__backup`, payload);
+}
 
 describe('settings dialog theme interactions', () => {
   let cleanup;
+  let globals;
 
   afterEach(() => {
     if (typeof cleanup === 'function') {
       cleanup();
       cleanup = undefined;
     }
+    globals = undefined;
     localStorage.clear();
   });
 
   test('closing settings keeps custom accent overrides while pink mode stays active', () => {
-    localStorage.setItem('pinkMode', 'true');
-    localStorage.setItem('accentColor', '#ff8800');
+    seedUiPreferences({
+      pinkMode: 'true',
+      accentColor: '#ff8800',
+    });
 
-    const { cleanup: clean } = setupScriptEnvironment();
+    const { cleanup: clean, globals: stubs } = setupScriptEnvironment();
     cleanup = clean;
+    globals = stubs;
 
     expect(document.body.classList.contains('pink-mode')).toBe(true);
 
@@ -37,10 +51,11 @@ describe('settings dialog theme interactions', () => {
   });
 
   test('pink mode without custom accent continues to rely on theme defaults', () => {
-    localStorage.setItem('pinkMode', 'true');
+    seedUiPreferences({ pinkMode: 'true' });
 
-    const { cleanup: clean } = setupScriptEnvironment();
+    const { cleanup: clean, globals: stubs } = setupScriptEnvironment();
     cleanup = clean;
+    globals = stubs;
 
     expect(document.body.classList.contains('pink-mode')).toBe(true);
 
@@ -60,10 +75,11 @@ describe('settings dialog theme interactions', () => {
   });
 
   test('pink mode can be toggled from settings dialog', () => {
-    localStorage.setItem('pinkMode', 'false');
+    seedUiPreferences({ pinkMode: 'false' });
 
-    const { cleanup: clean } = setupScriptEnvironment();
+    const { cleanup: clean, globals: stubs } = setupScriptEnvironment();
     cleanup = clean;
+    globals = stubs;
 
     expect(document.body.classList.contains('pink-mode')).toBe(false);
 
@@ -83,14 +99,15 @@ describe('settings dialog theme interactions', () => {
     settingsSave.click();
 
     expect(document.body.classList.contains('pink-mode')).toBe(true);
-    expect(localStorage.getItem('pinkMode')).toBe('true');
+    expect(globals.getUiPreference('pinkMode')).toBe('true');
   });
 
   test('pink mode toggles auto-save from settings dialog', () => {
-    localStorage.setItem('pinkMode', 'false');
+    seedUiPreferences({ pinkMode: 'false' });
 
-    const { cleanup: clean } = setupScriptEnvironment();
+    const { cleanup: clean, globals: stubs } = setupScriptEnvironment();
     cleanup = clean;
+    globals = stubs;
 
     const settingsButton = document.getElementById('settingsButton');
     const settingsPinkMode = document.getElementById('settingsPinkMode');
@@ -106,20 +123,21 @@ describe('settings dialog theme interactions', () => {
     settingsPinkMode.dispatchEvent(new Event('change', { bubbles: true }));
 
     expect(document.body.classList.contains('pink-mode')).toBe(true);
-    expect(localStorage.getItem('pinkMode')).toBe('true');
+    expect(globals.getUiPreference('pinkMode')).toBe('true');
 
     settingsPinkMode.checked = false;
     settingsPinkMode.dispatchEvent(new Event('change', { bubbles: true }));
 
     expect(document.body.classList.contains('pink-mode')).toBe(false);
-    expect(localStorage.getItem('pinkMode')).toBe('false');
+    expect(globals.getUiPreference('pinkMode')).toBe('false');
   });
 
   test('pink mode auto-save can be reverted by cancelling settings', () => {
-    localStorage.setItem('pinkMode', 'false');
+    seedUiPreferences({ pinkMode: 'false' });
 
-    const { cleanup: clean } = setupScriptEnvironment();
+    const { cleanup: clean, globals: stubs } = setupScriptEnvironment();
     cleanup = clean;
+    globals = stubs;
 
     const settingsButton = document.getElementById('settingsButton');
     const settingsPinkMode = document.getElementById('settingsPinkMode');
@@ -137,19 +155,20 @@ describe('settings dialog theme interactions', () => {
     settingsPinkMode.dispatchEvent(new Event('change', { bubbles: true }));
 
     expect(document.body.classList.contains('pink-mode')).toBe(true);
-    expect(localStorage.getItem('pinkMode')).toBe('true');
+    expect(globals.getUiPreference('pinkMode')).toBe('true');
 
     settingsCancel.click();
 
     expect(document.body.classList.contains('pink-mode')).toBe(false);
-    expect(localStorage.getItem('pinkMode')).toBe('false');
+    expect(globals.getUiPreference('pinkMode')).toBe('false');
   });
 
   test('pink mode auto-save can be reverted when closing with escape', () => {
-    localStorage.setItem('pinkMode', 'false');
+    seedUiPreferences({ pinkMode: 'false' });
 
-    const { cleanup: clean } = setupScriptEnvironment();
+    const { cleanup: clean, globals: stubs } = setupScriptEnvironment();
     cleanup = clean;
+    globals = stubs;
 
     const settingsButton = document.getElementById('settingsButton');
     const settingsPinkMode = document.getElementById('settingsPinkMode');
@@ -163,11 +182,11 @@ describe('settings dialog theme interactions', () => {
     settingsPinkMode.dispatchEvent(new Event('change', { bubbles: true }));
 
     expect(document.body.classList.contains('pink-mode')).toBe(true);
-    expect(localStorage.getItem('pinkMode')).toBe('true');
+    expect(globals.getUiPreference('pinkMode')).toBe('true');
 
     document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
 
     expect(document.body.classList.contains('pink-mode')).toBe(false);
-    expect(localStorage.getItem('pinkMode')).toBe('false');
+    expect(globals.getUiPreference('pinkMode')).toBe('false');
   });
 });

--- a/tests/script/static-theme.test.js
+++ b/tests/script/static-theme.test.js
@@ -1,5 +1,7 @@
 const path = require('path');
 
+const UI_PREFERENCES_STORAGE_KEY = 'cameraPowerPlanner_uiPreferences';
+
 describe('static theme preferences', () => {
   let readyStateValue;
   let originalReadyStateDescriptor;
@@ -53,12 +55,17 @@ describe('static theme preferences', () => {
   };
 
   test('applies stored theme preferences immediately when DOM is ready', () => {
-    localStorage.setItem('highContrast', 'true');
-    localStorage.setItem('pinkMode', 'false');
-    localStorage.setItem('fontSize', '18');
-    localStorage.setItem('fontFamily', 'Atkinson Hyperlegible');
-    localStorage.setItem('darkMode', 'true');
-    localStorage.setItem('accentColor', '#ff8800');
+    const preferences = {
+      highContrast: 'true',
+      pinkMode: 'false',
+      fontSize: '18',
+      fontFamily: 'Atkinson Hyperlegible',
+      darkMode: 'true',
+      accentColor: '#ff8800',
+    };
+    const payload = JSON.stringify(preferences);
+    localStorage.setItem(UI_PREFERENCES_STORAGE_KEY, payload);
+    localStorage.setItem(`${UI_PREFERENCES_STORAGE_KEY}__backup`, payload);
 
     loadStaticTheme();
 
@@ -119,12 +126,10 @@ describe('static theme preferences', () => {
   });
 
   test('retains stored custom accent when pink mode is enabled', () => {
+    const payload = JSON.stringify({ pinkMode: 'true', accentColor: '#ff8800' });
     localStorage.getItem.mockImplementation(key => {
-      if (key === 'pinkMode') {
-        return 'true';
-      }
-      if (key === 'accentColor') {
-        return '#ff8800';
+      if (key === UI_PREFERENCES_STORAGE_KEY) {
+        return payload;
       }
       return null;
     });

--- a/tests/unit/storage.test.js
+++ b/tests/unit/storage.test.js
@@ -51,6 +51,9 @@ const {
   saveAutoGearAutoPresetId,
   loadAutoGearBackupVisibility,
   saveAutoGearBackupVisibility,
+  getUiPreference,
+  setUiPreference,
+  clearUiPreferences,
 } = require('../../src/scripts/storage');
 
 const DEVICE_KEY = 'cameraPowerPlanner_devices';
@@ -69,6 +72,7 @@ const AUTO_GEAR_AUTO_PRESET_KEY = 'cameraPowerPlanner_autoGearAutoPreset';
 const AUTO_GEAR_BACKUP_VISIBILITY_KEY = 'cameraPowerPlanner_autoGearShowBackups';
 const CUSTOM_FONT_KEY = 'cameraPowerPlanner_customFonts';
 const CUSTOM_LOGO_KEY = 'customLogo';
+const UI_PREFERENCES_KEY = 'cameraPowerPlanner_uiPreferences';
 
 const BACKUP_SUFFIX = '__backup';
 const backupKeyFor = (key) => `${key}${BACKUP_SUFFIX}`;
@@ -387,6 +391,7 @@ describe('session state storage', () => {
   beforeEach(() => {
     localStorage.clear();
     sessionStorage.clear();
+    clearUiPreferences({ includeLegacy: true });
   });
 
   test('saveSessionState stores JSON in localStorage', () => {
@@ -636,6 +641,7 @@ describe('clearAllData', () => {
   beforeEach(() => {
     localStorage.clear();
     sessionStorage.clear();
+    clearUiPreferences({ includeLegacy: true });
   });
 
   test('removes all stored planner data', () => {
@@ -657,14 +663,12 @@ describe('clearAllData', () => {
     saveAutoGearAutoPresetId('preset-auto');
     saveAutoGearBackupVisibility(true);
     localStorage.setItem(SCHEMA_CACHE_KEY, JSON.stringify({ cached: true }));
-    localStorage.setItem(CUSTOM_LOGO_KEY, 'data:image/svg+xml;base64,AAAA');
-    localStorage.setItem(backupKeyFor(CUSTOM_LOGO_KEY), 'data:image/svg+xml;base64,AAAA');
-    localStorage.setItem(
+    setUiPreference('darkMode', true);
+    setUiPreference('accentColor', '#abcdef');
+    setUiPreference('language', 'es');
+    setUiPreference(CUSTOM_LOGO_KEY, 'data:image/svg+xml;base64,AAAA');
+    setUiPreference(
       CUSTOM_FONT_KEY,
-      JSON.stringify([{ id: 'font-1', name: 'My Font', data: 'data:font/woff;base64,BBBB' }]),
-    );
-    localStorage.setItem(
-      backupKeyFor(CUSTOM_FONT_KEY),
       JSON.stringify([{ id: 'font-1', name: 'My Font', data: 'data:font/woff;base64,BBBB' }]),
     );
     clearAllData();
@@ -682,8 +686,13 @@ describe('clearAllData', () => {
     expect(localStorage.getItem(AUTO_GEAR_AUTO_PRESET_KEY)).toBeNull();
     expect(localStorage.getItem(AUTO_GEAR_BACKUP_VISIBILITY_KEY)).toBeNull();
     expect(localStorage.getItem(SCHEMA_CACHE_KEY)).toBeNull();
-    expect(localStorage.getItem(CUSTOM_LOGO_KEY)).toBeNull();
-    expect(localStorage.getItem(CUSTOM_FONT_KEY)).toBeNull();
+    expect(getUiPreference('darkMode')).toBeNull();
+    expect(getUiPreference('accentColor')).toBeNull();
+    expect(getUiPreference('language')).toBeNull();
+    expect(getUiPreference(CUSTOM_LOGO_KEY)).toBeNull();
+    expect(getUiPreference(CUSTOM_FONT_KEY)).toBeNull();
+    expect(localStorage.getItem(UI_PREFERENCES_KEY)).toBeNull();
+    expect(localStorage.getItem(`${UI_PREFERENCES_KEY}__backup`)).toBeNull();
 
     expect(localStorage.getItem(backupKeyFor(DEVICE_KEY))).toBeNull();
     expect(localStorage.getItem(backupKeyFor(SETUP_KEY))).toBeNull();
@@ -703,6 +712,7 @@ describe('export/import all data', () => {
   beforeEach(() => {
     localStorage.clear();
     sessionStorage.clear();
+    clearUiPreferences({ includeLegacy: true });
   });
 
     test('exportAllData collects all planner data', () => {
@@ -712,17 +722,17 @@ describe('export/import all data', () => {
       saveFeedback({ note: 'hi' });
       saveProject('Proj', { gearList: '<ul></ul>' });
       saveFavorites({ cat: ['A'] });
-      localStorage.setItem('darkMode', 'true');
-      localStorage.setItem('pinkMode', 'true');
-      localStorage.setItem('highContrast', 'true');
-      localStorage.setItem('showAutoBackups', 'true');
-      localStorage.setItem('accentColor', '#ff00ff');
-      localStorage.setItem('fontSize', '18');
-      localStorage.setItem('fontFamily', "'My Font', sans-serif");
-      localStorage.setItem('language', 'de');
-      localStorage.setItem('customLogo', 'data:image/svg+xml;base64,PHN2Zw==');
-      localStorage.setItem(
-        'cameraPowerPlanner_customFonts',
+      setUiPreference('darkMode', true);
+      setUiPreference('pinkMode', true);
+      setUiPreference('highContrast', true);
+      setUiPreference('showAutoBackups', true);
+      setUiPreference('accentColor', '#ff00ff');
+      setUiPreference('fontSize', '18');
+      setUiPreference('fontFamily', "'My Font', sans-serif");
+      setUiPreference('language', 'de');
+      setUiPreference('customLogo', 'data:image/svg+xml;base64,PHN2Zw==');
+      setUiPreference(
+        CUSTOM_FONT_KEY,
         JSON.stringify([
           { id: 'font-1', name: 'My Font', data: 'data:font/woff;base64,AAAA' }
         ]),
@@ -827,18 +837,18 @@ describe('export/import all data', () => {
     expect(loadAutoGearActivePresetId()).toBe('preset-restore');
     expect(loadAutoGearAutoPresetId()).toBe('preset-restore');
       expect(loadAutoGearBackupVisibility()).toBe(true);
-      expect(localStorage.getItem('customLogo')).toBe('data:image/svg+xml;base64,PE1PQ0s+');
-      expect(localStorage.getItem('darkMode')).toBe('true');
-      expect(localStorage.getItem('pinkMode')).toBe('false');
-      expect(localStorage.getItem('highContrast')).toBe('true');
-      expect(localStorage.getItem('showAutoBackups')).toBe('true');
-      expect(localStorage.getItem('accentColor')).toBe('#00ff00');
-      expect(localStorage.getItem('fontSize')).toBe('20');
-      expect(localStorage.getItem('fontFamily')).toBe("'Other Font', serif");
-    expect(localStorage.getItem('language')).toBe('fr');
-    expect(JSON.parse(localStorage.getItem('cameraPowerPlanner_customFonts'))).toEqual([
-      { id: 'font-restore', name: 'Restore Font', data: 'data:font/woff;base64,BBBB' }
-    ]);
+      expect(getUiPreference('customLogo')).toBe('data:image/svg+xml;base64,PE1PQ0s+');
+      expect(getUiPreference('darkMode')).toBe('true');
+      expect(getUiPreference('pinkMode')).toBe('false');
+      expect(getUiPreference('highContrast')).toBe('true');
+      expect(getUiPreference('showAutoBackups')).toBe('true');
+      expect(getUiPreference('accentColor')).toBe('#00ff00');
+      expect(getUiPreference('fontSize')).toBe('20');
+      expect(getUiPreference('fontFamily')).toBe("'Other Font', serif");
+      expect(getUiPreference('language')).toBe('fr');
+      expect(JSON.parse(getUiPreference(CUSTOM_FONT_KEY))).toEqual([
+        { id: 'font-restore', name: 'Restore Font', data: 'data:font/woff;base64,BBBB' }
+      ]);
   });
 
   test('importAllData clears stored device overrides when payload sets devices to null', () => {


### PR DESCRIPTION
## Summary
- extract reusable UI preference stubs from `setupScriptEnvironment` and export the UI preference storage key for tests
- update script tests to seed aggregated UI preferences and assert changes through the helper stubs instead of raw `localStorage`
- ensure helper environments (feature search, backups, factory reset) install the UI preference stubs before loading the app

## Testing
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68cf1344948c83208beef0c7f7f3bd2a