### PR TITLE
Fix splitGearListHtml fallback for missing requirement headings

### DIFF
--- a/src/scripts/app-core.js
+++ b/src/scripts/app-core.js
@@ -13872,11 +13872,53 @@ function splitGearListHtml(html) {
   }
   const doc = new DOMParser().parseFromString(html, 'text/html');
   const title = doc.querySelector('h2');
-  const h3s = doc.querySelectorAll('h3');
-  const reqHeading = h3s[0];
   const reqGrid = doc.querySelector('.requirements-grid');
   const titleHtml = title ? title.outerHTML : '';
-  const projectHtml = reqHeading && reqGrid ? titleHtml + reqHeading.outerHTML + reqGrid.outerHTML : '';
+  let headingHtml = '';
+  let headingNodeUsed = null;
+  if (reqGrid) {
+    const isHeadingTag = element => Boolean(element && /^H[1-6]$/i.test(element.tagName));
+    const headingIsProjectTitle = element => Boolean(title && element && typeof element.isSameNode === 'function' && element.isSameNode(title));
+    const headingBeforeGrid = element => {
+      if (!element || typeof element.compareDocumentPosition !== 'function') return false;
+      return Boolean(element.compareDocumentPosition(reqGrid) & Node.DOCUMENT_POSITION_FOLLOWING);
+    };
+
+    let headingNode = null;
+    let sibling = reqGrid.previousElementSibling;
+    while (sibling) {
+      if (isHeadingTag(sibling) && !headingIsProjectTitle(sibling) && headingBeforeGrid(sibling)) {
+        headingNode = sibling;
+        break;
+      }
+      sibling = sibling.previousElementSibling;
+    }
+
+    if (!headingNode) {
+      const parent = reqGrid.parentElement;
+      if (parent) {
+        const candidates = Array.from(parent.querySelectorAll('h1, h2, h3, h4, h5, h6'));
+        for (let i = candidates.length - 1; i >= 0; i -= 1) {
+          const candidate = candidates[i];
+          if (!isHeadingTag(candidate)) continue;
+          if (headingIsProjectTitle(candidate)) continue;
+          if (headingBeforeGrid(candidate)) {
+            headingNode = candidate;
+            break;
+          }
+        }
+      }
+    }
+
+    if (headingNode) {
+      headingNodeUsed = headingNode;
+      headingHtml = headingNode.outerHTML;
+    } else {
+      const fallbackLabel = reqGrid.getAttribute('data-heading') || 'Project Requirements';
+      headingHtml = `<h3>${escapeHtml(fallbackLabel)}</h3>`;
+    }
+  }
+  const projectHtml = reqGrid ? titleHtml + headingHtml + reqGrid.outerHTML : '';
   const projectName = extractProjectNameFromHeading(title);
   let table = doc.querySelector('.gear-table');
   if (!table) {
@@ -13905,9 +13947,18 @@ function splitGearListHtml(html) {
         const cloneTitle = bodyClone.querySelector('h2');
         if (cloneTitle) cloneTitle.remove();
       }
-      if (reqHeading) {
+      if (headingNodeUsed) {
+        const headingTag = headingNodeUsed.tagName ? headingNodeUsed.tagName.toLowerCase() : '';
+        const headingText = headingNodeUsed.textContent ? headingNodeUsed.textContent.trim() : '';
+        const cloneHeading = headingTag ? bodyClone.querySelector(headingTag) : null;
+        if (cloneHeading && (!headingText || (cloneHeading.textContent || '').trim() === headingText)) {
+          cloneHeading.remove();
+        }
+      } else {
         const cloneHeading = bodyClone.querySelector('h3');
-        if (cloneHeading) cloneHeading.remove();
+        if (cloneHeading && /project requirements/i.test(cloneHeading.textContent || '')) {
+          cloneHeading.remove();
+        }
       }
       if (reqGrid) {
         const cloneGrid = bodyClone.querySelector('.requirements-grid');

--- a/tests/script/splitGearListHtml.test.js
+++ b/tests/script/splitGearListHtml.test.js
@@ -48,6 +48,36 @@ describe('splitGearListHtml', () => {
     expect(gearHtml).not.toContain('id="requirements"');
   });
 
+  test('reconstructs project requirements when heading markup is missing', () => {
+    const legacyHtml = `
+      <h2>Project Two</h2>
+      <div class="requirements-grid"><div class="requirement-box">Codec: H.264</div></div>
+      <h3>Gear List</h3>
+      <table class="gear-table"><tr><td>Main Kit Item</td></tr></table>
+    `;
+    const { projectHtml, gearHtml } = global.splitGearListHtml(legacyHtml);
+
+    expect(projectHtml).toContain('requirements-grid');
+    expect(projectHtml).toContain('Codec: H.264');
+    expect(projectHtml).toContain('<h3>Project Requirements</h3>');
+    const h2Matches = projectHtml.match(/<h2>/g) || [];
+    expect(h2Matches).toHaveLength(1);
+    expect(gearHtml).toContain('Gear List');
+  });
+
+  test('uses custom heading label stored on the requirements grid when missing heading markup', () => {
+    const legacyHtml = `
+      <h2>Projekt Eins</h2>
+      <div class="requirements-grid" data-heading="Projektdetails"><div class="requirement-box">Codec: ARRIRAW</div></div>
+      <h3>Gear List</h3>
+      <table class="gear-table"><tr><td>Main Kit Item</td></tr></table>
+    `;
+    const { projectHtml } = global.splitGearListHtml(legacyHtml);
+
+    expect(projectHtml).toContain('<h3>Projektdetails</h3>');
+    expect(projectHtml).toContain('requirements-grid');
+  });
+
   test('wraps category rows into tbody groups when missing grouping markup', () => {
     const legacyHtml = `
       <h2>Project Overview for "Night Shoot"</h2>


### PR DESCRIPTION
## Summary
- ensure splitGearListHtml detects the requirement heading even when the saved markup lacks a dedicated <h3>
- fall back to data-heading or a default label without duplicating the project title
- add regression tests covering saved gear lists that miss requirement headings

## Testing
- npm test -- splitGearListHtml

------
https://chatgpt.com/codex/tasks/task_e_68d1d0398f5083209233beef841068a5