### PR TITLE
Use lighter font weight for header title

### DIFF
--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -2512,6 +2512,7 @@ input[type="file"]:disabled::-webkit-file-upload-button {
 #topBar h1 {
   font-size: calc(var(--font-size-relative-base) * var(--font-scale-xxl));
   margin: 0;
+  font-weight: var(--font-weight-light);
 }
 
 #topBar .branding {


### PR DESCRIPTION
## Summary
- use the existing light font weight token on the top bar title so it appears thinner

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cf461b73548320ac14ce7d5dfefefc