### PR TITLE
Restyle settings tabs with UIcons accent styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -794,23 +794,12 @@
           aria-controls="settingsPanel-general"
           aria-selected="true"
         >
-          <span class="settings-tab-icon icon-glyph icon-svg" aria-hidden="true">
-            <svg viewBox="0 0 24 24" fill="none" aria-hidden="true">
-              <path
-                d="M9.593 3.94c.09-.542.559-.94 1.11-.94h2.594c.55 0 1.019.398 1.11.94l.213 1.281c.062.374.312.686.644.87.074.041.147.083.22.127.332.183.721.257 1.076.124l1.217-.456a1.125 1.125 0 0 1 1.369.491l1.297 2.246a1.125 1.125 0 0 1-.259 1.431l-1.004.826c-.293.241-.438.612-.431.991.001.042.002.084.002.127s0 .085-.002.127c-.007.379.138.75.431.991l1.004.827a1.125 1.125 0 0 1 .259 1.43l-1.297 2.247a1.125 1.125 0 0 1-1.369.49l-1.217-.455a1.35 1.35 0 0 0-1.076.124 5.58 5.58 0 0 1-.864.495 1.35 1.35 0 0 0-.644.87l-.213 1.281c-.09.542-.559.94-1.11.94H10.703a1.125 1.125 0 0 1-1.11-.94l-.214-1.281a1.35 1.35 0 0 0-.644-.87 5.446 5.446 0 0 1-.864-.495 1.35 1.35 0 0 0-1.076-.124l-1.217.455a1.125 1.125 0 0 1-1.369-.49L3.557 15.377a1.125 1.125 0 0 1 .259-1.431l1.004-.826c.292-.241.437-.613.43-.992a4.643 4.643 0 0 1-.002-.254c0-.042.001-.084.002-.127.007-.379-.138-.75-.43-.991l-1.005-.827A1.125 1.125 0 0 1 3.557 8.623l1.297-2.246a1.125 1.125 0 0 1 1.369-.491l1.217.456c.355.133.75.072 1.076-.124.073-.044.147-.086.22-.127.332-.183.582-.495.644-.87l.213-1.281Z"
-                stroke="currentColor"
-                stroke-width="1.5"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-              />
-              <path
-                d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z"
-                stroke="currentColor"
-                stroke-width="1.5"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-              />
-            </svg>
+          <span
+            class="settings-tab-icon icon-glyph"
+            aria-hidden="true"
+            data-icon-font="uicons"
+          >
+            &#xEAC4;
           </span>
           <span class="settings-tab-label">General</span>
         </button>
@@ -823,19 +812,12 @@
           aria-selected="false"
           tabindex="-1"
         >
-          <span class="settings-tab-icon icon-glyph icon-svg" aria-hidden="true">
-            <svg viewBox="0 0 24 24" fill="none" aria-hidden="true">
-              <circle cx="6.5" cy="7" r="2.5" stroke="currentColor" stroke-width="1.5" />
-              <circle cx="17.5" cy="7" r="2.5" stroke="currentColor" stroke-width="1.5" />
-              <circle cx="12" cy="17.5" r="2.5" stroke="currentColor" stroke-width="1.5" />
-              <path
-                d="m8.5 8.5 3.5 3.5 3.5-3.5M12 12l-3 4.25M12 12l3 4.25"
-                stroke="currentColor"
-                stroke-width="1.5"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-              />
-            </svg>
+          <span
+            class="settings-tab-icon icon-glyph"
+            aria-hidden="true"
+            data-icon-font="uicons"
+          >
+            &#xE467;
           </span>
           <span class="settings-tab-label">Automatic Gear</span>
         </button>
@@ -848,17 +830,12 @@
           aria-selected="false"
           tabindex="-1"
         >
