### PR TITLE
Remove shadows from print layout

### DIFF
--- a/src/styles/overview-print.css
+++ b/src/styles/overview-print.css
@@ -55,6 +55,7 @@ body.dark-mode {
   --surface-color: #fff;
   --text-color: #000;
   --panel-shadow: none;
+  --panel-shadow-hover: none;
   --button-size: 24px;
   --diagram-node-fill: #f0f0f0;
   --power-color: #d33;
@@ -75,6 +76,12 @@ body.dark-mode {
   print-color-adjust: exact;
   background: var(--surface-color);
   color: var(--text-color);
+}
+
+#overviewDialogContent *,
+#overviewDialogContent *::before,
+#overviewDialogContent *::after {
+  box-shadow: none !important;
 }
 #overviewDialogContent,
 #overviewDialogContent.dark-mode {


### PR DESCRIPTION
## Summary
- ensure the print stylesheet disables hover panel shadows so variables never introduce drop shadows
- strip box-shadow from all overview dialog elements during printing for a clean print export

## Testing
- npm run lint *(fails: existing lint errors in src/scripts/script.js and other files unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68d1b6cba6d083208f867cbd82257d57