### PR TITLE
Include iOS PWA help preference in storage exports

### DIFF
--- a/src/scripts/storage.js
+++ b/src/scripts/storage.js
@@ -2872,6 +2872,11 @@ function clearAllData() {
       preferences.language = language;
     }
 
+    const iosPwaHelpShown = parseStoredBoolean(readLocalStorageValue('iosPwaHelpShown'));
+    if (iosPwaHelpShown !== null) {
+      preferences.iosPwaHelpShown = iosPwaHelpShown;
+    }
+
     return preferences;
   }
 

--- a/tests/unit/storage.test.js
+++ b/tests/unit/storage.test.js
@@ -799,6 +799,7 @@ describe('export/import all data', () => {
       localStorage.setItem('fontSize', '18');
       localStorage.setItem('fontFamily', "'My Font', sans-serif");
       localStorage.setItem('language', 'de');
+      localStorage.setItem('iosPwaHelpShown', 'true');
       localStorage.setItem('customLogo', 'data:image/svg+xml;base64,PHN2Zw==');
       localStorage.setItem(
         'cameraPowerPlanner_customFonts',
@@ -848,6 +849,7 @@ describe('export/import all data', () => {
           fontSize: '18',
           fontFamily: "'My Font', sans-serif",
           language: 'de',
+          iosPwaHelpShown: true,
         },
         customLogo: 'data:image/svg+xml;base64,PHN2Zw==',
         customFonts: [
@@ -886,6 +888,7 @@ describe('export/import all data', () => {
           fontSize: '20',
           fontFamily: "'Other Font', serif",
           language: 'fr',
+          iosPwaHelpShown: true,
         },
         customLogo: 'data:image/svg+xml;base64,PE1PQ0s+',
         customFonts: [
@@ -914,7 +917,8 @@ describe('export/import all data', () => {
       expect(localStorage.getItem('accentColor')).toBe('#00ff00');
       expect(localStorage.getItem('fontSize')).toBe('20');
       expect(localStorage.getItem('fontFamily')).toBe("'Other Font', serif");
-    expect(localStorage.getItem('language')).toBe('fr');
+      expect(localStorage.getItem('language')).toBe('fr');
+      expect(localStorage.getItem('iosPwaHelpShown')).toBe('true');
     expect(JSON.parse(localStorage.getItem('cameraPowerPlanner_customFonts'))).toEqual([
       { id: 'font-restore', name: 'Restore Font', data: 'data:font/woff;base64,BBBB' }
     ]);


### PR DESCRIPTION
## Summary
- add the iosPwaHelpShown flag to the exported preference snapshot so backups preserve the onboarding state
- extend import/export storage tests to cover the iosPwaHelpShown preference

## Testing
- npm test -- --runTestsByPath tests/unit/storage.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d0339c1c788320a8e4d3863ed66c00