### PR TITLE
Improve printable overview title and requirement layout

### DIFF
--- a/src/scripts/overview.js
+++ b/src/scripts/overview.js
@@ -8,6 +8,7 @@ function generatePrintableOverview() {
     const now = new Date();
     const localeMap = { de: 'de-DE', es: 'es-ES', fr: 'fr-FR', en: 'en-US', it: 'it-IT' };
     const lang = typeof currentLang === 'string' ? currentLang : 'en';
+    const t = (typeof texts === 'object' && texts) ? (texts[lang] || texts.en || {}) : {};
     const locale = localeMap[lang] || 'en-US';
     const dateTimeString = now.toLocaleDateString(locale) + ' ' + now.toLocaleTimeString();
     const fallbackProjectName = currentProjectInfo && typeof currentProjectInfo.projectName === 'string'
@@ -28,14 +29,18 @@ function generatePrintableOverview() {
     const formattedDate = `${now.getFullYear()}-${padTwo(now.getMonth() + 1)}-${padTwo(now.getDate())}`;
     const formattedTime = `${padTwo(now.getHours())}-${padTwo(now.getMinutes())}-${padTwo(now.getSeconds())}`;
     const timestampLabel = `${formattedDate} ${formattedTime}`.trim();
+    const safeTimestampLabel = sanitizeTitleSegment(timestampLabel) || timestampLabel;
     const projectTitleSegment = sanitizeTitleSegment(projectNameForTitle) || 'Project';
-    const printDocumentTitle = [timestampLabel, projectTitleSegment, '- -', 'Project Overview and Gear List']
+    const overviewLabel = sanitizeTitleSegment((t.overviewTitle || '').trim());
+    const gearListLabel = sanitizeTitleSegment((t.gearListNav || '').trim());
+    const suffixRaw = [overviewLabel, gearListLabel].filter(Boolean).join(' – ');
+    const suffixSegment = sanitizeTitleSegment(suffixRaw) || 'Project Overview and Gear List';
+    const printDocumentTitle = [safeTimestampLabel, projectTitleSegment, suffixSegment]
         .filter(Boolean)
-        .join(' ')
+        .join(' - ')
         .replace(/\s+/g, ' ')
         .trim();
     const originalDocumentTitle = typeof document !== 'undefined' ? document.title : '';
-    const t = (typeof texts === 'object' && texts) ? (texts[lang] || texts.en || {}) : {};
     const customLogo = typeof localStorage !== 'undefined' ? localStorage.getItem('customLogo') : null;
 
     let deviceListHtml = '<div class="device-category-container">';
@@ -437,13 +442,14 @@ function generatePrintableOverview() {
         const bodyElement = typeof document !== 'undefined' ? document.body : null;
         const bodyClassName = bodyElement ? bodyElement.className : '';
         const bodyInlineStyle = bodyElement ? bodyElement.getAttribute('style') || '' : '';
+        const escapedPrintDocumentTitle = escapeHtmlSafe(printDocumentTitle);
         doc.open();
         doc.write(`<!DOCTYPE html>
 <html>
 <head>
 <meta charset="utf-8">
 <meta name="color-scheme" content="light dark">
-<title></title>
+<title>${escapedPrintDocumentTitle}</title>
 <link rel="stylesheet" href="src/styles/style.css">
 <link rel="stylesheet" href="src/styles/overview.css">
 <link rel="stylesheet" href="src/styles/overview-print.css" media="print">

--- a/src/styles/overview-print.css
+++ b/src/styles/overview-print.css
@@ -294,6 +294,37 @@ table, th, td {
   border: 1px solid var(--text-color);
   box-shadow: var(--panel-shadow);
 }
+
+#overviewDialogContent .requirements-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(130px, 1fr));
+  gap: 0.35cm;
+  align-items: stretch;
+  page-break-inside: avoid;
+  break-inside: avoid;
+}
+
+#overviewDialogContent .requirements-grid .requirement-box {
+  padding: 0.45em 0.6em;
+  font-size: 0.95em;
+  -webkit-column-break-inside: avoid;
+  -webkit-region-break-inside: avoid;
+  page-break-inside: avoid;
+  break-inside: avoid;
+}
+
+#overviewDialogContent .requirements-grid .requirement-box .req-icon {
+  --req-icon-size: 1.8rem;
+  margin-bottom: 0.35em;
+}
+
+#overviewDialogContent .requirements-grid .requirement-box .req-label {
+  font-size: 0.95em;
+}
+
+#overviewDialogContent .requirements-grid .requirement-box .req-value {
+  font-size: 0.9em;
+}
 #overviewDialogContent .gear-table td,
 #overviewDialogContent.dark-mode .gear-table td,
 body:not(.light-mode) .gear-table td {


### PR DESCRIPTION
## Summary
- sanitize and localize the printable overview title using the current project name and translations
- ensure the fallback print window embeds the escaped title so saved printouts inherit the expected filename
- reflow and shrink project requirement boxes in the print stylesheet to keep each box intact on the page

## Testing
- npm test --silent *(fails: eslint reports thousands of existing global "not defined" errors)*
- npm run test:jest --silent *(fails: Jest cannot parse pre-existing UMD wrapper in src/scripts/script.js)*

------
https://chatgpt.com/codex/tasks/task_e_68d1b636cba083208c4e47097b350388