### PR TITLE
Redesign settings tabs layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -776,25 +776,6 @@
     <div class="modal-surface modal-surface-scrollable settings-content">
       <h2 id="settingsTitle">Settings</h2>
       <div class="settings-tabs-container">
-        <button
-          type="button"
-          class="settings-tabs-scroll"
-          id="settingsTabsScrollPrev"
-          aria-label="Scroll settings tabs left"
-          hidden
-        >
-          <span class="icon-glyph icon-svg" aria-hidden="true">
-            <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-              <path
-                d="M14.25 5.75 8.75 12l5.5 6.25"
-                stroke="currentColor"
-                stroke-width="1.5"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-              />
-            </svg>
-          </span>
-        </button>
         <div
           id="settingsTablist"
           class="settings-tabs"
@@ -828,10 +809,7 @@
               />
             </svg>
           </span>
-          <span class="settings-tab-text">
-            <span class="settings-tab-label">General</span>
-            <span class="settings-tab-caption">Language, theme and fonts.</span>
-          </span>
+          <span class="settings-tab-label">General</span>
         </button>
         <button
           type="button"
@@ -856,10 +834,7 @@
               />
             </svg>
           </span>
-          <span class="settings-tab-text">
-            <span class="settings-tab-label">Automatic Gear</span>
-            <span class="settings-tab-caption">Automate recommended gear selections.</span>
-          </span>
+          <span class="settings-tab-label">Automatic Gear</span>
         </button>
         <button
           type="button"
@@ -882,10 +857,7 @@
               />
             </svg>
           </span>
-          <span class="settings-tab-text">
-            <span class="settings-tab-label">Accessibility</span>
-            <span class="settings-tab-caption">Contrast, motion and readability options.</span>
-          </span>
+          <span class="settings-tab-label">Accessibility</span>
         </button>
         <button
           type="button"
@@ -916,10 +888,7 @@
               />
             </svg>
           </span>
-          <span class="settings-tab-text">
-            <span class="settings-tab-label">Backup &amp; Restore</span>
-            <span class="settings-tab-caption">Safeguard projects, devices and settings.</span>
-          </span>
+          <span class="settings-tab-label">Backup &amp; Restore</span>
         </button>
         <button
           type="button"
@@ -956,10 +925,7 @@
               />
             </svg>
           </span>
-          <span class="settings-tab-text">
-            <span class="settings-tab-label">Data &amp; Storage</span>
-            <span class="settings-tab-caption">Manage local storage and cache data.</span>
-          </span>
+          <span class="settings-tab-label">Data &amp; Storage</span>
         </button>
         <button
           type="button"
@@ -988,31 +954,9 @@
               />
             </svg>
           </span>
-          <span class="settings-tab-text">
-            <span class="settings-tab-label">About &amp; Support</span>
-            <span class="settings-tab-caption">Guides, troubleshooting and contact info.</span>
-          </span>
+          <span class="settings-tab-label">About &amp; Support</span>
         </button>
         </div>
