### PR TITLE
Update Teradek iOS monitoring gear names

### DIFF
--- a/legacy/data/devices/gearList.js
+++ b/legacy/data/devices/gearList.js
@@ -547,7 +547,7 @@ function _arrayWithHoles(r) { if (Array.isArray(r)) return r; }
       }
     },
     "iosVideo": {
-      "Teradek Serv": {
+    "Teradek - Serv 4K v2": {
         "powerDrawWatts": 9,
         "videoInputs": [{
           "type": "HDMI"
@@ -565,9 +565,9 @@ function _arrayWithHoles(r) { if (Array.isArray(r)) return r; }
             "type": "D-Tap"
           }]
         },
-        "notes": "Streams to iOS devices for on-set monitoring"
-      },
-      "Teradek Serv + Link": {
+      "notes": "Streams to iOS devices for on-set monitoring"
+    },
+    "Teradek - Link AX WifiRouter/Access Point": {
         "powerDrawWatts": 9,
         "videoInputs": [{
           "type": "HDMI"
@@ -585,8 +585,8 @@ function _arrayWithHoles(r) { if (Array.isArray(r)) return r; }
             "type": "D-Tap"
           }]
         },
-        "notes": "Streams to iOS devices for on-set monitoring; includes Link access point"
-      }
+      "notes": "Streams to iOS devices for on-set monitoring; includes Link AX Wi-Fi router/access point"
+    }
     },
     "accessories": {
       "powerPlates": {

--- a/legacy/scripts/app-core.js
+++ b/legacy/scripts/app-core.js
@@ -1930,7 +1930,7 @@ function buildDefaultVideoDistributionAutoGearRules() {
         });
       }
       if (!additions.length) {
-        var fallback = createItem('Teradek Serv + Link', 'Monitoring');
+        var fallback = createItem('Teradek - Link AX WifiRouter/Access Point', 'Monitoring');
         if (fallback) additions.push(fallback);
       }
       var pushSupport = function pushSupport(name, category) {

--- a/src/data/devices/gearList.js
+++ b/src/data/devices/gearList.js
@@ -481,7 +481,7 @@ const gear = {
     }
   },
   "iosVideo": {
-    "Teradek Serv": {
+    "Teradek - Serv 4K v2": {
       "powerDrawWatts": 9,
       "videoInputs": [
         {
@@ -507,7 +507,7 @@ const gear = {
       },
       "notes": "Streams to iOS devices for on-set monitoring"
     },
-    "Teradek Serv + Link": {
+    "Teradek - Link AX WifiRouter/Access Point": {
       "powerDrawWatts": 9,
       "videoInputs": [
         {
@@ -531,7 +531,7 @@ const gear = {
           }
         ]
       },
-      "notes": "Streams to iOS devices for on-set monitoring; includes Link access point"
+      "notes": "Streams to iOS devices for on-set monitoring; includes Link AX Wi-Fi router/access point"
     }
   },
   "accessories": {

--- a/src/scripts/app-core.js
+++ b/src/scripts/app-core.js
@@ -2150,7 +2150,7 @@ function buildDefaultVideoDistributionAutoGearRules(baseInfo = {}) {
       }
 
       if (!additions.length) {
-        const fallback = createItem('Teradek Serv + Link', 'Monitoring');
+        const fallback = createItem('Teradek - Link AX WifiRouter/Access Point', 'Monitoring');
         if (fallback) additions.push(fallback);
       }
 


### PR DESCRIPTION
## Summary
- rename the iOS video monitoring gear entries to the updated Teradek Serv 4K v2 and Link AX models
- refresh the autogenerated monitoring fallback to point at the renamed Link AX access point

## Testing
- npm test -- --runTestsByPath tests/dom/utils.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d44cf132088320a20f2d2bee7e4b9b