### PR TITLE
Fix mattebox selection persistence

### DIFF
--- a/src/scripts/app-core.js
+++ b/src/scripts/app-core.js
@@ -18362,14 +18362,10 @@ function projectInfoEquals(a, b) {
 
 function ensureDefaultProjectInfoSnapshot() {
   if (defaultProjectInfoSnapshot !== null) return;
-  if (!projectForm) {
-    defaultProjectInfoSnapshot = {};
-    return;
-  }
-  const baseInfo = collectProjectFormData ? collectProjectFormData() : {};
-  baseInfo.sliderBowl = getSliderBowlValue();
-  baseInfo.easyrig = getEasyrigValue();
-  defaultProjectInfoSnapshot = sanitizeProjectInfo(baseInfo) || {};
+  // Treat an entirely empty project info payload as the only "default" state so
+  // any restored values—including those matching the UI's initial selections—are
+  // preserved when sanitizing project info for storage.
+  defaultProjectInfoSnapshot = {};
 }
 
 function deriveProjectInfo(info) {


### PR DESCRIPTION
## Summary
- treat the default project info snapshot as empty so sanitized values are never discarded
- prevent mattebox and other restored selections from being lost when sessions are reloaded

## Testing
- npm run test:unit

------
https://chatgpt.com/codex/tasks/task_e_68d455c85c8483209bb4d0a3de727a7e