### PR TITLE
Adjust video distribution selector height

### DIFF
--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -533,6 +533,15 @@ main.legal-content {
   height: clamp(14rem, 45vh, 20rem);
 }
 
+.form-row .auto-gear-video-distribution {
+  flex: 0 1 320px;
+  width: min(100%, 320px);
+  max-width: 100%;
+  overflow-y: auto;
+  min-height: 12rem;
+  height: clamp(14rem, 45vh, 20rem);
+}
+
 #crewContainer {
   flex: 1;
   display: flex;


### PR DESCRIPTION
## Summary
- increase the automatic gear rules video distribution multiselect height to show all entries without scrolling

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cf2fc675a4832099e32d200f59c4ab