### PR TITLE
Document offline-first workflows across READMEs

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -4,6 +4,48 @@ Dieses browserbasierte Werkzeug hilft dir bei der Planung professioneller Kamera
 
 Sämtliche Planungen, Eingaben und Exporte bleiben auf deinem Gerät. Spracheinstellungen, Projekte, eigene Geräte, Favoriten und Laufzeit-Feedback werden im Browser gespeichert, und Service-Worker-Updates stammen direkt aus diesem Repository. Du kannst den Planner offline von der lokalen Festplatte öffnen oder intern hosten, damit jede Abteilung dieselbe geprüfte Version nutzt.
 
+## Auf einen Blick
+
+- **Netzwerkfrei planen.** Alle Symbole, Schriften und Hilfsskripte liegen in diesem Repository, sodass du `index.html` direkt
+  öffnen und offline arbeiten kannst.
+- **Projekte bleiben lokal.** Speicherstände, Laufzeit-Feedback, eigene Geräte, Favoriten und Gerätelisten bleiben auf dem
+  Gerät; Backups und teilbare Bundles sind menschenlesbare JSON-Dateien.
+- **Updates bewusst steuern.** Der Service Worker aktualisiert sich erst, nachdem du **Neu laden erzwingen** gedrückt hast –
+  ideal für Reisen und Drehs mit wenig Verbindung.
+- **Mehrstufige Sicherheitsnetze.** Manuelle Speicherungen, Auto-Saves und automatisch erzeugte Zeitstempel-Backups erleichtern
+  Wiederherstellungsproben vor dem Dreh.
+
+## Schnellstart
+
+1. Lade das Repository herunter oder klone es und öffne `index.html` in einem modernen Browser.
+2. (Optional) Stelle den Ordner lokal bereit (zum Beispiel mit `npx http-server` oder `python -m http.server`), damit sich der
+   Service Worker registriert und Assets für den Offline-Betrieb zwischenspeichert.
+3. Lade den Planner einmal, schließe den Tab, trenne die Verbindung und öffne `index.html` erneut. Das Offline-Badge sollte
+   kurz aufleuchten, während das zwischengespeicherte Interface lädt.
+4. Lege ein Projekt an, drücke **Enter** (oder **Strg+S**/`⌘S`) zum Speichern und beobachte das automatische Backup, das nach
+   wenigen Minuten im Projektmenü erscheint.
+5. Exportiere **Einstellungen → Backup & Wiederherstellung → Backup**, importiere die Datei in einem privaten Browserprofil und
+   prüfe, ob Projekte, Favoriten und eigene Geräte vollständig zurückkehren.
+6. Übe den Export einer `.cpproject`-Datei und den Import auf einem zweiten Gerät oder Profil, damit die Kette Speichern →
+   Teilen → Importieren vor dem Set-Einsatz geprüft ist.
+
+## Zentrale Arbeitsabläufe
+
+- **Rig planen.** Kombiniere Kameras, Platten, Funkstrecken, Monitore, Motoren und Zubehör, während Verbrauchs- und Laufzeitwerte
+  sofort mitlaufen.
+- **Versionen sichern.** Halte Projekte bewusst fest und lass automatisch Zeitstempel-Backups alle zehn Minuten entstehen.
+- **Sicher teilen.** Exportiere `.cpproject`-Bundles, die offline bleiben, beim Import validiert werden und auf Wunsch automatische
+  Gear-Regeln enthalten.
+- **Alles sichern.** Vollständige Planner-Backups beinhalten Projekte, Favoriten, eigene Geräte, Laufzeitdaten und UI-Präferenzen,
+  damit kein Kontext verloren geht.
+
+## Datensicherheit im Offline-Betrieb
+
+- Prüfe regelmäßig die Offline-Bereitschaft: Anwendung laden, Verbindung trennen, aktualisieren und sicherstellen, dass Projekte
+  erreichbar bleiben.
+- Bewahre redundante Backups auf beschrifteten Datenträgern auf und importiere sie nach jedem Export in einem zweiten Profil.
+- Erstelle vor Updates oder größeren Datenänderungen ein manuelles Backup und teste die Wiederherstellung.
+
 ---
 
 ## 🌍 Sprachen

--- a/README.en.md
+++ b/README.en.md
@@ -8,6 +8,48 @@ browser, and service worker updates are driven directly by this repository. Run
 the planner offline from disk or host it internally so every department uses the
 same audited version.
 
