### PR TITLE
Fix diagram popup positioning

### DIFF
--- a/src/scripts/app-core.js
+++ b/src/scripts/app-core.js
@@ -23194,20 +23194,40 @@ function attachDiagramPopups(map) {
       popup.innerHTML = html;
       popup.style.display = 'block';
 
-      const rect = setupDiagramContainer.getBoundingClientRect();
-      const relX = pointer.clientX - rect.left;
-      const relY = pointer.clientY - rect.top;
-      const offset = 10;
-      const popupWidth = popup.offsetWidth;
+      const offset = 12;
+      const viewportWidth = window.visualViewport?.width
+        || window.innerWidth
+        || document.documentElement?.clientWidth
+        || 0;
+      const viewportHeight = window.visualViewport?.height
+        || window.innerHeight
+        || document.documentElement?.clientHeight
+        || 0;
+      const popupWidth = popup.offsetWidth || 0;
+      const popupHeight = popup.offsetHeight || 0;
 
-      // Open the popup to the left if it would otherwise overflow the container
-      let left = relX + offset;
-      if (relX + popupWidth + offset > rect.width) {
-        left = Math.max(0, relX - popupWidth - offset);
+      const pointerX = pointer.clientX;
+      const pointerY = pointer.clientY;
+
+      let left = pointerX + offset;
+      if (viewportWidth > 0 && popupWidth > 0 && left + popupWidth + offset > viewportWidth) {
+        left = Math.max(offset, pointerX - popupWidth - offset);
       }
 
-      popup.style.left = `${left}px`;
-      popup.style.top = `${relY + offset}px`;
+      let top = pointerY + offset;
+      if (viewportHeight > 0 && popupHeight > 0 && top + popupHeight + offset > viewportHeight) {
+        top = Math.max(offset, pointerY - popupHeight - offset);
+      }
+
+      const maxLeft = viewportWidth > 0 && popupWidth > 0
+        ? Math.max(offset, viewportWidth - popupWidth - offset)
+        : left;
+      const maxTop = viewportHeight > 0 && popupHeight > 0
+        ? Math.max(offset, viewportHeight - popupHeight - offset)
+        : top;
+
+      popup.style.left = `${Math.max(offset, Math.min(left, maxLeft))}px`;
+      popup.style.top = `${Math.max(offset, Math.min(top, maxTop))}px`;
     };
     const hide = () => { popup.style.display = 'none'; };
     if (isTouchDevice) {

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -4304,7 +4304,7 @@ body.light-mode #topBar select:focus-visible {
 
 .diagram-popup {
   display: none;
-  position: absolute;
+  position: fixed;
   pointer-events: none;
   background: var(--surface-color);
   color: var(--text-color);
@@ -4316,6 +4316,7 @@ body.light-mode #topBar select:focus-visible {
   box-shadow: var(--panel-shadow);
   z-index: 10;
   max-width: 320px;
+  max-height: min(70vh, 480px);
   overflow: auto;
 }
 


### PR DESCRIPTION
## Summary
- allow diagram hover popups to escape the diagram container by using fixed positioning and a viewport-height cap
- reposition popups relative to the viewport so they avoid the bottom and right edges on all screen sizes

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d45b0a797c832099b5674e2488703d