### PR TITLE
Update tripod type options

### DIFF
--- a/index.html
+++ b/index.html
@@ -4840,9 +4840,9 @@
             <div class="form-row">
               <label for="tripodTypes" id="tripodTypesLabel">Tripod types:</label>
               <select id="tripodTypes" name="tripodTypes" multiple size="4">
-                <option value="Standard Tripod">Standard Tripod</option>
-                <option value="Baby Tripod">Baby Tripod</option>
-                <option value="Frog Tripod">Frog Tripod</option>
+                <option value="Long">Long</option>
+                <option value="Medium">Medium</option>
+                <option value="Short">Short</option>
                 <option value="Hi-Head">Hi-Head</option>
               </select>
             </div>

--- a/legacy/scripts/app-setups.js
+++ b/legacy/scripts/app-setups.js
@@ -3269,7 +3269,8 @@ function generateGearListHtml() {
     gripItems.push("".concat(headName, " ").concat(bowlType));
   }
   tripodTypes.forEach(function (t) {
-    var base = bowlType ? "".concat(bowlType, " ").concat(t) : t;
+    var typeLabel = t === 'Hi-Head' ? 'Hi-Head' : "".concat(t, " Tripod");
+    var base = bowlType ? "".concat(bowlType, " ").concat(typeLabel) : typeLabel;
     if (t === 'Hi-Head') {
       gripItems.push(base);
     } else if (spreader) {
@@ -3277,17 +3278,17 @@ function generateGearListHtml() {
     } else {
       gripItems.push(base);
     }
-    if (t === 'Frog Tripod') {
-      gripItems.push('Sand bag (Frog Tripod)');
+    if (t === 'Short') {
+      gripItems.push('Sand bag (Short Tripod)');
     }
     if (t === 'Hi-Head') {
       gripItems.push('Sand bag (Hi-Head)');
     }
   });
   if (needsStandardTripod && !gripItems.some(function (item) {
-    return /Standard Tripod/.test(item);
+    return /Long Tripod/.test(item);
   })) {
-    gripItems.push('Standard Tripod');
+    gripItems.push('Long Tripod');
   }
   var standCount = gripItems.filter(function (item) {
     return /\bstand\b/i.test(item) && !/wheel/i.test(item);

--- a/src/scripts/app-core.js
+++ b/src/scripts/app-core.js
@@ -850,7 +850,7 @@ function extractAutoGearContextNotes(name) {
   let match = baseName.match(contextPattern);
   while (match) {
     const candidate = match[2].trim();
-    if (/handheld\b/i.test(candidate) || /15-21\"?$/.test(candidate)) {
+    if (/handheld\b/i.test(candidate) || /15-21"?$/.test(candidate)) {
       contexts.unshift(candidate);
       baseName = match[1].trim();
     } else {

--- a/src/scripts/app-setups.js
+++ b/src/scripts/app-setups.js
@@ -3219,7 +3219,8 @@ function generateGearListHtml(info = {}) {
         gripItems.push(`${headName} ${bowlType}`);
     }
     tripodTypes.forEach(t => {
-        const base = bowlType ? `${bowlType} ${t}` : t;
+        const typeLabel = t === 'Hi-Head' ? 'Hi-Head' : `${t} Tripod`;
+        const base = bowlType ? `${bowlType} ${typeLabel}` : typeLabel;
         if (t === 'Hi-Head') {
             gripItems.push(base);
         } else if (spreader) {
@@ -3227,15 +3228,15 @@ function generateGearListHtml(info = {}) {
         } else {
             gripItems.push(base);
         }
-        if (t === 'Frog Tripod') {
-            gripItems.push('Sand bag (Frog Tripod)');
+        if (t === 'Short') {
+            gripItems.push('Sand bag (Short Tripod)');
         }
         if (t === 'Hi-Head') {
             gripItems.push('Sand bag (Hi-Head)');
         }
     });
-    if (needsStandardTripod && !gripItems.some(item => /Standard Tripod/.test(item))) {
-        gripItems.push('Standard Tripod');
+    if (needsStandardTripod && !gripItems.some(item => /Long Tripod/.test(item))) {
+        gripItems.push('Long Tripod');
     }
     const standCount = gripItems.filter(item => /\bstand\b/i.test(item) && !/wheel/i.test(item)).length;
     if (standCount) {


### PR DESCRIPTION
## Summary
- rename the tripod type selector options to Long, Medium, Short and Hi-Head
- adjust gear list generation to use the new tripod type labels and associated sandbag items
- ensure default tripod additions and sandbag helpers reflect the updated naming, including the legacy scripts build
- fix a lint issue flagged during testing by removing an unnecessary escape in the auto gear context parser

## Testing
- `npm test -- --runInBand` *(fails: JavaScript heap out of memory during Jest run)*

------
https://chatgpt.com/codex/tasks/task_e_68d4495baddc8320b97922f2974d42e7