### PR TITLE
Fix print warning colors in dark mode

### DIFF
--- a/src/styles/overview-print.css
+++ b/src/styles/overview-print.css
@@ -45,6 +45,20 @@ select:focus-visible {
   color: var(--status-error-text-color);
 }
 
+#overviewDialogContent .status-message--warning,
+#overviewDialogContent .status-message--danger,
+#overviewDialogContent.dark-mode .status-message--warning,
+#overviewDialogContent.dark-mode .status-message--danger {
+  color: #000 !important;
+}
+
+#overviewDialogContent .status-message--warning strong,
+#overviewDialogContent .status-message--danger strong,
+#overviewDialogContent.dark-mode .status-message--warning strong,
+#overviewDialogContent.dark-mode .status-message--danger strong {
+  color: inherit !important;
+}
+
 @page {
   size: A4;
   margin: 1cm;


### PR DESCRIPTION
## Summary
- ensure printable overview warning messages render with black text even when dark mode classes are applied

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d45e89dc8c8320848561a1abd31d94