### PR TITLE
Fix autosave to retain project-specific requirements

### DIFF
--- a/src/scripts/app-events.js
+++ b/src/scripts/app-events.js
@@ -371,7 +371,26 @@ setupSelect.addEventListener("change", (event) => {
   let autoSaveFlushed = false;
   if (typeof scheduleProjectAutoSave === 'function') {
     try {
-      scheduleProjectAutoSave(true);
+      const normalizeForOverride = typeof normalizeSetupName === 'function'
+        ? normalizeSetupName
+        : (value => (typeof value === 'string' ? value.trim() : ''));
+      const previousSelection = normalizeForOverride(
+        typeof lastSetupName === 'string' ? lastSetupName : '',
+      );
+      const storageKeyOverride = normalizeForOverride(previousKey);
+      const overrides = {
+        setupNameState: {
+          typedName,
+          selectedName: previousSelection,
+          storageKey: storageKeyOverride,
+          renameInProgress: Boolean(
+            previousSelection
+            && typedName
+            && typedName !== previousSelection,
+          ),
+        },
+      };
+      scheduleProjectAutoSave({ immediate: true, overrides });
       autoSaveFlushed = true;
     } catch (error) {
       console.warn('Failed to flush project autosave before switching setups', error);


### PR DESCRIPTION
## Summary
- add an autosave override context so switching setups preserves the previous project's requirements
- adjust the setup change handler to flush autosave with the previous setup's storage key
- ensure gear list saves honor the override when persisting project data

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d4eb310ef4832090bdf717ac62b7e7