### PR TITLE
docs: sync recent features across translations

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -60,8 +60,12 @@ Beim ersten Start übernimmt die Anwendung automatisch die Sprache deines Browse
 ---
 
 ## 🆕 Neueste Funktionen
+- Versionsvergleiche für Backups lassen dich beliebige manuelle Speicherungen oder automatisch datierte Backups auswählen, um Diffs zu prüfen, Vorfallnotizen zu ergänzen und vor einem Rollback oder einer Übergabe an die Post einen Bericht zu exportieren.
+- Wiederherstellungsproben laden ein komplettes App-Backup oder Projekt-Bundle in eine isolierte Sandbox, damit du Inhalte mit den Live-Daten abgleichen kannst, ohne Produktionsprofile anzutasten.
 - Die neuen automatischen Gear-Regeln fügen szenariobasierte Ergänzungen oder Entfernungen hinzu, lassen sich exportieren und gemeinsam mit Bundles wiederherstellen.
-- Das Daten- & Speicher-Dashboard prüft gespeicherte Projekte, Gerätelisten, eigene Geräte, Favoriten und Laufzeit-Feedback direkt in den Einstellungen.
+- Das Daten- & Speicher-Dashboard prüft gespeicherte Projekte, Gerätelisten, eigene Geräte, Favoriten und Laufzeit-Feedback direkt in den Einstellungen und zeigt die geschätzte Backup-Größe an.
+- Ein Overlay für den Auto-Save-Status spiegelt die letzte Auto-Save-Notiz im Einstellungsdialog, damit Teams Hintergrundaktivität während Wiederherstellungsübungen sehen.
+- Ein monitoring-sensitiver Gerätemanager blendet zusätzliche Monitor- und Videozubehörfelder nur ein, wenn Szenarien sie verlangen, damit Regeln fokussiert bleiben.
 - Akzent- und Typografie-Regler in den Einstellungen erlauben dir Akzentfarbe, Grundschriftgröße und Schriftfamilie sowie die Themes Dunkel, Pink und Hoher Kontrast einstellen.
 - Tastenkürzel für die globale Suche setzen den Fokus sofort mit / oder Strg+K (⌘K auf macOS) – selbst wenn es im eingeklappten mobilen Seitenmenü steckt.
 - Die Aktion „Neu laden erzwingen" leert zwischengespeicherte Service-Worker-Dateien, damit sich die Offline-Anwendung aktualisiert, ohne Projekte oder Geräte zu löschen.

--- a/README.en.md
+++ b/README.en.md
@@ -64,8 +64,12 @@ The app automatically uses your browser language on first load, and you can swit
 ---
 
 ## 🆕 Recent Features
+- Backup version comparisons let you pick any manual save or timestamped auto-backup to review diffs, add incident notes and export a log before rolling a change back or handing footage to post.
+- Restore rehearsals load a full-app backup or project bundle into an isolated sandbox so you can confirm its contents match live data without touching production profiles.
 - Automatic gear rules let you design scenario-driven additions or removals, export the configuration and restore it alongside project bundles.
 - Data & storage dashboard audits saved projects, gear lists, custom devices, favorites and runtime feedback directly inside Settings.
+- Autosave status overlay mirrors the latest autosave note inside Settings so crews can see background activity while practicing recovery drills.
+- Monitoring-aware gear editor surfaces extra monitoring and video accessories only when scenarios demand them so rule authoring stays focused.
 - Accent and typography controls in Settings let you adjust the accent color, base font size and typeface alongside dark, pink and high contrast themes.
 - Keyboard shortcuts for the global search let you press / or Ctrl+K (⌘K on macOS) to focus the feature search instantly, even when it sits inside the collapsed mobile side menu.
 - Force reload button clears cached service worker files so the offline app refreshes without deleting saved projects or devices.

--- a/README.es.md
+++ b/README.es.md
@@ -63,8 +63,12 @@ La aplicación adopta automáticamente el idioma de tu navegador en la primera v
 ---
 
 ## 🆕 Novedades recientes
+- Las comparaciones de versiones de respaldos permiten elegir cualquier guardado manual o copia automática con marca de tiempo para revisar diferencias, añadir notas de incidentes y exportar un registro antes de revertir cambios o entregar material a postproducción.
+- Los ensayos de restauración cargan una copia completa de la aplicación o un paquete de proyecto en un entorno aislado para confirmar que su contenido coincide con los datos en vivo sin tocar los perfiles de producción.
 - Las reglas automáticas de equipo permiten diseñar adiciones o retiradas según el escenario, exportar la configuración y restaurarla junto con los paquetes de proyecto.
