### PR TITLE
Validate automatic gear rule imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,12 @@ Use Cine Power Planner end-to-end with the following routine:
   gear rules** toggle during export to decide whether your automations ship with
   the bundle; teammates who import the file can ignore them, apply them only to
   the imported project or merge them into their global ruleset.
+- **Standalone rule imports validate metadata offline.** When you import an
+  `auto-gear-rules-*.json` file, the planner now checks the file type, semantic
+  version and timestamp metadata before touching your saved rules—even without
+  connectivity. You’ll see a warning if the payload came from an older or newer
+  build or if required fields were removed, and the previous snapshot is restored
+  automatically if validation fails.
 - **Restores are double-buffered.** Importing a bundle prompts you to save a
   backup of your current environment first. After choosing the bundle file, the
   planner validates its JSON schema, merges new devices and places the restored
@@ -350,8 +356,10 @@ Use Cine Power Planner end-to-end with the following routine:
   font and branding asset so a restore never loses context.
 - **`auto-gear-rules-*.json` (rule exports).** Optional downloads from
   **Automatic Gear Rules** provide timestamped copies of your automation setup.
-  Store them alongside full backups so custom presets never disappear during
-  cross-team handoffs.
+  They now embed file type, semantic version and timestamp metadata so the
+  importer can validate payloads offline. Store them alongside full backups so
+  custom presets never disappear during cross-team handoffs, and keep an eye on
+  import warnings if you restore them on a different build.
 
 ## Interface Tour
 

--- a/docs/offline-readiness.md
+++ b/docs/offline-readiness.md
@@ -46,7 +46,10 @@ connectivity:
    match the production log.
 3. **Generate redundancy.** Export a fresh planner backup and project bundle, then import
    both files into an isolated browser profile. Document the validation date, machine name
-   and any notes about data changes since the last rehearsal.
+   and any notes about data changes since the last rehearsal. Include a standalone
+   `auto-gear-rules-*.json` export in this drill—the import flow now verifies the file
+   type, semantic version and timestamp metadata entirely offline, warning you about
+   mismatches and restoring the pre-import snapshot automatically if validation fails.
 4. **Simulate outages.** With the verification profile still offline, reload the planner
    and navigate the interface. Confirm locally stored Uicons, fonts and helper scripts stay
    available and that autosave warnings do not appear.
@@ -83,7 +86,9 @@ this triage list:
    saves. This protects data from automated cleanup.
 3. **Validate in isolation.** Import the suspect project bundle into a private profile that
    stays offline. Compare its contents against the production machine to confirm which data
-   diverged.
+   diverged. Re-run the latest automatic gear rules export as well; the validator highlights
+   missing metadata or version drift and protects the existing rules by rolling back
+   automatically if the payload cannot be trusted.
 4. **Restore with safeguards.** After validation, restore the fresh backup on the primary
    machine. The app captures a pre-restore snapshot automatically, so retain it for diffing
    if you need to merge notes.

--- a/src/scripts/app-core.js
+++ b/src/scripts/app-core.js
@@ -14415,6 +14415,98 @@ function deleteAutoGearRule(ruleId) {
   }
 }
 
