### PR TITLE
Adjust overview dialog width to A4 size

### DIFF
--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -4380,7 +4380,7 @@ body:not(.dark-mode) .requirement-box,
 
 /* Overview dialog */
 #overviewDialog {
-  width: min(96vw, 1100px);
+  width: min(96vw, 210mm);
   max-width: none;
   padding: 0;
   border: none;


### PR DESCRIPTION
## Summary
- set the overview dialog width to match an A4 page using a 210mm target while keeping responsiveness for smaller viewports

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d1bf9f905c8320b297e1f179edc17f