### PR TITLE
Align overview section icons with headings

### DIFF
--- a/src/styles/overview-print.css
+++ b/src/styles/overview-print.css
@@ -151,6 +151,12 @@ body.dark-mode {
   color: var(--text-color) !important;
 }
 
+#overviewDialogContent .device-category h3 {
+  display: flex;
+  align-items: center;
+  gap: 0.4em;
+}
+
 #overviewDialogContent.logo-present {
   position: relative;
   padding-top: 80px;

--- a/src/styles/overview.css
+++ b/src/styles/overview.css
@@ -179,6 +179,9 @@ th { background-color: var(--control-bg); font-weight: var(--font-weight-bold); 
   margin-bottom: 5px;
   border-bottom: 1px solid var(--divider-color);
   padding-bottom: 3px;
+  display: flex;
+  align-items: center;
+  gap: 0.4em;
 }
 
 @media (max-width: 600px) {


### PR DESCRIPTION
## Summary
- align the Project Overview dialog section headers with their glyph icons by flex-centering the heading row
- mirror the icon alignment fix inside the printable overview stylesheet so generated exports keep the improved layout

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d033f955708320ab02780085699672