### PR TITLE
Fix global backup history function redeclaration error

### DIFF
--- a/src/scripts/storage.js
+++ b/src/scripts/storage.js
@@ -2750,7 +2750,7 @@ function saveFullBackupHistory(entries) {
   );
 }
 
-function recordFullBackupHistoryEntry(entry) {
+const recordFullBackupHistoryEntry = entry => {
   const normalized = normalizeFullBackupHistoryEntry(entry);
   if (!normalized) {
     return loadFullBackupHistory();
@@ -2760,7 +2760,7 @@ function recordFullBackupHistoryEntry(entry) {
   const trimmed = history.slice(-MAX_FULL_BACKUP_HISTORY_ENTRIES);
   saveFullBackupHistory(trimmed);
   return trimmed;
-}
+};
 
 function normalizeImportedFullBackupHistory(value) {
   if (value === null || value === undefined) {


### PR DESCRIPTION
## Summary
- declare the `recordFullBackupHistoryEntry` helper with block scope to avoid redeclaring a global function

## Testing
- npm run test:unit

------
https://chatgpt.com/codex/tasks/task_e_68d1cf4634308320b9b78e00e60eb76e