### PR TITLE
Remove PDF blob fallback from overview export

### DIFF
--- a/legacy/scripts/overview.js
+++ b/legacy/scripts/overview.js
@@ -4,10 +4,6 @@ function _unsupportedIterableToArray(r, a) { if (r) { if ("string" == typeof r) 
 function _iterableToArray(r) { if ("undefined" != typeof Symbol && null != r[Symbol.iterator] || null != r["@@iterator"]) return Array.from(r); }
 function _arrayWithoutHoles(r) { if (Array.isArray(r)) return _arrayLikeToArray(r); }
 function _arrayLikeToArray(r, a) { (null == a || a > r.length) && (a = r.length); for (var e = 0, n = Array(a); e < a; e++) n[e] = r[e]; return n; }
-function _regenerator() { var e, t, r = "function" == typeof Symbol ? Symbol : {}, n = r.iterator || "@@iterator", o = r.toStringTag || "@@toStringTag"; function i(r, n, o, i) { var c = n && n.prototype instanceof Generator ? n : Generator, u = Object.create(c.prototype); return _regeneratorDefine2(u, "_invoke", function (r, n, o) { var i, c, u, f = 0, p = o || [], y = !1, G = { p: 0, n: 0, v: e, a: d, f: d.bind(e, 4), d: function d(t, r) { return i = t, c = 0, u = e, G.n = r, a; } }; function d(r, n) { for (c = r, u = n, t = 0; !y && f && !o && t < p.length; t++) { var o, i = p[t], d = G.p, l = i[2]; r > 3 ? (o = l === n) && (u = i[(c = i[4]) ? 5 : (c = 3, 3)], i[4] = i[5] = e) : i[0] <= d && ((o = r < 2 && d < i[1]) ? (c = 0, G.v = n, G.n = i[1]) : d < l && (o = r < 3 || i[0] > n || n > l) && (i[4] = r, i[5] = n, G.n = l, c = 0)); } if (o || r > 1) return a; throw y = !0, n; } return function (o, p, l) { if (f > 1) throw TypeError("Generator is already running"); for (y && 1 === p && d(p, l), c = p, u = l; (t = c < 2 ? e : u) || !y;) { i || (c ? c < 3 ? (c > 1 && (G.n = -1), d(c, u)) : G.n = u : G.v = u); try { if (f = 2, i) { if (c || (o = "next"), t = i[o]) { if (!(t = t.call(i, u))) throw TypeError("iterator result is not an object"); if (!t.done) return t; u = t.value, c < 2 && (c = 0); } else 1 === c && (t = i.return) && t.call(i), c < 2 && (u = TypeError("The iterator does not provide a '" + o + "' method"), c = 1); i = e; } else if ((t = (y = G.n < 0) ? u : r.call(n, G)) !== a) break; } catch (t) { i = e, c = 1, u = t; } finally { f = 1; } } return { value: t, done: y }; }; }(r, o, i), !0), u; } var a = {}; function Generator() {} function GeneratorFunction() {} function GeneratorFunctionPrototype() {} t = Object.getPrototypeOf; var c = [][n] ? t(t([][n]())) : (_regeneratorDefine2(t = {}, n, function () { return this; }), t), u = GeneratorFunctionPrototype.prototype = Generator.prototype = Object.create(c); function f(e) { return Object.setPrototypeOf ? Object.setPrototypeOf(e, GeneratorFunctionPrototype) : (e.__proto__ = GeneratorFunctionPrototype, _regeneratorDefine2(e, o, "GeneratorFunction")), e.prototype = Object.create(u), e; } return GeneratorFunction.prototype = GeneratorFunctionPrototype, _regeneratorDefine2(u, "constructor", GeneratorFunctionPrototype), _regeneratorDefine2(GeneratorFunctionPrototype, "constructor", GeneratorFunction), GeneratorFunction.displayName = "GeneratorFunction", _regeneratorDefine2(GeneratorFunctionPrototype, o, "GeneratorFunction"), _regeneratorDefine2(u), _regeneratorDefine2(u, o, "Generator"), _regeneratorDefine2(u, n, function () { return this; }), _regeneratorDefine2(u, "toString", function () { return "[object Generator]"; }), (_regenerator = function _regenerator() { return { w: i, m: f }; })(); }
-function _regeneratorDefine2(e, r, n, t) { var i = Object.defineProperty; try { i({}, "", {}); } catch (e) { i = 0; } _regeneratorDefine2 = function _regeneratorDefine(e, r, n, t) { if (r) i ? i(e, r, { value: n, enumerable: !t, configurable: !t, writable: !t }) : e[r] = n;else { function o(r, n) { _regeneratorDefine2(e, r, function (e) { return this._invoke(r, n, e); }); } o("next", 0), o("throw", 1), o("return", 2); } }, _regeneratorDefine2(e, r, n, t); }
-function asyncGeneratorStep(n, t, e, r, o, a, c) { try { var i = n[a](c), u = i.value; } catch (n) { return void e(n); } i.done ? t(u) : Promise.resolve(u).then(r, o); }
-function _asyncToGenerator(n) { return function () { var t = this, e = arguments; return new Promise(function (r, o) { var a = n.apply(t, e); function _next(n) { asyncGeneratorStep(a, r, o, _next, _throw, "next", n); } function _throw(n) { asyncGeneratorStep(a, r, o, _next, _throw, "throw", n); } _next(void 0); }); }; }
 function _typeof(o) { "@babel/helpers - typeof"; return _typeof = "function" == typeof Symbol && "symbol" == typeof Symbol.iterator ? function (o) { return typeof o; } : function (o) { return o && "function" == typeof Symbol && o.constructor === Symbol && o !== Symbol.prototype ? "symbol" : typeof o; }, _typeof(o); }
 function generatePrintableOverview() {
   var escapeHtmlSafe = function escapeHtmlSafe(value) {
@@ -52,919 +48,12 @@ function generatePrintableOverview() {
   var originalDocumentTitle = typeof document !== 'undefined' ? document.title : '';
   var customLogo = typeof localStorage !== 'undefined' ? localStorage.getItem('customLogo') : null;
   var generatedOnLabel = t.generatedOnLabel || 'Generated on';
-  var defaultPdfWarningHeading = t.pdfWarningsHeading || 'Warnings';
-  var diagramPdfNote = t.diagramPdfNote || 'The visual connection diagram is not included in the PDF export. Open the print view to review the layout.';
   var ensureLabelSuffix = function ensureLabelSuffix(label) {
     var base = typeof label === 'string' ? label.trim() : '';
     if (!base) return '';
     return /[:：]$/.test(base) ? base : "".concat(base, ":");
   };
-  var normalizeForPdf = function normalizeForPdf(value) {
-    if (value === null || value === undefined) {
-      return '';
-    }
-    var text = String(value);
-    if (typeof text.normalize === 'function') {
-      text = text.normalize('NFKD');
-    }
-    text = text.replace(/[\u0300-\u036f]/g, '').replace(/\u00DF/g, 'ss').replace(/[\u00A0\u202F\u2007]/g, ' ').replace(/[\u2010\u2011\u2012\u2013\u2014\u2212]/g, '-').replace(/\u00B0/g, ' deg ').replace(/\u00D7/g, 'x').replace(/\u00B5/g, 'u').replace(/\u2126/g, 'Ohm').replace(/\u20AC/g, 'EUR').replace(/\u00A3/g, 'GBP').replace(/\u00A5/g, 'JPY').replace(/\u00BD/g, '1/2').replace(/\u00BC/g, '1/4').replace(/\u00BE/g, '3/4').replace(/\u2022/g, '-').replace(/[\u2018\u2019\u201A\u201B]/g, "'").replace(/[\u201C\u201D\u201E\u201F]/g, '"');
-    text = text.replace(/[^\x20-\x7E]/g, '?');
-    return text.replace(/\s+/g, ' ').trim();
-  };
-  var wrapPdfText = function wrapPdfText(text, maxLength) {
-    var result = [];
-    var limit = Math.max(10, maxLength || 80);
-    var normalized = normalizeForPdf(text);
-    if (!normalized) {
-      return result;
-    }
-    var words = normalized.split(' ');
-    var currentLine = '';
-    for (var i = 0; i < words.length; i += 1) {
-      var word = words[i];
-      if (!word) {
-        continue;
-      }
-      if (!currentLine) {
-        if (word.length <= limit) {
-          currentLine = word;
-        } else {
-          var chunks = [];
-          for (var start = 0; start < word.length; start += limit) {
-            chunks.push(word.slice(start, start + limit));
-          }
-          if (chunks.length) {
-            result.push(chunks[0]);
-            for (var c = 1; c < chunks.length - 1; c += 1) {
-              result.push(chunks[c]);
-            }
-            currentLine = chunks[chunks.length - 1];
-          }
-        }
-        continue;
-      }
-      var candidate = "".concat(currentLine, " ").concat(word);
-      if (candidate.length <= limit) {
-        currentLine = candidate;
-      } else if (word.length > limit) {
-        result.push(currentLine);
-        var _chunks = [];
-        for (var _start = 0; _start < word.length; _start += limit) {
-          _chunks.push(word.slice(_start, _start + limit));
-        }
-        if (_chunks.length) {
-          for (var _c = 0; _c < _chunks.length - 1; _c += 1) {
-            result.push(_chunks[_c]);
-          }
-          currentLine = _chunks[_chunks.length - 1];
-        } else {
-          currentLine = '';
-        }
-      } else {
-        result.push(currentLine);
-        currentLine = word;
-      }
-    }
-    if (currentLine) {
-      result.push(currentLine);
-    }
-    return result;
-  };
-  var flattenPdfEntries = function flattenPdfEntries(entries) {
-    var lines = [];
-    if (!Array.isArray(entries) || entries.length === 0) {
-      return ['No data available'];
-    }
-    for (var i = 0; i < entries.length; i += 1) {
-      var entry = entries[i];
-      if (!entry) {
-        continue;
-      }
-      if (entry.type === 'blank') {
-        if (lines.length && lines[lines.length - 1] !== '') {
-          lines.push('');
-        }
-        continue;
-      }
-      var indent = Math.max(0, Math.min(40, entry.indent || 0));
-      var indentStr = indent ? ' '.repeat(indent) : '';
-      var normalized = normalizeForPdf(entry.text);
-      if (!normalized) {
-        continue;
-      }
-      var available = Math.max(10, 94 - indentStr.length);
-      var wrapped = wrapPdfText(normalized, available);
-      if (!wrapped.length) {
-        continue;
-      }
-      for (var w = 0; w < wrapped.length; w += 1) {
-        lines.push(indentStr + wrapped[w]);
-      }
-    }
-    if (!lines.length) {
-      lines.push('No data available');
-    }
-    return lines;
-  };
-  var splitLinesIntoPages = function splitLinesIntoPages(lines, maxLinesPerPage) {
-    var pages = [];
-    var limit = Math.max(1, maxLinesPerPage || 46);
-    var current = [];
-    for (var i = 0; i < lines.length; i += 1) {
-      var line = lines[i];
-      if (current.length >= limit) {
-        pages.push(current);
-        current = [];
-      }
-      if (line === '' && current.length === 0) {
-        continue;
-      }
-      current.push(line);
-    }
-    if (current.length) {
-      pages.push(current);
-    }
-    if (!pages.length) {
-      pages.push(['No data available']);
-    }
-    return pages;
-  };
-  var pdfEscape = function pdfEscape(text) {
-    return String(text).replace(/\\/g, '\\\\').replace(/\(/g, '\\(').replace(/\)/g, '\\)').replace(/\r/g, ' ').replace(/\n/g, ' ');
-  };
-  var createTextOverviewPdfBlob = function createTextOverviewPdfBlob(entries) {
-    var options = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
-    var fontRefName = '/F1';
-    var lines = flattenPdfEntries(entries);
-    var pages = splitLinesIntoPages(lines, 46);
-    var pageWidth = 612;
-    var pageHeight = 792;
-    var marginLeft = 72;
-    var marginTop = 72;
-    var fontSize = 12;
-    var leading = 14;
-    var nextObjectId = 1;
-    var bodies = {};
-    var order = [];
-    var reserveObject = function reserveObject() {
-      var id = nextObjectId;
-      nextObjectId += 1;
-      order.push(id);
-      bodies[id] = null;
-      return id;
-    };
-    var setObjectBody = function setObjectBody(id, body) {
-      bodies[id] = body;
-    };
-    var addObject = function addObject(body) {
-      var id = reserveObject();
-      setObjectBody(id, body);
-      return id;
-    };
-    var fontRef = addObject('<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>');
-    var pagesRef = reserveObject();
-    var pageRefs = [];
-    for (var p = 0; p < pages.length; p += 1) {
-      var pageLines = pages[p];
-      var _content = 'BT\n';
-      _content += "".concat(fontRefName, " ").concat(fontSize, " Tf\n");
-      _content += "".concat(leading, " TL\n");
-      _content += "".concat(marginLeft, " ").concat(pageHeight - marginTop, " Td\n");
-      var firstLine = true;
-      for (var l = 0; l < pageLines.length; l += 1) {
-        var line = pageLines[l];
-        if (!firstLine) {
-          _content += 'T*\n';
-        } else {
-          firstLine = false;
-        }
-        if (!line) {
-          continue;
-        }
-        _content += "(".concat(pdfEscape(line), ") Tj\n");
-      }
-      _content += 'ET';
-      var streamBody = "<< /Length ".concat(_content.length, " >>\nstream\n").concat(_content, "\nendstream");
-      var contentRef = addObject(streamBody);
-      var pageBody = "<< /Type /Page /Parent ".concat(pagesRef, " 0 R /MediaBox [0 0 ").concat(pageWidth, " ").concat(pageHeight, "] /Contents ").concat(contentRef, " 0 R /Resources << /Font << ").concat(fontRefName, " ").concat(fontRef, " 0 R >> >> >>");
-      var pageRef = addObject(pageBody);
-      pageRefs.push(pageRef);
-    }
-    var kids = pageRefs.map(function (ref) {
-      return "".concat(ref, " 0 R");
-    }).join(' ');
-    setObjectBody(pagesRef, "<< /Type /Pages /Count ".concat(pageRefs.length, " /Kids [").concat(kids, "] >>"));
-    var creationDate = "D:".concat(now.getFullYear()).concat(padTwo(now.getMonth() + 1)).concat(padTwo(now.getDate())).concat(padTwo(now.getHours())).concat(padTwo(now.getMinutes())).concat(padTwo(now.getSeconds()));
-    var infoParts = ['/Producer (Cine Power Planner)', '/Creator (Cine Power Planner Overview Export)', "/CreationDate (".concat(creationDate, ")")];
-    if (options && options.title) {
-      var normalizedTitle = normalizeForPdf(options.title);
-      if (normalizedTitle) {
-        infoParts.push("/Title (".concat(pdfEscape(normalizedTitle), ")"));
-      }
-    }
-    var infoRef = addObject("<< ".concat(infoParts.join(' '), " >>"));
-    var catalogRef = addObject("<< /Type /Catalog /Pages ".concat(pagesRef, " 0 R >>"));
-    var pdf = '%PDF-1.4\n';
-    var offsets = [0];
-    var offset = pdf.length;
-    for (var i = 0; i < order.length; i += 1) {
-      var id = order[i];
-      var body = bodies[id];
-      if (body === null || body === undefined) {
-        throw new Error('Missing PDF object body.');
-      }
-      var objectString = "".concat(id, " 0 obj\n").concat(body, "\nendobj\n");
-      offsets.push(offset);
-      pdf += objectString;
-      offset += objectString.length;
-    }
-    var startXref = offset;
-    pdf += "xref\n0 ".concat(order.length + 1, "\n");
-    pdf += '0000000000 65535 f \n';
-    for (var _i = 1; _i < offsets.length; _i += 1) {
-      pdf += "".concat(offsets[_i].toString().padStart(10, '0'), " 00000 n \n");
-    }
-    pdf += "trailer\n<< /Size ".concat(order.length + 1, " /Root ").concat(catalogRef, " 0 R /Info ").concat(infoRef, " 0 R >>\nstartxref\n").concat(startXref, "\n%%EOF");
-    return new Blob([pdf], {
-      type: 'application/pdf'
-    });
-  };
-  var downloadBlobAsFile = function () {
-    var _ref = _asyncToGenerator(_regenerator().m(function _callee(blob, filename) {
-      var defaultName, handle, writable, url, link, parentNode, _t;
-      return _regenerator().w(function (_context) {
-        while (1) switch (_context.p = _context.n) {
-          case 0:
-            if (blob instanceof Blob) {
-              _context.n = 1;
-              break;
-            }
-            throw new Error('PDF export failed: invalid file data.');
-          case 1:
-            defaultName = filename || 'overview.pdf';
-            if (!(typeof window !== 'undefined' && typeof window.showSaveFilePicker === 'function')) {
-              _context.n = 10;
-              break;
-            }
-            _context.p = 2;
-            _context.n = 3;
-            return window.showSaveFilePicker({
-              suggestedName: defaultName,
-              types: [{
-                description: 'PDF',
-                accept: {
-                  'application/pdf': ['.pdf']
-                }
-              }]
-            });
-          case 3:
-            handle = _context.v;
-            if (!handle) {
-              _context.n = 7;
-              break;
-            }
-            _context.n = 4;
-            return handle.createWritable();
-          case 4:
-            writable = _context.v;
-            _context.n = 5;
-            return writable.write(blob);
-          case 5:
-            _context.n = 6;
-            return writable.close();
-          case 6:
-            return _context.a(2, true);
-          case 7:
-            _context.n = 10;
-            break;
-          case 8:
-            _context.p = 8;
-            _t = _context.v;
-            if (!(_t && _t.name === 'AbortError')) {
-              _context.n = 9;
-              break;
-            }
-            return _context.a(2, false);
-          case 9:
-            console.warn('Save file picker unavailable, falling back to download link.', _t);
-          case 10:
-            url = URL.createObjectURL(blob);
-            try {
-              link = document.createElement('a');
-              link.href = url;
-              link.download = defaultName;
-              link.rel = 'noopener';
-              link.style.display = 'none';
-              parentNode = document.body || document.documentElement;
-              if (parentNode) {
-                parentNode.appendChild(link);
-              }
-              link.click();
-              if (parentNode && link.parentNode === parentNode) {
-                parentNode.removeChild(link);
-              } else {
-                link.remove();
-              }
-            } finally {
-              setTimeout(function () {
-                URL.revokeObjectURL(url);
-              }, 0);
-            }
-            return _context.a(2, true);
-        }
-      }, _callee, null, [[2, 8]]);
-    }));
-    return function downloadBlobAsFile(_x, _x2) {
-      return _ref.apply(this, arguments);
-    };
-  }();
-  var htmlToPlainTextLines = function htmlToPlainTextLines(html) {
-    if (!html) {
-      return [];
-    }
-    var container = document.createElement('div');
-    container.innerHTML = html;
-    var blockSelectors = ['p', 'div', 'section', 'li', 'h1', 'h2', 'h3', 'h4', 'tr', 'table', 'thead', 'tbody', 'tfoot', 'caption'];
-    for (var b = 0; b < blockSelectors.length; b += 1) {
-      var elements = container.getElementsByTagName(blockSelectors[b]);
-      for (var i = 0; i < elements.length; i += 1) {
-        elements[i].appendChild(document.createTextNode('\n'));
-      }
-    }
-    var lineBreaks = container.querySelectorAll('br');
-    for (var _i2 = 0; _i2 < lineBreaks.length; _i2 += 1) {
-      var br = lineBreaks[_i2];
-      if (br && br.parentNode) {
-        br.parentNode.replaceChild(document.createTextNode('\n'), br);
-      }
-    }
-    var text = container.textContent || '';
-    return text.split('\n').map(function (line) {
-      return line.replace(/\s+/g, ' ').trim();
-    }).filter(Boolean);
-  };
-  var pdfEntries = [];
-  var pdfPushLine = function pdfPushLine(text) {
-    var indent = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : 0;
-    if (text === null || text === undefined) {
-      return;
-    }
-    var value = String(text);
-    if (!value.trim()) {
-      return;
-    }
-    pdfEntries.push({
-      type: 'line',
-      text: value,
-      indent: indent
-    });
-  };
-  var pdfPushBlank = function pdfPushBlank() {
-    if (!pdfEntries.length || pdfEntries[pdfEntries.length - 1].type === 'blank') {
-      return;
-    }
-    pdfEntries.push({
-      type: 'blank'
-    });
-  };
-  var pdfPushSectionHeading = function pdfPushSectionHeading(text) {
-    if (!text) {
-      return;
-    }
-    if (pdfEntries.length) {
-      pdfPushBlank();
-    }
-    pdfPushLine(text);
-  };
-  var pdfPushList = function pdfPushList(items) {
-    var indent = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : 2;
-    var prefix = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : '- ';
-    if (!Array.isArray(items)) {
-      return;
-    }
-    for (var i = 0; i < items.length; i += 1) {
-      var item = items[i];
-      if (!item) {
-        continue;
-      }
-      pdfPushLine("".concat(prefix).concat(item), indent);
-    }
-  };
-  var mmToPt = function mmToPt(value) {
-    return value * 72 / 25.4;
-  };
-  var formatPdfNumber = function formatPdfNumber(value) {
-    if (!Number.isFinite(value)) {
-      return '0';
-    }
-    var rounded = Math.round(value * 1000) / 1000;
-    if (Math.abs(rounded) < 1e-6) {
-      return '0';
-    }
-    return rounded.toString();
-  };
-  var getTextEncoder = function getTextEncoder() {
-    if (typeof TextEncoder === 'function') {
-      return new TextEncoder();
-    }
-    return null;
-  };
-  var encodeText = function encodeText(text, encoder) {
-    if (encoder) {
-      return encoder.encode(text);
-    }
-    var safeText = String(text || '');
-    var bytes = new Uint8Array(safeText.length);
-    for (var i = 0; i < safeText.length; i += 1) {
-      bytes[i] = safeText.charCodeAt(i) & 0xFF;
-    }
-    return bytes;
-  };
-  var ensureFontsReady = function () {
-    var _ref2 = _asyncToGenerator(_regenerator().m(function _callee2(doc) {
-      var _t2;
-      return _regenerator().w(function (_context2) {
-        while (1) switch (_context2.p = _context2.n) {
-          case 0:
-            if (!(!doc || !doc.fonts || !doc.fonts.ready || typeof doc.fonts.ready.then !== 'function')) {
-              _context2.n = 1;
-              break;
-            }
-            return _context2.a(2);
-          case 1:
-            _context2.p = 1;
-            _context2.n = 2;
-            return doc.fonts.ready;
-          case 2:
-            _context2.n = 4;
-            break;
-          case 3:
-            _context2.p = 3;
-            _t2 = _context2.v;
-            console.warn('Font loading check failed during PDF export.', _t2);
-          case 4:
-            return _context2.a(2);
-        }
-      }, _callee2, null, [[1, 3]]);
-    }));
-    return function ensureFontsReady(_x3) {
-      return _ref2.apply(this, arguments);
-    };
-  }();
-  var waitForImagesToLoad = function () {
-    var _ref3 = _asyncToGenerator(_regenerator().m(function _callee3(root) {
-      var images, promises;
-      return _regenerator().w(function (_context3) {
-        while (1) switch (_context3.n) {
-          case 0:
-            if (!(!root || typeof root.querySelectorAll !== 'function')) {
-              _context3.n = 1;
-              break;
-            }
-            return _context3.a(2);
-          case 1:
-            images = Array.from(root.querySelectorAll('img'));
-            if (root.tagName === 'IMG') {
-              images.push(root);
-            }
-            promises = images.map(function (img) {
-              return new Promise(function (resolve) {
-                if (!img) {
-                  resolve();
-                  return;
-                }
-                if (img.complete && img.naturalWidth !== 0) {
-                  resolve();
-                  return;
-                }
-                var _finalize = function finalize() {
-                  img.removeEventListener('load', _finalize);
-                  img.removeEventListener('error', _finalize);
-                  resolve();
-                };
-                img.addEventListener('load', _finalize, {
-                  once: true
-                });
-                img.addEventListener('error', _finalize, {
-                  once: true
-                });
-              });
-            });
-            _context3.n = 2;
-            return Promise.all(promises);
-          case 2:
-            return _context3.a(2);
-        }
-      }, _callee3);
-    }));
-    return function waitForImagesToLoad(_x4) {
-      return _ref3.apply(this, arguments);
-    };
-  }();
-  var TEXT_NODE = typeof Node !== 'undefined' ? Node.TEXT_NODE : 3;
-  var ELEMENT_NODE = typeof Node !== 'undefined' ? Node.ELEMENT_NODE : 1;
-  var _cloneNodeWithComputedStyles = function cloneNodeWithComputedStyles(node) {
-    if (!node) {
-      return null;
-    }
-    if (node.nodeType === TEXT_NODE) {
-      return node.cloneNode(true);
-    }
-    if (node.nodeType !== ELEMENT_NODE) {
-      return node.cloneNode(true);
-    }
-    var clone = node.cloneNode(false);
-    var win = node.ownerDocument ? node.ownerDocument.defaultView : null;
-    if (win && typeof win.getComputedStyle === 'function') {
-      var computed = win.getComputedStyle(node);
-      if (computed) {
-        var styles = [];
-        for (var i = 0; i < computed.length; i += 1) {
-          var prop = computed[i];
-          if (!prop) {
-            continue;
-          }
-          styles.push("".concat(prop, ":").concat(computed.getPropertyValue(prop), ";"));
-        }
-        if (styles.length) {
-          clone.setAttribute('style', styles.join(''));
-        }
-      }
-    }
-    var childNodes = node.childNodes;
-    for (var _i3 = 0; _i3 < childNodes.length; _i3 += 1) {
-      var childClone = _cloneNodeWithComputedStyles(childNodes[_i3]);
-      if (childClone) {
-        clone.appendChild(childClone);
-      }
-    }
-    return clone;
-  };
-  var renderElementToCanvas = function () {
-    var _ref4 = _asyncToGenerator(_regenerator().m(function _callee4(element) {
-      var options,
-        doc,
-        rect,
-        width,
-        height,
-        scale,
-        clone,
-        wrapper,
-        serialized,
-        svg,
-        svgUrl,
-        image,
-        canvas,
-        ctx,
-        _args4 = arguments;
-      return _regenerator().w(function (_context4) {
-        while (1) switch (_context4.n) {
-          case 0:
-            options = _args4.length > 1 && _args4[1] !== undefined ? _args4[1] : {};
-            if (!(!element || typeof document === 'undefined' || typeof window === 'undefined')) {
-              _context4.n = 1;
-              break;
-            }
-            return _context4.a(2, null);
-          case 1:
-            doc = element.ownerDocument || document;
-            rect = element.getBoundingClientRect();
-            width = Math.max(1, Math.ceil(rect.width));
-            height = Math.max(1, Math.ceil(element.scrollHeight || rect.height));
-            scale = Math.max(1, Math.min(3, options.scale || window.devicePixelRatio || 1));
-            clone = _cloneNodeWithComputedStyles(element);
-            if (clone) {
-              _context4.n = 2;
-              break;
-            }
-            return _context4.a(2, null);
-          case 2:
-            wrapper = doc.createElement('div');
-            wrapper.setAttribute('xmlns', 'http://www.w3.org/1999/xhtml');
-            wrapper.setAttribute('style', "position:relative;box-sizing:border-box;width:".concat(width, "px;height:auto;background:#ffffff;"));
-            wrapper.appendChild(clone);
-            serialized = new XMLSerializer().serializeToString(wrapper);
-            svg = "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"".concat(width, "\" height=\"").concat(height, "\"><foreignObject width=\"100%\" height=\"100%\">").concat(serialized, "</foreignObject></svg>");
-            svgUrl = "data:image/svg+xml;charset=utf-8,".concat(encodeURIComponent(svg));
-            image = new Image();
-            image.decoding = 'async';
-            image.src = svgUrl;
-            _context4.n = 3;
-            return new Promise(function (resolve, reject) {
-              var timer = setTimeout(function () {
-                resolve();
-              }, 2000);
-              image.onload = function () {
-                clearTimeout(timer);
-                resolve();
-              };
-              image.onerror = function (error) {
-                clearTimeout(timer);
-                reject(error);
-              };
-            });
-          case 3:
-            canvas = doc.createElement('canvas');
-            canvas.width = Math.max(1, Math.ceil(width * scale));
-            canvas.height = Math.max(1, Math.ceil(height * scale));
-            ctx = canvas.getContext('2d');
-            if (ctx) {
-              _context4.n = 4;
-              break;
-            }
-            return _context4.a(2, null);
-          case 4:
-            ctx.scale(scale, scale);
-            ctx.fillStyle = '#ffffff';
-            ctx.fillRect(0, 0, width, height);
-            ctx.drawImage(image, 0, 0);
-            return _context4.a(2, {
-              canvas: canvas,
-              width: width,
-              height: height,
-              scale: scale
-            });
-        }
-      }, _callee4);
-    }));
-    return function renderElementToCanvas(_x5) {
-      return _ref4.apply(this, arguments);
-    };
-  }();
-  var dataUrlToUint8 = function dataUrlToUint8(dataUrl) {
-    if (!dataUrl || typeof dataUrl !== 'string') {
-      return new Uint8Array(0);
-    }
-    var commaIndex = dataUrl.indexOf(',');
-    var base64 = commaIndex >= 0 ? dataUrl.slice(commaIndex + 1) : dataUrl;
-    var binary = atob(base64);
-    var length = binary.length;
-    var bytes = new Uint8Array(length);
-    for (var i = 0; i < length; i += 1) {
-      bytes[i] = binary.charCodeAt(i);
-    }
-    return bytes;
-  };
-  var createImageBasedPdf = function createImageBasedPdf(pages) {
-    var metadata = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
-    var pageWidthPt = metadata.pageWidthPt || mmToPt(210);
-    var pageHeightPt = metadata.pageHeightPt || mmToPt(297);
-    var marginPt = metadata.marginPt || mmToPt(10);
-    var encoder = getTextEncoder();
-    var objects = [];
-    var registerObject = function registerObject(factory) {
-      var id = objects.length + 1;
-      objects.push({
-        id: id,
-        factory: factory
-      });
-      return id;
-    };
-    var pagesCount = pages.length;
-    var imageIds = [];
-    var contentIds = [];
-    var pageIds = [];
-    var pagesRootId = null;
-    var blankPageContentId = null;
-    var blankPageId = null;
-    var _loop = function _loop(i) {
-      var page = pages[i];
-      var imageId = registerObject(function () {
-        var header = "<< /Type /XObject /Subtype /Image /Width ".concat(page.pixelWidth, " /Height ").concat(page.pixelHeight, " /ColorSpace /DeviceRGB /BitsPerComponent 8 /Filter /DCTDecode /Length ").concat(page.data.length, " >>\nstream\n");
-        return [header, page.data, '\nendstream\n'];
-      });
-      imageIds.push(imageId);
-      var translateY = pageHeightPt - marginPt - page.heightPt;
-      var stream = "q ".concat(formatPdfNumber(page.widthPt), " 0 0 ").concat(formatPdfNumber(page.heightPt), " ").concat(formatPdfNumber(marginPt), " ").concat(formatPdfNumber(translateY), " cm /Im").concat(i, " Do Q\n");
-      var contentId = registerObject(function () {
-        return ["<< /Length ".concat(stream.length, " >>\nstream\n"), stream, '\nendstream\n'];
-      });
-      contentIds.push(contentId);
-      var pageId = registerObject(function () {
-        return ["<< /Type /Page /Parent ".concat(pagesRootId, " 0 R /Resources << /XObject << /Im").concat(i, " ").concat(imageId, " 0 R >> /ProcSet [/PDF /ImageC] >> /MediaBox [0 0 ").concat(formatPdfNumber(pageWidthPt), " ").concat(formatPdfNumber(pageHeightPt), "] /Contents ").concat(contentId, " 0 R >>\n")];
-      });
-      pageIds.push(pageId);
-    };
-    for (var i = 0; i < pagesCount; i += 1) {
-      _loop(i);
-    }
-    pagesRootId = registerObject(function () {
-      if (!pageIds.length) {
-        return ["<< /Type /Pages /Count 1 /Kids [".concat(blankPageId, " 0 R] >>\n")];
-      }
-      var kids = pageIds.map(function (id) {
-        return "".concat(id, " 0 R");
-      }).join(' ');
-      return ["<< /Type /Pages /Count ".concat(pageIds.length, " /Kids [").concat(kids, "] >>\n")];
-    });
-    if (!pageIds.length) {
-      blankPageContentId = registerObject(function () {
-        return ['<< /Length 0 >>\nstream\n\nendstream\n'];
-      });
-      blankPageId = registerObject(function () {
-        return ["<< /Type /Page /Parent ".concat(pagesRootId, " 0 R /MediaBox [0 0 ").concat(formatPdfNumber(pageWidthPt), " ").concat(formatPdfNumber(pageHeightPt), "] /Contents ").concat(blankPageContentId, " 0 R >>\n")];
-      });
-    }
-    var infoId = registerObject(function () {
-      var nowDate = new Date();
-      var pad = function pad(value) {
-        return String(value).padStart(2, '0');
-      };
-      var creationDate = "D:".concat(nowDate.getFullYear()).concat(pad(nowDate.getMonth() + 1)).concat(pad(nowDate.getDate())).concat(pad(nowDate.getHours())).concat(pad(nowDate.getMinutes())).concat(pad(nowDate.getSeconds()));
-      var entries = ['/Producer (Camera Power Planner)', '/Creator (Camera Power Planner Overview Export)', "/CreationDate (".concat(creationDate, ")")];
-      if (metadata.title) {
-        var normalizedTitle = normalizeForPdf(metadata.title);
-        if (normalizedTitle) {
-          entries.push("/Title (".concat(pdfEscape(normalizedTitle), ")"));
-        }
-      }
-      return ["<< ".concat(entries.join(' '), " >>\n")];
-    });
-    var catalogId = registerObject(function () {
-      return ["<< /Type /Catalog /Pages ".concat(pagesRootId, " 0 R >>\n")];
-    });
-    var chunks = [];
-    var position = 0;
-    var offsets = [0];
-    var pushChunk = function pushChunk(chunk) {
-      chunks.push(chunk);
-      position += chunk.length;
-    };
-    var writeString = function writeString(text) {
-      var bytes = encodeText(text, encoder);
-      pushChunk(bytes);
-    };
-    writeString('%PDF-1.4\n');
-    for (var _i4 = 0; _i4 < objects.length; _i4 += 1) {
-      var object = objects[_i4];
-      offsets.push(position);
-      writeString("".concat(object.id, " 0 obj\n"));
-      var parts = object.factory ? object.factory() : [];
-      for (var j = 0; j < parts.length; j += 1) {
-        var part = parts[j];
-        if (typeof part === 'string') {
-          writeString(part);
-        } else if (part instanceof Uint8Array) {
-          pushChunk(part);
-        }
-      }
-      writeString('endobj\n');
-    }
-    var xrefPosition = position;
-    writeString("xref\n0 ".concat(objects.length + 1, "\n"));
-    writeString('0000000000 65535 f \n');
-    for (var _i5 = 1; _i5 < offsets.length; _i5 += 1) {
-      var line = "".concat(offsets[_i5].toString().padStart(10, '0'), " 00000 n \n");
-      writeString(line);
-    }
-    var trailerParts = ["trailer\n<< /Size ".concat(objects.length + 1, " /Root ").concat(catalogId, " 0 R /Info ").concat(infoId, " 0 R >>\nstartxref\n").concat(xrefPosition, "\n%%EOF")];
-    trailerParts.forEach(function (part) {
-      return writeString(part);
-    });
-    return new Blob(chunks, {
-      type: 'application/pdf'
-    });
-  };
-  var renderOverviewPdf = function () {
-    var _ref5 = _asyncToGenerator(_regenerator().m(function _callee5(element) {
-      var options,
-        doc,
-        pixelRatio,
-        renderScale,
-        rendered,
-        canvas,
-        width,
-        height,
-        scale,
-        pageWidthPt,
-        pageHeightPt,
-        marginPt,
-        availableWidthPt,
-        widthScale,
-        availableHeightPt,
-        pageHeightPxLimit,
-        pages,
-        offsetPx,
-        sliceHeightPx,
-        pageCanvas,
-        ctx,
-        dataUrl,
-        _args5 = arguments,
-        _t3;
-      return _regenerator().w(function (_context5) {
-        while (1) switch (_context5.p = _context5.n) {
-          case 0:
-            options = _args5.length > 1 && _args5[1] !== undefined ? _args5[1] : {};
-            if (!(!element || typeof window === 'undefined' || typeof document === 'undefined')) {
-              _context5.n = 1;
-              break;
-            }
-            return _context5.a(2, null);
-          case 1:
-            _context5.p = 1;
-            doc = element.ownerDocument || document;
-            _context5.n = 2;
-            return ensureFontsReady(doc);
-          case 2:
-            _context5.n = 3;
-            return waitForImagesToLoad(element);
-          case 3:
-            pixelRatio = typeof window.devicePixelRatio === 'number' ? window.devicePixelRatio : 1;
-            renderScale = Math.max(1.5, Math.min(2.5, pixelRatio * 1.25));
-            _context5.n = 4;
-            return renderElementToCanvas(element, {
-              scale: renderScale
-            });
-          case 4:
-            rendered = _context5.v;
-            if (rendered) {
-              _context5.n = 5;
-              break;
-            }
-            return _context5.a(2, null);
-          case 5:
-            canvas = rendered.canvas, width = rendered.width, height = rendered.height, scale = rendered.scale;
-            pageWidthPt = mmToPt(210);
-            pageHeightPt = mmToPt(297);
-            marginPt = mmToPt(10);
-            availableWidthPt = pageWidthPt - marginPt * 2;
-            widthScale = availableWidthPt / Math.max(1, width);
-            availableHeightPt = pageHeightPt - marginPt * 2;
-            pageHeightPxLimit = Math.max(1, Math.floor(availableHeightPt / widthScale));
-            pages = [];
-            offsetPx = 0;
-          case 6:
-            if (!(offsetPx < height)) {
-              _context5.n = 8;
-              break;
-            }
-            sliceHeightPx = Math.min(pageHeightPxLimit, height - offsetPx);
-            pageCanvas = doc.createElement('canvas');
-            pageCanvas.width = Math.max(1, Math.ceil(width * scale));
-            pageCanvas.height = Math.max(1, Math.ceil(sliceHeightPx * scale));
-            ctx = pageCanvas.getContext('2d');
-            if (ctx) {
-              _context5.n = 7;
-              break;
-            }
-            return _context5.a(3, 8);
-          case 7:
-            ctx.drawImage(canvas, 0, offsetPx * scale, width * scale, sliceHeightPx * scale, 0, 0, width * scale, sliceHeightPx * scale);
-            dataUrl = pageCanvas.toDataURL('image/jpeg', 0.92);
-            pages.push({
-              data: dataUrlToUint8(dataUrl),
-              pixelWidth: pageCanvas.width,
-              pixelHeight: pageCanvas.height,
-              widthPt: availableWidthPt,
-              heightPt: sliceHeightPx * widthScale
-            });
-            offsetPx += sliceHeightPx;
-            _context5.n = 6;
-            break;
-          case 8:
-            if (pages.length) {
-              _context5.n = 9;
-              break;
-            }
-            return _context5.a(2, createImageBasedPdf([], {
-              pageWidthPt: pageWidthPt,
-              pageHeightPt: pageHeightPt,
-              marginPt: marginPt,
-              title: options.title
-            }));
-          case 9:
-            return _context5.a(2, createImageBasedPdf(pages, {
-              pageWidthPt: pageWidthPt,
-              pageHeightPt: pageHeightPt,
-              marginPt: marginPt,
-              title: options.title
-            }));
-          case 10:
-            _context5.p = 10;
-            _t3 = _context5.v;
-            console.error('Unable to render overview PDF using layout capture.', _t3);
-            return _context5.a(2, null);
-        }
-      }, _callee5, null, [[1, 10]]);
-    }));
-    return function renderOverviewPdf(_x6) {
-      return _ref5.apply(this, arguments);
-    };
-  }();
-  var addHtmlAsPdfLines = function addHtmlAsPdfLines(html) {
-    var indent = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : 2;
-    var lines = htmlToPlainTextLines(html);
-    for (var i = 0; i < lines.length; i += 1) {
-      pdfPushLine(lines[i], indent);
-    }
-  };
   var generatedOnDisplayLabel = ensureLabelSuffix(generatedOnLabel);
-  var setupNameDisplayLabel = ensureLabelSuffix(t.setupNameLabel || 'Project Name');
-  pdfPushLine(t.overviewTitle || 'Project Overview');
-  pdfPushBlank();
-  pdfPushLine("".concat(setupNameDisplayLabel, " ").concat(setupName || '-'));
-  pdfPushLine("".concat(generatedOnDisplayLabel, " ").concat(dateTimeString));
-  var sectionTextMap = {};
   var deviceListHtml = '<div class="device-category-container">';
   var sections = {};
   var sectionOrder = [];
@@ -974,13 +63,6 @@ function generatePrintableOverview() {
       sectionOrder.push(key);
     }
     sections[key].push(itemHtml);
-    if (!sectionTextMap[key]) {
-      sectionTextMap[key] = [];
-    }
-    var textLines = htmlToPlainTextLines(itemHtml);
-    if (textLines.length) {
-      sectionTextMap[key].push(textLines.join(' — '));
-    }
   };
   var processSelectForOverview = function processSelectForOverview(selectElement, headingKey, category) {
     var subcategory = arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : null;
@@ -1026,17 +108,6 @@ function generatePrintableOverview() {
     deviceListHtml += "<div class=\"device-category\"><h3>".concat(iconHtml).concat(heading, "</h3><div class=\"").concat(gridClasses, "\">").concat(sections[key].join(''), "</div></div>");
   });
   deviceListHtml += '</div>';
-  if (sectionOrder.length) {
-    pdfPushSectionHeading(t.overviewDeviceSelectionHeading || t.deviceSelectionHeading || 'Camera Setup Devices');
-    sectionOrder.forEach(function (key, index) {
-      var heading = t[key] || key;
-      pdfPushLine(heading);
-      pdfPushList(sectionTextMap[key] || [], 2);
-      if (index < sectionOrder.length - 1) {
-        pdfPushBlank();
-      }
-    });
-  }
   var breakdownHtml = breakdownListElem.innerHTML;
   var batteryLifeUnitElem = document.getElementById("batteryLifeUnit");
   var powerDiagramElem = typeof document !== 'undefined' ? document.getElementById('powerDiagram') : null;
@@ -1102,22 +173,6 @@ function generatePrintableOverview() {
   };
   var warningHtml = buildStatusMarkup(pinWarnElem) + buildStatusMarkup(dtapWarnElem);
   var resultsSectionHtml = "\n        <section id=\"resultsSection\" class=\"results-section print-section\">\n            <h2>".concat(t.resultsHeading, "</h2>\n            <div class=\"results-body\">\n                ").concat(resultsHtml, "\n                ").concat(warningHtml ? "<div class=\"results-warnings\">".concat(warningHtml, "</div>") : '', "\n            </div>\n        </section>\n    ");
-  var resultsLinesForPdf = ["".concat(ensureLabelSuffix(t.totalPowerLabel || 'Total Power'), " ").concat(totalPowerElem.textContent, " W"), "".concat(ensureLabelSuffix(t.totalCurrent144Label || 'Total Current (14.4V)'), " ").concat(totalCurrent144Elem.textContent, " A"), "".concat(ensureLabelSuffix(t.totalCurrent12Label || 'Total Current (12V)'), " ").concat(totalCurrent12Elem.textContent, " A"), "".concat(ensureLabelSuffix(t.batteryLifeLabel || 'Estimated Battery Life'), " ").concat(batteryLifeElem.textContent, " ").concat(batteryLifeUnitElem ? batteryLifeUnitElem.textContent : '').trim(), "".concat(ensureLabelSuffix(t.batteryCountLabel || 'Battery Count'), " ").concat(batteryCountElem.textContent)].filter(function (line) {
-    return line && line.trim();
-  });
-  if (resultsLinesForPdf.length) {
-    pdfPushSectionHeading(t.resultsHeading || 'Power Summary');
-    resultsLinesForPdf.forEach(function (line) {
-      return pdfPushLine(line, 2);
-    });
-  }
-  if (warningHtml) {
-    var warningLines = htmlToPlainTextLines(warningHtml);
-    if (warningLines.length) {
-      pdfPushSectionHeading(defaultPdfWarningHeading);
-      pdfPushList(warningLines, 2, '! ');
-    }
-  }
   var batteryComparisonSection = typeof document !== 'undefined' ? document.getElementById('batteryComparison') : null;
   var isSectionRenderable = function isSectionRenderable(section) {
     if (!section) return false;
@@ -1153,10 +208,6 @@ function generatePrintableOverview() {
     }
     batteryComparisonHtml = "<div class=\"page-break\"></div>".concat(_clone.outerHTML);
   }
-  if (batteryComparisonHtml) {
-    pdfPushSectionHeading(t.batteryComparisonHeading || 'Battery Comparison');
-    addHtmlAsPdfLines(batteryComparisonHtml, 2);
-  }
   var safeSetupName = escapeHtmlSafe(setupName);
   var diagramCss = getDiagramCss(false);
   var diagramAreaHtml = '';
@@ -1174,19 +225,6 @@ function generatePrintableOverview() {
   var diagramHintHtml = diagramHint ? diagramHint.outerHTML : '';
   var diagramDescHtml = document.getElementById('diagramDesc') ? document.getElementById('diagramDesc').outerHTML : '';
   var diagramSectionHtml = diagramAreaHtml ? "<section id=\"setupDiagram\" class=\"diagram-section print-section\"><h2>".concat(t.setupDiagramHeading, "</h2>").concat(diagramDescHtml).concat(diagramAreaHtml).concat(diagramLegendHtml).concat(diagramHintHtml, "</section>") : '';
-  if (diagramSectionHtml) {
-    pdfPushSectionHeading(t.setupDiagramHeading || 'Connection Diagram');
-    if (diagramDescHtml) {
-      addHtmlAsPdfLines(diagramDescHtml, 2);
-    }
-    if (diagramLegendHtml) {
-      addHtmlAsPdfLines(diagramLegendHtml, 2);
-    }
-    if (diagramHintHtml) {
-      addHtmlAsPdfLines(diagramHintHtml, 2);
-    }
-    pdfPushLine(diagramPdfNote, 2);
-  }
   var hasGeneratedGearList = function () {
     if (typeof document === 'undefined') return false;
     var container = document.getElementById('gearListOutput');
@@ -1215,13 +253,9 @@ function generatePrintableOverview() {
     };
     if (parts.projectHtml) {
       projectSectionHtml = "<section id=\"projectRequirementsOutput\" class=\"print-section project-requirements-section\">".concat(parts.projectHtml, "</section>");
-      pdfPushSectionHeading(t.projectRequirementsNav || 'Project Requirements');
-      addHtmlAsPdfLines(parts.projectHtml, 2);
     }
     if (parts.gearHtml && hasGeneratedGearList) {
       gearSectionHtml = "<section id=\"gearListOutput\" class=\"gear-list-section\">".concat(parts.gearHtml, "</section>");
-      pdfPushSectionHeading(t.gearListNav || 'Gear List');
-      addHtmlAsPdfLines(parts.gearHtml, 2);
     }
   }
   var gearListHtmlCombined = projectSectionHtml || gearSectionHtml ? "".concat(projectSectionHtml || '').concat(gearSectionHtml || '') : '';
@@ -1243,13 +277,6 @@ function generatePrintableOverview() {
     return '<span class="btn-icon icon-glyph" aria-hidden="true" data-icon-font="uicons">&#xE7AB;</span>';
   }();
   var overviewHtml = "\n        <div id=\"overviewDialogContent\" class=\"".concat(contentClass, "\">\n            <div class=\"overview-actions\">\n                <button id=\"closeOverviewBtn\" class=\"back-btn\"><span class=\"btn-icon icon-glyph\" aria-hidden=\"true\" data-icon-font=\"essential\">&#xF131;</span>").concat(escapeHtmlSafe(t.backToAppBtn), "</button>\n                <button id=\"printOverviewBtn\" class=\"print-btn\"><span class=\"btn-icon icon-glyph\" aria-hidden=\"true\" data-icon-font=\"uicons\">&#xE7AB;</span>").concat(escapeHtmlSafe(t.printBtn), "</button>\n                <button id=\"exportPdfBtn\" class=\"print-btn export-pdf-btn\">").concat(exportIconHtml).concat(escapeHtmlSafe(exportPdfLabel), "</button>\n            </div>\n            ").concat(logoHtml, "\n            <h1>").concat(t.overviewTitle, "</h1>\n            <p><strong>").concat(t.setupNameLabel, "</strong> ").concat(safeSetupName, "</p>\n            <p><em>").concat(generatedOnDisplay, "</em></p>\n\n            <h2>").concat(t.overviewDeviceSelectionHeading || t.deviceSelectionHeading, "</h2>\n            ").concat(deviceListHtml, "\n\n            ").concat(resultsSectionHtml, "\n\n            ").concat(diagramSectionHtml, "\n\n            ").concat(gearListHtmlCombined, "\n            ").concat(gearListActionsHtml, "\n            ").concat(batteryComparisonHtml, "\n        </div>\n    ");
-  var sanitizedProjectSegmentForFile = sanitizeTitleSegment(projectTitleSegment) || 'Project';
-  var pdfFileName = "".concat(formattedDate, "_").concat(formattedTime, "_").concat(sanitizedProjectSegmentForFile, "_Overview.pdf");
-  var pdfExportConfig = {
-    entries: pdfEntries.slice(),
-    fileName: pdfFileName,
-    title: printDocumentTitle
-  };
   var overviewDialog = document.getElementById('overviewDialog');
   overviewDialog.innerHTML = overviewHtml;
   var content = overviewDialog.querySelector('#overviewDialogContent');
@@ -1409,72 +436,32 @@ function generatePrintableOverview() {
     });
     return true;
   };
-  var exportBtn = overviewDialog.querySelector('#exportPdfBtn');
-  if (exportBtn) {
-    exportBtn.addEventListener('click', _asyncToGenerator(_regenerator().m(function _callee6() {
-      var pdfBlob, _t4;
-      return _regenerator().w(function (_context6) {
-        while (1) switch (_context6.p = _context6.n) {
-          case 0:
-            if (!exportBtn.disabled) {
-              _context6.n = 1;
-              break;
-            }
-            return _context6.a(2);
-          case 1:
-            exportBtn.disabled = true;
-            _context6.p = 2;
-            pdfBlob = null;
-            if (!content) {
-              _context6.n = 4;
-              break;
-            }
-            _context6.n = 3;
-            return renderOverviewPdf(content, {
-              title: pdfExportConfig.title
-            });
-          case 3:
-            pdfBlob = _context6.v;
-          case 4:
-            if (!pdfBlob) {
-              pdfBlob = createTextOverviewPdfBlob(pdfExportConfig.entries, {
-                title: pdfExportConfig.title
-              });
-            }
-            _context6.n = 5;
-            return downloadBlobAsFile(pdfBlob, pdfExportConfig.fileName);
-          case 5:
-            _context6.n = 7;
-            break;
-          case 6:
-            _context6.p = 6;
-            _t4 = _context6.v;
-            console.error('Failed to export overview PDF.', _t4);
-          case 7:
-            _context6.p = 7;
-            exportBtn.disabled = false;
-            return _context6.f(7);
-          case 8:
-            return _context6.a(2);
-        }
-      }, _callee6, null, [[2, 6, 7, 8]]);
-    })));
-  }
-  var printBtn = overviewDialog.querySelector('#printOverviewBtn');
-  if (printBtn) {
-    printBtn.addEventListener('click', function () {
-      var handlePrintError = function handlePrintError(error) {
-        if (error && error.name === 'AbortError') {
-          return;
-        }
-        console.warn('window.print() failed; using fallback print window.', error);
-        if (openFallbackPrintView()) {
-          _closeAfterPrint();
-        }
-      };
-      if (typeof window.print !== 'function') {
-        handlePrintError(new Error('Print API unavailable'));
-        return;
+  var triggerPrintWorkflow = function triggerPrintWorkflow() {
+    var options = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
+    var _options$preferFallba = options.preferFallback,
+      preferFallback = _options$preferFallba === void 0 ? false : _options$preferFallba,
+      _options$reason = options.reason,
+      reason = _options$reason === void 0 ? 'print' : _options$reason;
+    var logPrefix = reason === 'export' ? 'Overview PDF export' : 'Overview print';
+    var fallbackAttempts = 0;
+    var attemptFallback = function attemptFallback(error) {
+      fallbackAttempts += 1;
+      if (error && error.name !== 'AbortError') {
+        console.warn("".concat(logPrefix, ": falling back to print window."), error);
+      }
+      var opened = openFallbackPrintView();
+      if (opened) {
+        _closeAfterPrint();
+        return true;
+      }
+      if (error && error.name !== 'AbortError') {
+        console.error("".concat(logPrefix, ": unable to open fallback print window."), error);
+      }
+      return false;
+    };
+    var attemptNative = function attemptNative() {
+      if (typeof window === 'undefined' || typeof window.print !== 'function') {
+        return false;
       }
       try {
         if (typeof document !== 'undefined') {
@@ -1482,10 +469,64 @@ function generatePrintableOverview() {
         }
         var result = window.print();
         if (result && typeof result.then === 'function') {
-          result.catch(handlePrintError);
+          result.catch(function (error) {
+            if (!fallbackAttempts) {
+              attemptFallback(error);
+            }
+          });
+        }
+        return true;
+      } catch (error) {
+        return attemptFallback(error);
+      }
+    };
+    var success = false;
+    if (preferFallback) {
+      success = attemptFallback();
+      if (!success) {
+        success = attemptNative();
+      }
+    } else {
+      success = attemptNative();
+    }
+    if (!success && fallbackAttempts === 0) {
+      success = attemptFallback();
+    }
+    if (!success && typeof document !== 'undefined' && document.title === printDocumentTitle) {
+      document.title = originalDocumentTitle;
+    }
+    return success;
+  };
+  var exportBtn = overviewDialog.querySelector('#exportPdfBtn');
+  if (exportBtn) {
+    exportBtn.addEventListener('click', function () {
+      if (exportBtn.disabled) {
+        return;
+      }
+      exportBtn.disabled = true;
+      try {
+        var printStarted = triggerPrintWorkflow({
+          preferFallback: true,
+          reason: 'export'
+        });
+        if (!printStarted) {
+          console.error('Unable to start the PDF export print workflow. Please enable pop-ups and try again.');
         }
       } catch (error) {
-        handlePrintError(error);
+        console.error('Failed to export overview PDF via print workflow.', error);
+      } finally {
+        exportBtn.disabled = false;
+      }
+    });
+  }
+  var printBtn = overviewDialog.querySelector('#printOverviewBtn');
+  if (printBtn) {
+    printBtn.addEventListener('click', function () {
+      var success = triggerPrintWorkflow({
+        reason: 'print'
+      });
+      if (!success) {
+        console.error('Unable to open the print dialog. Please check your browser settings and try again.');
       }
     });
   }

--- a/src/scripts/overview.js
+++ b/src/scripts/overview.js
@@ -43,802 +43,13 @@ function generatePrintableOverview() {
     const originalDocumentTitle = typeof document !== 'undefined' ? document.title : '';
     const customLogo = typeof localStorage !== 'undefined' ? localStorage.getItem('customLogo') : null;
     const generatedOnLabel = t.generatedOnLabel || 'Generated on';
-    const defaultPdfWarningHeading = t.pdfWarningsHeading || 'Warnings';
-    const diagramPdfNote = t.diagramPdfNote
-        || 'The visual connection diagram is not included in the PDF export. Open the print view to review the layout.';
-
     const ensureLabelSuffix = (label) => {
         const base = typeof label === 'string' ? label.trim() : '';
         if (!base) return '';
         return /[:：]$/.test(base) ? base : `${base}:`;
     };
 
-    const normalizeForPdf = (value) => {
-        if (value === null || value === undefined) {
-            return '';
-        }
-        let text = String(value);
-        if (typeof text.normalize === 'function') {
-            text = text.normalize('NFKD');
-        }
-        text = text
-            .replace(/[\u0300-\u036f]/g, '')
-            .replace(/\u00DF/g, 'ss')
-            .replace(/[\u00A0\u202F\u2007]/g, ' ')
-            .replace(/[\u2010\u2011\u2012\u2013\u2014\u2212]/g, '-')
-            .replace(/\u00B0/g, ' deg ')
-            .replace(/\u00D7/g, 'x')
-            .replace(/\u00B5/g, 'u')
-            .replace(/\u2126/g, 'Ohm')
-            .replace(/\u20AC/g, 'EUR')
-            .replace(/\u00A3/g, 'GBP')
-            .replace(/\u00A5/g, 'JPY')
-            .replace(/\u00BD/g, '1/2')
-            .replace(/\u00BC/g, '1/4')
-            .replace(/\u00BE/g, '3/4')
-            .replace(/\u2022/g, '-')
-            .replace(/[\u2018\u2019\u201A\u201B]/g, "'")
-            .replace(/[\u201C\u201D\u201E\u201F]/g, '"');
-        text = text.replace(/[^\x20-\x7E]/g, '?');
-        return text.replace(/\s+/g, ' ').trim();
-    };
-
-    const wrapPdfText = (text, maxLength) => {
-        const result = [];
-        const limit = Math.max(10, maxLength || 80);
-        const normalized = normalizeForPdf(text);
-        if (!normalized) {
-            return result;
-        }
-        const words = normalized.split(' ');
-        let currentLine = '';
-        for (let i = 0; i < words.length; i += 1) {
-            const word = words[i];
-            if (!word) {
-                continue;
-            }
-            if (!currentLine) {
-                if (word.length <= limit) {
-                    currentLine = word;
-                } else {
-                    const chunks = [];
-                    for (let start = 0; start < word.length; start += limit) {
-                        chunks.push(word.slice(start, start + limit));
-                    }
-                    if (chunks.length) {
-                        result.push(chunks[0]);
-                        for (let c = 1; c < chunks.length - 1; c += 1) {
-                            result.push(chunks[c]);
-                        }
-                        currentLine = chunks[chunks.length - 1];
-                    }
-                }
-                continue;
-            }
-            const candidate = `${currentLine} ${word}`;
-            if (candidate.length <= limit) {
-                currentLine = candidate;
-            } else if (word.length > limit) {
-                result.push(currentLine);
-                const chunks = [];
-                for (let start = 0; start < word.length; start += limit) {
-                    chunks.push(word.slice(start, start + limit));
-                }
-                if (chunks.length) {
-                    for (let c = 0; c < chunks.length - 1; c += 1) {
-                        result.push(chunks[c]);
-                    }
-                    currentLine = chunks[chunks.length - 1];
-                } else {
-                    currentLine = '';
-                }
-            } else {
-                result.push(currentLine);
-                currentLine = word;
-            }
-        }
-        if (currentLine) {
-            result.push(currentLine);
-        }
-        return result;
-    };
-
-    const flattenPdfEntries = (entries) => {
-        const lines = [];
-        if (!Array.isArray(entries) || entries.length === 0) {
-            return ['No data available'];
-        }
-        for (let i = 0; i < entries.length; i += 1) {
-            const entry = entries[i];
-            if (!entry) {
-                continue;
-            }
-            if (entry.type === 'blank') {
-                if (lines.length && lines[lines.length - 1] !== '') {
-                    lines.push('');
-                }
-                continue;
-            }
-            const indent = Math.max(0, Math.min(40, entry.indent || 0));
-            const indentStr = indent ? ' '.repeat(indent) : '';
-            const normalized = normalizeForPdf(entry.text);
-            if (!normalized) {
-                continue;
-            }
-            const available = Math.max(10, 94 - indentStr.length);
-            const wrapped = wrapPdfText(normalized, available);
-            if (!wrapped.length) {
-                continue;
-            }
-            for (let w = 0; w < wrapped.length; w += 1) {
-                lines.push(indentStr + wrapped[w]);
-            }
-        }
-        if (!lines.length) {
-            lines.push('No data available');
-        }
-        return lines;
-    };
-
-    const splitLinesIntoPages = (lines, maxLinesPerPage) => {
-        const pages = [];
-        const limit = Math.max(1, maxLinesPerPage || 46);
-        let current = [];
-        for (let i = 0; i < lines.length; i += 1) {
-            const line = lines[i];
-            if (current.length >= limit) {
-                pages.push(current);
-                current = [];
-            }
-            if (line === '' && current.length === 0) {
-                continue;
-            }
-            current.push(line);
-        }
-        if (current.length) {
-            pages.push(current);
-        }
-        if (!pages.length) {
-            pages.push(['No data available']);
-        }
-        return pages;
-    };
-
-    const pdfEscape = (text) => String(text)
-        .replace(/\\/g, '\\\\')
-        .replace(/\(/g, '\\(')
-        .replace(/\)/g, '\\)')
-        .replace(/\r/g, ' ')
-        .replace(/\n/g, ' ');
-
-    const createTextOverviewPdfBlob = (entries, options = {}) => {
-        const fontRefName = '/F1';
-        const lines = flattenPdfEntries(entries);
-        const pages = splitLinesIntoPages(lines, 46);
-        const pageWidth = 612;
-        const pageHeight = 792;
-        const marginLeft = 72;
-        const marginTop = 72;
-        const fontSize = 12;
-        const leading = 14;
-
-        let nextObjectId = 1;
-        const bodies = {};
-        const order = [];
-
-        const reserveObject = () => {
-            const id = nextObjectId;
-            nextObjectId += 1;
-            order.push(id);
-            bodies[id] = null;
-            return id;
-        };
-
-        const setObjectBody = (id, body) => {
-            bodies[id] = body;
-        };
-
-        const addObject = (body) => {
-            const id = reserveObject();
-            setObjectBody(id, body);
-            return id;
-        };
-
-        const fontRef = addObject('<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>');
-        const pagesRef = reserveObject();
-        const pageRefs = [];
-
-        for (let p = 0; p < pages.length; p += 1) {
-            const pageLines = pages[p];
-            let content = 'BT\n';
-            content += `${fontRefName} ${fontSize} Tf\n`;
-            content += `${leading} TL\n`;
-            content += `${marginLeft} ${pageHeight - marginTop} Td\n`;
-            let firstLine = true;
-            for (let l = 0; l < pageLines.length; l += 1) {
-                const line = pageLines[l];
-                if (!firstLine) {
-                    content += 'T*\n';
-                } else {
-                    firstLine = false;
-                }
-                if (!line) {
-                    continue;
-                }
-                content += `(${pdfEscape(line)}) Tj\n`;
-            }
-            content += 'ET';
-            const streamBody = `<< /Length ${content.length} >>\nstream\n${content}\nendstream`;
-            const contentRef = addObject(streamBody);
-            const pageBody = `<< /Type /Page /Parent ${pagesRef} 0 R /MediaBox [0 0 ${pageWidth} ${pageHeight}] /Contents ${contentRef} 0 R /Resources << /Font << ${fontRefName} ${fontRef} 0 R >> >> >>`;
-            const pageRef = addObject(pageBody);
-            pageRefs.push(pageRef);
-        }
-
-        const kids = pageRefs.map(ref => `${ref} 0 R`).join(' ');
-        setObjectBody(pagesRef, `<< /Type /Pages /Count ${pageRefs.length} /Kids [${kids}] >>`);
-
-        const creationDate = `D:${now.getFullYear()}${padTwo(now.getMonth() + 1)}${padTwo(now.getDate())}${padTwo(now.getHours())}${padTwo(now.getMinutes())}${padTwo(now.getSeconds())}`;
-        const infoParts = [
-            '/Producer (Cine Power Planner)',
-            '/Creator (Cine Power Planner Overview Export)',
-            `/CreationDate (${creationDate})`,
-        ];
-        if (options && options.title) {
-            const normalizedTitle = normalizeForPdf(options.title);
-            if (normalizedTitle) {
-                infoParts.push(`/Title (${pdfEscape(normalizedTitle)})`);
-            }
-        }
-        const infoRef = addObject(`<< ${infoParts.join(' ')} >>`);
-        const catalogRef = addObject(`<< /Type /Catalog /Pages ${pagesRef} 0 R >>`);
-
-        let pdf = '%PDF-1.4\n';
-        const offsets = [0];
-        let offset = pdf.length;
-        for (let i = 0; i < order.length; i += 1) {
-            const id = order[i];
-            const body = bodies[id];
-            if (body === null || body === undefined) {
-                throw new Error('Missing PDF object body.');
-            }
-            const objectString = `${id} 0 obj\n${body}\nendobj\n`;
-            offsets.push(offset);
-            pdf += objectString;
-            offset += objectString.length;
-        }
-        const startXref = offset;
-        pdf += `xref\n0 ${order.length + 1}\n`;
-        pdf += '0000000000 65535 f \n';
-        for (let i = 1; i < offsets.length; i += 1) {
-            pdf += `${offsets[i].toString().padStart(10, '0')} 00000 n \n`;
-        }
-        pdf += `trailer\n<< /Size ${order.length + 1} /Root ${catalogRef} 0 R /Info ${infoRef} 0 R >>\nstartxref\n${startXref}\n%%EOF`;
-        return new Blob([pdf], { type: 'application/pdf' });
-    };
-
-    const downloadBlobAsFile = async (blob, filename) => {
-        if (!(blob instanceof Blob)) {
-            throw new Error('PDF export failed: invalid file data.');
-        }
-        const defaultName = filename || 'overview.pdf';
-        if (typeof window !== 'undefined' && typeof window.showSaveFilePicker === 'function') {
-            try {
-                const handle = await window.showSaveFilePicker({
-                    suggestedName: defaultName,
-                    types: [
-                        {
-                            description: 'PDF',
-                            accept: { 'application/pdf': ['.pdf'] }
-                        }
-                    ]
-                });
-                if (handle) {
-                    const writable = await handle.createWritable();
-                    await writable.write(blob);
-                    await writable.close();
-                    return true;
-                }
-            } catch (error) {
-                if (error && error.name === 'AbortError') {
-                    return false;
-                }
-                console.warn('Save file picker unavailable, falling back to download link.', error);
-            }
-        }
-        const url = URL.createObjectURL(blob);
-        try {
-            const link = document.createElement('a');
-            link.href = url;
-            link.download = defaultName;
-            link.rel = 'noopener';
-            link.style.display = 'none';
-            const parentNode = document.body || document.documentElement;
-            if (parentNode) {
-                parentNode.appendChild(link);
-            }
-            link.click();
-            if (parentNode && link.parentNode === parentNode) {
-                parentNode.removeChild(link);
-            } else {
-                link.remove();
-            }
-        } finally {
-            setTimeout(() => {
-                URL.revokeObjectURL(url);
-            }, 0);
-        }
-        return true;
-    };
-
-    const htmlToPlainTextLines = (html) => {
-        if (!html) {
-            return [];
-        }
-        const container = document.createElement('div');
-        container.innerHTML = html;
-        const blockSelectors = ['p', 'div', 'section', 'li', 'h1', 'h2', 'h3', 'h4', 'tr', 'table', 'thead', 'tbody', 'tfoot', 'caption'];
-        for (let b = 0; b < blockSelectors.length; b += 1) {
-            const elements = container.getElementsByTagName(blockSelectors[b]);
-            for (let i = 0; i < elements.length; i += 1) {
-                elements[i].appendChild(document.createTextNode('\n'));
-            }
-        }
-        const lineBreaks = container.querySelectorAll('br');
-        for (let i = 0; i < lineBreaks.length; i += 1) {
-            const br = lineBreaks[i];
-            if (br && br.parentNode) {
-                br.parentNode.replaceChild(document.createTextNode('\n'), br);
-            }
-        }
-        const text = container.textContent || '';
-        return text
-            .split('\n')
-            .map(line => line.replace(/\s+/g, ' ').trim())
-            .filter(Boolean);
-    };
-
-    const pdfEntries = [];
-    const pdfPushLine = (text, indent = 0) => {
-        if (text === null || text === undefined) {
-            return;
-        }
-        const value = String(text);
-        if (!value.trim()) {
-            return;
-        }
-        pdfEntries.push({ type: 'line', text: value, indent });
-    };
-
-    const pdfPushBlank = () => {
-        if (!pdfEntries.length || pdfEntries[pdfEntries.length - 1].type === 'blank') {
-            return;
-        }
-        pdfEntries.push({ type: 'blank' });
-    };
-
-    const pdfPushSectionHeading = (text) => {
-        if (!text) {
-            return;
-        }
-        if (pdfEntries.length) {
-            pdfPushBlank();
-        }
-        pdfPushLine(text);
-    };
-
-    const pdfPushList = (items, indent = 2, prefix = '- ') => {
-        if (!Array.isArray(items)) {
-            return;
-        }
-        for (let i = 0; i < items.length; i += 1) {
-            const item = items[i];
-            if (!item) {
-                continue;
-            }
-            pdfPushLine(`${prefix}${item}`, indent);
-        }
-    };
-
-    const mmToPt = (value) => (value * 72) / 25.4;
-    const formatPdfNumber = (value) => {
-        if (!Number.isFinite(value)) {
-            return '0';
-        }
-        const rounded = Math.round(value * 1000) / 1000;
-        if (Math.abs(rounded) < 1e-6) {
-            return '0';
-        }
-        return rounded.toString();
-    };
-
-    const getTextEncoder = () => {
-        if (typeof TextEncoder === 'function') {
-            return new TextEncoder();
-        }
-        return null;
-    };
-
-    const encodeText = (text, encoder) => {
-        if (encoder) {
-            return encoder.encode(text);
-        }
-        const safeText = String(text || '');
-        const bytes = new Uint8Array(safeText.length);
-        for (let i = 0; i < safeText.length; i += 1) {
-            bytes[i] = safeText.charCodeAt(i) & 0xFF;
-        }
-        return bytes;
-    };
-
-    const ensureFontsReady = async (doc) => {
-        if (!doc || !doc.fonts || !doc.fonts.ready || typeof doc.fonts.ready.then !== 'function') {
-            return;
-        }
-        try {
-            await doc.fonts.ready;
-        } catch (error) {
-            console.warn('Font loading check failed during PDF export.', error);
-        }
-    };
-
-    const waitForImagesToLoad = async (root) => {
-        if (!root || typeof root.querySelectorAll !== 'function') {
-            return;
-        }
-        const images = Array.from(root.querySelectorAll('img'));
-        if (root.tagName === 'IMG') {
-            images.push(root);
-        }
-        const promises = images.map(img => new Promise(resolve => {
-            if (!img) {
-                resolve();
-                return;
-            }
-            if (img.complete && img.naturalWidth !== 0) {
-                resolve();
-                return;
-            }
-            const finalize = () => {
-                img.removeEventListener('load', finalize);
-                img.removeEventListener('error', finalize);
-                resolve();
-            };
-            img.addEventListener('load', finalize, { once: true });
-            img.addEventListener('error', finalize, { once: true });
-        }));
-        await Promise.all(promises);
-    };
-
-    const TEXT_NODE = typeof Node !== 'undefined' ? Node.TEXT_NODE : 3;
-    const ELEMENT_NODE = typeof Node !== 'undefined' ? Node.ELEMENT_NODE : 1;
-
-    const cloneNodeWithComputedStyles = (node) => {
-        if (!node) {
-            return null;
-        }
-        if (node.nodeType === TEXT_NODE) {
-            return node.cloneNode(true);
-        }
-        if (node.nodeType !== ELEMENT_NODE) {
-            return node.cloneNode(true);
-        }
-        const clone = node.cloneNode(false);
-        const win = node.ownerDocument ? node.ownerDocument.defaultView : null;
-        if (win && typeof win.getComputedStyle === 'function') {
-            const computed = win.getComputedStyle(node);
-            if (computed) {
-                const styles = [];
-                for (let i = 0; i < computed.length; i += 1) {
-                    const prop = computed[i];
-                    if (!prop) {
-                        continue;
-                    }
-                    styles.push(`${prop}:${computed.getPropertyValue(prop)};`);
-                }
-                if (styles.length) {
-                    clone.setAttribute('style', styles.join(''));
-                }
-            }
-        }
-        const childNodes = node.childNodes;
-        for (let i = 0; i < childNodes.length; i += 1) {
-            const childClone = cloneNodeWithComputedStyles(childNodes[i]);
-            if (childClone) {
-                clone.appendChild(childClone);
-            }
-        }
-        return clone;
-    };
-
-    const renderElementToCanvas = async (element, options = {}) => {
-        if (!element || typeof document === 'undefined' || typeof window === 'undefined') {
-            return null;
-        }
-        const doc = element.ownerDocument || document;
-        const rect = element.getBoundingClientRect();
-        const width = Math.max(1, Math.ceil(rect.width));
-        const height = Math.max(1, Math.ceil(element.scrollHeight || rect.height));
-        const scale = Math.max(1, Math.min(3, options.scale || window.devicePixelRatio || 1));
-        const clone = cloneNodeWithComputedStyles(element);
-        if (!clone) {
-            return null;
-        }
-        const wrapper = doc.createElement('div');
-        wrapper.setAttribute('xmlns', 'http://www.w3.org/1999/xhtml');
-        wrapper.setAttribute('style', `position:relative;box-sizing:border-box;width:${width}px;height:auto;background:#ffffff;`);
-        wrapper.appendChild(clone);
-        const serialized = new XMLSerializer().serializeToString(wrapper);
-        const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}"><foreignObject width="100%" height="100%">${serialized}</foreignObject></svg>`;
-        const svgUrl = `data:image/svg+xml;charset=utf-8,${encodeURIComponent(svg)}`;
-        const image = new Image();
-        image.decoding = 'async';
-        image.src = svgUrl;
-        await new Promise((resolve, reject) => {
-            const timer = setTimeout(() => {
-                resolve();
-            }, 2000);
-            image.onload = () => {
-                clearTimeout(timer);
-                resolve();
-            };
-            image.onerror = (error) => {
-                clearTimeout(timer);
-                reject(error);
-            };
-        });
-        const canvas = doc.createElement('canvas');
-        canvas.width = Math.max(1, Math.ceil(width * scale));
-        canvas.height = Math.max(1, Math.ceil(height * scale));
-        const ctx = canvas.getContext('2d');
-        if (!ctx) {
-            return null;
-        }
-        ctx.scale(scale, scale);
-        ctx.fillStyle = '#ffffff';
-        ctx.fillRect(0, 0, width, height);
-        ctx.drawImage(image, 0, 0);
-        return { canvas, width, height, scale };
-    };
-
-    const dataUrlToUint8 = (dataUrl) => {
-        if (!dataUrl || typeof dataUrl !== 'string') {
-            return new Uint8Array(0);
-        }
-        const commaIndex = dataUrl.indexOf(',');
-        const base64 = commaIndex >= 0 ? dataUrl.slice(commaIndex + 1) : dataUrl;
-        const binary = atob(base64);
-        const length = binary.length;
-        const bytes = new Uint8Array(length);
-        for (let i = 0; i < length; i += 1) {
-            bytes[i] = binary.charCodeAt(i);
-        }
-        return bytes;
-    };
-
-    const createImageBasedPdf = (pages, metadata = {}) => {
-        const pageWidthPt = metadata.pageWidthPt || mmToPt(210);
-        const pageHeightPt = metadata.pageHeightPt || mmToPt(297);
-        const marginPt = metadata.marginPt || mmToPt(10);
-        const encoder = getTextEncoder();
-        const objects = [];
-        const registerObject = (factory) => {
-            const id = objects.length + 1;
-            objects.push({ id, factory });
-            return id;
-        };
-
-        const pagesCount = pages.length;
-        const imageIds = [];
-        const contentIds = [];
-        const pageIds = [];
-        let pagesRootId = null;
-        let blankPageContentId = null;
-        let blankPageId = null;
-
-        for (let i = 0; i < pagesCount; i += 1) {
-            const page = pages[i];
-            const imageId = registerObject(() => {
-                const header = `<< /Type /XObject /Subtype /Image /Width ${page.pixelWidth} /Height ${page.pixelHeight} /ColorSpace /DeviceRGB /BitsPerComponent 8 /Filter /DCTDecode /Length ${page.data.length} >>\nstream\n`;
-                return [
-                    header,
-                    page.data,
-                    '\nendstream\n'
-                ];
-            });
-            imageIds.push(imageId);
-
-            const translateY = pageHeightPt - marginPt - page.heightPt;
-            const stream = `q ${formatPdfNumber(page.widthPt)} 0 0 ${formatPdfNumber(page.heightPt)} ${formatPdfNumber(marginPt)} ${formatPdfNumber(translateY)} cm /Im${i} Do Q\n`;
-            const contentId = registerObject(() => {
-                return [
-                    `<< /Length ${stream.length} >>\nstream\n`,
-                    stream,
-                    '\nendstream\n'
-                ];
-            });
-            contentIds.push(contentId);
-
-            const pageId = registerObject(() => {
-                return [
-                    `<< /Type /Page /Parent ${pagesRootId} 0 R /Resources << /XObject << /Im${i} ${imageId} 0 R >> /ProcSet [/PDF /ImageC] >> /MediaBox [0 0 ${formatPdfNumber(pageWidthPt)} ${formatPdfNumber(pageHeightPt)}] /Contents ${contentId} 0 R >>\n`
-                ];
-            });
-            pageIds.push(pageId);
-        }
-
-        pagesRootId = registerObject(() => {
-            if (!pageIds.length) {
-                return [
-                    `<< /Type /Pages /Count 1 /Kids [${blankPageId} 0 R] >>\n`
-                ];
-            }
-            const kids = pageIds.map(id => `${id} 0 R`).join(' ');
-            return [
-                `<< /Type /Pages /Count ${pageIds.length} /Kids [${kids}] >>\n`
-            ];
-        });
-
-        if (!pageIds.length) {
-            blankPageContentId = registerObject(() => ['<< /Length 0 >>\nstream\n\nendstream\n']);
-            blankPageId = registerObject(() => [
-                `<< /Type /Page /Parent ${pagesRootId} 0 R /MediaBox [0 0 ${formatPdfNumber(pageWidthPt)} ${formatPdfNumber(pageHeightPt)}] /Contents ${blankPageContentId} 0 R >>\n`
-            ]);
-        }
-
-        const infoId = registerObject(() => {
-            const nowDate = new Date();
-            const pad = (value) => String(value).padStart(2, '0');
-            const creationDate = `D:${nowDate.getFullYear()}${pad(nowDate.getMonth() + 1)}${pad(nowDate.getDate())}${pad(nowDate.getHours())}${pad(nowDate.getMinutes())}${pad(nowDate.getSeconds())}`;
-            const entries = [
-                '/Producer (Camera Power Planner)',
-                '/Creator (Camera Power Planner Overview Export)',
-                `/CreationDate (${creationDate})`
-            ];
-            if (metadata.title) {
-                const normalizedTitle = normalizeForPdf(metadata.title);
-                if (normalizedTitle) {
-                    entries.push(`/Title (${pdfEscape(normalizedTitle)})`);
-                }
-            }
-            return [`<< ${entries.join(' ')} >>\n`];
-        });
-
-        const catalogId = registerObject(() => [`<< /Type /Catalog /Pages ${pagesRootId} 0 R >>\n`]);
-
-        const chunks = [];
-        let position = 0;
-        const offsets = [0];
-        const pushChunk = (chunk) => {
-            chunks.push(chunk);
-            position += chunk.length;
-        };
-
-        const writeString = (text) => {
-            const bytes = encodeText(text, encoder);
-            pushChunk(bytes);
-        };
-
-        writeString('%PDF-1.4\n');
-
-        for (let i = 0; i < objects.length; i += 1) {
-            const object = objects[i];
-            offsets.push(position);
-            writeString(`${object.id} 0 obj\n`);
-            const parts = object.factory ? object.factory() : [];
-            for (let j = 0; j < parts.length; j += 1) {
-                const part = parts[j];
-                if (typeof part === 'string') {
-                    writeString(part);
-                } else if (part instanceof Uint8Array) {
-                    pushChunk(part);
-                }
-            }
-            writeString('endobj\n');
-        }
-
-        const xrefPosition = position;
-        writeString(`xref\n0 ${objects.length + 1}\n`);
-        writeString('0000000000 65535 f \n');
-        for (let i = 1; i < offsets.length; i += 1) {
-            const line = `${offsets[i].toString().padStart(10, '0')} 00000 n \n`;
-            writeString(line);
-        }
-        const trailerParts = [`trailer\n<< /Size ${objects.length + 1} /Root ${catalogId} 0 R /Info ${infoId} 0 R >>\nstartxref\n${xrefPosition}\n%%EOF`];
-        trailerParts.forEach(part => writeString(part));
-        return new Blob(chunks, { type: 'application/pdf' });
-    };
-
-    const renderOverviewPdf = async (element, options = {}) => {
-        if (!element || typeof window === 'undefined' || typeof document === 'undefined') {
-            return null;
-        }
-        try {
-            const doc = element.ownerDocument || document;
-            await ensureFontsReady(doc);
-            await waitForImagesToLoad(element);
-            const pixelRatio = typeof window.devicePixelRatio === 'number' ? window.devicePixelRatio : 1;
-            const renderScale = Math.max(1.5, Math.min(2.5, pixelRatio * 1.25));
-            const rendered = await renderElementToCanvas(element, { scale: renderScale });
-            if (!rendered) {
-                return null;
-            }
-            const { canvas, width, height, scale } = rendered;
-            const pageWidthPt = mmToPt(210);
-            const pageHeightPt = mmToPt(297);
-            const marginPt = mmToPt(10);
-            const availableWidthPt = pageWidthPt - (marginPt * 2);
-            const widthScale = availableWidthPt / Math.max(1, width);
-            const availableHeightPt = pageHeightPt - (marginPt * 2);
-            const pageHeightPxLimit = Math.max(1, Math.floor(availableHeightPt / widthScale));
-            const pages = [];
-            let offsetPx = 0;
-            while (offsetPx < height) {
-                const sliceHeightPx = Math.min(pageHeightPxLimit, height - offsetPx);
-                const pageCanvas = doc.createElement('canvas');
-                pageCanvas.width = Math.max(1, Math.ceil(width * scale));
-                pageCanvas.height = Math.max(1, Math.ceil(sliceHeightPx * scale));
-                const ctx = pageCanvas.getContext('2d');
-                if (!ctx) {
-                    break;
-                }
-                ctx.drawImage(
-                    canvas,
-                    0,
-                    offsetPx * scale,
-                    width * scale,
-                    sliceHeightPx * scale,
-                    0,
-                    0,
-                    width * scale,
-                    sliceHeightPx * scale
-                );
-                const dataUrl = pageCanvas.toDataURL('image/jpeg', 0.92);
-                pages.push({
-                    data: dataUrlToUint8(dataUrl),
-                    pixelWidth: pageCanvas.width,
-                    pixelHeight: pageCanvas.height,
-                    widthPt: availableWidthPt,
-                    heightPt: sliceHeightPx * widthScale
-                });
-                offsetPx += sliceHeightPx;
-            }
-            if (!pages.length) {
-                return createImageBasedPdf([], {
-                    pageWidthPt,
-                    pageHeightPt,
-                    marginPt,
-                    title: options.title
-                });
-            }
-            return createImageBasedPdf(pages, {
-                pageWidthPt,
-                pageHeightPt,
-                marginPt,
-                title: options.title
-            });
-        } catch (error) {
-            console.error('Unable to render overview PDF using layout capture.', error);
-            return null;
-        }
-    };
-
-    const addHtmlAsPdfLines = (html, indent = 2) => {
-        const lines = htmlToPlainTextLines(html);
-        for (let i = 0; i < lines.length; i += 1) {
-            pdfPushLine(lines[i], indent);
-        }
-    };
-
     const generatedOnDisplayLabel = ensureLabelSuffix(generatedOnLabel);
-    const setupNameDisplayLabel = ensureLabelSuffix(t.setupNameLabel || 'Project Name');
-
-    pdfPushLine(t.overviewTitle || 'Project Overview');
-    pdfPushBlank();
-    pdfPushLine(`${setupNameDisplayLabel} ${setupName || '-'}`);
-    pdfPushLine(`${generatedOnDisplayLabel} ${dateTimeString}`);
-
-    const sectionTextMap = {};
 
     let deviceListHtml = '<div class="device-category-container">';
     const sections = {};
@@ -849,13 +60,6 @@ function generatePrintableOverview() {
             sectionOrder.push(key);
         }
         sections[key].push(itemHtml);
-        if (!sectionTextMap[key]) {
-            sectionTextMap[key] = [];
-        }
-        const textLines = htmlToPlainTextLines(itemHtml);
-        if (textLines.length) {
-            sectionTextMap[key].push(textLines.join(' — '));
-        }
     };
     const processSelectForOverview = (selectElement, headingKey, category, subcategory = null) => {
         if (selectElement.value && selectElement.value !== "None") {
@@ -906,18 +110,6 @@ function generatePrintableOverview() {
       deviceListHtml += `<div class="device-category"><h3>${iconHtml}${heading}</h3><div class="${gridClasses}">${sections[key].join('')}</div></div>`;
     });
     deviceListHtml += '</div>';
-
-    if (sectionOrder.length) {
-        pdfPushSectionHeading(t.overviewDeviceSelectionHeading || t.deviceSelectionHeading || 'Camera Setup Devices');
-        sectionOrder.forEach((key, index) => {
-            const heading = t[key] || key;
-            pdfPushLine(heading);
-            pdfPushList(sectionTextMap[key] || [], 2);
-            if (index < sectionOrder.length - 1) {
-                pdfPushBlank();
-            }
-        });
-    }
 
     const breakdownHtml = breakdownListElem.innerHTML;
     const batteryLifeUnitElem = document.getElementById("batteryLifeUnit");
@@ -1007,25 +199,6 @@ function generatePrintableOverview() {
         </section>
     `;
 
-    const resultsLinesForPdf = [
-        `${ensureLabelSuffix(t.totalPowerLabel || 'Total Power')} ${totalPowerElem.textContent} W`,
-        `${ensureLabelSuffix(t.totalCurrent144Label || 'Total Current (14.4V)')} ${totalCurrent144Elem.textContent} A`,
-        `${ensureLabelSuffix(t.totalCurrent12Label || 'Total Current (12V)')} ${totalCurrent12Elem.textContent} A`,
-        `${ensureLabelSuffix(t.batteryLifeLabel || 'Estimated Battery Life')} ${batteryLifeElem.textContent} ${batteryLifeUnitElem ? batteryLifeUnitElem.textContent : ''}`.trim(),
-        `${ensureLabelSuffix(t.batteryCountLabel || 'Battery Count')} ${batteryCountElem.textContent}`,
-    ].filter(line => line && line.trim());
-    if (resultsLinesForPdf.length) {
-        pdfPushSectionHeading(t.resultsHeading || 'Power Summary');
-        resultsLinesForPdf.forEach(line => pdfPushLine(line, 2));
-    }
-    if (warningHtml) {
-        const warningLines = htmlToPlainTextLines(warningHtml);
-        if (warningLines.length) {
-            pdfPushSectionHeading(defaultPdfWarningHeading);
-            pdfPushList(warningLines, 2, '! ');
-        }
-    }
-
     const batteryComparisonSection = typeof document !== 'undefined'
         ? document.getElementById('batteryComparison')
         : null;
@@ -1065,11 +238,6 @@ function generatePrintableOverview() {
         batteryComparisonHtml = `<div class="page-break"></div>${clone.outerHTML}`;
     }
 
-    if (batteryComparisonHtml) {
-        pdfPushSectionHeading(t.batteryComparisonHeading || 'Battery Comparison');
-        addHtmlAsPdfLines(batteryComparisonHtml, 2);
-    }
-
     const safeSetupName = escapeHtmlSafe(setupName);
     const diagramCss = getDiagramCss(false);
 
@@ -1091,19 +259,6 @@ function generatePrintableOverview() {
         ? `<section id="setupDiagram" class="diagram-section print-section"><h2>${t.setupDiagramHeading}</h2>${diagramDescHtml}${diagramAreaHtml}${diagramLegendHtml}${diagramHintHtml}</section>`
         : '';
 
-    if (diagramSectionHtml) {
-        pdfPushSectionHeading(t.setupDiagramHeading || 'Connection Diagram');
-        if (diagramDescHtml) {
-            addHtmlAsPdfLines(diagramDescHtml, 2);
-        }
-        if (diagramLegendHtml) {
-            addHtmlAsPdfLines(diagramLegendHtml, 2);
-        }
-        if (diagramHintHtml) {
-            addHtmlAsPdfLines(diagramHintHtml, 2);
-        }
-        pdfPushLine(diagramPdfNote, 2);
-    }
     // Only surface the gear list in the overview when the generator has
     // produced visible output in the main interface.
     const hasGeneratedGearList = (() => {
@@ -1136,13 +291,9 @@ function generatePrintableOverview() {
             : { projectHtml: '', gearHtml: '' };
         if (parts.projectHtml) {
             projectSectionHtml = `<section id="projectRequirementsOutput" class="print-section project-requirements-section">${parts.projectHtml}</section>`;
-            pdfPushSectionHeading(t.projectRequirementsNav || 'Project Requirements');
-            addHtmlAsPdfLines(parts.projectHtml, 2);
         }
         if (parts.gearHtml && hasGeneratedGearList) {
             gearSectionHtml = `<section id="gearListOutput" class="gear-list-section">${parts.gearHtml}</section>`;
-            pdfPushSectionHeading(t.gearListNav || 'Gear List');
-            addHtmlAsPdfLines(parts.gearHtml, 2);
         }
     }
     const gearListHtmlCombined = projectSectionHtml || gearSectionHtml
@@ -1192,14 +343,6 @@ function generatePrintableOverview() {
             ${batteryComparisonHtml}
         </div>
     `;
-
-    const sanitizedProjectSegmentForFile = sanitizeTitleSegment(projectTitleSegment) || 'Project';
-    const pdfFileName = `${formattedDate}_${formattedTime}_${sanitizedProjectSegmentForFile}_Overview.pdf`;
-    const pdfExportConfig = {
-        entries: pdfEntries.slice(),
-        fileName: pdfFileName,
-        title: printDocumentTitle,
-    };
 
     const overviewDialog = document.getElementById('overviewDialog');
     overviewDialog.innerHTML = overviewHtml;
@@ -1386,24 +529,85 @@ function generatePrintableOverview() {
         return true;
     };
 
+    const triggerPrintWorkflow = (options = {}) => {
+        const { preferFallback = false, reason = 'print' } = options;
+        const logPrefix = reason === 'export' ? 'Overview PDF export' : 'Overview print';
+        let fallbackAttempts = 0;
+
+        const attemptFallback = (error) => {
+            fallbackAttempts += 1;
+            if (error && error.name !== 'AbortError') {
+                console.warn(`${logPrefix}: falling back to print window.`, error);
+            }
+            const opened = openFallbackPrintView();
+            if (opened) {
+                closeAfterPrint();
+                return true;
+            }
+            if (error && error.name !== 'AbortError') {
+                console.error(`${logPrefix}: unable to open fallback print window.`, error);
+            }
+            return false;
+        };
+
+        const attemptNative = () => {
+            if (typeof window === 'undefined' || typeof window.print !== 'function') {
+                return false;
+            }
+            try {
+                if (typeof document !== 'undefined') {
+                    document.title = printDocumentTitle;
+                }
+                const result = window.print();
+                if (result && typeof result.then === 'function') {
+                    result.catch(error => {
+                        if (!fallbackAttempts) {
+                            attemptFallback(error);
+                        }
+                    });
+                }
+                return true;
+            } catch (error) {
+                return attemptFallback(error);
+            }
+        };
+
+        let success = false;
+
+        if (preferFallback) {
+            success = attemptFallback();
+            if (!success) {
+                success = attemptNative();
+            }
+        } else {
+            success = attemptNative();
+        }
+
+        if (!success && fallbackAttempts === 0) {
+            success = attemptFallback();
+        }
+
+        if (!success && typeof document !== 'undefined' && document.title === printDocumentTitle) {
+            document.title = originalDocumentTitle;
+        }
+
+        return success;
+    };
+
     const exportBtn = overviewDialog.querySelector('#exportPdfBtn');
     if (exportBtn) {
-        exportBtn.addEventListener('click', async () => {
+        exportBtn.addEventListener('click', () => {
             if (exportBtn.disabled) {
                 return;
             }
             exportBtn.disabled = true;
             try {
-                let pdfBlob = null;
-                if (content) {
-                    pdfBlob = await renderOverviewPdf(content, { title: pdfExportConfig.title });
+                const printStarted = triggerPrintWorkflow({ preferFallback: true, reason: 'export' });
+                if (!printStarted) {
+                    console.error('Unable to start the PDF export print workflow. Please enable pop-ups and try again.');
                 }
-                if (!pdfBlob) {
-                    pdfBlob = createTextOverviewPdfBlob(pdfExportConfig.entries, { title: pdfExportConfig.title });
-                }
-                await downloadBlobAsFile(pdfBlob, pdfExportConfig.fileName);
             } catch (error) {
-                console.error('Failed to export overview PDF.', error);
+                console.error('Failed to export overview PDF via print workflow.', error);
             } finally {
                 exportBtn.disabled = false;
             }
@@ -1413,31 +617,9 @@ function generatePrintableOverview() {
     const printBtn = overviewDialog.querySelector('#printOverviewBtn');
     if (printBtn) {
         printBtn.addEventListener('click', () => {
-            const handlePrintError = (error) => {
-                if (error && error.name === 'AbortError') {
-                    return;
-                }
-                console.warn('window.print() failed; using fallback print window.', error);
-                if (openFallbackPrintView()) {
-                    closeAfterPrint();
-                }
-            };
-
-            if (typeof window.print !== 'function') {
-                handlePrintError(new Error('Print API unavailable'));
-                return;
-            }
-
-            try {
-                if (typeof document !== 'undefined') {
-                    document.title = printDocumentTitle;
-                }
-                const result = window.print();
-                if (result && typeof result.then === 'function') {
-                    result.catch(handlePrintError);
-                }
-            } catch (error) {
-                handlePrintError(error);
+            const success = triggerPrintWorkflow({ reason: 'print' });
+            if (!success) {
+                console.error('Unable to open the print dialog. Please check your browser settings and try again.');
             }
         });
     }


### PR DESCRIPTION
## Summary
- strip the manual PDF generation helpers from the overview dialog and keep only the HTML-building path
- route the export button through the same print workflow that already powers the print button so browsers handle PDF creation
- regenerate the legacy bundle so the older build matches the simplified workflow

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1dca58660832089c7f359503893bc