### PR TITLE
Adjust icon alignment for inline labels

### DIFF
--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -1747,6 +1747,7 @@ body.pink-mode .auto-gear-rule-title,
   align-items: center;
   justify-content: center;
   line-height: 1;
+  vertical-align: middle;
   font-size: var(--icon-size, 1em);
   width: var(--icon-size, 1em);
   height: var(--icon-size, 1em);


### PR DESCRIPTION
## Summary
- align inline icon glyphs with adjacent text by vertically centering them

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cf4852b99883208c97b26ac1396b4f