### PR TITLE
Improve help dialog results feedback

### DIFF
--- a/index.html
+++ b/index.html
@@ -1119,6 +1119,12 @@
         <h3 id="helpQuickLinksHeading">Jump to a topic</h3>
         <ul id="helpQuickLinksList"></ul>
       </nav>
+      <p
+        id="helpResultsSummary"
+        class="help-results-summary"
+        aria-live="polite"
+        hidden
+      ></p>
       <p id="helpNoResults" aria-live="polite" hidden>No results found.</p>
       <div id="helpSections">
         <section

--- a/src/scripts/script.js
+++ b/src/scripts/script.js
@@ -2761,6 +2761,7 @@ if (typeof texts === 'undefined') {
 // Determine initial language (default English)
 let currentLang = "en";
 let updateHelpQuickLinksForLanguage;
+let updateHelpResultsSummaryText;
 let lastRuntimeHours = null;
 try {
   const savedLang = localStorage.getItem("language");
@@ -4091,6 +4092,9 @@ function setLanguage(lang) {
       document.getElementById("helpTitle").textContent = texts[lang].helpTitle;
     }
     if (helpNoResults) helpNoResults.textContent = texts[lang].helpNoResults;
+    if (typeof updateHelpResultsSummaryText === 'function') {
+      updateHelpResultsSummaryText();
+    }
     if (typeof updateHelpQuickLinksForLanguage === 'function') {
       updateHelpQuickLinksForLanguage(lang);
     }
@@ -6953,6 +6957,7 @@ const helpDialog      = document.getElementById("helpDialog");
 const closeHelpBtn    = document.getElementById("closeHelp");
 const helpSearch      = document.getElementById("helpSearch");
 const helpNoResults   = document.getElementById("helpNoResults");
+const helpResultsSummary = document.getElementById("helpResultsSummary");
 const helpSearchClear = document.getElementById("helpSearchClear");
 const helpSectionsContainer = document.getElementById("helpSections");
 const helpQuickLinksNav = document.getElementById("helpQuickLinks");
@@ -24035,9 +24040,73 @@ if (helpButton && helpDialog) {
     return `(${parts.join('')})`;
   };
 
+  updateHelpResultsSummaryText = ({
+    totalCount,
+    visibleCount,
+    hasQuery,
+    queryText
+  } = {}) => {
+    if (!helpResultsSummary) return;
+    if (typeof totalCount === 'number' && Number.isFinite(totalCount)) {
+      helpResultsSummary.dataset.totalCount = String(totalCount);
+    }
+    if (typeof visibleCount === 'number' && Number.isFinite(visibleCount)) {
+      helpResultsSummary.dataset.visibleCount = String(visibleCount);
+    }
+    if (typeof hasQuery === 'boolean') {
+      helpResultsSummary.dataset.hasQuery = hasQuery ? 'true' : 'false';
+    }
+    if (typeof queryText === 'string') {
+      helpResultsSummary.dataset.query = queryText;
+    }
+    const storedTotal = Number(helpResultsSummary.dataset.totalCount || 0);
+    if (!storedTotal) {
+      helpResultsSummary.textContent = '';
+      helpResultsSummary.setAttribute('hidden', '');
+      return;
+    }
+    const storedVisible = Number(
+      helpResultsSummary.dataset.visibleCount || 0
+    );
+    const storedHasQuery = helpResultsSummary.dataset.hasQuery === 'true';
+    const storedQuery = helpResultsSummary.dataset.query || '';
+    const langTexts = (texts && texts[currentLang]) || {};
+    const fallbackTexts = (texts && texts.en) || {};
+    let summaryText = '';
+    if (storedHasQuery) {
+      const template =
+        langTexts.helpResultsSummaryFiltered ||
+        fallbackTexts.helpResultsSummaryFiltered;
+      if (template) {
+        summaryText = template
+          .replace('%1$s', storedVisible)
+          .replace('%2$s', storedTotal)
+          .replace('%3$s', storedQuery);
+      } else if (storedQuery) {
+        summaryText = `Showing ${storedVisible} of ${storedTotal} help topics for “${storedQuery}”.`;
+      } else {
+        summaryText = `Showing ${storedVisible} of ${storedTotal} help topics.`;
+      }
+    } else {
+      const template =
+        langTexts.helpResultsSummaryAll ||
+        fallbackTexts.helpResultsSummaryAll;
+      if (template) {
+        summaryText = template.replace('%s', storedTotal);
+      } else {
+        summaryText = `All ${storedTotal} help topics are shown.`;
+      }
+    }
+    helpResultsSummary.textContent = summaryText;
+    helpResultsSummary.removeAttribute('hidden');
+  };
+
   const filterHelp = () => {
     // Bail out early if the search input is missing
-    if (!helpSearch) return;
+    if (!helpSearch) {
+      if (helpResultsSummary) helpResultsSummary.setAttribute('hidden', '');
+      return;
+    }
     const rawQuery = helpSearch.value.trim();
     const normalizedQuery = normaliseHelpSearchText(rawQuery);
     const hasQuery = normalizedQuery.length > 0;
@@ -24047,7 +24116,8 @@ if (helpButton && helpDialog) {
     );
     const items = Array.from(helpDialog.querySelectorAll('.faq-item'));
     const elements = sections.concat(items);
-    let anyVisible = false;
+    const totalCount = elements.length;
+    let visibleCount = 0;
     const highlightPattern = hasQuery
       ? buildHelpHighlightPattern(normalizedQuery)
       : null;
@@ -24139,7 +24209,7 @@ if (helpButton && helpDialog) {
             el.removeAttribute('open');
           }
         }
-        anyVisible = true;
+        visibleCount += 1;
       } else {
         // Hide entries that do not match and collapse FAQ answers while they
         // are filtered out so reopening the dialog starts from a clean state.
@@ -24149,9 +24219,17 @@ if (helpButton && helpDialog) {
         }
       }
     });
