### PR TITLE
Fix video distribution auto gear rule merging

### DIFF
--- a/src/scripts/script.js
+++ b/src/scripts/script.js
@@ -913,21 +913,9 @@ function getBaseAutoGearRules() {
 }
 
 function autoGearRuleSignature(rule) {
-  if (!rule || typeof rule !== 'object') return '';
-  const normalizeList = list => Array.isArray(list)
-    ? list.map(item => ({
-        name: typeof item.name === 'string' ? item.name : '',
-        category: typeof item.category === 'string' ? item.category : '',
-        quantity: normalizeAutoGearQuantity(item.quantity),
-      }))
-    : [];
-  return stableStringify({
-    label: typeof rule.label === 'string' ? rule.label : '',
-    scenarios: Array.isArray(rule.scenarios) ? rule.scenarios : [],
-    mattebox: Array.isArray(rule.mattebox) ? rule.mattebox : [],
-    add: normalizeList(rule.add),
-    remove: normalizeList(rule.remove),
-  });
+  const snapshot = snapshotAutoGearRuleForFingerprint(rule);
+  if (!snapshot) return '';
+  return stableStringify(snapshot);
 }
 
 function mergeAutoGearRules(existing, incoming) {

--- a/tests/script/autoGearRules.test.js
+++ b/tests/script/autoGearRules.test.js
@@ -838,6 +838,53 @@ describe('applyAutoGearRulesToTableHtml', () => {
     expect(stored[0].label).toBe('Shared grip tweak');
   });
 
+  test('shared rule merging keeps distinct video distribution triggers', () => {
+    env = setupScriptEnvironment();
+
+    const { importAutoGearRulesFromData, applySharedSetup, getAutoGearRules } = env.utils;
+
+    const baseRule = {
+      id: 'base-video-rule',
+      label: 'Wireless village',
+      scenarios: ['Village'],
+      mattebox: [],
+      cameraHandle: [],
+      viewfinderExtension: [],
+      videoDistribution: [],
+      add: [
+        { id: 'base-add', name: 'Village monitor kit', category: 'Monitoring', quantity: 1 }
+      ],
+      remove: [],
+    };
+
+    importAutoGearRulesFromData([baseRule], { silent: true });
+
+    const sharedRule = {
+      id: 'shared-video-rule',
+      label: 'Wireless village',
+      scenarios: ['Village'],
+      mattebox: [],
+      cameraHandle: [],
+      viewfinderExtension: [],
+      videoDistribution: ['IOS Video'],
+      add: [
+        { id: 'base-add', name: 'Village monitor kit', category: 'Monitoring', quantity: 1 }
+      ],
+      remove: [],
+    };
+
+    applySharedSetup({ setupName: 'Shared import' }, {
+      sharedAutoGearRules: [sharedRule],
+      autoGearMode: ['global'],
+    });
+
+    const merged = getAutoGearRules();
+    expect(merged).toEqual(expect.arrayContaining([
+      expect.objectContaining({ id: 'base-video-rule', videoDistribution: [] }),
+      expect.objectContaining({ id: 'shared-video-rule', videoDistribution: ['IOS Video'] }),
+    ]));
+  });
+
   test('rule editor accepts multiple additions at once', () => {
     env = setupScriptEnvironment();
 


### PR DESCRIPTION
## Summary
- ensure auto gear rule signatures include the full normalized trigger snapshot so video distribution conditions survive merges
- add a regression test that exercises merging shared rules with unique video distribution requirements

## Testing
- npm test -- --runTestsByPath tests/script/autoGearRules.test.js

------
https://chatgpt.com/codex/tasks/task_e_68cf457ec5448320b072f7f0aafad8ab