### PR TITLE
Enhance help dialog guidance for saving and sharing

### DIFF
--- a/index.html
+++ b/index.html
@@ -1253,6 +1253,52 @@
         </section>
         <section
           data-help-section
+          id="savingAndSharing"
+          data-help-keywords="save saving project projects share sharing export import backup restore safety offline data management json download recover undo history"
+        >
+          <h3>
+            <span class="help-icon icon-glyph" aria-hidden="true" data-icon-font="essential">&#xF207;</span>Saving, Sharing &amp; Restoring Projects
+          </h3>
+          <ul>
+            <li>Name your project in <em>Project Overview</em> and press <strong>Save</strong> (or hit Enter/Ctrl+S/⌘S) to capture the current configuration without leaving the planner.</li>
+            <li><strong>Export project</strong> downloads a portable JSON bundle with devices, requirements, automatic gear rules and runtime feedback so you can archive or share the setup safely offline.</li>
+            <li>Use <strong>Import project</strong> to load any saved JSON file. Imports keep your existing projects; choose <strong>Save</strong> afterwards if you want to store the imported version alongside them.</li>
+            <li>Open Settings → <em>Backup &amp; Restore</em> whenever you need a full-application snapshot. Backups include saved projects, device edits, preferences, favorites and feedback. Restores automatically create a fresh safety copy before applying the selected file.</li>
+            <li>Everything stays on this device so you can keep working offline. Hourly background backups and the 10‑minute auto snapshots below add extra recovery points without touching your current project.</li>
+          </ul>
+          <div class="help-link-group" aria-label="Saving and sharing shortcuts">
+            <a
+              class="help-link button-link"
+              href="#setup-manager"
+              data-help-target="#saveSetupBtn"
+              data-help-highlight="#setup-manager"
+            >Save project</a>
+            <a
+              class="help-link button-link"
+              href="#setup-manager"
+              data-help-target="#shareSetupBtn"
+              data-help-highlight="#setup-manager"
+            >Export project</a>
+            <a
+              class="help-link button-link"
+              href="#setup-manager"
+              data-help-target="#applySharedLinkBtn"
+              data-help-highlight="#setup-manager"
+            >Import project</a>
+            <a
+              class="help-link button-link"
+              href="#settingsDialog"
+              data-help-target="#backupSettings"
+            >Open Backup</a>
+            <a
+              class="help-link button-link"
+              href="#settingsDialog"
+              data-help-target="#restoreSettings"
+            >Open Restore</a>
+          </div>
+        </section>
+        <section
+          data-help-section
           id="settingsHelp"
           data-help-keywords="settings preferences customization customise personalize colour color font typeface accent high contrast theme backup restore"
         >


### PR DESCRIPTION
## Summary
- add a dedicated help dialog section that explains saving, exporting, importing, and restoring projects
- surface quick links to project save, export, import, backup, and restore controls while highlighting offline safety copies

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cf1cd411a48320923da0a714774e55