### PR TITLE
Adjust gear filter label width

### DIFF
--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -5799,7 +5799,7 @@ body.dark-mode.pink-mode #gearListOutput h2,
 
 #gearListFilterDetails .filter-detail {
   display: grid;
-  grid-template-columns: minmax(8.5rem, max-content) minmax(0, 1fr);
+  grid-template-columns: minmax(6.5rem, max-content) minmax(0, 1fr);
   column-gap: 0.5rem;
   row-gap: 0.125rem;
   align-items: center;


### PR DESCRIPTION
## Summary
- reduce the minimum width of each gear filter label column to tighten spacing before the size selector

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d440ca32a8832083054c5e91a378a4