### PR TITLE
Adjust diagram font sizing for better readability

### DIFF
--- a/src/scripts/script.js
+++ b/src/scripts/script.js
@@ -13751,7 +13751,7 @@ const diagramCssLight = `
 .conn.blue{fill:#369;}
 .conn.green{fill:#090;}
 text{font-family:system-ui,sans-serif;}
-.edge-label{font-size:var(--font-size-diagram-label, 10px);}
+.edge-label{font-size:var(--font-size-diagram-label, 11px);}
 line{stroke:#333;stroke-width:2px;}
 path.edge-path{stroke:#333;stroke-width:2px;fill:none;}
 path.power{stroke:#d33;}
@@ -13766,6 +13766,7 @@ const diagramCssDark = `
 .node-icon{font-size:var(--font-size-diagram-icon, 20px);font-family:'UiconsThinStraightV2',system-ui,sans-serif;font-style:normal;}
 .node-icon[data-icon-font='essential']{font-family:'EssentialIconsV2',system-ui,sans-serif;}
 text{fill:#fff;font-family:system-ui,sans-serif;}
+.edge-label{font-size:var(--font-size-diagram-label, 11px);}
 line{stroke:#fff;}
 path.edge-path{stroke:#fff;}
 path.power{stroke:#ff6666;}
@@ -16909,9 +16910,9 @@ function renderSetupDiagram() {
   const DEFAULT_NODE_W = 120;
   const nodeHeights = {};
   const nodeWidths = {};
-  const diagramLabelFontSize = 'var(--font-size-diagram-label, 10px)';
-  const diagramTextFontSize = 'var(--font-size-diagram-text, 12px)';
-  const DIAGRAM_LABEL_LINE_HEIGHT = 12;
+  const diagramLabelFontSize = 'var(--font-size-diagram-label, 11px)';
+  const diagramTextFontSize = 'var(--font-size-diagram-text, 13px)';
+  const DIAGRAM_LABEL_LINE_HEIGHT = 13;
   const DIAGRAM_ICON_TEXT_GAP = 8;
   const DEFAULT_DIAGRAM_ICON_SIZE = 24;
 
@@ -16922,7 +16923,7 @@ function renderSetupDiagram() {
     const hasIcon = diagramIcons[id] || id.startsWith('controller') || id.startsWith('motor');
     nodeHeights[id] = Math.max(
       DEFAULT_NODE_H,
-      lines.length * 12 + (hasIcon ? 30 : 20)
+      lines.length * DIAGRAM_LABEL_LINE_HEIGHT + (hasIcon ? 30 : 20)
     );
     const longest = lines.reduce((m, l) => Math.max(m, l.length), 0);
     nodeWidths[id] = Math.max(DEFAULT_NODE_W, longest * 9 + 20);
@@ -17384,8 +17385,22 @@ function renderSetupDiagram() {
     svgEl.style.width = '100%';
     if (!isTouchDevice) {
       const bodyFontSize = parseFloat(getComputedStyle(document.body).fontSize) || 16;
-      const MAX_NODE_FONT = 12; // largest base font size used in diagram text
-      const maxAutoScale = bodyFontSize / MAX_NODE_FONT;
+      let diagramFontSizePx = Number.NaN;
+      if (document.body) {
+        const measureEl = document.createElement('span');
+        measureEl.style.position = 'absolute';
+        measureEl.style.visibility = 'hidden';
+        measureEl.style.fontSize = 'var(--font-size-diagram-text)';
+        measureEl.textContent = 'M';
+        document.body.appendChild(measureEl);
+        diagramFontSizePx = parseFloat(getComputedStyle(measureEl).fontSize);
+        measureEl.remove();
+      }
+      const DEFAULT_MAX_NODE_FONT = 13; // fallback when diagram font size cannot be measured
+      const referenceFontSize = Number.isFinite(diagramFontSizePx) && diagramFontSizePx > 0
+        ? diagramFontSizePx
+        : DEFAULT_MAX_NODE_FONT;
+      const maxAutoScale = bodyFontSize / referenceFontSize;
       svgEl.style.maxWidth = `${viewWidth * maxAutoScale}px`;
     }
   }

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -51,6 +51,8 @@
   --font-scale-display: 1.8;
   --font-scale-icon-lg: 1.25;
   --font-scale-icon-sm: 0.625;
+  --font-scale-diagram-label: 0.7;
+  --font-scale-diagram-text: 0.8;
   --icon-size-xs: calc(var(--font-size-relative-base) * var(--font-scale-xs));
   --icon-size-sm: calc(var(--font-size-relative-base) * var(--font-scale-sm));
   --icon-size-md: calc(var(--font-size-relative-base) * var(--font-scale-lg));
@@ -62,8 +64,8 @@
   --font-weight-semibold: 600;
   --font-weight-bold: 700;
   --font-size-diagram-icon: calc(var(--font-size-base) * var(--font-scale-icon-lg));
-  --font-size-diagram-label: calc(var(--font-size-base) * var(--font-scale-icon-sm));
-  --font-size-diagram-text: calc(var(--font-size-base) * var(--font-scale-xxs));
+  --font-size-diagram-label: calc(var(--font-size-base) * var(--font-scale-diagram-label));
+  --font-size-diagram-text: calc(var(--font-size-base) * var(--font-scale-diagram-text));
   --diagram-node-fill: #f0f0f0;
   --power-color: #d33;
   --video-color: #369;
@@ -3154,7 +3156,7 @@ body.pink-mode #topBar #logo .logo-center {
   background: var(--surface-color);
   color: var(--text-color);
   border: 1px solid var(--panel-border);
-  font-size: var(--font-size-diagram-text);
+  font-size: var(--font-size-relative-base);
   line-height: var(--line-height-supporting);
   padding: clamp(0.5rem, 1vw, 0.75rem);
   border-radius: var(--border-radius);


### PR DESCRIPTION
## Summary
- increase the setup diagram typography variables so node labels, legends, and hints render slightly larger
- make diagram hover popups use the global app font size and update export fallbacks and layout math to match the new sizing

## Testing
- npm run lint
- npm run check-consistency
- npm run test:unit
- npm test *(fails: JavaScript heap out of memory in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d06efbade4832094032e4753c05770