### PR TITLE
Reduce extra padding on gear list selectors

### DIFF
--- a/src/scripts/app-core.js
+++ b/src/scripts/app-core.js
@@ -16746,7 +16746,9 @@ function getTimecodes() {
     const borderLeft = parseFloat(styles.borderLeftWidth) || 0;
     const borderRight = parseFloat(styles.borderRightWidth) || 0;
     const fontSize = parseFloat(styles.fontSize) || 16;
-    const arrowReserve = Math.max(fontSize, 16);
+    // Reserve a slightly smaller space for the native arrow to trim the extra
+    // padding on the right while keeping the disclosure indicator visible.
+    const arrowReserve = Math.max(fontSize * 0.65, 12);
     const minWidth = Math.max(fontSize * 4, 56);
     const widthPx = Math.max(
       Math.ceil(textWidth + paddingLeft + paddingRight + borderLeft + borderRight + arrowReserve),


### PR DESCRIPTION
## Summary
- reduce the reserved arrow width when sizing gear list selectors so their right edge hugs the selected item more closely while keeping the native indicator visible

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1da7f30948320a2f57341341056fc