### PR TITLE
Surface autosave note above settings backdrop

### DIFF
--- a/src/scripts/autosave-overlay.js
+++ b/src/scripts/autosave-overlay.js
@@ -1,0 +1,220 @@
+(function () {
+  if (typeof document === 'undefined') {
+    return;
+  }
+
+  var SETTINGS_DIALOG_ID = 'settingsDialog';
+  var SOURCE_NOTE_ID = 'gearListAutosaveNote';
+  var OVERLAY_NOTE_ID = 'gearListAutosaveOverlayNote';
+  var VISIBLE_CLASS = 'is-visible';
+
+  var dialog = null;
+  var overlay = null;
+  var sourceNote = null;
+  var lastText = '';
+  var sourceObserver = null;
+  var dialogObserver = null;
+  var bodyObserver = null;
+
+  function getDialog() {
+    if (!dialog || !document.contains(dialog)) {
+      dialog = document.getElementById(SETTINGS_DIALOG_ID) || null;
+    }
+    return dialog;
+  }
+
+  function ensureOverlay(targetDialog) {
+    if (!targetDialog) {
+      return null;
+    }
+
+    if (!overlay || !targetDialog.contains(overlay)) {
+      overlay = targetDialog.querySelector('#' + OVERLAY_NOTE_ID);
+    }
+
+    if (!overlay) {
+      overlay = document.createElement('p');
+      overlay.id = OVERLAY_NOTE_ID;
+      overlay.className = 'gear-list-autosave-note gear-list-autosave-note--overlay';
+      overlay.setAttribute('role', 'status');
+      overlay.setAttribute('aria-live', 'polite');
+      overlay.setAttribute('aria-atomic', 'true');
+      overlay.hidden = true;
+      overlay.setAttribute('aria-hidden', 'true');
+      targetDialog.appendChild(overlay);
+    }
+
+    return overlay;
+  }
+
+  function updateOverlayText(note) {
+    if (!overlay) {
+      return;
+    }
+
+    var text = lastText;
+    if (note && typeof note.textContent === 'string') {
+      text = note.textContent.trim();
+    }
+
+    if (typeof text !== 'string') {
+      text = '';
+    }
+
+    if (text !== lastText) {
+      lastText = text;
+    }
+
+    if (overlay.textContent !== text) {
+      overlay.textContent = text;
+    }
+  }
+
+  function updateOverlayVisibility(note) {
+    if (!overlay || !dialog) {
+      return;
+    }
+
+    var notePresent = !!(note && document.contains(note));
+    var noteHidden = false;
+
+    if (notePresent) {
+      if (note.hasAttribute && note.hasAttribute('hidden')) {
+        noteHidden = true;
+      } else if (note.classList && note.classList.contains('hidden')) {
+        noteHidden = true;
+      } else if (note.style && (note.style.display === 'none' || note.style.visibility === 'hidden')) {
+        noteHidden = true;
+      }
+    }
+
+    var hasText = typeof lastText === 'string' && lastText.trim().length > 0;
+    var shouldShow = !!(dialog.open && notePresent && !noteHidden && hasText);
+
+    overlay.setAttribute('aria-hidden', shouldShow ? 'false' : 'true');
+
+    if (shouldShow) {
+      overlay.hidden = false;
+      if (overlay.classList) {
+        overlay.classList.add(VISIBLE_CLASS);
+      }
+    } else {
+      if (overlay.classList) {
+        overlay.classList.remove(VISIBLE_CLASS);
+      }
+      overlay.hidden = true;
+    }
+  }
+
+  function observeSource(note) {
+    if (sourceObserver) {
+      sourceObserver.disconnect();
+      sourceObserver = null;
+    }
+
+    if (!note || typeof MutationObserver !== 'function') {
+      return;
+    }
+
+    sourceObserver = new MutationObserver(function () {
+      updateOverlayText(note);
+      updateOverlayVisibility(note);
+    });
+    sourceObserver.observe(note, {
+      childList: true,
+      subtree: true,
+      characterData: true,
+      attributes: true,
+    });
+  }
+
+  function observeDialog(targetDialog) {
+    if (dialogObserver) {
+      dialogObserver.disconnect();
+      dialogObserver = null;
+    }
+
+    if (!targetDialog || typeof MutationObserver !== 'function') {
+      return;
+    }
+
+    dialogObserver = new MutationObserver(function () {
+      updateOverlayVisibility(sourceNote);
+    });
+    dialogObserver.observe(targetDialog, {
+      attributes: true,
+      attributeFilter: ['open'],
+    });
+  }
+
+  function observeBody() {
+    if (bodyObserver || typeof MutationObserver !== 'function') {
+      return;
+    }
+
+    bodyObserver = new MutationObserver(function () {
+      var latestSource = document.getElementById(SOURCE_NOTE_ID);
+      if (latestSource !== sourceNote) {
+        sourceNote = latestSource || null;
+        observeSource(sourceNote);
+        updateOverlayText(sourceNote);
+        updateOverlayVisibility(sourceNote);
+      }
+    });
+    bodyObserver.observe(document.body, {
+      childList: true,
+      subtree: true,
+    });
+  }
+
+  function bindDialogEvents(targetDialog) {
+    if (!targetDialog || typeof targetDialog.addEventListener !== 'function') {
+      return;
+    }
+
+    var handler = function () {
+      updateOverlayVisibility(sourceNote);
+    };
+
+    targetDialog.addEventListener('close', handler);
+    targetDialog.addEventListener('cancel', handler);
+    targetDialog.addEventListener('submit', handler);
+  }
+
+  function bindLanguageChange() {
+    if (typeof window === 'undefined' || typeof window.addEventListener !== 'function') {
+      return;
+    }
+
+    window.addEventListener('languagechange', function () {
+      sourceNote = document.getElementById(SOURCE_NOTE_ID) || null;
+      updateOverlayText(sourceNote);
+      updateOverlayVisibility(sourceNote);
+    });
+  }
+
+  function setup() {
+    var targetDialog = getDialog();
+    if (!targetDialog) {
+      return;
+    }
+
+    ensureOverlay(targetDialog);
+    sourceNote = document.getElementById(SOURCE_NOTE_ID) || null;
+
+    updateOverlayText(sourceNote);
+    updateOverlayVisibility(sourceNote);
+
+    observeDialog(targetDialog);
+    observeSource(sourceNote);
+    observeBody();
+    bindDialogEvents(targetDialog);
+    bindLanguageChange();
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', setup, { once: true });
+  } else {
+    setup();
+  }
+})();

