### PR TITLE
Ensure overview diagram stays full width in overview dialog

### DIFF
--- a/src/styles/overview-print.css
+++ b/src/styles/overview-print.css
@@ -267,11 +267,18 @@ table, th, td {
   break-inside: avoid;
 }
 #overviewDialogContent #setupDiagram svg {
-  width: 90% !important;
-  max-width: 90%;
+  width: 100% !important;
+  max-width: none !important;
   height: auto !important;
   margin: 0 auto;
   display: block;
+}
+
+@media print {
+  #overviewDialogContent #setupDiagram svg {
+    width: 90% !important;
+    max-width: 90% !important;
+  }
 }
 #overviewDialogContent #setupDiagram #diagramArea {
   background: none !important;


### PR DESCRIPTION
## Summary
- set the default overview diagram SVG width for screen contexts to fill the available space
- restrict the diagram to 90% width only within print media so printed output keeps its intended margins

## Testing
- npm run test:jest -- --runTestsByPath tests/unit/service-worker.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d1b771d0188320a715da3d1788d7ca