### PR TITLE
Document export toggle in help and guides

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -74,7 +74,7 @@ Beim ersten Start übernimmt die Anwendung automatisch die Sprache deines Browse
 - Neues High-Contrast-Theme für bessere Lesbarkeit.
 - Geräteformulare füllen die Kategorien dynamisch anhand der Schema-Attribute aus.
 - Überarbeitete Oberfläche mit verbessertem Kontrast und großzügigerem Spacing für ein klares Erlebnis auf jedem Gerät.
-- Projekt-Sharing wurde vereinfacht: Lade eine JSON-Datei mit Auswahl, Anforderungen, Geräteliste, Laufzeit-Feedback und eigenen Geräten herunter und importiere sie anschließend, um alles wiederherzustellen.
+- Projekt-Sharing wurde vereinfacht: Lade eine JSON-Datei mit Auswahl, Anforderungen, Geräteliste, Laufzeit-Feedback und eigenen Geräten herunter und importiere sie anschließend, um alles wiederherzustellen. Aktiviere bei Bedarf den Schalter **Automatische Gear-Regeln einschließen**, damit deine Automationen mitreisen oder lokal bleiben.
 - Eigene Symbole für verpflichtende Szenarien machen Projektanforderungen auf einen Blick sichtbar.
 - Interaktives Projekt-Diagramm zum Verschieben, Zoomen, Einrasten und Exportieren als SVG oder JPG.
 - Verspieltes pinkes Akzent-Theme, das zwischen Besuchen erhalten bleibt.

--- a/README.en.md
+++ b/README.en.md
@@ -120,7 +120,7 @@ The app automatically uses your browser language on first load, and you can swit
 ### ✅ Project Management
 - Save, load and delete multiple camera projects (press Enter or Ctrl+S/⌘S to save quickly; the Save button stays disabled until a name is entered).
 - Automatic snapshots are created every 10 minutes while the planner is open, and the Settings dialog can trigger hourly backup exports as a reminder to archive data.
-- Download a JSON project file that bundles selections, requirements, gear lists, runtime feedback and custom devices; load it through the Import Project picker to restore everything in one step.
+- Download a JSON project file that bundles selections, requirements, gear lists, runtime feedback and custom devices—flip the **Include automatic gear rules** toggle if you also want your automations embedded; load it through the Import Project picker to restore everything in one step.
 - Data is stored locally via `localStorage` and favorites are preserved in backups; use the **Factory reset** option in Settings to capture a backup automatically before wiping cached projects and device edits.
 - Generate printable overviews for any saved project and add a custom logo so exports and backups match your production branding.
 - Save project requirements along with each project so gear lists retain full context.

--- a/README.es.md
+++ b/README.es.md
@@ -77,7 +77,7 @@ La aplicación adopta automáticamente el idioma de tu navegador en la primera v
 - Opciones de accesibilidad con alto contraste, animación reducida y espaciado relajado mejoran la legibilidad y la comodidad.
 - Los formularios de dispositivos rellenan los campos de categoría dinámicamente a partir de los atributos del esquema.
 - Interfaz rediseñada con mayor contraste y espaciado para una experiencia más limpia en cualquier dispositivo.
-- Compartir proyectos es más sencillo: descarga un archivo JSON que agrupa selecciones, requisitos, listas de equipo, comentarios de autonomía y dispositivos personalizados, e impórtalo para restaurarlo todo.
+- Compartir proyectos es más sencillo: descarga un archivo JSON que agrupa selecciones, requisitos, listas de equipo, comentarios de autonomía y dispositivos personalizados, e impórtalo para restaurarlo todo. Activa el interruptor **Incluir reglas automáticas de equipo** cuando quieras que tus automatizaciones viajen en el archivo o déjalo desmarcado para mantenerlas locales.
 - Iconos exclusivos para los escenarios obligatorios distinguen los requisitos del proyecto.
 - Diagrama de proyecto interactivo para arrastrar dispositivos, hacer zoom, ajustar los nodos a la cuadrícula y exportar el plano como SVG o JPG.
 - Tema rosa divertido que se mantiene entre visitas.

--- a/README.fr.md
+++ b/README.fr.md
@@ -75,7 +75,7 @@ L’application adopte automatiquement la langue de votre navigateur lors de la 
 - Nouveau thème à fort contraste pour améliorer la lisibilité.
 - Les formulaires d’appareils complètent les catégories dynamiquement à partir du schéma.
 - Interface repensée avec contraste renforcé et espacements plus généreux pour une expérience plus nette sur tout appareil.
