### PR TITLE
Improve loader legacy fallback logic

### DIFF
--- a/legacy/scripts/loader.js
+++ b/legacy/scripts/loader.js
@@ -23,10 +23,42 @@
     if (typeof stringProto.includes !== 'function' || typeof stringProto.startsWith !== 'function') {
       return false;
     }
-    try {
+    var syntaxTest = function syntaxTest() {
       var test = new Function('var obj = { a: { b: 1 } }; var value = obj?.a?.b ?? 2; return value;');
       return test() === 1;
-    } catch (error) {
+    };
+    var overrideSource = null;
+    if (typeof window !== 'undefined') {
+      overrideSource = window;
+    } else if (typeof globalThis !== 'undefined') {
+      overrideSource = globalThis;
+    }
+    if (overrideSource && typeof overrideSource.__CINE_POWER_SYNTAX_TEST__ === 'function') {
+      syntaxTest = overrideSource.__CINE_POWER_SYNTAX_TEST__;
+    }
+    try {
+      return Boolean(syntaxTest());
+    } catch (err) {
+      var message = err && err.message || '';
+      var isCspEvalError = typeof EvalError !== 'undefined' && err instanceof EvalError || typeof message === 'string' && message.indexOf('unsafe-eval') !== -1;
+      if (isCspEvalError) {
+        return true;
+      }
+      var isSyntaxError = false;
+      if (typeof SyntaxError !== 'undefined' && err instanceof SyntaxError) {
+        isSyntaxError = true;
+      } else if (typeof message === 'string' && message) {
+        isSyntaxError = /syntax|unexpected token|parse error|unterminated|invalid|expected/i.test(message);
+      }
+      if (!isSyntaxError) {
+        if (typeof console !== 'undefined' && typeof console.warn === 'function') {
+          console.warn('Modern bundle enabled despite unexpected error during syntax support detection.', err);
+        }
+        return true;
+      }
+      if (typeof console !== 'undefined' && typeof console.warn === 'function') {
+        console.warn('Legacy bundle enabled: falling back due to syntax support test failure.', err);
+      }
       return false;
     }
   }
@@ -57,8 +89,18 @@
   var modernScripts = ['src/scripts/globalthis-polyfill.js', 'src/data/devices/index.js', 'src/data/devices/cameras.js', 'src/data/devices/monitors.js', 'src/data/devices/video.js', 'src/data/devices/fiz.js', 'src/data/devices/batteries.js', 'src/data/devices/batteryHotswaps.js', 'src/data/devices/cages.js', 'src/data/devices/gearList.js', 'src/data/devices/wirelessReceivers.js', 'src/scripts/storage.js', 'src/scripts/translations.js', 'src/vendor/lz-string.min.js', 'src/vendor/lottie-light.min.js', 'src/scripts/script.js', 'src/scripts/overview.js'];
   var legacyScripts = ['legacy/polyfills/core-js-bundle.min.js', 'legacy/polyfills/regenerator-runtime.js', 'legacy/scripts/globalthis-polyfill.js', 'legacy/data/devices/index.js', 'legacy/data/devices/cameras.js', 'legacy/data/devices/monitors.js', 'legacy/data/devices/video.js', 'legacy/data/devices/fiz.js', 'legacy/data/devices/batteries.js', 'legacy/data/devices/batteryHotswaps.js', 'legacy/data/devices/cages.js', 'legacy/data/devices/gearList.js', 'legacy/data/devices/wirelessReceivers.js', 'legacy/scripts/storage.js', 'legacy/scripts/translations.js', 'src/vendor/lz-string.min.js', 'src/vendor/lottie-light.min.js', 'legacy/scripts/script.js', 'legacy/scripts/overview.js'];
   var scriptsToLoad = supportsModernFeatures() ? modernScripts : legacyScripts;
-  if (scriptsToLoad === legacyScripts) {
+  if (typeof window !== 'undefined' && scriptsToLoad === legacyScripts) {
     window.__CINE_POWER_LEGACY_BUNDLE__ = true;
   }
-  loadScriptsSequentially(scriptsToLoad);
+  if (typeof document !== 'undefined' && document) {
+    loadScriptsSequentially(scriptsToLoad);
+  }
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = {
+      supportsModernFeatures: supportsModernFeatures,
+      loadScriptsSequentially: loadScriptsSequentially,
+      modernScripts: modernScripts,
+      legacyScripts: legacyScripts
+    };
+  }
 })();

--- a/tests/unit/loader.test.js
+++ b/tests/unit/loader.test.js
@@ -1,0 +1,39 @@
+const path = require('path');
+
+describe('loader supportsModernFeatures', () => {
+  const loaderPath = path.join(__dirname, '..', '..', 'src', 'scripts', 'loader.js');
+
+  beforeEach(() => {
+    jest.resetModules();
+    delete global.__CINE_POWER_SYNTAX_TEST__;
+    global.window = {};
+  });
+
+  afterEach(() => {
+    delete global.__CINE_POWER_SYNTAX_TEST__;
+    if (global.window) {
+      delete global.window.__CINE_POWER_SYNTAX_TEST__;
+    }
+    delete global.window;
+  });
+
+  test('returns false when syntax is unsupported', () => {
+    global.window.__CINE_POWER_SYNTAX_TEST__ = () => {
+      throw new SyntaxError('Unexpected token ?.');
+    };
+
+    const { supportsModernFeatures } = require(loaderPath);
+    expect(supportsModernFeatures()).toBe(false);
+  });
+
+  test('ignores non-syntax errors when detecting support', () => {
+    global.window.__CINE_POWER_SYNTAX_TEST__ = () => {
+      const error = new Error('storage state unavailable');
+      error.name = 'StorageError';
+      throw error;
+    };
+
+    const { supportsModernFeatures } = require(loaderPath);
+    expect(supportsModernFeatures()).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- refine the loader’s feature detection so only syntax failures force the legacy bundle and unexpected errors keep the modern build
- expose test hooks, guard DOM usage for non-browser environments, and export the detection helpers for reuse
- add unit coverage for the loader to verify syntax-error and non-syntax-error scenarios

## Testing
- npm run test:unit

------
https://chatgpt.com/codex/tasks/task_e_68cf20e9032c8320961bfdd8048639d5