+function normalizeAutoGearPayloadMetadata(candidate) {
+  if (!candidate || typeof candidate !== 'object') return null;
+  const metadata = {};
+
+  const assignIfString = (key, value) => {
+    if (typeof value !== 'string') return;
+    const trimmed = value.trim();
+    if (!trimmed) return;
+    if (!Object.prototype.hasOwnProperty.call(metadata, key) || !metadata[key]) {
+      metadata[key] = trimmed;
+    }
+  };
+
+  assignIfString('type', candidate.type);
+  assignIfString('version', candidate.version);
+
+  const timestampFields = [
+    ['createdAt', 'createdAt'],
+    ['created_at', 'createdAt'],
+    ['created', 'createdAt'],
+    ['timestamp', 'timestamp'],
+    ['exportedAt', 'exportedAt'],
+    ['exported_at', 'exportedAt'],
+    ['savedAt', 'savedAt'],
+    ['saved_at', 'savedAt'],
+    ['updatedAt', 'updatedAt'],
+    ['updated_at', 'updatedAt'],
+    ['modifiedAt', 'updatedAt'],
+    ['modified_at', 'updatedAt'],
+  ];
+
+  timestampFields.forEach(([prop, target]) => {
+    if (metadata[target]) return;
+    assignIfString(target, candidate[prop]);
+  });
+
+  if (!metadata.timestamp) {
+    const orderedKeys = ['createdAt', 'timestamp', 'exportedAt', 'savedAt', 'updatedAt'];
+    for (let i = 0; i < orderedKeys.length; i += 1) {
+      const key = orderedKeys[i];
+      if (metadata[key]) {
+        metadata.timestamp = metadata[key];
+        metadata.timestampSource = key;
+        break;
+      }
+    }
+  }
+
+  if (metadata.timestamp && !metadata.timestampSource) {
+    metadata.timestampSource = 'timestamp';
+  }
+
+  return Object.keys(metadata).length ? metadata : null;
+}
+
+function collectAutoGearPayloadMetadata(...sources) {
+  const queue = [];
+  const visited = new Set();
+  const metadata = {};
+
+  const enqueue = value => {
+    if (!value || typeof value !== 'object') return;
+    if (visited.has(value)) return;
+    visited.add(value);
+    queue.push(value);
+  };
+
+  sources.forEach(source => enqueue(source));
+
+  while (queue.length) {
+    const candidate = queue.shift();
+    const normalized = normalizeAutoGearPayloadMetadata(candidate);
+    if (normalized) {
+      ['type', 'version', 'createdAt', 'exportedAt', 'savedAt', 'updatedAt', 'timestamp', 'timestampSource'].forEach(key => {
+        if (!normalized[key]) return;
+        if (!Object.prototype.hasOwnProperty.call(metadata, key) || !metadata[key]) {
+          metadata[key] = normalized[key];
+        }
+      });
+    }
+
+    if (candidate.meta && typeof candidate.meta === 'object') {
+      enqueue(candidate.meta);
+    }
+    if (candidate.metadata && typeof candidate.metadata === 'object') {
+      enqueue(candidate.metadata);
+    }
+  }
+
+  return Object.keys(metadata).length ? metadata : null;
+}
+
 function parseAutoGearImportPayload(data) {
   const extractMonitorDefaults = source => {
     if (!source || typeof source !== 'object') return null;
@@ -14462,7 +14554,8 @@ function parseAutoGearImportPayload(data) {
 
   const initialValue = resolveValue(data);
   if (Array.isArray(initialValue)) {
-    return { rules: initialValue, monitorDefaults: null };
+    const metadata = collectAutoGearPayloadMetadata(initialValue);
+    return { rules: initialValue, monitorDefaults: null, metadata };
   }
   if (!initialValue || typeof initialValue !== 'object') {
     return null;
@@ -14481,7 +14574,13 @@ function parseAutoGearImportPayload(data) {
         const monitorDefaults = (parent ? extractMonitorDefaults(parent) : null)
           || (root ? extractMonitorDefaults(root) : null)
           || null;
-        return { rules: value, monitorDefaults };
+        const metadata = collectAutoGearPayloadMetadata(
+          parent,
+          value,
+          root,
+          baseRoot,
+        );
+        return { rules: value, monitorDefaults, metadata };
       }
       value.forEach(item => {
         if (item && typeof item === 'object') {
@@ -14507,14 +14606,26 @@ function parseAutoGearImportPayload(data) {
       ? resolveValue(value.autoGearRules)
       : null;
     if (Array.isArray(rawAutoGearRules)) {
-      return { rules: rawAutoGearRules, monitorDefaults: fallbackDefaults };
+      const metadata = collectAutoGearPayloadMetadata(
+        value,
+        parent,
+        root,
+        baseRoot,
+      );
+      return { rules: rawAutoGearRules, monitorDefaults: fallbackDefaults, metadata };
     }
 
     const rawRules = Object.prototype.hasOwnProperty.call(value, 'rules')
       ? resolveValue(value.rules)
       : null;
     if (Array.isArray(rawRules)) {
-      return { rules: rawRules, monitorDefaults: fallbackDefaults };
+      const metadata = collectAutoGearPayloadMetadata(
+        value,
+        parent,
+        root,
+        baseRoot,
+      );
+      return { rules: rawRules, monitorDefaults: fallbackDefaults, metadata };
     }
     if (rawRules && typeof rawRules === 'object') {
       const nestedAutoGearRules = Object.prototype.hasOwnProperty.call(rawRules, 'autoGearRules')
@@ -14522,9 +14633,17 @@ function parseAutoGearImportPayload(data) {
         : null;
       if (Array.isArray(nestedAutoGearRules)) {
         const nestedDefaults = extractMonitorDefaults(rawRules) || fallbackDefaults;
+        const metadata = collectAutoGearPayloadMetadata(
+          rawRules,
+          value,
+          parent,
+          root,
+          baseRoot,
+        );
         return {
           rules: nestedAutoGearRules,
           monitorDefaults: nestedDefaults,
+          metadata,
         };
       }
     }
@@ -14541,6 +14660,8 @@ function parseAutoGearImportPayload(data) {
       { value: value.autoGear, key: 'autoGear' },
       { value: value.rules, key: 'rules' },
       { value: value.autoGearRules, key: 'autoGearRules' },
+      { value: value.meta, key: 'meta' },
+      { value: value.metadata, key: 'metadata' },
     ];
     containerEntries.forEach(entry => {
       if (!entry.value) return;
@@ -14567,27 +14688,277 @@ function parseAutoGearImportPayload(data) {
   return null;
 }
 
+function parseSemanticVersion(version) {
+  if (typeof version !== 'string') return null;
+  const trimmed = version.trim();
+  if (!trimmed) return null;
+  const match = trimmed.match(/^(\d+)\.(\d+)\.(\d+)(?:[-+].*)?$/);
+  if (!match) return null;
+  return {
+    major: Number.parseInt(match[1], 10),
+    minor: Number.parseInt(match[2], 10),
+    patch: Number.parseInt(match[3], 10),
+    raw: trimmed,
+  };
+}
+
+function compareSemanticVersions(a, b) {
+  if (!a || !b) return null;
+  if (a.major !== b.major) {
+    return a.major > b.major ? 1 : -1;
+  }
+  if (a.minor !== b.minor) {
+    return a.minor > b.minor ? 1 : -1;
+  }
+  if (a.patch !== b.patch) {
+    return a.patch > b.patch ? 1 : -1;
+  }
+  return 0;
+}
+
+function isValidIsoTimestamp(value) {
+  if (typeof value !== 'string') return false;
+  const trimmed = value.trim();
+  if (!trimmed) return false;
+  const parsed = Date.parse(trimmed);
+  if (Number.isNaN(parsed)) return false;
+  return Number.isFinite(parsed);
+}
+
+function validateAutoGearImportPayload(parsed) {
+  const initialMetadata = parsed?.metadata && typeof parsed.metadata === 'object'
+    ? { ...parsed.metadata }
+    : {};
+  const validation = {
+    metadata: initialMetadata,
+    warnings: [],
+    errors: [],
+  };
+
+  if (!parsed || !Array.isArray(parsed.rules)) {
+    validation.errors.push({ code: 'invalid-rules' });
+    return validation;
+  }
+
+  const metadata = validation.metadata;
+  const expectedType = 'camera-power-planner/auto-gear-rules';
+  const typeValue = typeof metadata.type === 'string' ? metadata.type.trim() : '';
+  if (!typeValue) {
+    validation.warnings.push({ code: 'missing-metadata', field: 'type' });
+  } else if (typeValue !== expectedType) {
+    validation.errors.push({ code: 'type-mismatch', expected: expectedType, actual: typeValue });
+  } else {
+    metadata.type = typeValue;
+  }
+
+  let versionValue = '';
+  if (typeof metadata.version === 'string') {
+    versionValue = metadata.version.trim();
+    if (!versionValue) {
+      validation.warnings.push({ code: 'missing-metadata', field: 'version' });
+    }
+  } else if (metadata.version != null) {
+    validation.warnings.push({ code: 'invalid-metadata', field: 'version' });
+  } else {
+    validation.warnings.push({ code: 'missing-metadata', field: 'version' });
+  }
+
+  const parsedVersion = parseSemanticVersion(versionValue);
+  if (versionValue && !parsedVersion) {
+    validation.warnings.push({ code: 'invalid-version-format', value: versionValue });
+  }
+  metadata.version = versionValue;
+
+  const timestampValue = typeof metadata.timestamp === 'string' ? metadata.timestamp.trim() : '';
+  if (!timestampValue) {
+    validation.warnings.push({ code: 'missing-metadata', field: 'timestamp' });
+  } else if (!isValidIsoTimestamp(timestampValue)) {
+    validation.warnings.push({ code: 'invalid-timestamp', value: timestampValue });
+  }
+  metadata.timestamp = timestampValue;
+
+  const localVersion = typeof APP_VERSION === 'string' ? parseSemanticVersion(APP_VERSION) : null;
+  if (parsedVersion && localVersion) {
+    const comparison = compareSemanticVersions(parsedVersion, localVersion);
+    if (comparison > 0) {
+      validation.warnings.push({
+        code: 'newer-version',
+        importedVersion: parsedVersion.raw,
+        currentVersion: localVersion.raw,
+      });
+    } else if (comparison < 0) {
+      validation.warnings.push({
+        code: 'older-version',
+        importedVersion: parsedVersion.raw,
+        currentVersion: localVersion.raw,
+      });
+    }
+  }
+
+  if (!metadata.type && !metadata.version && !metadata.timestamp) {
+    validation.metadata = null;
+  }
+
+  return validation;
+}
+
+function getAutoGearImportMetadataFieldLabel(field) {
+  const localeTexts = getLanguageTexts(currentLang);
+  const englishTexts = getLanguageTexts('en');
+  const key = field === 'timestamp'
+    ? 'autoGearImportMetadataLabelTimestamp'
+    : field === 'version'
+      ? 'autoGearImportMetadataLabelVersion'
+      : 'autoGearImportMetadataLabelType';
+  return localeTexts?.[key]
+    || englishTexts?.[key]
+    || field;
+}
+
+function formatAutoGearImportWarningMessage(warning, metadata) {
+  const localeTexts = getLanguageTexts(currentLang);
+  const englishTexts = getLanguageTexts('en');
+
+  switch (warning.code) {
+    case 'newer-version': {
+      const template = localeTexts?.autoGearImportNewerVersionWarning
+        || englishTexts?.autoGearImportNewerVersionWarning
+        || 'Imported rules were created with version {importVersion}, which is newer than this build ({appVersion}).';
+      return template
+        .replace('{importVersion}', warning.importedVersion || metadata?.version || '')
+        .replace('{appVersion}', warning.currentVersion || APP_VERSION || '');
+    }
+    case 'older-version': {
+      const template = localeTexts?.autoGearImportOlderVersionWarning
+        || englishTexts?.autoGearImportOlderVersionWarning
+        || 'Imported rules were created with version {importVersion}, which is older than this build ({appVersion}).';
+      return template
+        .replace('{importVersion}', warning.importedVersion || metadata?.version || '')
+        .replace('{appVersion}', warning.currentVersion || APP_VERSION || '');
+    }
+    case 'invalid-version-format': {
+      const template = localeTexts?.autoGearImportInvalidVersionWarning
+        || englishTexts?.autoGearImportInvalidVersionWarning
+        || 'Imported rules report version "{value}", which is not a valid semantic version string.';
+      return template.replace('{value}', warning.value || metadata?.version || '');
+    }
+    case 'invalid-timestamp': {
+      const template = localeTexts?.autoGearImportInvalidTimestampWarning
+        || englishTexts?.autoGearImportInvalidTimestampWarning
+        || 'The import timestamp "{value}" could not be verified.';
+      return template.replace('{value}', warning.value || metadata?.timestamp || '');
+    }
+    default:
+      return '';
+  }
+}
+
+function displayAutoGearImportWarnings(warnings, metadata) {
+  if (!Array.isArray(warnings) || !warnings.length) return;
+  const missingFields = [];
+  const invalidFields = [];
+
+  warnings.forEach(warning => {
+    if (!warning || typeof warning !== 'object') return;
+    if (warning.code === 'missing-metadata' && warning.field) {
+      if (!missingFields.includes(warning.field)) {
+        missingFields.push(warning.field);
+      }
+    } else if (warning.code === 'invalid-metadata' && warning.field) {
+      if (!invalidFields.includes(warning.field)) {
+        invalidFields.push(warning.field);
+      }
+    } else {
+      const message = formatAutoGearImportWarningMessage(warning, metadata);
+      if (message) {
+        showNotification('warning', message);
+      }
+    }
+  });
+
+  const localeTexts = getLanguageTexts(currentLang);
+  const englishTexts = getLanguageTexts('en');
+
+  if (missingFields.length) {
+    const labels = missingFields.map(field => getAutoGearImportMetadataFieldLabel(field));
+    const labelList = formatListForLang(currentLang, labels);
+    const template = localeTexts?.autoGearImportMissingMetadataWarning
+      || englishTexts?.autoGearImportMissingMetadataWarning
+      || 'Imported rules are missing required metadata: {fields}.';
+    showNotification('warning', template.replace('{fields}', labelList));
+  }
+
+  if (invalidFields.length) {
+    const labels = invalidFields.map(field => getAutoGearImportMetadataFieldLabel(field));
+    const labelList = formatListForLang(currentLang, labels);
+    const template = localeTexts?.autoGearImportInvalidMetadataWarning
+      || englishTexts?.autoGearImportInvalidMetadataWarning
+      || 'Imported rules include invalid metadata: {fields}.';
+    showNotification('warning', template.replace('{fields}', labelList));
+  }
+}
+
 function importAutoGearRulesFromData(data, options = {}) {
+  const previousRules = getAutoGearRules();
+  const previousMonitorDefaults = getAutoGearMonitorDefaultsSnapshot();
   const parsed = parseAutoGearImportPayload(data);
   if (!parsed || !Array.isArray(parsed.rules)) {
-    throw new Error('Invalid automatic gear rules import payload');
+    const error = new Error('Invalid automatic gear rules import payload');
+    error.userMessage = texts[currentLang]?.autoGearImportSchemaError
+      || texts.en?.autoGearImportSchemaError
+      || 'Import failed. The file does not match the automatic gear rules export format.';
+    error.validationWarnings = [];
+    error.validationMetadata = null;
+    throw error;
   }
-  setAutoGearRules(parsed.rules);
-  if (parsed.monitorDefaults && typeof parsed.monitorDefaults === 'object') {
-    setAutoGearMonitorDefaults(parsed.monitorDefaults);
-  } else {
-    updateAutoGearMonitorDefaultOptions();
+
+  const validation = validateAutoGearImportPayload(parsed);
+  if (validation.errors.length) {
+    const message = texts[currentLang]?.autoGearImportSchemaError
+      || texts.en?.autoGearImportSchemaError
+      || 'Import failed. The file does not match the automatic gear rules export format.';
+    const error = new Error(message);
+    error.userMessage = message;
+    error.validationErrors = validation.errors;
+    error.validationWarnings = validation.warnings;
+    error.validationMetadata = validation.metadata;
+    throw error;
+  }
+
+  try {
+    setAutoGearRules(parsed.rules);
+    if (parsed.monitorDefaults && typeof parsed.monitorDefaults === 'object') {
+      setAutoGearMonitorDefaults(parsed.monitorDefaults);
+    } else {
+      updateAutoGearMonitorDefaultOptions();
+      renderAutoGearMonitorDefaultsControls();
+    }
+    closeAutoGearEditor();
+    renderAutoGearRulesList();
+    updateAutoGearCatalogOptions();
+    if (typeof refreshGearListIfVisible === 'function') {
+      refreshGearListIfVisible();
+    }
+  } catch (error) {
+    setAutoGearRules(previousRules);
+    setAutoGearMonitorDefaults(previousMonitorDefaults, { skipRender: true, skipRefresh: true });
+    renderAutoGearRulesList();
+    updateAutoGearCatalogOptions();
     renderAutoGearMonitorDefaultsControls();
+    if (typeof refreshGearListIfVisible === 'function') {
+      refreshGearListIfVisible();
+    }
+    throw error;
   }
-  closeAutoGearEditor();
-  renderAutoGearRulesList();
-  updateAutoGearCatalogOptions();
+
   if (!options.silent) {
     const message = texts[currentLang]?.autoGearImportSuccess
       || texts.en?.autoGearImportSuccess
       || 'Automatic gear rules imported.';
     showNotification('success', message);
   }
+
+  displayAutoGearImportWarnings(validation.warnings, validation.metadata);
   return getAutoGearRules();
 }
 
@@ -14748,9 +15119,15 @@ function handleAutoGearImportSelection(event) {
       importAutoGearRulesFromData(parsed);
     } catch (error) {
       console.warn('Automatic gear rules import failed', error);
-      const errorMsg = texts[currentLang]?.autoGearImportError
+      if (Array.isArray(error?.validationWarnings) && error.validationWarnings.length) {
+        displayAutoGearImportWarnings(error.validationWarnings, error.validationMetadata || null);
+      }
+      const fallbackErrorMsg = texts[currentLang]?.autoGearImportError
         || texts.en?.autoGearImportError
         || 'Import failed. Please choose a valid automatic gear rules file.';
+      const errorMsg = typeof error?.userMessage === 'string' && error.userMessage.trim()
+        ? error.userMessage
+        : fallbackErrorMsg;
       showNotification('error', errorMsg);
     } finally {
       if (input) input.value = '';

--- a/src/scripts/translations.js
+++ b/src/scripts/translations.js
@@ -308,6 +308,23 @@ const texts = {
     autoGearImportConfirm: "Replace your automatic gear rules with the imported file?",
     autoGearImportSuccess: "Automatic gear rules imported.",
     autoGearImportError: "Import failed. Please choose a valid automatic gear rules file.",
+    autoGearImportSchemaError:
+      "Import failed. The file does not match the automatic gear rules export format.",
+    autoGearImportMetadataLabelType: "type marker",
+    autoGearImportMetadataLabelVersion: "version",
+    autoGearImportMetadataLabelTimestamp: "timestamp",
+    autoGearImportMissingMetadataWarning:
+      "Imported rules are missing required metadata: {fields}. Confirm the file comes from a trusted export before saving.",
+    autoGearImportInvalidMetadataWarning:
+      "Imported rules include invalid metadata: {fields}. Confirm the file comes from a trusted export before saving.",
+    autoGearImportNewerVersionWarning:
+      "Imported rules were created with version {importVersion}, which is newer than this build ({appVersion}). Double-check compatibility before relying on them.",
+    autoGearImportOlderVersionWarning:
+      "Imported rules were created with version {importVersion}, which is older than this build ({appVersion}). Review them to confirm they still match your workflow.",
+    autoGearImportInvalidVersionWarning:
+      "Imported rules report version \"{value}\", which is not a valid semantic version string.",
+    autoGearImportInvalidTimestampWarning:
+      "The import timestamp \"{value}\" could not be verified. Confirm the file has not been modified.",
     autoGearBackupsHeading: "Automatic backups",
     autoGearBackupsDescription:
       "Backups save your rules every 10 minutes when changes occur. Restore a snapshot if something goes wrong.",
@@ -1811,6 +1828,23 @@ const texts = {
     autoGearImportSuccess: "Regole automatiche dell'equipaggiamento importate.",
     autoGearImportError:
       "Importazione non riuscita. Scegli un file valido di regole automatiche dell'equipaggiamento.",
+    autoGearImportSchemaError:
+      "Importazione non riuscita. Il file non corrisponde al formato di esportazione delle regole automatiche dell'equipaggiamento.",
+    autoGearImportMetadataLabelType: "indicatore di tipo",
+    autoGearImportMetadataLabelVersion: "versione",
+    autoGearImportMetadataLabelTimestamp: "timestamp",
+    autoGearImportMissingMetadataWarning:
+      "Le regole importate non includono tutti i metadati richiesti: {fields}. Assicurati che il file provenga da un'esportazione affidabile prima di salvarlo.",
+    autoGearImportInvalidMetadataWarning:
+      "Le regole importate contengono metadati non validi: {fields}. Assicurati che il file provenga da un'esportazione affidabile prima di salvarlo.",
+    autoGearImportNewerVersionWarning:
+      "Le regole importate sono state create con la versione {importVersion}, più recente rispetto a questa build ({appVersion}). Verifica la compatibilità prima di usarle.",
+    autoGearImportOlderVersionWarning:
+      "Le regole importate sono state create con la versione {importVersion}, più vecchia rispetto a questa build ({appVersion}). Controlla che siano ancora adatte al tuo flusso di lavoro.",
+    autoGearImportInvalidVersionWarning:
+      "Le regole importate indicano la versione \"{value}\", che non è una versione semantica valida.",
+    autoGearImportInvalidTimestampWarning:
+      "Il timestamp di importazione \"{value}\" non può essere verificato. Assicurati che il file non sia stato modificato.",
     autoGearBackupsHeading: "Backup automatici",
     autoGearBackupsDescription:
       "Viene salvato un backup ogni 10 minuti quando ci sono modifiche. Ripristina una versione se qualcosa va storto.",
@@ -2893,6 +2927,23 @@ const texts = {
     autoGearImportSuccess: "Reglas automáticas de equipo importadas.",
     autoGearImportError:
       "La importación falló. Elige un archivo válido de reglas automáticas de equipo.",
+    autoGearImportSchemaError:
+      "La importación falló. El archivo no coincide con el formato de exportación de las reglas automáticas de equipo.",
+    autoGearImportMetadataLabelType: "marcador de tipo",
+    autoGearImportMetadataLabelVersion: "versión",
+    autoGearImportMetadataLabelTimestamp: "marca de tiempo",
+    autoGearImportMissingMetadataWarning:
+      "Las reglas importadas no incluyen todos los metadatos requeridos: {fields}. Asegúrate de que el archivo provenga de una exportación de confianza antes de guardarlo.",
+    autoGearImportInvalidMetadataWarning:
+      "Las reglas importadas incluyen metadatos no válidos: {fields}. Asegúrate de que el archivo provenga de una exportación de confianza antes de guardarlo.",
+    autoGearImportNewerVersionWarning:
+      "Las reglas importadas se crearon con la versión {importVersion}, que es más reciente que esta compilación ({appVersion}). Comprueba la compatibilidad antes de utilizarlas.",
+    autoGearImportOlderVersionWarning:
+      "Las reglas importadas se crearon con la versión {importVersion}, que es anterior a esta compilación ({appVersion}). Revisa que sigan encajando con tu flujo de trabajo.",
+    autoGearImportInvalidVersionWarning:
+      "Las reglas importadas indican la versión \"{value}\", que no es una versión semántica válida.",
+    autoGearImportInvalidTimestampWarning:
+      "No se pudo verificar la marca de tiempo de importación \"{value}\". Asegúrate de que el archivo no haya sido modificado.",
     autoGearBackupsHeading: "Copias de seguridad automáticas",
     autoGearBackupsDescription:
       "Guarda una copia cada 10 minutos cuando hay cambios. Restaura una versión si algo sale mal.",
@@ -3977,6 +4028,23 @@ const texts = {
     autoGearImportSuccess: "Règles automatiques d’équipement importées.",
     autoGearImportError:
       "Échec de l'import. Choisissez un fichier de règles automatiques d’équipement valide.",
+    autoGearImportSchemaError:
+      "Échec de l’import. Le fichier ne correspond pas au format d’export des règles automatiques d’équipement.",
+    autoGearImportMetadataLabelType: "identifiant de type",
+    autoGearImportMetadataLabelVersion: "version",
+    autoGearImportMetadataLabelTimestamp: "horodatage",
+    autoGearImportMissingMetadataWarning:
+      "Les règles importées n’incluent pas toutes les métadonnées requises : {fields}. Assurez-vous que le fichier provient d’une exportation de confiance avant d’enregistrer.",
+    autoGearImportInvalidMetadataWarning:
+      "Les règles importées contiennent des métadonnées invalides : {fields}. Assurez-vous que le fichier provient d’une exportation de confiance avant d’enregistrer.",
+    autoGearImportNewerVersionWarning:
+      "Les règles importées ont été créées avec la version {importVersion}, plus récente que cette version ({appVersion}). Vérifiez la compatibilité avant de les utiliser.",
+    autoGearImportOlderVersionWarning:
+      "Les règles importées ont été créées avec la version {importVersion}, plus ancienne que cette version ({appVersion}). Vérifiez qu’elles correspondent toujours à votre flux de travail.",
+    autoGearImportInvalidVersionWarning:
+      "Les règles importées indiquent la version \"{value}\", qui n’est pas une version sémantique valide.",
+    autoGearImportInvalidTimestampWarning:
+      "L’horodatage d’import \"{value}\" n’a pas pu être vérifié. Assurez-vous que le fichier n’a pas été modifié.",
     autoGearBackupsHeading: "Sauvegardes automatiques",
     autoGearBackupsDescription:
       "Une sauvegarde est créée toutes les 10 minutes en cas de changement. Restaurez une version si nécessaire.",
@@ -5064,6 +5132,23 @@ const texts = {
     autoGearImportSuccess: "Automatische Gear-Regeln importiert.",
     autoGearImportError:
       "Import fehlgeschlagen. Bitte wähle eine gültige Datei für automatische Gear-Regeln.",
+    autoGearImportSchemaError:
+      "Import fehlgeschlagen. Die Datei entspricht nicht dem Exportformat für automatische Gear-Regeln.",
+    autoGearImportMetadataLabelType: "Typ-Markierung",
+    autoGearImportMetadataLabelVersion: "Version",
+    autoGearImportMetadataLabelTimestamp: "Zeitstempel",
+    autoGearImportMissingMetadataWarning:
+      "Die importierten Regeln enthalten nicht alle erforderlichen Metadaten: {fields}. Stelle sicher, dass die Datei aus einem vertrauenswürdigen Export stammt, bevor du sie speicherst.",
+    autoGearImportInvalidMetadataWarning:
+      "Die importierten Regeln enthalten ungültige Metadaten: {fields}. Stelle sicher, dass die Datei aus einem vertrauenswürdigen Export stammt, bevor du sie speicherst.",
+    autoGearImportNewerVersionWarning:
+      "Die importierten Regeln wurden mit Version {importVersion} erstellt, die neuer ist als dieser Build ({appVersion}). Prüfe die Kompatibilität, bevor du sie verwendest.",
+    autoGearImportOlderVersionWarning:
+      "Die importierten Regeln wurden mit Version {importVersion} erstellt, die älter ist als dieser Build ({appVersion}). Prüfe, ob sie weiterhin zu deinem Ablauf passen.",
+    autoGearImportInvalidVersionWarning:
+      "Die importierten Regeln geben die Version \"{value}\" an, die kein gültiges semantisches Versionsformat ist.",
+    autoGearImportInvalidTimestampWarning:
+      "Der Import-Zeitstempel \"{value}\" konnte nicht verifiziert werden. Stelle sicher, dass die Datei nicht verändert wurde.",
     autoGearBackupsHeading: "Automatische Sicherungen",
     autoGearBackupsDescription:
       "Alle 10 Minuten wird bei Änderungen eine Sicherung erstellt. Stelle eine Version wieder her, falls etwas schiefgeht.",


### PR DESCRIPTION
## Summary
- validate automatic gear rule imports against type, version and timestamp metadata with automatic rollback on failure
- surface localized warnings for version drift, missing metadata and schema mismatches during imports
- document the offline validation workflow for standalone rule imports in the README and offline runbook

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d47fc9aa2083209678df8e3d559d59