### PR TITLE
Adjust video distribution selector height

### DIFF
--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -547,9 +547,9 @@ main.legal-content {
   flex: 0 1 320px;
   width: min(100%, 320px);
   max-width: 100%;
-  overflow-y: auto;
-  min-height: 12rem;
-  height: clamp(14rem, 45vh, 20rem);
+  overflow-y: visible;
+  min-height: auto;
+  height: auto;
 }
 
 #crewContainer {


### PR DESCRIPTION
## Summary
- let the auto gear video distribution selector grow only to the height required by its options by removing the forced minimum height and scroll

## Testing
- npm run lint *(fails: existing `src/scripts/script.js` undefined variable `remainder`)*

------
https://chatgpt.com/codex/tasks/task_e_68d07b8cd434832082a39663f53b2161