### PR TITLE
Use logical icon spacing for buttons

### DIFF
--- a/src/styles/overview-print.css
+++ b/src/styles/overview-print.css
@@ -436,7 +436,7 @@ body:not(.light-mode) .gear-table .category-row td {
 }
 
 #overviewDialogContent .diagram-controls button .btn-icon:only-child {
-  margin-right: 0 !important;
+  margin-inline-end: 0 !important;
 }
 
 .warning {

--- a/src/styles/overview.css
+++ b/src/styles/overview.css
@@ -210,7 +210,7 @@ th { background-color: var(--control-bg); font-weight: var(--font-weight-bold); 
     grid-template-columns: 1fr;
   }
 }
-.category-icon { margin-right: 4px; }
+.category-icon { margin-inline-end: 4px; }
 .category-icon.icon-glyph {
   --icon-size: var(--icon-size-md);
 }
@@ -231,7 +231,7 @@ th { background-color: var(--control-bg); font-weight: var(--font-weight-bold); 
 }
 
 .diagram-controls button .btn-icon:only-child {
-  margin-right: 0;
+  margin-inline-end: 0;
 }
 
 .diagram-controls button {

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -2164,16 +2164,16 @@ body.dark-mode .help-callout {
 .category-icon,
 .scenario-icon,
 .icon-box .icon {
-  margin-right: var(--icon-gap);
+  margin-inline-end: var(--icon-gap);
 }
 
 button .btn-icon:only-child {
-  margin-right: 0;
+  margin-inline-end: 0;
 }
 
 button .btn-icon:not(:only-child),
 .button-link .btn-icon:not(:only-child) {
-  margin-right: var(--button-icon-gap);
+  margin-inline-end: var(--button-icon-gap);
 }
 
 .favorite-icon.icon-glyph {


### PR DESCRIPTION
## Summary
- switch global button icon margins to logical `margin-inline-end` so icon/text spacing works in all writing directions
- align overview and print styles with the same logical spacing rules to keep button icons consistent outside the main app

## Testing
- npm run lint
- npm run check-consistency
- node --max-old-space-size=4096 ./node_modules/jest/bin/jest.js --runInBand --selectProjects unit

------
https://chatgpt.com/codex/tasks/task_e_68d05fc8a7ec8320a0913824d83dbf22