### PR TITLE
Clear autosaved preset when resetting factory additions

### DIFF
--- a/tests/unit/storage.test.js
+++ b/tests/unit/storage.test.js
@@ -695,6 +695,44 @@ describe('automatic gear storage', () => {
     expect(localStorage.getItem(AUTO_GEAR_AUTO_PRESET_KEY)).toBe('legacy-auto');
     expect(localStorage.getItem('cinePowerPlanner_autoGearAutoPreset')).toBeNull();
   });
+
+  test('clearing the auto preset removes the autosaved entry from presets', () => {
+    const presets = [
+      { id: 'manual-1', label: 'Manual preset', rules: [] },
+      { id: 'auto-123', label: 'Autosaved rules', rules: [] },
+    ];
+
+    saveAutoGearPresets(presets);
+    saveAutoGearAutoPresetId('auto-123');
+
+    saveAutoGearAutoPresetId('');
+
+    const stored = JSON.parse(localStorage.getItem(AUTO_GEAR_PRESETS_KEY));
+    expect(stored).toEqual([
+      { id: 'manual-1', label: 'Manual preset', rules: [] },
+    ]);
+    expect(localStorage.getItem(AUTO_GEAR_AUTO_PRESET_KEY)).toBeNull();
+  });
+
+  test('replacing the auto preset id removes the previous autosaved entry', () => {
+    saveAutoGearPresets([
+      { id: 'auto-old', label: 'Autosaved rules', rules: [{ id: 'rule-1' }] },
+      { id: 'manual-1', label: 'Manual preset', rules: [] },
+    ]);
+    saveAutoGearAutoPresetId('auto-old');
+
+    saveAutoGearPresets([
+      { id: 'auto-new', label: 'Autosaved rules', rules: [{ id: 'rule-2' }] },
+      { id: 'manual-1', label: 'Manual preset', rules: [] },
+    ]);
+    saveAutoGearAutoPresetId('auto-new');
+
+    const stored = JSON.parse(localStorage.getItem(AUTO_GEAR_PRESETS_KEY));
+    expect(stored).toEqual([
+      { id: 'auto-new', label: 'Autosaved rules', rules: [{ id: 'rule-2' }] },
+      { id: 'manual-1', label: 'Manual preset', rules: [] },
+    ]);
+  });
 });
 
 describe('clearAllData', () => {


### PR DESCRIPTION
## Summary
- remove the lingering autosaved automatic gear preset when the autosave id is cleared or replaced so factory resets restore default rules cleanly
- mirror the storage cleanup in the legacy bundle to keep both script variants in sync
- add unit tests that confirm autosaved presets are pruned when the auto preset id is cleared or swapped

## Testing
- npx jest --runInBand --runTestsByPath tests/unit/storage.test.js
- npm run test:unit *(fails: Unable to find version in src/scripts/script.js)*

------
https://chatgpt.com/codex/tasks/task_e_68d07cf82f408320bcf2df5000e33195