### PR TITLE
Align project action buttons

### DIFF
--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -2322,7 +2322,9 @@ button {
 
 .share-import-group button {
   margin: 0;
-  align-self: center;
+  flex: 1 1 100%;
+  width: 100%;
+  align-self: stretch;
 }
 button:hover {
   background-color: var(--control-hover-bg);


### PR DESCRIPTION
## Summary
- ensure the Import Project button stretches to fill its container so all project action buttons share the same width

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cf4113c3d48320968a0b70dbd7779c