### PR TITLE
Refresh auto gear trigger selects consistently

### DIFF
--- a/src/scripts/script.js
+++ b/src/scripts/script.js
@@ -3525,6 +3525,15 @@ function setLanguage(lang) {
   if (autoGearMatteboxSelect) {
     refreshAutoGearMatteboxOptions(autoGearEditorDraft?.mattebox);
   }
+  if (autoGearCameraHandleSelect) {
+    refreshAutoGearCameraHandleOptions(autoGearEditorDraft?.cameraHandle);
+  }
+  if (autoGearViewfinderExtensionSelect) {
+    refreshAutoGearViewfinderExtensionOptions(autoGearEditorDraft?.viewfinderExtension);
+  }
+  if (autoGearVideoDistributionSelect) {
+    refreshAutoGearVideoDistributionOptions(autoGearEditorDraft?.videoDistribution);
+  }
   seedAutoGearRulesFromCurrentProject();
   renderAutoGearRulesList();
   renderAutoGearDraftLists();
@@ -20673,6 +20682,10 @@ if (settingsButton && settingsDialog) {
     if (autoGearEditor) {
       closeAutoGearEditor();
       refreshAutoGearScenarioOptions();
+      refreshAutoGearMatteboxOptions();
+      refreshAutoGearCameraHandleOptions();
+      refreshAutoGearViewfinderExtensionOptions();
+      refreshAutoGearVideoDistributionOptions();
       populateAutoGearCategorySelect(autoGearAddCategorySelect, '');
       populateAutoGearCategorySelect(autoGearRemoveCategorySelect, '');
       renderAutoGearRulesList();


### PR DESCRIPTION
## Summary
- refresh camera handle, viewfinder extension, and video distribution selectors whenever translations are applied
- repopulate the new automatic gear condition selectors when reopening the settings dialog

## Testing
- npm test -- autoGearRules

------
https://chatgpt.com/codex/tasks/task_e_68cf27c5401883208be271a98b29a847