### PR TITLE
Improve legacy backup compatibility

### DIFF
--- a/legacy/scripts/app-session.js
+++ b/legacy/scripts/app-session.js
@@ -1449,7 +1449,7 @@ function sanitizeBackupPayload(raw) {
 var BACKUP_STORAGE_KEY_PREFIXES = ['cameraPowerPlanner_'];
 var BACKUP_STORAGE_KNOWN_KEYS = new Set(['darkMode', 'pinkMode', 'highContrast', 'showAutoBackups', 'accentColor', 'fontSize', 'fontFamily', 'customLogo', 'language', IOS_PWA_HELP_STORAGE_KEY]);
 var BACKUP_METADATA_BASE_KEYS = new Set(['settings', 'storage', 'localStorage', 'values', 'entries', 'sessionStorage', 'sessionState', 'sessionEntries', 'payload', 'plannerData', 'allData', 'generatedAt', 'version', 'appVersion', 'applicationVersion']);
-var BACKUP_DATA_KEYS = ['devices', 'setups', 'session', 'feedback', 'project', 'projects', 'gearList', 'favorites', 'autoGearRules', 'autoGearSeeded', 'autoGearBackups', 'autoGearPresets', 'autoGearActivePresetId', 'autoGearAutoPresetId', 'autoGearShowBackups', 'customLogo', 'customFonts', 'preferences'];
+var BACKUP_DATA_KEYS = ['devices', 'setups', 'session', 'feedback', 'project', 'projects', 'gearList', 'favorites', 'autoGearRules', 'autoGearSeeded', 'autoGearBackups', 'autoGearPresets', 'autoGearActivePresetId', 'autoGearAutoPresetId', 'autoGearShowBackups', 'customLogo', 'customFonts', 'preferences', 'schemaCache', 'fullBackupHistory', 'fullBackups'];
 function isPlainObject(value) {
   return value !== null && _typeof(value) === 'object' && !Array.isArray(value);
 }

--- a/src/scripts/app-session.js
+++ b/src/scripts/app-session.js
@@ -1510,6 +1510,9 @@ const BACKUP_DATA_KEYS = [
   'customLogo',
   'customFonts',
   'preferences',
+  'schemaCache',
+  'fullBackupHistory',
+  'fullBackups',
 ];
 
 function isPlainObject(value) {

--- a/tests/script/backupCompatibility.test.js
+++ b/tests/script/backupCompatibility.test.js
@@ -61,5 +61,23 @@ describe('backup compatibility utilities', () => {
     );
     expect(sections.sessionStorage).toEqual({ activeSetup: 'Main' });
   });
+
+  test('extractBackupSections preserves legacy top-level backup data keys', () => {
+    const { extractBackupSections } = loadApp();
+
+    const legacyBackup = {
+      fullBackupHistory: [{ createdAt: '2024-01-01T00:00:00.000Z', fileName: 'snapshot.json' }],
+      fullBackups: [{ createdAt: '2023-12-31T00:00:00.000Z' }],
+      schemaCache: '{"checksum":"abc123"}',
+    };
+
+    const sections = extractBackupSections(legacyBackup);
+
+    expect(sections.data.fullBackupHistory).toEqual([
+      { createdAt: '2024-01-01T00:00:00.000Z', fileName: 'snapshot.json' },
+    ]);
+    expect(sections.data.fullBackups).toEqual([{ createdAt: '2023-12-31T00:00:00.000Z' }]);
+    expect(sections.data.schemaCache).toBe('{"checksum":"abc123"}');
+  });
 });
 


### PR DESCRIPTION
## Summary
- include schema cache and backup history keys in the legacy backup data fallback to keep older exports compatible
- sync the prebuilt legacy bundle with the new fallback list and add a regression test covering legacy top-level keys

## Testing
- npm run lint
- npm run test:script

------
https://chatgpt.com/codex/tasks/task_e_68d1d37533b48320add31cd9d70c5cf2