### PR TITLE
Prevent duplicate filter entries in gear list

### DIFF
--- a/legacy/scripts/script.js
+++ b/legacy/scripts/script.js
@@ -18294,8 +18294,17 @@ function generateGearListHtml() {
   var needsSwingAway = filterTypes.some(function (t) {
     return t === 'ND Grad HE' || t === 'ND Grad SE';
   });
+  var filterEntries = buildFilterGearEntries(parsedFilters);
   var filterSelections = collectFilterAccessories(parsedFilters);
-  var filterSelectHtml = buildFilterSelectHtml(parsedFilters);
+  if (filterEntries.length && filterSelections.length) {
+    var filterNames = new Set(filterEntries.map(function (entry) {
+      return normalizeGearNameForComparison(entry.gearName);
+    }));
+    filterSelections = filterSelections.filter(function (item) {
+      return !filterNames.has(normalizeGearNameForComparison(item));
+    });
+  }
+  var filterSelectHtml = buildFilterSelectHtml(parsedFilters, filterEntries);
   if (info.mattebox && !needsSwingAway) {
     var matteboxSelection = info.mattebox.toLowerCase();
     if (matteboxSelection.includes('clamp')) {
@@ -23713,9 +23722,24 @@ function applyFilterSelectionsToGearList() {
   updateGearListFilterEntries(entries);
   adjustGearListSelectWidths(gearListOutput);
 }
+function normalizeGearNameForComparison(name) {
+  if (!name) return '';
+  var normalized = String(name);
+  if (typeof normalized.normalize === 'function') {
+    normalized = normalized.normalize('NFD');
+  } else if (typeof String.prototype.normalize === 'function') {
+    normalized = String.prototype.normalize.call(normalized, 'NFD');
+  }
+  normalized = normalized.replace(/[\u0300-\u036f]/g, '');
+  normalized = normalized.replace(/\bfuer\b/gi, 'for');
+  normalized = normalized.replace(/\bfur\b/gi, 'for');
+  normalized = normalized.toLowerCase();
+  return normalized.replace(/[^a-z0-9]+/g, '');
+}
 function buildFilterSelectHtml() {
   var filters = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : [];
-  var entries = buildFilterGearEntries(filters);
+  var precomputedEntries = arguments.length > 1 ? arguments[1] : undefined;
+  var entries = Array.isArray(precomputedEntries) ? precomputedEntries : buildFilterGearEntries(filters);
   var summaryHtml = entries.map(function (entry) {
     var attrs = ['class="gear-item"', "data-gear-name=\"".concat(escapeHtml(entry.gearName), "\""), "data-filter-entry=\"".concat(escapeHtml(entry.id), "\""), "data-filter-label=\"".concat(escapeHtml(entry.label), "\"")];
     if (entry.type) attrs.push("data-filter-type=\"".concat(escapeHtml(entry.type), "\""));

--- a/src/scripts/script.js
+++ b/src/scripts/script.js
@@ -18908,8 +18908,17 @@ function generateGearListHtml(info = {}) {
     const parsedFilters = parseFilterTokens(info.filter);
     const filterTypes = parsedFilters.map(f => f.type);
     const needsSwingAway = filterTypes.some(t => t === 'ND Grad HE' || t === 'ND Grad SE');
+    const filterEntries = buildFilterGearEntries(parsedFilters);
     let filterSelections = collectFilterAccessories(parsedFilters);
-    const filterSelectHtml = buildFilterSelectHtml(parsedFilters);
+    if (filterEntries.length && filterSelections.length) {
+        const filterNames = new Set(
+            filterEntries.map(entry => normalizeGearNameForComparison(entry.gearName))
+        );
+        filterSelections = filterSelections.filter(item =>
+            !filterNames.has(normalizeGearNameForComparison(item))
+        );
+    }
+    const filterSelectHtml = buildFilterSelectHtml(parsedFilters, filterEntries);
     if (info.mattebox && !needsSwingAway) {
         const matteboxSelection = info.mattebox.toLowerCase();
         if (matteboxSelection.includes('clamp')) {
@@ -24476,8 +24485,25 @@ function applyFilterSelectionsToGearList(info = currentProjectInfo) {
   adjustGearListSelectWidths(gearListOutput);
 }
 
-function buildFilterSelectHtml(filters = []) {
-  const entries = buildFilterGearEntries(filters);
+function normalizeGearNameForComparison(name) {
+  if (!name) return '';
+  let normalized = String(name);
+  if (typeof normalized.normalize === 'function') {
+    normalized = normalized.normalize('NFD');
+  } else if (typeof String.prototype.normalize === 'function') {
+    normalized = String.prototype.normalize.call(normalized, 'NFD');
+  }
+  normalized = normalized.replace(/[\u0300-\u036f]/g, '');
+  normalized = normalized.replace(/\bfuer\b/gi, 'for');
+  normalized = normalized.replace(/\bfur\b/gi, 'for');
+  normalized = normalized.toLowerCase();
+  return normalized.replace(/[^a-z0-9]+/g, '');
+}
+
+function buildFilterSelectHtml(filters = [], precomputedEntries) {
+  const entries = Array.isArray(precomputedEntries)
+    ? precomputedEntries
+    : buildFilterGearEntries(filters);
   const summaryHtml = entries.map(entry => {
     const attrs = [
       'class="gear-item"',


### PR DESCRIPTION
## Summary
- deduplicate automatic filter accessory items when a selected filter already appears in the gear list summary
- normalize gear names before comparison and reuse precomputed filter entries while rendering the filter selector output
- mirror the duplicate-prevention logic in the legacy bundle to keep both builds aligned

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cf3cc7ed8c832093ffc30a99704986