### PR TITLE
Refine localized planner terminology

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -2,7 +2,7 @@
 
 Dieses browserbasierte Werkzeug hilft dir bei der Planung professioneller Kamera-Setups mit V‑Mount-, B‑Mount- oder Gold-Mount-Akkus. Es berechnet den **Gesamtverbrauch**, die **Stromaufnahme** (bei 14,4 V und 12 V) sowie die **geschätzte Laufzeit** und prüft gleichzeitig, ob der Akku die benötigte Leistung zuverlässig liefern kann.
 
-Sämtliche Planungen, Eingaben und Exporte bleiben auf deinem Gerät. Spracheinstellungen, Projekte, eigene Geräte, Favoriten und Laufzeit-Feedback werden im Browser gespeichert, und Service-Worker-Updates stammen direkt aus diesem Repository. Du kannst den Planner offline von der lokalen Festplatte öffnen oder intern hosten, damit jede Abteilung dieselbe geprüfte Version nutzt.
+Sämtliche Planungen, Eingaben und Exporte bleiben auf deinem Gerät. Spracheinstellungen, Projekte, eigene Geräte, Favoriten und Laufzeit-Feedback werden im Browser gespeichert, und Service-Worker-Updates stammen direkt aus diesem Repository. Du kannst Cine Power Planner offline von der lokalen Festplatte öffnen oder intern hosten, damit jede Abteilung dieselbe geprüfte Version nutzt.
 
 ---
 
@@ -53,11 +53,11 @@ Beim ersten Start übernimmt die Anwendung automatisch die Sprache deines Browse
 - **Komplexe Rigs ohne Ratespiel bauen.** Kombiniere Kameras, Akkuplatten, Funkstrecken, Monitore, Motoren und Zubehör und verfolge Gesamtverbrauch sowie Stromaufnahme bei 14,4 V/12 V (bzw. 33,6 V/21,6 V bei B‑Mount) mit realistischen Laufzeiten aus gewichteten Felddaten. Das Batterie-Vergleichspanel warnt vor Überlastungen, bevor falsches Equipment eingepackt wird.
 - **Alle Gewerke auf Stand halten.** Speichere mehrere Projekte mit Anforderungen, Crew-Kontakten, Szenarien und Notizen. Druckbare Gerätelisten gruppieren Equipment nach Kategorie, führen Duplikate zusammen, zeigen technische Metadaten und berücksichtigen Szenario-Zubehör, damit Kamera-, Licht- und Grip-Teams synchron bleiben.
 - **Überall produktiv arbeiten.** Öffne `index.html` direkt oder liefere den Ordner über HTTPS aus, um den Service Worker zu aktivieren. Offline-Caching bewahrt Sprache, Themes, Favoriten und Projekte, und **Neu laden erzwingen** aktualisiert Assets, ohne gespeicherte Daten anzutasten.
-- **Planner auf das Team zuschneiden.** Wechsle sofort zwischen Deutsch, Englisch, Spanisch, Italienisch und Französisch, passe Schriftgröße und -familie an, wähle eine eigene Akzentfarbe, lade ein Drucklogo hoch und schalte zwischen hellem, dunklem, pinkem oder kontrastreichem Theme. Tippen-zum-Suchen, angepinnte Favoriten, Duplizieren-Buttons und Hover-Hilfe sparen Zeit am Set.
+- **Cine Power Planner auf das Team zuschneiden.** Wechsle sofort zwischen Deutsch, Englisch, Spanisch, Italienisch und Französisch, passe Schriftgröße und -familie an, wähle eine eigene Akzentfarbe, lade ein Drucklogo hoch und schalte zwischen hellem, dunklem, pinkem oder kontrastreichem Theme. Tippen-zum-Suchen, angepinnte Favoriten, Duplizieren-Buttons und Hover-Hilfe sparen Zeit am Set.
 
 ### ✅ Projektverwaltung
 - Speichere, lade und lösche mehrere Kameraprojekte (drücke Enter oder Strg+S/⌘S zum schnellen Speichern; der Button bleibt deaktiviert, bis ein Name eingetragen ist).
