### PR TITLE
Align recording info boxes in diagram hover summaries

### DIFF
--- a/src/scripts/script.js
+++ b/src/scripts/script.js
@@ -19133,7 +19133,9 @@ function generateConnectorSummary(device) {
     const formatted = uniqueList(values);
     if (!formatted.length) return html;
     const iconHtml = iconMarkup(icon);
-    return `${html}<span class="info-box ${cls}">${iconHtml}${label}: ${formatted.join(', ')}</span>`;
+    const labelHtml = `<span class="info-box-label">${label}:</span>`;
+    const valuesHtml = `<span class="info-box-values">${formatted.join(', ')}</span>`;
+    return `${html}<span class="info-box ${cls} info-box-list">${iconHtml}${labelHtml}${valuesHtml}</span>`;
   };
 
   let recordingHtml = '';

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -3165,6 +3165,24 @@ body.pink-mode #topBar #logo .logo-center {
   font-size: calc(var(--font-size-relative-base) * var(--font-scale-xxs));
 }
 
+.info-box-list {
+  gap: 4px;
+  flex-wrap: nowrap;
+}
+
+.info-box-list .info-box-label {
+  flex: 0 0 auto;
+  font-weight: var(--font-weight-medium);
+  margin-right: 2px;
+}
+
+.info-box-list .info-box-values {
+  flex: 1 1 auto;
+  min-width: 0;
+  white-space: normal;
+  overflow-wrap: anywhere;
+}
+
 .scenario-box,
 .icon-box {
   display: flex;


### PR DESCRIPTION
## Summary
- update the diagram hover summary builder so sensor modes, resolutions, codecs, and media entries render with labeled spans beside their icons
- add supporting styles so the new labeled info boxes keep the icon, label, and values on a single line while still wrapping long values cleanly

## Testing
- npm run lint
- npm run test:script -- --runTestsByPath tests/script/script.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d05d43f4a48320a05441e373c3e1dd