### PR TITLE
Use UIcons for dynamic add/remove buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -391,8 +391,12 @@
     </div>
     <div id="diagramLegend" class="diagram-legend"></div>
     <div class="diagram-controls">
-      <button id="zoomOut" type="button" title="Zoom out" aria-label="Zoom out">-</button>
-      <button id="zoomIn" type="button" title="Zoom in" aria-label="Zoom in">+</button>
+      <button id="zoomOut" type="button" title="Zoom out" aria-label="Zoom out">
+        <span class="btn-icon icon-glyph" aria-hidden="true" data-icon-font="uicons">&#xE9E0;</span>
+      </button>
+      <button id="zoomIn" type="button" title="Zoom in" aria-label="Zoom in">
+        <span class="btn-icon icon-glyph" aria-hidden="true" data-icon-font="uicons">&#xE02E;</span>
+      </button>
       <button id="resetView" type="button">
         <span class="btn-icon icon-glyph" aria-hidden="true" data-icon-font="uicons">&#xEB6D;</span>
         Reset View
@@ -2633,17 +2637,23 @@
             <div class="form-row" id="crewListRow">
               <label id="crewLabel">Crew:</label>
               <div id="crewContainer" aria-labelledby="crewLabel"></div>
-              <button type="button" id="addPersonBtn">+</button>
+              <button type="button" id="addPersonBtn">
+                <span class="btn-icon icon-glyph" aria-hidden="true" data-icon-font="uicons">&#xE02E;</span>
+              </button>
             </div>
             <div class="form-row" id="prepListRow">
               <label id="prepLabel">Prep Days:</label>
               <div id="prepContainer"></div>
-              <button type="button" id="addPrepBtn">+</button>
+              <button type="button" id="addPrepBtn">
+                <span class="btn-icon icon-glyph" aria-hidden="true" data-icon-font="uicons">&#xE02E;</span>
+              </button>
             </div>
             <div class="form-row" id="shootListRow">
               <label id="shootLabel">Shooting Days:</label>
               <div id="shootContainer"></div>
-              <button type="button" id="addShootBtn">+</button>
+              <button type="button" id="addShootBtn">
+                <span class="btn-icon icon-glyph" aria-hidden="true" data-icon-font="uicons">&#xE02E;</span>
+              </button>
             </div>
           </div>
         </section>

--- a/src/scripts/script.js
+++ b/src/scripts/script.js
@@ -5386,6 +5386,59 @@ function setButtonLabelWithIcon(button, label, glyph = ICON_GLYPHS.save) {
   button.innerHTML = `${iconHtml}${safeLabel}`;
 }
 
