### PR TITLE
Adjust button icon spacing

### DIFF
--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -44,7 +44,7 @@
   --button-link-padding-block: var(--button-padding-block);
   --button-link-padding-inline: 12px;
   --icon-gap: 0.3em;
-  --button-icon-gap: 1.35em;
+  --button-icon-gap: 0.75em;
   --form-control-font-size: var(--font-size-relative-base);
   --form-label-width: 150px;
   --form-label-min-width: 120px;
@@ -174,7 +174,7 @@ body.relaxed-spacing {
   --form-label-min-width: 140px;
   --button-size: 30px;
   --button-line-height: 1.45;
-  --button-icon-gap: 1.6em;
+  --button-icon-gap: 1em;
   --form-row-margin-block: 8px;
   --button-link-padding-inline: 16px;
 }


### PR DESCRIPTION
## Summary
- reduce the default gap between button icons and their labels for tighter alignment
- tune the relaxed spacing variant to keep a proportional gap adjustment

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1dd23bd50832085564ef822c0c48c