### PR TITLE
Normalize unicode fractions in search

### DIFF
--- a/legacy/scripts/app-core.js
+++ b/legacy/scripts/app-core.js
@@ -11245,6 +11245,35 @@ var normaliseMarkVariants = function normaliseMarkVariants(str) {
     return "mk".concat(suffix);
   });
 };
+var UNICODE_FRACTIONS = new Map([
+  ['¼', '1/4'],
+  ['½', '1/2'],
+  ['¾', '3/4'],
+  ['⅓', '1/3'],
+  ['⅔', '2/3'],
+  ['⅕', '1/5'],
+  ['⅖', '2/5'],
+  ['⅗', '3/5'],
+  ['⅘', '4/5'],
+  ['⅙', '1/6'],
+  ['⅚', '5/6'],
+  ['⅛', '1/8'],
+  ['⅜', '3/8'],
+  ['⅝', '5/8'],
+  ['⅞', '7/8'],
+  ['⅑', '1/9'],
+  ['⅒', '1/10'],
+  ['⅐', '1/7']
+]);
+var UNICODE_FRACTION_PATTERN = UNICODE_FRACTIONS.size > 0 ? new RegExp("[".concat(Array.from(UNICODE_FRACTIONS.keys()).join(''), "]"), 'g') : null;
+var normalizeUnicodeFractions = function normalizeUnicodeFractions(str) {
+  if (!UNICODE_FRACTION_PATTERN || typeof str !== 'string' || !str) {
+    return str;
+  }
+  return str.replace(UNICODE_FRACTION_PATTERN, function (match) {
+    return UNICODE_FRACTIONS.get(match) || match;
+  });
+};
 var SPELLING_VARIANTS = new Map([['analyse', 'analyze'], ['analysed', 'analyzed'], ['analyses', 'analyzes'], ['analysing', 'analyzing'], ['behaviour', 'behavior'], ['behaviours', 'behaviors'], ['behavioural', 'behavioral'], ['behaviourally', 'behaviorally'], ['centre', 'center'], ['centres', 'centers'], ['colour', 'color'], ['colourful', 'colorful'], ['colouring', 'coloring'], ['colourings', 'colorings'], ['colourless', 'colorless'], ['colours', 'colors'], ['customisation', 'customization'], ['customisations', 'customizations'], ['customise', 'customize'], ['customised', 'customized'], ['customises', 'customizes'], ['customising', 'customizing'], ['defence', 'defense'], ['defences', 'defenses'], ['favour', 'favor'], ['favourable', 'favorable'], ['favourably', 'favorably'], ['favoured', 'favored'], ['favourite', 'favorite'], ['favourites', 'favorites'], ['favouring', 'favoring'], ['favours', 'favors'], ['licence', 'license'], ['licences', 'licenses'], ['localisation', 'localization'], ['localisations', 'localizations'], ['localise', 'localize'], ['localised', 'localized'], ['localises', 'localizes'], ['localising', 'localizing'], ['modelling', 'modeling'], ['modeller', 'modeler'], ['modellers', 'modelers'], ['optimisation', 'optimization'], ['optimisations', 'optimizations'], ['optimise', 'optimize'], ['optimised', 'optimized'], ['optimises', 'optimizes'], ['optimising', 'optimizing'], ['organisation', 'organization'], ['organisations', 'organizations'], ['organise', 'organize'], ['organised', 'organized'], ['organises', 'organizes'], ['organising', 'organizing'], ['personalisation', 'personalization'], ['personalisations', 'personalizations'], ['personalise', 'personalize'], ['personalised', 'personalized'], ['personalises', 'personalizes'], ['personalising', 'personalizing'], ['practise', 'practice'], ['practised', 'practiced'], ['practises', 'practices'], ['practising', 'practicing'], ['theatre', 'theater'], ['theatres', 'theaters'], ['traveller', 'traveler'], ['travellers', 'travelers'], ['travelling', 'traveling']]);
 var SPELLING_VARIANT_PATTERN = SPELLING_VARIANTS.size > 0 ? new RegExp("\\b(".concat(Array.from(SPELLING_VARIANTS.keys()).join('|'), ")\\b"), 'g') : null;
 var normalizeSpellingVariants = function normalizeSpellingVariants(str) {
@@ -11261,6 +11290,7 @@ var searchKey = function searchKey(str) {
     normalized = normalized.normalize('NFD');
   }
   normalized = normalized.replace(/[\u0300-\u036f]/g, '').replace(/ß/g, 'ss').replace(/æ/g, 'ae').replace(/œ/g, 'oe').replace(/ø/g, 'o').replace(/&/g, 'and').replace(/\+/g, 'plus').replace(/[°º˚]/g, 'deg').replace(/\bdegrees?\b/g, 'deg').replace(/[×✕✖✗✘]/g, 'x');
+  normalized = normalizeUnicodeFractions(normalized);
   normalized = normalizeSpellingVariants(normalized);
   normalized = normaliseMarkVariants(normalized);
   var simplified = normalized.replace(/[^a-z0-9]+/g, '');
@@ -11274,6 +11304,7 @@ var searchTokens = function searchTokens(str) {
     normalized = normalized.normalize('NFD');
   }
   normalized = normalized.replace(/[\u0300-\u036f]/g, '').replace(/ß/g, 'ss').replace(/æ/g, 'ae').replace(/œ/g, 'oe').replace(/ø/g, 'o').replace(/&/g, ' and ').replace(/\+/g, ' plus ').replace(/[°º˚]/g, ' deg ').replace(/\bdegrees?\b/g, ' deg ').replace(/[×✕✖✗✘]/g, ' x by ');
+  normalized = normalizeUnicodeFractions(normalized);
   var tokens = new Set();
   var initialWords = [];
   var addToken = function addToken(token) {

--- a/src/scripts/app-core.js
+++ b/src/scripts/app-core.js
@@ -12027,6 +12027,42 @@ const normaliseMarkVariants = str =>
     return `mk${suffix}`;
   });
 
