### PR TITLE
Hide overview favorites controls and sync selector background

### DIFF
--- a/src/styles/overview-print.css
+++ b/src/styles/overview-print.css
@@ -392,6 +392,10 @@ body:not(.light-mode) .gear-table .auto-gear-item {
   min-width: 0;
   max-width: 100%;
   flex: 0 0 auto;
+  background-color: var(--panel-bg);
+  color: inherit;
+  border-color: var(--panel-border);
+  box-shadow: none;
 }
 
 #overviewDialogContent .gear-table .gear-item select + select {

--- a/src/styles/overview.css
+++ b/src/styles/overview.css
@@ -84,6 +84,17 @@ th { background-color: var(--control-bg); font-weight: var(--font-weight-bold); 
   page-break-inside: avoid;
 }
 
+#overviewDialogContent .favorite-toggle {
+  display: none !important;
+}
+
+#overviewDialogContent .gear-table .gear-item select {
+  background-color: var(--panel-bg);
+  color: inherit;
+  border-color: var(--panel-border);
+  box-shadow: none;
+}
+
 .gear-table .category-row td {
   border-top: 1px solid var(--accent-color);
   border-bottom: 1px solid var(--accent-color);


### PR DESCRIPTION
## Summary
- hide favorite toggle buttons inside the overview dialog so they stay out of printable exports
- match gear-list selector backgrounds to the section background in screen and print styles for a cohesive view

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d1babca1808320a800ac4ae60a1f45