-- El panel Datos y almacenamiento audita proyectos guardados, listas de equipo, dispositivos personalizados, favoritos y comentarios de autonomía directamente desde Ajustes.
+- El panel Datos y almacenamiento audita proyectos guardados, listas de equipo, dispositivos personalizados, favoritos y comentarios de autonomía directamente desde Ajustes y muestra el tamaño aproximado del respaldo.
+- La superposición del estado de auto-guardado refleja la nota más reciente dentro de Ajustes para que los equipos vean la actividad en segundo plano mientras practican los ejercicios de recuperación.
+- El editor de equipo consciente del monitoreo muestra accesorios adicionales de monitor y video solo cuando los escenarios lo requieren para mantener enfocado el diseño de reglas.
 - Los controles de acento y tipografía en Ajustes permiten ajustar el color de acento, el tamaño base de la fuente y la familia tipográfica junto a los temas oscuro, rosa y de alto contraste.
 - Los atajos de teclado de la búsqueda global enfocan la búsqueda de funciones al instante con / o Ctrl+K (⌘K en macOS), incluso cuando está dentro del menú lateral móvil contraído.
 - El botón **Forzar recarga** borra los archivos del service worker en caché para que la aplicación sin conexión se actualice sin eliminar proyectos ni dispositivos guardados.

--- a/README.fr.md
+++ b/README.fr.md
@@ -61,8 +61,12 @@ L’application adopte automatiquement la langue de votre navigateur lors de la 
 ---
 
 ## 🆕 Nouveautés
+- Les comparaisons de versions de sauvegarde permettent de sélectionner n’importe quel enregistrement manuel ou sauvegarde automatique horodatée pour analyser les différences, ajouter des notes d’incident et exporter un journal avant un retour arrière ou une remise d’images à la post-production.
+- Les répétitions de restauration chargent une sauvegarde complète de l’application ou un bundle de projet dans un bac à sable isolé pour confirmer que son contenu correspond aux données actives sans toucher aux profils de production.
 - Les règles automatiques d’équipement ajoutent ou retirent du matériel selon le scénario, avec export/import aux côtés des bundles partagés.
-- Le tableau de bord Données & stockage audite projets enregistrés, listes de matériel, appareils personnalisés, favoris et retours d’autonomie depuis les Réglages.
+- Le tableau de bord Données & stockage audite projets enregistrés, listes de matériel, appareils personnalisés, favoris et retours d’autonomie depuis les Réglages et affiche la taille approximative des sauvegardes.
+- Une superposition d’état d’enregistrement automatique reflète la dernière note dans Paramètres afin que les équipes visualisent l’activité en arrière-plan pendant les exercices de récupération.
+- Un éditeur d’équipement sensible au monitoring affiche des accessoires supplémentaires de monitoring et de vidéo uniquement lorsque les scénarios l’exigent, pour garder la conception des règles focalisée.
 - Les réglages d’accent et de typographie dans Paramètres permettent d’ajuster couleur d’accent, taille de base et famille de police, aux côtés des thèmes sombre, rose et à fort contraste.
 - Les raccourcis clavier de la recherche globale placent le focus sur le champ instantanément avec / ou Ctrl+K (⌘K sur macOS), même lorsqu’il se trouve dans le menu latéral replié.
 - Le bouton **Forcer le rechargement** vide les fichiers mis en cache par le service worker afin de mettre à jour l’application hors ligne sans effacer projets ou appareils.

--- a/README.it.md
+++ b/README.it.md
@@ -61,8 +61,12 @@ Al primo avvio l’applicazione adotta la lingua del browser; puoi cambiarla dal
 ---
 
 ## 🆕 Novità
+- I confronti delle versioni dei backup permettono di scegliere qualsiasi salvataggio manuale o backup automatico con timestamp per rivedere le differenze, aggiungere note sugli incidenti ed esportare un registro prima di annullare una modifica o consegnare il materiale alla post.
+- Le prove di ripristino caricano un backup completo dell’app o un bundle di progetto in una sandbox isolata così puoi confermare che il contenuto corrisponde ai dati live senza toccare i profili di produzione.
 - Le regole automatiche dell'attrezzatura consentono di definire aggiunte o rimozioni guidate dallo scenario, esportarle e ripristinarle insieme ai bundle condivisi.
-- Il cruscotto Dati e archiviazione controlla progetti salvati, elenchi, dispositivi personalizzati, preferiti e feedback sulle autonomie direttamente nelle Impostazioni.
+- Il cruscotto Dati e archiviazione controlla progetti salvati, elenchi, dispositivi personalizzati, preferiti e feedback sulle autonomie direttamente nelle Impostazioni e mostra la dimensione approssimativa del backup.
+- Un overlay di stato dell'autosalvataggio riporta l’ultima nota di autosalvataggio dentro alle Impostazioni così le squadre vedono l’attività in background mentre provano le procedure di recupero.
+- Un editor dell'attrezzatura sensibile al monitoraggio mette in evidenza accessori aggiuntivi per monitor e video solo quando gli scenari lo richiedono, mantenendo la creazione delle regole concentrata.
 - I controlli di accento e tipografia nelle Impostazioni consentono di regolare colore, dimensione base e famiglia del font insieme ai temi scuro, rosa e ad alto contrasto.
 - Le scorciatoie della ricerca globale portano il focus sul campo all’istante con / o Ctrl+K (⌘K su macOS), anche quando è nascosto nel menu laterale compresso.
 - Il pulsante **Forza ricarica** cancella i file del service worker in cache per aggiornare l’applicazione offline senza eliminare progetti o dispositivi salvati.


### PR DESCRIPTION
## Summary
- add backup version comparison and restore rehearsal notes to each localized README
- document the autosave status overlay and monitoring-aware gear editor across translations

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d4799179908320a8991ed4cd31d5bc