### PR TITLE
Highlight ND grad filter sets

### DIFF
--- a/src/styles/overview-print.css
+++ b/src/styles/overview-print.css
@@ -68,6 +68,7 @@ body.dark-mode {
   --status-warning-bg: #ff6b6b;
   --status-warning-text-color: #000000;
   --status-error-text-color: #000;
+  --nd-grad-border-color: var(--accent-color);
   --font-size-base: 11pt;
   font-family: 'Ubuntu', sans-serif;
   font-weight: var(--font-weight-light);
@@ -108,8 +109,20 @@ strong {
   --power-color: #d33;
   --video-color: #369;
   --fiz-color: #090;
+  --nd-grad-border-color: var(--accent-color);
   background: var(--surface-color) !important;
   color: var(--text-color) !important;
+}
+
+body.dark-mode,
+#overviewDialogContent.dark-mode {
+  --nd-grad-border-color: #ffffff;
+}
+
+html.pink-mode,
+body.pink-mode,
+#overviewDialogContent.pink-mode {
+  --nd-grad-border-color: #ff69b4;
 }
 
 /* Ensure setup diagram uses light theme when printing */
@@ -441,7 +454,7 @@ body:not(.light-mode) .gear-table .category-row {
 #overviewDialogContent .gear-table .gear-item[data-gear-name^="ND Grad HE Filter Set"],
 #overviewDialogContent .gear-table .gear-item[data-gear-name^="ND Grad SE Filter Set"] {
   padding: 0.15em 0.45em;
-  border: 1px solid var(--panel-border);
+  border: 1px solid var(--nd-grad-border-color, var(--accent-color));
   border-radius: calc(var(--border-radius) * 0.75);
   background-color: color-mix(in srgb, var(--panel-bg) 88%, transparent);
 }

--- a/src/styles/overview-print.css
+++ b/src/styles/overview-print.css
@@ -438,6 +438,14 @@ body:not(.light-mode) .gear-table .category-row {
   white-space: nowrap;
 }
 
+#overviewDialogContent .gear-table .gear-item[data-gear-name^="ND Grad HE Filter Set"],
+#overviewDialogContent .gear-table .gear-item[data-gear-name^="ND Grad SE Filter Set"] {
+  padding: 0.15em 0.45em;
+  border: 1px solid var(--panel-border);
+  border-radius: calc(var(--border-radius) * 0.75);
+  background-color: color-mix(in srgb, var(--panel-bg) 88%, transparent);
+}
+
 #overviewDialogContent .gear-table .auto-gear-item,
 #overviewDialogContent.dark-mode .gear-table .auto-gear-item,
 body:not(.light-mode) .gear-table .auto-gear-item {

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -147,6 +147,7 @@
   --connector-label-neutral-color: #000000;
   --auto-gear-highlight-bg: rgba(255, 210, 64, 0.35);
   --auto-gear-highlight-border: rgba(255, 181, 0, 0.7);
+  --nd-grad-border-color: var(--accent-color);
   --auto-gear-highlight-text: var(--text-color);
 }
 @media (max-width: 600px) {
@@ -5662,7 +5663,7 @@ body.dark-mode .requirement-box,
   align-items: center;
   gap: 0.35em;
   padding: 0.15em 0.45em;
-  border: 1px solid var(--panel-border);
+  border: 1px solid var(--nd-grad-border-color, var(--accent-color));
   border-radius: calc(var(--border-radius) * 0.75);
   background-color: color-mix(in srgb, var(--panel-bg) 88%, transparent);
 }
@@ -6211,6 +6212,19 @@ body.light-mode #sideMenu a:focus-visible,
 body.light-mode #sideMenu button[data-sidebar-action]:focus-visible {
   outline: 2px solid color-mix(in srgb, var(--accent-color) 70%, var(--surface-color));
   outline-offset: 3px;
+}
+
+.dark-mode,
+#gearListOutput.dark-mode,
+#overviewDialogContent.dark-mode {
+  --nd-grad-border-color: #ffffff;
+}
+
+html.pink-mode,
+body.pink-mode,
+#gearListOutput.pink-mode,
+#overviewDialogContent.pink-mode {
+  --nd-grad-border-color: #ff69b4;
 }
 
 .dark-mode #sideMenu ul {

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -5656,6 +5656,17 @@ body.dark-mode .requirement-box,
   page-break-after: avoid;
 }
 
+.gear-item[data-gear-name^="ND Grad HE Filter Set"],
+.gear-item[data-gear-name^="ND Grad SE Filter Set"] {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35em;
+  padding: 0.15em 0.45em;
+  border: 1px solid var(--panel-border);
+  border-radius: calc(var(--border-radius) * 0.75);
+  background-color: color-mix(in srgb, var(--panel-bg) 88%, transparent);
+}
+
 body.light-mode .gear-table strong,
 #gearListOutput:not(.dark-mode) .gear-table strong,
 #overviewDialogContent:not(.dark-mode) .gear-table strong {


### PR DESCRIPTION
## Summary
- add a subtle bordered chip treatment for the ND Grad HE and ND Grad SE filter sets in the gear list
- mirror the same styling in the printable overview so the visual grouping remains consistent when exporting or printing

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d43e94b4c88320823ed51f688ca9f2