### PR TITLE
Enhance diagram hover details with recording metadata

### DIFF
--- a/src/scripts/script.js
+++ b/src/scripts/script.js
@@ -17841,6 +17841,10 @@ function generateConnectorSummary(device) {
   if (device.power?.input?.voltageRange) {
     specHtml += `<span class="info-box power-conn">${iconMarkup(ICON_GLYPHS.batteryBolt)}Voltage: ${escapeHtml(String(device.power.input.voltageRange))}V</span>`;
   }
+  if (typeof device.weight_g === 'number') {
+    const weightLabel = `${device.weight_g} g`;
+    specHtml += `<span class="info-box neutral-conn">${iconMarkup(ICON_GLYPHS.gears)}Weight: ${escapeHtml(weightLabel)}</span>`;
+  }
   if (typeof device.capacity === 'number') {
         specHtml += `<span class="info-box power-conn">${iconMarkup(ICON_GLYPHS.batteryFull)}Capacity: ${device.capacity} Wh</span>`;
     }
@@ -17872,6 +17876,42 @@ function generateConnectorSummary(device) {
     specHtml += `<span class="info-box power-conn">${iconMarkup(diagramConnectorIcons.powerSource)}Power Source: ${escapeHtml(String(device.powerSource))}</span>`;
   }
 
+  const uniqueList = list => {
+    if (!Array.isArray(list)) return [];
+    const seen = new Set();
+    const values = [];
+    list.forEach(entry => {
+      const str = entry != null ? String(entry).trim() : '';
+      if (!str || seen.has(str)) return;
+      seen.add(str);
+      values.push(escapeHtml(str));
+    });
+    return values;
+  };
+
+  const appendListBox = (html, values, label, cls, icon) => {
+    const formatted = uniqueList(values);
+    if (!formatted.length) return html;
+    const iconHtml = iconMarkup(icon);
+    return `${html}<span class="info-box ${cls}">${iconHtml}${label}: ${formatted.join(', ')}</span>`;
+  };
+
+  let recordingHtml = '';
+  if (Array.isArray(device.sensorModes)) {
+    recordingHtml = appendListBox(recordingHtml, device.sensorModes, 'Sensor Modes', 'video-conn', ICON_GLYPHS.sensor);
+  }
+  if (Array.isArray(device.resolutions)) {
+    recordingHtml = appendListBox(recordingHtml, device.resolutions, 'Resolutions', 'video-conn', ICON_GLYPHS.screen);
+  }
+  if (Array.isArray(device.recordingCodecs)) {
+    recordingHtml = appendListBox(recordingHtml, device.recordingCodecs, 'Codecs', 'video-conn', ICON_GLYPHS.camera);
+  }
+  if (Array.isArray(device.recordingMedia)) {
+    const mediaTypes = device.recordingMedia
+      .map(item => (item && item.type ? item.type : ''));
+    recordingHtml = appendListBox(recordingHtml, mediaTypes, 'Media', 'video-conn', ICON_GLYPHS.save);
+  }
+
     let extraHtml = '';
     if (Array.isArray(device.power?.batteryPlateSupport) && device.power.batteryPlateSupport.length) {
         const types = device.power.batteryPlateSupport.map(p => {
@@ -17879,10 +17919,6 @@ function generateConnectorSummary(device) {
             return `${escapeHtml(p.type)}${mount}`;
         });
         extraHtml += `<span class="info-box power-conn">Battery Plate: ${types.join(', ')}</span>`;
-    }
-    if (Array.isArray(device.recordingMedia) && device.recordingMedia.length) {
-        const types = device.recordingMedia.map(m => escapeHtml(m.type));
-        extraHtml += `<span class="info-box video-conn">Media: ${types.join(', ')}</span>`;
     }
     if (Array.isArray(device.viewfinder) && device.viewfinder.length) {
         const types = device.viewfinder.map(v => escapeHtml(v.type));
@@ -17916,6 +17952,7 @@ function generateConnectorSummary(device) {
 
     html += section('Ports', portHtml);
     html += section('Specs', specHtml);
+    html += section('Recording', recordingHtml);
     html += section('Extras', extraHtml);
     if (lensHtml) html += `<div class="info-label">Lens Mount</div>${lensHtml}`;
 


### PR DESCRIPTION
## Summary
- add device weight and new recording attributes to the diagram/overview connector summary
- group sensor modes, resolutions, codecs, and media into a dedicated recording section styled with existing categories
- keep existing extras while ensuring hover popups and overview boxes show the expanded details consistently

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d03312215c8320b2957a1d9c0039ac