### PR TITLE
Remove text from diagram zoom buttons

### DIFF
--- a/legacy/scripts/script.js
+++ b/legacy/scripts/script.js
@@ -3856,13 +3856,13 @@ function setLanguage(lang) {
     resetViewBtn.setAttribute("data-help", texts[lang].resetViewHelp);
   }
   if (zoomInBtn) {
-    setButtonLabelWithIcon(zoomInBtn, texts[lang].zoomInLabel, ICON_GLYPHS.add);
+    setButtonLabelWithIcon(zoomInBtn, '', ICON_GLYPHS.add);
     zoomInBtn.setAttribute("title", texts[lang].zoomInLabel);
     zoomInBtn.setAttribute("aria-label", texts[lang].zoomInLabel);
     zoomInBtn.setAttribute("data-help", texts[lang].zoomInHelp);
   }
   if (zoomOutBtn) {
-    setButtonLabelWithIcon(zoomOutBtn, texts[lang].zoomOutLabel, ICON_GLYPHS.minus);
+    setButtonLabelWithIcon(zoomOutBtn, '', ICON_GLYPHS.minus);
     zoomOutBtn.setAttribute("title", texts[lang].zoomOutLabel);
     zoomOutBtn.setAttribute("aria-label", texts[lang].zoomOutLabel);
     zoomOutBtn.setAttribute("data-help", texts[lang].zoomOutHelp);

--- a/src/scripts/script.js
+++ b/src/scripts/script.js
@@ -4118,13 +4118,13 @@ function setLanguage(lang) {
     resetViewBtn.setAttribute("data-help", texts[lang].resetViewHelp);
   }
   if (zoomInBtn) {
-    setButtonLabelWithIcon(zoomInBtn, texts[lang].zoomInLabel, ICON_GLYPHS.add);
+    setButtonLabelWithIcon(zoomInBtn, '', ICON_GLYPHS.add);
     zoomInBtn.setAttribute("title", texts[lang].zoomInLabel);
     zoomInBtn.setAttribute("aria-label", texts[lang].zoomInLabel);
     zoomInBtn.setAttribute("data-help", texts[lang].zoomInHelp);
   }
   if (zoomOutBtn) {
-    setButtonLabelWithIcon(zoomOutBtn, texts[lang].zoomOutLabel, ICON_GLYPHS.minus);
+    setButtonLabelWithIcon(zoomOutBtn, '', ICON_GLYPHS.minus);
     zoomOutBtn.setAttribute("title", texts[lang].zoomOutLabel);
     zoomOutBtn.setAttribute("aria-label", texts[lang].zoomOutLabel);
     zoomOutBtn.setAttribute("data-help", texts[lang].zoomOutHelp);

--- a/src/scripts/storage.js
+++ b/src/scripts/storage.js
@@ -3164,7 +3164,7 @@ function parseSnapshotJSONValue(entry) {
     }
     try {
       return JSON.parse(trimmed);
-    } catch (error) {
+    } catch {
       return raw;
     }
   }

--- a/src/styles/overview-print.css
+++ b/src/styles/overview-print.css
@@ -423,6 +423,10 @@ body:not(.light-mode) .gear-table .category-row td {
   height: auto !important;
 }
 
+#overviewDialogContent .diagram-controls button .btn-icon:only-child {
+  margin-right: 0 !important;
+}
+
 .warning {
   font-weight: var(--font-weight-bold);
 }

--- a/src/styles/overview.css
+++ b/src/styles/overview.css
@@ -227,6 +227,10 @@ th { background-color: var(--control-bg); font-weight: var(--font-weight-bold); 
   flex-wrap: wrap;
 }
 
+.diagram-controls button .btn-icon:only-child {
+  margin-right: 0;
+}
+
 .diagram-controls button {
   min-width: var(--button-size);
   min-height: var(--button-size);

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -1922,6 +1922,10 @@ body.pink-mode .auto-gear-rule-title,
   margin-right: 0.3em;
 }
 
+button .btn-icon:only-child {
+  margin-right: 0;
+}
+
 .favorite-icon.icon-glyph {
   --icon-size: calc(var(--font-size-relative-base) * var(--font-scale-md));
 }


### PR DESCRIPTION
## Summary
- strip text labels from the connection diagram zoom controls while keeping localized tooltips and help text
- adjust button icon spacing so icon-only controls stay centered in the main, overview, and print layouts
- drop an unused error variable in storage parsing to satisfy lint rules

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cff0e5143483209e9a247e1ebbd6c7