### PR TITLE
Adjust gear category weight

### DIFF
--- a/src/styles/overview-print.css
+++ b/src/styles/overview-print.css
@@ -346,7 +346,7 @@ body:not(.light-mode) .gear-table .auto-gear-item {
 body:not(.light-mode) .gear-table .category-row td {
   border-top: 1px solid var(--accent-color);
   border-bottom: 1px solid var(--accent-color);
-  font-weight: var(--font-weight-bold);
+  font-weight: var(--font-weight-medium);
   color: var(--accent-color);
   break-after: avoid;
   page-break-after: avoid;

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -4045,7 +4045,7 @@ body.dark-mode.dark-accent-boost:not(.pink-mode) .settings-content.modal-surface
 .gear-table .category-row td {
   border-top: 1px solid var(--accent-color);
   border-bottom: 1px solid var(--accent-color);
-  font-weight: var(--font-weight-bold);
+  font-weight: var(--font-weight-medium);
   color: var(--accent-color);
   break-after: avoid;
   page-break-after: avoid;


### PR DESCRIPTION
## Summary
- reduce the gear list category font weight to a thinner style across default and overview print styles

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cf49552d54832092bef37e5ce0afbb