### PR TITLE
Reset custom fonts during factory reset

### DIFF
--- a/tests/script/factoryReset.test.js
+++ b/tests/script/factoryReset.test.js
@@ -100,4 +100,35 @@ describe('factory reset cleanup', () => {
     const rulesAfterReset = getAutoGearRules();
     expect(rulesAfterReset.some((rule) => rule.label === 'Custom Reset Rule')).toBe(false);
   });
+
+  test('resetPlannerStateAfterFactoryReset removes uploaded custom fonts', async () => {
+    const app = loadApp();
+    const { resetPlannerStateAfterFactoryReset, __customFontInternals } = app;
+    const fontSelect = document.getElementById('settingsFontFamily');
+
+    await __customFontInternals.addFromData(
+      'Factory Reset Font',
+      'data:font/woff;base64,AAAA',
+      { persist: false },
+    );
+
+    expect(__customFontInternals.getEntries().length).toBe(1);
+
+    const uploadedOptionsBefore = Array.from(fontSelect.options).filter(
+      (option) => option?.dataset?.source === 'uploaded',
+    );
+    expect(uploadedOptionsBefore.length).toBeGreaterThan(0);
+    const fontId = uploadedOptionsBefore[0].dataset.fontId;
+    const styleId = `customFontStyle-${fontId}`;
+    expect(document.getElementById(styleId)).not.toBeNull();
+
+    resetPlannerStateAfterFactoryReset();
+
+    expect(__customFontInternals.getEntries().length).toBe(0);
+    const uploadedOptionsAfter = Array.from(fontSelect.options).filter(
+      (option) => option?.dataset?.source === 'uploaded',
+    );
+    expect(uploadedOptionsAfter.length).toBe(0);
+    expect(document.getElementById(styleId)).toBeNull();
+  });
 });


### PR DESCRIPTION
## Summary
- ensure factory reset clears uploaded custom fonts by removing runtime entries, font options, and injected styles
- expose custom font helpers for tests and add coverage verifying custom fonts are cleared during factory reset

## Testing
- npm test -- factoryReset

------
https://chatgpt.com/codex/tasks/task_e_68d037be262c8320a5d6b5e201cb9958