### PR TITLE
Adjust icon spacing in Project Overview buttons

### DIFF
--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -1911,6 +1911,10 @@ body.pink-mode .auto-gear-rule-title,
   --icon-size: var(--button-icon-size);
 }
 
+#setup-manager button .btn-icon {
+  margin-right: 0.5em;
+}
+
 .help-icon,
 .btn-icon,
 .legend-icon,


### PR DESCRIPTION
## Summary
- increase the margin between Project Overview button icons and their labels for better legibility while leaving icon-only buttons unchanged

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d0382246208320895ccba6861a69ab