### PR TITLE
Add delivery resolution condition to automatic gear rules

### DIFF
--- a/index.html
+++ b/index.html
@@ -1105,6 +1105,7 @@
                     <option value="mattebox">Mattebox options</option>
                     <option value="cameraHandle">Camera handles</option>
                     <option value="viewfinderExtension">Viewfinder extension</option>
+                    <option value="deliveryResolution">Delivery resolution</option>
                     <option value="videoDistribution">Video distribution</option>
                     <option value="camera">Camera</option>
                     <option value="monitor">Onboard monitor</option>
@@ -1241,6 +1242,34 @@
                   <select
                     id="autoGearViewfinderExtension"
                     class="auto-gear-viewfinder-extension auto-gear-multiselect"
+                    multiple
+                    size="10"
+                  ></select>
+                </section>
+                <section
+                  id="autoGearCondition-deliveryResolution"
+                  class="auto-gear-condition"
+                  data-condition="deliveryResolution"
+                  hidden
+                  aria-hidden="true"
+                >
+                  <div class="auto-gear-condition-header">
+                    <label for="autoGearDeliveryResolution" id="autoGearDeliveryResolutionLabel"
+                      >Delivery resolution</label
+                    >
+                    <div class="auto-gear-condition-actions">
+                      <button type="button" class="auto-gear-condition-add" data-action="add">Add</button>
+                      <button
+                        type="button"
+                        class="auto-gear-condition-remove"
+                        data-action="remove"
+                        data-condition="deliveryResolution"
+                      >Remove</button>
+                    </div>
+                  </div>
+                  <select
+                    id="autoGearDeliveryResolution"
+                    class="auto-gear-delivery-resolution auto-gear-multiselect"
                     multiple
                     size="10"
                   ></select>