+const UNICODE_FRACTIONS = new Map([
+  ['¼', '1/4'],
+  ['½', '1/2'],
+  ['¾', '3/4'],
+  ['⅓', '1/3'],
+  ['⅔', '2/3'],
+  ['⅕', '1/5'],
+  ['⅖', '2/5'],
+  ['⅗', '3/5'],
+  ['⅘', '4/5'],
+  ['⅙', '1/6'],
+  ['⅚', '5/6'],
+  ['⅛', '1/8'],
+  ['⅜', '3/8'],
+  ['⅝', '5/8'],
+  ['⅞', '7/8'],
+  ['⅑', '1/9'],
+  ['⅒', '1/10'],
+  ['⅐', '1/7']
+]);
+
+const UNICODE_FRACTION_PATTERN =
+  UNICODE_FRACTIONS.size > 0
+    ? new RegExp(`[${Array.from(UNICODE_FRACTIONS.keys()).join('')}]`, 'g')
+    : null;
+
+const normalizeUnicodeFractions = (str) => {
+  if (!UNICODE_FRACTION_PATTERN || typeof str !== 'string' || !str) {
+    return str;
+  }
+  return str.replace(
+    UNICODE_FRACTION_PATTERN,
+    match => UNICODE_FRACTIONS.get(match) || match
+  );
+};
+
 const SPELLING_VARIANTS = new Map([
   ['analyse', 'analyze'],
   ['analysed', 'analyzed'],
@@ -12128,6 +12164,7 @@ const searchKey       = str => {
     .replace(/[°º˚]/g, 'deg')
     .replace(/\bdegrees?\b/g, 'deg')
     .replace(/[×✕✖✗✘]/g, 'x');
+  normalized = normalizeUnicodeFractions(normalized);
   normalized = normalizeSpellingVariants(normalized);
   normalized = normaliseMarkVariants(normalized);
   const simplified = normalized.replace(/[^a-z0-9]+/g, '');
@@ -12152,6 +12189,7 @@ const searchTokens = str => {
     .replace(/[°º˚]/g, ' deg ')
     .replace(/\bdegrees?\b/g, ' deg ')
     .replace(/[×✕✖✗✘]/g, ' x by ');
+  normalized = normalizeUnicodeFractions(normalized);
   const tokens = new Set();
   const initialWords = [];
   const addToken = token => {

--- a/tests/script/featureSearch.test.js
+++ b/tests/script/featureSearch.test.js
@@ -176,6 +176,15 @@ describe('global feature search helpers', () => {
     expect(searchKey('3840×2160')).toBe(searchKey('3840 x 2160'));
   });
 
+  test('searchKey normalizes unicode fraction characters', () => {
+    expect(searchKey('¼"-20 Mount')).toBe(
+      searchKey('1/4"-20 Mount')
+    );
+    expect(searchKey('⅜-16 Thread Adapter')).toBe(
+      searchKey('3/8-16 Thread Adapter')
+    );
+  });
+
   test('searchTokens expose degree and multiplication variants', () => {
     expect(searchTokens('35° Tilt Module')).toEqual(
       expect.arrayContaining(['35', 'deg'])
@@ -185,6 +194,15 @@ describe('global feature search helpers', () => {
     );
     expect(searchTokens('3840×2160 (UHD)')).toEqual(
       expect.arrayContaining(['3840', '2160', 'x', 'by'])
+    );
+  });
+
+  test('searchTokens expose unicode fraction variants', () => {
+    expect(searchTokens('¼-20 Mounting Point')).toEqual(
+      expect.arrayContaining(['1420', '1', '4', '20'])
+    );
+    expect(searchTokens('⅜-16 Mounting Point')).toEqual(
+      expect.arrayContaining(['3816', '3', '8', '16'])
     );
   });
 
@@ -245,6 +263,25 @@ describe('global feature search helpers', () => {
       searchTokens('3840 by 2160')
     );
     expect(resolutionMatch?.value.label).toBe('3840×2160 (UHD)');
+  });
+
+  test('findBestSearchMatch links unicode fraction queries to ascii entries', () => {
+    const entries = new Map();
+    entries.set(
+      searchKey('1/4-20 Mount Adapter'),
+      {
+        label: '1/4-20 Mount Adapter',
+        tokens: searchTokens('1/4-20 Mount Adapter')
+      }
+    );
+
+    const fractionMatch = findBestSearchMatch(
+      entries,
+      searchKey('¼-20 mount adapter'),
+      searchTokens('¼-20 mount adapter')
+    );
+
+    expect(fractionMatch?.value.label).toBe('1/4-20 Mount Adapter');
   });
 
   test('searchKey treats mark and mk numbering the same', () => {


### PR DESCRIPTION
## Summary
- normalize unicode fraction glyphs before computing search keys and tokens so fractional thread sizes match regardless of notation
- mirror the unicode fraction handling in the legacy bundle to keep offline builds consistent
- extend the feature search test suite to cover unicode fraction keys, tokens, and matching behaviour

## Testing
- npx jest --runInBand --selectProjects script --runTestsByPath tests/script/featureSearch.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d1c4d0e2988320a86135a8a078c243