### PR TITLE
Restore visible cage selector

### DIFF
--- a/index.html
+++ b/index.html
@@ -308,13 +308,17 @@
       </div>
       <div class="form-row">
         <label for="videoSelect" id="videoLabel">Wireless Transmitter:</label>
-      <div class="select-wrapper">
+        <div class="select-wrapper">
           <select id="videoSelect" aria-labelledby="videoLabel"></select>
         </div>
       </div>
 
-      <!-- Hidden cage select maintained for gear list synchronization -->
-      <select id="cageSelect" hidden></select>
+      <div class="form-row">
+        <label for="cageSelect" id="cageLabel">Camera Cage:</label>
+        <div class="select-wrapper">
+          <select id="cageSelect" aria-labelledby="cageLabel"></select>
+        </div>
+      </div>
 
     <fieldset>
       <legend id="fizLegend">FIZ (Follow Focus) Systems</legend>

--- a/src/scripts/script.js
+++ b/src/scripts/script.js
@@ -16124,7 +16124,7 @@ updateBatteryPlateVisibility();
 updateBatteryOptions();
 
 // Enable search inside dropdowns
-[cameraSelect, monitorSelect, videoSelect, distanceSelect, batterySelect, hotswapSelect, lensSelect]
+[cameraSelect, monitorSelect, videoSelect, cageSelect, distanceSelect, batterySelect, hotswapSelect, lensSelect]
   .forEach(sel => attachSelectSearch(sel));
 motorSelects.forEach(sel => attachSelectSearch(sel));
 controllerSelects.forEach(sel => attachSelectSearch(sel));


### PR DESCRIPTION
## Summary
- restore the dedicated camera cage dropdown in the setup form so users can actively choose cages again
- hook the cage select into the in-select search helper so it matches the usability of the other dropdowns

## Testing
- `npm run lint`
- `npm run check-consistency`
- `npm run test:unit`

------
https://chatgpt.com/codex/tasks/task_e_68d072602d08832098176d7e1fe06bcb