### PR TITLE
Add missing Ultra Prime lens metadata

### DIFF
--- a/legacy/data/devices/gearList.js
+++ b/legacy/data/devices/gearList.js
@@ -2293,10 +2293,14 @@ function _arrayWithHoles(r) { if (Array.isArray(r)) return r; }
           "frontDiameterMm": 95,
           "clampOn": true,
           "tStop": 1.9,
+          "mount": "PL",
           "rodStandard": "15mm",
           "rodLengthCm": 30,
           "needsLensSupport": false,
-          "lensType": "spherical"
+          "lensType": "spherical",
+          "minFocusMeters": 0.38,
+          "weight_g": 1000,
+          "lengthMm": 91
         },
         "ARRI/ZEISS Ultra Prime 50mm T1.9": {
           "brand": "ARRI/ZEISS",
@@ -2309,17 +2313,22 @@ function _arrayWithHoles(r) { if (Array.isArray(r)) return r; }
           "needsLensSupport": false,
           "lensType": "spherical",
           "minFocusMeters": 0.6,
-          "weight_g": 1000
+          "weight_g": 1000,
+          "lengthMm": 91
         },
         "ARRI/ZEISS Ultra Prime 65mm T1.9": {
           "brand": "ARRI/ZEISS",
           "frontDiameterMm": 95,
           "clampOn": true,
           "tStop": 1.9,
+          "mount": "PL",
           "rodStandard": "15mm",
           "rodLengthCm": 30,
           "needsLensSupport": false,
-          "lensType": "spherical"
+          "lensType": "spherical",
+          "minFocusMeters": 0.65,
+          "weight_g": 1100,
+          "lengthMm": 91
         },
         "ARRI/ZEISS Ultra Prime 85mm T1.9": {
           "brand": "ARRI/ZEISS",
@@ -2340,10 +2349,28 @@ function _arrayWithHoles(r) { if (Array.isArray(r)) return r; }
           "frontDiameterMm": 95,
           "clampOn": true,
           "tStop": 1.9,
+          "mount": "PL",
           "rodStandard": "15mm",
           "rodLengthCm": 30,
           "needsLensSupport": false,
-          "lensType": "spherical"
+          "lensType": "spherical",
+          "minFocusMeters": 1,
+          "weight_g": 1200,
+          "lengthMm": 91
+        },
+        "ARRI/ZEISS Ultra Prime 135mm T1.9": {
+          "brand": "ARRI/ZEISS",
+          "frontDiameterMm": 95,
+          "clampOn": true,
+          "tStop": 1.9,
+          "mount": "PL",
+          "rodStandard": "15mm",
+          "rodLengthCm": 30,
+          "needsLensSupport": false,
+          "lensType": "spherical",
+          "minFocusMeters": 1.5,
+          "weight_g": 1600,
+          "lengthMm": 119
         },
         "ZEISS Master Prime 12mm T1.3": {
           "brand": "ZEISS/ARRI",

--- a/src/data/devices/gearList.js
+++ b/src/data/devices/gearList.js
@@ -2838,10 +2838,14 @@ const gear = {
           "frontDiameterMm": 95,
           "clampOn": true,
           "tStop": 1.9,
+          "mount": "PL",
           "rodStandard": "15mm",
           "rodLengthCm": 30,
           "needsLensSupport": false,
-          "lensType": "spherical"
+          "lensType": "spherical",
+          "minFocusMeters": 0.38,
+          "weight_g": 1000,
+          "lengthMm": 91
         },
         "ARRI/ZEISS Ultra Prime 50mm T1.9": {
           "brand": "ARRI/ZEISS",
@@ -2854,17 +2858,22 @@ const gear = {
           "needsLensSupport": false,
           "lensType": "spherical",
           "minFocusMeters": 0.6,
-          "weight_g": 1000
+          "weight_g": 1000,
+          "lengthMm": 91
         },
         "ARRI/ZEISS Ultra Prime 65mm T1.9": {
           "brand": "ARRI/ZEISS",
           "frontDiameterMm": 95,
           "clampOn": true,
           "tStop": 1.9,
+          "mount": "PL",
           "rodStandard": "15mm",
           "rodLengthCm": 30,
           "needsLensSupport": false,
-          "lensType": "spherical"
+          "lensType": "spherical",
+          "minFocusMeters": 0.65,
+          "weight_g": 1100,
+          "lengthMm": 91
         },
         "ARRI/ZEISS Ultra Prime 85mm T1.9": {
           "brand": "ARRI/ZEISS",
@@ -2885,16 +2894,35 @@ const gear = {
           "frontDiameterMm": 95,
           "clampOn": true,
           "tStop": 1.9,
+          "mount": "PL",
           "rodStandard": "15mm",
           "rodLengthCm": 30,
           "needsLensSupport": false,
-          "lensType": "spherical"
+          "lensType": "spherical",
+          "minFocusMeters": 1,
+          "weight_g": 1200,
+          "lengthMm": 91
+        },
+        "ARRI/ZEISS Ultra Prime 135mm T1.9": {
+          "brand": "ARRI/ZEISS",
+          "frontDiameterMm": 95,
+          "clampOn": true,
+          "tStop": 1.9,
+          "mount": "PL",
+          "rodStandard": "15mm",
+          "rodLengthCm": 30,
+          "needsLensSupport": false,
+          "lensType": "spherical",
+          "minFocusMeters": 1.5,
+          "weight_g": 1600,
+          "lengthMm": 119
         },
         "ARRI/ZEISS Ultra Prime 180mm T1.9": {
           "brand": "ARRI/ZEISS",
           "frontDiameterMm": 114,
           "clampOn": true,
           "tStop": 1.9,
+          "mount": "PL",
           "rodStandard": "15mm",
           "rodLengthCm": 30,
           "needsLensSupport": false,


### PR DESCRIPTION
## Summary
- add missing mount, focus, weight, and length metadata for ARRI/ZEISS Ultra Prime mid-range primes
- add the 135mm Ultra Prime entry to the main and legacy gear lists
- ensure the 180mm Ultra Prime includes mount information

## Testing
- npm run check-consistency

------
https://chatgpt.com/codex/tasks/task_e_68cf1a15cac8832082ab1ef61238605d