### PR TITLE
Increase spacing between button icons and text

### DIFF
--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -44,7 +44,7 @@
   --button-link-padding-block: var(--button-padding-block);
   --button-link-padding-inline: 12px;
   --icon-gap: 0.3em;
-  --button-icon-gap: 0.55em;
+  --button-icon-gap: 0.75em;
   --form-control-font-size: var(--font-size-relative-base);
   --form-label-width: 150px;
   --form-label-min-width: 120px;
@@ -172,7 +172,7 @@ body.relaxed-spacing {
   --form-label-min-width: 140px;
   --button-size: 30px;
   --button-line-height: 1.45;
-  --button-icon-gap: 0.7em;
+  --button-icon-gap: 0.9em;
   --form-row-margin-block: 8px;
   --button-link-padding-inline: 16px;
 }


### PR DESCRIPTION
## Summary
- widen the global button icon gap variable to give icons more breathing room beside their labels
- keep the relaxed spacing mode proportional by increasing its icon/text gap as well

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d09484a7b48320a6c277ec0097b37d