### PR TITLE
Refine gear list filter display

### DIFF
--- a/legacy/scripts/app-session.js
+++ b/legacy/scripts/app-session.js
@@ -4541,6 +4541,8 @@ function renderGearListFilterDetails(details) {
   details.forEach(function (detail) {
     var type = detail.type,
       label = detail.label,
+      gearName = detail.gearName,
+      entryId = detail.entryId,
       size = detail.size,
       values = detail.values,
       needsSize = detail.needsSize,
@@ -4548,7 +4550,11 @@ function renderGearListFilterDetails(details) {
     var row = document.createElement('div');
     row.className = 'filter-detail';
     var heading = document.createElement('div');
-    heading.className = 'filter-detail-label';
+    heading.className = 'filter-detail-label gear-item';
+    if (entryId) heading.setAttribute('data-filter-entry', entryId);
+    if (gearName) heading.setAttribute('data-gear-name', gearName);
+    if (label) heading.setAttribute('data-filter-label', label);
+    if (type) heading.setAttribute('data-filter-type', type);
     var displaySize = size && label && label.includes(size) ? '' : size;
     var displayValues = Array.isArray(values) ? values : undefined;
     if (label) {
@@ -4670,10 +4676,15 @@ function renderFilterDetails() {
     var needsSize = type !== 'Diopter';
     var needsValues = filterTypeNeedsValueSelect(type);
     var _resolveFilterDisplay6 = resolveFilterDisplayInfo(type, size),
-      label = _resolveFilterDisplay6.label;
+      label = _resolveFilterDisplay6.label,
+      gearName = _resolveFilterDisplay6.gearName;
+    var entryId = "filter-".concat(filterId(type));
+    if (type === 'Diopter') entryId = "".concat(entryId, "-set");
     return {
       type: type,
       label: label,
+      gearName: gearName,
+      entryId: entryId,
       size: size,
       values: Array.isArray(prev.values) ? prev.values.slice() : [],
       needsSize: needsSize,
@@ -4784,18 +4795,7 @@ function normalizeGearNameForComparison(name) {
   return normalized.replace(/[^a-z0-9]+/g, '');
 }
 function buildFilterSelectHtml() {
-  var filters = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : [];
-  var precomputedEntries = arguments.length > 1 ? arguments[1] : undefined;
-  var entries = Array.isArray(precomputedEntries) ? precomputedEntries : buildFilterGearEntries(filters);
-  var summaryHtml = entries.map(function (entry) {
-    var attrs = ['class="gear-item"', "data-gear-name=\"".concat(escapeHtml(entry.gearName), "\""), "data-filter-entry=\"".concat(escapeHtml(entry.id), "\""), "data-filter-label=\"".concat(escapeHtml(entry.label), "\"")];
-    if (entry.type) attrs.push("data-filter-type=\"".concat(escapeHtml(entry.type), "\""));
-    var text = formatFilterEntryText(entry);
-    return "<span ".concat(attrs.join(' '), ">").concat(escapeHtml(text), "</span>");
-  }).join('<br>');
-  var detailsContainer = entries.length ? '<div id="gearListFilterDetails" class="hidden" aria-live="polite"></div>' : '';
-  var summaryContainer = summaryHtml ? "<div class=\"gear-list-filter-summary\">".concat(summaryHtml, "</div>") : '';
-  return [detailsContainer, summaryContainer].filter(Boolean).join('');
+  return '<div id="gearListFilterDetails" class="hidden" aria-live="polite"></div>';
 }
 function collectFilterAccessories() {
   var filters = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : [];

--- a/src/scripts/app-session.js
+++ b/src/scripts/app-session.js
@@ -4810,11 +4810,24 @@ function renderGearListFilterDetails(details) {
   }
   container.classList.remove('hidden');
   details.forEach(detail => {
-    const { type, label, size, values, needsSize, needsValues } = detail;
+    const {
+      type,
+      label,
+      gearName,
+      entryId,
+      size,
+      values,
+      needsSize,
+      needsValues
+    } = detail;
     const row = document.createElement('div');
     row.className = 'filter-detail';
     const heading = document.createElement('div');
-    heading.className = 'filter-detail-label';
+    heading.className = 'filter-detail-label gear-item';
+    if (entryId) heading.setAttribute('data-filter-entry', entryId);
+    if (gearName) heading.setAttribute('data-gear-name', gearName);
+    if (label) heading.setAttribute('data-filter-label', label);
+    if (type) heading.setAttribute('data-filter-type', type);
     const displaySize = size && label && label.includes(size) ? '' : size;
     const displayValues = Array.isArray(values) ? values : undefined;
     if (label) {
@@ -4931,10 +4944,14 @@ function renderFilterDetails() {
     const size = prev.size || DEFAULT_FILTER_SIZE;
     const needsSize = type !== 'Diopter';
     const needsValues = filterTypeNeedsValueSelect(type);
-    const { label } = resolveFilterDisplayInfo(type, size);
+    const { label, gearName } = resolveFilterDisplayInfo(type, size);
+    let entryId = `filter-${filterId(type)}`;
+    if (type === 'Diopter') entryId = `${entryId}-set`;
     return {
       type,
       label,
+      gearName,
+      entryId,
       size,
       values: Array.isArray(prev.values) ? prev.values.slice() : [],
       needsSize,
@@ -5033,28 +5050,8 @@ function normalizeGearNameForComparison(name) {
   return normalized.replace(/[^a-z0-9]+/g, '');
 }
 
-function buildFilterSelectHtml(filters = [], precomputedEntries) {
-  const entries = Array.isArray(precomputedEntries)
-    ? precomputedEntries
-    : buildFilterGearEntries(filters);
-  const summaryHtml = entries.map(entry => {
-    const attrs = [
-      'class="gear-item"',
-      `data-gear-name="${escapeHtml(entry.gearName)}"`,
-      `data-filter-entry="${escapeHtml(entry.id)}"`,
-      `data-filter-label="${escapeHtml(entry.label)}"`
-    ];
-    if (entry.type) attrs.push(`data-filter-type="${escapeHtml(entry.type)}"`);
-    const text = formatFilterEntryText(entry);
-    return `<span ${attrs.join(' ')}>${escapeHtml(text)}</span>`;
-  }).join('<br>');
-  const detailsContainer = entries.length
-    ? '<div id="gearListFilterDetails" class="hidden" aria-live="polite"></div>'
-    : '';
-  const summaryContainer = summaryHtml
-    ? `<div class="gear-list-filter-summary">${summaryHtml}</div>`
-    : '';
-  return [detailsContainer, summaryContainer].filter(Boolean).join('');
+function buildFilterSelectHtml() {
+  return '<div id="gearListFilterDetails" class="hidden" aria-live="polite"></div>';
 }
 
 function collectFilterAccessories(filters = []) {

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -4759,9 +4759,9 @@ body.dark-mode.pink-mode #gearListOutput h2,
 #gearListFilterDetails {
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
-  margin-top: 0.375rem;
-  line-height: var(--line-height-base);
+  gap: 0.125rem;
+  margin-top: 0.25rem;
+  line-height: inherit;
 }
 
 #gearListFilterDetails.hidden {
@@ -4772,19 +4772,20 @@ body.dark-mode.pink-mode #gearListOutput h2,
   display: grid;
   grid-template-columns: minmax(9.5rem, max-content) minmax(0, 1fr);
   column-gap: 0.75rem;
-  row-gap: 0.25rem;
+  row-gap: 0.125rem;
   align-items: center;
-  padding: 0.125rem 0;
+  padding: 0;
   border: none;
   border-radius: 0;
   background: none;
 }
 
 #gearListFilterDetails .filter-detail-label {
+  font-size: inherit;
   font-weight: var(--font-weight-regular);
   min-width: 0;
   margin-right: 0;
-  line-height: var(--line-height-base);
+  line-height: inherit;
 }
 
 #gearListFilterDetails .filter-detail-controls {
@@ -4814,6 +4815,7 @@ body.dark-mode.pink-mode #gearListOutput h2,
 #gearListFilterDetails .filter-detail-size .select-wrapper select {
   min-width: 3.5rem;
   margin: 0;
+  width: var(--gear-select-width, auto);
 }
 
 #gearListFilterDetails .filter-detail-size .select-wrapper select:focus-visible {
@@ -4862,11 +4864,6 @@ body.dark-mode.pink-mode #gearListOutput h2,
   border-color: var(--accent-color);
   box-shadow: 0 0 0 1px var(--accent-color);
   background-color: var(--panel-bg);
-}
-
-.gear-list-filter-summary {
-  margin-top: 0.5rem;
-  line-height: var(--line-height-base);
 }
 
 @media (max-width: 640px) {


### PR DESCRIPTION
## Summary
- remove the duplicate filter summary entries and attach gear metadata to the selector rows
- render only the filter controls in the gear list so their typography matches other items
- adjust filter detail spacing and select sizing to align with the rest of the gear list layout

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d1d86d197c83209645c96237158b64