### PR TITLE
Fix import of ambiguous auto gear flags

### DIFF
--- a/legacy/scripts/storage.js
+++ b/legacy/scripts/storage.js
@@ -3515,7 +3515,7 @@ function importAllData(allData) {
   if (Object.prototype.hasOwnProperty.call(allData, 'autoGearSeeded')) {
     var flag = normalizeImportedBoolean(allData.autoGearSeeded);
     if (flag === null) {
-      saveAutoGearSeedFlag(Boolean(allData.autoGearSeeded));
+      saveAutoGearSeedFlag(false);
     } else {
       saveAutoGearSeedFlag(flag);
     }
@@ -3534,7 +3534,7 @@ function importAllData(allData) {
   if (Object.prototype.hasOwnProperty.call(allData, 'autoGearShowBackups')) {
     var visibility = normalizeImportedBoolean(allData.autoGearShowBackups);
     if (visibility === null) {
-      saveAutoGearBackupVisibility(Boolean(allData.autoGearShowBackups));
+      saveAutoGearBackupVisibility(false);
     } else {
       saveAutoGearBackupVisibility(visibility);
     }

--- a/src/scripts/storage.js
+++ b/src/scripts/storage.js
@@ -4659,7 +4659,7 @@ function importAllData(allData, options = {}) {
   if (Object.prototype.hasOwnProperty.call(allData, 'autoGearSeeded')) {
     const flag = normalizeImportedBoolean(allData.autoGearSeeded);
     if (flag === null) {
-      saveAutoGearSeedFlag(Boolean(allData.autoGearSeeded));
+      saveAutoGearSeedFlag(false);
     } else {
       saveAutoGearSeedFlag(flag);
     }
@@ -4680,7 +4680,7 @@ function importAllData(allData, options = {}) {
   if (Object.prototype.hasOwnProperty.call(allData, 'autoGearShowBackups')) {
     const visibility = normalizeImportedBoolean(allData.autoGearShowBackups);
     if (visibility === null) {
-      saveAutoGearBackupVisibility(Boolean(allData.autoGearShowBackups));
+      saveAutoGearBackupVisibility(false);
     } else {
       saveAutoGearBackupVisibility(visibility);
     }

--- a/tests/unit/storage.test.js
+++ b/tests/unit/storage.test.js
@@ -1404,6 +1404,18 @@ describe('export/import all data', () => {
     expect(localStorage.getItem(AUTO_GEAR_BACKUP_VISIBILITY_KEY)).toBe('1');
   });
 
+  test('importAllData treats ambiguous automatic gear booleans as disabled', () => {
+    importAllData({
+      autoGearSeeded: '   ',
+      autoGearShowBackups: { enabled: '   ' },
+    });
+
+    expect(loadAutoGearSeedFlag()).toBe(false);
+    expect(localStorage.getItem(AUTO_GEAR_SEEDED_KEY)).toBeNull();
+    expect(loadAutoGearBackupVisibility()).toBe(false);
+    expect(localStorage.getItem(AUTO_GEAR_BACKUP_VISIBILITY_KEY)).toBeNull();
+  });
+
   test('importAllData accepts automatic gear data stored as object maps', () => {
     const payload = {
       autoGearRules: {


### PR DESCRIPTION
## Summary
- ensure importAllData treats ambiguous auto gear booleans as disabled instead of enabling them
- apply the same fix to the legacy storage implementation
- add regression coverage for ambiguous automatic gear flags in storage tests

## Testing
- npm run lint
- npm run test:unit

------
https://chatgpt.com/codex/tasks/task_e_68d44fce86a48320b74982ef1d2889f9