-        <button
-          type="button"
-          class="settings-tabs-scroll"
-          id="settingsTabsScrollNext"
-          aria-label="Scroll settings tabs right"
-          hidden
-        >
-          <span class="icon-glyph icon-svg" aria-hidden="true">
-            <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-              <path
-                d="M9.75 5.75 15.25 12l-5.5 6.25"
-                stroke="currentColor"
-                stroke-width="1.5"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-              />
-            </svg>
-          </span>
-        </button>
       </div>
       <section
         id="settingsPanel-general"

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -1233,118 +1233,22 @@ main.legal-content {
 }
 
 .settings-tabs-container {
-  display: grid;
-  grid-template-columns: auto 1fr auto;
-  align-items: center;
-  gap: 8px;
-  position: relative;
-  padding: 8px 8px 12px;
-  margin-bottom: 8px;
-  border: 1px solid color-mix(in srgb, var(--panel-border) 70%, transparent);
+  padding: 12px;
+  margin-bottom: 12px;
+  border: 1px solid color-mix(in srgb, var(--panel-border) 55%, transparent);
   border-radius: calc(var(--border-radius) * 0.9);
-  background: color-mix(in srgb, var(--surface-color) 82%, var(--panel-bg));
-  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--panel-border) 12%, transparent);
-}
-
-.settings-tabs-container::before,
-.settings-tabs-container::after {
-  content: '';
-  position: absolute;
-  top: 8px;
-  bottom: 16px;
-  width: 28px;
-  pointer-events: none;
-  opacity: 0;
-  transition: opacity 0.2s ease;
-  z-index: 1;
-}
-
-.settings-tabs-container::before {
-  left: 8px;
-  background: linear-gradient(to right, var(--surface-color) 5%, transparent 90%);
-}
-
-.settings-tabs-container::after {
-  right: 8px;
-  background: linear-gradient(to left, var(--surface-color) 5%, transparent 90%);
-}
-
-.settings-tabs-container.is-scrollable:not(.is-at-start)::before {
-  opacity: 1;
-}
-
-.settings-tabs-container.is-scrollable:not(.is-at-end)::after {
-  opacity: 1;
+  background: color-mix(in srgb, var(--surface-color) 75%, var(--panel-bg));
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--panel-border) 10%, transparent);
 }
 
 .settings-tabs {
-  display: flex;
-  flex-wrap: nowrap;
-  gap: 12px;
-  align-items: center;
-  padding: 6px 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(130px, 1fr));
+  gap: 10px;
+  padding: 0;
   margin: 0;
