### PR TITLE
Hide monitor-only auto gear editor fields until monitoring category selected

### DIFF
--- a/index.html
+++ b/index.html
@@ -1012,11 +1012,11 @@
                   <label for="autoGearAddQuantity" id="autoGearAddQuantityLabel">Qty</label>
                   <input type="number" id="autoGearAddQuantity" min="1" value="1" />
                 </div>
-                <div class="auto-gear-field">
+                <div class="auto-gear-field" hidden>
                   <label for="autoGearAddScreenSize" id="autoGearAddScreenSizeLabel">Screen size</label>
                   <input type="text" id="autoGearAddScreenSize" inputmode="decimal" />
                 </div>
-                <div class="auto-gear-field">
+                <div class="auto-gear-field" hidden>
                   <label for="autoGearAddSelectorType" id="autoGearAddSelectorTypeLabel">Selector</label>
                   <select id="autoGearAddSelectorType">
                     <option value="none">No selector</option>
@@ -1024,11 +1024,11 @@
                     <option value="directorMonitor">Director monitor selector</option>
                   </select>
                 </div>
-                <div class="auto-gear-field">
+                <div class="auto-gear-field" hidden>
                   <label for="autoGearAddSelectorDefault" id="autoGearAddSelectorDefaultLabel">Default item</label>
                   <input type="text" id="autoGearAddSelectorDefault" list="autoGearMonitorCatalog" />
                 </div>
-                <div class="auto-gear-field auto-gear-checkbox-field">
+                <div class="auto-gear-field auto-gear-checkbox-field" hidden>
                   <input type="checkbox" id="autoGearAddSelectorInclude" />
                   <label for="autoGearAddSelectorInclude" id="autoGearAddSelectorIncludeLabel">Include selector</label>
                 </div>
@@ -1055,11 +1055,11 @@
                   <label for="autoGearRemoveQuantity" id="autoGearRemoveQuantityLabel">Qty</label>
                   <input type="number" id="autoGearRemoveQuantity" min="1" value="1" />
                 </div>
-                <div class="auto-gear-field">
+                <div class="auto-gear-field" hidden>
                   <label for="autoGearRemoveScreenSize" id="autoGearRemoveScreenSizeLabel">Screen size</label>
                   <input type="text" id="autoGearRemoveScreenSize" inputmode="decimal" />
                 </div>
-                <div class="auto-gear-field">
+                <div class="auto-gear-field" hidden>
                   <label for="autoGearRemoveSelectorType" id="autoGearRemoveSelectorTypeLabel">Selector</label>
                   <select id="autoGearRemoveSelectorType">
                     <option value="none">No selector</option>
@@ -1067,11 +1067,11 @@
                     <option value="directorMonitor">Director monitor selector</option>
                   </select>
                 </div>
-                <div class="auto-gear-field">
+                <div class="auto-gear-field" hidden>
                   <label for="autoGearRemoveSelectorDefault" id="autoGearRemoveSelectorDefaultLabel">Default item</label>
                   <input type="text" id="autoGearRemoveSelectorDefault" list="autoGearMonitorCatalog" />
                 </div>
-                <div class="auto-gear-field auto-gear-checkbox-field">
+                <div class="auto-gear-field auto-gear-checkbox-field" hidden>
                   <input type="checkbox" id="autoGearRemoveSelectorInclude" />
                   <label for="autoGearRemoveSelectorInclude" id="autoGearRemoveSelectorIncludeLabel">Include selector</label>
                 </div>


### PR DESCRIPTION
## Summary
- hide the monitor-specific fields in the automatic gear rule editor until the Monitoring category is selected for both add and remove lists

## Testing
- npm test -- --runTestsByPath tests/script/autoGearRules.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d05a33f42483208d4871fc01c0c93d