### PR TITLE
Improve button icon spacing

### DIFF
--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -2354,13 +2354,15 @@ body.dark-mode .help-callout {
   margin-inline-end: var(--icon-gap);
 }
 
-button .btn-icon:only-child {
-  margin-inline-end: 0;
+button,
+.button-link,
+.button-link:visited {
+  gap: var(--button-icon-gap);
 }
 
-button .btn-icon:not(:only-child),
-.button-link .btn-icon:not(:only-child) {
-  margin-inline-end: var(--button-icon-gap);
+button .btn-icon,
+.button-link .btn-icon {
+  margin-inline-end: 0;
 }
 
 .favorite-icon.icon-glyph {


### PR DESCRIPTION
## Summary
- add flex gap to buttons and button links so icon spacing reliably uses the design variable
- reset button icon margins inside buttons to avoid the icon being treated as an only child and collapsing spacing

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1d94a07588320ae4388aae2205571