### PR TITLE
Use coding icon for codec indicator

### DIFF
--- a/src/scripts/script.js
+++ b/src/scripts/script.js
@@ -5221,7 +5221,7 @@ const ICON_GLYPHS = Object.freeze({
   share: iconGlyph('\uF219', ICON_FONT_KEYS.ESSENTIAL),
   paperPlane: iconGlyph('\uED67', ICON_FONT_KEYS.UICONS),
   magnet: iconGlyph('\uF1B5', ICON_FONT_KEYS.ESSENTIAL),
-  codec: iconGlyph('\uF373', ICON_FONT_KEYS.UICONS),
+  codec: iconGlyph('\uE4CD', ICON_FONT_KEYS.UICONS),
   timecode: iconGlyph('\uF10E', ICON_FONT_KEYS.FILM),
   audioIn: iconGlyph('\uF1C3', ICON_FONT_KEYS.ESSENTIAL),
   audioOut: iconGlyph('\uF22F', ICON_FONT_KEYS.ESSENTIAL),


### PR DESCRIPTION
## Summary
- switch the codec glyph to a coding-themed icon from the local UIcons set to better match the field purpose

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d0691f707483208140ae2407c4ec96