### PR TITLE
Fix duplicate global backup history binding

### DIFF
--- a/src/scripts/app-session.js
+++ b/src/scripts/app-session.js
@@ -8,16 +8,16 @@ const temperaturePreferenceStorageKey =
       ? resolveTemperatureStorageKey()
       : 'cameraPowerPlanner_temperatureUnit';
 
-let recordFullBackupHistoryEntry = () => {};
+let recordFullBackupHistoryEntryFn = () => {};
 try {
-  ({ recordFullBackupHistoryEntry } = require('./storage.js'));
+  ({ recordFullBackupHistoryEntry: recordFullBackupHistoryEntryFn } = require('./storage.js'));
 } catch (error) {
   if (
     typeof window !== 'undefined'
     && window
     && typeof window.recordFullBackupHistoryEntry === 'function'
   ) {
-    recordFullBackupHistoryEntry = window.recordFullBackupHistoryEntry;
+    recordFullBackupHistoryEntryFn = window.recordFullBackupHistoryEntry;
   } else {
     void error;
   }
@@ -2123,7 +2123,7 @@ function createSettingsBackup(notify = true, timestamp = new Date()) {
       throw new Error('No supported download method available');
     }
     try {
-      recordFullBackupHistoryEntry({ createdAt: iso, fileName });
+      recordFullBackupHistoryEntryFn({ createdAt: iso, fileName });
     } catch (historyError) {
       console.warn('Failed to record full backup history entry', historyError);
     }


### PR DESCRIPTION
## Summary
- rename the local recordFullBackupHistoryEntry reference in app-session to avoid conflicting with the global assignment
- continue wiring the function from storage or window into the renamed reference and use it when recording backups

## Testing
- npm run test:unit

------
https://chatgpt.com/codex/tasks/task_e_68d1cd3822c0832083a15bfafbf6afa4