### PR TITLE
Align gear list filter typography with gear items

### DIFF
--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -4466,7 +4466,7 @@ body.dark-mode.pink-mode #gearListOutput h2,
   flex-direction: column;
   gap: 0.375rem;
   margin-top: 0.375rem;
-  line-height: var(--line-height-supporting);
+  line-height: var(--line-height-relaxed);
 }
 
 #gearListFilterDetails.hidden {
@@ -4502,7 +4502,7 @@ body.dark-mode.pink-mode #gearListOutput h2,
   display: inline-flex;
   align-items: center;
   gap: 0.5rem;
-  font-weight: 500;
+  font-weight: var(--font-weight-regular);
   padding: 0.125rem 0.375rem;
   border-radius: var(--border-radius);
   background-color: transparent;
@@ -4543,7 +4543,7 @@ body.dark-mode.pink-mode #gearListOutput h2,
 }
 
 #gearListFilterDetails .filter-detail-sublabel {
-  font-weight: 500;
+  font-weight: var(--font-weight-regular);
 }
 
 #gearListFilterDetails .filter-detail-sublabel::after {


### PR DESCRIPTION
## Summary
- align gear list filter line height with standard gear entries
- use regular font weight on filter controls to match gear list items

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d05f4d2e508320954c355ea4ce55ff