+## At a glance
+
+- **Plan without a network.** Every icon, font and helper script ships inside this repository so you can open `index.html`
+  directly and work offline.
+- **Keep projects on-device.** Saves, runtime feedback, custom devices, favorites and gear lists remain local; backups and
+  shareable bundles are human-readable JSON.
+- **Stay in control of updates.** The service worker only refreshes after you press **Force reload**, keeping crews on a trusted
+  build during travel.
+- **Rely on layered safety nets.** Manual saves, auto-saves and timestamped auto-backups make it easy to rehearse recovery before
+  a shoot.
+
+## Quick start
+
+1. Download or clone the repository and open `index.html` in a modern browser.
+2. (Optional) Serve the folder locally (for example with `npx http-server` or `python -m http.server`) so the service worker
+   registers and caches assets for offline use.
+3. Load the planner once, close the tab, go offline and reopen `index.html`. The offline badge should flash briefly while the
+   cached interface loads.
+4. Create a project, press **Enter** (or **Ctrl+S**/`⌘S`) to save and watch for the automatic backup that appears after a few
+   minutes.
+5. Export **Settings → Backup & Restore → Backup**, import the file in a private browser profile and confirm every project,
+   favorite and custom device restores correctly.
+6. Practice exporting a `.cpproject` bundle and importing it on another machine or profile so the save → share → import loop is
+   proven before you arrive on set.
+
+## Core workflows
+
+- **Plan a rig.** Combine cameras, plates, wireless links, monitors, motors and accessories while watching draw calculations and
+  runtime estimates update instantly.
+- **Save versions.** Maintain explicit project snapshots and let timestamped auto-backups capture in-progress work every 10
+  minutes.
+- **Share securely.** Export `.cpproject` bundles that stay offline, validate schema on import and optionally include automatic
+  gear rules.
+- **Back up everything.** Full planner backups include projects, favorites, custom devices, runtime data and UI preferences so no
+  context is lost.
+
+## Protecting data offline
+
+- Verify offline readiness regularly: load the app, disconnect, refresh and confirm your projects stay accessible.
+- Keep redundant backups on labelled storage and re-import them in a secondary profile after every export.
+- Before applying updates or major data edits, capture a manual backup and confirm it restores cleanly.
+
 ---
 
 ## 🌍 Languages

--- a/README.es.md
+++ b/README.es.md
@@ -4,6 +4,51 @@ Esta herramienta basada en navegador ayuda a planificar proyectos de cámara pro
 
 Toda la planificación, las entradas y las exportaciones permanecen en tu dispositivo. El idioma, los proyectos, el equipo personalizado, los favoritos y los comentarios de autonomía se guardan en tu navegador, y las actualizaciones del service worker provienen directamente de este repositorio. Ejecuta el planner sin conexión desde el disco o aloja la carpeta internamente para que cada departamento use la misma versión auditada.
 