-          <span class="settings-tab-icon icon-glyph icon-svg" aria-hidden="true">
-            <svg viewBox="0 0 24 24" fill="none" aria-hidden="true">
-              <circle cx="12" cy="6.5" r="2.25" stroke="currentColor" stroke-width="1.5" />
-              <path
-                d="M5 11h14M12 8.75V19M8.5 19.5l3.5-7 3.5 7"
-                stroke="currentColor"
-                stroke-width="1.5"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-              />
-            </svg>
+          <span
+            class="settings-tab-icon icon-glyph"
+            aria-hidden="true"
+            data-icon-font="uicons"
+          >
+            &#xE597;
           </span>
           <span class="settings-tab-label">Accessibility</span>
         </button>
@@ -871,25 +848,12 @@
           aria-selected="false"
           tabindex="-1"
         >
-          <span class="settings-tab-icon icon-glyph icon-svg" aria-hidden="true">
-            <svg viewBox="0 0 24 24" fill="none" aria-hidden="true">
-              <rect
-                x="4.75"
-                y="7.75"
-                width="14.5"
-                height="9.5"
-                rx="2"
-                stroke="currentColor"
-                stroke-width="1.5"
-              />
-              <path
-                d="M12 4v3.5M10.25 5.75 12 4l1.75 1.75M12 16.75V20M10.25 18.25 12 20l1.75-1.75"
-                stroke="currentColor"
-                stroke-width="1.5"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-              />
-            </svg>
+          <span
+            class="settings-tab-icon icon-glyph"
+            aria-hidden="true"
+            data-icon-font="uicons"
+          >
+            &#xE825;
           </span>
           <span class="settings-tab-label">Backup &amp; Restore</span>
         </button>
@@ -902,31 +866,12 @@
           aria-selected="false"
           tabindex="-1"
         >
-          <span class="settings-tab-icon icon-glyph icon-svg" aria-hidden="true">
-            <svg viewBox="0 0 24 24" fill="none" aria-hidden="true">
-              <ellipse
-                cx="12"
-                cy="7"
-                rx="6.5"
-                ry="3.5"
-                stroke="currentColor"
-                stroke-width="1.5"
-              />
-              <path
-                d="M5.5 7v7c0 1.93 2.91 3.5 6.5 3.5s6.5-1.57 6.5-3.5V7"
-                stroke="currentColor"
-                stroke-width="1.5"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-              />
-              <path
-                d="M5.5 12c0 1.93 2.91 3.5 6.5 3.5s6.5-1.57 6.5-3.5"
-                stroke="currentColor"
-                stroke-width="1.5"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-              />
-            </svg>
+          <span
+            class="settings-tab-icon icon-glyph"
+            aria-hidden="true"
+            data-icon-font="uicons"
+          >
+            &#xF2DF;
           </span>
           <span class="settings-tab-label">Data &amp; Storage</span>
         </button>
@@ -939,23 +884,12 @@
           aria-selected="false"
           tabindex="-1"
         >
