### PR TITLE
Preserve unlabeled auto backups when trimming

### DIFF
--- a/src/scripts/storage.js
+++ b/src/scripts/storage.js
@@ -896,6 +896,19 @@ function collectAutoBackupEntries(container, prefix) {
     });
 }
 
+function getAutoBackupLabelKey(entry) {
+  if (!entry || typeof entry !== 'object') {
+    return '';
+  }
+  if (typeof entry.label === 'string' && entry.label.trim()) {
+    return entry.label.trim();
+  }
+  if (typeof entry.key === 'string') {
+    return entry.key;
+  }
+  return '';
+}
+
 function createStableValueSignature(value) {
   if (value === null) {
     return 'null';
@@ -951,7 +964,7 @@ function removeDuplicateAutoBackupEntries(container, entries) {
     if (!entry || typeof entry.key !== 'string') {
       continue;
     }
-    const labelKey = typeof entry.label === 'string' ? entry.label : '';
+    const labelKey = getAutoBackupLabelKey(entry);
     const labelSignatures = seenSignaturesByLabel.get(labelKey) || new Set();
     const value = Object.prototype.hasOwnProperty.call(container, entry.key)
       ? container[entry.key]
@@ -981,7 +994,7 @@ function pruneAutoBackupEntries(container, entries, limit, removedKeys) {
     if (!entry || typeof entry !== 'object') {
       continue;
     }
-    const labelKey = typeof entry.label === 'string' ? entry.label : '';
+    const labelKey = getAutoBackupLabelKey(entry);
     labelCounts.set(labelKey, (labelCounts.get(labelKey) || 0) + 1);
   }
 
@@ -992,9 +1005,9 @@ function pruneAutoBackupEntries(container, entries, limit, removedKeys) {
       index += 1;
       continue;
     }
-    const labelKey = typeof entry.label === 'string' ? entry.label : '';
+    const labelKey = getAutoBackupLabelKey(entry);
     const count = labelCounts.get(labelKey) || 0;
-    if (count > 1) {
+    if (labelKey && count > 1) {
       delete container[entry.key];
       entries.splice(index, 1);
       labelCounts.set(labelKey, count - 1);
@@ -1015,7 +1028,7 @@ function pruneAutoBackupEntries(container, entries, limit, removedKeys) {
       index += 1;
       continue;
     }
-    const labelKey = typeof entry.label === 'string' ? entry.label : '';
+    const labelKey = getAutoBackupLabelKey(entry);
     const count = labelCounts.get(labelKey) || 0;
     delete container[entry.key];
     entries.splice(index, 1);

--- a/tests/unit/storage.test.js
+++ b/tests/unit/storage.test.js
@@ -329,8 +329,8 @@ describe('setup storage', () => {
       setups[key] = { camera: `Camera ${index}` };
     }
     const duplicateValue = { camera: 'Shared Camera', lens: 'Shared Lens' };
-    const oldDuplicateKey = 'auto-backup-2024-01-01-01-00';
-    const newDuplicateKey = 'auto-backup-2024-01-02-00-00';
+    const oldDuplicateKey = 'auto-backup-2024-01-01-01-00-Project Alpha';
+    const newDuplicateKey = 'auto-backup-2024-01-02-00-00-Project Alpha';
     setups[oldDuplicateKey] = duplicateValue;
     setups[newDuplicateKey] = duplicateValue;
 
@@ -388,6 +388,27 @@ describe('setup storage', () => {
     expect(betaKeys.length).toBeGreaterThan(0);
     expect(alphaKeys[alphaKeys.length - 1]).toBe('auto-backup-2024-01-01-00-58-Project Alpha');
     expect(betaKeys[betaKeys.length - 1]).toBe('auto-backup-2024-01-01-00-59-Project Beta');
+  });
+
+  test('saveSetups keeps multiple unlabeled auto backups when trimming', () => {
+    const setups = {};
+    for (let index = 0; index < 60; index += 1) {
+      const minute = String(index).padStart(2, '0');
+      const key = `auto-backup-2024-01-01-00-${minute}`;
+      setups[key] = {
+        camera: 'Camera 1',
+        projectInfo: { projectName: '' },
+      };
+    }
+
+    saveSetups(setups);
+
+    const stored = JSON.parse(localStorage.getItem(SETUP_KEY));
+    const autoKeys = Object.keys(stored).filter((name) => name.startsWith('auto-backup-')).sort();
+
+    expect(autoKeys.length).toBe(50);
+    expect(autoKeys[0]).toBe('auto-backup-2024-01-01-00-10');
+    expect(autoKeys[autoKeys.length - 1]).toBe('auto-backup-2024-01-01-00-59');
   });
 
   test('saveSetup adds and persists single setup', () => {
@@ -580,12 +601,12 @@ describe('project storage', () => {
     const projects = {};
     for (let index = 0; index < 49; index += 1) {
       const minute = String(index).padStart(2, '0');
-      const key = `auto-backup-2024-01-01-00-${minute}`;
+      const key = `auto-backup-2024-01-01-00-${minute}-Project Alpha`;
       projects[key] = { gearList: `<ul>${index}</ul>`, projectInfo: null };
     }
     const duplicateValue = { gearList: '<ul>duplicate</ul>', projectInfo: null };
-    const oldDuplicateKey = 'auto-backup-2024-01-01-01-00';
-    const newDuplicateKey = 'auto-backup-2024-01-02-00-00';
+    const oldDuplicateKey = 'auto-backup-2024-01-01-01-00-Project Alpha';
+    const newDuplicateKey = 'auto-backup-2024-01-02-00-00-Project Alpha';
     projects[oldDuplicateKey] = duplicateValue;
     projects[newDuplicateKey] = duplicateValue;
     localStorage.setItem(PROJECT_KEY, JSON.stringify(projects));


### PR DESCRIPTION
## Summary
- avoid collapsing unlabeled auto backups during automatic pruning by falling back to per-entry label keys
- share a helper for auto backup label grouping to keep duplicate trimming behavior for named projects
- expand storage unit tests to cover unlabeled backups and adjusted duplicate scenarios

## Testing
- npm run test:unit -- storage.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d46dd261e88320ba2240b149e2d3a2