### PR TITLE
Add manual download fallback for backups

### DIFF
--- a/src/scripts/app-session.js
+++ b/src/scripts/app-session.js
@@ -1657,9 +1657,151 @@ function encodeBackupDataUrl(payload) {
   }
 }
 
-function downloadBackupPayload(payload, fileName) {
-  if (typeof payload !== 'string') {
+function getManualDownloadFallbackMessage() {
+  if (typeof texts === 'object' && texts) {
+    const lang = typeof currentLang === 'string' && texts[currentLang]
+      ? currentLang
+      : 'en';
+    const langTexts = texts[lang] || texts.en || {};
+    const fallback = langTexts.manualDownloadFallback || texts.en?.manualDownloadFallback;
+    if (fallback) {
+      return fallback;
+    }
+  }
+  return 'The download did not start automatically. A new tab opened so you can copy or save the file manually.';
+}
+
+function getManualDownloadCopyHint() {
+  if (typeof texts === 'object' && texts) {
+    const lang = typeof currentLang === 'string' && texts[currentLang]
+      ? currentLang
+      : 'en';
+    const langTexts = texts[lang] || texts.en || {};
+    const fallback = langTexts.manualDownloadCopyHint || texts.en?.manualDownloadCopyHint;
+    if (fallback) {
+      return fallback;
+    }
+  }
+  return 'Select all the text below and copy it to store the file safely.';
+}
+
+function openBackupFallbackWindow(payload, fileName) {
+  if (typeof window === 'undefined' || typeof window.open !== 'function') {
     return false;
+  }
+
+  let backupWindow = null;
+  try {
+    backupWindow = window.open('', '_blank');
+  } catch (openError) {
+    console.warn('Failed to open manual backup window', openError);
+    backupWindow = null;
+  }
+
+  if (!backupWindow) {
+    return false;
+  }
+
+  try {
+    const doc = backupWindow.document;
+    if (!doc) {
+      return false;
+    }
+
+    const langAttr = document && document.documentElement && document.documentElement.getAttribute
+      ? document.documentElement.getAttribute('lang')
+      : 'en';
+    doc.open();
+    doc.write(`<!DOCTYPE html><html lang="${langAttr || 'en'}"><head><meta charset="utf-8"><title>Manual download</title></head><body></body></html>`);
+    doc.close();
+
+    try {
+      doc.title = fileName || 'backup.json';
+    } catch (titleError) {
+      void titleError;
+    }
+
+    const body = doc.body;
+    if (!body) {
+      return false;
+    }
+
+    body.style.margin = '0';
+    body.style.padding = '1.5rem';
+    body.style.background = '#f8f9fb';
+    body.style.color = '#0f172a';
+    body.style.fontFamily = "system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif";
+
+    const container = doc.createElement('div');
+    container.style.maxWidth = '960px';
+    container.style.margin = '0 auto';
+    container.style.display = 'flex';
+    container.style.flexDirection = 'column';
+    container.style.gap = '1rem';
+
+    const heading = doc.createElement('h1');
+    heading.textContent = fileName || 'Manual backup';
+    heading.style.margin = '0';
+    heading.style.fontSize = '1.5rem';
+    heading.style.fontWeight = '600';
+
+    const description = doc.createElement('p');
+    description.textContent = getManualDownloadFallbackMessage();
+    description.style.margin = '0';
+    description.style.lineHeight = '1.5';
+
+    const helper = doc.createElement('p');
+    helper.textContent = getManualDownloadCopyHint();
+    helper.style.margin = '0';
+    helper.style.lineHeight = '1.5';
+
+    const textArea = doc.createElement('textarea');
+    textArea.value = payload;
+    textArea.readOnly = true;
+    textArea.spellcheck = false;
+    textArea.style.width = '100%';
+    textArea.style.height = '70vh';
+    textArea.style.resize = 'vertical';
+    textArea.style.padding = '1rem';
+    textArea.style.borderRadius = '1rem';
+    textArea.style.border = '1px solid rgba(15, 23, 42, 0.15)';
+    textArea.style.background = '#ffffff';
+    textArea.style.fontFamily = "'SFMono-Regular', 'Roboto Mono', 'Menlo', 'Courier New', monospace";
+    textArea.style.fontSize = '0.875rem';
+    textArea.style.lineHeight = '1.5';
+    textArea.style.boxShadow = '0 0.75rem 2.5rem rgba(15, 23, 42, 0.16)';
+
+    container.appendChild(heading);
+    container.appendChild(description);
+    container.appendChild(helper);
+    container.appendChild(textArea);
+    body.appendChild(container);
+
+    try {
+      textArea.focus();
+      textArea.select();
+    } catch (focusError) {
+      void focusError;
+    }
+
+    try {
+      backupWindow.focus();
+    } catch (focusWindowError) {
+      void focusWindowError;
+    }
+
+    return true;
+  } catch (renderError) {
+    console.warn('Failed to render manual backup window', renderError);
+    return false;
+  }
+}
+
+function downloadBackupPayload(payload, fileName) {
+  const failureResult = { success: false, method: null };
+
+  if (typeof payload !== 'string') {
+    return failureResult;
   }
 
   let blob = null;
@@ -1676,7 +1818,7 @@ function downloadBackupPayload(payload, fileName) {
     if (typeof navigator !== 'undefined' && typeof navigator.msSaveOrOpenBlob === 'function') {
       try {
         navigator.msSaveOrOpenBlob(blob, fileName);
-        return true;
+        return { success: true, method: 'ms-save' };
       } catch (msError) {
         console.warn('Saving backup via msSaveOrOpenBlob failed', msError);
       }
@@ -1702,7 +1844,7 @@ function downloadBackupPayload(payload, fileName) {
         }
 
         if (triggered) {
-          return true;
+          return { success: true, method: 'object-url' };
         }
       }
     }
@@ -1710,10 +1852,17 @@ function downloadBackupPayload(payload, fileName) {
 
   const dataUrl = encodeBackupDataUrl(payload);
   if (dataUrl) {
-    return triggerBackupDownload(dataUrl, fileName);
+    const triggered = triggerBackupDownload(dataUrl, fileName);
+    if (triggered) {
+      return { success: true, method: 'data-url' };
+    }
   }
 
-  return false;
+  if (openBackupFallbackWindow(payload, fileName)) {
+    return { success: true, method: 'window-fallback' };
+  }
+
+  return failureResult;
 }
 
 function createSettingsBackup(notify = true, timestamp = new Date()) {
@@ -1732,11 +1881,17 @@ function createSettingsBackup(notify = true, timestamp = new Date()) {
       data: typeof exportAllData === 'function' ? exportAllData() : {},
     };
     const payload = JSON.stringify(backup);
-    const downloaded = downloadBackupPayload(payload, fileName);
-    if (!downloaded) {
+    const downloadResult = downloadBackupPayload(payload, fileName);
+    if (!downloadResult || !downloadResult.success) {
       throw new Error('No supported download method available');
     }
-    if (shouldNotify) {
+    if (downloadResult.method === 'window-fallback') {
+      const manualMessage = getManualDownloadFallbackMessage();
+      showNotification('warning', manualMessage);
+      if (typeof alert === 'function') {
+        alert(manualMessage);
+      }
+    } else if (shouldNotify) {
       showNotification('success', 'Full app backup downloaded');
     }
     return fileName;

--- a/src/scripts/app-setups.js
+++ b/src/scripts/app-setups.js
@@ -176,14 +176,32 @@ function downloadSharedProject(shareFileName, includeAutoGear) {
     return;
   }
 
-  const downloaded = downloadBackupPayload(json, shareFileName);
+  const downloadResult = downloadBackupPayload(json, shareFileName);
 
   if (shareIncludeAutoGearCheckbox) {
     shareIncludeAutoGearCheckbox.checked = includeAutoGear && hasAutoGearRules;
   }
 
-  if (!downloaded) {
+  if (!downloadResult || !downloadResult.success) {
     notifyShareFailure();
+    return;
+  }
+
+  if (downloadResult.method === 'window-fallback') {
+    const manualMessage = typeof getManualDownloadFallbackMessage === 'function'
+      ? getManualDownloadFallbackMessage()
+      : getLocalizedText('manualDownloadFallback')
+        || 'The download did not start automatically. A new tab opened so you can copy or save the file manually.';
+    if (shareLinkMessage) {
+      shareLinkMessage.textContent = manualMessage;
+      setStatusLevel(shareLinkMessage, 'warning');
+      shareLinkMessage.classList.remove('hidden');
+      if (typeof setTimeout === 'function') {
+        setTimeout(() => shareLinkMessage.classList.add('hidden'), 8000);
+      }
+    } else if (typeof alert === 'function') {
+      alert(manualMessage);
+    }
     return;
   }
 

--- a/src/scripts/translations.js
+++ b/src/scripts/translations.js
@@ -340,6 +340,9 @@ const texts = {
       "Automatic backup saved. Restore it anytime from Saved Projects.",
     preDeleteBackupFailed: "Automatic backup failed. The action was cancelled.",
     restoreBackupFailed: "Backup failed. Restore cancelled.",
+    manualDownloadFallback:
+      "The download didn't start automatically. A new tab opened with the file contents so you can copy or save them manually.",
+    manualDownloadCopyHint: "Select all the text below and copy it to keep the file safe.",
     dataHeading: "Data & Storage",
     dataHeadingHelp:
       "Review what the planner stores locally and how much space backups take.",
@@ -1600,6 +1603,10 @@ const texts = {
       "Backup automatico salvato. Puoi ripristinarlo da Progetti salvati.",
     preDeleteBackupFailed: "Backup automatico non riuscito. L'operazione è stata annullata.",
     restoreBackupFailed: "Backup non riuscito. Ripristino annullato.",
+    manualDownloadFallback:
+      "Il download non è partito automaticamente. Si è aperta una nuova scheda con il contenuto del file così puoi copiarlo o salvarlo manualmente.",
+    manualDownloadCopyHint:
+      "Seleziona tutto il testo qui sotto e copialo per conservare il file in modo sicuro.",
     dataHeading: "Dati e archiviazione",
     dataHeadingHelp:
       "Controlla quali dati vengono salvati localmente e quanto spazio occupano i backup.",
@@ -2461,6 +2468,10 @@ const texts = {
       "Copia de seguridad automática guardada. Puedes restaurarla desde Proyectos guardados.",
     preDeleteBackupFailed: "La copia de seguridad automática falló. La acción se canceló.",
     restoreBackupFailed: "La copia de seguridad falló. Restauración cancelada.",
+    manualDownloadFallback:
+      "La descarga no se inició automáticamente. Se abrió una pestaña nueva con el contenido del archivo para que puedas copiarlo o guardarlo manualmente.",
+    manualDownloadCopyHint:
+      "Selecciona todo el texto de abajo y cópialo para guardar el archivo de forma segura.",
     dataHeading: "Datos y almacenamiento",
     dataHeadingHelp:
       "Revisa qué guarda el planificador en este navegador y cuánto ocupan las copias de seguridad.",
@@ -3324,6 +3335,10 @@ const texts = {
       "Sauvegarde automatique enregistrée. Vous pouvez la restaurer depuis Projets enregistrés.",
     preDeleteBackupFailed: "La sauvegarde automatique a échoué. L’action a été annulée.",
     restoreBackupFailed: "Échec de la sauvegarde. Restauration annulée.",
+    manualDownloadFallback:
+      "Le téléchargement ne s’est pas lancé automatiquement. Un nouvel onglet s’est ouvert avec le contenu du fichier pour que vous puissiez le copier ou l’enregistrer manuellement.",
+    manualDownloadCopyHint:
+      "Sélectionnez tout le texte ci-dessous et copiez-le pour conserver le fichier en lieu sûr.",
     dataHeading: "Données et stockage",
     dataHeadingHelp:
       "Consultez ce que le planificateur conserve localement et la taille des sauvegardes.",
@@ -4190,6 +4205,10 @@ const texts = {
       "Automatische Sicherung gespeichert. Du kannst sie in Gespeicherte Projekte wiederherstellen.",
     preDeleteBackupFailed: "Automatische Sicherung fehlgeschlagen. Die Aktion wurde abgebrochen.",
     restoreBackupFailed: "Backup fehlgeschlagen. Wiederherstellung abgebrochen.",
+    manualDownloadFallback:
+      "Der Download wurde nicht automatisch gestartet. Ein neuer Tab mit dem Dateiinhalt wurde geöffnet, damit du ihn manuell kopieren oder speichern kannst.",
+    manualDownloadCopyHint:
+      "Markiere den gesamten Text unten und kopiere ihn, um die Datei sicher zu speichern.",
     dataHeading: "Daten & Speicherung",
     dataHeadingHelp:
       "Zeigt, welche Planer-Daten lokal gespeichert sind und wie groß Sicherungen werden.",


### PR DESCRIPTION
## Summary
- add a manual browser-tab fallback when backup downloads are blocked so users can still copy their data
- reuse the fallback flow for shared project exports and surface warnings when manual steps are required
- localize new manual download guidance across all supported languages

## Testing
- npm run lint *(fails: existing eslint errors in the codebase not introduced in this change)*

------
https://chatgpt.com/codex/tasks/task_e_68d1b9e55588832098acdac6f2924124