-- Partage simplifié : téléchargez un fichier JSON regroupant sélections, exigences, liste de matériel, retours d’autonomie et appareils personnalisés, puis importez-le pour tout restaurer.
+- Partage simplifié : téléchargez un fichier JSON regroupant sélections, exigences, liste de matériel, retours d’autonomie et appareils personnalisés, puis importez-le pour tout restaurer. Activez l’option **Inclure les règles automatiques d’équipement** si vous souhaitez embarquer vos automatisations ou laissez-la désactivée pour les conserver en local.
 - Des icônes dédiées pour les scénarios obligatoires mettent en évidence les contraintes du projet.
 - Diagramme de projet interactif pour déplacer les appareils, zoomer, aligner sur la grille et exporter en SVG ou JPG.
 - Thème rose ludique qui persiste entre les visites.

--- a/README.it.md
+++ b/README.it.md
@@ -75,7 +75,7 @@ Al primo avvio l’applicazione adotta la lingua del browser; puoi cambiarla dal
 - Nuovo tema ad alto contrasto per migliorare la leggibilità.
 - I moduli dei dispositivi compilano le categorie in modo dinamico partendo dallo schema.
 - Interfaccia ridisegnata con contrasto maggiore e spaziature più generose per un’esperienza più pulita su qualsiasi dispositivo.
-- Condividere i progetti è più semplice: scarica un file JSON con selezioni, requisiti, lista attrezzatura, feedback di autonomia e dispositivi personalizzati, quindi importalo per ripristinare tutto.
+- Condividere i progetti è più semplice: scarica un file JSON con selezioni, requisiti, lista attrezzatura, feedback di autonomia e dispositivi personalizzati, quindi importalo per ripristinare tutto. Attiva l'interruttore **Includi regole automatiche dell'attrezzatura** se vuoi che le automazioni viaggino con l'export oppure lascialo disattivato per mantenerle locali.
 - Icone dedicate per gli scenari obbligatori evidenziano subito i requisiti del progetto.
 - Diagramma del progetto interattivo per trascinare i dispositivi, fare zoom, allineare alla griglia ed esportare in SVG o JPG.
 - Tema rosa giocoso che resta attivo tra una visita e l’altra.

--- a/README.md
+++ b/README.md
@@ -314,9 +314,10 @@ Use Cine Power Planner end-to-end with the following routine:
   referenced custom devices. Rename the file if your archiving standards call
   for a `.cpproject` extension, then send it via your preferred secure channel;
   recipients can import without needing internet access.
-- **Automatic gear rules travel with bundles.** Decide whether to include your
-  rules during export; teammates who import the bundle can ignore them, apply
-  them only to the imported project or merge them into their global ruleset.
+- **Automatic gear rules travel with bundles.** Flip the **Include automatic
+  gear rules** toggle during export to decide whether your automations ship with
+  the bundle; teammates who import the file can ignore them, apply them only to
+  the imported project or merge them into their global ruleset.
 - **Restores are double-buffered.** Importing a bundle prompts you to save a
   backup of your current environment first. After choosing the bundle file, the
   planner validates its JSON schema, merges new devices and places the restored

--- a/index.html
+++ b/index.html
@@ -2764,7 +2764,14 @@
                 data-help-highlight="#setup-manager"
               ><strong>Export project</strong></a>
               downloads a portable JSON bundle with devices, requirements, automatic gear rules and runtime feedback so you can
-              archive or share the setup safely offline using your own storage or transfer tools.
+              archive or share the setup safely offline using your own storage or transfer tools. Toggle
+              <a
+                class="help-link"
+                href="#shareIncludeAutoGearLabel"
+                data-help-target="#shareIncludeAutoGearLabel"
+                data-help-highlight="#setup-manager"
+              ><em>Include automatic gear rules</em></a>
+              to decide whether your automation travels with the export or stays on this device.
             </li>
             <li>
               Use the


### PR DESCRIPTION
## Summary
- Highlight the **Include automatic gear rules** toggle inside the in-app help export guidance.
- Update English and localized README files to mention the export toggle when describing project bundle sharing.

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d479874b948320b78d2835f6f67daa