-- Alle zehn Minuten entstehen automatisch Sicherungsschnappschüsse, solange der Planner geöffnet ist; im Einstellungsdialog lassen sich stündliche Backup-Exporte als Erinnerung aktivieren.
+- Alle zehn Minuten entstehen automatisch Sicherungsschnappschüsse, solange Cine Power Planner geöffnet ist; im Einstellungsdialog lassen sich stündliche Backup-Exporte als Erinnerung aktivieren.
 - Lade eine JSON-Datei herunter, die Auswahl, Anforderungen, Geräteliste, Laufzeit-Feedback und eigene Geräte bündelt; über den Import-Picker holst du alles in einem Schritt zurück.
 - Die Daten liegen lokal im `localStorage`, Favoriten landen ebenfalls in Backups; die Option **Werkseinstellungen** legt vor dem Zurücksetzen automatisch eine Sicherung ab.
 - Erstelle druckbare Übersichten für jedes gespeicherte Projekt und füge ein individuelles Logo hinzu, damit Exporte und Backups zum Produktionsbranding passen.
@@ -217,7 +217,7 @@ Der Generator verwandelt deine Auswahl in eine nach Kategorien sortierte Packlis
 
 ## 📱 Als Anwendung installieren
 
-Der Planner ist eine Progressive-Web-App und lässt sich direkt aus dem Browser installieren:
+Cine Power Planner ist eine Progressive-Web-App und lässt sich direkt aus dem Browser installieren:
 
 - **Chrome/Edge (Desktop):** Auf das Installationssymbol in der Adressleiste klicken.
 - **Android:** Browsermenü öffnen und *Zum Startbildschirm hinzufügen* wählen.

--- a/README.es.md
+++ b/README.es.md
@@ -2,7 +2,7 @@
 
 Esta herramienta basada en navegador ayuda a planificar proyectos de cámara profesionales alimentados con baterías V‑Mount, B‑Mount o Gold-Mount. Calcula el **consumo total de energía**, la **corriente demandada** (a 14,4 V y 12 V) y la **autonomía estimada** mientras comprueba que la batería pueda suministrar con seguridad la potencia necesaria.
 
-Toda la planificación, las entradas y las exportaciones permanecen en tu dispositivo. El idioma, los proyectos, el equipo personalizado, los favoritos y los comentarios de autonomía se guardan en tu navegador, y las actualizaciones del service worker provienen directamente de este repositorio. Ejecuta el planner sin conexión desde el disco o aloja la carpeta internamente para que cada departamento use la misma versión auditada.
+Toda la planificación, las entradas y las exportaciones permanecen en tu dispositivo. El idioma, los proyectos, el equipo personalizado, los favoritos y los comentarios de autonomía se guardan en tu navegador, y las actualizaciones del service worker provienen directamente de este repositorio. Ejecuta Cine Power Planner sin conexión desde el disco o aloja la carpeta internamente para que cada departamento use la misma versión auditada.
 
 ---
 
@@ -53,11 +53,11 @@ La aplicación adopta automáticamente el idioma de tu navegador en la primera v
 - **Diseña rigs complejos sin adivinar.** Combina cámaras, placas de batería, enlaces inalámbricos, monitores, motores y accesorios mientras supervisas el consumo total a 14,4 V/12 V (y 33,6 V/21,6 V en B‑Mount) junto a autonomías realistas basadas en datos de campo ponderados. El panel de comparación de baterías avisa de sobrecargas antes de que el equipo salga al rodaje.
 - **Mantén coordinados a todos los departamentos.** Guarda varios proyectos con requisitos, contactos del equipo, escenarios y notas. Las listas imprimibles agrupan el material por categoría, fusionan duplicados, muestran metadatos técnicos e incluyen accesorios condicionados por los escenarios para que cámara, iluminación y grip trabajen con el mismo contexto.
 - **Trabaja con seguridad estés donde estés.** Abre `index.html` directamente o sirve la carpeta por HTTPS para activar el service worker. La caché sin conexión conserva idioma, temas, favoritos y proyectos, y **Forzar recarga** actualiza los recursos almacenados sin tocar tus datos.
