### PR TITLE
Maintain button height across locales

### DIFF
--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -28,6 +28,7 @@
   --gap-size: 10px;
   --button-size: 24px;
   --button-icon-size: var(--icon-size-md);
+  --button-line-height: 1.25;
   --icon-gap: 0.3em;
   --button-icon-gap: 0.55em;
   --form-control-font-size: var(--font-size-relative-base);
@@ -2719,6 +2720,8 @@ button {
   font-size: var(--form-control-font-size);
   min-height: var(--button-size);
   height: auto;
+  /* Keep single-line buttons consistent in every locale without preventing wrapping */
+  line-height: var(--button-line-height);
   display: inline-flex;
   align-items: center;
   justify-content: center;


### PR DESCRIPTION
## Summary
- add a dedicated `--button-line-height` token so buttons can share a consistent single-line height
- apply the new line-height to the base button styling while still allowing labels to wrap when needed

## Testing
- npm run lint
- npm test *(fails: Node.js heap OOM in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d063f78b008320b4ce587a882a8c07