### PR TITLE
Fix project requirements edit button and add regression test

### DIFF
--- a/src/scripts/script.js
+++ b/src/scripts/script.js
@@ -13256,12 +13256,25 @@ function ensureEditProjectButton() {
   if (!btn) {
     btn = document.createElement('button');
     btn.id = 'editProjectBtn';
+  }
+
+  const legacyButtonParent = btn.parentElement;
+  if (legacyButtonParent && legacyButtonParent !== container && legacyButtonParent.id !== 'editProjectBtn') {
+    legacyButtonParent.removeChild(btn);
+  }
+
+  if (!btn.dataset.editProjectBound) {
+    btn.type = 'button';
     btn.addEventListener('click', () => {
-      populateRecordingResolutionDropdown(currentProjectInfo && currentProjectInfo.recordingResolution);
-      populateSensorModeDropdown(currentProjectInfo && currentProjectInfo.sensorMode);
-      populateCodecDropdown(currentProjectInfo && currentProjectInfo.codec);
+      const infoForDialog = currentProjectInfo
+        ? { ...currentProjectInfo }
+        : (projectForm ? collectProjectFormData() : {});
+      if (projectForm) {
+        populateProjectForm(infoForDialog || {});
+      }
       openDialog(projectDialog);
     });
+    btn.dataset.editProjectBound = 'true';
   }
   const title = container.querySelector('h2');
   if (title && btn.parentElement !== container) {
@@ -13269,6 +13282,7 @@ function ensureEditProjectButton() {
   } else if (!title && btn.parentElement !== container) {
     container.prepend(btn);
   }
+  btn.type = 'button';
   setEditProjectBtnText();
 }
 

--- a/tests/dom/editProjectButton.test.js
+++ b/tests/dom/editProjectButton.test.js
@@ -1,0 +1,54 @@
+const { setupScriptEnvironment } = require('../helpers/scriptEnvironment');
+
+const legacyProjectHtml = `
+  <h2>Project Legacy</h2>
+  <h3>Project Requirements</h3>
+  <div class="requirements-grid">
+    <button id="editProjectBtn" type="button">Legacy Edit</button>
+    <div class="requirement-box" data-field="productionCompany">
+      <span class="req-label">Production Company</span>
+      <span class="req-value">Acme</span>
+    </div>
+  </div>
+  <h3>Gear List</h3>
+  <table class="gear-table"><tr><td>Saved Item</td></tr></table>
+`;
+
+describe('edit project requirements button', () => {
+  let env;
+
+  beforeEach(() => {
+    env = setupScriptEnvironment();
+  });
+
+  afterEach(() => {
+    env?.cleanup();
+  });
+
+  test('re-binds legacy edit button and loads saved project requirements', () => {
+    env.utils.displayGearAndRequirements(legacyProjectHtml);
+
+    const container = document.getElementById('projectRequirementsOutput');
+    const button = document.getElementById('editProjectBtn');
+    expect(button).not.toBeNull();
+    expect(button.parentElement).toBe(container);
+    expect(button.type).toBe('button');
+    expect(button.dataset.editProjectBound).toBe('true');
+
+    env.utils.setCurrentProjectInfo({ productionCompany: 'Acme Studios' });
+
+    const productionInput = document.querySelector('[name="productionCompany"]');
+    expect(productionInput).not.toBeNull();
+    productionInput.value = 'Different Company';
+
+    button.click();
+
+    const formData = env.utils.collectProjectFormData();
+    expect(formData.productionCompany).toBe('Acme Studios');
+
+    const dialog = document.getElementById('projectDialog');
+    expect(dialog).not.toBeNull();
+    expect(dialog.hasAttribute('open') || dialog.open === true).toBe(true);
+  });
+});
+


### PR DESCRIPTION
## Summary
- ensure the Edit Project Requirements button is always bound even when restored from saved markup and prefill the dialog with the latest project info before opening
- normalise the button placement/type to avoid legacy markup leaving it buried in requirement grids
- add a DOM regression test covering the legacy button scenario and verifying the dialog is populated

## Testing
- npm run test:dom

------
https://chatgpt.com/codex/tasks/task_e_68d0750316e48320a1378c9cd912ea88