### PR TITLE
Simplify settings tab layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -775,14 +775,13 @@
   <dialog id="settingsDialog" class="app-modal" role="dialog" aria-modal="true" aria-labelledby="settingsTitle" hidden>
     <div class="modal-surface modal-surface-scrollable settings-content">
       <h2 id="settingsTitle">Settings</h2>
-      <div class="settings-tabs-container">
-        <div
-          id="settingsTablist"
-          class="settings-tabs"
-          role="tablist"
-          aria-label="Settings sections"
-          aria-orientation="horizontal"
-        >
+      <div
+        id="settingsTablist"
+        class="settings-tabs"
+        role="tablist"
+        aria-label="Settings sections"
+        aria-orientation="horizontal"
+      >
         <button
           type="button"
           class="settings-tab"
@@ -956,7 +955,6 @@
           </span>
           <span class="settings-tab-label">About &amp; Support</span>
         </button>
-        </div>
       </div>
       <section
         id="settingsPanel-general"

--- a/src/scripts/script.js
+++ b/src/scripts/script.js
@@ -7725,7 +7725,7 @@ const settingsTabButtons = settingsTablist
   ? Array.from(settingsTablist.querySelectorAll('[role="tab"]'))
   : [];
 const settingsTabsContainer = settingsTablist
-  ? settingsTablist.closest('.settings-tabs-container')
+  ? settingsTablist.closest('.settings-tabs-container') || settingsTablist
   : null;
 const settingsTabsScrollPrev = document.getElementById('settingsTabsScrollPrev');
 const settingsTabsScrollNext = document.getElementById('settingsTabsScrollNext');

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -1232,15 +1232,6 @@ main.legal-content {
   gap: 20px;
 }
 
-.settings-tabs-container {
-  padding: 12px;
-  margin-bottom: 12px;
-  border: 1px solid color-mix(in srgb, var(--panel-border) 55%, transparent);
-  border-radius: calc(var(--border-radius) * 0.9);
-  background: color-mix(in srgb, var(--surface-color) 75%, var(--panel-bg));
-  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--panel-border) 10%, transparent);
-}
-
 .settings-tabs {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(130px, 1fr));
@@ -1249,12 +1240,6 @@ main.legal-content {
   margin: 0;
   list-style: none;
   align-items: stretch;
-}
-
-body.high-contrast .settings-tabs-container {
-  background: var(--surface-color);
-  box-shadow: none;
-  border: 1px solid var(--panel-border);
 }
 
 .settings-tab {


### PR DESCRIPTION
## Summary
- remove the extra settings tab wrapper so the header no longer looks like a separate section
- keep the settings tab overflow logic working by falling back to the tablist element when no wrapper exists

## Testing
- npm run lint
- npm run test:script *(fails: JavaScript heap out of memory after running for several minutes)*

------
https://chatgpt.com/codex/tasks/task_e_68d06d832f9c8320b4003f08f5f72176