### PR TITLE
Link crew contacts in overview and exports

### DIFF
--- a/tests/script/crewLinks.test.js
+++ b/tests/script/crewLinks.test.js
@@ -1,0 +1,40 @@
+const { setupScriptEnvironment } = require('../helpers/scriptEnvironment');
+
+describe('crew contact links', () => {
+  let env;
+
+  afterEach(() => {
+    if (env && typeof env.cleanup === 'function') {
+      env.cleanup();
+    }
+    env = null;
+  });
+
+  test('crew entries render tel and mailto links', () => {
+    env = setupScriptEnvironment();
+    const { generateGearListHtml } = env.utils;
+    const html = generateGearListHtml({
+      people: [
+        {
+          role: 'Director',
+          name: 'Jamie Crew',
+          phone: '+1 555 123 4567',
+          email: 'jamie.crew@example.com'
+        }
+      ]
+    });
+    const container = document.createElement('div');
+    container.innerHTML = html;
+    const crewBox = container.querySelector('.requirement-box[data-field="crew"]');
+    expect(crewBox).not.toBeNull();
+    const value = crewBox.querySelector('.req-value');
+    expect(value).not.toBeNull();
+    const phoneLink = value.querySelector('a[href="tel:+15551234567"]');
+    expect(phoneLink).not.toBeNull();
+    expect(phoneLink.textContent).toBe('+1 555 123 4567');
+    const mailLink = value.querySelector('a[href="mailto:jamie.crew@example.com"]');
+    expect(mailLink).not.toBeNull();
+    expect(mailLink.textContent).toBe('jamie.crew@example.com');
+    expect(value.textContent).toContain('Director: Jamie Crew');
+  });
+});


### PR DESCRIPTION
## Summary
- sanitize crew phone numbers and email addresses into tel/mailto links when rendering project requirements
- allow requirement rendering to accept preformatted HTML so crew contact links remain clickable in the overview and PDF
- add a script-level unit test that verifies crew contacts include tel and mailto anchors

## Testing
- `npm run test:script` *(fails: JavaScript heap out of memory)*
- `npx jest tests/script/crewLinks.test.js --runInBand`


------
https://chatgpt.com/codex/tasks/task_e_68d05e321568832090cdd35e228a58ec