-- **Ajusta el planner a tu equipo.** Cambia al instante entre español, inglés, alemán, italiano y francés, ajusta el tamaño de la fuente y la tipografía, define un color de acento, sube un logotipo para impresión y alterna entre temas claro, oscuro, rosa o de alto contraste. Los selectores con búsqueda, los favoritos fijados, los botones de duplicar y las ayudas flotantes mantienen ágil el trabajo en set.
+- **Ajusta Cine Power Planner a tu equipo.** Cambia al instante entre español, inglés, alemán, italiano y francés, ajusta el tamaño de la fuente y la tipografía, define un color de acento, sube un logotipo para impresión y alterna entre temas claro, oscuro, rosa o de alto contraste. Los selectores con búsqueda, los favoritos fijados, los botones de duplicar y las ayudas flotantes mantienen ágil el trabajo en set.
 
 ### ✅ Gestión de proyectos
 - Guarda, carga y elimina múltiples proyectos (pulsa Enter o Ctrl+S/⌘S para guardar rápido; el botón Guardar permanece desactivado hasta introducir un nombre).
-- Se generan instantáneas automáticas cada 10 minutos mientras el planner está abierto, y el cuadro de Ajustes puede lanzar exportaciones de copias de seguridad cada hora como recordatorio.
+- Se generan instantáneas automáticas cada 10 minutos mientras Cine Power Planner está abierto, y el cuadro de Ajustes puede lanzar exportaciones de copias de seguridad cada hora como recordatorio.
 - Descarga un archivo JSON que reúne selecciones, requisitos, listas de equipo, comentarios de autonomía y dispositivos personalizados; impórtalo mediante el selector de proyectos para recuperarlo todo de una vez.
 - Los datos se guardan localmente mediante `localStorage`, y los favoritos se incluyen en las copias de seguridad; usa la opción **Restablecimiento de fábrica** para descargar automáticamente una copia antes de limpiar proyectos y dispositivos guardados.
 - Genera vistas imprimibles de cualquier proyecto y añade un logotipo personalizado para que exportaciones y copias coincidan con tu identidad de producción.
@@ -217,7 +217,7 @@ El generador convierte tus selecciones en una lista de empaque categorizada:
 
 ## 📱 Instalar como aplicación
 
-El planner es una aplicación web progresiva y puede instalarse directamente desde el navegador:
+Cine Power Planner es una aplicación web progresiva y puede instalarse directamente desde el navegador:
 
 - **Chrome/Edge (escritorio):** haz clic en el icono de instalación de la barra de direcciones.
 - **Android:** abre el menú del navegador y elige *Añadir a pantalla de inicio*.

--- a/README.fr.md
+++ b/README.fr.md
@@ -2,7 +2,7 @@
 
 Cet outil basé sur le navigateur aide à planifier des projets caméra professionnels alimentés par des batteries V‑Mount, B‑Mount ou Gold-Mount. Il calcule la **consommation totale**, l’**intensité demandée** (à 14,4 V et 12 V) et l’**autonomie estimée**, tout en vérifiant que la batterie peut fournir la puissance requise en toute sécurité.
 
-L’ensemble de la planification, des saisies et des exports reste sur votre appareil. La langue, les projets, les appareils personnalisés, les favoris et les retours d’autonomie sont stockés dans votre navigateur, et les mises à jour du service worker proviennent directement de ce dépôt. Lancez le planner hors ligne depuis le disque ou hébergez-le en interne pour que chaque département exploite la même version auditée.
+L’ensemble de la planification, des saisies et des exports reste sur votre appareil. La langue, les projets, les appareils personnalisés, les favoris et les retours d’autonomie sont stockés dans votre navigateur, et les mises à jour du service worker proviennent directement de ce dépôt. Lancez Cine Power Planner hors ligne depuis le disque ou hébergez-le en interne pour que chaque département exploite la même version auditée.
 
 ---
 