-  overflow-x: auto;
-  overflow-y: hidden;
-  overscroll-behavior-x: contain;
-  -webkit-overflow-scrolling: touch;
-  scroll-behavior: smooth;
-  scrollbar-width: thin;
-  scroll-snap-type: x proximity;
-}
-
-.settings-tabs-scroll {
-  appearance: none;
-  border: 1px solid color-mix(in srgb, var(--panel-border) 70%, transparent);
-  border-radius: 999px;
-  background: color-mix(in srgb, var(--surface-color) 75%, var(--panel-bg));
-  box-shadow: 0 2px 6px color-mix(in srgb, var(--shadow-color, rgba(0, 0, 0, 0.24)) 15%, transparent);
-  color: inherit;
-  width: 36px;
-  height: 36px;
-  min-width: 36px;
-  min-height: 36px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  cursor: pointer;
-  transition: background-color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease, color 0.2s ease;
-  z-index: 2;
-}
-
-.settings-tabs-scroll[hidden] {
-  display: none;
-}
-
-.settings-tabs-scroll:hover,
-.settings-tabs-scroll:focus-visible {
-  border-color: var(--accent-color);
-  color: var(--accent-color);
-  background: color-mix(in srgb, var(--accent-color) 20%, var(--panel-bg));
-  box-shadow: 0 4px 12px color-mix(in srgb, var(--accent-color) 20%, transparent);
-}
-
-.settings-tabs-scroll:focus-visible {
-  outline: none;
-  box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent-color) 25%, transparent);
-}
-
-.settings-tabs-scroll:disabled,
-.settings-tabs-scroll[disabled] {
-  opacity: 0.45;
-  cursor: default;
-  box-shadow: none;
-  color: color-mix(in srgb, var(--muted-text-color) 80%, currentColor);
-}
-
-.settings-tabs-scroll:disabled:hover,
-.settings-tabs-scroll:disabled:focus-visible,
-.settings-tabs-scroll[disabled]:hover,
-.settings-tabs-scroll[disabled]:focus-visible {
-  border-color: color-mix(in srgb, var(--panel-border) 70%, transparent);
-  background: color-mix(in srgb, var(--surface-color) 75%, var(--panel-bg));
-  box-shadow: none;
-  outline: none;
+  list-style: none;
+  align-items: stretch;
 }
 
 body.high-contrast .settings-tabs-container {
@@ -1353,136 +1257,100 @@ body.high-contrast .settings-tabs-container {
   border: 1px solid var(--panel-border);
 }
 
-body.high-contrast .settings-tabs-container::before,
-body.high-contrast .settings-tabs-container::after {
-  display: none;
-}
-
 .settings-tab {
   appearance: none;
-  border: 1px solid color-mix(in srgb, var(--panel-border) 65%, transparent);
-  border-radius: calc(var(--border-radius) * 1.1);
-  background: linear-gradient(
-    135deg,
-    color-mix(in srgb, var(--panel-bg) 88%, var(--accent-color) 12%),
-    color-mix(in srgb, var(--panel-bg) 94%, transparent)
-  );
+  border: 1px solid color-mix(in srgb, var(--panel-border) 55%, transparent);
+  border-radius: calc(var(--border-radius) * 0.9);
+  background: color-mix(in srgb, var(--panel-bg) 92%, transparent);
   color: inherit;
   font: inherit;
-  font-weight: 600;
-  padding: 14px 16px;
+  font-weight: 500;
+  letter-spacing: 0.01em;
+  padding: 10px 12px;
   cursor: pointer;
   transition: background-color 0.25s ease, border-color 0.25s ease, color 0.25s ease,
     box-shadow 0.25s ease, transform 0.25s ease;
   white-space: normal;
-  text-align: left;
-  flex: 0 0 clamp(200px, 30vw, 260px);
-  scroll-snap-align: center;
+  text-align: center;
   display: flex;
-  align-items: flex-start;
-  gap: 14px;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
   position: relative;
   isolation: isolate;
+  min-height: 92px;
 }
 
 .settings-tab:hover,
 .settings-tab:focus-visible {
-  border-color: color-mix(in srgb, var(--accent-color) 65%, transparent);
-  box-shadow: 0 8px 24px color-mix(in srgb, var(--accent-color) 18%, transparent);
+  border-color: color-mix(in srgb, var(--accent-color) 55%, transparent);
+  background: color-mix(in srgb, var(--accent-color) 12%, var(--panel-bg));
+  box-shadow: 0 6px 18px color-mix(in srgb, var(--accent-color) 15%, transparent);
 }
 
 .settings-tab[aria-selected="true"] {
-  background: linear-gradient(
-    135deg,
-    color-mix(in srgb, var(--accent-color) 26%, var(--panel-bg)),
-    color-mix(in srgb, var(--panel-bg) 90%, transparent)
-  );
-  border-color: color-mix(in srgb, var(--accent-color) 70%, transparent);
-  box-shadow: 0 10px 28px color-mix(in srgb, var(--accent-color) 24%, transparent);
+  background: color-mix(in srgb, var(--accent-color) 18%, var(--panel-bg));
+  border-color: color-mix(in srgb, var(--accent-color) 65%, transparent);
+  box-shadow: 0 10px 24px color-mix(in srgb, var(--accent-color) 22%, transparent);
 }
 
 .settings-tab.active {
-  box-shadow: 0 10px 28px color-mix(in srgb, var(--accent-color) 24%, transparent);
+  box-shadow: 0 10px 24px color-mix(in srgb, var(--accent-color) 22%, transparent);
 }
 
 .settings-tab:focus-visible {
   outline: none;
-  box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent-color) 30%, transparent),
-    0 10px 28px color-mix(in srgb, var(--accent-color) 24%, transparent);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent-color) 28%, transparent),
+    0 8px 20px color-mix(in srgb, var(--accent-color) 18%, transparent);
 }
 
 .settings-tab-icon {
-  --icon-size: 26px;
-  inline-size: 44px;
-  block-size: 44px;
-  min-inline-size: 44px;
-  min-block-size: 44px;
+  --icon-size: 22px;
+  inline-size: 36px;
+  block-size: 36px;
+  min-inline-size: 36px;
+  min-block-size: 36px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  border-radius: 14px;
-  background: color-mix(in srgb, var(--accent-color) 10%, transparent);
-  color: color-mix(in srgb, var(--accent-color) 65%, currentColor);
-  flex: 0 0 44px;
-  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--accent-color) 12%, transparent);
-  transition: transform 0.25s ease, background-color 0.25s ease, color 0.25s ease,
-    box-shadow 0.25s ease;
+  border-radius: 12px;
+  background: color-mix(in srgb, var(--accent-color) 14%, transparent);
+  color: color-mix(in srgb, var(--accent-color) 60%, currentColor);
+  flex: 0 0 36px;
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--accent-color) 10%, transparent);
+  transition: transform 0.2s ease, background-color 0.2s ease, color 0.2s ease,
+    box-shadow 0.2s ease;
 }
 
 .settings-tab:hover .settings-tab-icon,
 .settings-tab:focus-visible .settings-tab-icon {
-  background: color-mix(in srgb, var(--accent-color) 20%, transparent);
+  background: color-mix(in srgb, var(--accent-color) 26%, transparent);
   color: var(--accent-color);
   transform: translateY(-1px);
-  box-shadow: 0 6px 18px color-mix(in srgb, var(--accent-color) 20%, transparent);
+  box-shadow: 0 6px 18px color-mix(in srgb, var(--accent-color) 22%, transparent);
 }
 
 .settings-tab[aria-selected="true"] .settings-tab-icon,
 .settings-tab.active .settings-tab-icon {
-  background: color-mix(in srgb, var(--accent-color) 28%, transparent);
+  background: color-mix(in srgb, var(--accent-color) 32%, transparent);
   color: var(--accent-color);
-  box-shadow: 0 10px 24px color-mix(in srgb, var(--accent-color) 26%, transparent);
+  box-shadow: 0 10px 24px color-mix(in srgb, var(--accent-color) 24%, transparent);
   transform: translateY(-1px) scale(1.02);
 }
 
