### PR TITLE
refactor: load modular runtime in tests without lint noise

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -2,9 +2,9 @@ const js = require('@eslint/js');
 const globals = require('globals');
 
 module.exports = [
-  { ignores: ['vendor/**', 'src/vendor/**', 'legacy/**'] },
-  js.configs.recommended,
+  { ignores: ['vendor/**', 'src/vendor/**'] },
   {
+    ...js.configs.recommended,
     files: ['**/*.js'],
     ignores: ['node_modules/**', 'vendor/**', 'src/vendor/**', 'legacy/**'],
     languageOptions: {
@@ -38,6 +38,21 @@ module.exports = [
   },
   {
     files: ['src/scripts/app-*.js'],
+    rules: {
+      'no-undef': 'off',
+      'no-unused-vars': 'off',
+    },
+  },
+  {
+    files: ['legacy/**/*.js'],
+    languageOptions: {
+      ecmaVersion: 2021,
+      sourceType: 'module',
+      globals: {
+        ...globals.browser,
+        ...globals.node,
+      },
+    },
     rules: {
       'no-undef': 'off',
       'no-unused-vars': 'off',

--- a/tests/helpers/runtimeLoader.js
+++ b/tests/helpers/runtimeLoader.js
@@ -1,0 +1,84 @@
+const fs = require('fs');
+const path = require('path');
+const { createRequire } = require('module');
+
+const ROOT_DIR = path.join(__dirname, '..', '..');
+const SCRIPTS_DIR = path.join(ROOT_DIR, 'src', 'scripts');
+const SCRIPT_FILENAME = path.join(SCRIPTS_DIR, 'script.js');
+
+const RUNTIME_PARTS = ['app-core.js', 'app-events.js', 'app-setups.js', 'app-session.js'];
+
+const NODE_PRELUDE = [
+  "var __cineGlobal = typeof globalThis !== 'undefined' ? globalThis : (typeof global !== 'undefined' ? global : this);",
+  "var window = __cineGlobal.window || __cineGlobal;",
+  "if (!__cineGlobal.window) __cineGlobal.window = window;",
+  "var self = __cineGlobal.self || window;",
+  "if (!__cineGlobal.self) __cineGlobal.self = self;",
+  "var document = __cineGlobal.document || (window && window.document) || undefined;",
+  "if (document && !window.document) window.document = document;",
+  "if (!__cineGlobal.document && document) __cineGlobal.document = document;",
+  "var navigator = __cineGlobal.navigator || (window && window.navigator) || undefined;",
+  "if (navigator && !window.navigator) window.navigator = navigator;",
+  "if (!__cineGlobal.navigator && navigator) __cineGlobal.navigator = navigator;",
+  "var localStorage = __cineGlobal.localStorage || (window && window.localStorage) || undefined;",
+  "if (localStorage && !window.localStorage) window.localStorage = localStorage;",
+  "if (!__cineGlobal.localStorage && localStorage) __cineGlobal.localStorage = localStorage;",
+  "var sessionStorage = __cineGlobal.sessionStorage || (window && window.sessionStorage) || undefined;",
+  "if (sessionStorage && !window.sessionStorage) window.sessionStorage = sessionStorage;",
+  "if (!__cineGlobal.sessionStorage && sessionStorage) __cineGlobal.sessionStorage = sessionStorage;",
+  "var location = __cineGlobal.location || (window && window.location) || undefined;",
+  "if (location && !window.location) window.location = location;",
+  "if (!__cineGlobal.location && location) __cineGlobal.location = location;",
+  "var caches = __cineGlobal.caches || (window && window.caches) || undefined;",
+  "if (caches && !window.caches) window.caches = caches;",
+  "if (!__cineGlobal.caches && caches) __cineGlobal.caches = caches;"
+].join('\n');
+
+const { version: APP_VERSION } = require(path.join(ROOT_DIR, 'package.json'));
+
+let combinedSource;
+
+function buildCombinedSource() {
+  if (!combinedSource) {
+    const partsSource = RUNTIME_PARTS
+      .map(part => fs.readFileSync(path.join(SCRIPTS_DIR, part), 'utf8'))
+      .join('\n');
+    combinedSource = `${NODE_PRELUDE}\n${partsSource}`;
+  }
+  return combinedSource;
+}
+
+function loadRuntime() {
+  const runtimeModule = { exports: {} };
+  const runtimeRequire = createRequire(SCRIPT_FILENAME);
+
+  const factory = new Function(
+    'exports',
+    'require',
+    'module',
+    '__filename',
+    '__dirname',
+    buildCombinedSource()
+  );
+
+  factory(runtimeModule.exports, runtimeRequire, runtimeModule, SCRIPT_FILENAME, SCRIPTS_DIR);
+
+  const { exports } = runtimeModule;
+  const combinedAppVersion = exports && exports.APP_VERSION;
+
+  if (combinedAppVersion && combinedAppVersion !== APP_VERSION) {
+    throw new Error(
+      `Combined app version (${combinedAppVersion}) does not match package version (${APP_VERSION}).`
+    );
+  }
+
+  if (exports && !combinedAppVersion) {
+    exports.APP_VERSION = APP_VERSION;
+  }
+
+  return exports;
+}
+
+module.exports = {
+  loadRuntime,
+};

--- a/tests/helpers/scriptEnvironment.js
+++ b/tests/helpers/scriptEnvironment.js
@@ -143,7 +143,8 @@ function setupScriptEnvironment(options = {}) {
 
   let utils;
   jest.isolateModules(() => {
-    utils = require('../../src/scripts/script.js');
+    const { loadRuntime } = require('./runtimeLoader');
+    utils = loadRuntime();
   });
 
   restoreReadyState(readyStateDescriptor);

--- a/tests/script/backupAutomation.test.js
+++ b/tests/script/backupAutomation.test.js
@@ -61,7 +61,8 @@ const loadApp = () => {
   global.clearAllData = jest.fn();
   global.showNotification = jest.fn();
 
-  return require('../../src/scripts/script.js');
+  const { loadRuntime } = require('../helpers/runtimeLoader');
+  return loadRuntime();
 };
 
 let fakeTimersActive = false;

--- a/tests/script/helpers/loadApp.js
+++ b/tests/script/helpers/loadApp.js
@@ -57,7 +57,8 @@ function loadApp() {
   global.clearAllData = jest.fn();
   global.showNotification = jest.fn();
 
-  return require('../../../src/scripts/script.js');
+  const { loadRuntime } = require('../../helpers/runtimeLoader');
+  return loadRuntime();
 }
 
 module.exports = {


### PR DESCRIPTION
## Summary
- apply the recommended ESLint rules to application sources while relaxing checks for generated legacy files
- add a reusable runtime loader helper that recreates the modular browser bundle for Node-based tests
- update script test helpers to load the runtime through the new helper so Jest can execute the split modules reliably

## Testing
- npm run lint
- npm test --silent

------
https://chatgpt.com/codex/tasks/task_e_68d1bd0d0a608320a2eacca3f53904d4