+    if (typeof updateHelpResultsSummaryText === 'function') {
+      updateHelpResultsSummaryText({
+        totalCount,
+        visibleCount,
+        hasQuery,
+        queryText: rawQuery || normalizedQuery
+      });
+    }
     if (helpNoResults) {
       // Show or hide the "no results" indicator
-      if (anyVisible) {
+      if (visibleCount > 0) {
         helpNoResults.setAttribute('hidden', '');
       } else {
         helpNoResults.removeAttribute('hidden');

--- a/src/scripts/translations.js
+++ b/src/scripts/translations.js
@@ -762,6 +762,8 @@ const texts = {
     helpTitle: "How to use",
     helpSearchPlaceholder: "Search help topics...",
     helpSearchLabel: "Search help topics",
+    helpResultsSummaryAll: "All %s help topics are shown.",
+    helpResultsSummaryFiltered: "Showing %1$s of %2$s help topics for “%3$s”.",
     helpNoResults: "No results found. Try shorter keywords or clear the search to browse all topics.",
     helpSearchClear: "Clear search",
     helpSearchHelp:
@@ -1564,6 +1566,8 @@ const texts = {
     helpTitle: "Come usare",
     helpSearchPlaceholder: "Cerca negli argomenti dell'aiuto...",
     helpSearchLabel: "Cerca negli argomenti dell'aiuto",
+    helpResultsSummaryAll: "Sono visualizzati tutti i %s argomenti dell'aiuto.",
+    helpResultsSummaryFiltered: "Visualizzati %1$s argomenti dell'aiuto su %2$s per “%3$s”.",
     helpNoResults: "Nessun risultato trovato. Prova con parole chiave più brevi oppure cancella la ricerca per vedere tutti gli argomenti.",
     helpSearchClear: "Cancella ricerca",
     helpSearchHelp:
@@ -2373,6 +2377,8 @@ const texts = {
     helpTitle: "Cómo usar",
     helpSearchPlaceholder: "Buscar temas de ayuda...",
     helpSearchLabel: "Buscar temas de ayuda",
+    helpResultsSummaryAll: "Se muestran los %s temas de ayuda.",
+    helpResultsSummaryFiltered: "Mostrando %1$s de %2$s temas de ayuda para “%3$s”.",
     helpNoResults: "No se encontraron resultados. Prueba con palabras clave más cortas o borra la búsqueda para ver todos los temas.",
     helpSearchClear: "Borrar búsqueda",
     helpSearchHelp:
@@ -3184,6 +3190,8 @@ const texts = {
     helpTitle: "Comment utiliser",
     helpSearchPlaceholder: "Rechercher des sujets d'aide...",
     helpSearchLabel: "Rechercher des sujets d'aide",
+    helpResultsSummaryAll: "Tous les %s sujets d’aide sont affichés.",
+    helpResultsSummaryFiltered: "Affichage de %1$s sujet(s) d’aide sur %2$s pour « %3$s ».",
     helpNoResults: "Aucun résultat trouvé. Essayez avec des mots-clés plus courts ou effacez la recherche pour afficher tous les sujets.",
     helpSearchClear: "Effacer la recherche",
     helpSearchHelp:
@@ -3997,6 +4005,8 @@ const texts = {
     helpTitle: "Bedienung",
     helpSearchPlaceholder: "Hilfe-Themen durchsuchen...",
     helpSearchLabel: "Hilfe-Themen durchsuchen",
+    helpResultsSummaryAll: "Alle %s Hilfethemen werden angezeigt.",
+    helpResultsSummaryFiltered: "Es werden %1$s von %2$s Hilfethemen für „%3$s“ angezeigt.",
     helpNoResults: "Keine Ergebnisse gefunden. Verwende kürzere Suchbegriffe oder lösche die Suche, um alle Themen anzuzeigen.",
     helpSearchClear: "Suche löschen",
     helpSearchHelp:

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -1614,6 +1614,16 @@ body.pink-mode .auto-gear-rule-title,
   border-radius: var(--border-radius);
 }
 
+#helpResultsSummary {
+  margin: 0 0 12px;
+  color: var(--muted-text-color);
+  font-size: 0.95rem;
+}
+
+#helpResultsSummary[hidden] {
+  display: none;
+}
+
 #helpQuickLinks[hidden] {
   display: none;
 }


### PR DESCRIPTION
## Summary
- show a live "results" summary in the help dialog, including styling and persisted counts
- refactor help filtering to store summary metadata and update it across language changes
- localize the new summary text for all bundled languages

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d047098d288320baafc51e99755cb8