### PR TITLE
Expand auto gear selectors for multi selection

### DIFF
--- a/index.html
+++ b/index.html
@@ -1097,47 +1097,102 @@
           </div>
           <div class="form-row">
             <label for="autoGearScenarios" id="autoGearScenariosLabel">Required scenarios</label>
-            <select id="autoGearScenarios" class="auto-gear-scenarios" multiple></select>
+            <select
+              id="autoGearScenarios"
+              class="auto-gear-scenarios auto-gear-multiselect"
+              multiple
+              size="10"
+            ></select>
           </div>
           <div class="form-row">
             <label for="autoGearMattebox" id="autoGearMatteboxLabel">Mattebox options</label>
-            <select id="autoGearMattebox" class="auto-gear-mattebox" multiple></select>
+            <select
+              id="autoGearMattebox"
+              class="auto-gear-mattebox auto-gear-multiselect"
+              multiple
+              size="10"
+            ></select>
           </div>
           <div class="form-row">
             <label for="autoGearCameraHandle" id="autoGearCameraHandleLabel">Camera handles</label>
-            <select id="autoGearCameraHandle" class="auto-gear-camera-handle" multiple></select>
+            <select
+              id="autoGearCameraHandle"
+              class="auto-gear-camera-handle auto-gear-multiselect"
+              multiple
+              size="10"
+            ></select>
           </div>
           <div class="form-row">
             <label for="autoGearViewfinderExtension" id="autoGearViewfinderExtensionLabel">Viewfinder extension</label>
-            <select id="autoGearViewfinderExtension" class="auto-gear-viewfinder-extension" multiple></select>
+            <select
+              id="autoGearViewfinderExtension"
+              class="auto-gear-viewfinder-extension auto-gear-multiselect"
+              multiple
+              size="10"
+            ></select>
           </div>
           <div class="form-row">
             <label for="autoGearVideoDistribution" id="autoGearVideoDistributionLabel">Video distribution</label>
-            <select id="autoGearVideoDistribution" class="auto-gear-video-distribution" multiple></select>
+            <select
+              id="autoGearVideoDistribution"
+              class="auto-gear-video-distribution auto-gear-multiselect"
+              multiple
+              size="10"
+            ></select>
           </div>
           <div class="form-row">
             <label for="autoGearCamera" id="autoGearCameraLabel">Camera</label>
-            <select id="autoGearCamera" class="auto-gear-camera" multiple></select>
+            <select
+              id="autoGearCamera"
+              class="auto-gear-camera auto-gear-multiselect"
+              multiple
+              size="10"
+            ></select>
           </div>
           <div class="form-row">
             <label for="autoGearMonitor" id="autoGearMonitorLabel">Onboard monitor</label>
-            <select id="autoGearMonitor" class="auto-gear-monitor" multiple></select>
+            <select
+              id="autoGearMonitor"
+              class="auto-gear-monitor auto-gear-multiselect"
+              multiple
+              size="10"
+            ></select>
           </div>
           <div class="form-row">
             <label for="autoGearWireless" id="autoGearWirelessLabel">Wireless transmitter</label>
-            <select id="autoGearWireless" class="auto-gear-wireless" multiple></select>
+            <select
+              id="autoGearWireless"
+              class="auto-gear-wireless auto-gear-multiselect"
+              multiple
+              size="10"
+            ></select>
           </div>
           <div class="form-row">
             <label for="autoGearMotors" id="autoGearMotorsLabel">FIZ motors</label>
-            <select id="autoGearMotors" class="auto-gear-motors" multiple></select>
+            <select
+              id="autoGearMotors"
+              class="auto-gear-motors auto-gear-multiselect"
+              multiple
+              size="10"
+            ></select>
           </div>
           <div class="form-row">
             <label for="autoGearControllers" id="autoGearControllersLabel">FIZ controllers</label>
-            <select id="autoGearControllers" class="auto-gear-controllers" multiple></select>
+            <select
+              id="autoGearControllers"
+              class="auto-gear-controllers auto-gear-multiselect"
+              multiple
+              size="10"
+            ></select>
           </div>
           <div class="form-row">
             <label for="autoGearDistance" id="autoGearDistanceLabel">FIZ distance devices</label>
-            <select id="autoGearDistance" class="auto-gear-distance" multiple></select>
+            <select
+              id="autoGearDistance"
+              class="auto-gear-distance auto-gear-multiselect"
+              multiple
+              size="10"
+            ></select>
           </div>
           <div class="auto-gear-editor-columns">
             <div class="auto-gear-column">

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -1645,11 +1645,23 @@ body.pink-mode .auto-gear-rule-title,
   vertical-align: top;
 }
 
-.auto-gear-selector {
+.auto-gear-selector,
+.auto-gear-multiselect {
   width: 100%;
   height: auto;
   max-height: 18rem;
   overflow-y: auto;
+}
+
+.auto-gear-multiselect {
+  min-height: 14rem;
+  max-height: min(24rem, 60vh);
+}
+
+@media (max-width: 640px) {
+  .auto-gear-multiselect {
+    min-height: 12rem;
+  }
 }
 
 .auto-gear-selector-hint {

--- a/tests/script/autoGearRules.test.js
+++ b/tests/script/autoGearRules.test.js
@@ -66,6 +66,35 @@ describe('applyAutoGearRulesToTableHtml', () => {
     }
   });
 
+  test('rule editor selectors allow multiple choices and show expanded lists', () => {
+    env = setupScriptEnvironment();
+
+    document.getElementById('autoGearAddRule').click();
+
+    const selectorIds = [
+      'autoGearScenarios',
+      'autoGearMattebox',
+      'autoGearCameraHandle',
+      'autoGearViewfinderExtension',
+      'autoGearVideoDistribution',
+      'autoGearCamera',
+      'autoGearMonitor',
+      'autoGearWireless',
+      'autoGearMotors',
+      'autoGearControllers',
+      'autoGearDistance',
+    ];
+
+    selectorIds.forEach(id => {
+      const select = document.getElementById(id);
+      expect(select).not.toBeNull();
+      if (!select) return;
+      expect(select.multiple).toBe(true);
+      const visibleRows = Number.parseInt(select.getAttribute('size') || '0', 10);
+      expect(visibleRows).toBeGreaterThanOrEqual(8);
+    });
+  });
+
   test('removes matching gear without duplicating categories', () => {
     localStorage.setItem(
       STORAGE_KEY,


### PR DESCRIPTION
## Summary
- add a shared auto-gear-multiselect class and expand each automatic gear selector to expose multi-select behaviour with more visible rows
- update styling so the automatic gear multi-select lists display a taller scrollable panel while remaining responsive
- assert in the script tests that every automatic gear selector retains multi-select support and an expanded visible size

## Testing
- `npm run test:script` *(fails: ReferenceError: remainder is not defined at src/scripts/script.js:1:7)*

------
https://chatgpt.com/codex/tasks/task_e_68d07d76f21883209909304648435bbc