### PR TITLE
Improve CLI help layout and coverage

### DIFF
--- a/tools/cliHelp.js
+++ b/tools/cliHelp.js
@@ -1,31 +1,102 @@
 #!/usr/bin/env node
-const lines = [
+
+const sections = [
+  {
+    title: 'Essential workflows',
+    commands: [
+      { label: 'npm run help', description: 'Show this reference.' },
+      { label: 'npm run lint', description: 'Lint JavaScript and JSON files with ESLint.' },
+      {
+        label: 'npm test',
+        description: 'Run linting, data validation and every Jest project.'
+      },
+      {
+        label: 'npm run test:jest',
+        description: 'Run all Jest projects (unit, data, dom, script) without linting.'
+      },
+      {
+        label: 'npm run build:legacy',
+        description: 'Generate the ES5-compatible offline bundle for legacy browsers.'
+      }
+    ]
+  },
+  {
+    title: 'Focused test suites',
+    commands: [
+      { label: 'npm run test:unit', description: 'Execute only the unit tests.' },
+      { label: 'npm run test:data', description: 'Execute only the data integrity tests.' },
+      { label: 'npm run test:dom', description: 'Execute only the DOM integration tests.' },
+      { label: 'npm run test:script', description: 'Execute only the script harness tests for script.js.' }
+    ]
+  },
+  {
+    title: 'Data maintenance pipeline (run after editing src/data/devices/)',
+    commands: [
+      {
+        label: 'npm run check-consistency',
+        description: 'Report missing required fields in src/data/devices/.'
+      },
+      {
+        label: 'npm run normalize',
+        description: 'Normalize metadata and rebuild derived data into src/data/index.js.'
+      },
+      {
+        label: 'npm run unify-ports',
+        description: 'Standardize connector and port definitions across src/data/index.js.'
+      },
+      {
+        label: 'npm run generate-schema',
+        description: 'Refresh src/data/schema.json based on the latest data.'
+      }
+    ],
+    footer: 'Run normalize → unify-ports → generate-schema together so UI selectors and schema exports stay in sync.'
+  }
+];
+
+const tips = [
+  'Pass --help to supported scripts above to see detailed usage instructions.',
+  'Use npm run <script> -- --watch to forward extra flags to the underlying tool.',
+  'Commit regenerated files with their source changes to preserve offline builds and shared data exports.'
+];
+
+const titleLines = [
   'Cine Power Planner – development command reference',
   '',
   'Usage: npm run <command> [-- --options]',
-  '',
-  'Essential workflows:',
-  '  npm run help                Show this reference.',
-  '  npm run lint                Lint JavaScript and JSON files with ESLint.',
-  '  npm test                    Run linting, data validation and every Jest project.',
-  '  npm run test:jest           Run all Jest projects (unit, data, dom, script) without linting.',
-  '  npm run test:unit           Execute only the unit tests.',
-  '  npm run test:data           Execute only the data integrity tests.',
-  '  npm run test:dom            Execute only the DOM integration tests.',
-  '  npm run test:script         Execute only the script harness tests for script.js.',
-  '',
-  'Data maintenance pipeline (run after editing src/data/devices/):',
-  '  npm run check-consistency   Report missing required fields in src/data/devices/.',
-  '  npm run normalize           Normalize metadata and rebuild derived data into src/data/index.js.',
-  '  npm run unify-ports         Standardize connector and port definitions across src/data/index.js.',
-  '  npm run generate-schema     Refresh src/data/schema.json based on the latest data.',
-  '',
-  'Housekeeping tips:',
-  '  • Pass --help to supported scripts above to see detailed usage instructions.',
-  '  • npm run <script> -- --watch forwards extra flags to the underlying tool.',
-  '  • Run normalize → unify-ports → generate-schema together so UI selectors and schema exports stay in sync.',
-  '  • Commit regenerated files with their source changes to preserve offline builds and shared data exports.',
-  '',
-  'For contributing guidelines and additional background, open README.md.',
+  ''
 ];
+
+const longestLabel = sections.reduce((max, section) => {
+  const sectionMax = section.commands.reduce((innerMax, command) => {
+    const length = command.label.length;
+    return length > innerMax ? length : innerMax;
+  }, 0);
+  return sectionMax > max ? sectionMax : max;
+}, 0);
+
+const formatCommand = command => {
+  const padding = ' '.repeat(longestLabel - command.label.length + 2);
+  return `  ${command.label}${padding}${command.description}`;
+};
+
+const lines = [...titleLines];
+
+for (const section of sections) {
+  lines.push(`${section.title}:`);
+  for (const command of section.commands) {
+    lines.push(formatCommand(command));
+  }
+  if (section.footer) {
+    lines.push(`  • ${section.footer}`);
+  }
+  lines.push('');
+}
+
+lines.push('Housekeeping tips:');
+for (const tip of tips) {
+  lines.push(`  • ${tip}`);
+}
+lines.push('');
+lines.push('For contributing guidelines and additional background, open README.md.');
+
 console.log(lines.join('\n'));


### PR DESCRIPTION
## Summary
- restructure the CLI help generator to build each section programmatically with padded command columns
- add the legacy build task and a focused test suites section so the reference covers every workflow
- expand the housekeeping tips while preserving guidance about the data maintenance order

## Testing
- node tools/cliHelp.js

------
https://chatgpt.com/codex/tasks/task_e_68cf2717d610832080d37ee96448451d