### PR TITLE
Prevent animated icons from disappearing on click

### DIFF
--- a/src/scripts/app-core.js
+++ b/src/scripts/app-core.js
@@ -7414,59 +7414,6 @@ function spawnPinkModeIconRainInstance(templates) {
     templateName: typeof template.name === 'string' ? template.name : null
   };
 
-  const stopEventPropagation = event => {
-    if (!event) {
-      return;
-    }
-    if (typeof event.stopImmediatePropagation === 'function') {
-      event.stopImmediatePropagation();
-    }
-    if (typeof event.stopPropagation === 'function') {
-      event.stopPropagation();
-    }
-  };
-
-  const preventAndStopEvent = event => {
-    stopEventPropagation(event);
-    if (event && typeof event.preventDefault === 'function') {
-      try {
-        event.preventDefault();
-      } catch (error) {
-        // Ignore errors when preventDefault isn't allowed (e.g. passive listeners)
-      }
-    }
-  };
-
-  const supportsPointerEvents =
-    typeof window !== 'undefined' && typeof window.PointerEvent === 'function';
-
-  const handleIconRainPress = event => {
-    preventAndStopEvent(event);
-    destroyPinkModeIconRainInstance(instance);
-  };
-
-  const handleIconRainClick = event => {
-    preventAndStopEvent(event);
-  };
-
-  const pressEvents = supportsPointerEvents
-    ? ['pointerdown']
-    : ['mousedown', 'touchstart'];
-
-  pressEvents.forEach(eventName => {
-    container.addEventListener(eventName, handleIconRainPress, {
-      passive: false
-    });
-  });
-  container.addEventListener('click', handleIconRainClick, true);
-
-  instance.cleanup = () => {
-    pressEvents.forEach(eventName => {
-      container.removeEventListener(eventName, handleIconRainPress, false);
-    });
-    container.removeEventListener('click', handleIconRainClick, true);
-  };
-
   container.addEventListener(
     'animationend',
     () => {
@@ -7765,60 +7712,6 @@ function spawnPinkModeAnimatedIconInstance(templates) {
     animation: animationInstance,
     destroyed: false,
     templateName: typeof template.name === 'string' ? template.name : null
-  };
-
-  const stopEventPropagation = event => {
-    if (!event) {
-      return;
-    }
-    if (typeof event.stopImmediatePropagation === 'function') {
-      event.stopImmediatePropagation();
-    }
-    if (typeof event.stopPropagation === 'function') {
-      event.stopPropagation();
-    }
-  };
-
-  const preventAndStopEvent = event => {
-    stopEventPropagation(event);
-    if (event && typeof event.preventDefault === 'function') {
-      try {
-        event.preventDefault();
-      } catch (error) {
-        // Ignore errors when preventDefault isn't allowed (e.g. passive listeners)
-      }
-    }
-  };
-
-  const supportsPointerEvents =
-    typeof window !== 'undefined' && typeof window.PointerEvent === 'function';
-
-  const handleIconPress = event => {
-    preventAndStopEvent(event);
-    destroyPinkModeAnimatedIconInstance(instance);
-  };
-
-  const handleIconClick = event => {
-    preventAndStopEvent(event);
-  };
-
-  const pressEvents = supportsPointerEvents
-    ? ['pointerdown']
-    : ['mousedown', 'touchstart'];
-
-  pressEvents.forEach(eventName => {
-    container.addEventListener(eventName, handleIconPress, {
-      passive: false
-    });
-  });
-
-  container.addEventListener('click', handleIconClick, true);
-
-  instance.cleanup = () => {
-    pressEvents.forEach(eventName => {
-      container.removeEventListener(eventName, handleIconPress, false);
-    });
-    container.removeEventListener('click', handleIconClick, true);
   };
 
   container.addEventListener(

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -3064,8 +3064,8 @@ body.pink-mode .pink-mode-icon {
   transform-origin: center;
   will-change: transform, opacity;
   filter: drop-shadow(0 4px 12px rgba(255, 105, 180, 0.25));
-  pointer-events: auto;
-  cursor: pointer;
+  pointer-events: none;
+  cursor: default;
   touch-action: none;
   -webkit-tap-highlight-color: transparent;
   user-select: none;
@@ -3082,8 +3082,8 @@ body.pink-mode .pink-mode-icon {
   animation-name: pink-mode-rain-icon;
   animation-duration: var(--pink-mode-rain-duration, 4800ms);
   animation-timing-function: ease-in;
-  pointer-events: auto;
-  cursor: pointer;
+  pointer-events: none;
+  cursor: default;
   touch-action: none;
   user-select: none;
   -webkit-user-drag: none;


### PR DESCRIPTION
## Summary
- stop removing pink mode animated icons and rain drops when they receive pointer events so they stay visible
- disable pointer event hit-testing on the animated icon containers to keep them decorative while leaving the underlying UI usable

## Testing
- npm test *(fails: eslint reports `ensureAutoBackupsFromProjects` is not defined in src/scripts/app-session.js)*

------
https://chatgpt.com/codex/tasks/task_e_68d3cb55756883209e71dd46f8c53ac5