### PR TITLE
Use solid border for FIZ connector in print stylesheet

### DIFF
--- a/src/styles/overview-print.css
+++ b/src/styles/overview-print.css
@@ -459,7 +459,7 @@ body:not(.light-mode) .gear-table .category-row td {
 
 .fiz-conn {
   background: var(--panel-bg) !important;
-  border: 1px dashed var(--fiz-color) !important;
+  border: 1px solid var(--fiz-color) !important;
   --icon-color: var(--fiz-color);
 }
 


### PR DESCRIPTION
## Summary
- switch the FIZ connector print styling to a solid border so it matches the on-screen presentation

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1ddbc70ec8320b326ac7380bf88a7