### PR TITLE
Refresh settings tab layout with icons and summaries

### DIFF
--- a/index.html
+++ b/index.html
@@ -802,15 +802,36 @@
           aria-label="Settings sections"
           aria-orientation="horizontal"
         >
-          <button
-            type="button"
-            class="settings-tab"
-            id="settingsTab-general"
-            role="tab"
+        <button
+          type="button"
+          class="settings-tab"
+          id="settingsTab-general"
+          role="tab"
           aria-controls="settingsPanel-general"
           aria-selected="true"
         >
-          General
+          <span class="settings-tab-icon icon-glyph icon-svg" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" aria-hidden="true">
+              <path
+                d="M9.593 3.94c.09-.542.559-.94 1.11-.94h2.594c.55 0 1.019.398 1.11.94l.213 1.281c.062.374.312.686.644.87.074.041.147.083.22.127.332.183.721.257 1.076.124l1.217-.456a1.125 1.125 0 0 1 1.369.491l1.297 2.246a1.125 1.125 0 0 1-.259 1.431l-1.004.826c-.293.241-.438.612-.431.991.001.042.002.084.002.127s0 .085-.002.127c-.007.379.138.75.431.991l1.004.827a1.125 1.125 0 0 1 .259 1.43l-1.297 2.247a1.125 1.125 0 0 1-1.369.49l-1.217-.455a1.35 1.35 0 0 0-1.076.124 5.58 5.58 0 0 1-.864.495 1.35 1.35 0 0 0-.644.87l-.213 1.281c-.09.542-.559.94-1.11.94H10.703a1.125 1.125 0 0 1-1.11-.94l-.214-1.281a1.35 1.35 0 0 0-.644-.87 5.446 5.446 0 0 1-.864-.495 1.35 1.35 0 0 0-1.076-.124l-1.217.455a1.125 1.125 0 0 1-1.369-.49L3.557 15.377a1.125 1.125 0 0 1 .259-1.431l1.004-.826c.292-.241.437-.613.43-.992a4.643 4.643 0 0 1-.002-.254c0-.042.001-.084.002-.127.007-.379-.138-.75-.43-.991l-1.005-.827A1.125 1.125 0 0 1 3.557 8.623l1.297-2.246a1.125 1.125 0 0 1 1.369-.491l1.217.456c.355.133.75.072 1.076-.124.073-.044.147-.086.22-.127.332-.183.582-.495.644-.87l.213-1.281Z"
+                stroke="currentColor"
+                stroke-width="1.5"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+              <path
+                d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z"
+                stroke="currentColor"
+                stroke-width="1.5"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+            </svg>
+          </span>
+          <span class="settings-tab-text">
+            <span class="settings-tab-label">General</span>
+            <span class="settings-tab-caption">Language, theme and fonts.</span>
+          </span>
         </button>
         <button
           type="button"
@@ -821,7 +842,24 @@
           aria-selected="false"
           tabindex="-1"
         >
-          Automatic Gear
+          <span class="settings-tab-icon icon-glyph icon-svg" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" aria-hidden="true">
+              <circle cx="6.5" cy="7" r="2.5" stroke="currentColor" stroke-width="1.5" />
+              <circle cx="17.5" cy="7" r="2.5" stroke="currentColor" stroke-width="1.5" />
+              <circle cx="12" cy="17.5" r="2.5" stroke="currentColor" stroke-width="1.5" />
+              <path
+                d="m8.5 8.5 3.5 3.5 3.5-3.5M12 12l-3 4.25M12 12l3 4.25"
+                stroke="currentColor"
+                stroke-width="1.5"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+            </svg>
+          </span>
+          <span class="settings-tab-text">
+            <span class="settings-tab-label">Automatic Gear</span>
+            <span class="settings-tab-caption">Automate recommended gear selections.</span>
+          </span>
         </button>
         <button
           type="button"
@@ -832,7 +870,22 @@
           aria-selected="false"
           tabindex="-1"
         >
-          Accessibility
+          <span class="settings-tab-icon icon-glyph icon-svg" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" aria-hidden="true">
+              <circle cx="12" cy="6.5" r="2.25" stroke="currentColor" stroke-width="1.5" />
+              <path
+                d="M5 11h14M12 8.75V19M8.5 19.5l3.5-7 3.5 7"
+                stroke="currentColor"
+                stroke-width="1.5"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+            </svg>
+          </span>
+          <span class="settings-tab-text">
+            <span class="settings-tab-label">Accessibility</span>
+            <span class="settings-tab-caption">Contrast, motion and readability options.</span>
+          </span>
         </button>
         <button
           type="button"
