### PR TITLE
Adjust gear list favorite spacing

### DIFF
--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -4321,6 +4321,8 @@ body.dark-mode.pink-mode #gearListOutput h2,
 #gearListOutput .select-wrapper .favorite-toggle,
 #projectRequirementsOutput .select-wrapper .favorite-toggle {
   flex: 0 0 auto;
+  margin-inline-end: var(--gap-size);
+  margin-right: var(--gap-size);
 }
 
 #gearListActions {


### PR DESCRIPTION
## Summary
- add right-side margin to gear list favourite toggles so adjacent text has additional breathing room

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cf335b2544832086190e61a59561fd