### PR TITLE
Use saved project name in requirements dialog

### DIFF
--- a/index.html
+++ b/index.html
@@ -2575,10 +2575,6 @@
         <section class="project-dialog-section project-dialog-section-basic">
           <div class="project-section-content">
             <div class="form-row">
-              <label for="projectName" id="projectNameLabel">Project Name:</label>
-              <input type="text" id="projectName" name="projectName" />
-            </div>
-            <div class="form-row">
               <label for="productionCompany" id="productionCompanyLabel">Production Company:</label>
               <input type="text" id="productionCompany" name="productionCompany" />
             </div>

--- a/src/scripts/script.js
+++ b/src/scripts/script.js
@@ -18092,7 +18092,6 @@ function collectProjectFormData() {
     const proGaffWidth2 = getGearValue('gearListProGaffWidth2');
 
     const info = {
-        projectName: getValue('projectName'),
         productionCompany: getValue('productionCompany'),
         rentalHouse: getValue('rentalHouse'),
         ...(people.length ? { people } : {}),
@@ -18154,6 +18153,11 @@ function collectProjectFormData() {
         info.proGaffWidth2 = proGaffWidth2 || '';
     }
 
+    const currentProjectName = getCurrentProjectName();
+    if (currentProjectName) {
+        info.projectName = currentProjectName;
+    }
+
     return info;
 }
 
@@ -18178,7 +18182,6 @@ function populateProjectForm(info = {}) {
     populateSensorModeDropdown(info.sensorMode);
     populateCodecDropdown(info.codec);
 
-    setVal('projectName', info.projectName);
     setVal('productionCompany', info.productionCompany);
     setVal('rentalHouse', info.rentalHouse);
     if (crewContainer) {
@@ -19042,7 +19045,8 @@ function generateGearListHtml(info = {}) {
     delete projectInfo.viewfinderSettings;
     delete projectInfo.frameGuides;
     delete projectInfo.aspectMaskOpacity;
-    const projectTitle = escapeHtml(info.projectName || setupNameInput.value);
+    const projectTitleSource = getCurrentProjectName() || info.projectName || '';
+    const projectTitle = escapeHtml(projectTitleSource);
     const projectLabels = texts[currentLang]?.projectFields || texts.en?.projectFields || {};
     const projectFormTexts = texts[currentLang]?.projectForm || texts.en?.projectForm || {};
     const excludedFields = new Set([

--- a/tests/script/backupAutomation.test.js
+++ b/tests/script/backupAutomation.test.js
@@ -116,7 +116,7 @@ describe('automated backups', () => {
 
     const { autoBackup } = loadApp();
 
-    const setupsStore = { 'Main Setup': { projectInfo: { projectName: 'Epic Shoot' } } };
+    const setupsStore = { 'Main Setup': { projectInfo: { projectName: 'Main Setup' } } };
     global.loadSetups.mockImplementation(() => setupsStore);
     global.saveSetups.mockImplementation((next) => next);
 
@@ -128,9 +128,6 @@ describe('automated backups', () => {
     setupSelect.appendChild(option);
     setupSelect.value = 'Main Setup';
     setupNameInput.value = 'Main Setup';
-
-    const projectNameInput = document.getElementById('projectName');
-    projectNameInput.value = 'Epic Shoot';
 
     const gearListOutput = document.getElementById('gearListOutput');
     gearListOutput.classList.remove('hidden');
@@ -149,14 +146,14 @@ describe('automated backups', () => {
     expect(projectCalls.length).toBeGreaterThan(0);
     expect(projectCalls[projectCalls.length - 1][1]).toEqual(
       expect.objectContaining({
-        projectInfo: expect.objectContaining({ projectName: 'Epic Shoot' }),
+        projectInfo: expect.objectContaining({ projectName: 'Main Setup' }),
         gearList: expect.stringContaining('Alexa 35'),
       }),
     );
 
     expect(setupsStore[backupKey]).toEqual(
       expect.objectContaining({
-        projectInfo: expect.objectContaining({ projectName: 'Epic Shoot' }),
+        projectInfo: expect.objectContaining({ projectName: 'Main Setup' }),
         gearList: expect.stringContaining('Alexa 35'),
       }),
     );
@@ -169,7 +166,7 @@ describe('automated backups', () => {
 
     const { autoBackup } = loadApp();
 
-    const setupsStore = { 'Main Setup': { projectInfo: { projectName: 'Epic Shoot' } } };
+    const setupsStore = { 'Main Setup': { projectInfo: { projectName: 'Main Setup' } } };
     global.loadSetups.mockImplementation(() => setupsStore);
     global.saveSetups.mockImplementation(() => {});
 

--- a/tests/script/factoryReset.test.js
+++ b/tests/script/factoryReset.test.js
@@ -23,7 +23,6 @@ describe('factory reset cleanup', () => {
     const cameraSelect = document.getElementById('cameraSelect');
     const gearListOutput = document.getElementById('gearListOutput');
     const projectRequirementsOutput = document.getElementById('projectRequirementsOutput');
-    const projectNameInput = document.getElementById('projectName');
 
     const customRules = [
       {
@@ -39,8 +38,7 @@ describe('factory reset cleanup', () => {
     syncAutoGearRulesFromStorage(customRules);
     expect(getAutoGearRules().some((rule) => rule.label === 'Custom Reset Rule')).toBe(true);
 
-    setCurrentProjectInfo({ projectName: 'Active project' });
-    projectNameInput.value = 'Active project';
+    setCurrentProjectInfo({ productionCompany: 'Active project' });
 
     setupNameInput.value = 'Main setup';
     const customOption = new Option('Main setup', 'Main setup');
@@ -65,7 +63,6 @@ describe('factory reset cleanup', () => {
     resetPlannerStateAfterFactoryReset();
 
     expect(getCurrentProjectInfo()).toBeNull();
-    expect(projectNameInput.value).toBe('');
     expect(setupNameInput.value).toBe('');
     expect(setupSelect.value).toBe('');
     expect(Array.from(setupSelect.options).some((opt) => opt.value === 'Main setup')).toBe(false);


### PR DESCRIPTION
## Summary
- remove the standalone project name field from the Project Requirements dialog and rely on the saved project title
- capture the active project name when collecting requirement data so gear list and overview headers stay in sync
- align backup and factory reset tests with the header-driven project name workflow

## Testing
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68cf3c43561083209ed33c35df9e0a8a