### PR TITLE
Increase icon-text spacing in buttons

### DIFF
--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -28,6 +28,8 @@
   --gap-size: 10px;
   --button-size: 24px;
   --button-icon-size: var(--icon-size-md);
+  --icon-gap: 0.3em;
+  --button-icon-gap: 0.55em;
   --form-control-font-size: var(--font-size-relative-base);
   --form-label-width: 150px;
   --form-label-min-width: 120px;
@@ -1973,10 +1975,6 @@ body.dark-mode .help-callout {
   --icon-size: var(--button-icon-size);
 }
 
-#setup-manager button .btn-icon {
-  margin-right: 0.5em;
-}
-
 .help-icon,
 .btn-icon,
 .legend-icon,
@@ -1985,11 +1983,16 @@ body.dark-mode .help-callout {
 .category-icon,
 .scenario-icon,
 .icon-box .icon {
-  margin-right: 0.3em;
+  margin-right: var(--icon-gap);
 }
 
 button .btn-icon:only-child {
   margin-right: 0;
+}
+
+button .btn-icon:not(:only-child),
+.button-link .btn-icon:not(:only-child) {
+  margin-right: var(--button-icon-gap);
 }
 
 .favorite-icon.icon-glyph {


### PR DESCRIPTION
## Summary
- add theme variables to control icon spacing
- increase the gap between button icons and text without affecting icon-only buttons

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d047db893c8320bf99956aff70e0b7