@@ -843,7 +896,30 @@
           aria-selected="false"
           tabindex="-1"
         >
-          Backup &amp; Restore
+          <span class="settings-tab-icon icon-glyph icon-svg" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" aria-hidden="true">
+              <rect
+                x="4.75"
+                y="7.75"
+                width="14.5"
+                height="9.5"
+                rx="2"
+                stroke="currentColor"
+                stroke-width="1.5"
+              />
+              <path
+                d="M12 4v3.5M10.25 5.75 12 4l1.75 1.75M12 16.75V20M10.25 18.25 12 20l1.75-1.75"
+                stroke="currentColor"
+                stroke-width="1.5"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+            </svg>
+          </span>
+          <span class="settings-tab-text">
+            <span class="settings-tab-label">Backup &amp; Restore</span>
+            <span class="settings-tab-caption">Safeguard projects, devices and settings.</span>
+          </span>
         </button>
         <button
           type="button"
@@ -854,7 +930,36 @@
           aria-selected="false"
           tabindex="-1"
         >
-          Data &amp; Storage
+          <span class="settings-tab-icon icon-glyph icon-svg" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" aria-hidden="true">
+              <ellipse
+                cx="12"
+                cy="7"
+                rx="6.5"
+                ry="3.5"
+                stroke="currentColor"
+                stroke-width="1.5"
+              />
+              <path
+                d="M5.5 7v7c0 1.93 2.91 3.5 6.5 3.5s6.5-1.57 6.5-3.5V7"
+                stroke="currentColor"
+                stroke-width="1.5"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+              <path
+                d="M5.5 12c0 1.93 2.91 3.5 6.5 3.5s6.5-1.57 6.5-3.5"
+                stroke="currentColor"
+                stroke-width="1.5"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+            </svg>
+          </span>
+          <span class="settings-tab-text">
+            <span class="settings-tab-label">Data &amp; Storage</span>
+            <span class="settings-tab-caption">Manage local storage and cache data.</span>
+          </span>
         </button>
         <button
           type="button"
@@ -865,7 +970,28 @@
           aria-selected="false"
           tabindex="-1"
         >
-          About &amp; Support
+          <span class="settings-tab-icon icon-glyph icon-svg" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" aria-hidden="true">
+              <path
+                d="M20 11.5c0 4.694-3.806 8.5-8.5 8.5-1.166 0-2.28-.235-3.292-.662L4 20l.676-4.208A8.463 8.463 0 0 1 3.5 11.5C3.5 6.806 7.306 3 12 3s8 3.806 8 8.5Z"
+                stroke="currentColor"
+                stroke-width="1.5"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+              <path
+                d="M12 9.25c0-.69.56-1.25 1.25-1.25S14.5 8.56 14.5 9.25c0 .69-.56 1.25-1.25 1.25-.69 0-1.25.56-1.25 1.25v.5M12 15.75h.01"
+                stroke="currentColor"
+                stroke-width="1.5"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+            </svg>
+          </span>
+          <span class="settings-tab-text">
+            <span class="settings-tab-label">About &amp; Support</span>
+            <span class="settings-tab-caption">Guides, troubleshooting and contact info.</span>
+          </span>
         </button>
         </div>
         <button

--- a/src/scripts/script.js
+++ b/src/scripts/script.js
@@ -3746,20 +3746,79 @@ function setLanguage(lang) {
       'Settings sections';
     settingsTablist.setAttribute('aria-label', sectionsLabel);
   }