@@ -57,7 +57,7 @@ L’application adopte automatiquement la langue de votre navigateur lors de la 
 
 ### ✅ Gestion de projet
 - Enregistrez, chargez et supprimez plusieurs projets caméra (appuyez sur Entrée ou Ctrl+S/⌘S pour sauvegarder rapidement ; le bouton reste inactif tant qu’aucun nom n’est saisi).
-- Des instantanés automatiques se créent toutes les 10 minutes tant que le planner est ouvert, et la boîte de dialogue Paramètres peut déclencher des exports de sauvegarde horaires en guise de rappel.
+- Des instantanés automatiques se créent toutes les 10 minutes tant que Cine Power Planner est ouvert, et la boîte de dialogue Paramètres peut déclencher des exports de sauvegarde horaires en guise de rappel.
 - Téléchargez un fichier JSON qui regroupe sélections, exigences, liste de matériel, retours d’autonomie et appareils personnalisés ; importez-le via le sélecteur de projet pour tout restaurer d’un coup.
 - Les données se stockent localement via `localStorage` et les favoris sont inclus dans les sauvegardes ; utilisez l’option **Réinitialisation d’usine** pour enregistrer automatiquement une copie avant d’effacer projets et modifications d’appareils.
 - Générez des aperçus imprimables pour chaque projet et ajoutez un logo personnalisé afin d’aligner exports et sauvegardes sur l’identité de votre production.
@@ -217,7 +217,7 @@ Le générateur transforme vos sélections en une liste de préparation classée
 
 ## 📱 Installer l’application
 
-Le planner est une application web progressive installable directement depuis le navigateur :
+Cine Power Planner est une application web progressive installable directement depuis le navigateur :
 
 - **Chrome/Edge (bureau) :** cliquez sur l’icône d’installation dans la barre d’adresse.
 - **Android :** ouvrez le menu du navigateur et choisissez *Ajouter à l’écran d’accueil*.

--- a/README.it.md
+++ b/README.it.md
@@ -2,7 +2,7 @@
 
 Questo strumento basato sul browser ti aiuta a pianificare progetti camera professionali alimentati da batterie V‑Mount, B‑Mount o Gold-Mount. Calcola il **consumo totale**, la **corrente assorbita** (a 14,4 V e 12 V) e l’**autonomia stimata**, verificando che il pacco batteria possa erogare in sicurezza la potenza richiesta.
 
-Tutta la pianificazione, gli input e gli export restano sul dispositivo davanti a te. Lingua, progetti, dispositivi personalizzati, preferiti e feedback sulle autonomie vivono nel browser, e gli aggiornamenti del service worker arrivano direttamente da questo repository. Avvia il planner offline dal disco o ospitalo internamente così che ogni reparto utilizzi la stessa versione verificata.
+Tutta la pianificazione, gli input e gli export restano sul dispositivo davanti a te. Lingua, progetti, dispositivi personalizzati, preferiti e feedback sulle autonomie vivono nel browser, e gli aggiornamenti del service worker arrivano direttamente da questo repository. Avvia Cine Power Planner offline dal disco o ospitalo internamente così che ogni reparto utilizzi la stessa versione verificata.
 
 ---
 
@@ -53,11 +53,11 @@ Al primo avvio l’applicazione adotta la lingua del browser; puoi cambiarla dal
 - **Progetta rig complessi senza tentativi.** Combina camere, piastre batteria, link wireless, monitor, motori e accessori tenendo sotto controllo il consumo totale a 14,4 V/12 V (e 33,6 V/21,6 V per B‑Mount) e autonomie realistiche basate su dati di campo ponderati. Il pannello di confronto batterie segnala eventuali sovraccarichi prima che l’attrezzatura parta.
 - **Mantieni allineati tutti i reparti.** Salva più progetti con requisiti, contatti della troupe, scenari e note. Le liste stampabili raggruppano il materiale per categoria, uniscono i duplicati, mostrano metadati tecnici e aggiungono accessori legati agli scenari così che camera, luce e grip condividano lo stesso contesto.
 - **Lavora con serenità ovunque.** Apri `index.html` direttamente oppure servi la cartella via HTTPS per attivare il service worker. La cache offline conserva lingua, temi, preferiti e progetti, e **Forza ricarica** aggiorna gli asset senza toccare i dati salvati.
