### PR TITLE
Align gear list emphasis with accent in bright mode

### DIFF
--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -4566,6 +4566,12 @@ body:not(.dark-mode) .requirement-box,
   page-break-after: avoid;
 }
 
+body.light-mode .gear-table strong,
+#gearListOutput:not(.dark-mode) .gear-table strong,
+#overviewDialogContent:not(.dark-mode) .gear-table strong {
+  color: var(--accent-color);
+}
+
 .dark-mode .gear-table td {
   border-top: 1px solid var(--inverse-text-color);
   border-bottom: 1px solid var(--inverse-text-color);


### PR DESCRIPTION
## Summary
- colorize bold gear list text with the current accent when using the light theme
- ensure overview and exported gear tables share the same accent styling in bright mode

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d105846d0c832080e89d6b992c85b2