### PR TITLE
Prevent setup diagram from shrinking below the intended default size

### DIFF
--- a/src/scripts/app-core.js
+++ b/src/scripts/app-core.js
@@ -18342,7 +18342,8 @@ function renderSetupDiagram() {
         ? diagramFontSizePx
         : DEFAULT_MAX_NODE_FONT;
       const maxAutoScale = bodyFontSize / referenceFontSize;
-      svgEl.style.maxWidth = `${viewWidth * maxAutoScale}px`;
+      const scaleFactor = Math.max(1, maxAutoScale);
+      svgEl.style.maxWidth = `${viewWidth * scaleFactor}px`;
     }
   }
 


### PR DESCRIPTION
## Summary
- ensure the setup diagram never scales below its computed default width on desktop

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1ccd6f81883209618f35456531115