### PR TITLE
Clarify offline validation steps in docs

### DIFF
--- a/docs/offline-readiness.md
+++ b/docs/offline-readiness.md
@@ -24,7 +24,10 @@ time:
    cached assets render exactly as they did online.
 3. **Exercise persistence.** Create a dummy project, trigger a manual save, then refresh
    the app while still offline. The project selector should show the saved entry and the
-   timestamped `auto-backup-…` snapshot once the autosave routine runs.
+   timestamped `auto-backup-…` snapshot once the autosave routine runs. Open **Settings →
+   Backup & Restore** to confirm the autosave status overlay reflects the same timestamp,
+   then review **Settings → Data & Storage** to verify project, backup and gear counts
+   updated as expected.
 4. **Capture baseline exports.** While still offline, export both a planner backup
    (`planner-backup.json`) and a project bundle (`project-name.json`). Import the files into
    a private browser profile that also stays offline. Once you confirm the restore loop
@@ -60,7 +63,8 @@ Re-run these checks each morning and evening while you are on location:
 
 1. **Morning warm-up.** Before editing anything, open the help dialog and legal pages to
    keep caches fresh, then load the day’s project and confirm the timestamp of the latest
-   `auto-backup-…` entry.
+   `auto-backup-…` entry. Open **Settings → Backup & Restore** so the autosave status
+   overlay proves background saves are healthy.
 2. **During the day.** When significant edits land, trigger a manual save and export a
    planner backup. Label the file with the project name, location, operator and time so it
    is easy to trace.

--- a/docs/testing-plan.md
+++ b/docs/testing-plan.md
@@ -35,3 +35,31 @@ threatening saved data.
 
 If higher-resource environments are available, the deleted suites can be restored from
 version control for extended regression testing.
+
+## Manual offline validation checklist
+
+Automated coverage now concentrates on the code paths that protect user data and
+offline workflows. Pair those suites with a short hands-on rehearsal whenever
+you prepare a release candidate or validate a workstation:
+
+1. **Prime caches while online.** Launch `index.html`, open the help dialog and
+   legal pages, then toggle each theme once so locally stored Uicons, OpenMoji
+   art and typography files stay cached.
+2. **Verify autosave health.** Create or load a project, trigger a manual save
+   (`Enter`/`Ctrl+S`/`⌘S`) and confirm the new timestamp in the selector. Open
+   **Settings → Backup & Restore** and ensure the autosave status overlay mirrors
+   the same timestamp before continuing.
+3. **Inspect data inventory.** Visit **Settings → Data & Storage** to confirm
+   project, backup, gear list and custom device counts match expectations. This
+   step catches storage issues before they risk user data.
+4. **Exercise backups and bundles.** Export a planner backup and a
+   `project-name.json` bundle, import both into an offline private profile and
+   review gear lists, automatic gear rules, runtime dashboards and favorites for
+   parity. Delete the profile after verification.
+5. **Simulate loss of connectivity.** While the verification profile stays
+   offline, refresh the planner and make sure the offline indicator appears,
+   cached assets render instantly and the restored project remains intact.
+
+Document the drill results alongside your automated test logs so every release
+carries evidence that saving, sharing, importing, backup and restore routines
+were validated end-to-end.


### PR DESCRIPTION
## Summary
- expand the offline readiness runbook with checks for the autosave status overlay and data inventory review
- add a manual offline validation checklist to the testing plan so releases document end-to-end save, share, import, backup and restore drills

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d480b9a32c8320b0e41999090695b5