-- **Adatta il planner alla tua troupe.** Passa subito tra italiano, inglese, tedesco, spagnolo e francese, regola dimensione e font, scegli un colore accento personale, carica un logo per la stampa e alterna tema chiaro, scuro, rosa o ad alto contrasto. Selettori con ricerca, preferiti fissati, pulsanti di duplicazione e guide contestuali mantengono il ritmo sul set.
+- **Adatta Cine Power Planner alla tua troupe.** Passa subito tra italiano, inglese, tedesco, spagnolo e francese, regola dimensione e font, scegli un colore accento personale, carica un logo per la stampa e alterna tema chiaro, scuro, rosa o ad alto contrasto. Selettori con ricerca, preferiti fissati, pulsanti di duplicazione e guide contestuali mantengono il ritmo sul set.
 
 ### ✅ Gestione dei progetti
 - Salva, carica e cancella più progetti (premi Invio o Ctrl+S/⌘S per salvare rapidamente; il pulsante rimane disattivato finché non inserisci un nome).
-- Vengono creati snapshot automatici ogni 10 minuti mentre il planner è aperto, e nelle Impostazioni puoi attivare export orari di backup come promemoria.
+- Vengono creati snapshot automatici ogni 10 minuti mentre Cine Power Planner è aperto, e nelle Impostazioni puoi attivare export orari di backup come promemoria.
 - Scarica un file JSON che raggruppa selezioni, requisiti, lista attrezzatura, feedback di autonomia e dispositivi personalizzati; importalo dal selettore per ripristinare tutto in un passo.
 - I dati si salvano localmente tramite `localStorage` e i preferiti vengono inclusi nei backup; l’opzione **Ripristino di fabbrica** scarica automaticamente una copia prima di cancellare progetti e modifiche ai dispositivi.
 - Genera anteprime stampabili per ogni progetto e aggiungi un logo personalizzato così esportazioni e backup rispettano l’identità della produzione.
@@ -217,7 +217,7 @@ Il generatore trasforma le tue scelte in una lista di carico ordinata per catego
 
 ## 📱 Installare come applicazione
 
-Il planner è un’applicazione web progressiva installabile direttamente dal browser:
+Cine Power Planner è un’applicazione web progressiva installabile direttamente dal browser:
 
 - **Chrome/Edge (desktop):** fai clic sull’icona di installazione nella barra degli indirizzi.
 - **Android:** apri il menu del browser e scegli *Aggiungi alla schermata Home*.

