### PR TITLE
Restore gear list filter control syncing

### DIFF
--- a/src/scripts/script.js
+++ b/src/scripts/script.js
@@ -27567,6 +27567,11 @@ function renderGearListFilterDetails(details) {
       sizeWrapper.className = 'select-wrapper';
       const sizeSelect = createFilterSizeSelect(type, size, { includeId: false });
       sizeSelect.setAttribute('data-storage-id', `filter-size-${filterId(type)}`);
+      sizeSelect.addEventListener('change', () => {
+        const storageId = sizeSelect.getAttribute('data-storage-id');
+        if (!storageId) return;
+        syncGearListFilterSize(storageId, sizeSelect.value);
+      });
       sizeWrapper.appendChild(sizeSelect);
       sizeLabel.append(sizeText, sizeWrapper);
       controls.appendChild(sizeLabel);
@@ -27580,6 +27585,7 @@ function renderGearListFilterDetails(details) {
       const optionsWrap = document.createElement('span');
       optionsWrap.className = 'filter-values-container';
       optionsWrap.setAttribute('data-storage-values', `filter-values-${filterId(type)}`);
+      const storageValuesId = optionsWrap.getAttribute('data-storage-values');
       const { opts, defaults = [] } = getFilterValueConfig(type);
       const currentValues = values == null ? defaults : (Array.isArray(values) ? values : []);
       opts.forEach(value => {
@@ -27592,6 +27598,10 @@ function renderGearListFilterDetails(details) {
           cb.checked = true;
           cb.setAttribute('checked', '');
         }
+        cb.addEventListener('change', () => {
+          if (!storageValuesId) return;
+          syncGearListFilterValue(storageValuesId, value, cb.checked);
+        });
         lbl.append(cb, document.createTextNode(value));
         optionsWrap.appendChild(lbl);
       });


### PR DESCRIPTION
## Summary
- add change listeners to gear list filter size and strength controls so they sync with stored selections
- keep the gear list display responsive to checkbox and dropdown changes

## Testing
- npm run test:script *(fails: JavaScript heap out of memory in the test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d0729643b883208e53b7b699bc1b0c