### PR TITLE
Enhance help quick start guidance

### DIFF
--- a/index.html
+++ b/index.html
@@ -1422,6 +1422,74 @@
               along and verify every step.
             </li>
           </ul>
+          <div
+            id="helpQuickStartGuide"
+            class="help-callout"
+            role="note"
+            aria-label="Quick start checklist"
+          >
+            <h4>Quick start checklist</h4>
+            <ol>
+              <li>
+                Name your project and press <strong>Save</strong> (or press <kbd>Enter</kbd>/<kbd>Ctrl</kbd>+<kbd>S</kbd>) to
+                capture the current rig before experimenting—saved entries stay available offline.
+              </li>
+              <li>
+                Walk through <em>Configure Devices</em>, the <em>Power Summary</em> and the <em>Connection Diagram</em> in
+                order. Each section updates immediately so you can verify power draw, cable routing and runtime checks at a
+                glance.
+              </li>
+              <li>
+                Before wrapping up, download an <strong>Export project</strong> JSON and a full-app <strong>Backup</strong> so
+                you have two offline recovery copies that can be restored from the <em>Backup &amp; Restore</em> panel.
+              </li>
+            </ol>
+            <p class="help-callout-note">
+              Tip: Keep backups on separate drives when travelling—restoring always makes a fresh safety copy so nothing is
+              lost if you undo a change.
+            </p>
+          </div>
+          <div
+            id="helpKeyboardShortcuts"
+            class="help-callout"
+            role="note"
+            aria-label="Essential keyboard shortcuts"
+          >
+            <h4>Essential shortcuts</h4>
+            <ul>
+              <li><kbd>?</kbd>, <kbd>H</kbd> or <kbd>F1</kbd> — open this help dialog instantly.</li>
+              <li><kbd>Ctrl</kbd>+<kbd>/</kbd> (<kbd>⌘</kbd>+<kbd>/</kbd>) — toggle help even while typing in a field.</li>
+              <li><kbd>/</kbd> or <kbd>Ctrl</kbd>+<kbd>F</kbd> (<kbd>⌘</kbd>+<kbd>F</kbd>) — jump straight to the help search.</li>
+              <li><kbd>Ctrl</kbd>+<kbd>K</kbd> (<kbd>⌘</kbd>+<kbd>K</kbd>) — focus the global feature search and jump to any
+                planner screen.</li>
+              <li><kbd>Ctrl</kbd>+<kbd>,</kbd> (<kbd>⌘</kbd>+<kbd>,</kbd>) — open Settings to adjust themes, backups and
+                preferences.</li>
+              <li><kbd>Ctrl</kbd>+<kbd>S</kbd> (<kbd>⌘</kbd>+<kbd>S</kbd>) — save the active project without leaving the
+                planner.</li>
+              <li><kbd>D</kbd> — toggle dark mode on or off to match your lighting environment.</li>
+              <li><kbd>P</kbd> — switch the playful pink theme and store the preference for next time.</li>
+            </ul>
+          </div>
+          <div class="help-link-group" aria-label="Help basics shortcuts">
+            <a
+              class="help-link button-link"
+              href="#helpQuickStartGuide"
+              data-help-target="#helpQuickStartGuide"
+              data-help-highlight="#helpQuickStartGuide"
+            >Quick start checklist</a>
+            <a
+              class="help-link button-link"
+              href="#helpKeyboardShortcuts"
+              data-help-target="#helpKeyboardShortcuts"
+              data-help-highlight="#helpKeyboardShortcuts"
+            >Keyboard shortcuts</a>
+            <a
+              class="help-link button-link"
+              href="#helpDialog"
+              data-help-target="#hoverHelpButton"
+              data-help-highlight="#hoverHelpButton"
+            >Enable hover help</a>
+          </div>
         </section>
         <section
           data-help-section


### PR DESCRIPTION
## Summary
- add a quick start checklist callout in the help dialog that emphasises saving, walking through core planners and keeping offline backups
- highlight essential keyboard shortcuts for help, search, settings, saving and theme toggles to speed up navigation
- provide quick links from the Start Here section to jump directly to the new callouts and hover-help toggle

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d1d1c8012883208a3ab3673486e2c7