### PR TITLE
Handle auto gear rules without video distribution selection

### DIFF
--- a/src/scripts/translations.js
+++ b/src/scripts/translations.js
@@ -173,6 +173,7 @@ const texts = {
     autoGearVideoDistributionHelp:
       "Apply this rule when these video distribution preferences are selected.",
     autoGearVideoDistributionPlaceholder: "Select video distribution options",
+    autoGearVideoDistributionNone: "No video distribution selected",
     autoGearRuleConditionRequired:
       "Select at least one scenario, mattebox option, camera handle, viewfinder extension or video distribution before saving.",
     autoGearAddItemsHeading: "Add these items",
@@ -1379,6 +1380,7 @@ const texts = {
     autoGearVideoDistributionHelp:
       "Applica la regola quando sono selezionate queste preferenze di distribuzione video.",
     autoGearVideoDistributionPlaceholder: "Seleziona opzioni di distribuzione video",
+    autoGearVideoDistributionNone: "Nessuna distribuzione video selezionata",
     autoGearRuleConditionRequired:
       "Seleziona almeno uno scenario, un'opzione di matte box, una maniglia camera, una prolunga mirino o una distribuzione video prima di salvare.",
     autoGearAddItemsHeading: "Aggiungi questi elementi",
@@ -2186,6 +2188,7 @@ const texts = {
     autoGearVideoDistributionHelp:
       "Aplica la regla cuando se eligen estas preferencias de distribución de vídeo.",
     autoGearVideoDistributionPlaceholder: "Selecciona opciones de distribución de vídeo",
+    autoGearVideoDistributionNone: "Sin distribución de vídeo seleccionada",
     autoGearRuleConditionRequired:
       "Selecciona al menos un escenario, una opción de matte box, una empuñadura de cámara, una extensión de visor o una distribución de vídeo antes de guardar.",
     autoGearAddItemsHeading: "Agregar estos elementos",
@@ -2996,6 +2999,7 @@ const texts = {
     autoGearVideoDistributionHelp:
       "Appliquer la règle lorsque ces préférences de distribution vidéo sont sélectionnées.",
     autoGearVideoDistributionPlaceholder: "Sélectionnez des options de distribution vidéo",
+    autoGearVideoDistributionNone: "Aucune distribution vidéo sélectionnée",
     autoGearRuleConditionRequired:
       "Sélectionnez au moins un scénario, une option de matte box, une poignée caméra, une extension de viseur ou une distribution vidéo avant d’enregistrer.",
     autoGearAddItemsHeading: "Ajouter ces éléments",
@@ -3809,6 +3813,7 @@ const texts = {
     autoGearVideoDistributionHelp:
       "Regel anwenden, wenn diese Videoverteilungsoptionen ausgewählt sind.",
     autoGearVideoDistributionPlaceholder: "Videoverteilungsoptionen auswählen",
+    autoGearVideoDistributionNone: "Keine Videoverteilung ausgewählt",
     autoGearRuleConditionRequired:
       "Wähle mindestens ein Szenario, eine Mattebox-Option, einen Kamera-Handgriff, eine Sucher-Verlängerung oder eine Videoverteilung, bevor du speicherst.",
     autoGearAddItemsHeading: "Diese Geräte hinzufügen",

--- a/tests/script/autoGearRules.test.js
+++ b/tests/script/autoGearRules.test.js
@@ -452,6 +452,51 @@ describe('applyAutoGearRulesToTableHtml', () => {
     expect(entries).toHaveLength(1);
   });
 
+  test('applies video distribution rules when no distribution is selected', () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify([
+        {
+          id: 'rule-video-none',
+          label: 'Baseline monitors',
+          scenarios: [],
+          mattebox: [],
+          cameraHandle: [],
+          viewfinderExtension: [],
+          videoDistribution: ['__none__'],
+          add: [
+            {
+              id: 'add-video-none',
+              name: 'HDMI Switcher',
+              category: 'Monitoring',
+              quantity: 1,
+            }
+          ],
+          remove: []
+        }
+      ])
+    );
+
+    env = setupScriptEnvironment();
+    const { applyAutoGearRulesToTableHtml } = env.utils;
+
+    const tableHtml = `
+      <table class="gear-table">
+        <tbody class="category-group">
+          <tr class="category-row"><td>Monitoring</td></tr>
+          <tr><td></td></tr>
+        </tbody>
+      </table>
+    `;
+
+    const result = applyAutoGearRulesToTableHtml(tableHtml, { videoDistribution: '' });
+    const container = document.createElement('div');
+    container.innerHTML = result;
+
+    const entries = container.querySelectorAll('[data-gear-name="HDMI Switcher"]');
+    expect(entries).toHaveLength(1);
+  });
+
   test('seeds default mattebox rules when they are missing', () => {
     localStorage.setItem(
       STORAGE_KEY,


### PR DESCRIPTION
## Summary
- allow automatic gear rules to target cases where no video distribution option is selected by normalizing a dedicated `__none__` trigger value
- surface a "No video distribution selected" label across languages and expose the option in the rule editor so presets and tooltips remain friendly
- extend rule application logic and tests to verify gear additions fire when no distribution is chosen

## Testing
- npm test -- autoGearRules

------
https://chatgpt.com/codex/tasks/task_e_68d040b053d083208aaf803d1baf12a8