### PR TITLE
Adjust hover help tooltip styling

### DIFF
--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -4366,26 +4366,6 @@ body.light-mode #topBar select:focus-visible {
   color: var(--connector-label-neutral-color);
 }
 
-.power-conn .info-box-label,
-.info-box.power-conn strong:first-child {
-  color: var(--power-color);
-}
-
-.video-conn .info-box-label,
-.info-box.video-conn strong:first-child {
-  color: var(--video-color);
-}
-
-.fiz-conn .info-box-label,
-.info-box.fiz-conn strong:first-child {
-  color: var(--fiz-color);
-}
-
-.neutral-conn .info-box-label,
-.info-box.neutral-conn strong:first-child {
-  color: var(--connector-label-neutral-color);
-}
-
 .info-box-list .info-box-label {
   flex: 0 0 auto;
 }

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -3254,10 +3254,13 @@ body.pink-mode .favorite-toggle.favorited:active {
 #hoverHelpTooltip {
   position: absolute;
   z-index: 1000;
-  background: var(--accent-color);
-  color: var(--inverse-text-color);
+  background: var(--surface-color);
+  color: var(--text-color);
+  border: 1px solid color-mix(in srgb, var(--accent-color) 70%, transparent);
+  box-shadow: var(--panel-shadow);
   padding: 4px 8px;
   border-radius: 4px;
+  --icon-color: var(--accent-color);
   /* Allow icon glyphs from all local fonts to render inside hover help */
   font-family: var(--font-family), 'EssentialIconsV2', 'FilmIndustryIconsV2', 'GadgetIconsV2';
   font-size: calc(var(--font-size-base) * var(--font-scale-compact));


### PR DESCRIPTION
## Summary
- restyle the hover help tooltip to use the standard surface background and text color
- keep accent-driven chrome by adding an accent border, panel shadow, and icon color variable

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d45a7dbfa48320b62ba8a7821469a8