### PR TITLE
Improve feature search tokenization for alpha-numeric queries

### DIFF
--- a/src/scripts/app-core.js
+++ b/src/scripts/app-core.js
@@ -12132,6 +12132,32 @@ const searchTokens = str => {
     const cleaned = token.replace(/[^a-z0-9]+/g, '');
     if (cleaned) tokens.add(cleaned);
   };
+  const isAlpha = value => /^[a-z]+$/.test(value);
+  const isNumeric = value => /^\d+$/.test(value);
+  const addAlphaNumericVariants = segment => {
+    if (!segment) return;
+    const groups = segment.match(/[a-z]+|\d+/g);
+    if (!groups || groups.length <= 1) return;
+    groups.forEach(part => {
+      if (isNumeric(part) || part.length > 1) {
+        addToken(part);
+      }
+    });
+    for (let index = 0; index < groups.length - 1; index += 1) {
+      const current = groups[index];
+      const next = groups[index + 1];
+      if (!current || !next) continue;
+      const combined = `${current}${next}`;
+      if (!combined || combined === segment) continue;
+      if (
+        (isAlpha(current) && isNumeric(next)) ||
+        (isNumeric(current) && isAlpha(next)) ||
+        (current.length > 1 && next.length > 1)
+      ) {
+        addToken(combined);
+      }
+    }
+  };
   const processParts = (strToProcess, collectInitials = false) => {
     strToProcess.split(/\s+/).forEach(part => {
       if (!part) return;
@@ -12141,6 +12167,7 @@ const searchTokens = str => {
         .filter(Boolean)
         .forEach(segment => {
           addToken(segment);
+          addAlphaNumericVariants(segment);
           if (collectInitials && /^[a-z]/.test(segment)) {
             initialWords.push(segment);
           }

--- a/tests/script/featureSearch.test.js
+++ b/tests/script/featureSearch.test.js
@@ -132,6 +132,13 @@ describe('global feature search helpers', () => {
     );
   });
 
+  test('searchTokens expose tokens split across letter and number boundaries', () => {
+    const tokens = searchTokens('FX6 4K120p Module');
+    expect(tokens).toEqual(
+      expect.arrayContaining(['fx', '6', '4k', '120p', '120'])
+    );
+  });
+
   test('findBestSearchMatch resolves initialism queries', () => {
     const entries = new Map();
     entries.set(


### PR DESCRIPTION
## Summary
- extend search tokenization to add tokens across letter/number boundaries so queries like "FX 6" or "4K 120p" rank correctly
- update the feature search unit tests to cover the new token exposure

## Testing
- npm run test:jest

------
https://chatgpt.com/codex/tasks/task_e_68d1c1073f448320bfc83e4f3adc6c8f