### PR TITLE
Improve hover help text aggregation

### DIFF
--- a/src/scripts/script.js
+++ b/src/scripts/script.js
@@ -24178,9 +24178,18 @@ if (helpButton && helpDialog) {
       if (!parts.includes(trimmed)) parts.push(trimmed);
     };
 
-    addText(el.getAttribute('data-help'));
-    addText(el.getAttribute('aria-label'));
-    addText(el.getAttribute('title'));
+    const addTextFromElement = (element, { includeTextContent = false } = {}) => {
+      if (!element) return;
+      addText(element.getAttribute('data-help'));
+      addText(element.getAttribute('aria-label'));
+      addText(element.getAttribute('aria-description'));
+      addText(element.getAttribute('title'));
+      if (includeTextContent) {
+        addText(element.textContent);
+      }
+    };
+
+    addTextFromElement(el);
 
     const applyFromIds = ids => {
       if (!ids) return;
@@ -24190,16 +24199,21 @@ if (helpButton && helpDialog) {
         .forEach(id => {
           const ref = document.getElementById(id);
           if (!ref) return;
-          addText(ref.getAttribute('data-help'));
-          addText(ref.getAttribute('aria-label'));
-          addText(ref.getAttribute('title'));
-          addText(ref.textContent);
+          addTextFromElement(ref, { includeTextContent: true });
         });
     };
 
     applyFromIds(el.getAttribute('aria-labelledby'));
     addText(el.getAttribute('alt'));
     applyFromIds(el.getAttribute('aria-describedby'));
+
+    findAssociatedLabelElements(el).forEach(labelEl => {
+      addTextFromElement(labelEl, { includeTextContent: true });
+    });
+
+    if (!parts.length) {
+      addText(el.textContent);
+    }
 
     return parts;
   };


### PR DESCRIPTION
## Summary
- include aria-description, associated label text, and related attributes when building hover help copy
- fall back to visible text when metadata is absent so more controls describe themselves

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d040a189448320ab3ba2086403feb9