### PR TITLE
Use Ubuntu glyphs for add/remove controls

### DIFF
--- a/src/scripts/script.js
+++ b/src/scripts/script.js
@@ -4767,7 +4767,8 @@ const ICON_FONT_KEYS = Object.freeze({
   ESSENTIAL: 'essential',
   FILM: 'film',
   GADGET: 'gadget',
-  UICONS: 'uicons'
+  UICONS: 'uicons',
+  TEXT: 'text'
 });
 
 const VALID_ICON_FONTS = new Set(Object.values(ICON_FONT_KEYS));
@@ -4912,8 +4913,8 @@ const ICON_GLYPHS = Object.freeze({
   trash: iconGlyph('\uF254', ICON_FONT_KEYS.ESSENTIAL),
   reload: iconGlyph('\uF202', ICON_FONT_KEYS.ESSENTIAL),
   load: iconGlyph('\uE0E0', ICON_FONT_KEYS.UICONS),
-  add: iconGlyph('\uE02E', ICON_FONT_KEYS.UICONS),
-  minus: iconGlyph('\uE9E0', ICON_FONT_KEYS.UICONS),
+  add: Object.freeze({ char: '+', font: ICON_FONT_KEYS.TEXT, className: 'icon-text' }),
+  minus: Object.freeze({ char: '−', font: ICON_FONT_KEYS.TEXT, className: 'icon-text' }),
   check: iconGlyph('\uE3D8', ICON_FONT_KEYS.UICONS),
   fileExport: iconGlyph('\uE7AB', ICON_FONT_KEYS.UICONS),
   fileImport: iconGlyph('\uE7C7', ICON_FONT_KEYS.UICONS),

--- a/src/styles/overview-print.css
+++ b/src/styles/overview-print.css
@@ -118,6 +118,10 @@ body.dark-mode {
 #overviewDialogContent #setupDiagram .node-icon[data-icon-font='essential'] {
   font-family: 'EssentialIconsV2', system-ui, sans-serif;
 }
+#overviewDialogContent #setupDiagram .node-icon[data-icon-font='text'] {
+  font-family: 'Ubuntu', system-ui, sans-serif;
+  font-weight: var(--font-weight-medium);
+}
 #overviewDialogContent #setupDiagram line,
 #overviewDialogContent #setupDiagram path.edge-path {
   stroke: var(--control-text);

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -1917,9 +1917,14 @@ body.dark-mode .help-callout {
   font-family: 'GadgetIconsV2';
 }
 
+.icon-glyph[data-icon-font='text'] {
+  font-family: 'Ubuntu', sans-serif;
+  font-weight: var(--font-weight-medium);
+}
+
 .icon-glyph.icon-text {
   font-family: 'Ubuntu', sans-serif;
-  font-weight: var(--font-weight-light);
+  font-weight: var(--font-weight-medium);
 }
 
 .icon-glyph.icon-svg {
@@ -3159,6 +3164,10 @@ body.pink-mode #topBar #logo .logo-center {
 }
 #setupDiagram .node-icon[data-icon-font='essential'] {
   font-family: 'EssentialIconsV2', system-ui, sans-serif;
+}
+#setupDiagram .node-icon[data-icon-font='text'] {
+  font-family: 'Ubuntu', system-ui, sans-serif;
+  font-weight: var(--font-weight-medium);
 }
 #setupDiagram .conn {
   stroke: none;


### PR DESCRIPTION
## Summary
- add a dedicated icon font key for text glyphs so controls can use Ubuntu characters
- swap the add/remove button icons to use Ubuntu-style plus and minus characters
- update shared styles to render text glyphs with the Ubuntu font in regular and print layouts

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d04b9bf8f08320ab4850ad075e394e