--- a/src/scripts/translations.js
+++ b/src/scripts/translations.js
@@ -806,12 +806,12 @@ const texts = {
     skipToContent: "Vai al contenuto",
     offlineIndicator: "Non in linea",
     offlineIndicatorHelp:
-      "Compare quando il planner è offline. Tutti i progetti, i backup e i dati dei dispositivi restano salvati su questo dispositivo così puoi continuare a lavorare.",
+      "Compare quando l’app è offline. Tutti i progetti, i backup e i dati dei dispositivi restano salvati su questo dispositivo così puoi continuare a lavorare.",
     installBannerText: "Installa Cine Power Planner sul tuo dispositivo per un accesso rapido.",
     installHelpTitleIos: "Installa Cine Power Planner su iOS",
     installHelpTitleAndroid: "Installa Cine Power Planner su Android",
-    installHelpIntroIos: "Aggiungi il planner alla schermata Home per usarlo come un'app.",
-    installHelpIntroAndroid: "Aggiungi il planner alla schermata Home per usarlo come un'app.",
+    installHelpIntroIos: "Aggiungi Cine Power Planner alla schermata Home per usarlo come app.",
+    installHelpIntroAndroid: "Aggiungi Cine Power Planner alla schermata Home per usarlo come app.",
     installHelpStepsIos: [
       "Apri Cine Power Planner in Safari.",
       "Tocca il pulsante Condividi.",
@@ -871,9 +871,9 @@ const texts = {
     pinkModeLabel: "Attiva modalità rosa",
     menuToggleLabel: "Menu",
     menuToggleHelp:
-      "Apri la barra laterale per raggiungere rapidamente le sezioni del planner o mostrare i controlli sugli schermi piccoli. Premi di nuovo per chiuderla.",
+      "Apri la barra laterale per raggiungere rapidamente le sezioni dell’app o mostrare i controlli sugli schermi piccoli. Premi di nuovo per chiuderla.",
     sideMenuHelp:
-      "Navigazione laterale con le sezioni del planner. Seleziona una sezione per scorrere fino a essa e chiudere automaticamente il menu.",
+      "Navigazione laterale con le sezioni dell’app. Seleziona una sezione per scorrere fino a essa e chiudere automaticamente il menu.",
     featureSearchPlaceholder: "Cerca funzionalità o dispositivi...",
     featureSearchLabel: "Cerca funzionalità, dispositivi e aiuto",
     featureSearchHelp:
@@ -1375,7 +1375,7 @@ const texts = {
     autoGearCancelEdit: "Annulla",
     autoGearResetFactoryButton: "Ripristina aggiunte di fabbrica",
     autoGearResetFactoryHelp:
-      "Ripristina le regole automatiche generate dagli scenari predefiniti del planner.",
+      "Ripristina le regole automatiche generate dagli scenari predefiniti dell’app.",
     autoGearResetFactoryConfirm:
       "Sostituire le regole automatiche con le aggiunte predefinite?",
     autoGearResetFactoryDone:
@@ -1449,13 +1449,13 @@ const texts = {
       "Carica uno snapshot JSON esportato in precedenza per ripristinare dati e impostazioni.",
     factoryResetButton: "Ripristino di fabbrica",
     factoryResetButtonHelp:
-      "Crea un backup e cancella tutti i dati del planner dopo la conferma.",
-    confirmFactoryReset: "Creare un backup e cancellare tutti i dati del planner?",
+      "Crea un backup e cancella tutti i dati dell’app dopo la conferma.",
+    confirmFactoryReset: "Creare un backup e cancellare tutti i dati dell’app?",
     confirmFactoryResetAgain:
       "Ultimo avviso: tutti i progetti, dispositivi, impostazioni e feedback salvati verranno eliminati. Continuare?",
     factoryResetBackupFailed: "Backup non riuscito. I dati non sono stati eliminati.",
     factoryResetSuccess:
-      "Backup scaricato. Tutti i dati del planner sono stati cancellati. Ricaricamento in corso…",
+      "Backup scaricato. Tutti i dati dell’app sono stati cancellati. Ricaricamento in corso…",
     factoryResetError: "Ripristino di fabbrica non riuscito. Riprova.",
     preDeleteBackupSuccess:
       "Backup automatico salvato. Puoi ripristinarlo da Progetti salvati.",
@@ -1468,7 +1468,7 @@ const texts = {
       "Tutto ciò che segue rimane in questo browser finché non lo esporti o lo elimini.",
     storageSummaryFootnote:
       "I backup scaricano ogni voce in JSON leggibile.",
-    storageSummaryEmpty: "Nessun dato del planner è attualmente salvato.",
+    storageSummaryEmpty: "Nessun dato dell’app è attualmente salvato.",
     storageKeyProjects: "Progetti salvati",
     storageKeyProjectsDesc: "Configurazioni salvate da Gestione progetto.",
     storageProjectsCountOne: "%s progetto",
@@ -1518,7 +1518,7 @@ const texts = {
     helpButtonTitle: "Aiuto (premi ?, H, F1 o Ctrl+/)",
     helpButtonHelp: "Apri la finestra di aiuto (premi ?, H, F1 o Ctrl+/).",
     helpClose: "Chiudi (Esc)",
-    helpCloseHelp: "Chiudi la finestra di aiuto e torna al planner (premi Esc).",
+    helpCloseHelp: "Chiudi la finestra di aiuto e torna all’app (premi Esc).",
     helpTitle: "Come usare",
     helpSearchPlaceholder: "Cerca negli argomenti dell'aiuto...",
     helpSearchLabel: "Cerca negli argomenti dell'aiuto",
@@ -1584,8 +1584,8 @@ const texts = {
     installBannerText: "Instala Cine Power Planner en tu dispositivo para acceder rápidamente.",
     installHelpTitleIos: "Instala Cine Power Planner en iOS",
     installHelpTitleAndroid: "Instala Cine Power Planner en Android",
-    installHelpIntroIos: "Añade el planner a la pantalla de inicio para usarlo como una aplicación.",
-    installHelpIntroAndroid: "Añade el planner a la pantalla de inicio para usarlo como una aplicación.",
+    installHelpIntroIos: "Añade Cine Power Planner a la pantalla de inicio para usarlo como una aplicación.",
+    installHelpIntroAndroid: "Añade Cine Power Planner a la pantalla de inicio para usarlo como una aplicación.",
     installHelpStepsIos: [
       "Abre Cine Power Planner en Safari.",
       "Toca el botón Compartir.",
@@ -2373,8 +2373,8 @@ const texts = {
     installBannerText: "Installez Cine Power Planner sur votre appareil pour un accès rapide.",
     installHelpTitleIos: "Installer Cine Power Planner sur iOS",
     installHelpTitleAndroid: "Installer Cine Power Planner sur Android",
-    installHelpIntroIos: "Ajoutez le planner à votre écran d’accueil pour l’utiliser comme une application.",
-    installHelpIntroAndroid: "Ajoutez le planner à votre écran d’accueil pour l’utiliser comme une application.",
+    installHelpIntroIos: "Ajoutez Cine Power Planner à votre écran d’accueil pour l’utiliser comme une application.",
+    installHelpIntroAndroid: "Ajoutez Cine Power Planner à votre écran d’accueil pour l’utiliser comme une application.",
     installHelpStepsIos: [
       "Ouvrez Cine Power Planner dans Safari.",
       "Touchez le bouton Partager.",
@@ -3163,8 +3163,8 @@ const texts = {
     installBannerText: "Installiere Cine Power Planner auf deinem Gerät für schnellen Zugriff.",
     installHelpTitleIos: "Cine Power Planner auf iOS installieren",
     installHelpTitleAndroid: "Cine Power Planner auf Android installieren",
-    installHelpIntroIos: "Füge den Planner deinem Home-Bildschirm hinzu, um ihn wie eine App zu nutzen.",
-    installHelpIntroAndroid: "Füge den Planner deinem Home-Bildschirm hinzu, um ihn wie eine App zu nutzen.",
+    installHelpIntroIos: "Füge Cine Power Planner deinem Home-Bildschirm hinzu, um ihn wie eine App zu nutzen.",
+    installHelpIntroAndroid: "Füge Cine Power Planner deinem Home-Bildschirm hinzu, um ihn wie eine App zu nutzen.",
     installHelpStepsIos: [
       "Öffne Cine Power Planner in Safari.",
       "Tippe auf die Teilen-Taste.",
@@ -3658,7 +3658,7 @@ const texts = {
       "Bestimme die Grundschriftgröße für bessere Lesbarkeit oder mehr Platz auf dem Bildschirm.",
     fontFamilySetting: "Schrift",
     fontFamilySettingHelp:
-      "Wähle die im Planner verwendete Schrift. Hinzugefügte lokale Fonts erscheinen in der Liste.",
+      "Wähle die im Planer verwendete Schrift. Hinzugefügte lokale Fonts erscheinen in der Liste.",
     bundledFontsGroup: "Mitgelieferte Schriften",
     localFontsGroup: "Lokale Schriften",
     localFontsButton: "Lokale Schrift hinzufügen…",
@@ -3743,7 +3743,7 @@ const texts = {
     autoGearCancelEdit: "Abbrechen",
     autoGearResetFactoryButton: "Auf Werks-Ergänzungen zurücksetzen",
     autoGearResetFactoryHelp:
-      "Stellt die automatisch erzeugten Regeln aus den Standardszenarien des Planners wieder her.",
+      "Stellt die automatisch erzeugten Regeln aus den Standardszenarien des Planers wieder her.",
     autoGearResetFactoryConfirm:
       "Automatische Gear-Regeln durch die Standard-Ergänzungen ersetzen?",
     autoGearResetFactoryDone:
@@ -3817,13 +3817,13 @@ const texts = {
       "Importiere eine zuvor exportierte JSON-Sicherung, um Daten und Einstellungen wiederherzustellen.",
     factoryResetButton: "Werkseinstellungen",
     factoryResetButtonHelp:
-      "Erstellt ein Backup und löscht nach Bestätigung alle Planner-Daten.",
-    confirmFactoryReset: "Backup erstellen und alle Planner-Daten löschen?",
+      "Erstellt ein Backup und löscht nach Bestätigung alle Planer-Daten.",
+    confirmFactoryReset: "Backup erstellen und alle Planer-Daten löschen?",
     confirmFactoryResetAgain:
       "Letzte Warnung: Alle gespeicherten Projekte, Geräte, Einstellungen und Rückmeldungen werden gelöscht. Fortfahren?",
     factoryResetBackupFailed: "Backup fehlgeschlagen. Daten wurden nicht gelöscht.",
     factoryResetSuccess:
-      "Backup heruntergeladen. Alle Planner-Daten wurden gelöscht. Seite wird neu geladen…",
+      "Backup heruntergeladen. Alle Planer-Daten wurden gelöscht. Seite wird neu geladen…",
     factoryResetError: "Zurücksetzen auf Werkseinstellungen fehlgeschlagen. Bitte erneut versuchen.",
     preDeleteBackupSuccess:
       "Automatische Sicherung gespeichert. Du kannst sie in Gespeicherte Projekte wiederherstellen.",
@@ -3831,12 +3831,12 @@ const texts = {
     restoreBackupFailed: "Backup fehlgeschlagen. Wiederherstellung abgebrochen.",
     dataHeading: "Daten & Speicherung",
     dataHeadingHelp:
-      "Zeigt, welche Planner-Daten lokal gespeichert sind und wie groß Sicherungen werden.",
+      "Zeigt, welche Planer-Daten lokal gespeichert sind und wie groß Sicherungen werden.",
     storageSummaryIntro:
       "Alles unten bleibt in diesem Browser, bis du es exportierst oder löschst.",
     storageSummaryFootnote:
       "Backups laden jede Position als gut lesbares JSON herunter.",
-    storageSummaryEmpty: "Derzeit sind keine Planner-Daten gespeichert.",
+    storageSummaryEmpty: "Derzeit sind keine Planer-Daten gespeichert.",
     storageKeyProjects: "Gespeicherte Projekte",
     storageKeyProjectsDesc: "Konfigurationen aus Projekt verwalten.",
     storageProjectsCountOne: "%s Projekt",


### PR DESCRIPTION
## Summary
- replace remaining English "planner" references in Italian, Spanish, French and German UI strings with localized wording or the product name
- update localized READMEs to use Cine Power Planner or native terminology when referring to the app for clarity and consistency

## Testing
- npm test -- --runTestsByPath tests/data/gearItemsTranslations.test.js

------
https://chatgpt.com/codex/tasks/task_e_68cf37fa37808320bc042a826360cb71