### PR TITLE
Add clamp-on matte box backings for unique lens diameters

### DIFF
--- a/src/scripts/script.js
+++ b/src/scripts/script.js
@@ -21666,7 +21666,10 @@ function generateGearListHtml(info = {}) {
             const diameters = [...new Set(lensNames
                 .map(n => devices.lenses && devices.lenses[n] && devices.lenses[n].frontDiameterMm)
                 .filter(Boolean))];
-            diameters.forEach(d => filterSelections.push(`ARRI LMB 4x5 Clamp Adapter ${d}mm`));
+            diameters.forEach(diameterMm => {
+                filterSelections.push(`ARRI LMB 4x5 Clamp Adapter ${diameterMm}mm`);
+                filterSelections.push(`Clamp-on backing ${diameterMm}mm`);
+            });
         }
     }
     viewfinderExtSelections.forEach(vf => supportAccNoCages.push(vf));

--- a/tests/script/matteboxClampBackings.test.js
+++ b/tests/script/matteboxClampBackings.test.js
@@ -1,0 +1,47 @@
+const { setupScriptEnvironment } = require('../helpers/scriptEnvironment');
+
+describe('clamp-on matte box gear list additions', () => {
+  let env;
+
+  afterEach(() => {
+    if (env && typeof env.cleanup === 'function') {
+      env.cleanup();
+    }
+    env = null;
+  });
+
+  const renderMatteboxItems = (info = {}, deviceOverrides = {}) => {
+    env = setupScriptEnvironment({ devices: deviceOverrides });
+    const { generateGearListHtml } = env.utils;
+    const html = generateGearListHtml(info);
+    const container = document.createElement('div');
+    container.innerHTML = html;
+    const group = Array.from(container.querySelectorAll('tbody.category-group')).find(section => {
+      const header = section.querySelector('.category-row td');
+      return header && header.textContent.trim() === 'Matte box + filter';
+    });
+    if (!group) return [];
+    return Array.from(group.querySelectorAll('.gear-item')).map(item => item.textContent.trim());
+  };
+
+  test('adds one clamp-on backing per unique lens front diameter', () => {
+    const lenses = {
+      'Lens A 25mm': { frontDiameterMm: 114 },
+      'Lens B 50mm': { frontDiameterMm: 95 },
+      'Lens C 85mm': { frontDiameterMm: 95 }
+    };
+    const info = {
+      mattebox: 'Clamp On',
+      lenses: Object.keys(lenses).join(', ')
+    };
+    const items = renderMatteboxItems(info, { lenses });
+    const backingEntries = items.filter(text => text.includes('Clamp-on backing'));
+
+    expect(backingEntries).toEqual(expect.arrayContaining([
+      '1x Clamp-on backing 114mm',
+      '1x Clamp-on backing 95mm'
+    ]));
+    expect(backingEntries.filter(text => text.includes('95mm'))).toHaveLength(1);
+  });
+});
+


### PR DESCRIPTION
## Summary
- add clamp-on backing entries alongside adapter rings when a clamp-on matte box is selected
- ensure each backing is only added once per unique lens front diameter in the gear list
- cover the new behavior with a script-level regression test for generateGearListHtml

## Testing
- npm run lint
- npx jest tests/script/matteboxClampBackings.test.js --runInBand


------
https://chatgpt.com/codex/tasks/task_e_68d072f2cabc8320895474ece050c4e9