### PR TITLE
Ensure pink mode icons respect layout boundaries

### DIFF
--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -3089,11 +3089,15 @@ body.pink-mode .pink-mode-icon {
 }
 
 .pink-mode-animation-layer {
-  position: fixed;
+  position: absolute;
   inset: 0;
   pointer-events: none;
   z-index: 2;
   overflow: visible;
+}
+
+.pink-mode-animation-layer.pink-mode-animation-layer--global {
+  position: fixed;
 }
 
 .pink-mode-animation-instance {


### PR DESCRIPTION
## Summary
- attach the standard pink mode animation layer to the main content while giving rain effects their own global host
- clean up the rain overlay when no instances remain to avoid lingering fixed layers
- update CSS so layout-hosted icons position absolutely while rain overlays stay fixed to the viewport

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d45a50b0308320b11d24935a263195