### PR TITLE
Remove limit label background from power diagram

### DIFF
--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -2992,7 +2992,7 @@ body.pink-mode #topBar #logo .logo-center {
   top: -1.2em;
   left: 50%;
   transform: translateX(-50%);
-  background: var(--surface-color);
+  background: none;
   color: var(--danger-color);
   font-size: calc(var(--font-size-relative-base) * var(--font-scale-xxs));
   padding: 0 2px;


### PR DESCRIPTION
## Summary
- remove the background fill from the power diagram limit label so the Max Pin A indicator is transparent

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d0637081f08320a2b0993668612b45