### PR TITLE
chore: update legacy build

### DIFF
--- a/legacy/scripts/app-core.js
+++ b/legacy/scripts/app-core.js
@@ -9917,7 +9917,9 @@ function updateInstallBannerVisibility() {
 }
 function updateInstallBannerColors() {
   if (!installPromptBanner) return;
-  if (typeof window === 'undefined' || typeof window.getComputedStyle !== 'function') return;
+  if (typeof window === 'undefined' || typeof window.getComputedStyle !== 'function') {
+    return;
+  }
   try {
     var root = document.documentElement;
     if (!root) return;
@@ -10030,7 +10032,7 @@ function setupInstallBanner() {
   if (installPromptBannerDismiss) {
     installPromptBannerDismiss.addEventListener('click', function (event) {
       event.preventDefault();
-      if (event.stopPropagation) event.stopPropagation();
+      event.stopPropagation();
       markInstallBannerDismissed();
       updateInstallBannerVisibility();
     });

--- a/legacy/scripts/overview.js
+++ b/legacy/scripts/overview.js
@@ -23,6 +23,7 @@ function generatePrintableOverview() {
     it: 'it-IT'
   };
   var lang = typeof currentLang === 'string' ? currentLang : 'en';
+  var t = (typeof texts === "undefined" ? "undefined" : _typeof(texts)) === 'object' && texts ? texts[lang] || texts.en || {} : {};
   var locale = localeMap[lang] || 'en-US';
   var dateTimeString = now.toLocaleDateString(locale) + ' ' + now.toLocaleTimeString();
   var fallbackProjectName = currentProjectInfo && typeof currentProjectInfo.projectName === 'string' ? currentProjectInfo.projectName.trim() : '';
@@ -37,10 +38,14 @@ function generatePrintableOverview() {
   var formattedDate = "".concat(now.getFullYear(), "-").concat(padTwo(now.getMonth() + 1), "-").concat(padTwo(now.getDate()));
   var formattedTime = "".concat(padTwo(now.getHours()), "-").concat(padTwo(now.getMinutes()), "-").concat(padTwo(now.getSeconds()));
   var timestampLabel = "".concat(formattedDate, " ").concat(formattedTime).trim();
+  var safeTimestampLabel = sanitizeTitleSegment(timestampLabel) || timestampLabel;
   var projectTitleSegment = sanitizeTitleSegment(projectNameForTitle) || 'Project';
-  var printDocumentTitle = [timestampLabel, projectTitleSegment, '- -', 'Project Overview and Gear List'].filter(Boolean).join(' ').replace(/\s+/g, ' ').trim();
+  var overviewLabel = sanitizeTitleSegment((t.overviewTitle || '').trim());
+  var gearListLabel = sanitizeTitleSegment((t.gearListNav || '').trim());
+  var suffixRaw = [overviewLabel, gearListLabel].filter(Boolean).join(' – ');
+  var suffixSegment = sanitizeTitleSegment(suffixRaw) || 'Project Overview and Gear List';
+  var printDocumentTitle = [safeTimestampLabel, projectTitleSegment, suffixSegment].filter(Boolean).join(' - ').replace(/\s+/g, ' ').trim();
   var originalDocumentTitle = typeof document !== 'undefined' ? document.title : '';
-  var t = (typeof texts === "undefined" ? "undefined" : _typeof(texts)) === 'object' && texts ? texts[lang] || texts.en || {} : {};
   var customLogo = typeof localStorage !== 'undefined' ? localStorage.getItem('customLogo') : null;
   var deviceListHtml = '<div class="device-category-container">';
   var sections = {};
@@ -364,8 +369,9 @@ function generatePrintableOverview() {
     var bodyElement = typeof document !== 'undefined' ? document.body : null;
     var bodyClassName = bodyElement ? bodyElement.className : '';
     var bodyInlineStyle = bodyElement ? bodyElement.getAttribute('style') || '' : '';
+    var escapedPrintDocumentTitle = escapeHtmlSafe(printDocumentTitle);
     doc.open();
-    doc.write("<!DOCTYPE html>\n<html>\n<head>\n<meta charset=\"utf-8\">\n<meta name=\"color-scheme\" content=\"light dark\">\n<title></title>\n<link rel=\"stylesheet\" href=\"src/styles/style.css\">\n<link rel=\"stylesheet\" href=\"src/styles/overview.css\">\n<link rel=\"stylesheet\" href=\"src/styles/overview-print.css\" media=\"print\">\n<link rel=\"stylesheet\" href=\"overview-print.css\" media=\"screen\">\n</head>\n<body></body>\n</html>");
+    doc.write("<!DOCTYPE html>\n<html>\n<head>\n<meta charset=\"utf-8\">\n<meta name=\"color-scheme\" content=\"light dark\">\n<title>".concat(escapedPrintDocumentTitle, "</title>\n<link rel=\"stylesheet\" href=\"src/styles/style.css\">\n<link rel=\"stylesheet\" href=\"src/styles/overview.css\">\n<link rel=\"stylesheet\" href=\"src/styles/overview-print.css\" media=\"print\">\n<link rel=\"stylesheet\" href=\"overview-print.css\" media=\"screen\">\n</head>\n<body></body>\n</html>"));
     doc.close();
     doc.title = printDocumentTitle;
     var fallbackHtml = doc.documentElement;

--- a/legacy/scripts/script.js
+++ b/legacy/scripts/script.js
@@ -1,50 +1,24 @@
+function _toConsumableArray(r) { return _arrayWithoutHoles(r) || _iterableToArray(r) || _unsupportedIterableToArray(r) || _nonIterableSpread(); }
+function _nonIterableSpread() { throw new TypeError("Invalid attempt to spread non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
+function _unsupportedIterableToArray(r, a) { if (r) { if ("string" == typeof r) return _arrayLikeToArray(r, a); var t = {}.toString.call(r).slice(8, -1); return "Object" === t && r.constructor && (t = r.constructor.name), "Map" === t || "Set" === t ? Array.from(r) : "Arguments" === t || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(t) ? _arrayLikeToArray(r, a) : void 0; } }
+function _iterableToArray(r) { if ("undefined" != typeof Symbol && null != r[Symbol.iterator] || null != r["@@iterator"]) return Array.from(r); }
+function _arrayWithoutHoles(r) { if (Array.isArray(r)) return _arrayLikeToArray(r); }
+function _arrayLikeToArray(r, a) { (null == a || a > r.length) && (a = r.length); for (var e = 0, n = Array(a); e < a; e++) n[e] = r[e]; return n; }
 if (typeof require === 'function' && typeof module !== 'undefined' && module && module.exports) {
   var fs = require('fs');
   var path = require('path');
   var parts = ['app-core.js', 'app-events.js', 'app-setups.js', 'app-session.js'];
-  var nodePrelude = [
-    "var __cineGlobal = typeof globalThis !== 'undefined' ? globalThis : (typeof global !== 'undefined' ? global : this);",
-    "var window = __cineGlobal.window || __cineGlobal;",
-    "if (!__cineGlobal.window) __cineGlobal.window = window;",
-    "var self = __cineGlobal.self || window;",
-    "if (!__cineGlobal.self) __cineGlobal.self = self;",
-    "var document = __cineGlobal.document || (window && window.document) || undefined;",
-    "if (document && !window.document) window.document = document;",
-    "if (!__cineGlobal.document && document) __cineGlobal.document = document;",
-    "var navigator = __cineGlobal.navigator || (window && window.navigator) || undefined;",
-    "if (navigator && !window.navigator) window.navigator = navigator;",
-    "if (!__cineGlobal.navigator && navigator) __cineGlobal.navigator = navigator;",
-    "var localStorage = __cineGlobal.localStorage || (window && window.localStorage) || undefined;",
-    "if (localStorage && !window.localStorage) window.localStorage = localStorage;",
-    "if (!__cineGlobal.localStorage && localStorage) __cineGlobal.localStorage = localStorage;",
-    "var sessionStorage = __cineGlobal.sessionStorage || (window && window.sessionStorage) || undefined;",
-    "if (sessionStorage && !window.sessionStorage) window.sessionStorage = sessionStorage;",
-    "if (!__cineGlobal.sessionStorage && sessionStorage) __cineGlobal.sessionStorage = sessionStorage;",
-    "var location = __cineGlobal.location || (window && window.location) || undefined;",
-    "if (location && !window.location) window.location = location;",
-    "if (!__cineGlobal.location && location) __cineGlobal.location = location;",
-    "var caches = __cineGlobal.caches || (window && window.caches) || undefined;",
-    "if (caches && !window.caches) window.caches = caches;",
-    "if (!__cineGlobal.caches && caches) __cineGlobal.caches = caches;"
-  ].join('\n');
-
-  var combinedSource = [nodePrelude];
-  for (var i = 0; i < parts.length; i += 1) {
-    combinedSource.push(fs.readFileSync(path.join(__dirname, parts[i]), 'utf8'));
-  }
-
-  var factory = new Function('exports', 'require', 'module', '__filename', '__dirname', combinedSource.join('\n'));
+  var nodePrelude = ["var __cineGlobal = typeof globalThis !== 'undefined' ? globalThis : (typeof global !== 'undefined' ? global : this);", "var window = __cineGlobal.window || __cineGlobal;", "if (!__cineGlobal.window) __cineGlobal.window = window;", "var self = __cineGlobal.self || window;", "if (!__cineGlobal.self) __cineGlobal.self = self;", "var document = __cineGlobal.document || (window && window.document) || undefined;", "if (document && !window.document) window.document = document;", "if (!__cineGlobal.document && document) __cineGlobal.document = document;", "var navigator = __cineGlobal.navigator || (window && window.navigator) || undefined;", "if (navigator && !window.navigator) window.navigator = navigator;", "if (!__cineGlobal.navigator && navigator) __cineGlobal.navigator = navigator;", "var localStorage = __cineGlobal.localStorage || (window && window.localStorage) || undefined;", "if (localStorage && !window.localStorage) window.localStorage = localStorage;", "if (!__cineGlobal.localStorage && localStorage) __cineGlobal.localStorage = localStorage;", "var sessionStorage = __cineGlobal.sessionStorage || (window && window.sessionStorage) || undefined;", "if (sessionStorage && !window.sessionStorage) window.sessionStorage = sessionStorage;", "if (!__cineGlobal.sessionStorage && sessionStorage) __cineGlobal.sessionStorage = sessionStorage;", "var location = __cineGlobal.location || (window && window.location) || undefined;", "if (location && !window.location) window.location = location;", "if (!__cineGlobal.location && location) __cineGlobal.location = location;", "var caches = __cineGlobal.caches || (window && window.caches) || undefined;", "if (caches && !window.caches) window.caches = caches;", "if (!__cineGlobal.caches && caches) __cineGlobal.caches = caches;"].join('\n');
+  var combinedSource = [nodePrelude].concat(_toConsumableArray(parts.map(function (part) {
+    return fs.readFileSync(path.join(__dirname, part), 'utf8');
+  }))).join('\n');
+  var factory = new Function('exports', 'require', 'module', '__filename', '__dirname', combinedSource);
   factory(module.exports, require, module, __filename, __dirname);
-
   var combinedAppVersion = module.exports && module.exports.APP_VERSION;
-  var APP_VERSION = "1.0.5"; // Version marker for consistency checks
-
+  var APP_VERSION = "1.0.5";
   if (combinedAppVersion && combinedAppVersion !== APP_VERSION) {
-    throw new Error(
-      "Combined app version (" + combinedAppVersion + ") does not match script marker (" + APP_VERSION + ")."
-    );
+    throw new Error("Combined app version (".concat(combinedAppVersion, ") does not match script marker (").concat(APP_VERSION, ")."));
   }
-
   if (module.exports && !module.exports.APP_VERSION) {
     module.exports.APP_VERSION = APP_VERSION;
   }


### PR DESCRIPTION
## Summary
- rebuild the legacy bundle so it includes the latest session/storage safeguards such as safe storage readers, backup payload sanitation, and temperature unit preference handling
- ensure the regenerated legacy overview output uses localized fallbacks and sanitized title fragments
- pull in the updated install banner guards and babel helpers from the current source tree

## Testing
- npm run test:script

------
https://chatgpt.com/codex/tasks/task_e_68d1bd134b208320bceb8ae95d1be8da