### PR TITLE
Improve legacy gear list heading extraction and adjust category styling

### DIFF
--- a/src/scripts/script.js
+++ b/src/scripts/script.js
@@ -13070,6 +13070,82 @@ function ensureGearTableCategoryGrouping(table) {
   });
 }
 
+let overviewTitleCandidatesCache = null;
+
+function getOverviewTitleCandidates() {
+  if (overviewTitleCandidatesCache && overviewTitleCandidatesCache.length) {
+    return overviewTitleCandidatesCache;
+  }
+  const variants = new Set();
+  if (typeof texts === 'object' && texts !== null) {
+    Object.values(texts).forEach(lang => {
+      const label = lang && typeof lang.overviewTitle === 'string'
+        ? lang.overviewTitle.trim()
+        : '';
+      if (label) variants.add(label);
+    });
+  }
+  variants.add('Project Overview and Gear List');
+  variants.add('Project Overview');
+  overviewTitleCandidatesCache = Array.from(variants)
+    .filter(Boolean)
+    .sort((a, b) => b.length - a.length);
+  return overviewTitleCandidatesCache;
+}
+
+function extractProjectNameFromHeading(titleElement) {
+  if (!titleElement) return '';
+  if (typeof titleElement.getAttribute === 'function') {
+    const attrName = titleElement.getAttribute('data-project-name');
+    if (typeof attrName === 'string') {
+      const trimmed = attrName.trim();
+      if (trimmed) return trimmed;
+    }
+  }
+  const textValue = typeof titleElement.textContent === 'string'
+    ? titleElement.textContent.replace(/\s+/g, ' ').trim()
+    : '';
+  if (!textValue) return '';
+
+  const quoteMatch = textValue.match(/[“"']([^“”"']+)[”"']/);
+  if (quoteMatch && quoteMatch[1] && quoteMatch[1].trim()) {
+    return quoteMatch[1].trim();
+  }
+  const guillemetMatch = textValue.match(/[«‹]([^»›]+)[»›]/);
+  if (guillemetMatch && guillemetMatch[1] && guillemetMatch[1].trim()) {
+    return guillemetMatch[1].trim();
+  }
+
+  const overviewCandidates = getOverviewTitleCandidates();
+  const lowerText = textValue.toLowerCase();
+  for (const label of overviewCandidates) {
+    const normalizedLabel = label.trim();
+    if (!normalizedLabel) continue;
+    const lowerLabel = normalizedLabel.toLowerCase();
+    if (lowerText.startsWith(lowerLabel)) {
+      let remainder = textValue.slice(normalizedLabel.length).trim();
+      if (!remainder) return '';
+      remainder = remainder.replace(/^(?:for|pour|für|per|para)\b\s*/i, '').trim();
+      remainder = remainder.replace(/^(?:the|le|la|les|den|die|das|el|los|las)\b\s*/i, '').trim();
+      remainder = remainder.replace(/^[–—:\-]+/, '').trim();
+      remainder = remainder.replace(/^["'“”«»‹›]+/, '').replace(/["'“”«»‹›]+$/, '').trim();
+      if (remainder) return remainder;
+      return '';
+    }
+  }
+
+  if (overviewCandidates.some(label => lowerText === label.toLowerCase())) {
+    return '';
+  }
+
+  const stripped = textValue.replace(/^["'“”«»‹›]+/, '').replace(/["'“”«»‹›]+$/, '').trim();
+  if (stripped && stripped !== textValue) {
+    return stripped;
+  }
+
+  return textValue;
+}
+
 function splitGearListHtml(html) {
   if (!html) return { projectHtml: '', gearHtml: '' };
   // Support legacy storage formats where the gear list and project
@@ -13090,7 +13166,7 @@ function splitGearListHtml(html) {
   const reqGrid = doc.querySelector('.requirements-grid');
   const titleHtml = title ? title.outerHTML : '';
   const projectHtml = reqHeading && reqGrid ? titleHtml + reqHeading.outerHTML + reqGrid.outerHTML : '';
-  const projectName = title ? title.textContent : '';
+  const projectName = extractProjectNameFromHeading(title);
   let table = doc.querySelector('.gear-table');
   if (!table) {
     const tables = Array.from(doc.querySelectorAll('table'));
@@ -13104,7 +13180,7 @@ function splitGearListHtml(html) {
       table = tableAfterGearHeading || tables[0];
     }
   }
-  const gearHeadingHtml = projectName ? `<h2>Gear List: “${projectName}”</h2>` : '';
+  const gearHeadingHtml = projectName ? `<h2>Gear List: “${escapeHtml(projectName)}”</h2>` : '';
   let gearHtml = '';
   if (table) {
     ensureGearTableCategoryGrouping(table);

--- a/src/styles/overview-print.css
+++ b/src/styles/overview-print.css
@@ -358,10 +358,18 @@ body:not(.light-mode) .gear-table .auto-gear-item {
 body:not(.light-mode) .gear-table .category-row td {
   border-top: 1px solid var(--accent-color);
   border-bottom: 1px solid var(--accent-color);
-  font-weight: var(--font-weight-medium);
   color: var(--accent-color);
   break-after: avoid;
   page-break-after: avoid;
+}
+
+#overviewDialogContent .gear-table .category-row td {
+  font-weight: var(--font-weight-regular);
+}
+
+#overviewDialogContent.dark-mode .gear-table .category-row td,
+body:not(.light-mode) .gear-table .category-row td {
+  font-weight: var(--font-weight-medium);
 }
 
 

--- a/src/styles/overview.css
+++ b/src/styles/overview.css
@@ -87,10 +87,14 @@ th { background-color: var(--control-bg); font-weight: var(--font-weight-bold); 
 .gear-table .category-row td {
   border-top: 1px solid var(--accent-color);
   border-bottom: 1px solid var(--accent-color);
-  font-weight: var(--font-weight-bold);
+  font-weight: var(--font-weight-regular);
   color: var(--accent-color);
   break-after: avoid;
   page-break-after: avoid;
+}
+
+.dark-mode .gear-table .category-row td {
+  font-weight: var(--font-weight-medium);
 }
 .print-btn,
 .back-btn {

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -3812,6 +3812,7 @@ body.dark-mode.dark-accent-boost:not(.pink-mode) .settings-content.modal-surface
     border-top: 1px solid var(--inverse-text-color);
     border-bottom: 1px solid var(--inverse-text-color);
     color: var(--inverse-text-color);
+    font-weight: var(--font-weight-medium);
   }
   body:not(.light-mode).pink-mode .gear-table td,
   body:not(.light-mode).dark-accent-boost:not(.pink-mode) .gear-table td {
@@ -3823,6 +3824,7 @@ body.dark-mode.dark-accent-boost:not(.pink-mode) .settings-content.modal-surface
     border-top: 1px solid var(--accent-color);
     border-bottom: 1px solid var(--accent-color);
     color: var(--accent-color);
+    font-weight: var(--font-weight-medium);
   }
   body:not(.light-mode).pink-mode .help-content,
   body:not(.light-mode).pink-mode .settings-content.modal-surface,
@@ -4409,7 +4411,7 @@ body:not(.dark-mode) .requirement-box,
 .gear-table .category-row td {
   border-top: 1px solid var(--accent-color);
   border-bottom: 1px solid var(--accent-color);
-  font-weight: var(--font-weight-medium);
+  font-weight: var(--font-weight-regular);
   color: var(--accent-color);
   break-after: avoid;
   page-break-after: avoid;
@@ -4424,6 +4426,7 @@ body:not(.dark-mode) .requirement-box,
   border-top: 1px solid var(--inverse-text-color);
   border-bottom: 1px solid var(--inverse-text-color);
   color: var(--inverse-text-color);
+  font-weight: var(--font-weight-medium);
 }
 
 .dark-mode.pink-mode .gear-table td,
@@ -4437,6 +4440,7 @@ body:not(.dark-mode) .requirement-box,
   border-top: 1px solid var(--accent-color);
   border-bottom: 1px solid var(--accent-color);
   color: var(--accent-color);
+  font-weight: var(--font-weight-medium);
 }
 
 #overviewDialogContent .gear-table td {

--- a/tests/script/splitGearListHtml.test.js
+++ b/tests/script/splitGearListHtml.test.js
@@ -40,4 +40,19 @@ describe('splitGearListHtml legacy compatibility', () => {
       cleanup();
     }
   });
+
+  test('derives project name from overview heading with embedded quotes', () => {
+    const { cleanup } = setupScriptEnvironment({ readyState: 'loading' });
+    try {
+      const legacyHtml = `
+        <h2>Project Overview for “Mini LF New old”</h2>
+        <h3>Gear List</h3>
+        <table class="gear-table"><tr><td>Legacy Item</td></tr></table>
+      `;
+      const { gearHtml } = global.splitGearListHtml(legacyHtml);
+      expect(gearHtml).toContain('Gear List: “Mini LF New old”');
+    } finally {
+      cleanup();
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- normalize project names from saved gear list headings, leveraging translation data when stripping legacy "Project Overview" prefixes and encoding the final heading safely
- align bright-mode gear list category rows with section header weight while preserving stronger emphasis in dark themes across app, overview, and print styles
- cover legacy heading parsing with a focused Jest test

## Testing
- `npm run test:script` *(fails: JavaScript heap out of memory despite --max-old-space-size=3072)*
- `node --max-old-space-size=3072 ./node_modules/jest/bin/jest.js --runInBand --runTestsByPath tests/script/splitGearListHtml.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68d071cba4448320bb4cd1b39b4e7a14