### PR TITLE
Ensure overview backgrounds print consistently

### DIFF
--- a/src/styles/overview-print.css
+++ b/src/styles/overview-print.css
@@ -87,7 +87,7 @@ body.dark-mode {
 #overviewDialogContent.dark-mode {
   --surface-color: #fff;
   --text-color: #000;
-  --panel-bg: #f9f9f9;
+  --panel-bg: #fff;
   --panel-border: #ddd;
   --control-bg: #f0f0f0;
   --control-text: #333;
@@ -412,14 +412,14 @@ body:not(.light-mode) .gear-table .category-row td {
 
 
 .device-category {
-  background: var(--panel-bg) !important;
+  background: #ffffff !important;
   border: 1px solid var(--panel-border) !important;
   box-shadow: var(--panel-shadow);
 }
 
 .device-block {
-  background: rgba(255, 255, 255, 0.95) !important;
-  border: 1px solid var(--control-text) !important;
+  background: #ffffff !important;
+  border: 1px solid var(--panel-border) !important;
   box-shadow: var(--panel-shadow);
 }
 

--- a/src/styles/overview.css
+++ b/src/styles/overview.css
@@ -45,7 +45,7 @@ select:focus-visible {
   color: var(--status-error-text-color);
 }
 
-body { font-family: 'Ubuntu', sans-serif; font-weight: var(--font-weight-light); margin: 25px; color: var(--control-text); font-size: calc(var(--font-size-relative-base) * var(--font-scale-sm)); line-height: var(--line-height-base, 1.6); -webkit-print-color-adjust: exact; print-color-adjust: exact; }
+body { font-family: 'Ubuntu', sans-serif; font-weight: var(--font-weight-light); margin: 25px; color: var(--control-text); font-size: calc(var(--font-size-relative-base) * var(--font-scale-sm)); line-height: var(--line-height-base, 1.6); -webkit-print-color-adjust: exact; print-color-adjust: exact; background-color: #ffffff; }
 @media (max-width: 600px) {
   body { margin: 10px; }
   h2 { padding-bottom: 8px; }
@@ -159,9 +159,9 @@ th { background-color: var(--control-bg); font-weight: var(--font-weight-bold); 
 .device-block-grid.fiz-single-column {
   grid-template-columns: 1fr;
 }
-.device-block {
-  background: rgba(255,255,255,0.95);
-  border: 1px solid var(--control-text);
+.device-block { 
+  background: #ffffff;
+  border: 1px solid var(--panel-border);
   border-radius: 6px;
   padding: 6px 10px;
   box-shadow: var(--panel-shadow);
@@ -169,8 +169,8 @@ th { background-color: var(--control-bg); font-weight: var(--font-weight-bold); 
 }
 .device-block strong { display: block; margin-bottom: 4px; }
 .device-category-container { display: flex; flex-wrap: wrap; gap: 10px; }
-.device-category {
-  background: var(--panel-bg);
+.device-category { 
+  background: #ffffff;
   border: 1px solid var(--panel-border);
   border-radius: var(--border-radius);
   padding: 10px;

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -4352,6 +4352,12 @@ body:not(.dark-mode) .requirement-box,
   font-family: var(--font-family);
   font-weight: var(--font-weight-light);
 }
+
+#overviewDialogContent:not(.dark-mode) {
+  --surface-color: #ffffff;
+  --panel-bg: #ffffff;
+  background-color: #ffffff;
+}
 #overviewDialogContent h1,
 #overviewDialogContent h2,
 #overviewDialogContent h3 {
@@ -4409,8 +4415,8 @@ body:not(.dark-mode) .requirement-box,
   background-color: var(--panel-bg);
 }
 #overviewDialogContent .device-block {
-  background: rgba(255, 255, 255, 0.95);
-  border: 1px solid var(--control-text);
+  background: #ffffff;
+  border: 1px solid var(--panel-border);
   border-radius: 6px;
   padding: 6px 10px;
   box-shadow: var(--panel-shadow);
@@ -4426,7 +4432,7 @@ body:not(.dark-mode) .requirement-box,
   gap: 10px;
 }
 #overviewDialogContent .device-category {
-  background: var(--panel-bg);
+  background: #ffffff;
   border: 1px solid var(--panel-border);
   border-radius: var(--border-radius);
   padding: 10px;


### PR DESCRIPTION
## Summary
- unify the overview dialog surface with the white background used for printing
- adopt lighter borders for overview device blocks and categories to match the thinner design
- update the standalone overview and print styles to share the same neutral base

## Testing
- npm run lint *(fails: existing lint errors in legacy scripts)*

------
https://chatgpt.com/codex/tasks/task_e_68d1b883b7488320abe0707fc734c29e