### PR TITLE
Update help text for project requirements metadata

### DIFF
--- a/index.html
+++ b/index.html
@@ -1493,7 +1493,8 @@
         >
           <h3><span class="help-icon icon-glyph" aria-hidden="true" data-icon-font="uicons">&#xE469;</span>Project Requirements</h3>
           <ul>
-            <li>Capture production details such as production company, rental house, DoP, crew roles with email contacts, shooting dates, resolutions, codecs and more for each project.</li>
+            <li>Capture production metadata such as production company, rental house, DoP, crew roles with email contacts and prep/shoot day ranges alongside delivery notes like resolutions, sensor modes, codecs and base frame rates so every project stays traceable.</li>
+            <li>Track creative requirements with lens sets, matte box and filter choices, monitoring configurations, frame guides, aspect mask opacity, user button layouts, video distribution and tripod preferences—all of which flow into project summaries.</li>
             <li>Multi-select lists let you specify multiple scenarios, accessories or monitoring setups.</li>
             <li>Use the + buttons to add crew entries or prep/shoot ranges, and tap the − buttons to remove items as plans change.</li>
             <li>A live summary under <strong>Required Scenarios</strong> displays icon-labelled chips for every selection so you can confirm which accessory packs will trigger; choosing <strong>Dolly</strong> unlocks <strong>Remote Head</strong> and automatically surfaces default monitor options to keep downstream lists complete.</li>
@@ -1543,10 +1544,12 @@
                 <ul>
                   <li><strong>Project Name</strong>, <strong>Production Company</strong>, <strong>Rental House</strong>, <strong>DoP</strong>, <strong>Prep</strong> and <strong>Shooting Days</strong> populate the printed header and can trigger weather gear with outdoor scenarios.</li>
                   <li><strong>Crew</strong> entries keep names, roles and email addresses attached so contact lists and call sheets stay current.</li>
+                  <li><strong>Delivery Resolution</strong>, <strong>Recording Resolution</strong>, <strong>Sensor Mode</strong>, <strong>Aspect Ratio</strong>, <strong>Codec</strong> and <strong>Base Frame Rate</strong> lock in capture specs so printed summaries and exports show the intended format.</li>
                   <li><strong>Required Scenarios</strong> toggle accessory packs as described above.</li>
-                  <li><strong>Camera Handle</strong>, <strong>Viewfinder Extension</strong> and <strong>User Button Layouts</strong> supply matching handles, VF extensions and notes for operators.</li>
+                  <li><strong>Lenses</strong> define the core set for the shoot, surface front diameters for matte-box adapters and inform balancing accessories when scenarios like gimbals are active.</li>
+                  <li><strong>Camera Handle</strong>, <strong>Viewfinder Extension</strong> and <strong>User Button Layouts</strong> supply matching handles, VF extensions and quick-reference notes for camera, monitor and viewfinder controls.</li>
                   <li><strong>Matte Box</strong> and <strong>Filter Set</strong> selections insert filter trays, donuts, adapters and storage cases.</li>
-                  <li><strong>Monitoring Configuration</strong> and <strong>Video Distribution</strong> choices attach wireless links, splitters, antennas and channel‑assignment notes.</li>
+                  <li><strong>Monitoring Configuration</strong>, <strong>Frame Guides</strong>, <strong>Aspect Mask Opacity</strong> and <strong>Video Distribution</strong> choices attach wireless links, overlays, splitters, antennas and channel‑assignment notes.</li>
                   <li><strong>Viewfinder Settings</strong> and <strong>Tripod Preferences</strong> add EVF mounts, extension brackets, tripod heads, spreaders and counterbalance details.</li>
                 </ul>
               </li>


### PR DESCRIPTION
## Summary
- expand the Project Requirements help section to cover the newer capture and creative metadata fields
- document how the additional form values feed printable summaries and gear list exports for safer sharing

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cf478295c88320890a4cc9b9cf5415