### PR TITLE
Update default iPad receiver recommendation

### DIFF
--- a/legacy/scripts/app-core.js
+++ b/legacy/scripts/app-core.js
@@ -1920,7 +1920,7 @@ function buildDefaultVideoDistributionAutoGearRules() {
         var item = createItem(name, category, quantity);
         if (item) additions.push(item);
       };
-      pushSupport('iPad receiver (Director)', 'Monitoring');
+      pushSupport('Apple iPad Air 5 or better', 'Monitoring', 1);
       pushSupport('iPad receiver (DoP)', 'Monitoring');
       pushSupport('iPad receiver (Gaffer)', 'Monitoring');
       pushSupport('USB-C Charger (iOS Video)', 'Monitoring support', 2);

--- a/legacy/scripts/app-core.js
+++ b/legacy/scripts/app-core.js
@@ -1921,8 +1921,6 @@ function buildDefaultVideoDistributionAutoGearRules() {
         if (item) additions.push(item);
       };
       pushSupport('Apple iPad Air 5 or better', 'Monitoring', 1);
-      pushSupport('iPad receiver (DoP)', 'Monitoring');
-      pushSupport('iPad receiver (Gaffer)', 'Monitoring');
       pushSupport('USB-C Charger (iOS Video)', 'Monitoring support', 2);
       pushSupport('Wi-Fi Router (iOS Video Village)', 'Monitoring support');
       if (additions.length) {

--- a/src/scripts/app-core.js
+++ b/src/scripts/app-core.js
@@ -2147,7 +2147,7 @@ function buildDefaultVideoDistributionAutoGearRules(baseInfo = {}) {
         if (item) additions.push(item);
       };
 
-      pushSupport('iPad receiver (Director)', 'Monitoring');
+      pushSupport('Apple iPad Air 5 or better', 'Monitoring', 1);
       pushSupport('iPad receiver (DoP)', 'Monitoring');
       pushSupport('iPad receiver (Gaffer)', 'Monitoring');
       pushSupport('USB-C Charger (iOS Video)', 'Monitoring support', 2);

--- a/src/scripts/app-core.js
+++ b/src/scripts/app-core.js
@@ -2148,8 +2148,6 @@ function buildDefaultVideoDistributionAutoGearRules(baseInfo = {}) {
       };
 
       pushSupport('Apple iPad Air 5 or better', 'Monitoring', 1);
-      pushSupport('iPad receiver (DoP)', 'Monitoring');
-      pushSupport('iPad receiver (Gaffer)', 'Monitoring');
       pushSupport('USB-C Charger (iOS Video)', 'Monitoring support', 2);
       pushSupport('Wi-Fi Router (iOS Video Village)', 'Monitoring support');
 


### PR DESCRIPTION
## Summary
- update the default iOS video fallback support entry to recommend an Apple iPad Air 5 or better in both modern and legacy bundles

## Testing
- npm run test:script *(fails: FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_68d44c0e952c8320a416180ce260e2b3