### PR TITLE
Prevent modal overlays from overscrolling

### DIFF
--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -1049,6 +1049,8 @@ main.legal-content {
   justify-content: center;
   padding: 20px;
   z-index: 200;
+  overflow: hidden;
+  overscroll-behavior: contain;
 }
 
 .modal-surface {
@@ -1068,6 +1070,7 @@ main.legal-content {
   max-height: 80vh;
   overflow-y: auto;
   -webkit-overflow-scrolling: touch;
+  overscroll-behavior: contain;
 }
 
 #installGuideDialog {
@@ -1079,8 +1082,8 @@ main.legal-content {
   justify-content: center;
   z-index: 205;
   padding: 20px;
-  overflow-y: auto;
-  -webkit-overflow-scrolling: touch;
+  overflow: hidden;
+  overscroll-behavior: contain;
 }
 
 #iosPwaHelpDialog {
@@ -1092,8 +1095,8 @@ main.legal-content {
   justify-content: center;
   z-index: 210;
   padding: 20px;
-  overflow-y: auto;
-  -webkit-overflow-scrolling: touch;
+  overflow: hidden;
+  overscroll-behavior: contain;
 }
 
 #feedbackForm fieldset {


### PR DESCRIPTION
## Summary
- contain modal overlay scroll chaining so popups stay fixed while their content scrolls
- limit install guide and iOS help overlays to internal scrolling only

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cf38f8888c832091e8b90e143d7f27