### PR TITLE
Adjust autosave note overlay spacing

### DIFF
--- a/src/scripts/autosave-overlay.js
+++ b/src/scripts/autosave-overlay.js
@@ -93,6 +93,14 @@
 
     overlay.setAttribute('aria-hidden', shouldShow ? 'false' : 'true');
 
+    if (dialog && dialog.classList) {
+      if (shouldShow) {
+        dialog.classList.add('has-gear-list-note');
+      } else {
+        dialog.classList.remove('has-gear-list-note');
+      }
+    }
+
     if (shouldShow) {
       overlay.hidden = false;
       if (overlay.classList) {

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -5001,6 +5001,16 @@ body.dark-mode.pink-mode #gearListOutput h2,
   transform: translate(-50%, 0);
 }
 
+#settingsDialog.has-gear-list-note .settings-content {
+  padding-bottom: clamp(6rem, 12vw, 8rem);
+}
+
+@media (max-width: 600px) {
+  #settingsDialog.has-gear-list-note .settings-content {
+    padding-bottom: clamp(7rem, 24vw, 10rem);
+  }
+}
+
 @media (max-width: 600px) {
   .gear-list-autosave-note--overlay {
     padding: 0.75rem;


### PR DESCRIPTION
## Summary
- add a dialog-level class toggle when the autosave note overlay is shown
- increase settings dialog bottom padding when the overlay is visible to keep action buttons clear

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1dfe213208320960ea3831f9f0a58