### PR TITLE
Fix sidebar toggle initialization and loader CSP detection

### DIFF
--- a/legacy/scripts/script.js
+++ b/legacy/scripts/script.js
@@ -1292,11 +1292,21 @@ function setupResponsiveControls() {
   mql.addEventListener('change', relocate);
   relocate();
 }
-if (typeof window !== 'undefined') {
-  document.addEventListener('DOMContentLoaded', function () {
+if (typeof window !== 'undefined' && typeof document !== 'undefined') {
+  var runLayoutInitialization = function runLayoutInitialization() {
     setupSideMenu();
     setupResponsiveControls();
-  });
+  };
+
+  if (document.readyState === 'loading') {
+    var onReady = function onReady() {
+      document.removeEventListener('DOMContentLoaded', onReady);
+      runLayoutInitialization();
+    };
+    document.addEventListener('DOMContentLoaded', onReady);
+  } else {
+    runLayoutInitialization();
+  }
 }
 var escapeDiv;
 function escapeHtml(str) {

--- a/src/scripts/loader.js
+++ b/src/scripts/loader.js
@@ -35,6 +35,16 @@
       var test = new Function('var obj = { a: { b: 1 } }; var value = obj?.a?.b ?? 2; return value;');
       return test() === 1;
     } catch (err) {
+      var message = (err && err.message) || '';
+      var isCspEvalError =
+        (typeof EvalError !== 'undefined' && err instanceof EvalError) ||
+        (typeof message === 'string' && message.indexOf('unsafe-eval') !== -1);
+      if (isCspEvalError) {
+        // Treat CSP "unsafe-eval" restrictions as a sign that modern syntax
+        // is supported but blocked. We can safely continue to load the modern
+        // bundle in this case.
+        return true;
+      }
       if (typeof console !== 'undefined' && typeof console.warn === 'function') {
         console.warn('Legacy bundle enabled: falling back due to syntax support test failure.', err);
       }

--- a/tests/dom/layoutControls.test.js
+++ b/tests/dom/layoutControls.test.js
@@ -88,6 +88,27 @@ describe('side menu accessibility controls', () => {
   });
 });
 
+describe('side menu automatic initialization', () => {
+  test('toggle opens the menu when the script loads after DOM ready', () => {
+    const env = setupScriptEnvironment({ readyState: 'complete' });
+    try {
+      const toggle = document.getElementById('menuToggle');
+      const menu = document.getElementById('sideMenu');
+
+      expect(toggle).not.toBeNull();
+      expect(menu).not.toBeNull();
+      expect(menu.classList.contains('open')).toBe(false);
+
+      toggle.dispatchEvent(new window.MouseEvent('click', { bubbles: true }));
+
+      expect(menu.classList.contains('open')).toBe(true);
+      expect(toggle.getAttribute('aria-expanded')).toBe('true');
+    } finally {
+      env?.cleanup();
+    }
+  });
+});
+
 describe('responsive control relocation', () => {
   let env;
   let originalMatchMedia;


### PR DESCRIPTION
## Summary
- treat CSP "unsafe-eval" blocks as modern feature support so the loader keeps the modern bundle
- ensure the legacy sidebar controls initialize immediately when the DOM is already ready
- add a regression test covering automatic menu setup after load

## Testing
- npm test -- --runTestsByPath tests/dom/layoutControls.test.js

------
https://chatgpt.com/codex/tasks/task_e_68cf1b5867dc8320ab36acd0cbfd1f44