### PR TITLE
Fix shared link button alignment

### DIFF
--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -700,6 +700,19 @@ main.legal-content {
   white-space: nowrap;
 }
 
+#setup-manager .form-row.form-row-actions .form-actions > .share-import-group:only-child,
+#setup-manager .form-row.form-row-actions .form-actions > button.hidden + .share-import-group,
+#setup-manager .form-row.form-row-actions .form-actions > button[hidden] + .share-import-group {
+  flex: 1 1 100%;
+  max-width: 100%;
+}
+
+#setup-manager .form-row.form-row-actions .form-actions > .share-import-group:only-child button,
+#setup-manager .form-row.form-row-actions .form-actions > button.hidden + .share-import-group button,
+#setup-manager .form-row.form-row-actions .form-actions > button[hidden] + .share-import-group button {
+  width: 100%;
+}
+
 
 .share-option {
   display: inline-flex;
@@ -2329,7 +2342,7 @@ button {
   margin: 0;
   flex: 1 1 100%;
   width: 100%;
-  align-self: stretch;
+  align-self: center;
 }
 button:hover {
   background-color: var(--control-hover-bg);


### PR DESCRIPTION
## Summary
- center the shared project import button within the project actions row so it aligns with its paired input
- keep the existing mobile overrides so the button still stretches to full width on small screens
- allow the shared import action to grow to the full row width whenever it is the only visible project action

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cf4d76118083209f389ce324f2c1a3