### PR TITLE
Make pink mode floating icons clickable without affecting icon rain

### DIFF
--- a/src/scripts/app-core.js
+++ b/src/scripts/app-core.js
@@ -7195,6 +7195,14 @@ function destroyPinkModeAnimatedIconInstance(instance) {
   if (!instance || instance.destroyed) {
     return;
   }
+  if (typeof instance.cleanup === 'function') {
+    try {
+      instance.cleanup();
+    } catch (cleanupError) {
+      console.warn('Could not detach pink mode animation interactions', cleanupError);
+    }
+    instance.cleanup = null;
+  }
   instance.destroyed = true;
   if (instance.animation && typeof instance.animation.destroy === 'function') {
     try {
@@ -7212,6 +7220,14 @@ function destroyPinkModeAnimatedIconInstance(instance) {
 function destroyPinkModeIconRainInstance(instance) {
   if (!instance || instance.destroyed) {
     return;
+  }
+  if (typeof instance.cleanup === 'function') {
+    try {
+      instance.cleanup();
+    } catch (cleanupError) {
+      console.warn('Could not detach pink mode rain interactions', cleanupError);
+    }
+    instance.cleanup = null;
   }
   instance.destroyed = true;
   if (instance.animation && typeof instance.animation.destroy === 'function') {
@@ -7371,6 +7387,59 @@ function spawnPinkModeIconRainInstance(templates) {
     animation: animationInstance,
     destroyed: false,
     templateName: typeof template.name === 'string' ? template.name : null
+  };
+
+  const stopEventPropagation = event => {
+    if (!event) {
+      return;
+    }
+    if (typeof event.stopImmediatePropagation === 'function') {
+      event.stopImmediatePropagation();
+    }
+    if (typeof event.stopPropagation === 'function') {
+      event.stopPropagation();
+    }
+  };
+
+  const preventAndStopEvent = event => {
+    stopEventPropagation(event);
+    if (event && typeof event.preventDefault === 'function') {
+      try {
+        event.preventDefault();
+      } catch (error) {
+        // Ignore errors when preventDefault isn't allowed (e.g. passive listeners)
+      }
+    }
+  };
+
+  const supportsPointerEvents =
+    typeof window !== 'undefined' && typeof window.PointerEvent === 'function';
+
+  const handleIconRainPress = event => {
+    preventAndStopEvent(event);
+    destroyPinkModeIconRainInstance(instance);
+  };
+
+  const handleIconRainClick = event => {
+    preventAndStopEvent(event);
+  };
+
+  const pressEvents = supportsPointerEvents
+    ? ['pointerdown']
+    : ['mousedown', 'touchstart'];
+
+  pressEvents.forEach(eventName => {
+    container.addEventListener(eventName, handleIconRainPress, {
+      passive: false
+    });
+  });
+  container.addEventListener('click', handleIconRainClick, true);
+
+  instance.cleanup = () => {
+    pressEvents.forEach(eventName => {
+      container.removeEventListener(eventName, handleIconRainPress, false);
+    });
+    container.removeEventListener('click', handleIconRainClick, true);
   };
 
   container.addEventListener(
@@ -7632,6 +7701,60 @@ function spawnPinkModeAnimatedIconInstance(templates) {
     animation: animationInstance,
     destroyed: false,
     templateName: typeof template.name === 'string' ? template.name : null
+  };
+
+  const stopEventPropagation = event => {
+    if (!event) {
+      return;
+    }
+    if (typeof event.stopImmediatePropagation === 'function') {
+      event.stopImmediatePropagation();
+    }
+    if (typeof event.stopPropagation === 'function') {
+      event.stopPropagation();
+    }
+  };
+
+  const preventAndStopEvent = event => {
+    stopEventPropagation(event);
+    if (event && typeof event.preventDefault === 'function') {
+      try {
+        event.preventDefault();
+      } catch (error) {
+        // Ignore errors when preventDefault isn't allowed (e.g. passive listeners)
+      }
+    }
+  };
+
+  const supportsPointerEvents =
+    typeof window !== 'undefined' && typeof window.PointerEvent === 'function';
+
+  const handleIconPress = event => {
+    preventAndStopEvent(event);
+    destroyPinkModeAnimatedIconInstance(instance);
+  };
+
+  const handleIconClick = event => {
+    preventAndStopEvent(event);
+  };
+
+  const pressEvents = supportsPointerEvents
+    ? ['pointerdown']
+    : ['mousedown', 'touchstart'];
+
+  pressEvents.forEach(eventName => {
+    container.addEventListener(eventName, handleIconPress, {
+      passive: false
+    });
+  });
+
+  container.addEventListener('click', handleIconClick, true);
+
+  instance.cleanup = () => {
+    pressEvents.forEach(eventName => {
+      container.removeEventListener(eventName, handleIconPress, false);
+    });
+    container.removeEventListener('click', handleIconClick, true);
   };
 
   container.addEventListener(

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -3064,6 +3064,12 @@ body.pink-mode .pink-mode-icon {
   transform-origin: center;
   will-change: transform, opacity;
   filter: drop-shadow(0 4px 12px rgba(255, 105, 180, 0.25));
+  pointer-events: auto;
+  cursor: pointer;
+  touch-action: none;
+  -webkit-tap-highlight-color: transparent;
+  user-select: none;
+  -webkit-user-drag: none;
 }
 
 .pink-mode-animation-instance svg {
@@ -3076,6 +3082,11 @@ body.pink-mode .pink-mode-icon {
   animation-name: pink-mode-rain-icon;
   animation-duration: var(--pink-mode-rain-duration, 4800ms);
   animation-timing-function: ease-in;
+  pointer-events: none;
+  cursor: default;
+  touch-action: auto;
+  user-select: auto;
+  -webkit-user-drag: auto;
 }
 
 .pink-mode-animation-instance.pink-mode-icon-rain svg {


### PR DESCRIPTION
## Summary
- enable non-rain pink mode animated icons to capture pointer/touch events, prevent propagation, and dismiss when pressed
- ensure cleanup hooks run during teardown to remove listeners for floating icons
- keep falling icon rain decorative by leaving it non-interactive while leaving pointer affordances on standard floating icons only

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d3c188be5c832088b93719d060bfd8