### PR TITLE
Remove shadows from print stylesheet

### DIFF
--- a/src/styles/overview-print.css
+++ b/src/styles/overview-print.css
@@ -54,7 +54,7 @@ body,
 body.dark-mode {
   --surface-color: #fff;
   --text-color: #000;
-  --panel-shadow: 0 2px 6px rgba(0, 0, 0, 0.05);
+  --panel-shadow: none;
   --button-size: 24px;
   --diagram-node-fill: #f0f0f0;
   --power-color: #d33;


### PR DESCRIPTION
## Summary
- set the print stylesheet's panel shadow variable to `none` so printed overview elements no longer render drop shadows.

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d034effd288320b44d6e3af89945c1