### PR TITLE
Remove gear list delete button from gear table

### DIFF
--- a/src/scripts/script.js
+++ b/src/scripts/script.js
@@ -19245,31 +19245,27 @@ function ensureGearListActions() {
     if (!actions) {
         actions = document.createElement('div');
         actions.id = 'gearListActions';
-        const deleteBtn = document.createElement('button');
-        deleteBtn.id = 'deleteGearListBtn';
-        const autoSaveNote = document.createElement('p');
+        gearListOutput.appendChild(actions);
+    }
+    const existingDeleteBtn = actions.querySelector('#deleteGearListBtn');
+    if (existingDeleteBtn) {
+        existingDeleteBtn.removeEventListener('click', deleteCurrentGearList);
+        existingDeleteBtn.remove();
+    }
+    let autoSaveNote = document.getElementById('gearListAutosaveNote');
+    if (!autoSaveNote) {
+        autoSaveNote = document.createElement('p');
         autoSaveNote.id = 'gearListAutosaveNote';
         autoSaveNote.className = 'gear-list-autosave-note';
-        actions.append(deleteBtn, autoSaveNote);
-        gearListOutput.appendChild(actions);
-        deleteBtn.addEventListener('click', deleteCurrentGearList);
+        actions.appendChild(autoSaveNote);
+    } else if (!actions.contains(autoSaveNote)) {
+        actions.appendChild(autoSaveNote);
     }
-    // Update texts for current language
-    const deleteBtn = document.getElementById('deleteGearListBtn');
-    const autoSaveNote = document.getElementById('gearListAutosaveNote');
-    const deleteHelp = texts[currentLang].deleteGearListBtnHelp || texts[currentLang].deleteGearListBtn;
-    if (autoSaveNote) {
-        const noteText = texts[currentLang].gearListAutosaveNote
-            || 'Gear lists save automatically with the project.';
-        autoSaveNote.textContent = noteText;
-        autoSaveNote.setAttribute('title', noteText);
-        autoSaveNote.setAttribute('data-help', noteText);
-    }
-    if (deleteBtn) {
-        deleteBtn.textContent = texts[currentLang].deleteGearListBtn;
-        deleteBtn.setAttribute('title', deleteHelp);
-        deleteBtn.setAttribute('data-help', deleteHelp);
-    }
+    const noteText = texts[currentLang].gearListAutosaveNote
+        || 'Gear lists save automatically with the project.';
+    autoSaveNote.textContent = noteText;
+    autoSaveNote.setAttribute('title', noteText);
+    autoSaveNote.setAttribute('data-help', noteText);
 
     if (!gearListOutput._filterListenerBound) {
         gearListOutput.addEventListener('change', e => {
@@ -19893,7 +19889,17 @@ function applySharedSetup(shared, options = {}) {
       if (activeRules && activeRules.length) {
         payload.autoGearRules = activeRules;
       }
-      saveProject(getCurrentProjectStorageKey({ allowTyped: true }), payload);
+      let storageKey = getCurrentProjectStorageKey({ allowTyped: true });
+      const typedName = setupNameInput && typeof setupNameInput.value === 'string'
+        ? setupNameInput.value.trim()
+        : '';
+      const selectedName = setupSelect && typeof setupSelect.value === 'string'
+        ? setupSelect.value.trim()
+        : '';
+      if (typedName && typedName !== selectedName) {
+        storageKey = typedName;
+      }
+      saveProject(storageKey, payload);
     }
   } catch (e) {
     console.error('Failed to apply shared setup', e);
@@ -23602,6 +23608,7 @@ if (typeof module !== "undefined" && module.exports) {
     saveCurrentSession,
     restoreSessionState,
     displayGearAndRequirements,
+    deleteCurrentGearList,
     ensureGearListActions,
     bindGearListEasyrigListener,
     populateSelect,

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -4318,10 +4318,6 @@ body.dark-mode.pink-mode #gearListOutput h2,
   margin-bottom: 1rem;
 }
 
-#gearListActions button {
-  margin: 0;
-}
-
 #gearListActions .gear-list-autosave-note {
   flex-basis: 100%;
   margin: 0;

--- a/tests/dom/deleteGearList.test.js
+++ b/tests/dom/deleteGearList.test.js
@@ -73,15 +73,24 @@ describe('delete gear list action', () => {
     env?.cleanup();
   });
 
-  test('removes persisted gear list for the active project', () => {
+  test('deleteCurrentGearList removes persisted gear list for the active project', () => {
     const deleteBtn = document.getElementById('deleteGearListBtn');
-    expect(deleteBtn).not.toBeNull();
+    expect(deleteBtn).toBeNull();
+
+    const actions = document.getElementById('gearListActions');
+    expect(actions).not.toBeNull();
+
+    const autosaveNote = document.getElementById('gearListAutosaveNote');
+    expect(autosaveNote).not.toBeNull();
+
+    expect(typeof env.utils.deleteCurrentGearList).toBe('function');
 
     const deletedEvents = [];
     const deletedListener = (event) => deletedEvents.push(event);
     document.addEventListener('gearlist:deleted', deletedListener);
 
-    deleteBtn.click();
+    const result = env.utils.deleteCurrentGearList();
+    expect(result).toBe(true);
 
     document.removeEventListener('gearlist:deleted', deletedListener);
 


### PR DESCRIPTION
## Summary
- remove the delete gear list button from the bottom of the gear table and keep only the autosave notice
- ensure the autosave notice is recreated and old delete buttons are cleaned up when loading saved gear lists
- prefer the typed project name when persisting imported shared setups so existing projects are not overwritten
- export the gear list deletion helper for tests and refresh the related DOM test expectations

## Testing
- npm run test:dom

------
https://chatgpt.com/codex/tasks/task_e_68cf212f76148320b9d4b6311d0f41b4