### PR TITLE
chore: bump version to 1.0.5

### DIFF
--- a/index.html
+++ b/index.html
@@ -1300,7 +1300,7 @@
       >
         <section class="settings-section" aria-labelledby="aboutHeading">
         <h3 id="aboutHeading">About &amp; Support</h3>
-        <p id="aboutVersion">Version 1.0.4</p>
+        <p id="aboutVersion">Version 1.0.5</p>
         <p><a href="https://github.com" id="supportLink" target="_blank">Support</a></p>
         </section>
       </section>

--- a/legacy/scripts/script.js
+++ b/legacy/scripts/script.js
@@ -1,4 +1,4 @@
-var APP_VERSION = "1.0.4";
+var APP_VERSION = "1.0.5";
 var manualQueryParamWarningShown = false;
 function getQueryParam(search, key) {
   if (!key) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cine-power-planner",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cine-power-planner",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "license": "ISC",
       "dependencies": {
         "lottie-web": "^5.13.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cine-power-planner",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Browser-based tool for planning professional camera setups powered by V-Mount or B-Mount batteries. It calculates total power consumption, current draw at 14.4 V and 12 V, and estimated battery runtime while checking that the battery can safely deliver the required power.",
   "main": "src/data/index.js",
   "scripts": {

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,5 +1,5 @@
 /* eslint-env serviceworker */
-const CACHE_NAME = 'cine-power-planner-v1.0.4';
+const CACHE_NAME = 'cine-power-planner-v1.0.5';
 const ASSETS = [
   './',
   './index.html',


### PR DESCRIPTION
## Summary
- bump the application version to 1.0.5 across package metadata, UI copy, and cache keys
- update the legacy script version constant to keep backups and exports aligned with the new release number

## Testing
- npm test *(fails in the current baseline: ReferenceError: remainder is not defined in src/scripts/script.js)*

------
https://chatgpt.com/codex/tasks/task_e_68d07a84c5108320b354f2e92001dbb2