### PR TITLE
Hide cage selector and filter compatible cages

### DIFF
--- a/index.html
+++ b/index.html
@@ -294,7 +294,7 @@
         </div>
       </div>
 
-      <div class="form-row">
+      <div class="form-row hidden" id="cageSelectRow">
         <label for="cageSelect" id="cageLabel">Camera Cage:</label>
         <div class="select-wrapper">
           <select id="cageSelect" aria-labelledby="cageLabel"></select>

--- a/src/scripts/app-events.js
+++ b/src/scripts/app-events.js
@@ -1,4 +1,5 @@
 // --- EVENT LISTENERS ---
+/* global updateCageSelectOptions */
 
 // Language selection
 languageSelect.addEventListener("change", (event) => {
@@ -174,6 +175,9 @@ deleteSetupBtn.addEventListener("click", () => {
           sel.selectedIndex = 0;
         }
       });
+      if (typeof updateCageSelectOptions === 'function') {
+        updateCageSelectOptions('None');
+      }
       const sbSel = getSliderBowlSelect();
       if (sbSel) sbSel.value = '';
       motorSelects.forEach(sel => { if (sel.options.length) sel.value = "None"; });
@@ -226,6 +230,9 @@ setupSelect.addEventListener("change", (event) => {
         sel.selectedIndex = 0;
       }
     });
+    if (typeof updateCageSelectOptions === 'function') {
+      updateCageSelectOptions('None');
+    }
     const sbSel = getSliderBowlSelect();
     if (sbSel) sbSel.value = '';
     motorSelects.forEach(sel => { if (sel.options.length) sel.value = "None"; });
@@ -254,7 +261,11 @@ setupSelect.addEventListener("change", (event) => {
       batteryPlateSelect.value = setup.batteryPlate || batteryPlateSelect.value;
       monitorSelect.value = setup.monitor;
       videoSelect.value = setup.video;
-      if (cageSelect) cageSelect.value = setup.cage || cageSelect.value;
+      if (typeof updateCageSelectOptions === 'function') {
+        updateCageSelectOptions(setup.cage);
+      } else if (cageSelect) {
+        cageSelect.value = setup.cage || cageSelect.value;
+      }
       (setup.motors || []).forEach((val, i) => { if (motorSelects[i]) motorSelects[i].value = val; });
       (setup.controllers || []).forEach((val, i) => { if (controllerSelects[i]) controllerSelects[i].value = val; });
       distanceSelect.value = setup.distance;

--- a/src/scripts/app-session.js
+++ b/src/scripts/app-session.js
@@ -1,5 +1,5 @@
 // --- SESSION STATE HANDLING ---
-/* global resolveTemperatureStorageKey, TEMPERATURE_STORAGE_KEY */
+/* global resolveTemperatureStorageKey, TEMPERATURE_STORAGE_KEY, updateCageSelectOptions */
 
 const temperaturePreferenceStorageKey =
   typeof TEMPERATURE_STORAGE_KEY === 'string'
@@ -229,7 +229,11 @@ function restoreSessionState() {
     updateBatteryOptions();
     setSelectValue(monitorSelect, state.monitor);
     setSelectValue(videoSelect, state.video);
-    setSelectValue(cageSelect, state.cage);
+    if (typeof updateCageSelectOptions === 'function') {
+      updateCageSelectOptions(state.cage);
+    } else {
+      setSelectValue(cageSelect, state.cage);
+    }
     setSelectValue(distanceSelect, state.distance);
     if (Array.isArray(state.motors)) {
       state.motors.forEach((val, i) => { if (motorSelects[i]) setSelectValue(motorSelects[i], val); });
@@ -404,7 +408,11 @@ function applySharedSetup(shared, options = {}) {
     updateBatteryOptions();
     setSelectValue(monitorSelect, decoded.monitor);
     setSelectValue(videoSelect, decoded.video);
-    setSelectValue(cageSelect, decoded.cage);
+    if (typeof updateCageSelectOptions === 'function') {
+      updateCageSelectOptions(decoded.cage);
+    } else {
+      setSelectValue(cageSelect, decoded.cage);
+    }
     setSelectValue(distanceSelect, decoded.distance);
     if (Array.isArray(decoded.motors)) {
       decoded.motors.forEach((val, i) => { if (motorSelects[i]) setSelectValue(motorSelects[i], val); });
@@ -573,6 +581,9 @@ if (cameraSelect) {
   cameraSelect.addEventListener('change', () => {
     updateBatteryPlateVisibility();
     updateBatteryOptions();
+    if (typeof updateCageSelectOptions === 'function') {
+      updateCageSelectOptions();
+    }
     populateRecordingResolutionDropdown(currentProjectInfo && currentProjectInfo.recordingResolution);
     populateSensorModeDropdown(currentProjectInfo && currentProjectInfo.sensorMode);
   });


### PR DESCRIPTION
## Summary
- hide the cage selector row in Configure Devices to keep the section uncluttered
- filter cage dropdown options to only cameras that match the selected body and refresh selections across session/setup flows

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d1d9a544c0832089a768689de1068a