### PR TITLE
Fix battery favorite toggle after option refresh

### DIFF
--- a/src/scripts/script.js
+++ b/src/scripts/script.js
@@ -2495,9 +2495,11 @@ function updateBatteryOptions() {
   if (Array.from(batterySelect.options).some(o => o.value === current)) {
     batterySelect.value = current;
   }
+  updateFavoriteButton(batterySelect);
   if (Array.from(hotswapSelect.options).some(o => o.value === currentSwap)) {
     hotswapSelect.value = currentSwap;
   }
+  updateFavoriteButton(hotswapSelect);
   updateBatteryLabel();
 }
 


### PR DESCRIPTION
## Summary
- ensure the battery selector re-enables its favorite toggle after refreshes triggered by mount filtering
- update the battery hotswap selector favorite button alongside restored selections

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d038a2267883208ad8310aa2ee1311