### PR TITLE
Improve legacy project normalization

### DIFF
--- a/tests/unit/storage.test.js
+++ b/tests/unit/storage.test.js
@@ -1179,10 +1179,87 @@ describe('export/import all data', () => {
     expect(loadProject('Legacy')).toEqual({ gearList: '<div>Legacy</div>', projectInfo: null });
   });
 
+  test('importAllData handles project map entries stored as JSON strings', () => {
+    const payload = {
+      project: {
+        Legacy: JSON.stringify({
+          gearList: '<div>Legacy</div>',
+          projectInfo: { projectName: 'Legacy JSON' },
+          autoGearRules: [
+            { id: 'legacy-json', label: 'Legacy JSON', scenarios: [], add: [], remove: [] },
+          ],
+        }),
+      },
+    };
+
+    importAllData(payload);
+
+    expect(loadProject('Legacy')).toEqual({
+      gearList: '<div>Legacy</div>',
+      projectInfo: { projectName: 'Legacy JSON' },
+      autoGearRules: [
+        { id: 'legacy-json', label: 'Legacy JSON', scenarios: [], add: [], remove: [] },
+      ],
+    });
+  });
+
   test('importAllData handles legacy single gearList', () => {
     const data = { gearList: '<p></p>' };
     importAllData(data);
     expect(loadProject('')).toEqual({ gearList: '<p></p>', projectInfo: null });
+  });
+
+  test('loadProject normalizes stored JSON string payloads', () => {
+    const jsonString = JSON.stringify({
+      gearList: '<section>Legacy</section>',
+      projectInfo: { projectName: 'Legacy Stored' },
+      autoGearRules: [
+        { id: 'stored-json', label: 'Stored JSON', scenarios: [], add: [], remove: [] },
+      ],
+    });
+    localStorage.setItem(PROJECT_KEY, JSON.stringify(jsonString));
+
+    const project = loadProject('');
+
+    expect(project).toEqual({
+      gearList: '<section>Legacy</section>',
+      projectInfo: { projectName: 'Legacy Stored' },
+      autoGearRules: [
+        { id: 'stored-json', label: 'Stored JSON', scenarios: [], add: [], remove: [] },
+      ],
+    });
+
+    const stored = JSON.parse(localStorage.getItem(PROJECT_KEY));
+    expect(stored['']).toEqual({
+      gearList: '<section>Legacy</section>',
+      projectInfo: { projectName: 'Legacy Stored' },
+      autoGearRules: [
+        { id: 'stored-json', label: 'Stored JSON', scenarios: [], add: [], remove: [] },
+      ],
+    });
+  });
+
+  test('loadProject normalizes project map entries saved as JSON strings', () => {
+    const stored = {
+      Legacy: JSON.stringify({
+        gearList: '<article>Legacy Map</article>',
+        projectInfo: { projectName: 'Legacy Map' },
+      }),
+    };
+    localStorage.setItem(PROJECT_KEY, JSON.stringify(stored));
+
+    const project = loadProject('Legacy');
+
+    expect(project).toEqual({
+      gearList: '<article>Legacy Map</article>',
+      projectInfo: { projectName: 'Legacy Map' },
+    });
+
+    const updated = JSON.parse(localStorage.getItem(PROJECT_KEY));
+    expect(updated.Legacy).toEqual({
+      gearList: '<article>Legacy Map</article>',
+      projectInfo: { projectName: 'Legacy Map' },
+    });
   });
 
   test('importAllData normalizes automatic gear booleans from strings', () => {


### PR DESCRIPTION
## Summary
- allow project normalization to parse JSON-string encoded project entries so legacy exports restore cleanly
- preserve nested project info and auto gear rules when the payload is double-serialized
- extend storage unit tests to cover legacy JSON-string project values and imports

## Testing
- npm run test:unit

------
https://chatgpt.com/codex/tasks/task_e_68d09637a7c4832088301ee1f3861214