### PR TITLE
Align gear list filter selectors with standard styling

### DIFF
--- a/src/scripts/script.js
+++ b/src/scripts/script.js
@@ -27095,9 +27095,12 @@ function renderGearListFilterDetails(details) {
       const sizeText = document.createElement('span');
       sizeText.className = 'filter-detail-sublabel';
       sizeText.textContent = 'Size';
+      const sizeWrapper = document.createElement('span');
+      sizeWrapper.className = 'select-wrapper';
       const sizeSelect = createFilterSizeSelect(type, size, { includeId: false });
       sizeSelect.setAttribute('data-storage-id', `filter-size-${filterId(type)}`);
-      sizeLabel.append(sizeText, sizeSelect);
+      sizeWrapper.appendChild(sizeSelect);
+      sizeLabel.append(sizeText, sizeWrapper);
       controls.appendChild(sizeLabel);
     }
     if (needsValues) {
@@ -27130,6 +27133,7 @@ function renderGearListFilterDetails(details) {
     row.appendChild(controls);
     container.appendChild(row);
   });
+  adjustGearListSelectWidths(container);
 }
 
 function syncGearListFilterSize(storageId, value) {

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -4687,36 +4687,25 @@ body.dark-mode.pink-mode #gearListOutput h2,
   align-items: center;
   gap: 0.375rem;
   font-weight: var(--font-weight-regular);
-  padding: 0.125rem 0.375rem;
-  border-radius: var(--border-radius);
-  background-color: transparent;
-  border: 1px solid transparent;
-  transition: border-color 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
-}
-
-#gearListFilterDetails .filter-detail-size select {
-  border: none;
-  background: transparent;
-  color: inherit;
   padding: 0;
-  margin: 0;
+  border: none;
+  background: none;
+}
+
+#gearListFilterDetails .filter-detail-size .select-wrapper {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+#gearListFilterDetails .filter-detail-size .select-wrapper select {
   min-width: 3.5rem;
-  font: inherit;
+  margin: 0;
 }
 
-#gearListFilterDetails .filter-detail-size select:focus-visible {
-  outline: none;
-}
-
-#gearListFilterDetails .filter-detail-size:hover {
-  border-color: var(--accent-color);
-  background-color: var(--panel-bg);
-}
-
-#gearListFilterDetails .filter-detail-size:focus-within {
-  border-color: var(--accent-color);
-  box-shadow: 0 0 0 1px var(--accent-color);
-  background-color: var(--panel-bg);
+#gearListFilterDetails .filter-detail-size .select-wrapper select:focus-visible {
+  outline: 2px solid var(--accent-color);
+  outline-offset: 2px;
 }
 
 #gearListFilterDetails .filter-detail-values {


### PR DESCRIPTION
## Summary
- wrap gear list filter size controls with the existing select-wrapper markup so they inherit standard selector styling
- refresh the filter selector width calculation after rendering to keep sizing consistent
- simplify filter detail size styles to piggyback on the shared select-wrapper rules while preserving focus outlines

## Testing
- npm run lint
- npm run check-consistency
- node --max-old-space-size=4096 ./node_modules/jest/bin/jest.js --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68d06bd2a85c8320959e5acef724b694