+function getLocalizedPathText(path, fallback = '') {
+  if (!path) return fallback;
+  const keys = Array.isArray(path) ? path : typeof path === 'string' ? [path] : [];
+  if (!keys.length) return fallback;
+  const langTexts = (texts && texts[currentLang]) || {};
+  const fallbackTexts = (texts && texts.en) || {};
+  const resolve = (source) => keys.reduce((acc, key) => {
+    if (acc && Object.prototype.hasOwnProperty.call(acc, key)) {
+      return acc[key];
+    }
+    return undefined;
+  }, source);
+  const localized = resolve(langTexts);
+  if (localized !== undefined && localized !== null && localized !== '') {
+    return String(localized);
+  }
+  const fallbackValue = resolve(fallbackTexts);
+  if (fallbackValue !== undefined && fallbackValue !== null && fallbackValue !== '') {
+    return String(fallbackValue);
+  }
+  return fallback;
+}
+
+function configureIconOnlyButton(button, glyph, options = {}) {
+  if (!button) return;
+  const {
+    contextPaths = [],
+    fallbackContext = '',
+    actionKey = 'addEntry'
+  } = options || {};
+  setButtonLabelWithIcon(button, '', glyph || ICON_GLYPHS.add);
+  const actionLabel = getLocalizedPathText(['projectForm', actionKey], actionKey === 'removeEntry' ? 'Remove' : 'Add');
+  const paths = Array.isArray(contextPaths) ? contextPaths : [contextPaths];
+  let contextLabel = '';
+  for (const path of paths) {
+    if (!path) continue;
+    const resolved = getLocalizedPathText(path, '');
+    if (resolved) {
+      contextLabel = resolved;
+      break;
+    }
+  }
+  if (!contextLabel && typeof fallbackContext === 'string') {
+    contextLabel = fallbackContext;
+  }
+  const normalizedContext = contextLabel ? contextLabel.replace(/[:：]\s*$/, '').trim() : '';
+  const combinedLabel = [actionLabel, normalizedContext].filter(Boolean).join(' ').trim();
+  if (combinedLabel) {
+    button.setAttribute('aria-label', combinedLabel);
+    button.setAttribute('title', combinedLabel);
+  }
+}
+
 function createCrewRow(data = {}) {
   if (!crewContainer) return;
   const row = document.createElement('div');
@@ -12407,14 +12460,22 @@ function createVideoOutputRow(value = '') {
   row.appendChild(createFieldWithLabel(select, 'Type'));
   const addBtn = document.createElement('button');
   addBtn.type = 'button';
-  addBtn.textContent = '+';
+  configureIconOnlyButton(addBtn, ICON_GLYPHS.add, {
+    contextPaths: ['videoOutputsHeading', ['cameraVideoOutputsLabel']],
+    fallbackContext: 'Video Outputs',
+    actionKey: 'addEntry'
+  });
   addBtn.addEventListener('click', () => {
     row.after(createVideoOutputRow());
   });
   row.appendChild(addBtn);
   const removeBtn = document.createElement('button');
   removeBtn.type = 'button';
-  removeBtn.textContent = '−';
+  configureIconOnlyButton(removeBtn, ICON_GLYPHS.minus, {
+    contextPaths: ['videoOutputsHeading', ['cameraVideoOutputsLabel']],
+    fallbackContext: 'Video Outputs',
+    actionKey: 'removeEntry'
+  });
   removeBtn.addEventListener('click', () => {
     if (videoOutputsContainer.children.length > 1) row.remove();
   });
@@ -12462,14 +12523,22 @@ function createMonitorVideoInputRow(value = '') {
   row.appendChild(createFieldWithLabel(select, 'Type'));
   const addBtn = document.createElement('button');
   addBtn.type = 'button';
-  addBtn.textContent = '+';
+  configureIconOnlyButton(addBtn, ICON_GLYPHS.add, {
+    contextPaths: ['monitorVideoInputsHeading', ['monitorVideoInputsLabel']],
+    fallbackContext: 'Video Inputs',
+    actionKey: 'addEntry'
+  });
   addBtn.addEventListener('click', () => {
     row.after(createMonitorVideoInputRow());
   });
   row.appendChild(addBtn);
   const removeBtn = document.createElement('button');
   removeBtn.type = 'button';
-  removeBtn.textContent = '−';
+  configureIconOnlyButton(removeBtn, ICON_GLYPHS.minus, {
+    contextPaths: ['monitorVideoInputsHeading', ['monitorVideoInputsLabel']],
+    fallbackContext: 'Video Inputs',
+    actionKey: 'removeEntry'
+  });
   removeBtn.addEventListener('click', () => {
     if (monitorVideoInputsContainer.children.length > 1) row.remove();
   });
@@ -12517,14 +12586,22 @@ function createMonitorVideoOutputRow(value = '') {
   row.appendChild(createFieldWithLabel(select, 'Type'));
   const addBtn = document.createElement('button');
   addBtn.type = 'button';
-  addBtn.textContent = '+';
+  configureIconOnlyButton(addBtn, ICON_GLYPHS.add, {
+    contextPaths: ['monitorVideoOutputsHeading', ['monitorVideoOutputsLabel']],
+    fallbackContext: 'Video Outputs',
+    actionKey: 'addEntry'
+  });
   addBtn.addEventListener('click', () => {
     row.after(createMonitorVideoOutputRow());
   });
   row.appendChild(addBtn);
   const removeBtn = document.createElement('button');
   removeBtn.type = 'button';
-  removeBtn.textContent = '−';
+  configureIconOnlyButton(removeBtn, ICON_GLYPHS.minus, {
+    contextPaths: ['monitorVideoOutputsHeading', ['monitorVideoOutputsLabel']],
+    fallbackContext: 'Video Outputs',
+    actionKey: 'removeEntry'
+  });
   removeBtn.addEventListener('click', () => {
     if (monitorVideoOutputsContainer.children.length > 1) row.remove();
   });
@@ -12572,14 +12649,22 @@ function createViewfinderVideoInputRow(value = '') {
   row.appendChild(createFieldWithLabel(select, 'Type'));
   const addBtn = document.createElement('button');
   addBtn.type = 'button';
-  addBtn.textContent = '+';
+  configureIconOnlyButton(addBtn, ICON_GLYPHS.add, {
+    contextPaths: ['viewfinderVideoInputsHeading', ['viewfinderVideoInputsLabel']],
+    fallbackContext: 'Video Inputs',
+    actionKey: 'addEntry'
+  });
   addBtn.addEventListener('click', () => {
     row.after(createViewfinderVideoInputRow());
   });
   row.appendChild(addBtn);
   const removeBtn = document.createElement('button');
   removeBtn.type = 'button';
-  removeBtn.textContent = '−';
+  configureIconOnlyButton(removeBtn, ICON_GLYPHS.minus, {
+    contextPaths: ['viewfinderVideoInputsHeading', ['viewfinderVideoInputsLabel']],
+    fallbackContext: 'Video Inputs',
+    actionKey: 'removeEntry'
+  });
   removeBtn.addEventListener('click', () => {
     if (viewfinderVideoInputsContainer && viewfinderVideoInputsContainer.children.length > 1) row.remove();
   });
@@ -12629,14 +12714,22 @@ function createViewfinderVideoOutputRow(value = '') {
   row.appendChild(createFieldWithLabel(select, 'Type'));
   const addBtn = document.createElement('button');
   addBtn.type = 'button';
-  addBtn.textContent = '+';
+  configureIconOnlyButton(addBtn, ICON_GLYPHS.add, {
+    contextPaths: ['viewfinderVideoOutputsHeading', ['viewfinderVideoOutputsLabel']],
+    fallbackContext: 'Video Outputs',
+    actionKey: 'addEntry'
+  });
   addBtn.addEventListener('click', () => {
     row.after(createViewfinderVideoOutputRow());
   });
   row.appendChild(addBtn);
   const removeBtn = document.createElement('button');
   removeBtn.type = 'button';
-  removeBtn.textContent = '−';
+  configureIconOnlyButton(removeBtn, ICON_GLYPHS.minus, {
+    contextPaths: ['viewfinderVideoOutputsHeading', ['viewfinderVideoOutputsLabel']],
+    fallbackContext: 'Video Outputs',
+    actionKey: 'removeEntry'
+  });
   removeBtn.addEventListener('click', () => {
     if (viewfinderVideoOutputsContainer && viewfinderVideoOutputsContainer.children.length > 1) row.remove();
   });
@@ -12689,14 +12782,22 @@ function createVideoInputRow(value = '') {
   row.appendChild(createFieldWithLabel(select, 'Type'));
   const addBtn = document.createElement('button');
   addBtn.type = 'button';
-  addBtn.textContent = '+';
+  configureIconOnlyButton(addBtn, ICON_GLYPHS.add, {
+    contextPaths: ['videoVideoInputsHeading', ['videoVideoInputsLabel']],
+    fallbackContext: 'Video Inputs',
+    actionKey: 'addEntry'
+  });
   addBtn.addEventListener('click', () => {
     row.after(createVideoInputRow());
   });
   row.appendChild(addBtn);
   const removeBtn = document.createElement('button');
   removeBtn.type = 'button';
-  removeBtn.textContent = '−';
+  configureIconOnlyButton(removeBtn, ICON_GLYPHS.minus, {
+    contextPaths: ['videoVideoInputsHeading', ['videoVideoInputsLabel']],
+    fallbackContext: 'Video Inputs',
+    actionKey: 'removeEntry'
+  });
   removeBtn.addEventListener('click', () => {
     if (videoVideoInputsContainer.children.length > 1) row.remove();
   });
@@ -12742,14 +12843,22 @@ function createVideoIOOutputRow(value = '') {
   row.appendChild(createFieldWithLabel(select, 'Type'));
   const addBtn = document.createElement('button');
   addBtn.type = 'button';
-  addBtn.textContent = '+';
+  configureIconOnlyButton(addBtn, ICON_GLYPHS.add, {
+    contextPaths: ['videoVideoOutputsHeading', ['videoVideoOutputsLabel']],
+    fallbackContext: 'Video Outputs',
+    actionKey: 'addEntry'
+  });
   addBtn.addEventListener('click', () => {
     row.after(createVideoIOOutputRow());
   });
   row.appendChild(addBtn);
   const removeBtn = document.createElement('button');
   removeBtn.type = 'button';
-  removeBtn.textContent = '−';
+  configureIconOnlyButton(removeBtn, ICON_GLYPHS.minus, {
+    contextPaths: ['videoVideoOutputsHeading', ['videoVideoOutputsLabel']],
+    fallbackContext: 'Video Outputs',
+    actionKey: 'removeEntry'
+  });
   removeBtn.addEventListener('click', () => {
     if (videoVideoOutputsContainer.children.length > 1) row.remove();
   });
@@ -12796,14 +12905,22 @@ function createFizConnectorRow(value = '') {
   row.appendChild(createFieldWithLabel(select, 'Type'));
   const addBtn = document.createElement('button');
   addBtn.type = 'button';
-  addBtn.textContent = '+';
+  configureIconOnlyButton(addBtn, ICON_GLYPHS.add, {
+    contextPaths: ['fizConnectorHeading', ['cameraFIZConnectorLabel']],
+    fallbackContext: 'FIZ Connector',
+    actionKey: 'addEntry'
+  });
   addBtn.addEventListener('click', () => {
     row.after(createFizConnectorRow());
   });
   row.appendChild(addBtn);
   const removeBtn = document.createElement('button');
   removeBtn.type = 'button';
-  removeBtn.textContent = '−';
+  configureIconOnlyButton(removeBtn, ICON_GLYPHS.minus, {
+    contextPaths: ['fizConnectorHeading', ['cameraFIZConnectorLabel']],
+    fallbackContext: 'FIZ Connector',
+    actionKey: 'removeEntry'
+  });
   removeBtn.addEventListener('click', () => {
     if (fizConnectorContainer.children.length > 1) row.remove();
   });
@@ -12897,7 +13014,11 @@ function createRecordingMediaRow(type = '', notes = '') {
 
   const addBtn = document.createElement('button');
   addBtn.type = 'button';
-  addBtn.textContent = '+';
+  configureIconOnlyButton(addBtn, ICON_GLYPHS.add, {
+    contextPaths: ['mediaHeading', ['cameraMediaLabel']],
+    fallbackContext: 'Recording Media',
+    actionKey: 'addEntry'
+  });
   addBtn.addEventListener('click', () => {
     row.after(createRecordingMediaRow());
   });
@@ -12905,7 +13026,11 @@ function createRecordingMediaRow(type = '', notes = '') {
 
   const removeBtn = document.createElement('button');
   removeBtn.type = 'button';
-  removeBtn.textContent = '−';
+  configureIconOnlyButton(removeBtn, ICON_GLYPHS.minus, {
+    contextPaths: ['mediaHeading', ['cameraMediaLabel']],
+    fallbackContext: 'Recording Media',
+    actionKey: 'removeEntry'
+  });
   removeBtn.addEventListener('click', () => {
     if (cameraMediaContainer.children.length > 1) row.remove();
   });
@@ -13088,7 +13213,11 @@ function createBatteryPlateRow(type = '', mount = 'native', notes = '') {
 
   const addBtn = document.createElement('button');
   addBtn.type = 'button';
-  addBtn.textContent = '+';
+  configureIconOnlyButton(addBtn, ICON_GLYPHS.add, {
+    contextPaths: ['cameraPlatesLabel', ['powerInputsHeading']],
+    fallbackContext: 'Battery Plates',
+    actionKey: 'addEntry'
+  });
   addBtn.addEventListener('click', () => {
     row.after(createBatteryPlateRow());
   });
@@ -13096,7 +13225,11 @@ function createBatteryPlateRow(type = '', mount = 'native', notes = '') {
 
   const removeBtn = document.createElement('button');
   removeBtn.type = 'button';
-  removeBtn.textContent = '−';
+  configureIconOnlyButton(removeBtn, ICON_GLYPHS.minus, {
+    contextPaths: ['cameraPlatesLabel', ['powerInputsHeading']],
+    fallbackContext: 'Battery Plates',
+    actionKey: 'removeEntry'
+  });
   removeBtn.addEventListener('click', () => {
     if (batteryPlatesContainer.children.length > 1) row.remove();
   });
@@ -13217,7 +13350,11 @@ function createViewfinderRow(type = '', resolution = '', connector = '', notes =
 
   const addBtn = document.createElement('button');
   addBtn.type = 'button';
-  addBtn.textContent = '+';
+  configureIconOnlyButton(addBtn, ICON_GLYPHS.add, {
+    contextPaths: ['viewfinderHeading', ['cameraViewfinderLabel']],
+    fallbackContext: 'Viewfinder',
+    actionKey: 'addEntry'
+  });
   addBtn.addEventListener('click', () => {
     row.after(createViewfinderRow());
   });
@@ -13225,7 +13362,11 @@ function createViewfinderRow(type = '', resolution = '', connector = '', notes =
 
   const removeBtn = document.createElement('button');
   removeBtn.type = 'button';
-  removeBtn.textContent = '−';
+  configureIconOnlyButton(removeBtn, ICON_GLYPHS.minus, {
+    contextPaths: ['viewfinderHeading', ['cameraViewfinderLabel']],
+    fallbackContext: 'Viewfinder',
+    actionKey: 'removeEntry'
+  });
   removeBtn.addEventListener('click', () => {
     if (viewfinderContainer.children.length > 1) row.remove();
   });
@@ -13333,7 +13474,11 @@ function createLensMountRow(type = '', mount = 'native') {
 
   const addBtn = document.createElement('button');
   addBtn.type = 'button';
-  addBtn.textContent = '+';
+  configureIconOnlyButton(addBtn, ICON_GLYPHS.add, {
+    contextPaths: ['lensMountHeading', ['cameraLensMountLabel']],
+    fallbackContext: 'Lens Mount',
+    actionKey: 'addEntry'
+  });
   addBtn.addEventListener('click', () => {
     row.after(createLensMountRow());
   });
@@ -13341,7 +13486,11 @@ function createLensMountRow(type = '', mount = 'native') {
 
   const removeBtn = document.createElement('button');
   removeBtn.type = 'button';
-  removeBtn.textContent = '−';
+  configureIconOnlyButton(removeBtn, ICON_GLYPHS.minus, {
+    contextPaths: ['lensMountHeading', ['cameraLensMountLabel']],
+    fallbackContext: 'Lens Mount',
+    actionKey: 'removeEntry'
+  });
   removeBtn.addEventListener('click', () => {
     if (lensMountContainer.children.length > 1) row.remove();
   });
@@ -13540,7 +13689,11 @@ function createPowerDistRow(type = '', voltage = '', current = '', wattage = '',
 
   const addBtn = document.createElement('button');
   addBtn.type = 'button';
-  addBtn.textContent = '+';
+  configureIconOnlyButton(addBtn, ICON_GLYPHS.add, {
+    contextPaths: ['powerDistributionHeading', ['cameraPowerDistLabel']],
+    fallbackContext: 'Power Distribution',
+    actionKey: 'addEntry'
+  });
   addBtn.addEventListener('click', () => {
     row.after(createPowerDistRow());
   });
@@ -13548,7 +13701,11 @@ function createPowerDistRow(type = '', voltage = '', current = '', wattage = '',
 
   const removeBtn = document.createElement('button');
   removeBtn.type = 'button';
-  removeBtn.textContent = '−';
+  configureIconOnlyButton(removeBtn, ICON_GLYPHS.minus, {
+    contextPaths: ['powerDistributionHeading', ['cameraPowerDistLabel']],
+    fallbackContext: 'Power Distribution',
+    actionKey: 'removeEntry'
+  });
   removeBtn.addEventListener('click', () => {
     if (powerDistContainer.children.length > 1) row.remove();
   });
@@ -13651,7 +13808,11 @@ function createTimecodeRow(type = '', notes = '') {
 
   const addBtn = document.createElement('button');
   addBtn.type = 'button';
-  addBtn.textContent = '+';
+  configureIconOnlyButton(addBtn, ICON_GLYPHS.add, {
+    contextPaths: ['timecodeHeading', ['cameraTimecodeLabel']],
+    fallbackContext: 'Timecode',
+    actionKey: 'addEntry'
+  });
   addBtn.addEventListener('click', () => {
     row.after(createTimecodeRow());
   });
@@ -13659,7 +13820,11 @@ function createTimecodeRow(type = '', notes = '') {
 
   const removeBtn = document.createElement('button');
   removeBtn.type = 'button';
-  removeBtn.textContent = '−';
+  configureIconOnlyButton(removeBtn, ICON_GLYPHS.minus, {
+    contextPaths: ['timecodeHeading', ['cameraTimecodeLabel']],
+    fallbackContext: 'Timecode',
+    actionKey: 'removeEntry'
+  });
   removeBtn.addEventListener('click', () => {
     if (timecodeContainer.children.length > 1) row.remove();
   });


### PR DESCRIPTION
## Summary
- replace hard-coded +/- buttons in the UI shell with UIcons
- add a helper to render icon-only buttons with localized labels
- update dynamic device editor rows to use the helper for add/remove controls

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d039a4939c8320a96c8cbdb86b48eb