+## De un vistazo
+
+- **Planifica sin conexión.** Todos los iconos, tipografías y scripts auxiliares viven en este repositorio; abre `index.html`
+  directamente y trabaja offline.
+- **Los proyectos se quedan en el dispositivo.** Los guardados, los datos de autonomía, los equipos personalizados, los
+  favoritos y las listas de equipo permanecen locales; las copias de seguridad y los paquetes compartibles son JSON legible por
+  personas.
+- **Controla las actualizaciones.** El service worker solo se actualiza después de pulsar **Forzar recarga**, manteniendo al
+  equipo en una versión fiable durante los traslados.
+- **Red de seguridad en capas.** Guardados manuales, auto guardados y copias de seguridad automáticas con marca de tiempo hacen
+  sencillo ensayar la recuperación antes del rodaje.
+
+## Puesta en marcha rápida
+
+1. Descarga o clona el repositorio y abre `index.html` en un navegador moderno.
+2. (Opcional) Sirve la carpeta en local (por ejemplo con `npx http-server` o `python -m http.server`) para que el service worker
+   se registre y almacene en caché los recursos para el uso sin conexión.
+3. Carga el planner una vez, cierra la pestaña, desconéctate de la red y vuelve a abrir `index.html`. El indicador offline debe
+   parpadear brevemente mientras se carga la interfaz almacenada.
+4. Crea un proyecto, pulsa **Intro** (o **Ctrl+S**/`⌘S`) para guardar y comprueba la copia de seguridad automática que aparece
+   en el selector tras unos minutos.
+5. Exporta **Ajustes → Copia de seguridad y restauración → Copia de seguridad**, importa el archivo en un perfil privado del
+   navegador y confirma que todos los proyectos, favoritos y equipos personalizados vuelven intactos.
+6. Practica la exportación de un paquete `.cpproject` y su importación en otra máquina o perfil para validar la cadena guardar →
+   compartir → importar antes de llegar al set.
+
+## Flujos de trabajo clave
+
+- **Planificar un rig.** Combina cámaras, placas, enlaces inalámbricos, monitores, motores y accesorios mientras las cifras de
+  consumo y autonomía se actualizan al instante.
+- **Guardar versiones.** Mantén instantáneas explícitas de los proyectos y deja que las copias de seguridad automáticas con marca
+  de tiempo capturen el trabajo en curso cada 10 minutos.
+- **Compartir con seguridad.** Exporta paquetes `.cpproject` que permanecen sin conexión, validan el esquema al importar e incluyen
+  reglas automáticas de equipo si lo necesitas.
+- **Respaldarlo todo.** Las copias de seguridad completas del planner incluyen proyectos, favoritos, equipos personalizados, datos
+  de autonomía y preferencias de la interfaz para no perder contexto.
+
+## Protección de datos sin conexión
+
+- Verifica con regularidad la preparación offline: carga la aplicación, desconéctate, actualiza y comprueba que tus proyectos siguen
+  disponibles.
+- Conserva copias redundantes en soportes etiquetados e impórtalas en un segundo perfil después de cada exportación.
+- Antes de aplicar actualizaciones o modificar datos importantes, genera una copia de seguridad manual y confirma que se restaura
+  correctamente.
+
 ---
 
 ## 🌍 Idiomas

--- a/README.fr.md
+++ b/README.fr.md
@@ -4,6 +4,49 @@ Cet outil basé sur le navigateur aide à planifier des projets caméra professi
 
 L’ensemble de la planification, des saisies et des exports reste sur votre appareil. La langue, les projets, les appareils personnalisés, les favoris et les retours d’autonomie sont stockés dans votre navigateur, et les mises à jour du service worker proviennent directement de ce dépôt. Lancez le planner hors ligne depuis le disque ou hébergez-le en interne pour que chaque département exploite la même version auditée.
 
+## En bref
+
+- **Planifiez sans réseau.** Toutes les icônes, polices et scripts d’assistance sont fournis dans ce dépôt ; ouvrez simplement
+  `index.html` pour travailler hors ligne.
+- **Les projets restent sur l’appareil.** Sauvegardes, retours d’autonomie, appareils personnalisés, favoris et listes de
+  matériel demeurent locaux ; les sauvegardes et paquets partageables sont des JSON lisibles.
+- **Gardez la main sur les mises à jour.** Le service worker ne se met à jour qu’après avoir cliqué sur **Forcer le rechargement**,
+  maintenant l’équipe sur une version fiable en déplacement.
+- **Filets de sécurité en cascade.** Sauvegardes manuelles, enregistrements automatiques et copies horodatées facilitent les
+  exercices de restauration avant le tournage.
+
+## Démarrage rapide
+
+1. Téléchargez ou clonez le dépôt et ouvrez `index.html` dans un navigateur moderne.
+2. (Optionnel) Servez le dossier en local (par exemple avec `npx http-server` ou `python -m http.server`) pour que le service
+   worker s’enregistre et mette en cache les ressources pour l’usage hors ligne.
+3. Chargez le planner une fois, fermez l’onglet, coupez la connexion et rouvrez `index.html`. L’indicateur hors ligne doit
+   clignoter brièvement pendant le chargement de l’interface en cache.
+4. Créez un projet, appuyez sur **Entrée** (ou **Ctrl+S**/`⌘S`) pour sauvegarder et surveillez la sauvegarde automatique qui
+   apparaît dans le sélecteur après quelques minutes.
+5. Exportez **Paramètres → Sauvegarde & Restauration → Sauvegarder**, importez le fichier dans un profil de navigation privé et
+   confirmez que projets, favoris et appareils personnalisés se restaurent correctement.
+6. Entraînez-vous à exporter un paquet `.cpproject` et à l’importer sur un autre appareil ou profil pour valider la chaîne
+   sauvegarde → partage → import avant d’arriver sur le plateau.
+
+## Flux de travail essentiels
+
+- **Planifier un rig.** Combinez caméras, plaques, liaisons sans fil, moniteurs, moteurs et accessoires tout en suivant en temps
+  réel la consommation et les estimations d’autonomie.
+- **Sauvegarder des versions.** Conservez des instantanés explicites et laissez les sauvegardes automatiques horodatées capturer
+  le travail en cours toutes les 10 minutes.
+- **Partager en toute sécurité.** Exportez des paquets `.cpproject` hors ligne qui valident le schéma à l’import et peuvent inclure
+  des règles automatiques de matériel.
+- **Sauvegarder l’ensemble.** Les sauvegardes complètes incluent projets, favoris, appareils personnalisés, données d’autonomie
+  et préférences d’interface pour ne perdre aucun contexte.
+
+## Protéger les données hors ligne
+
+- Vérifiez régulièrement la préparation hors ligne : chargez l’application, coupez la connexion, actualisez et assurez-vous que
+  vos projets restent accessibles.
+- Conservez des sauvegardes redondantes sur des supports étiquetés et réimportez-les dans un deuxième profil après chaque export.
+- Avant toute mise à jour ou modification importante, créez une sauvegarde manuelle et vérifiez que la restauration est propre.
+
 ---
 
 ## 🌍 Langues

