### PR TITLE
Avoid redeclaring temperature storage key in session module

### DIFF
--- a/src/scripts/app-session.js
+++ b/src/scripts/app-session.js
@@ -1,10 +1,12 @@
 // --- SESSION STATE HANDLING ---
-/* global resolveTemperatureStorageKey */
+/* global resolveTemperatureStorageKey, TEMPERATURE_STORAGE_KEY */
 
-const TEMPERATURE_STORAGE_KEY =
-  typeof resolveTemperatureStorageKey === 'function'
-    ? resolveTemperatureStorageKey()
-    : 'cameraPowerPlanner_temperatureUnit';
+const temperaturePreferenceStorageKey =
+  typeof TEMPERATURE_STORAGE_KEY === 'string'
+    ? TEMPERATURE_STORAGE_KEY
+    : typeof resolveTemperatureStorageKey === 'function'
+      ? resolveTemperatureStorageKey()
+      : 'cameraPowerPlanner_temperatureUnit';
 
 function saveCurrentSession(options = {}) {
   if (restoringSession || factoryResetInProgress) return;
@@ -2003,7 +2005,7 @@ function applyPreferencesFromStorage(safeGetItem) {
     return { showAutoBackups: false, accentColor: null, language: null };
   }
 
-  const restoredTemperatureUnit = safeGetItem(TEMPERATURE_STORAGE_KEY);
+  const restoredTemperatureUnit = safeGetItem(temperaturePreferenceStorageKey);
   if (restoredTemperatureUnit) {
     try {
       applyTemperatureUnitPreference(restoredTemperatureUnit, { persist: false });


### PR DESCRIPTION
## Summary
- reuse the existing temperature preference storage key instead of redeclaring it inside the session logic
- keep fallback resolution so the preference loader still works when the shared key is unavailable

## Testing
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68d1c1bad6a883209248fc88483dfaca