### PR TITLE
Use timecode icon for codec field

### DIFF
--- a/legacy/scripts/script.js
+++ b/legacy/scripts/script.js
@@ -4913,7 +4913,7 @@ var projectFieldIcons = {
   deliveryResolution: iconGlyph("\uEF69", ICON_FONT_KEYS.UICONS),
   recordingResolution: ICON_GLYPHS.camera,
   aspectRatio: ASPECT_RATIO_ICON,
-  codec: iconGlyph("\uE7A6", ICON_FONT_KEYS.UICONS),
+  codec: ICON_GLYPHS.timecode,
   baseFrameRate: iconGlyph("\uE46F", ICON_FONT_KEYS.UICONS),
   sensorMode: ICON_GLYPHS.sensor,
   requiredScenarios: REQUIRED_SCENARIOS_ICON,

--- a/src/scripts/script.js
+++ b/src/scripts/script.js
@@ -5334,7 +5334,7 @@ const projectFieldIcons = {
   deliveryResolution: iconGlyph('\uEF69', ICON_FONT_KEYS.UICONS),
   recordingResolution: ICON_GLYPHS.camera,
   aspectRatio: ASPECT_RATIO_ICON,
-  codec: iconGlyph('\uE7A6', ICON_FONT_KEYS.UICONS),
+  codec: ICON_GLYPHS.timecode,
   baseFrameRate: iconGlyph('\uE46F', ICON_FONT_KEYS.UICONS),
   sensorMode: ICON_GLYPHS.sensor,
   requiredScenarios: REQUIRED_SCENARIOS_ICON,


### PR DESCRIPTION
## Summary
- switch the project codec field icon to the existing timecode glyph
- mirror the change in the legacy bundle so both builds stay aligned

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cff134a0cc8320b47f36891c26ee15