### PR TITLE
Fix icon rain interactions

### DIFF
--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -3082,11 +3082,11 @@ body.pink-mode .pink-mode-icon {
   animation-name: pink-mode-rain-icon;
   animation-duration: var(--pink-mode-rain-duration, 4800ms);
   animation-timing-function: ease-in;
-  pointer-events: none;
-  cursor: default;
-  touch-action: auto;
-  user-select: auto;
-  -webkit-user-drag: auto;
+  pointer-events: auto;
+  cursor: pointer;
+  touch-action: none;
+  user-select: none;
+  -webkit-user-drag: none;
 }
 
 .pink-mode-animation-instance.pink-mode-icon-rain svg {


### PR DESCRIPTION
## Summary
- enable pointer interaction on pink mode rain icons so they can be dismissed when tapped or clicked
- keep rain icons non-selectable and non-draggable to match other animated icons

## Testing
- npm run lint *(fails: `ensureAutoBackupsFromProjects` is not defined in src/scripts/app-session.js)*

------
https://chatgpt.com/codex/tasks/task_e_68d3c99224b883208f24108866c38170