### PR TITLE
Improve force reload translation in Italian and German

### DIFF
--- a/src/scripts/translations.js
+++ b/src/scripts/translations.js
@@ -1186,8 +1186,9 @@ const texts = {
       "Passa tra tema chiaro e scuro; premi D per attivarlo. La scelta viene ricordata.",
     pinkModeHelp:
       "Aggiungi un tema rosa giocoso. Quando la modalità rosa è attiva, l’icona dell’unicorno cambia ogni 30 secondi con una delicata animazione pop e l’impostazione funziona in modalità chiara o scura ed è ricordata per la volta successiva.",
-    reloadAppLabel: "Ricarica",
-    reloadAppHelp: "Svuota la cache e ricarica l'app senza eliminare i dati salvati.",
+    reloadAppLabel: "Ricarica forzata",
+    reloadAppHelp:
+      "Svuota la cache ed esegue una ricarica forzata dell'app senza eliminare i dati salvati.",
 
     favoriteToggleLabel: "Preferito",
     favoriteToggleHelp:
@@ -4424,8 +4425,9 @@ const texts = {
       "Zwischen hellem und dunklem Design wechseln; mit D umschalten. Die Einstellung wird gespeichert.",
     pinkModeHelp:
       "Füge ein verspieltes pinkes Akzentthema hinzu. Während der Pinkmodus aktiv ist, wechselt das Einhorn-Symbol alle 30 Sekunden mit einer sanften Pop-Animation, und die Einstellung funktioniert in hellen wie dunklen Modi und bleibt für das nächste Mal gespeichert.",
-    reloadAppLabel: "Neu laden",
-    reloadAppHelp: "Cache leeren und Anwendung neu laden, ohne gespeicherte Daten zu entfernen.",
+    reloadAppLabel: "Neu laden erzwingen",
+    reloadAppHelp:
+      "Leert den Cache und erzwingt ein Neuladen, ohne gespeicherte Daten zu entfernen.",
 
     favoriteToggleLabel: "Favorit",
     favoriteToggleHelp:


### PR DESCRIPTION
## Summary
- align the Italian label with the intended "Force reload" action and clarify the descriptive help text
- update the German button label and explanation to explicitly mention the forced reload workflow

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d480c71fbc83208a347d9e6836502f