--- a/README.it.md
+++ b/README.it.md
@@ -4,6 +4,49 @@ Questo strumento basato sul browser ti aiuta a pianificare progetti camera profe
 
 Tutta la pianificazione, gli input e gli export restano sul dispositivo davanti a te. Lingua, progetti, dispositivi personalizzati, preferiti e feedback sulle autonomie vivono nel browser, e gli aggiornamenti del service worker arrivano direttamente da questo repository. Avvia il planner offline dal disco o ospitalo internamente così che ogni reparto utilizzi la stessa versione verificata.
 
+## A colpo d'occhio
+
+- **Pianifica senza rete.** Tutte le icone, i font e gli script ausiliari sono inclusi in questo repository; apri `index.html`
+  direttamente e lavora offline.
+- **I progetti restano sul dispositivo.** Salvataggi, feedback sulle autonomie, attrezzature personalizzate, preferiti e liste
+  di attrezzatura restano locali; backup e pacchetti condivisibili sono file JSON leggibili.
+- **Controlla gli aggiornamenti.** Il service worker si aggiorna solo dopo aver premuto **Forza ricarica**, mantenendo la
+  produzione su una versione affidabile durante gli spostamenti.
+- **Rete di sicurezza a più livelli.** Salvataggi manuali, auto-save e backup automatici con timestamp rendono semplice provare
+  il ripristino prima delle riprese.
+
+## Avvio rapido
+
+1. Scarica o clona il repository e apri `index.html` in un browser moderno.
+2. (Opzionale) Servi la cartella in locale (ad esempio con `npx http-server` o `python -m http.server`) così il service worker
+   si registra e memorizza nella cache le risorse per l'uso offline.
+3. Carica il planner una volta, chiudi la scheda, disconnettiti dalla rete e riapri `index.html`. L'indicatore offline dovrebbe
+   lampeggiare brevemente mentre viene caricata l'interfaccia in cache.
+4. Crea un progetto, premi **Invio** (o **Ctrl+S**/`⌘S`) per salvare e controlla il backup automatico che appare nel selettore
+   dopo qualche minuto.
+5. Esporta **Impostazioni → Backup e ripristino → Backup**, importa il file in un profilo privato del browser e verifica che
+   progetti, preferiti e attrezzature personalizzate si ripristinino correttamente.
+6. Esercitati a esportare un pacchetto `.cpproject` e a importarlo su un'altra macchina o profilo per validare la catena salvataggio →
+   condivisione → importazione prima di arrivare sul set.
+
+## Flussi di lavoro principali
+
+- **Pianificare un rig.** Combina camere, piastre, collegamenti wireless, monitor, motori e accessori osservando aggiornarsi
+  all'istante consumi e stime di autonomia.
+- **Salvare versioni.** Mantieni istantanee esplicite dei progetti e lascia che backup automatici con timestamp catturino il
+  lavoro in corso ogni 10 minuti.
+- **Condividere in sicurezza.** Esporta pacchetti `.cpproject` che restano offline, convalidano lo schema in import e possono
+  includere regole automatiche per l'attrezzatura.
+- **Eseguire backup completi.** I backup del planner includono progetti, preferiti, attrezzature personalizzate, dati sulle
+  autonomie e preferenze dell'interfaccia in modo da non perdere contesto.
+
+## Proteggere i dati offline
+
+- Verifica regolarmente la prontezza offline: carica l'applicazione, disconnettiti, aggiorna e assicurati che i progetti restino
+  accessibili.
+- Conserva copie ridondanti su supporti etichettati e importale in un secondo profilo dopo ogni esportazione.
+- Prima di applicare aggiornamenti o modifiche importanti ai dati, crea un backup manuale e assicurati che il ripristino sia pulito.
+
 ---
 
 ## 🌍 Lingue

