### PR TITLE
Fix missing connector summary generator guard

### DIFF
--- a/legacy/scripts/app-core.js
+++ b/legacy/scripts/app-core.js
@@ -50,6 +50,47 @@ try {
   var _require = require('./overview.js');
   generatePrintableOverview = _require.generatePrintableOverview;
 } catch (_unused2) {}
+
+function resolveConnectorSummaryGenerator() {
+  var scopes = [];
+  if (typeof globalThis !== 'undefined') scopes.push(globalThis);
+  if (typeof window !== 'undefined') scopes.push(window);
+  if (typeof global !== 'undefined') scopes.push(global);
+  if (typeof self !== 'undefined') scopes.push(self);
+
+  for (var i = 0; i < scopes.length; i++) {
+    var scope = scopes[i];
+    if (scope && typeof scope.generateConnectorSummary === 'function') {
+      return scope.generateConnectorSummary;
+    }
+  }
+
+  if (typeof generateConnectorSummary === 'function') {
+    return generateConnectorSummary;
+  }
+
+  return null;
+}
+
+function safeGenerateConnectorSummary(device) {
+  if (!device) {
+    return '';
+  }
+
+  var generator = resolveConnectorSummaryGenerator();
+  if (typeof generator !== 'function') {
+    return '';
+  }
+  try {
+    var summary = generator(device);
+    return summary || '';
+  } catch (error) {
+    if (typeof console !== 'undefined' && typeof console.warn === 'function') {
+      console.warn('Unable to generate connector summary', error);
+    }
+    return '';
+  }
+}
 if (typeof window !== 'undefined') {
   var lottie = window.lottie;
   if (lottie && typeof lottie.useWebWorker === 'function') {
@@ -13469,7 +13510,7 @@ function displayGearAndRequirements(html) {
         if (categoryParts.length) parts.push(categoryParts.join(' – '));
         if (libraryCategory) parts.push("Device library category: ".concat(libraryCategory));
         if (deviceInfo) {
-          var summary = generateConnectorSummary(deviceInfo);
+          var summary = safeGenerateConnectorSummary(deviceInfo);
           summary = summary ? summary.replace(/<[^>]+>/g, '').replace(/\s+/g, ' ').trim() : '';
           if (deviceInfo.notes) summary = summary ? "".concat(summary, "; Notes: ").concat(deviceInfo.notes) : deviceInfo.notes;
           if (summary) parts.push(summary);
@@ -17704,7 +17745,7 @@ function attachDiagramPopups(map) {
       var _devices$info$categor;
       deviceData = (_devices$info$categor = devices[info.category]) === null || _devices$info$categor === void 0 ? void 0 : _devices$info$categor[info.name];
     }
-    var connectors = deviceData ? generateConnectorSummary(deviceData) : '';
+    var connectors = deviceData ? safeGenerateConnectorSummary(deviceData) : '';
     var infoHtml = (deviceData && deviceData.latencyMs ? "<div class=\"info-box video-conn\"><strong>Latency:</strong> ".concat(escapeHtml(String(deviceData.latencyMs)), "</div>") : '') + (deviceData && deviceData.frequency ? "<div class=\"info-box video-conn\"><strong>Frequency:</strong> ".concat(escapeHtml(String(deviceData.frequency)), "</div>") : '');
     var html = "<strong>".concat(escapeHtml(info.name), "</strong>") + connectors + infoHtml;
     var show = function show(e) {
@@ -18044,7 +18085,7 @@ function renderDeviceList(categoryKey, ulElement) {
     header.className = "device-summary";
     var nameSpan = document.createElement("span");
     nameSpan.textContent = name;
-    var summary = generateConnectorSummary(deviceData);
+    var summary = safeGenerateConnectorSummary(deviceData);
     summary = summary ? summary.replace(/<[^>]+>/g, '').replace(/\s+/g, ' ').trim() : '';
     if (deviceData.notes) {
       summary = summary ? "".concat(summary, "; Notes: ").concat(deviceData.notes) : deviceData.notes;

--- a/src/scripts/app-core.js
+++ b/src/scripts/app-core.js
@@ -29,12 +29,37 @@ try {
   // overview generation not needed in test environments without module support
 }
 
+function resolveConnectorSummaryGenerator() {
+  const scopes = [];
+  if (typeof globalThis !== 'undefined') scopes.push(globalThis);
+  if (typeof window !== 'undefined') scopes.push(window);
+  if (typeof global !== 'undefined') scopes.push(global);
+  if (typeof self !== 'undefined') scopes.push(self);
+
+  for (const scope of scopes) {
+    if (scope && typeof scope.generateConnectorSummary === 'function') {
+      return scope.generateConnectorSummary;
+    }
+  }
+
+  if (typeof generateConnectorSummary === 'function') {
+    return generateConnectorSummary;
+  }
+
+  return null;
+}
+
 function safeGenerateConnectorSummary(device) {
-  if (!device || typeof generateConnectorSummary !== 'function') {
+  if (!device) {
+    return '';
+  }
+
+  const generator = resolveConnectorSummaryGenerator();
+  if (typeof generator !== 'function') {
     return '';
   }
   try {
-    const summary = generateConnectorSummary(device);
+    const summary = generator(device);
     return summary || '';
   } catch (error) {
     if (typeof console !== 'undefined' && typeof console.warn === 'function') {


### PR DESCRIPTION
## Summary
- resolve the connector summary generator from any available global scope before invoking it so that runtime loads without ReferenceErrors
- update the legacy bundle to reuse the safe connector summary helper wherever device summaries are needed

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d1ca7617b08320869265a04587b736