### PR TITLE
Adjust help button question mark weight

### DIFF
--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -3123,6 +3123,10 @@ body.pink-mode #topBar #logo .logo-center {
   font-size: var(--font-size-relative-base);
 }
 
+#helpButton .icon-text {
+  font-weight: var(--font-weight-light);
+}
+
 /* Breakdown list */
 #breakdownList {
   list-style: none;


### PR DESCRIPTION
## Summary
- lighten the top bar help button question mark by switching it to the light font weight for a thinner appearance

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1de97c51c83209cfa8716ad27d3a1