### PR TITLE
Expand sidebar navigation with planner sections and quick actions

### DIFF
--- a/index.html
+++ b/index.html
@@ -198,7 +198,33 @@
       <li><a href="#setup-config" data-nav-key="deviceSelectionHeading">Configure Devices</a></li>
       <li><a href="#results" data-nav-key="resultsHeading">Power Summary</a></li>
       <li><a href="#setupDiagram" data-nav-key="setupDiagramHeading">Connection Diagram</a></li>
+      <li><a href="#batteryComparison" data-nav-key="batteryComparisonHeading">Battery Comparison</a></li>
+      <li><a href="#projectRequirementsOutput" data-nav-key="projectRequirementsNav">Project Requirements</a></li>
+      <li><a href="#gearListOutput" data-nav-key="gearListNav">Gear List</a></li>
       <li><a href="#device-manager" data-nav-key="deviceManagerHeading">Device Library</a></li>
+      <li class="sidebar-divider" role="separator" aria-hidden="true"></li>
+      <li>
+        <button
+          type="button"
+          data-nav-key="openSettingsNav"
+          data-sidebar-action="open-settings"
+          aria-haspopup="dialog"
+          aria-controls="settingsDialog"
+        >
+          Open Settings
+        </button>
+      </li>
+      <li>
+        <button
+          type="button"
+          data-nav-key="openHelpNav"
+          data-sidebar-action="open-help"
+          aria-haspopup="dialog"
+          aria-controls="helpDialog"
+        >
+          Open Help Center
+        </button>
+      </li>
     </ul>
   </nav>
   <div id="menuOverlay" class="hidden"></div>

--- a/src/scripts/script.js
+++ b/src/scripts/script.js
@@ -1540,6 +1540,23 @@ function setupSideMenu() {
       closeSideMenu();
     });
   });