--- a/README.md
+++ b/README.md
@@ -8,6 +8,21 @@ B‑Mount or Gold‑Mount rigs, model runtime expectations, capture project
 requirements and export shareable bundles—entirely inside your browser, even
 when you are offline.
 
+## At a Glance
+
+- **Plan offline-first.** Build V‑Mount, B‑Mount or Gold‑Mount setups directly
+  in your browser. Every icon, font and helper script ships with the
+  repository so nothing relies on external CDNs or network access.
+- **Keep data on-device.** Projects, runtime feedback, favorites, custom
+  devices, gear lists and settings stay local. Backups and shareable bundles are
+  human-readable JSON files you control.
+- **Verify safety nets quickly.** Manual saves, background auto-saves and
+  timestamped auto-backups layer together so you can rehearse recovery before
+  leaving for set.
+- **Approve updates intentionally.** The service worker waits for you to
+  confirm a refresh, keeping teams on a known-good revision during travel or
+  low-connectivity shoots.
+
 ## Overview
 
 ### Built for crews
@@ -60,6 +75,7 @@ safe.
 
 ## Table of Contents
 
+- [At a Glance](#at-a-glance)
 - [Overview](#overview)
 - [Core Principles](#core-principles)
 - [Translations](#translations)
@@ -148,21 +164,19 @@ See the language-specific README files for release details in other locales.
    ```
    The app then caches itself for offline use and applies updates when you
    approve them.
-4. Confirm offline operation by loading the planner once, closing the tab,
-   disconnecting from the network (or toggling Airplane Mode) and reopening
-   `index.html`. The offline indicator in the header should light up briefly
-   while cached files load and the interface should match the last session
-   exactly.
-5. Create a project, add devices from the dropdowns and generate a printable
-   overview or gear list to brief collaborators. Use the runtime dashboard to
-   verify battery expectations before you export.
-6. Visit **Settings → Backup & Restore → Backup** before closing your first
-   session so you have a baseline snapshot to compare against future changes.
-   Import that backup into a private browser profile to confirm the restore
-   path works end to end.
-7. Practice exporting a project bundle and re-importing it on another machine
-   or browser profile. Verifying the full save → share → import loop in advance
-   keeps teams confident that no data will be lost when you are offline on set.
+4. Load the planner once, close the tab, disconnect from the network (or toggle
+   Airplane Mode) and reopen `index.html`. The offline indicator in the header
+   should flash briefly while cached files load. Confirm the interface mirrors
+   the last session exactly.
+5. Create your first project, press **Enter** (or **Ctrl+S**/`⌘S`) to capture a
+   manual save and review the project selector to see the timestamped
+   auto-backup that appears after a few minutes.
+6. Export **Settings → Backup & Restore → Backup** and import the resulting
+   `planner-backup.json` file into a private browser profile. Verifying the
+   restore path early proves that no saves are stranded on a single machine.
+7. Practice exporting a `.cpproject` bundle and re-importing it on a secondary
+   machine or profile. Rehearsing the full save → share → import loop keeps
+   crews confident that offline workflows are airtight.
 
 ## Everyday Workflow
 


### PR DESCRIPTION
## Summary
- add an "At a Glance" section to every README to highlight the offline-first model and data safety layers
- expand the Quick Start instructions with explicit offline verification, backup and bundle rehearsal steps across all locales
- document core workflows and offline protection routines so teams can rehearse save → share → restore loops without internet access

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68cf3817c6f88320a84e278471dc23dd