### PR TITLE
Ensure hover help tooltip renders icon fonts

### DIFF
--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -1966,6 +1966,8 @@ body.pink-mode .favorite-toggle.favorited:active {
   color: var(--inverse-text-color);
   padding: 4px 8px;
   border-radius: 4px;
+  /* Allow icon glyphs from all local fonts to render inside hover help */
+  font-family: var(--font-family), 'EssentialIconsV2', 'FilmIndustryIconsV2', 'GadgetIconsV2';
   font-size: calc(var(--font-size-base) * var(--font-scale-compact));
   pointer-events: none;
   /* Allow longer hover help descriptions */


### PR DESCRIPTION
## Summary
- allow hover help tooltips to inherit the local icon font families so glyphs render correctly

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d03c6ce3fc8320ab50329b21fa893e