### PR TITLE
Align help docs with gear list output label

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -161,7 +161,7 @@ The app automatically uses your browser language on first load, and you can swit
 ### 📋 Gear List
 The generator turns your selections into a categorized packing list:
 
-- Click **Generate Gear List** to compile chosen gear and project requirements into a table.
+- Click **Generate Gear List and Project Requirements** to compile chosen gear and project requirements into a table.
 - The table updates automatically when device selections or requirements change.
 - Items are grouped by category (camera, lens, power, monitoring, rigging, grip, accessories, consumables) and duplicates are merged with counts.
 - Required cables, rigging and accessories are added for monitors, motors, gimbals and weather scenarios.
@@ -282,7 +282,7 @@ The generator turns your selections into a categorized packing list:
 3. **Select Devices:** Choose gear from each category using the dropdowns—type to filter, click the star to pin favourites and let scenario presets fill in accessories automatically.
 4. **View Calculations:** See total draw, current and runtime once a battery is selected; warnings highlight when output limits are exceeded.
 5. **Save & Export Projects:** Name and save your configuration, auto-backups capture snapshots, and the Export button downloads a JSON bundle for collaborators while the Import button restores them.
-6. **Generate Gear Lists:** Press **Generate Gear List** to turn project requirements into a categorized packing list with tooltips and accessory packs.
+6. **Generate Gear Lists:** Press **Generate Gear List and Project Requirements** to turn project requirements into a categorized packing list with tooltips and accessory packs.
 7. **Manage Device Data:** Click “Edit Device Data…” to open the database editor, modify devices, export/import JSON or revert to the defaults.
 8. **Submit Runtime Feedback:** Use “Submit User Runtime Feedback” to record field measurements and refine weighted estimates.
 

--- a/README.md
+++ b/README.md
@@ -611,7 +611,7 @@ data.
 
 ## Gear Lists & Reporting
 
-- Click **Generate Gear List** to expand selections and project requirements into
+- Click **Generate Gear List and Project Requirements** to expand selections and project requirements into
   categorized packing tables. Lists refresh automatically when data changes.
 - Entries are grouped by category with duplicates merged. Scenario selections add
   matching rigging, weather protection and specialty accessories so the printed

--- a/index.html
+++ b/index.html
@@ -2345,7 +2345,7 @@
                 href="#generateGearListBtn"
                 data-help-target="#generateGearListBtn"
                 data-help-highlight="#setup-manager"
-              ><strong>Generate Gear List</strong></a>
+              ><strong>Generate Gear List and Project Requirements</strong></a>
               and
               <a
                 class="help-link button-link"
@@ -3337,16 +3337,16 @@
               >Project Requirements summary</a>
               beside the gear list.
             </li>
-              <li>
-                The information is saved with the project, included in printed overviews and ready to populate the
-                <a
-                  class="help-link button-link"
-                  href="#generateGearListBtn"
-                  data-help-target="#generateGearListBtn"
-                  data-help-highlight="#setup-manager"
-                >Generate Gear List</a>
-                dialog as soon as the requirements are ready.
-              </li>
+            <li>
+              The information is saved with the project, included in printed overviews and ready to populate the
+              <a
+                class="help-link button-link"
+                href="#generateGearListBtn"
+                data-help-target="#generateGearListBtn"
+                data-help-highlight="#setup-manager"
+              >Generate Gear List and Project Requirements</a>
+              dialog as soon as the requirements are ready.
+            </li>
             </ul>
         </section>
         <section
@@ -3356,16 +3356,16 @@
         >
           <h3><span class="help-icon icon-glyph" aria-hidden="true" data-icon-font="uicons">&#xE467;</span>Gear List</h3>
               <ul>
-                <li>
-                  The
-                  <a
-                    class="help-link button-link"
-                    href="#generateGearListBtn"
-                    data-help-target="#generateGearListBtn"
-                    data-help-highlight="#setup-manager"
-                  ><strong>Generate Gear List</strong></a>
-                  button expands every selected device and project detail into a rich table grouped by category and quantity.
-                </li>
+            <li>
+              The
+              <a
+                class="help-link button-link"
+                href="#generateGearListBtn"
+                data-help-target="#generateGearListBtn"
+                data-help-highlight="#setup-manager"
+              ><strong>Generate Gear List and Project Requirements</strong></a>
+              button expands every selected device and project detail into a rich table grouped by category and quantity.
+            </li>
               <li>Any change to devices, lenses, batteries or project information rebuilds the list so it always reflects the current configuration.</li>
               <li>The generator assembles the table step&nbsp;by&nbsp;step:
                 <ol>


### PR DESCRIPTION
## Summary
- update the in-app help dialog references so the gear list quick links match the "Generate Gear List and Project Requirements" button label
- refresh the English readme files to reference the combined gear list and project requirements output button

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68d46d5d754c8320904825836a88a39d