### PR TITLE
Refine camera setup connector styling

### DIFF
--- a/src/styles/overview-print.css
+++ b/src/styles/overview-print.css
@@ -392,23 +392,27 @@ body:not(.light-mode) .gear-table .category-row td {
 }
 
 .power-conn {
-  background-color: var(--power-conn-bg) !important;
+  background: var(--panel-bg) !important;
   border: 1px solid var(--power-color) !important;
+  --icon-color: var(--power-color);
 }
 
 .fiz-conn {
-  background-color: var(--fiz-conn-bg) !important;
+  background: var(--panel-bg) !important;
   border: 1px dashed var(--fiz-color) !important;
+  --icon-color: var(--fiz-color);
 }
 
 .video-conn {
-  background-color: var(--video-conn-bg) !important;
+  background: var(--panel-bg) !important;
   border: 1px dotted var(--video-color) !important;
+  --icon-color: var(--video-color);
 }
 
 .neutral-conn {
-  background-color: var(--neutral-conn-bg) !important;
+  background: var(--panel-bg) !important;
   border: 1px double var(--control-text) !important;
+  --icon-color: var(--control-text);
 }
 
 #overviewDialogContent .barContainer {

--- a/src/styles/overview.css
+++ b/src/styles/overview.css
@@ -224,10 +224,10 @@ th { background-color: var(--control-bg); font-weight: var(--font-weight-bold); 
 .connector-summary { margin-top: 5px; display: flex; flex-wrap: wrap; gap: 4px; }
 .connector-block { padding: 2px 4px; border-radius: 4px; margin: 2px 2px 0 0; font-size: calc(var(--font-size-relative-base) * var(--font-scale-xs)); }
 .info-box { margin-top: 5px; padding: 6px 10px; border-radius: 4px; }
-.power-conn { background-color: var(--power-conn-bg); }
-.fiz-conn { background-color: var(--fiz-conn-bg); }
-.video-conn { background-color: var(--video-conn-bg); }
-.neutral-conn { background-color: var(--neutral-conn-bg); }
+.power-conn { --icon-color: var(--danger-color); }
+.fiz-conn { --icon-color: var(--success-color); }
+.video-conn { --icon-color: var(--info-color); }
+.neutral-conn { --icon-color: var(--neutral-color); }
 .diagram-section { margin-top: 20px; }
 .diagram-controls {
   margin-bottom: 10px;
@@ -268,11 +268,7 @@ th { background-color: var(--control-bg); font-weight: var(--font-weight-bold); 
   .device-category { background: var(--panel-bg); border-color: var(--panel-border); box-shadow: var(--panel-shadow); }
   .device-category h3 { border-bottom: 1px solid var(--inverse-text-color); color: var(--inverse-text-color); }
   .device-block { background: rgba(255,255,255,0.1); border-color: var(--control-border); box-shadow: var(--panel-shadow); }
-  .connector-block, .info-box { background-color: rgba(255,255,255,0.1); }
-  .power-conn { background-color: var(--power-conn-bg); }
-  .fiz-conn { background-color: var(--fiz-conn-bg); }
-  .video-conn { background-color: var(--video-conn-bg); }
-  .neutral-conn { background-color: var(--neutral-conn-bg); }
+  .connector-block, .info-box { background-color: transparent; }
   .gear-table td {
     border-top: 1px solid var(--inverse-text-color);
     border-bottom: 1px solid var(--inverse-text-color);

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -3348,7 +3348,7 @@ body.pink-mode #topBar #logo .logo-center {
   margin: 2px;
   border-radius: 3px;
   border: 1px solid;
-  background-color: rgba(0,0,0,0.03);
+  background-color: transparent;
   font-size: calc(var(--font-size-relative-base) * var(--font-scale-xxs));
 }
 
@@ -3378,7 +3378,7 @@ body.pink-mode #topBar #logo .logo-center {
   margin: 2px;
   border-radius: 3px;
   border: 1px solid;
-  background-color: rgba(0,0,0,0.03);
+  background-color: transparent;
   font-size: calc(var(--font-size-relative-base) * var(--font-scale-xxs));
 }
 
@@ -3391,7 +3391,7 @@ body.pink-mode #topBar #logo .logo-center {
   margin-top: 4px;
   padding: 4px;
   border-radius: 3px;
-  background: rgba(0,0,0,0.05);
+  background: transparent;
   font-size: calc(var(--font-size-relative-base) * var(--font-scale-xxs));
 }
 
@@ -3439,19 +3439,19 @@ body.pink-mode #topBar #logo .logo-center {
 
 .power-conn {
   border-color: var(--danger-color);
-  background-color: var(--power-conn-bg);
+  --icon-color: var(--danger-color);
 }
 .fiz-conn {
   border-color: var(--success-color);
-  background-color: var(--fiz-conn-bg);
+  --icon-color: var(--success-color);
 }
 .video-conn {
   border-color: var(--info-color);
-  background-color: var(--video-conn-bg);
+  --icon-color: var(--info-color);
 }
 .neutral-conn {
   border-color: var(--neutral-color);
-  background-color: var(--neutral-conn-bg);
+  --icon-color: var(--neutral-color);
 }
 
 
@@ -3840,9 +3840,9 @@ body.dark-mode.pink-mode {
 .dark-mode .barContainer { background-color: var(--panel-bg); }
 .dark-mode .device-category h4 { color: var(--inverse-text-color); border-bottom: 1px solid var(--inverse-text-color); }
 .dark-mode .connector-block,
-.dark-mode .info-box { background-color: rgba(255,255,255,0.1); }
-.dark-mode .scenario-box { background-color: rgba(255,255,255,0.1); }
-.dark-mode .tray-box { background-color: rgba(255,255,255,0.1); }
+.dark-mode .info-box { background-color: transparent; }
+.dark-mode .scenario-box { background-color: transparent; }
+.dark-mode .tray-box { background-color: transparent; }
 .dark-mode #setupDiagram .first-fiz-highlight { stroke: url(#firstFizGrad); }
 .dark-mode #setupDiagram text { fill: var(--inverse-text-color); }
 .dark-mode #setupDiagram line { stroke: var(--inverse-text-color); }
@@ -3940,9 +3940,9 @@ body.dark-mode.dark-accent-boost:not(.pink-mode) .settings-content.modal-surface
   body:not(.light-mode) .barContainer { background-color: var(--panel-bg); }
   body:not(.light-mode) .device-category h4 { color: var(--inverse-text-color); border-bottom: 1px solid var(--inverse-text-color); }
   body:not(.light-mode) .connector-block,
-  body:not(.light-mode) .info-box { background-color: rgba(255,255,255,0.1); }
-  body:not(.light-mode) .scenario-box { background-color: rgba(255,255,255,0.1); }
-  body:not(.light-mode) .tray-box { background-color: rgba(255,255,255,0.1); }
+  body:not(.light-mode) .info-box { background-color: transparent; }
+  body:not(.light-mode) .scenario-box { background-color: transparent; }
+  body:not(.light-mode) .tray-box { background-color: transparent; }
   body:not(.light-mode) #setupDiagram .first-fiz-highlight { stroke: url(#firstFizGrad); }
   body:not(.light-mode) #setupDiagram text { fill: var(--inverse-text-color); }
   body:not(.light-mode) #setupDiagram line { stroke: var(--inverse-text-color); }


### PR DESCRIPTION
## Summary
- remove tinted backgrounds from camera setup device badges so they inherit the page surface and rely on colored outlines and icons
- colorize connector icons via CSS variables and keep consistent behavior in dark mode and reduced motion variants
- update the printable overview styles to match the neutral background treatment while preserving outline cues

## Testing
- npm run lint *(fails: existing ESLint configuration reports numerous undefined globals in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d1b70c0fc88320be2d4d88a6985f05