### PR TITLE
Ensure ND Grad filter boxes include controls

### DIFF
--- a/src/scripts/app-session.js
+++ b/src/scripts/app-session.js
@@ -7664,6 +7664,12 @@ function renderGearListFilterDetails(details) {
     } = detail;
     const row = document.createElement('div');
     row.className = 'filter-detail';
+    if (gearName) {
+      row.setAttribute('data-gear-name', gearName);
+    }
+    if (type) {
+      row.setAttribute('data-filter-type', type);
+    }
     const heading = document.createElement('div');
     heading.className = 'filter-detail-label gear-item';
     if (entryId) heading.setAttribute('data-filter-entry', entryId);

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -5688,6 +5688,29 @@ body.dark-mode .requirement-box,
   background-color: color-mix(in srgb, var(--panel-bg) 88%, transparent);
 }
 
+#gearListFilterDetails .filter-detail[data-gear-name^="ND Grad HE Filter Set"],
+#gearListFilterDetails .filter-detail[data-gear-name^="ND Grad SE Filter Set"] {
+  padding: 0.35rem 0.5rem;
+  border: 1px solid var(--nd-grad-border-color, var(--accent-color));
+  border-radius: calc(var(--border-radius) * 0.75);
+  background-color: color-mix(in srgb, var(--panel-bg) 88%, transparent);
+  align-items: flex-start;
+}
+
+#gearListFilterDetails .filter-detail[data-gear-name^="ND Grad HE Filter Set"] .filter-detail-label,
+#gearListFilterDetails .filter-detail[data-gear-name^="ND Grad SE Filter Set"] .filter-detail-label {
+  display: block;
+  padding: 0;
+  margin: 0;
+  border: none;
+  background: none;
+}
+
+#gearListFilterDetails .filter-detail[data-gear-name^="ND Grad HE Filter Set"] .filter-detail-controls,
+#gearListFilterDetails .filter-detail[data-gear-name^="ND Grad SE Filter Set"] .filter-detail-controls {
+  width: 100%;
+}
+
 body.light-mode .gear-table strong,
 #gearListOutput:not(.dark-mode) .gear-table strong,
 #overviewDialogContent:not(.dark-mode) .gear-table strong {


### PR DESCRIPTION
## Summary
- tag filter detail rows with their gear name and type for targeted styling
- expand the ND Grad filter styling so the highlight box wraps associated selectors and checkboxes

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d4605d1c848320ac47f598f7be054e