-.settings-tab-text {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-  align-items: flex-start;
-  min-width: 0;
-}
-
 .settings-tab-label {
-  font-size: 1rem;
-  font-weight: 600;
+  font-size: 0.92rem;
+  font-weight: 500;
   line-height: 1.25;
+  letter-spacing: 0.01em;
   color: currentColor;
 }
 
 .settings-tab[aria-selected="true"] .settings-tab-label,
 .settings-tab:hover .settings-tab-label,
 .settings-tab:focus-visible .settings-tab-label {
-  color: color-mix(in srgb, var(--accent-color) 75%, currentColor);
-}
-
-.settings-tab-caption {
-  font-size: 0.8rem;
-  line-height: 1.35;
-  color: color-mix(in srgb, var(--muted-text-color) 90%, currentColor);
-  max-width: 32ch;
-  display: -webkit-box;
-  -webkit-line-clamp: 2;
-  -webkit-box-orient: vertical;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  min-height: calc(1.35em * 2);
-}
-
-.settings-tab[aria-selected="true"] .settings-tab-caption,
-.settings-tab:hover .settings-tab-caption,
-.settings-tab:focus-visible .settings-tab-caption {
-  color: color-mix(in srgb, var(--accent-color) 55%, var(--muted-text-color));
+  color: color-mix(in srgb, var(--accent-color) 72%, currentColor);
 }
 
 body.high-contrast .settings-tab {
@@ -1506,13 +1374,13 @@ body.high-contrast .settings-tab-icon {
   box-shadow: none;
 }
 
-body.high-contrast .settings-tab-caption {
-  color: currentColor;
-}
-
 @media (max-width: 600px) {
+  .settings-tabs {
+    grid-template-columns: repeat(auto-fit, minmax(110px, 1fr));
+  }
   .settings-tab {
-    flex: 0 0 clamp(220px, 80vw, 260px);
+    min-height: 88px;
+    padding: 9px 10px;
   }
 }
 


### PR DESCRIPTION
## Summary
- remove the horizontal scroll controls from the settings dialog and keep only compact icon tabs
- restyle the settings tab buttons to use smaller typography, tighter padding, and a responsive grid layout

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d06a33a3408320b5d058bf46a456fe