### PR TITLE
Lighten section heading font weight

### DIFF
--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -340,6 +340,10 @@ h2 {
   border-bottom: 1px solid var(--accent-color);
 }
 
+section > h2 {
+  font-weight: var(--font-weight-light);
+}
+
 body.pink-mode:not(.dark-mode) h1,
 body.pink-mode:not(.dark-mode) h2,
 body.pink-mode:not(.dark-mode) h3 {


### PR DESCRIPTION
## Summary
- apply the light font weight to section headings to thin the section tile titles

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cf4631e27483209828d0f895690a7e