### PR TITLE
Improve backup restore resilience

### DIFF
--- a/src/scripts/storage.js
+++ b/src/scripts/storage.js
@@ -80,6 +80,7 @@ const STORAGE_MIGRATION_BACKUP_SUFFIX = '__legacyMigrationBackup';
 const RAW_STORAGE_BACKUP_KEYS = new Set([
   getCustomFontStorageKeyName(),
   CUSTOM_LOGO_STORAGE_KEY,
+  DEVICE_SCHEMA_CACHE_KEY,
 ]);
 
 function createStorageMigrationBackup(storage, key, originalValue) {
@@ -3126,6 +3127,11 @@ function clearAllData() {
     const customFonts = readStoredCustomFonts();
     if (customFonts.length) {
       payload.customFonts = customFonts;
+    }
+
+    const schemaCache = readLocalStorageValue(DEVICE_SCHEMA_CACHE_KEY);
+    if (schemaCache !== null && schemaCache !== undefined) {
+      payload.schemaCache = schemaCache;
     }
 
     return payload;

--- a/tests/unit/storage.test.js
+++ b/tests/unit/storage.test.js
@@ -939,6 +939,15 @@ describe('export/import all data', () => {
     expect(exported.customLogo).toBe(backupLogo);
   });
 
+  test('exportAllData includes stored schema cache values', () => {
+    const schemaPayload = JSON.stringify({ version: 1, checksum: 'abc123' });
+    localStorage.setItem(SCHEMA_CACHE_KEY, schemaPayload);
+
+    const exported = exportAllData();
+
+    expect(exported.schemaCache).toBe(schemaPayload);
+  });
+
   test('importAllData restores planner data', () => {
     const data = {
       devices: validDeviceData,


### PR DESCRIPTION
## Summary
- add reusable helpers to snapshot and restore local/session storage and preference state during backup restores
- ensure full backup exports include schema cache data and keep a raw backup copy of the cache
- extend automated backup tests to cover rollback behaviour and cover schema cache export logic

## Testing
- npm run test:unit -- tests/unit/storage.test.js *(fails: versionConsistency.test.js expects APP_VERSION in src/scripts/script.js in current tree)*
- npm run test:jest -- tests/script/backupAutomation.test.js tests/unit/storage.test.js *(fails: jest cannot parse src/scripts/script.js because the bundled runtime is missing, pre-existing issue)*
- npx eslint src/scripts/app-session.js src/scripts/storage.js tests/script/backupAutomation.test.js tests/unit/storage.test.js *(fails: pre-existing global symbol warnings in app-session.js)*

------
https://chatgpt.com/codex/tasks/task_e_68d1b67cba4883208910929de453d73d