### PR TITLE
Adjust gear list heading weight in bright mode

### DIFF
--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -4615,6 +4615,11 @@ body.dark-mode.dark-accent-boost:not(.pink-mode) .settings-content.modal-surface
   border-bottom: 1px solid var(--accent-color);
 }
 
+body:not(.dark-mode) #gearListOutput h2,
+#gearListOutput:not(.dark-mode) h2 {
+  font-weight: var(--font-weight-medium);
+}
+
 .dark-mode #gearListOutput h1,
 .dark-mode #gearListOutput h2,
 .dark-mode #gearListOutput h3,


### PR DESCRIPTION
## Summary
- keep the Gear List heading border styling intact while moving the medium font weight to light/bright contexts only
- ensure the bright gear list heading matches the category row weight without affecting dark themed variants

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d069ad03908320be7c39f93d6addd2