### PR TITLE
Improve feature search highlighting

### DIFF
--- a/src/scripts/script.js
+++ b/src/scripts/script.js
@@ -23066,6 +23066,7 @@ if (helpButton && helpDialog) {
   const helpQuickLinkItems = new Map();
   const helpSectionHighlightTimers = new Map();
   const appTargetHighlightTimers = new Map();
+  const featureSearchHighlightTimers = new Map();
 
   const highlightAppTarget = element => {
     if (!element) return;
@@ -23080,6 +23081,56 @@ if (helpButton && helpDialog) {
       appTargetHighlightTimers.delete(target);
     }, 2000);
     appTargetHighlightTimers.set(target, timeout);
+  };
+
+  const highlightFeatureSearchTargets = targets => {
+    if (!Array.isArray(targets) || targets.length === 0) return;
+    const seen = new Set();
+    targets.forEach(target => {
+      if (!target || typeof target.classList?.add !== 'function') return;
+      if (seen.has(target)) return;
+      seen.add(target);
+      const existing = featureSearchHighlightTimers.get(target);
+      if (existing) {
+        clearTimeout(existing);
+      }
+      target.classList.add('feature-search-focus');
+      const timeout = setTimeout(() => {
+        target.classList.remove('feature-search-focus');
+        featureSearchHighlightTimers.delete(target);
+      }, 2500);
+      featureSearchHighlightTimers.set(target, timeout);
+    });
+  };
+
+  const findAssociatedLabelElements = element => {
+    if (!element) return [];
+    const labels = new Set();
+    const doc = element.ownerDocument || (typeof document !== 'undefined' ? document : null);
+    if (element.labels && typeof element.labels === 'object') {
+      Array.from(element.labels).forEach(label => {
+        if (label) labels.add(label);
+      });
+    }
+    if (typeof element.closest === 'function') {
+      const wrappingLabel = element.closest('label');
+      if (wrappingLabel) labels.add(wrappingLabel);
+    }
+    if (doc && typeof element.getAttribute === 'function') {
+      const collectIdRefs = attrValue => {
+        if (!attrValue) return;
+        attrValue
+          .split(/\s+/)
+          .filter(Boolean)
+          .forEach(id => {
+            const ref = doc.getElementById(id);
+            if (ref) labels.add(ref);
+          });
+      };
+      collectIdRefs(element.getAttribute('aria-labelledby'));
+      collectIdRefs(element.getAttribute('aria-describedby'));
+    }
+    return Array.from(labels);
   };
 
   const focusFeatureElement = element => {
@@ -23299,6 +23350,14 @@ if (helpButton && helpDialog) {
         }
         highlightHelpSection(section);
         focusHelpSectionHeading(section);
+        const quickLinkHeading =
+          section.querySelector('h3, summary, h4, h5, h6, [role="heading"]') ||
+          section.querySelector('button, a');
+        if (quickLinkHeading) {
+          highlightFeatureSearchTargets([quickLinkHeading]);
+        } else {
+          highlightFeatureSearchTargets([section]);
+        }
       });
       li.appendChild(button);
       fragment.appendChild(li);
@@ -23347,6 +23406,10 @@ if (helpButton && helpDialog) {
         focusFeatureElement(focusEl);
         if (highlightEl) {
           highlightAppTarget(highlightEl);
+        }
+        const extraTargets = findAssociatedLabelElements(highlightEl || focusEl);
+        if (extraTargets.length) {
+          highlightFeatureSearchTargets(extraTargets);
         }
       };
       if (targetInsideHelp) {
@@ -23869,6 +23932,11 @@ if (helpButton && helpDialog) {
             updateFeatureSearchValue(device.label, originalNormalized);
           }
           focusFeatureElement(device.select);
+          const highlightTargets = [
+            device.select,
+            ...findAssociatedLabelElements(device.select)
+          ];
+          highlightFeatureSearchTargets(highlightTargets);
           return;
         }
       }
@@ -23881,6 +23949,11 @@ if (helpButton && helpDialog) {
             updateFeatureSearchValue(label, originalNormalized);
           }
           focusFeatureElement(featureEl);
+          const highlightTargets = [
+            featureEl,
+            ...findAssociatedLabelElements(featureEl)
+          ];
+          highlightFeatureSearchTargets(highlightTargets);
           return;
         }
       }
@@ -23905,6 +23978,14 @@ if (helpButton && helpDialog) {
           section.scrollIntoView({ behavior: 'smooth', block: 'start' });
         }
         highlightHelpSection(section);
+        const sectionHeading =
+          section.querySelector('h3, summary, h4, h5, h6, [role="heading"]') ||
+          section.querySelector('button, a');
+        if (sectionHeading) {
+          highlightFeatureSearchTargets([sectionHeading]);
+        } else {
+          highlightFeatureSearchTargets([section]);
+        }
         const quickLink = section.id ? helpQuickLinkItems.get(section.id) : null;
         if (helpQuickLinksList) {
           helpQuickLinksList
@@ -23921,6 +24002,7 @@ if (helpButton && helpDialog) {
     if (helpSearch) {
       helpSearch.value = clean;
       filterHelp();
+      highlightFeatureSearchTargets([helpSearch]);
     }
   };
 

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -1744,17 +1744,45 @@ body.pink-mode .auto-gear-rule-title,
   outline-offset: 2px;
 }
 
-.help-target-focus {
+.help-target-focus,
+.feature-search-focus {
   outline: 3px solid var(--accent-color);
   outline-offset: 4px;
   border-radius: var(--border-radius);
-  transition: outline-color 0.2s ease-in-out;
+  transition:
+    outline-color 0.2s ease-in-out,
+    background-color 0.2s ease-in-out,
+    box-shadow 0.2s ease-in-out;
 }
 
 .help-target-focus:focus,
-.help-target-focus:focus-visible {
+.help-target-focus:focus-visible,
+.feature-search-focus:focus,
+.feature-search-focus:focus-visible {
   outline: 3px solid var(--accent-color);
   outline-offset: 4px;
+}
+
+.feature-search-focus {
+  background-color: rgba(0, 0, 0, 0.04);
+  box-shadow: 0 0 0 2px rgba(0, 0, 0, 0.02);
+}
+
+.dark-mode .feature-search-focus {
+  background-color: rgba(255, 255, 255, 0.08);
+  box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.04);
+}
+
+@supports (background-color: color-mix(in srgb, red 10%, transparent)) {
+  .feature-search-focus {
+    background-color: color-mix(in srgb, var(--accent-color) 18%, transparent);
+    box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent-color) 24%, transparent);
+  }
+
+  .dark-mode .feature-search-focus {
+    background-color: color-mix(in srgb, var(--accent-color) 26%, transparent);
+    box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent-color) 32%, transparent);
+  }
 }
 
 .icon-glyph {


### PR DESCRIPTION
## Summary
- add reusable highlight utilities so feature search can emphasize precise targets and their labels when navigating via search or help quick links
- extend feature search handling to highlight device fields, feature headings, and help topics, including when falling back to the help dialog
- style the feature search highlight state for consistency across light and dark themes

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d03a1a4fd88320840b3718b81adad6