### PR TITLE
Increase spacing between button icons and labels

### DIFF
--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -44,7 +44,7 @@
   --button-link-padding-block: var(--button-padding-block);
   --button-link-padding-inline: 12px;
   --icon-gap: 0.3em;
-  --button-icon-gap: 0.75em;
+  --button-icon-gap: 1em;
   --form-control-font-size: var(--font-size-relative-base);
   --form-label-width: 150px;
   --form-label-min-width: 120px;
@@ -173,7 +173,7 @@ body.relaxed-spacing {
   --form-label-min-width: 140px;
   --button-size: 30px;
   --button-line-height: 1.45;
-  --button-icon-gap: 0.9em;
+  --button-icon-gap: 1.15em;
   --form-row-margin-block: 8px;
   --button-link-padding-inline: 16px;
 }


### PR DESCRIPTION
## Summary
- Increase the default `--button-icon-gap` CSS variable so button icons sit farther from their labels.
- Adjust the relaxed-spacing variant to keep its relative spacing increase in step with the default.

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d1d17bf7448320a862155e2c81263b