### PR TITLE
Migrate legacy auto gear monitor defaults storage key

### DIFF
--- a/legacy/scripts/storage.js
+++ b/legacy/scripts/storage.js
@@ -1139,6 +1139,9 @@ function migrateLegacyStorageKeys() {
     legacy: "".concat(legacyPrefix, "autoGearShowBackups"),
     modern: AUTO_GEAR_BACKUP_VISIBILITY_STORAGE_KEY
   }, {
+    legacy: "".concat(legacyPrefix, "autoGearMonitorDefaults"),
+    modern: AUTO_GEAR_MONITOR_DEFAULTS_STORAGE_KEY
+  }, {
     legacy: "".concat(legacyPrefix, "customFonts"),
     modern: CUSTOM_FONT_STORAGE_KEY_DEFAULT,
     updateFontKey: true

--- a/src/scripts/storage.js
+++ b/src/scripts/storage.js
@@ -1290,6 +1290,7 @@ function migrateLegacyStorageKeys() {
     { legacy: `${legacyPrefix}autoGearActivePreset`, modern: AUTO_GEAR_ACTIVE_PRESET_STORAGE_KEY },
     { legacy: `${legacyPrefix}autoGearAutoPreset`, modern: AUTO_GEAR_AUTO_PRESET_STORAGE_KEY },
     { legacy: `${legacyPrefix}autoGearShowBackups`, modern: AUTO_GEAR_BACKUP_VISIBILITY_STORAGE_KEY },
+    { legacy: `${legacyPrefix}autoGearMonitorDefaults`, modern: AUTO_GEAR_MONITOR_DEFAULTS_STORAGE_KEY },
     { legacy: `${legacyPrefix}customFonts`, modern: CUSTOM_FONT_STORAGE_KEY_DEFAULT, updateFontKey: true },
   ];
 

--- a/tests/unit/storage.test.js
+++ b/tests/unit/storage.test.js
@@ -49,6 +49,7 @@ const {
   saveAutoGearActivePresetId,
   loadAutoGearAutoPresetId,
   saveAutoGearAutoPresetId,
+  loadAutoGearMonitorDefaults,
   loadAutoGearBackupVisibility,
   saveAutoGearBackupVisibility,
   loadFullBackupHistory,
@@ -70,6 +71,7 @@ const AUTO_GEAR_PRESETS_KEY = 'cameraPowerPlanner_autoGearPresets';
 const AUTO_GEAR_ACTIVE_PRESET_KEY = 'cameraPowerPlanner_autoGearActivePreset';
 const AUTO_GEAR_AUTO_PRESET_KEY = 'cameraPowerPlanner_autoGearAutoPreset';
 const AUTO_GEAR_BACKUP_VISIBILITY_KEY = 'cameraPowerPlanner_autoGearShowBackups';
+const AUTO_GEAR_MONITOR_DEFAULTS_KEY = 'cameraPowerPlanner_autoGearMonitorDefaults';
 const CUSTOM_FONT_KEY = 'cameraPowerPlanner_customFonts';
 const CUSTOM_LOGO_KEY = 'customLogo';
 const TEMPERATURE_UNIT_KEY = 'cameraPowerPlanner_temperatureUnit';
@@ -979,6 +981,16 @@ describe('automatic gear storage', () => {
       { id: 'auto-new', label: 'Autosaved rules', rules: [{ id: 'rule-2' }] },
       { id: 'manual-1', label: 'Manual preset', rules: [] },
     ]);
+  });
+
+  test('loadAutoGearMonitorDefaults migrates legacy key prefix', () => {
+    const defaults = { focus: 'monitor-a' };
+    localStorage.setItem('cinePowerPlanner_autoGearMonitorDefaults', JSON.stringify(defaults));
+
+    const loaded = loadAutoGearMonitorDefaults();
+    expect(loaded).toEqual(defaults);
+    expect(JSON.parse(localStorage.getItem(AUTO_GEAR_MONITOR_DEFAULTS_KEY))).toEqual(defaults);
+    expect(localStorage.getItem('cinePowerPlanner_autoGearMonitorDefaults')).toBeNull();
   });
 });
 


### PR DESCRIPTION
## Summary
- migrate the legacy `cinePowerPlanner_autoGearMonitorDefaults` key to the modern storage namespace in both modern and legacy bundles
- add a regression test ensuring legacy auto gear monitor defaults are migrated when loading data

## Testing
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68d4797c52d08320bcea3a8bc12edbae