### PR TITLE
Improve modern loader fallback handling

### DIFF
--- a/legacy/scripts/loader.js
+++ b/legacy/scripts/loader.js
@@ -181,6 +181,47 @@
       scope[OPTIONAL_CHAINING_FLAG] = undefined;
     }
   }
+  function isSyntaxErrorEvent(event) {
+    if (!event) {
+      return false;
+    }
+    var error = event;
+    if (typeof event === 'object' && event !== null && event.error && typeof event.error === 'object') {
+      error = event.error;
+    }
+    if (error && typeof error.name === 'string' && error.name === 'SyntaxError') {
+      return true;
+    }
+    if (typeof SyntaxError !== 'undefined' && error instanceof SyntaxError) {
+      return true;
+    }
+    var message = '';
+    if (event && typeof event.message === 'string' && event.message) {
+      message = event.message;
+    } else if (error && typeof error.message === 'string' && error.message) {
+      message = error.message;
+    }
+    if (!message) {
+      return false;
+    }
+    var lower = message.toLowerCase();
+    if (lower.indexOf('unexpected token') !== -1) {
+      return true;
+    }
+    if (lower.indexOf('unexpected character') !== -1) {
+      return true;
+    }
+    if (lower.indexOf('cannot use optional chaining') !== -1) {
+      return true;
+    }
+    if (lower.indexOf('invalid or unexpected token') !== -1) {
+      return true;
+    }
+    if (lower.indexOf('failed to parse module') !== -1) {
+      return true;
+    }
+    return false;
+  }
   function supportsModernFeatures(callback) {
     var cb = typeof callback === 'function' ? callback : function () {};
     if (typeof window === 'undefined') {
@@ -237,10 +278,24 @@
     optionalCheckScript.src = 'src/scripts/modern-support-check.mjs';
     optionalCheckScript.onload = function () {
       var supported = !!(globalScope && globalScope[OPTIONAL_CHAINING_FLAG]);
+      if (!supported) {
+        supported = true;
+        if (typeof console !== 'undefined' && typeof console.warn === 'function') {
+          console.warn('Modern support check module loaded without reporting support flag. Assuming modern feature support.');
+        }
+      }
       finalize(supported);
     };
-    optionalCheckScript.onerror = function () {
-      finalize(false);
+    optionalCheckScript.onerror = function (event) {
+      var supported = !isSyntaxErrorEvent(event);
+      if (!supported) {
+        if (typeof console !== 'undefined' && typeof console.warn === 'function') {
+          console.warn('Modern support check failed due to syntax error. Falling back to legacy bundle.', event);
+        }
+      } else if (typeof console !== 'undefined' && typeof console.warn === 'function') {
+        console.warn('Modern support check could not be loaded. Assuming modern feature support.', event);
+      }
+      finalize(supported);
     };
     try {
       head.appendChild(optionalCheckScript);
@@ -248,7 +303,7 @@
       if (typeof console !== 'undefined' && typeof console.warn === 'function') {
         console.warn('Unable to append modern support check script.', appendError);
       }
-      finalize(false);
+      finalize(true);
     }
   }
   function loadScriptsSequentially(urls) {


### PR DESCRIPTION
## Summary
- treat failures to load the optional chaining probe as modern-compatible unless a syntax error indicates lack of support
- warn when assuming support and keep both modern and legacy loaders in sync with the new detection logic

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cf281c9a788320bd21b3d8ffdf19d3