### PR TITLE
Fix pink mode icon rain overlay

### DIFF
--- a/src/scripts/app-core.js
+++ b/src/scripts/app-core.js
@@ -7202,7 +7202,7 @@ function ensurePinkModeAnimationLayer() {
   if (!document) {
     return null;
   }
-  const host = document.getElementById('mainContent') || document.body;
+  const host = document.body || document.getElementById('mainContent');
   if (!host) {
     return null;
   }

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -3062,7 +3062,7 @@ body.pink-mode .pink-mode-icon {
 }
 
 .pink-mode-animation-layer {
-  position: absolute;
+  position: fixed;
   inset: 0;
   pointer-events: none;
   z-index: 2;


### PR DESCRIPTION
## Summary
- anchor the pink mode animation layer to the viewport so icon rain stays over the interface while scrolling
- default the animation overlay host to the document body to ensure consistent positioning across pages

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d44d9cda0c83208f4ba6a890661d51