### PR TITLE
Improve backup restore resilience

### DIFF
--- a/tests/script/backupCompatibility.test.js
+++ b/tests/script/backupCompatibility.test.js
@@ -25,5 +25,14 @@ describe('backup compatibility utilities', () => {
     );
     expect(sections.settings.darkMode).toBe('true');
   });
+
+  test('sanitizeBackupPayload removes UTF-8 BOM characters', () => {
+    const { sanitizeBackupPayload } = loadApp();
+
+    const bomPayload = '\ufeff{"version":"1.0.0"}';
+    const sanitized = sanitizeBackupPayload(bomPayload);
+
+    expect(sanitized).toBe('{"version":"1.0.0"}');
+  });
 });
 


### PR DESCRIPTION
## Summary
- sanitize backup payloads before parsing and add a file.text() fallback so restore succeeds even when FileReader fails
- ensure restore always resets the file input, logs failures consistently, and exports the sanitizer for reuse
- add script tests covering BOM-prefixed backups, the file.text() fallback path, and the sanitizer helper

## Testing
- npm run test:script

------
https://chatgpt.com/codex/tasks/task_e_68d047ab2e088320bf89713b08d9f0bb