### PR TITLE
Adjust auto gear rule layout on mobile

### DIFF
--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -1665,6 +1665,23 @@ body.pink-mode .auto-gear-rule-title,
   gap: 8px;
 }
 
+@media (max-width: 600px) {
+  .auto-gear-rule {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .auto-gear-rule-info,
+  .auto-gear-rule-items,
+  .auto-gear-rule-actions {
+    width: 100%;
+  }
+
+  .auto-gear-rule-actions {
+    justify-content: flex-start;
+  }
+}
+
 .auto-gear-editor {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- stack auto gear rule content vertically on small screens to let rule items span the full container width
- ensure associated sections stretch across the card for improved readability on mobile

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d09527fb2883208c050eeb8e727f0a