### PR TITLE
Increase spacing between button icons and text

### DIFF
--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -44,7 +44,7 @@
   --button-link-padding-block: var(--button-padding-block);
   --button-link-padding-inline: 12px;
   --icon-gap: 0.3em;
-  --button-icon-gap: 1em;
+  --button-icon-gap: 1.35em;
   --form-control-font-size: var(--font-size-relative-base);
   --form-label-width: 150px;
   --form-label-min-width: 120px;
@@ -173,7 +173,7 @@ body.relaxed-spacing {
   --form-label-min-width: 140px;
   --button-size: 30px;
   --button-line-height: 1.45;
-  --button-icon-gap: 1.15em;
+  --button-icon-gap: 1.6em;
   --form-row-margin-block: 8px;
   --button-link-padding-inline: 16px;
 }


### PR DESCRIPTION
## Summary
- increase the default `--button-icon-gap` to give button icons more breathing room next to their labels
- expand the relaxed spacing variant’s icon gap so it remains proportionally larger

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1d3628ae88320804d7f443c7fd6ae