### PR TITLE
Refine filter layout spacing

### DIFF
--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -4627,9 +4627,9 @@ body.dark-mode.pink-mode #gearListOutput h2,
 #gearListFilterDetails {
   display: flex;
   flex-direction: column;
-  gap: 0.375rem;
+  gap: 0.25rem;
   margin-top: 0.375rem;
-  line-height: var(--line-height-relaxed);
+  line-height: var(--line-height-base);
 }
 
 #gearListFilterDetails.hidden {
@@ -4637,10 +4637,11 @@ body.dark-mode.pink-mode #gearListOutput h2,
 }
 
 #gearListFilterDetails .filter-detail {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem;
-  align-items: flex-start;
+  display: grid;
+  grid-template-columns: minmax(9.5rem, max-content) minmax(0, 1fr);
+  column-gap: 0.75rem;
+  row-gap: 0.25rem;
+  align-items: center;
   padding: 0.125rem 0;
   border: none;
   border-radius: 0;
@@ -4650,21 +4651,22 @@ body.dark-mode.pink-mode #gearListOutput h2,
 #gearListFilterDetails .filter-detail-label {
   font-weight: var(--font-weight-regular);
   min-width: 0;
-  margin-right: 0.25rem;
+  margin-right: 0;
+  line-height: var(--line-height-base);
 }
 
 #gearListFilterDetails .filter-detail-controls {
   display: flex;
   flex: 1 1 auto;
   flex-wrap: wrap;
-  gap: 0.5rem;
+  gap: 0.375rem 0.5rem;
   align-items: center;
 }
 
 #gearListFilterDetails .filter-detail-size {
   display: inline-flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.375rem;
   font-weight: var(--font-weight-regular);
   padding: 0.125rem 0.375rem;
   border-radius: var(--border-radius);
@@ -4743,7 +4745,17 @@ body.dark-mode.pink-mode #gearListOutput h2,
 
 .gear-list-filter-summary {
   margin-top: 0.5rem;
-  line-height: var(--line-height-relaxed);
+  line-height: var(--line-height-base);
+}
+
+@media (max-width: 640px) {
+  #gearListFilterDetails .filter-detail {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  #gearListFilterDetails .filter-detail-label {
+    margin-bottom: 0.125rem;
+  }
 }
 
 @supports (color: color-mix(in srgb, #000 50%, white)) {


### PR DESCRIPTION
## Summary
- reduce vertical spacing in the gear list filter details for a denser layout
- rework the filter detail rows to use a grid for better label/control alignment
- adjust responsive rules so filters stay aligned on small screens

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d0671d05cc83208ba730c02c00276e