### PR TITLE
Reorder filter summary under interactive controls

### DIFF
--- a/src/scripts/script.js
+++ b/src/scripts/script.js
@@ -26474,7 +26474,10 @@ function buildFilterSelectHtml(filters = [], precomputedEntries) {
   const detailsContainer = entries.length
     ? '<div id="gearListFilterDetails" class="hidden" aria-live="polite"></div>'
     : '';
-  return [summaryHtml, detailsContainer].filter(Boolean).join('<br>');
+  const summaryContainer = summaryHtml
+    ? `<div class="gear-list-filter-summary">${summaryHtml}</div>`
+    : '';
+  return [detailsContainer, summaryContainer].filter(Boolean).join('');
 }
 
 function collectFilterAccessories(filters = []) {

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -4578,6 +4578,11 @@ body.dark-mode.pink-mode #gearListOutput h2,
   background-color: var(--panel-bg);
 }
 
+.gear-list-filter-summary {
+  margin-top: 0.5rem;
+  line-height: var(--line-height-relaxed);
+}
+
 @supports (color: color-mix(in srgb, #000 50%, white)) {
   #gearListFilterDetails .filter-detail-size:focus-within {
     box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent-color) 35%, transparent);


### PR DESCRIPTION
## Summary
- render the interactive filter detail controls before the text summary so the checkboxes appear at the top of the matte box section
- wrap the generated summary entries in a dedicated container and add spacing styles for improved layout

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d05edf3d90832089b79abb8ea15857