--- a/src/scripts/app-core.js
+++ b/src/scripts/app-core.js
@@ -924,6 +924,7 @@ function normalizeAutoGearRule(rule) {
   const mattebox = normalizeAutoGearTriggerList(rule.mattebox).sort((a, b) => a.localeCompare(b));
   const cameraHandle = normalizeAutoGearTriggerList(rule.cameraHandle).sort((a, b) => a.localeCompare(b));
   const viewfinderExtension = normalizeAutoGearTriggerList(rule.viewfinderExtension).sort((a, b) => a.localeCompare(b));
+  const deliveryResolution = normalizeAutoGearTriggerList(rule.deliveryResolution).sort((a, b) => a.localeCompare(b));
   const videoDistribution = normalizeVideoDistributionTriggerList(rule.videoDistribution)
     .sort((a, b) => a.localeCompare(b));
   const camera = normalizeAutoGearTriggerList(rule.camera).sort((a, b) => a.localeCompare(b));
@@ -938,6 +939,7 @@ function normalizeAutoGearRule(rule) {
     && !mattebox.length
     && !cameraHandle.length
     && !viewfinderExtension.length
+    && !deliveryResolution.length
     && !videoDistribution.length
     && !camera.length
     && !monitor.length
@@ -957,6 +959,7 @@ function normalizeAutoGearRule(rule) {
     mattebox,
     cameraHandle,
     viewfinderExtension,
+    deliveryResolution,
     videoDistribution,
     camera,
     monitor,
@@ -1031,6 +1034,7 @@ function snapshotAutoGearRuleForFingerprint(rule) {
     mattebox: normalized.mattebox.slice().sort((a, b) => a.localeCompare(b)),
     cameraHandle: normalized.cameraHandle.slice().sort((a, b) => a.localeCompare(b)),
     viewfinderExtension: normalized.viewfinderExtension.slice().sort((a, b) => a.localeCompare(b)),
+    deliveryResolution: normalized.deliveryResolution.slice().sort((a, b) => a.localeCompare(b)),
     videoDistribution: normalized.videoDistribution.slice().sort((a, b) => a.localeCompare(b)),
     camera: normalized.camera.slice().sort((a, b) => a.localeCompare(b)),
     monitor: normalized.monitor.slice().sort((a, b) => a.localeCompare(b)),
@@ -1049,6 +1053,7 @@ function autoGearRuleSortKey(rule) {
   const matteboxKey = Array.isArray(rule.mattebox) ? rule.mattebox.join('|') : '';
   const cameraHandleKey = Array.isArray(rule.cameraHandle) ? rule.cameraHandle.join('|') : '';
   const viewfinderKey = Array.isArray(rule.viewfinderExtension) ? rule.viewfinderExtension.join('|') : '';
+  const deliveryResolutionKey = Array.isArray(rule.deliveryResolution) ? rule.deliveryResolution.join('|') : '';
   const videoDistributionKey = Array.isArray(rule.videoDistribution) ? rule.videoDistribution.join('|') : '';
   const cameraKey = Array.isArray(rule.camera) ? rule.camera.join('|') : '';
   const monitorKey = Array.isArray(rule.monitor) ? rule.monitor.join('|') : '';
@@ -1058,7 +1063,7 @@ function autoGearRuleSortKey(rule) {
   const distanceKey = Array.isArray(rule.distance) ? rule.distance.join('|') : '';
   const addKey = Array.isArray(rule.add) ? rule.add.map(autoGearItemSortKey).join('|') : '';
   const removeKey = Array.isArray(rule.remove) ? rule.remove.map(autoGearItemSortKey).join('|') : '';
-  return `${alwaysKey}|${scenarioKey}|${matteboxKey}|${cameraHandleKey}|${viewfinderKey}|${videoDistributionKey}|${cameraKey}|${monitorKey}|${wirelessKey}|${motorsKey}|${controllersKey}|${distanceKey}|${rule.label || ''}|${addKey}|${removeKey}`;
+  return `${alwaysKey}|${scenarioKey}|${matteboxKey}|${cameraHandleKey}|${viewfinderKey}|${deliveryResolutionKey}|${videoDistributionKey}|${cameraKey}|${monitorKey}|${wirelessKey}|${motorsKey}|${controllersKey}|${distanceKey}|${rule.label || ''}|${addKey}|${removeKey}`;
 }
 
 function createAutoGearRulesFingerprint(rules) {
@@ -5313,6 +5318,16 @@ function setLanguage(lang) {
       autoGearViewfinderExtensionSelect.setAttribute('aria-label', label);
     }
   }
+  if (autoGearDeliveryResolutionLabel) {
+    const label = texts[lang].autoGearDeliveryResolutionLabel || texts.en?.autoGearDeliveryResolutionLabel || autoGearDeliveryResolutionLabel.textContent;
+    autoGearDeliveryResolutionLabel.textContent = label;
+    const help = texts[lang].autoGearDeliveryResolutionHelp || texts.en?.autoGearDeliveryResolutionHelp || label;
+    autoGearDeliveryResolutionLabel.setAttribute('data-help', help);
+    if (autoGearDeliveryResolutionSelect) {
+      autoGearDeliveryResolutionSelect.setAttribute('data-help', help);
+      autoGearDeliveryResolutionSelect.setAttribute('aria-label', label);
+    }
+  }
   if (autoGearVideoDistributionLabel) {
     const label = texts[lang].autoGearVideoDistributionLabel || texts.en?.autoGearVideoDistributionLabel || autoGearVideoDistributionLabel.textContent;
     autoGearVideoDistributionLabel.textContent = label;
@@ -5579,6 +5594,9 @@ function setLanguage(lang) {
   }
   if (autoGearViewfinderExtensionSelect) {
     refreshAutoGearViewfinderExtensionOptions(autoGearEditorDraft?.viewfinderExtension);
+  }
+  if (autoGearDeliveryResolutionSelect) {
+    refreshAutoGearDeliveryResolutionOptions(autoGearEditorDraft?.deliveryResolution);
   }
   if (autoGearVideoDistributionSelect) {
     refreshAutoGearVideoDistributionOptions(autoGearEditorDraft?.videoDistribution);
@@ -6186,6 +6204,7 @@ const crewLabelElem = document.getElementById("crewLabel");
 const prepLabelElem = document.getElementById("prepLabel");
 const shootLabelElem = document.getElementById("shootLabel");
 const deliveryResolutionLabel = document.getElementById("deliveryResolutionLabel");
+const deliveryResolutionSelect = document.getElementById("deliveryResolution");
 const recordingResolutionLabel = document.getElementById("recordingResolutionLabel");
 const sensorModeLabel = document.getElementById("sensorModeLabel");
 const aspectRatioLabel = document.getElementById("aspectRatioLabel");
@@ -9721,6 +9740,7 @@ const autoGearConditionSections = {
   mattebox: document.getElementById('autoGearCondition-mattebox'),
   cameraHandle: document.getElementById('autoGearCondition-cameraHandle'),
   viewfinderExtension: document.getElementById('autoGearCondition-viewfinderExtension'),
+  deliveryResolution: document.getElementById('autoGearCondition-deliveryResolution'),
   videoDistribution: document.getElementById('autoGearCondition-videoDistribution'),
   camera: document.getElementById('autoGearCondition-camera'),
   monitor: document.getElementById('autoGearCondition-monitor'),
@@ -9736,6 +9756,7 @@ const autoGearConditionAddShortcuts = {
   mattebox: autoGearConditionSections.mattebox?.querySelector('.auto-gear-condition-add') || null,
   cameraHandle: autoGearConditionSections.cameraHandle?.querySelector('.auto-gear-condition-add') || null,
   viewfinderExtension: autoGearConditionSections.viewfinderExtension?.querySelector('.auto-gear-condition-add') || null,
+  deliveryResolution: autoGearConditionSections.deliveryResolution?.querySelector('.auto-gear-condition-add') || null,
   videoDistribution: autoGearConditionSections.videoDistribution?.querySelector('.auto-gear-condition-add') || null,
   camera: autoGearConditionSections.camera?.querySelector('.auto-gear-condition-add') || null,
   monitor: autoGearConditionSections.monitor?.querySelector('.auto-gear-condition-add') || null,
@@ -9751,6 +9772,7 @@ const autoGearConditionRemoveButtons = {
   mattebox: autoGearConditionSections.mattebox?.querySelector('.auto-gear-condition-remove') || null,
   cameraHandle: autoGearConditionSections.cameraHandle?.querySelector('.auto-gear-condition-remove') || null,
   viewfinderExtension: autoGearConditionSections.viewfinderExtension?.querySelector('.auto-gear-condition-remove') || null,
+  deliveryResolution: autoGearConditionSections.deliveryResolution?.querySelector('.auto-gear-condition-remove') || null,
   videoDistribution: autoGearConditionSections.videoDistribution?.querySelector('.auto-gear-condition-remove') || null,
   camera: autoGearConditionSections.camera?.querySelector('.auto-gear-condition-remove') || null,
   monitor: autoGearConditionSections.monitor?.querySelector('.auto-gear-condition-remove') || null,
@@ -9780,6 +9802,8 @@ const autoGearCameraHandleSelect = document.getElementById('autoGearCameraHandle
 const autoGearCameraHandleLabel = document.getElementById('autoGearCameraHandleLabel');
 const autoGearViewfinderExtensionSelect = document.getElementById('autoGearViewfinderExtension');
 const autoGearViewfinderExtensionLabel = document.getElementById('autoGearViewfinderExtensionLabel');
+const autoGearDeliveryResolutionSelect = document.getElementById('autoGearDeliveryResolution');
+const autoGearDeliveryResolutionLabel = document.getElementById('autoGearDeliveryResolutionLabel');
 const autoGearVideoDistributionSelect = document.getElementById('autoGearVideoDistribution');
 const autoGearVideoDistributionLabel = document.getElementById('autoGearVideoDistributionLabel');
 const autoGearCameraSelect = document.getElementById('autoGearCamera');
@@ -9800,6 +9824,7 @@ const autoGearConditionLabels = {
   mattebox: autoGearMatteboxLabel,
   cameraHandle: autoGearCameraHandleLabel,
   viewfinderExtension: autoGearViewfinderExtensionLabel,
+  deliveryResolution: autoGearDeliveryResolutionLabel,
   videoDistribution: autoGearVideoDistributionLabel,
   camera: autoGearCameraLabel,
   monitor: autoGearMonitorLabel,
@@ -9814,6 +9839,7 @@ const autoGearConditionSelects = {
   mattebox: autoGearMatteboxSelect,
   cameraHandle: autoGearCameraHandleSelect,
   viewfinderExtension: autoGearViewfinderExtensionSelect,
+  deliveryResolution: autoGearDeliveryResolutionSelect,
   videoDistribution: autoGearVideoDistributionSelect,
   camera: autoGearCameraSelect,
   monitor: autoGearMonitorSelect,
@@ -9828,6 +9854,7 @@ const AUTO_GEAR_CONDITION_KEYS = [
   'mattebox',
   'cameraHandle',
   'viewfinderExtension',
+  'deliveryResolution',
   'videoDistribution',
   'camera',
   'monitor',
@@ -9842,6 +9869,7 @@ const AUTO_GEAR_CONDITION_FALLBACK_LABELS = {
   mattebox: 'Mattebox options',
   cameraHandle: 'Camera handles',
   viewfinderExtension: 'Viewfinder extension',
+  deliveryResolution: 'Delivery resolution',
   videoDistribution: 'Video distribution',
   camera: 'Camera',
   monitor: 'Onboard monitor',
@@ -9871,6 +9899,7 @@ const autoGearConditionRefreshers = {
   mattebox: refreshAutoGearMatteboxOptions,
   cameraHandle: refreshAutoGearCameraHandleOptions,
   viewfinderExtension: refreshAutoGearViewfinderExtensionOptions,
+  deliveryResolution: refreshAutoGearDeliveryResolutionOptions,
   videoDistribution: refreshAutoGearVideoDistributionOptions,
   camera: refreshAutoGearCameraOptions,
   monitor: refreshAutoGearMonitorOptions,
@@ -10443,6 +10472,7 @@ function autoGearRuleMatchesSearch(rule, query) {
   pushValues(rule?.mattebox);
   pushValues(rule?.cameraHandle);
   pushValues(rule?.viewfinderExtension);
+  pushValues(rule?.deliveryResolution);
   pushValues(rule?.videoDistribution);
   pushValues(rule?.camera);
   pushValues(rule?.monitor);
@@ -10575,6 +10605,7 @@ function createAutoGearDraft(rule) {
       mattebox: Array.isArray(rule.mattebox) ? rule.mattebox.slice() : [],
       cameraHandle: Array.isArray(rule.cameraHandle) ? rule.cameraHandle.slice() : [],
       viewfinderExtension: Array.isArray(rule.viewfinderExtension) ? rule.viewfinderExtension.slice() : [],
+      deliveryResolution: Array.isArray(rule.deliveryResolution) ? rule.deliveryResolution.slice() : [],
       videoDistribution: Array.isArray(rule.videoDistribution) ? rule.videoDistribution.slice() : [],
       camera: Array.isArray(rule.camera) ? rule.camera.slice() : [],
       monitor: Array.isArray(rule.monitor) ? rule.monitor.slice() : [],
@@ -10594,6 +10625,7 @@ function createAutoGearDraft(rule) {
     mattebox: [],
     cameraHandle: [],
     viewfinderExtension: [],
+    deliveryResolution: [],
     videoDistribution: [],
     camera: [],
     monitor: [],
@@ -10913,6 +10945,60 @@ function refreshAutoGearViewfinderExtensionOptions(selected) {
   const selectableOptions = Array.from(autoGearViewfinderExtensionSelect.options || []).filter(option => !option.disabled);
   autoGearViewfinderExtensionSelect.size = computeAutoGearMultiSelectSize(
     selectableOptions.length,
+    { minRows: AUTO_GEAR_FLEX_MULTI_SELECT_MIN_ROWS }
+  );
+}
+
+function refreshAutoGearDeliveryResolutionOptions(selected) {
+  if (!autoGearDeliveryResolutionSelect) return;
+
+  const selectedValues = collectAutoGearSelectedValues(selected, 'deliveryResolution');
+
+  autoGearDeliveryResolutionSelect.innerHTML = '';
+  autoGearDeliveryResolutionSelect.multiple = true;
+
+  const seen = new Set();
+  const addOption = (value, label) => {
+    const normalized = typeof value === 'string' ? value.trim() : '';
+    if (!normalized || seen.has(normalized)) return;
+    const option = document.createElement('option');
+    option.value = normalized;
+    option.textContent = label || normalized;
+    if (selectedValues.includes(normalized)) {
+      option.selected = true;
+    }
+    autoGearDeliveryResolutionSelect.appendChild(option);
+    seen.add(normalized);
+  };
+
+  if (deliveryResolutionSelect) {
+    Array.from(deliveryResolutionSelect.options || []).forEach(opt => {
+      if (!opt || typeof opt.value !== 'string') return;
+      const value = opt.value.trim();
+      if (!value) return;
+      const label = (opt.textContent || value).trim();
+      addOption(value, label);
+    });
+  }
+
+  selectedValues.forEach(value => {
+    if (!seen.has(value)) addOption(value, value);
+  });
+
+  if (!autoGearDeliveryResolutionSelect.options.length) {
+    const placeholder = document.createElement('option');
+    placeholder.value = '';
+    placeholder.textContent = texts[currentLang]?.autoGearDeliveryResolutionPlaceholder
+      || texts.en?.autoGearDeliveryResolutionPlaceholder
+      || 'Select delivery resolutions';
+    placeholder.disabled = true;
+    placeholder.selected = true;
+    autoGearDeliveryResolutionSelect.appendChild(placeholder);
+  }
+
+  const visibleCount = Array.from(autoGearDeliveryResolutionSelect.options || []).filter(option => !option.disabled).length;
+  autoGearDeliveryResolutionSelect.size = computeAutoGearMultiSelectSize(
+    visibleCount,
     { minRows: AUTO_GEAR_FLEX_MULTI_SELECT_MIN_ROWS }
   );
 }
@@ -11912,6 +11998,7 @@ function renderAutoGearRulesList() {
     const viewfinderDisplayList = rawViewfinderList.map(getViewfinderFallbackLabel);
     const videoDistributionList = Array.isArray(rule.videoDistribution) ? rule.videoDistribution : [];
     const videoDistributionDisplayList = videoDistributionList.map(getVideoDistributionFallbackLabel);
+    const deliveryResolutionList = Array.isArray(rule.deliveryResolution) ? rule.deliveryResolution : [];
     const cameraList = Array.isArray(rule.camera) ? rule.camera : [];
     const monitorList = Array.isArray(rule.monitor) ? rule.monitor : [];
     const wirelessList = Array.isArray(rule.wireless) ? rule.wireless : [];
@@ -11928,6 +12015,7 @@ function renderAutoGearRulesList() {
       matteboxList,
       cameraHandleList,
       viewfinderDisplayList,
+      deliveryResolutionList,
       videoDistributionDisplayList,
     ];
     const fallbackSource = scenarioList.length
@@ -12043,6 +12131,15 @@ function renderAutoGearRulesList() {
       videoDistMeta.className = 'auto-gear-rule-meta';
       videoDistMeta.textContent = `${videoDistLabelText}: ${videoDistributionDisplayList.join(' + ')}`;
       info.appendChild(videoDistMeta);
+    }
+    if (deliveryResolutionList.length) {
+      const deliveryLabelText = texts[currentLang]?.autoGearDeliveryResolutionLabel
+        || texts.en?.autoGearDeliveryResolutionLabel
+        || 'Delivery resolution';
+      const deliveryMeta = document.createElement('p');
+      deliveryMeta.className = 'auto-gear-rule-meta';
+      deliveryMeta.textContent = `${deliveryLabelText}: ${deliveryResolutionList.join(' + ')}`;
+      info.appendChild(deliveryMeta);
     }
     const addSummary = formatAutoGearCount(rule.add.length, 'autoGearAddsCountOne', 'autoGearAddsCountOther');
     const removeSummary = formatAutoGearCount(rule.remove.length, 'autoGearRemovalsCountOne', 'autoGearRemovalsCountOther');
@@ -12505,6 +12602,11 @@ function saveAutoGearRuleFromEditor() {
         .map(option => option.value)
         .filter(value => typeof value === 'string' && value.trim())
     : [];
+  const deliveryResolutionSelections = isAutoGearConditionActive('deliveryResolution') && autoGearDeliveryResolutionSelect
+    ? Array.from(autoGearDeliveryResolutionSelect.selectedOptions || [])
+        .map(option => option.value)
+        .filter(value => typeof value === 'string' && value.trim())
+    : [];
   let videoDistributionSelections = isAutoGearConditionActive('videoDistribution') && autoGearVideoDistributionSelect
     ? Array.from(autoGearVideoDistributionSelect.selectedOptions || [])
         .map(option => option.value)
@@ -12550,6 +12652,7 @@ function saveAutoGearRuleFromEditor() {
     && !matteboxSelections.length
     && !cameraHandleSelections.length
     && !viewfinderSelections.length
+    && !deliveryResolutionSelections.length
     && !videoDistributionSelections.length
     && !cameraSelections.length
     && !monitorSelections.length
@@ -12562,7 +12665,7 @@ function saveAutoGearRuleFromEditor() {
       || texts.en?.autoGearRuleConditionRequired
       || texts[currentLang]?.autoGearRuleScenarioRequired
       || texts.en?.autoGearRuleScenarioRequired
-      || 'Select at least one scenario, mattebox option, camera handle, viewfinder extension or video distribution before saving.';
+      || 'Select at least one scenario, mattebox option, camera handle, viewfinder extension, delivery resolution or video distribution before saving.';
     window.alert(message);
     return;
   }
@@ -12574,6 +12677,7 @@ function saveAutoGearRuleFromEditor() {
   autoGearEditorDraft.mattebox = matteboxSelections;
   autoGearEditorDraft.cameraHandle = cameraHandleSelections;
   autoGearEditorDraft.viewfinderExtension = viewfinderSelections;
+  autoGearEditorDraft.deliveryResolution = deliveryResolutionSelections;
   autoGearEditorDraft.videoDistribution = videoDistributionSelections;
   autoGearEditorDraft.camera = cameraSelections;
   autoGearEditorDraft.monitor = monitorSelections;

--- a/src/scripts/app-setups.js
+++ b/src/scripts/app-setups.js
@@ -1902,6 +1902,10 @@ function applyAutoGearRulesToTableHtml(tableHtml, info) {
   const normalizedViewfinderExtension = hasViewfinderSelection
       ? normalizeAutoGearTriggerValue(rawViewfinderExtension)
       : '';
+  const rawDeliveryResolution = info && typeof info.deliveryResolution === 'string'
+      ? info.deliveryResolution.trim()
+      : '';
+  const normalizedDeliveryResolution = normalizeAutoGearTriggerValue(rawDeliveryResolution);
   let videoDistribution = [];
   if (info && Array.isArray(info.videoDistribution)) {
     videoDistribution = info.videoDistribution;
@@ -2072,6 +2076,15 @@ function applyAutoGearRulesToTableHtml(tableHtml, info) {
             if (!normalizedTargets.length) return false;
             if (!normalizedViewfinderExtension) return false;
             if (!normalizedTargets.includes(normalizedViewfinderExtension)) return false;
+        }
+        const deliveryList = Array.isArray(rule.deliveryResolution) ? rule.deliveryResolution.filter(Boolean) : [];
+        if (deliveryList.length) {
+          const normalizedTargets = deliveryList
+            .map(normalizeAutoGearTriggerValue)
+            .filter(Boolean);
+          if (!normalizedTargets.length) return false;
+          if (!normalizedDeliveryResolution) return false;
+          if (!normalizedTargets.includes(normalizedDeliveryResolution)) return false;
         }
         const videoDistList = Array.isArray(rule.videoDistribution) ? rule.videoDistribution.filter(Boolean) : [];
         if (videoDistList.length) {

--- a/src/scripts/translations.js
+++ b/src/scripts/translations.js
@@ -214,6 +214,10 @@ const texts = {
     autoGearViewfinderExtensionHelp:
       "Apply this rule when these viewfinder extension choices are selected.",
     autoGearViewfinderExtensionPlaceholder: "Select viewfinder extension options",
+    autoGearDeliveryResolutionLabel: "Delivery resolution",
+    autoGearDeliveryResolutionHelp:
+      "Apply this rule when these delivery resolutions are selected.",
+    autoGearDeliveryResolutionPlaceholder: "Select delivery resolutions",
     autoGearVideoDistributionLabel: "Video distribution",
     autoGearVideoDistributionHelp:
       "Apply this rule when these video distribution preferences are selected.",
@@ -1636,6 +1640,10 @@ const texts = {
     autoGearViewfinderExtensionHelp:
       "Applica la regola quando sono selezionate queste scelte di prolunga mirino.",
     autoGearViewfinderExtensionPlaceholder: "Seleziona opzioni di prolunga mirino",
+    autoGearDeliveryResolutionLabel: "Risoluzione di consegna",
+    autoGearDeliveryResolutionHelp:
+      "Applica la regola quando sono selezionate queste risoluzioni di consegna.",
+    autoGearDeliveryResolutionPlaceholder: "Seleziona risoluzioni di consegna",
     autoGearVideoDistributionLabel: "Distribuzione video",
     autoGearVideoDistributionHelp:
       "Applica la regola quando sono selezionate queste preferenze di distribuzione video.",
@@ -2639,6 +2647,10 @@ const texts = {
     autoGearViewfinderExtensionHelp:
       "Aplica la regla cuando se eligen estas opciones de extensión de visor.",
     autoGearViewfinderExtensionPlaceholder: "Selecciona opciones de extensión de visor",
+    autoGearDeliveryResolutionLabel: "Resolución de entrega",
+    autoGearDeliveryResolutionHelp:
+      "Aplica la regla cuando se eligen estas resoluciones de entrega.",
+    autoGearDeliveryResolutionPlaceholder: "Selecciona resoluciones de entrega",
     autoGearVideoDistributionLabel: "Distribución de vídeo",
     autoGearVideoDistributionHelp:
       "Aplica la regla cuando se eligen estas preferencias de distribución de vídeo.",
@@ -3644,6 +3656,10 @@ const texts = {
     autoGearViewfinderExtensionHelp:
       "Appliquer la règle lorsque ces choix d’extension de viseur sont sélectionnés.",
     autoGearViewfinderExtensionPlaceholder: "Sélectionnez des options d’extension de viseur",
+    autoGearDeliveryResolutionLabel: "Résolution de livraison",
+    autoGearDeliveryResolutionHelp:
+      "Appliquer la règle lorsque ces résolutions de livraison sont sélectionnées.",
+    autoGearDeliveryResolutionPlaceholder: "Sélectionnez des résolutions de livraison",
     autoGearVideoDistributionLabel: "Distribution vidéo",
     autoGearVideoDistributionHelp:
       "Appliquer la règle lorsque ces préférences de distribution vidéo sont sélectionnées.",
@@ -4652,6 +4668,10 @@ const texts = {
     autoGearViewfinderExtensionHelp:
       "Regel anwenden, wenn diese Sucher-Verlängerungsoptionen ausgewählt sind.",
     autoGearViewfinderExtensionPlaceholder: "Sucher-Verlängerungsoptionen auswählen",
+    autoGearDeliveryResolutionLabel: "Auslieferungsauflösung",
+    autoGearDeliveryResolutionHelp:
+      "Regel anwenden, wenn diese Auslieferungsauflösungen ausgewählt sind.",
+    autoGearDeliveryResolutionPlaceholder: "Auslieferungsauflösungen auswählen",
     autoGearVideoDistributionLabel: "Videoverteilung",
     autoGearVideoDistributionHelp:
       "Regel anwenden, wenn diese Videoverteilungsoptionen ausgewählt sind.",

--- a/tests/script/autoGearRules.test.js
+++ b/tests/script/autoGearRules.test.js
@@ -88,6 +88,7 @@ describe('applyAutoGearRulesToTableHtml', () => {
       'mattebox',
       'cameraHandle',
       'viewfinderExtension',
+      'deliveryResolution',
       'videoDistribution',
       'camera',
       'monitor',
@@ -102,6 +103,7 @@ describe('applyAutoGearRulesToTableHtml', () => {
       'autoGearMattebox',
       'autoGearCameraHandle',
       'autoGearViewfinderExtension',
+      'autoGearDeliveryResolution',
       'autoGearVideoDistribution',
       'autoGearCamera',
       'autoGearMonitor',
@@ -153,6 +155,7 @@ describe('applyAutoGearRulesToTableHtml', () => {
       'mattebox',
       'cameraHandle',
       'viewfinderExtension',
+      'deliveryResolution',
       'videoDistribution',
       'camera',
       'monitor',
@@ -520,6 +523,99 @@ describe('applyAutoGearRulesToTableHtml', () => {
     container.innerHTML = result;
 
     const entries = container.querySelectorAll('[data-gear-name="Standard VF Cable"]');
+    expect(entries).toHaveLength(0);
+  });
+
+  test('applies delivery resolution rules when the selection matches', () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify([
+        {
+          id: 'rule-delivery',
+          label: '4K delivery kit',
+          scenarios: [],
+          mattebox: [],
+          cameraHandle: [],
+          viewfinderExtension: [],
+          deliveryResolution: ['4K'],
+          videoDistribution: [],
+          add: [
+            {
+              id: 'add-delivery',
+              name: 'Dedicated 4K Master Monitor',
+              category: 'Monitoring',
+              quantity: 1,
+            }
+          ],
+          remove: []
+        }
+      ])
+    );
+
+    env = setupScriptEnvironment();
+    const { applyAutoGearRulesToTableHtml } = env.utils;
+
+    const tableHtml = `
+      <table class="gear-table">
+        <tbody class="category-group">
+          <tr class="category-row"><td>Monitoring</td></tr>
+          <tr><td></td></tr>
+        </tbody>
+      </table>
+    `;
+
+    const result = applyAutoGearRulesToTableHtml(tableHtml, { deliveryResolution: '4K' });
+    const container = document.createElement('div');
+    container.innerHTML = result;
+
+    const entries = container.querySelectorAll('[data-gear-name="Dedicated 4K Master Monitor"]');
+    expect(entries).toHaveLength(1);
+    expect(entries[0].classList.contains('auto-gear-item')).toBe(true);
+  });
+
+  test('does not apply delivery resolution rules for a different selection', () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify([
+        {
+          id: 'rule-delivery-mismatch',
+          label: '8K finishing',
+          scenarios: [],
+          mattebox: [],
+          cameraHandle: [],
+          viewfinderExtension: [],
+          deliveryResolution: ['8K'],
+          videoDistribution: [],
+          add: [
+            {
+              id: 'add-delivery-mismatch',
+              name: '8K QC Station',
+              category: 'Monitoring',
+              quantity: 1,
+            }
+          ],
+          remove: []
+        }
+      ])
+    );
+
+    env = setupScriptEnvironment();
+    const { applyAutoGearRulesToTableHtml } = env.utils;
+
+    const tableHtml = `
+      <table class="gear-table">
+        <tbody class="category-group">
+          <tr class="category-row"><td>Monitoring</td></tr>
+          <tr><td></td></tr>
+        </tbody>
+      </table>
+    `;
+
+    const result = applyAutoGearRulesToTableHtml(tableHtml, { deliveryResolution: '4K' });
+    const container = document.createElement('div');
+    container.innerHTML = result;
+
+    const entries = container.querySelectorAll('[data-gear-name="8K QC Station"]');
     expect(entries).toHaveLength(0);
   });
 


### PR DESCRIPTION
## Summary
- add a delivery resolution option and editor section to the automatic gear condition picker
- extend automatic gear rule handling to normalize, persist, search and render delivery resolution triggers with localized labels
- require matching delivery resolutions when applying automatic gear rules and cover the behavior with new Jest tests

## Testing
- `npm test -- --runTestsByPath tests/script/autoGearRules.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68d3a5df7e00832095b3804190625f46