### PR TITLE
Improve legacy backup normalization

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -61,6 +61,7 @@ Beim ersten Start übernimmt die Anwendung automatisch die Sprache deines Browse
 
 ## 🆕 Neueste Funktionen
 - Versionsvergleiche für Backups lassen dich beliebige manuelle Speicherungen oder automatisch datierte Backups auswählen, um Diffs zu prüfen, Vorfallnotizen zu ergänzen und vor einem Rollback oder einer Übergabe an die Post einen Bericht zu exportieren.
+- Backups normalisieren jetzt ältere Datenpakete, die als JSON-Zeichenketten oder Eintragsarrays gespeichert wurden, damit alte Exporte zuverlässig wiederhergestellt werden.
 - Wiederherstellungsproben laden ein komplettes App-Backup oder Projekt-Bundle in eine isolierte Sandbox, damit du Inhalte mit den Live-Daten abgleichen kannst, ohne Produktionsprofile anzutasten.
 - Die neuen automatischen Gear-Regeln fügen szenariobasierte Ergänzungen oder Entfernungen hinzu, lassen sich exportieren und gemeinsam mit Bundles wiederherstellen.
 - Das Daten- & Speicher-Dashboard prüft gespeicherte Projekte, Gerätelisten, eigene Geräte, Favoriten und Laufzeit-Feedback direkt in den Einstellungen und zeigt die geschätzte Backup-Größe an.

--- a/README.en.md
+++ b/README.en.md
@@ -65,6 +65,7 @@ The app automatically uses your browser language on first load, and you can swit
 
 ## 🆕 Recent Features
 - Backup version comparisons let you pick any manual save or timestamped auto-backup to review diffs, add incident notes and export a log before rolling a change back or handing footage to post.
+- Backups now normalize legacy data bundles saved as JSON strings or entry arrays so older exports restore correctly.
 - Restore rehearsals load a full-app backup or project bundle into an isolated sandbox so you can confirm its contents match live data without touching production profiles.
 - Automatic gear rules let you design scenario-driven additions or removals, export the configuration and restore it alongside project bundles.
 - Data & storage dashboard audits saved projects, gear lists, custom devices, favorites and runtime feedback directly inside Settings.

--- a/README.es.md
+++ b/README.es.md
@@ -64,6 +64,7 @@ La aplicación adopta automáticamente el idioma de tu navegador en la primera v
 
 ## 🆕 Novedades recientes
 - Las comparaciones de versiones de respaldos permiten elegir cualquier guardado manual o copia automática con marca de tiempo para revisar diferencias, añadir notas de incidentes y exportar un registro antes de revertir cambios o entregar material a postproducción.
+- Las copias de seguridad ahora normalizan los paquetes de datos heredados guardados como cadenas JSON o como matrices de entradas para que los archivos antiguos se restauren correctamente.
 - Los ensayos de restauración cargan una copia completa de la aplicación o un paquete de proyecto en un entorno aislado para confirmar que su contenido coincide con los datos en vivo sin tocar los perfiles de producción.
 - Las reglas automáticas de equipo permiten diseñar adiciones o retiradas según el escenario, exportar la configuración y restaurarla junto con los paquetes de proyecto.
 - El panel Datos y almacenamiento audita proyectos guardados, listas de equipo, dispositivos personalizados, favoritos y comentarios de autonomía directamente desde Ajustes y muestra el tamaño aproximado del respaldo.

--- a/README.fr.md
+++ b/README.fr.md
@@ -62,6 +62,7 @@ L’application adopte automatiquement la langue de votre navigateur lors de la 
 
 ## 🆕 Nouveautés
 - Les comparaisons de versions de sauvegarde permettent de sélectionner n’importe quel enregistrement manuel ou sauvegarde automatique horodatée pour analyser les différences, ajouter des notes d’incident et exporter un journal avant un retour arrière ou une remise d’images à la post-production.
+- Les sauvegardes normalisent désormais les anciens paquets de données enregistrés en chaînes JSON ou en tableaux d’entrées afin que les exports historiques se restaurent correctement.
 - Les répétitions de restauration chargent une sauvegarde complète de l’application ou un bundle de projet dans un bac à sable isolé pour confirmer que son contenu correspond aux données actives sans toucher aux profils de production.
 - Les règles automatiques d’équipement ajoutent ou retirent du matériel selon le scénario, avec export/import aux côtés des bundles partagés.
 - Le tableau de bord Données & stockage audite projets enregistrés, listes de matériel, appareils personnalisés, favoris et retours d’autonomie depuis les Réglages et affiche la taille approximative des sauvegardes.

--- a/README.it.md
+++ b/README.it.md
@@ -62,6 +62,7 @@ Al primo avvio l’applicazione adotta la lingua del browser; puoi cambiarla dal
 
 ## 🆕 Novità
 - I confronti delle versioni dei backup permettono di scegliere qualsiasi salvataggio manuale o backup automatico con timestamp per rivedere le differenze, aggiungere note sugli incidenti ed esportare un registro prima di annullare una modifica o consegnare il materiale alla post.
+- I backup ora normalizzano i pacchetti di dati legacy salvati come stringhe JSON o array di voci, così gli export storici si ripristinano correttamente.
 - Le prove di ripristino caricano un backup completo dell’app o un bundle di progetto in una sandbox isolata così puoi confermare che il contenuto corrisponde ai dati live senza toccare i profili di produzione.
 - Le regole automatiche dell'attrezzatura consentono di definire aggiunte o rimozioni guidate dallo scenario, esportarle e ripristinarle insieme ai bundle condivisi.
 - Il cruscotto Dati e archiviazione controlla progetti salvati, elenchi, dispositivi personalizzati, preferiti e feedback sulle autonomie direttamente nelle Impostazioni e mostra la dimensione approssimativa del backup.


### PR DESCRIPTION
## Summary
- normalize legacy backup data containers by parsing JSON strings and entry arrays before restoring
- include autoGearMonitorDefaults in legacy data fallback detection and convert complex values for safe imports
- extend backup compatibility tests and document the enhanced legacy handling across all localized READMEs

## Testing
- RUN_HEAVY_TESTS=true npm test -- script/backupCompatibility.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d47b15d8688320949f8696cf0fab9f