+
+  const triggerSidebarAction = action => {
+    if (!action) return;
+    if (action === 'open-settings') {
+      document.getElementById('settingsButton')?.click();
+    } else if (action === 'open-help') {
+      document.getElementById('helpButton')?.click();
+    }
+  };
+
+  menu.querySelectorAll('[data-sidebar-action]').forEach(button => {
+    button.addEventListener('click', event => {
+      event.preventDefault();
+      triggerSidebarAction(button.dataset.sidebarAction);
+      closeSideMenu();
+    });
+  });
 }
 
 function setupResponsiveControls() {

--- a/src/scripts/translations.js
+++ b/src/scripts/translations.js
@@ -49,6 +49,16 @@ const texts = {
     deviceManagerHeading: "Device Library",
     batteryComparisonHeading: "Battery Comparison",
     setupDiagramHeading: "Connection Diagram",
+    projectRequirementsNav: "Project Requirements",
+    projectRequirementsNavHelp: "Jump to the Project Requirements output once generated.",
+    gearListNav: "Gear List",
+    gearListNavHelp: "View the generated gear list with all items and categories.",
+    openSettingsNav: "Open Settings",
+    openSettingsNavHelp:
+      "Open Settings to adjust language, themes, accessibility options and backups.",
+    openHelpNav: "Open Help Center",
+    openHelpNavHelp:
+      "Open the in-app help guide with tutorials, troubleshooting tips and shortcuts.",
     setupManageHeadingHelp:
       "Manage saved projects: save, load, or clear configurations.",
     deviceSelectionHeadingHelp:
@@ -868,6 +878,18 @@ const texts = {
     deviceManagerHeading: "Libreria dispositivi",
     batteryComparisonHeading: "Confronto batterie",
     setupDiagramHeading: "Diagramma delle connessioni",
+    projectRequirementsNav: "Requisiti di progetto",
+    projectRequirementsNavHelp:
+      "Vai all'output Requisiti di progetto quando è stato generato.",
+    gearListNav: "Lista attrezzatura",
+    gearListNavHelp:
+      "Visualizza la lista attrezzatura generata con tutti gli elementi e le categorie.",
+    openSettingsNav: "Apri Impostazioni",
+    openSettingsNavHelp:
+      "Apri le Impostazioni per modificare lingua, temi, opzioni di accessibilità e backup.",
+    openHelpNav: "Apri Centro assistenza",
+    openHelpNavHelp:
+      "Apri la guida in-app con tutorial, suggerimenti per la risoluzione dei problemi e scorciatoie.",
     setupManageHeadingHelp:
       "Gestisci le configurazioni salvate: salva, carica o cancella configurazioni.",
     deviceSelectionHeadingHelp:
@@ -1663,6 +1685,18 @@ const texts = {
     deviceManagerHeading: "Biblioteca de Dispositivos",
     batteryComparisonHeading: "Comparación de Baterías",
     setupDiagramHeading: "Diagrama de Conexiones",
+    projectRequirementsNav: "Requisitos del proyecto",
+    projectRequirementsNavHelp:
+      "Ir a la salida Requisitos del proyecto cuando esté disponible.",
+    gearListNav: "Lista de equipo",
+    gearListNavHelp:
+      "Ver la lista de equipo generada con todos los artículos y categorías.",
+    openSettingsNav: "Abrir Ajustes",
+    openSettingsNavHelp:
+      "Abrir Ajustes para cambiar idioma, temas, opciones de accesibilidad y copias de seguridad.",
+    openHelpNav: "Abrir Centro de ayuda",
+    openHelpNavHelp:
+      "Abrir la guía de ayuda integrada con tutoriales, consejos de resolución de problemas y atajos.",
     setupManageHeadingHelp:
       "Administra los proyectos guardados: guárdalos, cárgalos o borra la configuración actual.",
     deviceSelectionHeadingHelp:
@@ -2472,6 +2506,18 @@ const texts = {
     deviceManagerHeading: "Bibliothèque d’appareils",
     batteryComparisonHeading: "Comparaison des batteries",
     setupDiagramHeading: "Schéma de connexion",
+    projectRequirementsNav: "Exigences du projet",
+    projectRequirementsNavHelp:
+      "Accéder à la sortie Exigences du projet une fois générée.",
+    gearListNav: "Liste du matériel",
+    gearListNavHelp:
+      "Voir la liste du matériel générée avec tous les éléments et catégories.",
+    openSettingsNav: "Ouvrir les paramètres",
+    openSettingsNavHelp:
+      "Ouvrir les paramètres pour régler la langue, les thèmes, l’accessibilité et les sauvegardes.",
+    openHelpNav: "Ouvrir l’aide",
+    openHelpNavHelp:
+      "Ouvrir l’aide intégrée avec tutoriels, conseils de dépannage et raccourcis.",
     setupManageHeadingHelp:
       "Gérez les configurations enregistrées : sauvegarder, charger ou effacer.",
     deviceSelectionHeadingHelp:
@@ -3284,6 +3330,18 @@ const texts = {
     deviceManagerHeading: "Gerätebibliothek",
     batteryComparisonHeading: "Akkuvergleich",
     setupDiagramHeading: "Verbindungsdiagramm",
+    projectRequirementsNav: "Projektanforderungen",
+    projectRequirementsNavHelp:
+      "Zur Ausgabe Projektanforderungen springen, sobald sie erstellt wurde.",
+    gearListNav: "Gear-Liste",
+    gearListNavHelp:
+      "Die erzeugte Gear-Liste mit allen Geräten und Kategorien ansehen.",
+    openSettingsNav: "Einstellungen öffnen",
+    openSettingsNavHelp:
+      "Einstellungen öffnen, um Sprache, Designs, Barrierefreiheit und Backups anzupassen.",
+    openHelpNav: "Hilfe öffnen",
+    openHelpNavHelp:
+      "Die integrierte Hilfe mit Anleitungen, Tipps zur Fehlerbehebung und Tastenkürzeln öffnen.",
     setupManageHeadingHelp:
       "Gespeicherte Projekte verwalten: Projekte speichern, laden oder löschen.",
     deviceSelectionHeadingHelp:

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -4486,12 +4486,21 @@ body.dark-mode.pink-mode #gearListOutput h2,
   border-bottom: 1px solid var(--accent-color);
 }
 
-#sideMenu li {
+#sideMenu li { 
   margin: 0;
 }
 
 #sideMenu li + li {
   border-top: 1px solid var(--accent-color);
+}
+
+#sideMenu li.sidebar-divider {
+  padding: 8px 0;
+  margin: 12px 0;
+}
+
+#sideMenu li.sidebar-divider + li {
+  border-top: none;
 }
 
 #sideMenu a {
@@ -4500,6 +4509,27 @@ body.dark-mode.pink-mode #gearListOutput h2,
   font-size: calc(var(--font-size-relative-base) * var(--font-scale-lg));
   display: block;
   padding: 10px 0;
+}
+
+#sideMenu button[data-sidebar-action] {
+  display: block;
+  width: 100%;
+  padding: 10px 0;
+  background: none;
+  border: none;
+  color: var(--text-color);
+  font-size: calc(var(--font-size-relative-base) * var(--font-scale-lg));
+  text-align: left;
+  cursor: pointer;
+}
+
+#sideMenu button[data-sidebar-action]:hover {
+  color: var(--accent-color);
+}
+
+#sideMenu button[data-sidebar-action]:focus-visible {
+  outline: 2px solid var(--accent-color);
+  outline-offset: 2px;
 }
 
 .dark-mode #sideMenu ul {


### PR DESCRIPTION
## Summary
- extend the sidebar navigation with links to battery comparison, project requirements, gear list, and quick access to settings and help dialogs
- style the sidebar action buttons and divider so the new entries match the existing navigation look and feel
- add translations for all new sidebar labels and help text in every supported language

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d0412e40e88320bda08c1481cd9ad9