### PR TITLE
Show auto backup notification when switching setups

### DIFF
--- a/src/scripts/app-events.js
+++ b/src/scripts/app-events.js
@@ -234,7 +234,6 @@ setupSelect.addEventListener("change", (event) => {
   ) {
     try {
       autoBackup({
-        suppressSuccess: true,
         projectNameOverride: normalizeProjectName(previousKey),
       });
     } catch (error) {


### PR DESCRIPTION
## Summary
- allow the automatic backup notification to show when switching projects so users get the usual autosave popup

## Testing
- npm run test:dom -- projectAutosave

------
https://chatgpt.com/codex/tasks/task_e_68d45351422083209170b124532c0a3c