### PR TITLE
Center diagram contents within setup section

### DIFF
--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -3046,8 +3046,26 @@ body.pink-mode #topBar #logo .logo-center {
 }
 
 #diagramArea {
-  margin-top: 0.5em;
+  margin: 0.5em auto 0;
   position: relative;
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: left;
+}
+
+#diagramArea > * {
+  flex: 0 0 auto;
+}
+
+#diagramArea > svg,
+#diagramArea > canvas {
+  margin-inline: auto;
+}
+
+#diagramArea .diagram-placeholder {
+  text-align: center;
+  width: 100%;
 }
 
 #diagramArea.grid-snap {


### PR DESCRIPTION
## Summary
- allow the setup diagram container to center its rendered content by switching to a flex column layout
- ensure any rendered diagram canvas or placeholder is horizontally centered while keeping popup positioning intact

## Testing
- npm test *(fails: ReferenceError: remainder is not defined in src/scripts/script.js; existing issue in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68d07ad2e0fc8320abb73ef5fc4f041d