### PR TITLE
Increase diagram icon size

### DIFF
--- a/src/scripts/script.js
+++ b/src/scripts/script.js
@@ -13823,7 +13823,7 @@ const diagramCssLight = `
 .node-box{fill:#f0f0f0;stroke:none;}
 .node-box.first-fiz{stroke:none;}
 .first-fiz-highlight{stroke:url(#firstFizGrad);stroke-width:1px;fill:none;}
-.node-icon{font-size:var(--font-size-diagram-icon, 20px);font-family:'UiconsThinStraightV2',system-ui,sans-serif;font-style:normal;}
+.node-icon{font-size:var(--font-size-diagram-icon, 24px);font-family:'UiconsThinStraightV2',system-ui,sans-serif;font-style:normal;}
 .node-icon[data-icon-font='essential']{font-family:'EssentialIconsV2',system-ui,sans-serif;}
 .conn{stroke:none;}
 .conn.red{fill:#d33;}
@@ -13842,7 +13842,7 @@ const diagramCssDark = `
 .node-box{fill:#444;stroke:none;}
 .node-box.first-fiz{stroke:none;}
 .first-fiz-highlight{stroke:url(#firstFizGrad);}
-.node-icon{font-size:var(--font-size-diagram-icon, 20px);font-family:'UiconsThinStraightV2',system-ui,sans-serif;font-style:normal;}
+.node-icon{font-size:var(--font-size-diagram-icon, 24px);font-family:'UiconsThinStraightV2',system-ui,sans-serif;font-style:normal;}
 .node-icon[data-icon-font='essential']{font-family:'EssentialIconsV2',system-ui,sans-serif;}
 text{fill:#fff;font-family:system-ui,sans-serif;}
 .edge-label{font-size:var(--font-size-diagram-label, 11px);}

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -49,7 +49,7 @@
   --font-scale-xxl: 1.4;
   --font-scale-xxxl: 1.5;
   --font-scale-display: 1.8;
-  --font-scale-icon-lg: 1.25;
+  --font-scale-icon-lg: 1.5;
   --font-scale-icon-sm: 0.625;
   --font-scale-diagram-label: 0.7;
   --font-scale-diagram-text: 0.8;


### PR DESCRIPTION
## Summary
- increase the diagram icon scale variable so nodes display larger glyphs in the layout
- update the exported diagram CSS fallback size so downloads and printing use the same larger icons

## Testing
- node --max-old-space-size=4096 ./node_modules/jest/bin/jest.js --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68d0719c3c2483208753fdb2d9768777