### PR TITLE
Add hidden labels for dynamically generated form fields

### DIFF
--- a/legacy/scripts/app-core.js
+++ b/legacy/scripts/app-core.js
@@ -5967,6 +5967,37 @@ function configureIconOnlyButton(button, glyph) {
     button.setAttribute('title', combinedLabel);
   }
 }
+
+var generatedFieldIdCounter = 0;
+
+function sanitizeForId(value) {
+  var fallback = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : 'field';
+  if (value === undefined || value === null) return fallback;
+  var normalized = String(value).toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
+  return normalized || fallback;
+}
+
+function ensureElementId(element) {
+  var baseText = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : 'field';
+  if (!element) return '';
+  if (element.id) return element.id;
+  var base = sanitizeForId(baseText, 'field');
+  var id = '';
+  do {
+    generatedFieldIdCounter += 1;
+    id = "".concat(base, "-").concat(generatedFieldIdCounter);
+  } while (document.getElementById(id));
+  element.id = id;
+  return id;
+}
+
+function createHiddenLabel(forId, text) {
+  var label = document.createElement('label');
+  label.className = 'visually-hidden';
+  label.setAttribute('for', forId);
+  label.textContent = typeof text === 'string' ? text : '';
+  return label;
+}
 function createCrewRow() {
   var _texts$en128, _texts$currentLang2, _texts$currentLang3, _texts$en129, _texts$currentLang4, _texts$en130;
   var data = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
@@ -6004,6 +6035,14 @@ function createCrewRow() {
   emailInput.placeholder = projectFormTexts.crewEmailPlaceholder || fallbackProjectForm.crewEmailPlaceholder || 'Email';
   emailInput.className = 'person-email';
   emailInput.value = data.email || '';
+  var crewRoleLabelText = projectFormTexts.crewRoleLabel || fallbackProjectForm.crewRoleLabel || 'Crew role';
+  var crewNameLabelText = projectFormTexts.crewNameLabel || fallbackProjectForm.crewNameLabel || 'Crew member name';
+  var crewPhoneLabelText = projectFormTexts.crewPhoneLabel || fallbackProjectForm.crewPhoneLabel || 'Crew member phone';
+  var crewEmailLabelText = projectFormTexts.crewEmailLabel || fallbackProjectForm.crewEmailLabel || 'Crew member email';
+  var roleLabel = createHiddenLabel(ensureElementId(roleSel, crewRoleLabelText), crewRoleLabelText);
+  var nameLabel = createHiddenLabel(ensureElementId(nameInput, crewNameLabelText), crewNameLabelText);
+  var phoneLabel = createHiddenLabel(ensureElementId(phoneInput, crewPhoneLabelText), crewPhoneLabelText);
+  var emailLabel = createHiddenLabel(ensureElementId(emailInput, crewEmailLabelText), crewEmailLabelText);
   var removeBtn = document.createElement('button');
   removeBtn.type = 'button';
   var removeBase = ((_texts$currentLang3 = texts[currentLang]) === null || _texts$currentLang3 === void 0 || (_texts$currentLang3 = _texts$currentLang3.projectForm) === null || _texts$currentLang3 === void 0 ? void 0 : _texts$currentLang3.removeEntry) || ((_texts$en129 = texts.en) === null || _texts$en129 === void 0 || (_texts$en129 = _texts$en129.projectForm) === null || _texts$en129 === void 0 ? void 0 : _texts$en129.removeEntry) || 'Remove';
@@ -6017,7 +6056,7 @@ function createCrewRow() {
     row.remove();
     scheduleProjectAutoSave(true);
   });
-  row.append(roleSel, nameInput, phoneInput, emailInput, removeBtn);
+  row.append(roleLabel, roleSel, nameLabel, nameInput, phoneLabel, phoneInput, emailLabel, emailInput, removeBtn);
   crewContainer.appendChild(row);
 }
 function createPrepRow() {
@@ -6758,6 +6797,8 @@ function createDeviceCategorySection(categoryKey) {
   filterInput.className = 'list-filter';
   filterInput.id = "".concat(sanitizedId, "ListFilter");
   filterInput.dataset.categoryKey = categoryKey;
+  var filterLabel = createHiddenLabel(ensureElementId(filterInput, "".concat(sanitizedId, "-list-filter")), "Filter ".concat(categoryKey));
+  section.appendChild(filterLabel);
   section.appendChild(filterInput);
   var list = document.createElement('ul');
   list.className = 'device-ul';
@@ -6775,6 +6816,7 @@ function createDeviceCategorySection(categoryKey) {
     section: section,
     heading: heading,
     filterInput: filterInput,
+    filterLabel: filterLabel,
     list: list,
     sanitizedId: sanitizedId
   };
@@ -6800,6 +6842,10 @@ function updateDeviceManagerLocalization() {
       entry.filterInput.setAttribute('autocapitalize', 'off');
       entry.filterInput.setAttribute('spellcheck', 'false');
       entry.filterInput.setAttribute('inputmode', 'search');
+      if (entry.filterLabel) {
+        var labelText = placeholder.replace(/\s*(?:\.{3}|\u2026)$/, '');
+        entry.filterLabel.textContent = labelText;
+      }
       var clearBtn = entry.filterInput.nextElementSibling;
       if (clearBtn && clearBtn.classList.contains('clear-input-btn')) {
         clearBtn.setAttribute('aria-label', clearLabel);
@@ -14226,6 +14272,9 @@ function createFieldWithLabel(el, label) {
   var wrapper = document.createElement('div');
   wrapper.className = 'field-with-label';
   wrapper.dataset.label = label;
+  var fieldId = ensureElementId(el, label);
+  var hiddenLabel = createHiddenLabel(fieldId, label);
+  wrapper.appendChild(hiddenLabel);
   wrapper.appendChild(el);
   return wrapper;
 }

--- a/legacy/scripts/translations.js
+++ b/legacy/scripts/translations.js
@@ -627,7 +627,11 @@ var texts = {
       submit: "OK",
       crewNamePlaceholder: "Name",
       crewPhonePlaceholder: "Phone",
-      crewEmailPlaceholder: "Email"
+      crewEmailPlaceholder: "Email",
+      crewRoleLabel: "Crew role",
+      crewNameLabel: "Crew member name",
+      crewPhoneLabel: "Crew member phone",
+      crewEmailLabel: "Crew member email"
     },
     projectFields: {
       productionCompany: "Production Company",
@@ -1127,7 +1131,11 @@ var texts = {
       submit: "Salva",
       crewNamePlaceholder: "Nome",
       crewPhonePlaceholder: "Telefono",
-      crewEmailPlaceholder: "Email"
+      crewEmailPlaceholder: "Email",
+      crewRoleLabel: "Ruolo della troupe",
+      crewNameLabel: "Nome membro della troupe",
+      crewPhoneLabel: "Telefono membro della troupe",
+      crewEmailLabel: "Email membro della troupe"
     },
     projectFields: {
       productionCompany: "Casa di produzione",
@@ -1879,7 +1887,11 @@ var texts = {
       submit: "Aceptar",
       crewNamePlaceholder: "Nombre",
       crewPhonePlaceholder: "Teléfono",
-      crewEmailPlaceholder: "Correo"
+      crewEmailPlaceholder: "Correo",
+      crewRoleLabel: "Rol del equipo",
+      crewNameLabel: "Nombre del miembro del equipo",
+      crewPhoneLabel: "Teléfono del miembro del equipo",
+      crewEmailLabel: "Correo del miembro del equipo"
     },
     projectFields: {
       productionCompany: "Productora",
@@ -2631,7 +2643,11 @@ var texts = {
       submit: "Valider",
       crewNamePlaceholder: "Nom",
       crewPhonePlaceholder: "Téléphone",
-      crewEmailPlaceholder: "Courriel"
+      crewEmailPlaceholder: "Courriel",
+      crewRoleLabel: "Rôle de l'équipe",
+      crewNameLabel: "Nom du membre de l'équipe",
+      crewPhoneLabel: "Téléphone du membre de l'équipe",
+      crewEmailLabel: "Courriel du membre de l'équipe"
     },
     projectFields: {
       productionCompany: "Société de production",
@@ -3383,7 +3399,11 @@ var texts = {
       submit: "Speichern",
       crewNamePlaceholder: "Name",
       crewPhonePlaceholder: "Telefon",
-      crewEmailPlaceholder: "E-Mail"
+      crewEmailPlaceholder: "E-Mail",
+      crewRoleLabel: "Rolle im Team",
+      crewNameLabel: "Name des Crewmitglieds",
+      crewPhoneLabel: "Telefon des Crewmitglieds",
+      crewEmailLabel: "E-Mail des Crewmitglieds"
     },
     projectFields: {
       productionCompany: "Produktionsfirma",

--- a/src/scripts/app-core.js
+++ b/src/scripts/app-core.js
@@ -6478,6 +6478,38 @@ function configureIconOnlyButton(button, glyph, options = {}) {
   }
 }
 
+let generatedFieldIdCounter = 0;
+
+function sanitizeForId(value, fallback = 'field') {
+  if (value === undefined || value === null) return fallback;
+  const normalized = String(value)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  return normalized || fallback;
+}
+
+function ensureElementId(element, baseText = 'field') {
+  if (!element) return '';
+  if (element.id) return element.id;
+  const base = sanitizeForId(baseText, 'field');
+  let id = '';
+  do {
+    generatedFieldIdCounter += 1;
+    id = `${base}-${generatedFieldIdCounter}`;
+  } while (document.getElementById(id));
+  element.id = id;
+  return id;
+}
+
+function createHiddenLabel(forId, text) {
+  const label = document.createElement('label');
+  label.className = 'visually-hidden';
+  label.setAttribute('for', forId);
+  label.textContent = typeof text === 'string' ? text : '';
+  return label;
+}
+
 function createCrewRow(data = {}) {
   if (!crewContainer) return;
   const row = document.createElement('div');
@@ -6512,6 +6544,14 @@ function createCrewRow(data = {}) {
   emailInput.placeholder = projectFormTexts.crewEmailPlaceholder || fallbackProjectForm.crewEmailPlaceholder || 'Email';
   emailInput.className = 'person-email';
   emailInput.value = data.email || '';
+  const crewRoleLabelText = projectFormTexts.crewRoleLabel || fallbackProjectForm.crewRoleLabel || 'Crew role';
+  const crewNameLabelText = projectFormTexts.crewNameLabel || fallbackProjectForm.crewNameLabel || 'Crew member name';
+  const crewPhoneLabelText = projectFormTexts.crewPhoneLabel || fallbackProjectForm.crewPhoneLabel || 'Crew member phone';
+  const crewEmailLabelText = projectFormTexts.crewEmailLabel || fallbackProjectForm.crewEmailLabel || 'Crew member email';
+  const roleLabel = createHiddenLabel(ensureElementId(roleSel, crewRoleLabelText), crewRoleLabelText);
+  const nameLabel = createHiddenLabel(ensureElementId(nameInput, crewNameLabelText), crewNameLabelText);
+  const phoneLabel = createHiddenLabel(ensureElementId(phoneInput, crewPhoneLabelText), crewPhoneLabelText);
+  const emailLabel = createHiddenLabel(ensureElementId(emailInput, crewEmailLabelText), crewEmailLabelText);
   const removeBtn = document.createElement('button');
   removeBtn.type = 'button';
   const removeBase = texts[currentLang]?.projectForm?.removeEntry
@@ -6529,7 +6569,7 @@ function createCrewRow(data = {}) {
     row.remove();
     scheduleProjectAutoSave(true);
   });
-  row.append(roleSel, nameInput, phoneInput, emailInput, removeBtn);
+  row.append(roleLabel, roleSel, nameLabel, nameInput, phoneLabel, phoneInput, emailLabel, emailInput, removeBtn);
   crewContainer.appendChild(row);
 }
 
@@ -7315,6 +7355,8 @@ function createDeviceCategorySection(categoryKey) {
   filterInput.className = 'list-filter';
   filterInput.id = `${sanitizedId}ListFilter`;
   filterInput.dataset.categoryKey = categoryKey;
+  const filterLabel = createHiddenLabel(ensureElementId(filterInput, `${sanitizedId}-list-filter`), `Filter ${categoryKey}`);
+  section.appendChild(filterLabel);
   section.appendChild(filterInput);
   const list = document.createElement('ul');
   list.className = 'device-ul';
@@ -7326,7 +7368,7 @@ function createDeviceCategorySection(categoryKey) {
   section.appendChild(list);
   deviceListContainer.appendChild(section);
   bindFilterInput(filterInput, () => filterDeviceList(list, filterInput.value));
-  const entry = { section, heading, filterInput, list, sanitizedId };
+  const entry = { section, heading, filterInput, filterLabel, list, sanitizedId };
   deviceManagerLists.set(categoryKey, entry);
   return entry;
 }
@@ -7349,6 +7391,10 @@ function updateDeviceManagerLocalization(lang = currentLang) {
       entry.filterInput.setAttribute('autocapitalize', 'off');
       entry.filterInput.setAttribute('spellcheck', 'false');
       entry.filterInput.setAttribute('inputmode', 'search');
+      if (entry.filterLabel) {
+        const labelText = placeholder.replace(/\s*(?:\.{3}|\u2026)$/, '');
+        entry.filterLabel.textContent = labelText;
+      }
       const clearBtn = entry.filterInput.nextElementSibling;
       if (clearBtn && clearBtn.classList.contains('clear-input-btn')) {
         clearBtn.setAttribute('aria-label', clearLabel);
@@ -14995,6 +15041,9 @@ function createFieldWithLabel(el, label) {
   const wrapper = document.createElement('div');
   wrapper.className = 'field-with-label';
   wrapper.dataset.label = label;
+  const fieldId = ensureElementId(el, label);
+  const hiddenLabel = createHiddenLabel(fieldId, label);
+  wrapper.appendChild(hiddenLabel);
   wrapper.appendChild(el);
   return wrapper;
 }

--- a/src/scripts/translations.js
+++ b/src/scripts/translations.js
@@ -740,7 +740,11 @@ const texts = {
       submit: "OK",
       crewNamePlaceholder: "Name",
       crewPhonePlaceholder: "Phone",
-      crewEmailPlaceholder: "Email"
+      crewEmailPlaceholder: "Email",
+      crewRoleLabel: "Crew role",
+      crewNameLabel: "Crew member name",
+      crewPhoneLabel: "Crew member phone",
+      crewEmailLabel: "Crew member email"
     },
     projectFields: {
       productionCompany: "Production Company",
@@ -1300,7 +1304,11 @@ const texts = {
       submit: "Salva",
       crewNamePlaceholder: "Nome",
       crewPhonePlaceholder: "Telefono",
-      crewEmailPlaceholder: "Email"
+      crewEmailPlaceholder: "Email",
+      crewRoleLabel: "Ruolo della troupe",
+      crewNameLabel: "Nome membro della troupe",
+      crewPhoneLabel: "Telefono membro della troupe",
+      crewEmailLabel: "Email membro della troupe"
     },
     projectFields: {
       productionCompany: "Casa di produzione",
@@ -2177,7 +2185,11 @@ const texts = {
       submit: "Aceptar",
       crewNamePlaceholder: "Nombre",
       crewPhonePlaceholder: "Teléfono",
-      crewEmailPlaceholder: "Correo"
+      crewEmailPlaceholder: "Correo",
+      crewRoleLabel: "Rol del equipo",
+      crewNameLabel: "Nombre del miembro del equipo",
+      crewPhoneLabel: "Teléfono del miembro del equipo",
+      crewEmailLabel: "Correo del miembro del equipo"
     },
     projectFields: {
       productionCompany: "Productora",
@@ -3055,7 +3067,11 @@ const texts = {
       submit: "Valider",
       crewNamePlaceholder: "Nom",
       crewPhonePlaceholder: "Téléphone",
-      crewEmailPlaceholder: "Courriel"
+      crewEmailPlaceholder: "Courriel",
+      crewRoleLabel: "Rôle de l'équipe",
+      crewNameLabel: "Nom du membre de l'équipe",
+      crewPhoneLabel: "Téléphone du membre de l'équipe",
+      crewEmailLabel: "Courriel du membre de l'équipe"
     },
     projectFields: {
       productionCompany: "Société de production",
@@ -3937,7 +3953,11 @@ const texts = {
       submit: "Speichern",
       crewNamePlaceholder: "Name",
       crewPhonePlaceholder: "Telefon",
-      crewEmailPlaceholder: "E-Mail"
+      crewEmailPlaceholder: "E-Mail",
+      crewRoleLabel: "Rolle im Team",
+      crewNameLabel: "Name des Crewmitglieds",
+      crewPhoneLabel: "Telefon des Crewmitglieds",
+      crewEmailLabel: "E-Mail des Crewmitglieds"
     },
     projectFields: {
       productionCompany: "Produktionsfirma",


### PR DESCRIPTION
## Summary
- ensure dynamically generated crew details inputs receive hidden labels for accessibility
- add helpers that assign consistent element ids and visually hidden labels to reusable field wrappers and device filters
- localize the new crew labels across all supported languages and mirror the changes in the legacy build

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1d47d0a648320931200cbded7c9e6