--- a/src/scripts/loader.js
+++ b/src/scripts/loader.js
@@ -377,7 +377,8 @@
     'src/vendor/lz-string.min.js',
     'src/vendor/lottie-light.min.js',
     'src/scripts/script.js',
-    'src/scripts/overview.js'
+    'src/scripts/overview.js',
+    'src/scripts/autosave-overlay.js'
   ];
 
   var legacyScripts = [
@@ -400,7 +401,8 @@
     'src/vendor/lz-string.min.js',
     'src/vendor/lottie-light.min.js',
     'legacy/scripts/script.js',
-    'legacy/scripts/overview.js'
+    'legacy/scripts/overview.js',
+    'src/scripts/autosave-overlay.js'
   ];
 
   function startLoading() {

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -4729,6 +4729,39 @@ body.dark-mode.pink-mode #gearListOutput h2,
   color: var(--muted-text-color);
 }
 
+.gear-list-autosave-note--overlay {
+  position: fixed;
+  left: 50%;
+  bottom: calc(env(safe-area-inset-bottom, 0px) + clamp(1rem, 3vw, 2.5rem));
+  transform: translate(-50%, 1rem);
+  max-width: min(90vw, 40rem);
+  padding: 0.75rem 1rem;
+  border-radius: var(--border-radius);
+  border: 2px solid var(--panel-border);
+  background: var(--surface-color);
+  color: var(--text-color);
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.25);
+  text-align: center;
+  font-size: calc(var(--font-size-relative-base) * var(--font-scale-sm));
+  line-height: 1.4;
+  pointer-events: none;
+  z-index: 240;
+  opacity: 0;
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+.gear-list-autosave-note--overlay.is-visible {
+  opacity: 1;
+  transform: translate(-50%, 0);
+}
+
+@media (max-width: 600px) {
+  .gear-list-autosave-note--overlay {
+    padding: 0.75rem;
+    font-size: calc(var(--font-size-relative-base) * var(--font-scale-xs));
+  }
+}
+
 @media (max-width: 600px) {
   #gearListOutput,
   #projectRequirementsOutput {


### PR DESCRIPTION
## Summary
- add an autosave overlay helper that mirrors the gear list autosave note above the settings dialog backdrop
- style the floating autosave note for readability across viewports while keeping interactions unobstructed
- load the overlay helper for both modern and legacy bundles so the notice is available in every build

## Testing
- npm run test:dom *(fails: ReferenceError: remainder is not defined in src/scripts/script.js)*

------
https://chatgpt.com/codex/tasks/task_e_68d07c7c174083209f7b05d018ee7e1b