### PR TITLE
Reset shared import state during factory reset

### DIFF
--- a/src/scripts/script.js
+++ b/src/scripts/script.js
@@ -5768,6 +5768,29 @@ function clearStoredSharedImportData() {
   lastSharedAutoGearRules = null;
 }
 
+function resetSharedImportStateForFactoryReset() {
+  clearStoredSharedImportData();
+  sharedImportPromptActive = false;
+  if (sharedImportDialog) {
+    closeDialog(sharedImportDialog);
+  }
+  if (typeof configureSharedImportOptions === 'function') {
+    configureSharedImportOptions([]);
+  }
+  if (sharedLinkInput) {
+    if (
+      pendingSharedLinkListener
+      && typeof sharedLinkInput.removeEventListener === 'function'
+    ) {
+      sharedLinkInput.removeEventListener('change', pendingSharedLinkListener);
+    }
+    sharedLinkInput.value = '';
+  }
+  pendingSharedLinkListener = null;
+  sharedImportPreviousPresetId = '';
+  sharedImportProjectPresetActive = false;
+}
+
 function deactivateSharedImportProjectPreset() {
   if (!sharedImportProjectPresetActive) return;
   const targetPresetId = sharedImportPreviousPresetId || '';
@@ -22672,6 +22695,12 @@ function resetPlannerStateAfterFactoryReset() {
   }
 
   try {
+    resetSharedImportStateForFactoryReset();
+  } catch (error) {
+    console.warn('Failed to reset shared import state during factory reset', error);
+  }
+
+  try {
     updateAutoGearCatalogOptions();
   } catch (error) {
     console.warn('Failed to refresh automatic gear catalog during factory reset', error);
@@ -25105,6 +25134,32 @@ if (typeof module !== "undefined" && module.exports) {
     __customFontInternals: {
       addFromData: (name, dataUrl, options) => addCustomFontFromData(name, dataUrl, options),
       getEntries: () => Array.from(customFontEntries.values()),
+    },
+    __sharedImportInternals: {
+      getLastSharedSetupData: () => lastSharedSetupData,
+      setLastSharedSetupDataForTest: (value) => {
+        lastSharedSetupData = value;
+      },
+      getLastSharedAutoGearRules: () => lastSharedAutoGearRules,
+      setLastSharedAutoGearRulesForTest: (value) => {
+        lastSharedAutoGearRules = value;
+      },
+      isProjectPresetActive: () => sharedImportProjectPresetActive,
+      setProjectPresetActiveForTest: (value) => {
+        sharedImportProjectPresetActive = !!value;
+      },
+      getPreviousPresetId: () => sharedImportPreviousPresetId,
+      setPreviousPresetIdForTest: (value) => {
+        sharedImportPreviousPresetId = typeof value === 'string' ? value : '';
+      },
+      isPromptActive: () => sharedImportPromptActive,
+      setPromptActiveForTest: (value) => {
+        sharedImportPromptActive = !!value;
+      },
+      getPendingSharedLinkListener: () => pendingSharedLinkListener,
+      setPendingSharedLinkListenerForTest: (listener) => {
+        pendingSharedLinkListener = typeof listener === 'function' ? listener : null;
+      },
     },
     collectAutoGearCatalogNames,
     applyAutoGearRulesToTableHtml,


### PR DESCRIPTION
## Summary
- ensure factory reset clears shared project import state and closes the dialog
- expose shared import internals for testing and add a regression test that covers the cleanup

## Testing
- npm test -- factoryReset

------
https://chatgpt.com/codex/tasks/task_e_68d03b26953883209f89898c87caf127