### PR TITLE
Improve in-app help guidance

### DIFF
--- a/index.html
+++ b/index.html
@@ -1030,6 +1030,37 @@
       <div id="helpSections">
         <section
           data-help-section
+          id="helpBasics"
+          data-help-keywords="help basics introduction start here navigation search filter quick links keyboard shortcuts hover tooltip instructions"
+        >
+          <h3><span class="help-icon icon-glyph" aria-hidden="true" data-icon-font="uicons">&#xEAC4;</span>Start Here</h3>
+          <ul>
+            <li>
+              Open this guide from the header <strong>Help</strong> button or press <strong>?</strong>, <strong>H</strong>,
+              <strong>F1</strong> or <strong>Ctrl+/</strong> (<strong>⌘/</strong> on Mac). Press <strong>Esc</strong> to close
+              the dialog and return to your project.
+            </li>
+            <li>
+              The search box filters topics as you type and highlights matching words. Use the × button to clear the query, or
+              press <strong>/</strong> or <strong>Ctrl+F</strong> (<strong>⌘F</strong>) while the dialog is open to jump
+              straight to search.
+            </li>
+            <li>
+              Use the <strong>Jump to a topic</strong> quick links for instant navigation. The list stays in sync with your
+              search and focuses the selected heading so you can start reading immediately.
+            </li>
+            <li>
+              Select <strong>Hover for help</strong> to turn the cursor into a help pointer. Move across buttons, menus and
+              form fields to read concise tooltips without leaving this dialog.
+            </li>
+            <li>
+              Buttons inside each article highlight or focus the matching controls in the planner, making it easy to follow
+              along and verify every step.
+            </li>
+          </ul>
+        </section>
+        <section
+          data-help-section
           id="featuresOverview"
           data-help-keywords="overview summary capabilities highlights offline offline-mode favorites favourites pinned search global keyboard shortcuts themes personalization backups tour"
         >
@@ -1261,11 +1292,32 @@
             <span class="help-icon icon-glyph" aria-hidden="true" data-icon-font="essential">&#xF207;</span>Saving, Sharing &amp; Restoring Projects
           </h3>
           <ul>
-            <li>Name your project in <em>Project Overview</em> and press <strong>Save</strong> (or hit Enter/Ctrl+S/⌘S) to capture the current configuration without leaving the planner.</li>
-            <li><strong>Export project</strong> downloads a portable JSON bundle with devices, requirements, automatic gear rules and runtime feedback so you can archive or share the setup safely offline.</li>
-            <li>Use <strong>Import project</strong> to load any saved JSON file. Imports keep your existing projects; choose <strong>Save</strong> afterwards if you want to store the imported version alongside them.</li>
-            <li>Open Settings → <em>Backup &amp; Restore</em> whenever you need a full-application snapshot. Backups include saved projects, device edits, preferences, favorites and feedback. Restores automatically create a fresh safety copy before applying the selected file.</li>
-            <li>Everything stays on this device so you can keep working offline. Hourly background backups and the 10‑minute auto snapshots below add extra recovery points without touching your current project.</li>
+            <li>
+              Name your project in <em>Project Overview</em> and press <strong>Save</strong> (or hit Enter/Ctrl+S/⌘S) to
+              capture the current configuration without leaving the planner. Saving with the same name updates that entry;
+              change the name first if you want to keep both versions side by side.
+            </li>
+            <li>
+              <strong>Export project</strong> downloads a portable JSON bundle with devices, requirements, automatic gear rules
+              and runtime feedback so you can archive or share the setup safely offline using your own storage or transfer
+              tools.
+            </li>
+            <li>
+              Use <strong>Import project</strong> to load any saved JSON file. Imports never overwrite your existing projects
+              until you press <strong>Save</strong>, and you can choose whether shared automatic gear rules should stay with the
+              project, update your global library or be ignored altogether.
+            </li>
+            <li>
+              Open Settings → <em>Backup &amp; Restore</em> whenever you need a full-application snapshot. <strong>Backup</strong>
+              includes saved projects, device edits, preferences, favorites, automatic gear rules and runtime feedback.
+              <strong>Restore</strong> always captures a fresh safety copy before applying the selected file so nothing is lost
+              by mistake.
+            </li>
+            <li>
+              Before using <strong>Force reload</strong>, <strong>Factory reset</strong> or clearing the browser cache, download
+              a backup so every project, device edit and auto-gear preset remains recoverable. Hourly background backups and the
+              10‑minute auto snapshots below add extra insurance without disrupting your workflow.
+            </li>
           </ul>
           <div class="help-link-group" aria-label="Saving and sharing shortcuts">
             <a


### PR DESCRIPTION
## Summary
- add a "Start Here" section to the help dialog with tips for opening, searching and navigating topics
- clarify save, export, import and restore instructions with stronger guidance on backups and offline safety

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cf380083988320b859311b585186e9