### PR TITLE
Scale print diagram and guard crew autosave defaults

### DIFF
--- a/src/scripts/app-core.js
+++ b/src/scripts/app-core.js
@@ -8680,7 +8680,15 @@ function createCrewRow(data = {}) {
     opt.textContent = roleLabels[r] || r;
     roleSel.appendChild(opt);
   });
-  if (data.role) roleSel.value = data.role;
+  let presetRole = false;
+  if (data.role) {
+    roleSel.value = data.role;
+    presetRole = roleSel.value === data.role;
+  }
+  roleSel.dataset.userSelected = presetRole ? 'true' : 'false';
+  roleSel.addEventListener('change', () => {
+    roleSel.dataset.userSelected = 'true';
+  });
   const nameInput = document.createElement('input');
   nameInput.type = 'text';
   nameInput.name = 'crewName';

--- a/src/scripts/app-setups.js
+++ b/src/scripts/app-setups.js
@@ -1071,19 +1071,29 @@ function collectProjectFormData() {
 
     const people = Array.from(crewContainer?.querySelectorAll('.person-row') || [])
         .map(row => {
-            const roleValue = row.querySelector('select')?.value;
+            const roleSelect = row.querySelector('select');
+            const rawRole = typeof roleSelect?.value === 'string'
+                ? roleSelect.value.trim()
+                : (roleSelect == null ? '' : String(roleSelect.value).trim());
+            const roleSelected = roleSelect?.dataset.userSelected === 'true' && rawRole.length > 0;
             const nameInput = row.querySelector('.person-name');
             const phoneInput = row.querySelector('.person-phone');
             const emailInput = row.querySelector('.person-email');
-            const role = typeof roleValue === 'string'
-                ? roleValue.trim()
-                : (roleValue == null ? '' : String(roleValue));
             const name = typeof nameInput?.value === 'string' ? nameInput.value.trim() : '';
             const phone = typeof phoneInput?.value === 'string' ? phoneInput.value.trim() : '';
             const email = typeof emailInput?.value === 'string' ? emailInput.value.trim() : '';
-            return { role, name, phone, email };
+            const person = {
+                name,
+                phone,
+                email
+            };
+            if (roleSelected) {
+                person.role = rawRole;
+            }
+            const hasAnyField = roleSelected || name || phone || email;
+            return hasAnyField ? person : null;
         })
-        .filter(person => person.role || person.name || person.phone || person.email);
+        .filter(Boolean);
 
     const collectRanges = (container, startSel, endSel) => Array.from(container?.querySelectorAll('.period-row') || [])
         .map(row => {

--- a/src/styles/overview-print.css
+++ b/src/styles/overview-print.css
@@ -335,14 +335,14 @@ table, th, td {
 
 @media print {
   #overviewDialogContent #setupDiagram {
-    --font-size-diagram-icon: calc(var(--font-size-base) * 1.65);
-    --font-size-diagram-text: calc(var(--font-size-base) * 0.95);
-    --font-size-diagram-label: calc(var(--font-size-base) * 0.85);
+    --font-size-diagram-icon: calc(var(--font-size-base) * 2.05);
+    --font-size-diagram-text: calc(var(--font-size-base) * 1.15);
+    --font-size-diagram-label: calc(var(--font-size-base) * 1.05);
   }
 
   #overviewDialogContent #setupDiagram svg {
     width: 100% !important;
-    max-width: 20cm !important;
+    max-width: none !important;
   }
 }
 #overviewDialogContent #setupDiagram #diagramArea {


### PR DESCRIPTION
## Summary
- enlarge the print overview diagram so it fills more space and is easier to read on paper
- record whether a crew role was explicitly chosen when adding crew rows
- only persist crew roles during autosave when the user has selected one

## Testing
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68d45ef3c3548320ae6678f389bfc736