-          <span class="settings-tab-icon icon-glyph icon-svg" aria-hidden="true">
-            <svg viewBox="0 0 24 24" fill="none" aria-hidden="true">
-              <path
-                d="M20 11.5c0 4.694-3.806 8.5-8.5 8.5-1.166 0-2.28-.235-3.292-.662L4 20l.676-4.208A8.463 8.463 0 0 1 3.5 11.5C3.5 6.806 7.306 3 12 3s8 3.806 8 8.5Z"
-                stroke="currentColor"
-                stroke-width="1.5"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-              />
-              <path
-                d="M12 9.25c0-.69.56-1.25 1.25-1.25S14.5 8.56 14.5 9.25c0 .69-.56 1.25-1.25 1.25-.69 0-1.25.56-1.25 1.25v.5M12 15.75h.01"
-                stroke="currentColor"
-                stroke-width="1.5"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-              />
-            </svg>
+          <span
+            class="settings-tab-icon icon-glyph"
+            aria-hidden="true"
+            data-icon-font="uicons"
+          >
+            &#xF139;
           </span>
           <span class="settings-tab-label">About &amp; Support</span>
         </button>

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -1246,68 +1246,66 @@ main.legal-content {
 
 .settings-tab {
   appearance: none;
-  border: 1px solid color-mix(in srgb, var(--panel-border) 55%, transparent);
-  border-radius: calc(var(--border-radius) * 0.9);
-  background: color-mix(in srgb, var(--panel-bg) 92%, transparent);
+  border: 1px solid color-mix(in srgb, var(--panel-border) 65%, transparent);
+  border-radius: calc(var(--border-radius) * 0.8);
+  background: color-mix(in srgb, var(--panel-bg) 88%, transparent);
   color: inherit;
   font: inherit;
-  font-weight: 500;
+  font-weight: var(--font-weight-regular);
   letter-spacing: 0.01em;
-  padding: 10px 12px;
+  padding: 8px 10px;
   cursor: pointer;
   transition: background-color 0.25s ease, border-color 0.25s ease, color 0.25s ease,
-    box-shadow 0.25s ease, transform 0.25s ease;
+    transform 0.25s ease;
   white-space: normal;
   text-align: center;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 8px;
+  gap: 6px;
   position: relative;
   isolation: isolate;
-  min-height: 92px;
+  min-height: 80px;
 }
 
 .settings-tab:hover,
 .settings-tab:focus-visible {
-  border-color: color-mix(in srgb, var(--accent-color) 55%, transparent);
-  background: color-mix(in srgb, var(--accent-color) 12%, var(--panel-bg));
-  box-shadow: 0 6px 18px color-mix(in srgb, var(--accent-color) 15%, transparent);
+  border-color: color-mix(in srgb, var(--accent-color) 60%, transparent);
+  background: color-mix(in srgb, var(--accent-color) 16%, var(--panel-bg));
 }
 
 .settings-tab[aria-selected="true"] {
-  background: color-mix(in srgb, var(--accent-color) 18%, var(--panel-bg));
-  border-color: color-mix(in srgb, var(--accent-color) 65%, transparent);
-  box-shadow: 0 10px 24px color-mix(in srgb, var(--accent-color) 22%, transparent);
+  background: color-mix(in srgb, var(--accent-color) 22%, var(--panel-bg));
+  border-color: color-mix(in srgb, var(--accent-color) 70%, transparent);
+  color: color-mix(in srgb, var(--accent-color) 78%, currentColor);
 }
 
 .settings-tab.active {
-  box-shadow: 0 10px 24px color-mix(in srgb, var(--accent-color) 22%, transparent);
+  transform: translateY(-1px);
 }
 
 .settings-tab:focus-visible {
-  outline: none;
-  box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent-color) 28%, transparent),
-    0 8px 20px color-mix(in srgb, var(--accent-color) 18%, transparent);
+  outline: 2px solid var(--accent-color);
+  outline-offset: 2px;
 }
 
 .settings-tab-icon {
-  --icon-size: 22px;
-  inline-size: 36px;
-  block-size: 36px;
-  min-inline-size: 36px;
-  min-block-size: 36px;
+  --icon-size: 20px;
+  inline-size: 32px;
+  block-size: 32px;
+  min-inline-size: 32px;
+  min-block-size: 32px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  border-radius: 12px;
+  border-radius: 10px;
   background: color-mix(in srgb, var(--accent-color) 14%, transparent);
+  border: 1px solid color-mix(in srgb, var(--accent-color) 24%, transparent);
   color: color-mix(in srgb, var(--accent-color) 60%, currentColor);
-  flex: 0 0 36px;
-  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--accent-color) 10%, transparent);
+  flex: 0 0 32px;
   transition: transform 0.2s ease, background-color 0.2s ease, color 0.2s ease,
-    box-shadow 0.2s ease;
+    border-color 0.2s ease;
 }
 
 .settings-tab:hover .settings-tab-icon,
