### PR TITLE
Fix auto gear auto preset localStorage migration

### DIFF
--- a/legacy/scripts/loader.js
+++ b/legacy/scripts/loader.js
@@ -146,6 +146,9 @@
       legacy: legacyPrefix + 'autoGearActivePreset',
       modern: 'cameraPowerPlanner_autoGearActivePreset'
     }, {
+      legacy: legacyPrefix + 'autoGearAutoPreset',
+      modern: 'cameraPowerPlanner_autoGearAutoPreset'
+    }, {
       legacy: legacyPrefix + 'autoGearShowBackups',
       modern: 'cameraPowerPlanner_autoGearShowBackups'
     }, {

--- a/src/scripts/loader.js
+++ b/src/scripts/loader.js
@@ -141,6 +141,7 @@
       { legacy: legacyPrefix + 'autoGearSeeded', modern: 'cameraPowerPlanner_autoGearSeeded' },
       { legacy: legacyPrefix + 'autoGearPresets', modern: 'cameraPowerPlanner_autoGearPresets' },
       { legacy: legacyPrefix + 'autoGearActivePreset', modern: 'cameraPowerPlanner_autoGearActivePreset' },
+      { legacy: legacyPrefix + 'autoGearAutoPreset', modern: 'cameraPowerPlanner_autoGearAutoPreset' },
       { legacy: legacyPrefix + 'autoGearShowBackups', modern: 'cameraPowerPlanner_autoGearShowBackups' },
       { legacy: legacyPrefix + 'customFonts', modern: 'cameraPowerPlanner_customFonts', updateFontKey: true }
     ];


### PR DESCRIPTION
## Summary
- migrate legacy cinePowerPlanner_autoGearAutoPreset entries to the new cameraPowerPlanner key when the loader executes
- keep the transpiled legacy loader in sync so older browsers receive the same migration coverage

## Testing
- npm run test:unit

------
https://chatgpt.com/codex/tasks/task_e_68cf291fabe88320b5d019c6a47960a0