### PR TITLE
Center diagram container within setup section

### DIFF
--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -3046,8 +3046,10 @@ body.pink-mode #topBar #logo .logo-center {
 }
 
 #diagramArea {
-  margin-top: 0.5em;
+  margin: 0.5em auto 0;
   position: relative;
+  display: inline-block;
+  text-align: left;
 }
 
 #diagramArea.grid-snap {


### PR DESCRIPTION
## Summary
- ensure the setup diagram container recenters itself by switching to auto margins and inline-block layout

## Testing
- npm test *(fails: ReferenceError: remainder is not defined in src/scripts/script.js; existing issue in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68d07ad2e0fc8320abb73ef5fc4f041d