### PR TITLE
Add metadata for BPM/WPM/PM/IRND/FSND filter sets

### DIFF
--- a/legacy/data/devices/gearList.js
+++ b/legacy/data/devices/gearList.js
@@ -1036,6 +1036,21 @@ function _arrayWithHoles(r) { if (Array.isArray(r)) return r; }
           "brand": "Tilta",
           "kNumber": "MB-T16-POL"
         },
+        "BPM Filter Set": {
+          "brand": "Tiffen"
+        },
+        "WPM Filter Set": {
+          "brand": "Tiffen"
+        },
+        "PM Filter Set": {
+          "brand": "Tiffen"
+        },
+        "IRND Filter": {
+          "brand": "ARRI"
+        },
+        "FSND Filter Set": {
+          "brand": "ARRI"
+        },
         "Schneider CF DIOPTER FULL GEN2": {
           "brand": "Schneider",
           "kNumber": "68-000xxx"

--- a/src/data/devices/gearList.js
+++ b/src/data/devices/gearList.js
@@ -1000,6 +1000,21 @@ const gear = {
         "brand": "Tilta",
         "kNumber": "MB-T16-POL"
       },
+      "BPM Filter Set": {
+        "brand": "Tiffen"
+      },
+      "WPM Filter Set": {
+        "brand": "Tiffen"
+      },
+      "PM Filter Set": {
+        "brand": "Tiffen"
+      },
+      "IRND Filter": {
+        "brand": "ARRI"
+      },
+      "FSND Filter Set": {
+        "brand": "ARRI"
+      },
       "Schneider CF DIOPTER FULL GEN2": {
         "brand": "Schneider",
         "kNumber": "68-000xxx"


### PR DESCRIPTION
## Summary
- add BPM, WPM, PM, IRND, and FSND filter definitions so the gear list can surface brand details for the new sets
- mirror the new filter metadata in the legacy dataset for backwards compatibility

## Testing
- npm run test:data

------
https://chatgpt.com/codex/tasks/task_e_68cf344e36448320858d61434ef564fe