### PR TITLE
Update localized readmes for automation and storage dashboard

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -60,6 +60,8 @@ Beim ersten Start übernimmt die Anwendung automatisch die Sprache deines Browse
 ---
 
 ## 🆕 Neueste Funktionen
+- Die neuen automatischen Gear-Regeln fügen szenariobasierte Ergänzungen oder Entfernungen hinzu, lassen sich exportieren und gemeinsam mit Bundles wiederherstellen.
+- Das Daten- & Speicher-Dashboard prüft gespeicherte Projekte, Gerätelisten, eigene Geräte, Favoriten und Laufzeit-Feedback direkt in den Einstellungen.
 - Akzent- und Typografie-Regler in den Einstellungen erlauben dir Akzentfarbe, Grundschriftgröße und Schriftfamilie sowie die Themes Dunkel, Pink und Hoher Kontrast einstellen.
 - Tastenkürzel für die globale Suche setzen den Fokus sofort mit / oder Strg+K (⌘K auf macOS) – selbst wenn es im eingeklappten mobilen Seitenmenü steckt.
 - Die Aktion „Neu laden erzwingen" leert zwischengespeicherte Service-Worker-Dateien, damit sich die Offline-Anwendung aktualisiert, ohne Projekte oder Geräte zu löschen.

--- a/README.en.md
+++ b/README.en.md
@@ -64,6 +64,8 @@ The app automatically uses your browser language on first load, and you can swit
 ---
 
 ## 🆕 Recent Features
+- Automatic gear rules let you design scenario-driven additions or removals, export the configuration and restore it alongside project bundles.
+- Data & storage dashboard audits saved projects, gear lists, custom devices, favorites and runtime feedback directly inside Settings.
 - Accent and typography controls in Settings let you adjust the accent color, base font size and typeface alongside dark, pink and high contrast themes.
 - Keyboard shortcuts for the global search let you press / or Ctrl+K (⌘K on macOS) to focus the feature search instantly, even when it sits inside the collapsed mobile side menu.
 - Force reload button clears cached service worker files so the offline app refreshes without deleting saved projects or devices.

--- a/README.es.md
+++ b/README.es.md
@@ -63,6 +63,8 @@ La aplicación adopta automáticamente el idioma de tu navegador en la primera v
 ---
 
 ## 🆕 Novedades recientes
+- Las reglas automáticas de equipo permiten definir adiciones o retiradas según el escenario, exportarlas y restaurarlas junto con los paquetes compartidos.
+- El panel de datos y almacenamiento revisa proyectos guardados, listas, dispositivos personalizados, favoritos y comentarios de autonomía desde Ajustes.
 - Los controles de acento y tipografía en Ajustes permiten definir el color de acento, el tamaño base y la familia tipográfica junto con los temas oscuro, rosa y de alto contraste.
 - Los atajos de teclado de la búsqueda global enfocan el campo al instante con / o Ctrl+K (⌘K en macOS), incluso cuando está dentro del menú lateral móvil contraído.
 - El botón **Forzar recarga** vacía los archivos en caché del service worker para que la aplicación sin conexión se actualice sin borrar proyectos ni dispositivos guardados.

--- a/README.fr.md
+++ b/README.fr.md
@@ -61,6 +61,8 @@ L’application adopte automatiquement la langue de votre navigateur lors de la 
 ---
 
 ## 🆕 Nouveautés
+- Les règles automatiques d’équipement ajoutent ou retirent du matériel selon le scénario, avec export/import aux côtés des bundles partagés.
+- Le tableau de bord Données & stockage audite projets enregistrés, listes de matériel, appareils personnalisés, favoris et retours d’autonomie depuis les Réglages.
 - Les réglages d’accent et de typographie dans Paramètres permettent d’ajuster couleur d’accent, taille de base et famille de police, aux côtés des thèmes sombre, rose et à fort contraste.
 - Les raccourcis clavier de la recherche globale placent le focus sur le champ instantanément avec / ou Ctrl+K (⌘K sur macOS), même lorsqu’il se trouve dans le menu latéral replié.
 - Le bouton **Forcer le rechargement** vide les fichiers mis en cache par le service worker afin de mettre à jour l’application hors ligne sans effacer projets ou appareils.

--- a/README.it.md
+++ b/README.it.md
@@ -61,6 +61,8 @@ Al primo avvio l’applicazione adotta la lingua del browser; puoi cambiarla dal
 ---
 
 ## 🆕 Novità
+- Le regole automatiche dell'attrezzatura consentono di definire aggiunte o rimozioni guidate dallo scenario, esportarle e ripristinarle insieme ai bundle condivisi.
+- Il cruscotto Dati e archiviazione controlla progetti salvati, elenchi, dispositivi personalizzati, preferiti e feedback sulle autonomie direttamente nelle Impostazioni.
 - I controlli di accento e tipografia nelle Impostazioni consentono di regolare colore, dimensione base e famiglia del font insieme ai temi scuro, rosa e ad alto contrasto.
 - Le scorciatoie della ricerca globale portano il focus sul campo all’istante con / o Ctrl+K (⌘K su macOS), anche quando è nascosto nel menu laterale compresso.
 - Il pulsante **Forza ricarica** cancella i file del service worker in cache per aggiornare l’applicazione offline senza eliminare progetti o dispositivi salvati.


### PR DESCRIPTION
## Summary
- document automatic gear rules in the English and translated README files so scenario-driven bundles stay discoverable
- add the new data & storage dashboard callout across localized "Recent features" sections

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d03259fe908320b0ec830766e18200