### PR TITLE
Prefer native clear control for feature search

### DIFF
--- a/index.html
+++ b/index.html
@@ -66,16 +66,6 @@
     <div class="feature-search">
       <div id="featureSearchContainer">
         <input type="search" id="featureSearch" list="featureList" placeholder="Search features or devices..." aria-label="Search features, devices and help" />
-        <button
-          id="featureSearchClear"
-          class="clear-input-btn"
-          type="button"
-          aria-label="Clear search"
-          title="Clear search"
-          hidden
-        >
-          <span class="icon-glyph" aria-hidden="true" data-icon-font="essential">&#xF131;</span>
-        </button>
       </div>
       <datalist id="featureList"></datalist>
     </div>

--- a/legacy/scripts/script.js
+++ b/legacy/scripts/script.js
@@ -3476,11 +3476,6 @@ function setLanguage(lang) {
     featureSearch.setAttribute("aria-label", texts[lang].featureSearchLabel);
     featureSearch.setAttribute("data-help", texts[lang].featureSearchHelp || texts[lang].featureSearchLabel);
   }
-  if (featureSearchClear) {
-    featureSearchClear.setAttribute("title", texts[lang].featureSearchClear);
-    featureSearchClear.setAttribute("aria-label", texts[lang].featureSearchClear);
-    featureSearchClear.setAttribute("data-help", texts[lang].featureSearchClearHelp || texts[lang].featureSearchClear);
-  }
   if (helpButton) {
     helpButton.setAttribute("title", texts[lang].helpButtonTitle || texts[lang].helpButtonLabel);
     helpButton.setAttribute("aria-label", texts[lang].helpButtonLabel);
@@ -8384,7 +8379,6 @@ var supportLink = document.getElementById("supportLink");
 var settingsSave = document.getElementById("settingsSave");
 var settingsCancel = document.getElementById("settingsCancel");
 var featureSearch = document.getElementById("featureSearch");
-var featureSearchClear = document.getElementById("featureSearchClear");
 var featureList = document.getElementById("featureList");
 var featureMap = new Map();
 var normalizeSearchValue = function normalizeSearchValue(value) {
@@ -21756,37 +21750,15 @@ if (helpButton && helpDialog) {
     featureSearch.addEventListener('input', function () {
       var _featureSearch$showPi2;
       (_featureSearch$showPi2 = featureSearch.showPicker) === null || _featureSearch$showPi2 === void 0 || _featureSearch$showPi2.call(featureSearch);
-      if (featureSearchClear) {
-        if (featureSearch.value) {
-          featureSearchClear.removeAttribute('hidden');
-        } else {
-          featureSearchClear.setAttribute('hidden', '');
-        }
-      }
     });
     featureSearch.addEventListener('keydown', function (e) {
       if (e.key === 'Enter') {
         handle();
       } else if (e.key === 'Escape' && featureSearch.value) {
         featureSearch.value = '';
-        if (featureSearchClear) {
-          featureSearchClear.setAttribute('hidden', '');
-        }
         e.preventDefault();
       }
     });
-  }
-  if (featureSearchClear) {
-    featureSearchClear.addEventListener('click', function () {
-      if (featureSearch) {
-        featureSearch.value = '';
-        featureSearchClear.setAttribute('hidden', '');
-        focusFeatureSearchInput();
-      }
-    });
-    if (featureSearch && featureSearch.value) {
-      featureSearchClear.removeAttribute('hidden');
-    }
   }
   helpButton.addEventListener('click', toggleHelp);
   if (closeHelpBtn) closeHelpBtn.addEventListener('click', closeHelp);
@@ -22854,7 +22826,6 @@ if (typeof module !== "undefined" && module.exports) {
       deviceMap: deviceMap,
       helpMap: helpMap,
       featureSearchInput: featureSearch,
-      featureSearchClearButton: featureSearchClear,
       featureListElement: featureList
     },
     collectAutoGearCatalogNames: collectAutoGearCatalogNames,

--- a/src/scripts/script.js
+++ b/src/scripts/script.js
@@ -3651,14 +3651,6 @@ function setLanguage(lang) {
       texts[lang].featureSearchHelp || texts[lang].featureSearchLabel
     );
   }
-  if (featureSearchClear) {
-    featureSearchClear.setAttribute("title", texts[lang].featureSearchClear);
-    featureSearchClear.setAttribute("aria-label", texts[lang].featureSearchClear);
-    featureSearchClear.setAttribute(
-      "data-help",
-      texts[lang].featureSearchClearHelp || texts[lang].featureSearchClear
-    );
-  }
   if (helpButton) {
     helpButton.setAttribute("title", texts[lang].helpButtonTitle || texts[lang].helpButtonLabel);
     helpButton.setAttribute("aria-label", texts[lang].helpButtonLabel);
@@ -8778,7 +8770,6 @@ const supportLink = document.getElementById("supportLink");
 const settingsSave    = document.getElementById("settingsSave");
 const settingsCancel  = document.getElementById("settingsCancel");
 const featureSearch   = document.getElementById("featureSearch");
-const featureSearchClear = document.getElementById("featureSearchClear");
 const featureList     = document.getElementById("featureList");
 const featureMap      = new Map();
 const normalizeSearchValue = value =>
@@ -22529,41 +22520,17 @@ if (helpButton && helpDialog) {
     featureSearch.addEventListener('input', () => {
       updateFeatureSearchSuggestions(featureSearch.value);
       featureSearch.showPicker?.();
-      if (featureSearchClear) {
-        if (featureSearch.value) {
-          featureSearchClear.removeAttribute('hidden');
-        } else {
-          featureSearchClear.setAttribute('hidden', '');
-        }
-      }
     });
     featureSearch.addEventListener('keydown', e => {
       if (e.key === 'Enter') {
         handle();
       } else if (e.key === 'Escape' && featureSearch.value) {
         featureSearch.value = '';
-        if (featureSearchClear) {
-          featureSearchClear.setAttribute('hidden', '');
-        }
         restoreFeatureSearchDefaults();
+        featureSearch.showPicker?.();
         e.preventDefault();
       }
     });
-  }
-
-  if (featureSearchClear) {
-    featureSearchClear.addEventListener('click', () => {
-      if (featureSearch) {
-        featureSearch.value = '';
-        featureSearchClear.setAttribute('hidden', '');
-        focusFeatureSearchInput();
-        restoreFeatureSearchDefaults();
-        featureSearch.showPicker?.();
-      }
-    });
-    if (featureSearch && featureSearch.value) {
-      featureSearchClear.removeAttribute('hidden');
-    }
   }
 
   // Wire up button clicks and search field interactions
@@ -23623,7 +23590,6 @@ if (typeof module !== "undefined" && module.exports) {
       featureSearchEntries,
       featureSearchDefaultOptions,
       featureSearchInput: featureSearch,
-      featureSearchClearButton: featureSearchClear,
       featureListElement: featureList,
       restoreFeatureSearchDefaults,
       updateFeatureSearchSuggestions,

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -1869,7 +1869,6 @@ body.pink-mode .auto-gear-rule-title,
   }
 }
 
-#featureSearchClear .icon-glyph,
 #helpSearchClear .icon-glyph,
 .clear-input-btn .icon-glyph,
 .controls button .icon-glyph {
@@ -2561,7 +2560,6 @@ body.pink-mode #topBar #logo .logo-center {
 }
 
 #featureSearchContainer {
-  position: relative;
   width: 100%;
   max-width: 300px;
 }
@@ -2569,32 +2567,8 @@ body.pink-mode #topBar #logo .logo-center {
 #featureSearch {
   width: 100%;
   max-width: 300px;
-  padding: 2px 2em 2px 6px;
+  padding: 2px 10px 2px 6px;
   height: var(--button-size);
-}
-
-#featureSearchClear {
-  position: absolute;
-  top: 50%;
-  right: 10px;
-  transform: translateY(-50%);
-  margin: 0;
-  background: none;
-  border: none;
-  cursor: pointer;
-  font-size: var(--font-size-base);
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: var(--button-size);
-  height: var(--button-size);
-  padding: 0;
-  line-height: 1;
-  color: inherit;
-}
-
-#featureSearchClear[hidden] {
-  display: none;
 }
 
 .controls select,


### PR DESCRIPTION
## Summary
- remove the custom clear button from the feature search input so the browser's native affordance is displayed
- drop the related styling and script handlers in both the modern and legacy bundles while preserving escape-to-clear behavior

## Testing
- npm test -- --runTestsByPath tests/dom/layoutControls.test.js

------
https://chatgpt.com/codex/tasks/task_e_68cf1b443048832088a1135802eaeecd