### PR TITLE
Fix Bebob battery merging

### DIFF
--- a/src/scripts/app-setups.js
+++ b/src/scripts/app-setups.js
@@ -2624,15 +2624,20 @@ function generateGearListHtml(info = {}) {
     const infoHtml = infoEntries.length ? `<h3>${escapeHtml(requirementsHeading)}</h3>${boxesHtml}` : '';
     const formatItems = arr => {
         const counts = {};
-        arr.filter(Boolean).map(addArriKNumber).forEach(item => {
-            const match = item.trim().match(/^(.*?)(?: \(([^()]+)\))?$/);
-            const base = match ? match[1].trim() : item.trim();
+        arr.filter(Boolean).map(addArriKNumber).forEach(rawItem => {
+            const item = rawItem.trim();
+            const quantityMatch = item.match(/^(\d+)x\s+(.*)$/);
+            const quantity = quantityMatch ? parseInt(quantityMatch[1], 10) : 1;
+            const namePart = quantityMatch ? quantityMatch[2] : item;
+            const match = namePart.trim().match(/^(.*?)(?: \(([^()]+)\))?$/);
+            const base = match ? match[1].trim() : namePart.trim();
             const ctx = match && match[2] ? match[2].trim() : '';
             if (!counts[base]) {
                 counts[base] = { total: 0, ctxCounts: {} };
             }
-            counts[base].total++;
-            counts[base].ctxCounts[ctx] = (counts[base].ctxCounts[ctx] || 0) + 1;
+            counts[base].total += Number.isFinite(quantity) && quantity > 0 ? quantity : 1;
+            const current = counts[base].ctxCounts[ctx] || 0;
+            counts[base].ctxCounts[ctx] = current + (Number.isFinite(quantity) && quantity > 0 ? quantity : 1);
         });
         return Object.entries(counts)
             .sort(([a], [b]) => a.localeCompare(b, undefined, { sensitivity: 'base' }))
@@ -2652,6 +2657,17 @@ function generateGearListHtml(info = {}) {
                     } else if (base.startsWith('Bebob ')) {
                         const realEntries = Object.entries(ctxCounts)
                             .filter(([c]) => c && c.toLowerCase() !== 'spare')
+                            .map(([c, count]) => {
+                                const qtyMatch = c.match(/^(\d+)x\s+(.*)$/i);
+                                if (qtyMatch) {
+                                    const [, qty, label] = qtyMatch;
+                                    const qtyNum = parseInt(qty, 10);
+                                    if (Number.isFinite(qtyNum) && qtyNum > 0) {
+                                        return [label.trim(), count * qtyNum];
+                                    }
+                                }
+                                return [c, count];
+                            })
                             .sort(([a], [b]) => a.localeCompare(b, undefined, { sensitivity: 'base' }));
                         const usedCount = realEntries.reduce((sum, [, count]) => sum + count, 0);
                         const spareCount = total - usedCount;


### PR DESCRIPTION
## Summary
- ensure gear list parsing honours explicit quantity prefixes so duplicate Bebob battery entries merge correctly
- scale Bebob monitor battery contexts by embedded quantities while preserving spare counts in both modern and legacy bundles

## Testing
- npm run lint --silent
- npm run check-consistency --silent
- npm run test:unit --silent
- npm run test:data --silent
- npm run test:script --silent *(fails: exceeded reasonable execution time in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d442888e048320972e2eb41a641564