+  const getSettingsTabLabelText = button => {
+    if (!button || typeof button !== 'object') return '';
+    const labelNode = button.querySelector?.('.settings-tab-label');
+    if (labelNode && typeof labelNode.textContent === 'string') {
+      const trimmed = labelNode.textContent.trim();
+      if (trimmed) return trimmed;
+    }
+    return typeof button.textContent === 'string' ? button.textContent.trim() : '';
+  };
+  const summarizeSettingsTabHelp = helpText => {
+    if (typeof helpText !== 'string') return '';
+    const trimmed = helpText.trim();
+    if (!trimmed) return '';
+    const sentenceMatch = trimmed.match(/^[^.!?。！？]*[.!?。！？]/u);
+    if (sentenceMatch && sentenceMatch[0]) {
+      const sentence = sentenceMatch[0].trim();
+      if (sentence.length >= 24 || trimmed.length <= 90) {
+        return sentence;
+      }
+    }
+    if (trimmed.length <= 90) return trimmed;
+    const truncated = trimmed.slice(0, 90);
+    let cutIndex = truncated.length;
+    while (cutIndex > 0 && truncated[cutIndex - 1] && truncated[cutIndex - 1].trim() !== '') {
+      cutIndex -= 1;
+    }
+    const safeCut = cutIndex > 0 ? truncated.slice(0, cutIndex).trimEnd() : '';
+    return `${safeCut || truncated.trim()}…`;
+  };
   const applySettingsTabLabel = (button, labelValue, helpValue) => {
     if (!button) return;
-    const label = labelValue || button.textContent || '';
-    button.textContent = label;
-    button.setAttribute('aria-label', label);
-    const help = helpValue || label;
-    button.setAttribute('data-help', help);
-    button.setAttribute('title', help);
+    const label = (labelValue || getSettingsTabLabelText(button) || '').trim();
+    const labelElement = button.querySelector?.('.settings-tab-label');
+    if (labelElement) {
+      labelElement.textContent = label;
+    } else {
+      button.textContent = label;
+    }
+    if (label) {
+      button.setAttribute('aria-label', label);
+    } else {
+      button.removeAttribute('aria-label');
+    }
+    const help = (helpValue || label || '').trim();
+    if (help) {
+      button.setAttribute('data-help', help);
+      button.setAttribute('title', help);
+    } else {
+      button.removeAttribute('data-help');
+      button.removeAttribute('title');
+    }
+    const summary = summarizeSettingsTabHelp(help);
+    if (summary) {
+      button.setAttribute('data-summary', summary);
+    } else {
+      button.removeAttribute('data-summary');
+    }
+    const captionElement = button.querySelector?.('.settings-tab-caption');
+    if (captionElement) {
+      const captionText = summary || label;
+      captionElement.textContent = captionText;
+      if (captionText) {
+        captionElement.removeAttribute('hidden');
+      } else {
+        captionElement.setAttribute('hidden', '');
+      }
+    }
   };
   if (settingsTabGeneral) {
     const generalLabel =
       texts[lang].settingsTabGeneral ||
       texts.en?.settingsTabGeneral ||
-      settingsTabGeneral.textContent ||
+      getSettingsTabLabelText(settingsTabGeneral) ||
       'General';
     const generalHelp =
       texts[lang].settingsTabGeneralHelp ||

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -1279,9 +1279,9 @@ main.legal-content {
 .settings-tabs {
   display: flex;
   flex-wrap: nowrap;
-  gap: 8px;
+  gap: 12px;
   align-items: center;
-  padding: 4px 0;
+  padding: 6px 0;
   margin: 0;
   overflow-x: auto;
   overflow-y: hidden;
@@ -1359,38 +1359,167 @@ body.high-contrast .settings-tabs-container::after {
 
 .settings-tab {
   appearance: none;
-  border: 1px solid var(--panel-border);
-  border-radius: var(--border-radius);
-  background: var(--panel-bg);
+  border: 1px solid color-mix(in srgb, var(--panel-border) 65%, transparent);
+  border-radius: calc(var(--border-radius) * 1.1);
+  background: linear-gradient(
+    135deg,
+    color-mix(in srgb, var(--panel-bg) 88%, var(--accent-color) 12%),
+    color-mix(in srgb, var(--panel-bg) 94%, transparent)
+  );
   color: inherit;
   font: inherit;
   font-weight: 600;
-  padding: 10px 18px;
+  padding: 14px 16px;
   cursor: pointer;
-  transition: background-color 0.2s ease, border-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
-  white-space: nowrap;
-  flex: 0 0 auto;
-  scroll-snap-align: start;
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
+  transition: background-color 0.25s ease, border-color 0.25s ease, color 0.25s ease,
+    box-shadow 0.25s ease, transform 0.25s ease;
+  white-space: normal;
+  text-align: left;
+  flex: 0 0 clamp(200px, 30vw, 260px);
+  scroll-snap-align: center;
+  display: flex;
+  align-items: flex-start;
+  gap: 14px;
+  position: relative;
+  isolation: isolate;
 }
 
 .settings-tab:hover,
 .settings-tab:focus-visible {
-  border-color: var(--accent-color);
-  color: var(--accent-color);
+  border-color: color-mix(in srgb, var(--accent-color) 65%, transparent);
+  box-shadow: 0 8px 24px color-mix(in srgb, var(--accent-color) 18%, transparent);
 }
 
 .settings-tab[aria-selected="true"] {
-  background-color: color-mix(in srgb, var(--accent-color) 18%, var(--panel-bg));
-  border-color: var(--accent-color);
-  color: var(--accent-color);
-  box-shadow: 0 2px 10px color-mix(in srgb, var(--accent-color) 18%, transparent);
+  background: linear-gradient(
+    135deg,
+    color-mix(in srgb, var(--accent-color) 26%, var(--panel-bg)),
+    color-mix(in srgb, var(--panel-bg) 90%, transparent)
+  );
+  border-color: color-mix(in srgb, var(--accent-color) 70%, transparent);
+  box-shadow: 0 10px 28px color-mix(in srgb, var(--accent-color) 24%, transparent);
 }
 
 .settings-tab.active {
-  box-shadow: 0 2px 10px color-mix(in srgb, var(--accent-color) 18%, transparent);
+  box-shadow: 0 10px 28px color-mix(in srgb, var(--accent-color) 24%, transparent);
+}
+
+.settings-tab:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent-color) 30%, transparent),
+    0 10px 28px color-mix(in srgb, var(--accent-color) 24%, transparent);
+}
+
+.settings-tab-icon {
+  --icon-size: 26px;
+  inline-size: 44px;
+  block-size: 44px;
+  min-inline-size: 44px;
+  min-block-size: 44px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 14px;
+  background: color-mix(in srgb, var(--accent-color) 10%, transparent);
+  color: color-mix(in srgb, var(--accent-color) 65%, currentColor);
+  flex: 0 0 44px;
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--accent-color) 12%, transparent);
+  transition: transform 0.25s ease, background-color 0.25s ease, color 0.25s ease,
+    box-shadow 0.25s ease;
+}
+
+.settings-tab:hover .settings-tab-icon,
+.settings-tab:focus-visible .settings-tab-icon {
+  background: color-mix(in srgb, var(--accent-color) 20%, transparent);
+  color: var(--accent-color);
+  transform: translateY(-1px);
+  box-shadow: 0 6px 18px color-mix(in srgb, var(--accent-color) 20%, transparent);
+}
+
+.settings-tab[aria-selected="true"] .settings-tab-icon,
+.settings-tab.active .settings-tab-icon {
+  background: color-mix(in srgb, var(--accent-color) 28%, transparent);
+  color: var(--accent-color);
+  box-shadow: 0 10px 24px color-mix(in srgb, var(--accent-color) 26%, transparent);
+  transform: translateY(-1px) scale(1.02);
+}
+
+.settings-tab-text {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  align-items: flex-start;
+  min-width: 0;
+}
+
+.settings-tab-label {
+  font-size: 1rem;
+  font-weight: 600;
+  line-height: 1.25;
+  color: currentColor;
+}
+
+.settings-tab[aria-selected="true"] .settings-tab-label,
+.settings-tab:hover .settings-tab-label,
+.settings-tab:focus-visible .settings-tab-label {
+  color: color-mix(in srgb, var(--accent-color) 75%, currentColor);
+}
+
+.settings-tab-caption {
+  font-size: 0.8rem;
+  line-height: 1.35;
+  color: color-mix(in srgb, var(--muted-text-color) 90%, currentColor);
+  max-width: 32ch;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-height: calc(1.35em * 2);
+}
+
+.settings-tab[aria-selected="true"] .settings-tab-caption,
+.settings-tab:hover .settings-tab-caption,
+.settings-tab:focus-visible .settings-tab-caption {
+  color: color-mix(in srgb, var(--accent-color) 55%, var(--muted-text-color));
+}
+
+body.high-contrast .settings-tab {
+  background: var(--surface-color);
+  border: 1px solid var(--panel-border);
+  box-shadow: none;
+}
+
+body.high-contrast .settings-tab:hover,
+body.high-contrast .settings-tab:focus-visible,
+body.high-contrast .settings-tab[aria-selected="true"],
+body.high-contrast .settings-tab.active {
+  color: inherit;
+  border-color: var(--panel-border);
+  box-shadow: none;
+}
+
+body.high-contrast .settings-tab-icon {
+  background: transparent;
+  color: currentColor;
+  box-shadow: none;
+}
+
+body.high-contrast .settings-tab-caption {
+  color: currentColor;
+}
+
+@media (max-width: 600px) {
+  .settings-tab {
+    flex: 0 0 clamp(220px, 80vw, 260px);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .settings-tab,
+  .settings-tab-icon {
+    transition: none;
+  }
 }
 
 .settings-panel[hidden] {


### PR DESCRIPTION
## Summary
- redesign the settings tab bar with icon cards, captions, and richer hover/active styling
- add responsive CSS for the refreshed layout, high-contrast support, and reduced motion fallbacks
- update settings tab translation wiring to target label/caption spans and summarize help text safely

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68d05f7665008320bf43f29944db9ca8