### PR TITLE
chore: bump app version to 1.0.6

### DIFF
--- a/index.html
+++ b/index.html
@@ -1346,7 +1346,7 @@
         hidden
       >
         <h3 id="aboutHeading">About &amp; Support</h3>
-        <p id="aboutVersion">Version 1.0.5</p>
+        <p id="aboutVersion">Version 1.0.6</p>
         <p><a href="https://github.com" id="supportLink" target="_blank">Support</a></p>
       </section>
       <div class="button-row action-buttons">

--- a/legacy/scripts/app-core.js
+++ b/legacy/scripts/app-core.js
@@ -95,7 +95,7 @@ if (typeof window !== 'undefined') {
     }
   }
 }
-var APP_VERSION = "1.0.5";
+var APP_VERSION = "1.0.6";
 var IOS_PWA_HELP_STORAGE_KEY = 'iosPwaHelpShown';
 var INSTALL_BANNER_DISMISSED_KEY = 'installPromptDismissed';
 var DEVICE_SCHEMA_PATH = 'src/data/schema.json';

--- a/legacy/scripts/script.js
+++ b/legacy/scripts/script.js
@@ -19,7 +19,7 @@ if (typeof require === 'function' && typeof module !== 'undefined' && module && 
   wrapper.call(globalScope, module.exports, require, module, __filename, __dirname, globalScope);
   var aggregatedExports = module.exports;
   var combinedAppVersion = aggregatedExports && aggregatedExports.APP_VERSION;
-  var APP_VERSION = "1.0.5";
+  var APP_VERSION = "1.0.6";
   if (combinedAppVersion && combinedAppVersion !== APP_VERSION) {
     throw new Error("Combined app version (".concat(combinedAppVersion, ") does not match script marker (").concat(APP_VERSION, ")."));
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cine-power-planner",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cine-power-planner",
-      "version": "1.0.5",
+      "version": "1.0.6",
       "license": "ISC",
       "dependencies": {
         "lottie-web": "^5.13.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cine-power-planner",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Browser-based tool for planning professional camera setups powered by V-Mount or B-Mount batteries. It calculates total power consumption, current draw at 14.4 V and 12 V, and estimated battery runtime while checking that the battery can safely deliver the required power.",
   "main": "src/data/index.js",
   "scripts": {

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,5 +1,5 @@
 /* eslint-env serviceworker */
-const CACHE_NAME = 'cine-power-planner-v1.0.5';
+const CACHE_NAME = 'cine-power-planner-v1.0.6';
 const ASSETS = [
   './',
   './index.html',

--- a/src/scripts/app-core.js
+++ b/src/scripts/app-core.js
@@ -80,7 +80,7 @@ if (typeof window !== 'undefined') {
   }
 }
 
-const APP_VERSION = "1.0.5";
+const APP_VERSION = "1.0.6";
 const IOS_PWA_HELP_STORAGE_KEY = 'iosPwaHelpShown';
 const INSTALL_BANNER_DISMISSED_KEY = 'installPromptDismissed';
 

--- a/src/scripts/script.js
+++ b/src/scripts/script.js
@@ -56,7 +56,7 @@ if (typeof require === 'function' && typeof module !== 'undefined' && module && 
 
   const aggregatedExports = module.exports;
   const combinedAppVersion = aggregatedExports && aggregatedExports.APP_VERSION;
-  const APP_VERSION = "1.0.5"; // Version marker for consistency checks
+  const APP_VERSION = "1.0.6"; // Version marker for consistency checks
 
   if (combinedAppVersion && combinedAppVersion !== APP_VERSION) {
     throw new Error(


### PR DESCRIPTION
## Summary
- bump the app version to 1.0.6 across metadata, UI display, and runtime constants
- refresh the service worker cache name so offline assets pick up the new release

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d1df3ddbe88320911b1689fb039e75