@@ -1315,22 +1313,22 @@ main.legal-content {
   background: color-mix(in srgb, var(--accent-color) 26%, transparent);
   color: var(--accent-color);
   transform: translateY(-1px);
-  box-shadow: 0 6px 18px color-mix(in srgb, var(--accent-color) 22%, transparent);
+  border-color: color-mix(in srgb, var(--accent-color) 40%, transparent);
 }
 
 .settings-tab[aria-selected="true"] .settings-tab-icon,
 .settings-tab.active .settings-tab-icon {
-  background: color-mix(in srgb, var(--accent-color) 32%, transparent);
+  background: color-mix(in srgb, var(--accent-color) 34%, transparent);
   color: var(--accent-color);
-  box-shadow: 0 10px 24px color-mix(in srgb, var(--accent-color) 24%, transparent);
+  border-color: color-mix(in srgb, var(--accent-color) 48%, transparent);
   transform: translateY(-1px) scale(1.02);
 }
 
 .settings-tab-label {
-  font-size: 0.92rem;
-  font-weight: 500;
+  font-size: 0.9rem;
+  font-weight: var(--font-weight-regular);
   line-height: 1.25;
-  letter-spacing: 0.01em;
+  letter-spacing: 0.005em;
   color: currentColor;
 }
 
@@ -1338,6 +1336,41 @@ main.legal-content {
 .settings-tab:hover .settings-tab-label,
 .settings-tab:focus-visible .settings-tab-label {
   color: color-mix(in srgb, var(--accent-color) 72%, currentColor);
+}
+
+body.light-mode .settings-tab {
+  background: color-mix(in srgb, var(--accent-color) 12%, var(--surface-color));
+  border-color: color-mix(in srgb, var(--accent-color) 52%, transparent);
+  color: color-mix(in srgb, var(--accent-color) 70%, var(--text-color));
+}
+
+body.light-mode .settings-tab:hover,
+body.light-mode .settings-tab:focus-visible {
+  background: color-mix(in srgb, var(--accent-color) 20%, var(--surface-color));
+}
+
+body.light-mode .settings-tab[aria-selected="true"],
+body.light-mode .settings-tab.active {
+  background: color-mix(in srgb, var(--accent-color) 28%, var(--surface-color));
+  color: var(--accent-color);
+}
+
+body.light-mode .settings-tab-icon {
+  background: color-mix(in srgb, var(--accent-color) 24%, transparent);
+  border-color: color-mix(in srgb, var(--accent-color) 48%, transparent);
+  color: var(--accent-color);
+}
+
+body.light-mode .settings-tab:hover .settings-tab-icon,
+body.light-mode .settings-tab:focus-visible .settings-tab-icon {
+  background: color-mix(in srgb, var(--accent-color) 32%, transparent);
+  border-color: color-mix(in srgb, var(--accent-color) 56%, transparent);
+}
+
+body.light-mode .settings-tab[aria-selected="true"] .settings-tab-icon,
+body.light-mode .settings-tab.active .settings-tab-icon {
+  background: color-mix(in srgb, var(--accent-color) 38%, transparent);
+  border-color: color-mix(in srgb, var(--accent-color) 64%, transparent);
 }
 
 body.high-contrast .settings-tab {
@@ -1366,8 +1399,8 @@ body.high-contrast .settings-tab-icon {
     grid-template-columns: repeat(auto-fit, minmax(110px, 1fr));
   }
   .settings-tab {
-    min-height: 88px;
-    padding: 9px 10px;
+    min-height: 72px;
+    padding: 7px 8px;
   }
 }
 


### PR DESCRIPTION
## Summary
- switch the settings tab icons to the bundled UIcons glyphs for a consistent look across each section
- tighten the settings tab layout with lighter typography, smaller hit areas, and hover/focus treatments without drop shadows
- highlight tabs with the accent color in bright mode while keeping dark and high-contrast themes intact

## Testing
- npm run test:script *(fails: ReferenceError: remainder is not defined in src/scripts/script.js when loading the compiled bundle)*

------
https://chatgpt.com/codex/tasks/task_e_68d07b30ef148320a4d478609c2a0036