### PR TITLE
Ensure printed warnings use black text

### DIFF
--- a/src/styles/overview-print.css
+++ b/src/styles/overview-print.css
@@ -66,6 +66,7 @@ body.dark-mode {
   --neutral-conn-bg: rgba(158, 158, 158, 0.15);
   --status-warning-bg: #ffe066;
   --status-warning-text-color: #000;
+  --status-error-text-color: #000;
   font-family: 'Ubuntu', sans-serif;
   font-weight: var(--font-weight-light);
   font-size: var(--font-size-base);
@@ -89,6 +90,7 @@ body.dark-mode {
   --neutral-conn-bg: rgba(158, 158, 158, 0.15);
   --status-warning-bg: #ffe066;
   --status-warning-text-color: #000;
+  --status-error-text-color: #000;
   --diagram-node-fill: #f0f0f0;
   --power-color: #d33;
   --video-color: #369;

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -4508,6 +4508,18 @@ body.dark-mode.pink-mode #gearListOutput h2,
     display: none !important;
   }
 
+  html,
+  body,
+  #overviewDialogContent {
+    --status-warning-text-color: #000 !important;
+    --status-error-text-color: #000 !important;
+  }
+
+  .status-message--warning,
+  .status-message--danger {
+    color: #000 !important;
+  }
+
   #overviewDialog {
     display: block;
     position: static;


### PR DESCRIPTION
## Summary
- force warning and danger status messages to print with black text regardless of the active theme
- align the overview print stylesheet variables so error-state messages also render in black when printing

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d03521a6bc8320b5cd448fb4478f32