### PR TITLE
Add .gitattributes to normalize line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,24 @@
+# Ensure consistent LF line endings for text files
+* text=auto eol=lf
+
+# Treat common binary assets as binary to avoid line ending conversion
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.webp binary
+*.svg binary
+*.mp4 binary
+*.mov binary
+*.zip binary
+*.gz binary
+*.tgz binary
+*.bz2 binary
+*.pdf binary
+*.ttf binary
+*.otf binary
+*.woff binary
+*.woff2 binary
+*.mp3 binary
+*.wav binary


### PR DESCRIPTION
## Summary
- add a .gitattributes file to enforce LF endings for text files
- mark common binary asset types to avoid newline normalization on media

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1ad1079a08320a1ec8aed5a2f74ae