### PR TITLE
Adjust FIZ overview sections to single column

### DIFF
--- a/legacy/scripts/overview.js
+++ b/legacy/scripts/overview.js
@@ -76,7 +76,8 @@ function generatePrintableOverview() {
     var heading = t[key] || key;
     var icon = overviewSectionIcons[key] || '';
     var iconHtml = icon && typeof iconMarkup === 'function' ? iconMarkup(icon, 'category-icon') : icon ? "<span class=\"category-icon icon-glyph\" data-icon-font=\"uicons\" aria-hidden=\"true\">".concat(icon, "</span>") : '';
-    var gridClasses = key === 'category_fiz_motors' || key === 'category_fiz_controllers' ? 'device-block-grid two-column' : 'device-block-grid single-column';
+    var isFizList = key === 'category_fiz_motors' || key === 'category_fiz_controllers';
+    var gridClasses = isFizList ? 'device-block-grid two-column fiz-single-column' : 'device-block-grid single-column';
     deviceListHtml += "<div class=\"device-category\"><h3>".concat(iconHtml).concat(heading, "</h3><div class=\"").concat(gridClasses, "\">").concat(sections[key].join(''), "</div></div>");
   });
   deviceListHtml += '</div>';

--- a/src/scripts/overview.js
+++ b/src/scripts/overview.js
@@ -84,18 +84,19 @@ function generatePrintableOverview() {
     processSelectForOverview(batterySelect, 'category_batteries', 'batteries'); // Handle battery separately for capacity
     processSelectForOverview(hotswapSelect, 'category_batteryHotswaps', 'batteryHotswaps');
 
-      sectionOrder.forEach(key => {
-          const heading = t[key] || key;
-          const icon = overviewSectionIcons[key] || '';
-          const iconHtml = icon && typeof iconMarkup === 'function'
-            ? iconMarkup(icon, 'category-icon')
-            : icon
-              ? `<span class="category-icon icon-glyph" data-icon-font="uicons" aria-hidden="true">${icon}</span>`
-              : '';
-          const gridClasses = (key === 'category_fiz_motors' || key === 'category_fiz_controllers') ? 'device-block-grid two-column' : 'device-block-grid single-column';
-        deviceListHtml += `<div class="device-category"><h3>${iconHtml}${heading}</h3><div class="${gridClasses}">${sections[key].join('')}</div></div>`;
-      });
-      deviceListHtml += '</div>';
+    sectionOrder.forEach(key => {
+      const heading = t[key] || key;
+      const icon = overviewSectionIcons[key] || '';
+      const iconHtml = icon && typeof iconMarkup === 'function'
+        ? iconMarkup(icon, 'category-icon')
+        : icon
+          ? `<span class="category-icon icon-glyph" data-icon-font="uicons" aria-hidden="true">${icon}</span>`
+          : '';
+      const isFizList = key === 'category_fiz_motors' || key === 'category_fiz_controllers';
+      const gridClasses = isFizList ? 'device-block-grid two-column fiz-single-column' : 'device-block-grid single-column';
+      deviceListHtml += `<div class="device-category"><h3>${iconHtml}${heading}</h3><div class="${gridClasses}">${sections[key].join('')}</div></div>`;
+    });
+    deviceListHtml += '</div>';
 
     const breakdownHtml = breakdownListElem.innerHTML;
     const batteryLifeUnitElem = document.getElementById("batteryLifeUnit");

--- a/src/styles/overview.css
+++ b/src/styles/overview.css
@@ -152,6 +152,9 @@ th { background-color: var(--control-bg); font-weight: var(--font-weight-bold); 
 .device-block-grid.two-column {
   grid-template-columns: repeat(2, 1fr);
 }
+.device-block-grid.fiz-single-column {
+  grid-template-columns: 1fr;
+}
 .device-block {
   background: rgba(255,255,255,0.95);
   border: 1px solid var(--control-text);

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -4398,6 +4398,9 @@ body.dark-mode.dark-accent-boost:not(.pink-mode) .settings-content.modal-surface
 #overviewDialogContent .device-block-grid.two-column {
   grid-template-columns: repeat(2, 1fr);
 }
+#overviewDialogContent .device-block-grid.fiz-single-column {
+  grid-template-columns: 1fr;
+}
 
 @media screen and (max-width: 600px) {
   #overviewDialogContent .device-category-container {


### PR DESCRIPTION
## Summary
- ensure the overview dialog renders FIZ motor and controller sections with a single column grid
- add a dedicated helper class so screen styles can override the default two-column layout without disturbing print rules
- mirror the logic in the legacy bundle for consistent behaviour

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d066d2d5ac8320b5054d50f228bb89