### PR TITLE
Fix diagram area width to avoid clipping

### DIFF
--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -3230,9 +3230,9 @@ body.pink-mode #topBar #logo .logo-center {
 #diagramArea {
   margin: 0.5em auto 0;
   position: relative;
-  display: inline-flex;
-  flex-direction: column;
-  align-items: center;
+  display: block;
+  width: min(100%, var(--diagram-max-width, 100%));
+  max-width: var(--diagram-max-width, 100%);
   text-align: left;
 }
 
@@ -3243,6 +3243,9 @@ body.pink-mode #topBar #logo .logo-center {
 #diagramArea > svg,
 #diagramArea > canvas {
   margin-inline: auto;
+  width: 100%;
+  max-width: 100%;
+  display: block;
 }
 
 #diagramArea .diagram-placeholder {


### PR DESCRIPTION
## Summary
- make the setup diagram container block-level with full available width so the layout no longer clips inside a narrow box
- force the rendered SVG/canvas elements to expand to the container width for consistent sizing across views

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d1dbc7563c832080bf6e6ea15f59ce