### PR TITLE
Update localized documentation

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -1,320 +1,352 @@
-# 🎥 Cine Power Planner
+# Cine Power Planner
 
-Dieses browserbasierte Werkzeug hilft dir bei der Planung professioneller Kamera-Setups mit V‑Mount-, B‑Mount- oder Gold-Mount-Akkus. Es berechnet den **Gesamtverbrauch**, die **Stromaufnahme** (bei 14,4 V und 12 V) sowie die **geschätzte Laufzeit** und prüft gleichzeitig, ob der Akku die benötigte Leistung zuverlässig liefern kann.
+![Cine Power Planner icon](src/icons/app-icon.svg)
 
-Sämtliche Planungen, Eingaben und Exporte bleiben auf deinem Gerät. Spracheinstellungen, Projekte, eigene Geräte, Favoriten und Laufzeit-Feedback werden im Browser gespeichert, und Service-Worker-Updates stammen direkt aus diesem Repository. Du kannst Cine Power Planner offline von der lokalen Festplatte öffnen oder intern hosten, damit jede Abteilung dieselbe geprüfte Version nutzt.
+Cine Power Planner ist eine eigenständige Web-App zum Erstellen, Prüfen und Teilen professioneller Kamera-Strompläne, die dein Gerät niemals verlassen. Plane V‑Mount-, B‑Mount- oder Gold-Mount-Rigs, bewerte Laufzeiten, erfasse Projektanforderungen und exportiere teilbare Pakete – komplett im Browser, sogar offline. Alle Abhängigkeiten liegen in diesem Repository, damit dieselbe Erfahrung auf der Bühne, im Feld oder im Archivlaufwerk funktioniert, ohne nach Hause zu telefonieren.
 
 ## Auf einen Blick
 
-- **Netzwerkfrei planen.** Alle Symbole, Schriften und Hilfsskripte liegen in diesem Repository, sodass du `index.html` direkt
-  öffnen und offline arbeiten kannst.
-- **Projekte bleiben lokal.** Speicherstände, Laufzeit-Feedback, eigene Geräte, Favoriten und Gerätelisten bleiben auf dem
-  Gerät; Backups und teilbare Bundles sind menschenlesbare JSON-Dateien.
-- **Updates bewusst steuern.** Der Service Worker aktualisiert sich erst, nachdem du **Neu laden erzwingen** gedrückt hast –
-  ideal für Reisen und Drehs mit wenig Verbindung.
-- **Mehrstufige Sicherheitsnetze.** Manuelle Speicherungen, Auto-Saves und automatisch erzeugte Zeitstempel-Backups erleichtern
-  Wiederherstellungsproben vor dem Dreh.
+- **Offline zuerst planen.** Baue V‑Mount-, B‑Mount- oder Gold-Mount-Setups direkt im Browser. Alle Uicons, Schriften und Hilfsskripte liegen lokal, sodass nichts von externen CDNs oder Netzwerken abhängt. Klone das Repository, zieh das Netzwerkkabel ab und die Oberfläche funktioniert unverändert weiter.
+- **Daten bleiben auf dem Gerät.** Projekte, Laufzeit-Feedback, Favoriten, eigene Geräte, Gerätelisten und Einstellungen bleiben lokal. Backups und teilbare Pakete sind menschenlesbare JSON-Dateien, die du kontrollierst.
+- **Sicherheitsnetze schnell prüfen.** Manuelle Speicherungen, Hintergrund-Auto-Saves und automatische Zeitstempel-Backups greifen ineinander, damit du den Ablauf Speichern → Backup → Bundle → Wiederherstellen als ersten Schritt üben kannst.
+- **Updates bewusst freigeben.** Der Service Worker wartet auf deine Bestätigung, bevor er aktualisiert. Teams bleiben so auf einer geprüften Revision – selbst unterwegs oder bei schwacher Verbindung.
 
-## Schnellstart
+## Überblick
 
-1. Lade das Repository herunter oder klone es und öffne `index.html` in einem modernen Browser.
-2. (Optional) Stelle den Ordner lokal bereit (zum Beispiel mit `npx http-server` oder `python -m http.server`), damit sich der
-   Service Worker registriert und Assets für den Offline-Betrieb zwischenspeichert.
-3. Lade den Planner einmal, schließe den Tab, trenne die Verbindung und öffne `index.html` erneut. Das Offline-Badge sollte
-   kurz aufleuchten, während das zwischengespeicherte Interface lädt.
-4. Lege ein Projekt an, drücke **Enter** (oder **Strg+S**/`⌘S`) zum Speichern und beobachte das automatische Backup, das nach
-   wenigen Minuten im Projektmenü erscheint.
-5. Exportiere **Einstellungen → Backup & Wiederherstellung → Backup**, importiere die Datei in einem privaten Browserprofil und
-   prüfe, ob Projekte, Favoriten und eigene Geräte vollständig zurückkehren.
-6. Übe den Export einer `.cpproject`-Datei und den Import auf einem zweiten Gerät oder Profil, damit die Kette Speichern →
-   Teilen → Importieren vor dem Set-Einsatz geprüft ist.
+### Entwickelt für Crews
 
-## Zentrale Arbeitsabläufe
+Der Planner entstand für 1st ACs, Data Wrangler und DoPs. Sobald du Bodies, Batterieteller, Funkstrecken und Zubehör ergänzt, aktualisieren sich Gesamtverbrauch und Laufzeiten sofort. Sicherheitswarnungen markieren überlastete Akkus, und Gerätelisten bleiben an die Projektkontexte gebunden, damit beim Handover nichts fehlt.
 
-- **Rig planen.** Kombiniere Kameras, Platten, Funkstrecken, Monitore, Motoren und Zubehör, während Verbrauchs- und Laufzeitwerte
-  sofort mitlaufen.
-- **Versionen sichern.** Halte Projekte bewusst fest und lass automatisch Zeitstempel-Backups alle zehn Minuten entstehen.
-- **Sicher teilen.** Exportiere `.cpproject`-Bundles, die offline bleiben, beim Import validiert werden und auf Wunsch automatische
-  Gear-Regeln enthalten.
-- **Alles sichern.** Vollständige Planner-Backups beinhalten Projekte, Favoriten, eigene Geräte, Laufzeitdaten und UI-Präferenzen,
-  damit kein Kontext verloren geht.
-- **Verborgene Migrations-Backups.** Bevor gespeicherte Planner, Setups oder
-  Präferenzen überschrieben werden, bewahrt die App den vorherigen JSON-Snapshot
-  im geschützten Eintrag `__legacyMigrationBackup` auf. Schlägt ein Schreibvorgang
-  fehl oder entstehen beschädigte Daten, greifen die Wiederherstellungstools
-  automatisch auf diese Sicherheitskopie zurück, sodass keine Benutzerdaten
-  verloren gehen.
+### Gemacht für Reisen
 
-## Datensicherheit im Offline-Betrieb
+Öffne `index.html` direkt von der Festplatte oder hoste das Repository intern – ganz ohne Build-Prozess, Server oder Accounts. Ein Service Worker hält die App offline verfügbar, merkt sich jede Einstellung und aktualisiert nur nach deiner Freigabe. Speichern, Teilen, Importieren, Backup und Wiederherstellen laufen immer lokal, damit Benutzerdaten geschützt bleiben.
 
-- Prüfe regelmäßig die Offline-Bereitschaft: Anwendung laden, Verbindung trennen, aktualisieren und sicherstellen, dass Projekte
-  erreichbar bleiben.
-- Bewahre redundante Backups auf beschrifteten Datenträgern auf und importiere sie nach jedem Export in einem zweiten Profil.
-- Erstelle vor Updates oder größeren Datenänderungen ein manuelles Backup und teste die Wiederherstellung.
+### Warum Offline-first zählt
 
----
+Filmsets haben selten garantierte Konnektivität, Studios verlangen häufig luftgetrennte Planungstools. Cine Power Planner liefert identische Fähigkeiten unabhängig vom Netzwerkstatus: Alle Assets sind gebündelt, jeder Workflow läuft lokal und jede Sicherung erzeugt Artefakte für dein Archiv. Diese Abläufe vor dem Dreh zu prüfen gehört zur Checkliste, damit im Einsatz nichts an externe Dienste gebunden ist.
 
-## 🌍 Sprachen
+### Funktionssäulen
+
+- **Mit Vertrauen planen.** Berechne Stromaufnahme bei 14,4 V/12 V (und 33,6 V/21,6 V für B‑Mount), vergleiche kompatible Akkus und visualisiere Laufzeiteffekte über ein gewichtetetes Feedback-Dashboard.
+- **Produktionsbereit bleiben.** Projekte erfassen Geräte, Anforderungen, Szenarien, Crewdetails und Gerätelisten; Auto-Backups, Bundles und gesteuerte Aktualisierungen halten Daten aktuell, ohne Stabilität zu opfern.
+- **Arbeiten wie gewohnt.** Spracherkennung, Dark-, Pink- und High-Contrast-Themes, Typografie-Regler, Custom-Logo und Hover-Hilfe machen die Oberfläche on set und in der Vorbereitung zugänglich.
+
+## Grundprinzipien
+
+- **Immer offlinefähig.** Die komplette Anwendung inklusive Icons, Legal-Seiten und Tools liegt im Repository. Öffne `index.html` lokal oder über ein privates Intranet; der Service Worker hält Assets synchron, ohne Online-Zwang.
+- **Keine versteckten Datenpfade.** Speichern, Bundles, Importe, Backups und Wiederherstellungen passieren vollständig im Browser. Es verlässt nichts das Gerät, außer du exportierst es bewusst.
+- **Redundante Sicherheitsnetze.** Manuelle Saves, Hintergrund-Auto-Saves, periodische Auto-Backups, erzwungene Pre-Restore-Backups und menschenlesbare Exporte sorgen dafür, dass Benutzerdaten nicht verschwinden.
+- **Vorhersehbare Updates.** Aktualisierungen greifen nur nach deinem Trigger. Zwischengespeicherte Versionen bleiben verfügbar, bis du **Neu laden erzwingen** bestätigst.
+- **Konstante Darstellung.** Gebündelte Uicons, OpenMoji und Typografie-Dateien garantieren identische Optik – egal ob im Studio oder im Feld ohne Netz.
+
+## Inhaltsverzeichnis
+
+- [Auf einen Blick](#auf-einen-blick)
+- [Überblick](#überblick)
+- [Grundprinzipien](#grundprinzipien)
+- [Übersetzungen](#übersetzungen)
+- [Was ist neu](#was-ist-neu)
+- [Schnellstart](#schnellstart)
+- [Systemanforderungen & Browser-Support](#systemanforderungen--browser-support)
+- [Speicher-, Teil- & Import-Drill](#speicher--teil--import-drill)
+- [Täglicher Ablauf](#täglicher-ablauf)
+- [Speichern & Projektverwaltung](#speichern--projektverwaltung)
+- [Teilen & Importe](#teilen--importe)
+- [Projekt- & Backup-Dateiformate](#projekt--backup-dateiformate)
+- [Interface-Rundgang](#interface-rundgang)
+- [Anpassung & Barrierefreiheit](#anpassung--barrierefreiheit)
+- [Datensicherheit & Offline-Betrieb](#datensicherheit--offline-betrieb)
+- [Daten- & Speicherübersicht](#daten--speicherübersicht)
+- [Speicherbudget & Wartung](#speicherbudget--wartung)
+- [Backup & Wiederherstellung](#backup--wiederherstellung)
+- [Datenintegritäts-Drills](#datenintegritäts-drills)
+- [Operative Checklisten](#operative-checklisten)
+- [Notfall-Wiederherstellungsplan](#notfall-wiederherstellungsplan)
+- [Gerätelisten & Reporting](#gerätelisten--reporting)
+- [Automatische Gear-Regeln](#automatische-gear-regeln)
+- [Runtime-Intelligenz](#runtime-intelligenz)
+- [Tastenkürzel](#tastenkürzel)
+- [Lokalisierung](#lokalisierung)
+- [Als App installieren](#als-app-installieren)
+- [Gerätedaten-Workflow](#gerätedaten-workflow)
+- [Entwicklung](#entwicklung)
+- [Fehlerbehebung](#fehlerbehebung)
+- [Feedback & Support](#feedback--support)
+- [Mitwirken](#mitwirken)
+- [Danksagungen](#danksagungen)
+- [Lizenz](#lizenz)
+
+## Übersetzungen
+
+Die Dokumentation steht in mehreren Sprachen bereit. Die App erkennt beim ersten Start automatisch die Browsersprache, und du kannst jederzeit über das Sprachmenü oben rechts oder über **Einstellungen** wechseln.
+
 - 🇬🇧 [English](README.en.md)
 - 🇩🇪 [Deutsch](README.de.md)
 - 🇪🇸 [Español](README.es.md)
 - 🇮🇹 [Italiano](README.it.md)
 - 🇫🇷 [Français](README.fr.md)
 
-Beim ersten Start übernimmt die Anwendung automatisch die Sprache deines Browsers. Über das Menü oben rechts kannst du jederzeit umschalten – die Auswahl bleibt für den nächsten Besuch erhalten.
+Folge `docs/translation-guide.md` für Details zur Lokalisierung.
 
----
+## Was ist neu
 
-## 🆕 Neueste Funktionen
-- Versionsvergleiche für Backups lassen dich beliebige manuelle Speicherungen oder automatisch datierte Backups auswählen, um Diffs zu prüfen, Vorfallnotizen zu ergänzen und vor einem Rollback oder einer Übergabe an die Post einen Bericht zu exportieren.
-- Backups normalisieren jetzt ältere Datenpakete, die als JSON-Zeichenketten oder Eintragsarrays gespeichert wurden, damit alte Exporte zuverlässig wiederhergestellt werden.
-- Wiederherstellungsproben laden ein komplettes App-Backup oder Projekt-Bundle in eine isolierte Sandbox, damit du Inhalte mit den Live-Daten abgleichen kannst, ohne Produktionsprofile anzutasten.
-- Die neuen automatischen Gear-Regeln fügen szenariobasierte Ergänzungen oder Entfernungen hinzu, lassen sich exportieren und gemeinsam mit Bundles wiederherstellen.
-- Das Daten- & Speicher-Dashboard prüft gespeicherte Projekte, Gerätelisten, eigene Geräte, Favoriten und Laufzeit-Feedback direkt in den Einstellungen und zeigt die geschätzte Backup-Größe an.
-- Ein Overlay für den Auto-Save-Status spiegelt die letzte Auto-Save-Notiz im Einstellungsdialog, damit Teams Hintergrundaktivität während Wiederherstellungsübungen sehen.
-- Ein monitoring-sensitiver Gerätemanager blendet zusätzliche Monitor- und Videozubehörfelder nur ein, wenn Szenarien sie verlangen, damit Regeln fokussiert bleiben.
-- Akzent- und Typografie-Regler in den Einstellungen erlauben dir Akzentfarbe, Grundschriftgröße und Schriftfamilie sowie die Themes Dunkel, Pink und Hoher Kontrast einstellen.
-- Tastenkürzel für die globale Suche setzen den Fokus sofort mit / oder Strg+K (⌘K auf macOS) – selbst wenn es im eingeklappten mobilen Seitenmenü steckt.
-- Die Aktion „Neu laden erzwingen" leert zwischengespeicherte Service-Worker-Dateien, damit sich die Offline-Anwendung aktualisiert, ohne Projekte oder Geräte zu löschen.
-- Sternsymbole neben jeder Auswahl pinnen Lieblingskameras, ‑akkus und ‑zubehör oben an und nehmen sie in Backups auf.
-- Der **Werkseinstellungen**-Workflow lädt automatisch eine Sicherung herunter, bevor gespeicherte Projekte, Geräte und Einstellungen gelöscht werden.
-- Geräteliste und druckbare Übersicht zeigen den Projektnamen als schnelle Referenz.
-- Lade ein eigenes Logo hoch, das in druckbaren Übersichten und Backups erscheint.
-- Backups enthalten Favoriten und erstellen vor jeder Wiederherstellung eine automatische Sicherung.
-- Crew-Einträge besitzen jetzt ein Feld für E-Mail-Adressen.
-- Neues High-Contrast-Theme für bessere Lesbarkeit.
-- Geräteformulare füllen die Kategorien dynamisch anhand der Schema-Attribute aus.
-- Überarbeitete Oberfläche mit verbessertem Kontrast und großzügigerem Spacing für ein klares Erlebnis auf jedem Gerät.
-- Projekt-Sharing wurde vereinfacht: Lade eine JSON-Datei mit Auswahl, Anforderungen, Geräteliste, Laufzeit-Feedback und eigenen Geräten herunter und importiere sie anschließend, um alles wiederherzustellen. Aktiviere bei Bedarf den Schalter **Automatische Gear-Regeln einschließen**, damit deine Automationen mitreisen oder lokal bleiben.
-- Eigene Symbole für verpflichtende Szenarien machen Projektanforderungen auf einen Blick sichtbar.
-- Interaktives Projekt-Diagramm zum Verschieben, Zoomen, Einrasten und Exportieren als SVG oder JPG.
-- Verspieltes pinkes Akzent-Theme, das zwischen Besuchen erhalten bleibt.
-- Durchsuchbarer Hilfedialog mit Schritt-für-Schritt-Bereichen und FAQ; öffne ihn mit ?, H, F1 oder Strg+/.
-- Kontextuelle Hover-Hilfe für Schaltflächen, Felder, Dropdowns und Überschriften.
-- Globale Suchleiste zum schnellen Sprung zu Funktionen, Geräteselektoren oder Hilfethemen.
-- Unterstützung für Kameras mit V-, B- oder Gold-Mount-Akkuplatten.
-- Reiche Laufzeit-Feedback inklusive Temperatur ein, um Schätzungen zu verbessern.
-- Visuelles Dashboard zur Gewichtung der Laufzeiten zeigt, wie Einstellungen jeden Eintrag beeinflussen – sortiert nach Gewicht mit exakten Prozentangaben.
-- Erstelle Gerätelisten, die ausgewählte Geräte und Projektanforderungen bündeln.
-- Speichere Projektanforderungen mit jedem Projekt, damit Gerätelisten den vollständigen Kontext behalten.
-- Dupliziere Benutzereinträge in den Gerätelistenformularen per Gabelsymbol, um Felder sofort zu kopieren.
+- **Backup-Vergleiche** – Wähle manuelle Saves oder Auto-Backups, prüfe Diffs, ergänze Vorfallnotizen und exportiere Protokolle, bevor du Änderungen zurückrollst oder Daten an die Post übergibst.
+- **Restore-Proben** – Lade komplette Backups oder Projekt-Bundles in eine isolierte Sandbox, um Inhalte gegen Live-Daten zu checken, ohne Produktionsprofile anzurühren.
+- **Automatische Gear-Regeln** – Definiere szenariobasierte Ergänzungen oder Entfernungen mit Import/Export-Kontrollen und zeitgesteuerten Backups.
+- **Daten- & Speicher-Dashboard** – Prüfe gespeicherte Projekte, Gerätelisten, eigene Geräte, Favoriten und Laufzeitfeedback direkt in den Einstellungen und schätze die Backup-Größe.
+- **Autosave-Status-Overlay** – Spiegelt die letzte Autosave-Notiz im Einstellungsdialog, damit Teams Hintergrundaktivitäten während Recovery-Drills sehen.
+- **Monitoring-sensitiver Gear-Editor** – Blendet zusätzliche Monitor- und Videoverteilungsoptionen nur ein, wenn Szenarien sie verlangen.
+- **Akzent- & Typografie-Regler** – Passe Akzentfarbe, Schriftgröße und Schriftart an; Dark-, Pink- und High-Contrast-Themes bleiben zwischen Besuchen erhalten.
+- **Global-Search-Kürzel** – `/` oder `Strg+K` (`⌘K` auf macOS) fokussiert sofort die Funktionssuche – auch bei eingeklapptem Menü.
+- **Neu laden erzwingen** – Aktualisiere Service-Worker-Assets ohne gespeicherte Projekte oder Geräte zu löschen.
+- **Favoriten anpinnen** – Markiere Einträge mit Sternen, damit Lieblingskameras, Akkus und Zubehör oben bleiben und im Backup landen.
+- **Werkseinstellungen mit Sicherung** – Automatisches Backup vor jedem Zurücksetzen, damit keine Daten verloren gehen.
 
----
+Weitere Details findest du in den sprachspezifischen READMEs.
 
-## 🔧 Funktionen
+## Schnellstart
 
-### ✨ Highlights im Detail
+Führe diese Checkliste beim ersten Setup oder nach Updates aus. Sie beweist, dass Speichern, Teilen, Import, Backup und Wiederherstellen online wie offline identisch funktionieren.
 
-- **Komplexe Rigs ohne Ratespiel bauen.** Kombiniere Kameras, Akkuplatten, Funkstrecken, Monitore, Motoren und Zubehör und verfolge Gesamtverbrauch sowie Stromaufnahme bei 14,4 V/12 V (bzw. 33,6 V/21,6 V bei B‑Mount) mit realistischen Laufzeiten aus gewichteten Felddaten. Das Batterie-Vergleichspanel warnt vor Überlastungen, bevor falsches Equipment eingepackt wird.
-- **Alle Gewerke auf Stand halten.** Speichere mehrere Projekte mit Anforderungen, Crew-Kontakten, Szenarien und Notizen. Druckbare Gerätelisten gruppieren Equipment nach Kategorie, führen Duplikate zusammen, zeigen technische Metadaten und berücksichtigen Szenario-Zubehör, damit Kamera-, Licht- und Grip-Teams synchron bleiben.
-- **Überall produktiv arbeiten.** Öffne `index.html` direkt oder liefere den Ordner über HTTPS aus, um den Service Worker zu aktivieren. Offline-Caching bewahrt Sprache, Themes, Favoriten und Projekte, und **Neu laden erzwingen** aktualisiert Assets, ohne gespeicherte Daten anzutasten.
-- **Cine Power Planner auf das Team zuschneiden.** Wechsle sofort zwischen Deutsch, Englisch, Spanisch, Italienisch und Französisch, passe Schriftgröße und -familie an, wähle eine eigene Akzentfarbe, lade ein Drucklogo hoch und schalte zwischen hellem, dunklem, pinkem oder kontrastreichem Theme. Tippen-zum-Suchen, angepinnte Favoriten, Duplizieren-Buttons und Hover-Hilfe sparen Zeit am Set.
+1. Repository klonen oder herunterladen.
+2. `index.html` in einem modernen Browser öffnen.
+3. (Optional) Ordner lokal per HTTP(S) bereitstellen, z. B.:
+   ```bash
+   npx http-server
+   # oder
+   python -m http.server
+   ```
+   So installiert sich der Service Worker und wartet auf deine Freigabe, bevor Updates aktiv werden.
+4. Planner einmal laden, Tab schließen, Netzwerk trennen (oder Flugmodus aktivieren) und `index.html` erneut öffnen. Das Offline-Badge sollte kurz aufleuchten, während gecachte Assets – inklusive lokal gespeicherter Uicons – geladen werden.
+5. Erstes Projekt anlegen, **Enter** (oder **Strg+S**/`⌘S`) drücken und im Projektmenü das zeitgestempelte Auto-Backup prüfen, das nach wenigen Minuten erscheint.
+6. **Einstellungen → Backup & Wiederherstellung → Backup** exportieren und die `planner-backup.json` in einem privaten Profil importieren. So stellst du sicher, dass keine Sicherung auf einem Gerät festsitzt und der erzwungene Pre-Restore-Export funktioniert.
+7. Projekt-Bundle exportieren (`project-name.json`) und auf einem zweiten Gerät/Profil importieren. Das trainiert die komplette Kette Speichern → Teilen → Importieren und stellt sicher, dass Uicons, Fonts und Scripts offline mitreisen.
+8. Verifiziertes Backup und Projekt-Bundle zusammen mit der Repository-Kopie archivieren. So bleiben alle Workflows synchron und du hast redundante Medien für Reisen.
 
-### ✅ Projektverwaltung
-- Speichere, lade und lösche mehrere Kameraprojekte (drücke Enter oder Strg+S/⌘S zum schnellen Speichern; der Button bleibt deaktiviert, bis ein Name eingetragen ist).
-- Alle zehn Minuten entstehen automatisch Sicherungsschnappschüsse, solange Cine Power Planner geöffnet ist; im Einstellungsdialog lassen sich stündliche Backup-Exporte als Erinnerung aktivieren.
-- Lade eine JSON-Datei herunter, die Auswahl, Anforderungen, Geräteliste, Laufzeit-Feedback und eigene Geräte bündelt; über den Import-Picker holst du alles in einem Schritt zurück.
-- Die Daten liegen lokal im `localStorage`, Favoriten landen ebenfalls in Backups; die Option **Werkseinstellungen** legt vor dem Zurücksetzen automatisch eine Sicherung ab.
-- Erstelle druckbare Übersichten für jedes gespeicherte Projekt und füge ein individuelles Logo hinzu, damit Exporte und Backups zum Produktionsbranding passen.
-- Projektanforderungen werden gemeinsam mit dem Projekt gespeichert, sodass Gerätelisten den kompletten Kontext behalten.
-- Funktioniert vollständig offline dank installiertem Service Worker – Sprache, Theme, Gerätedaten und Favoriten bleiben erhalten.
-- Responsives Layout passt sich nahtlos an Desktop, Tablet und Smartphone an.
-- Wähle bei kompatiblen Kameras zwischen **V‑Mount**, **B‑Mount** oder **Gold-Mount**; die Akkuliste aktualisiert sich automatisch.
+## Systemanforderungen & Browser-Support
 
-### 🧭 Interface-Überblick
-- **Schnellzugriff:**
-  - **Globale Suche** (`/` oder `Strg+K`/`⌘K`) springt zu Funktionen, Selektoren oder Hilfethemen – auch wenn das Seitenmenü eingeklappt ist.
-  - **Hilfecenter** (`?`, `H`, `F1` oder `Strg+/`) zeigt durchsuchbare Guides, FAQs, Tastenkürzel und den optionalen Hover-Hilfemodus.
-  - **Projekt-Diagramm** visualisiert Verbindungen; halte Umschalt gedrückt, um beim Download ein JPG statt eines SVG zu speichern und Kompatibilitäts-Hinweise zu sehen.
-  - **Batterievergleich** zeigt, wie kompatible Packs performen und markiert Überlastungsrisiken frühzeitig.
-  - **Gerätelisten-Generator** erstellt kategorisierte Tabellen mit Metadaten, Crew-E-Mails und szenarioabhängigen Ergänzungen – bereit für Druck oder PDF.
-  - **Offline-Badge & Neu laden erzwingen** zeigen den Verbindungsstatus und aktualisieren zwischengespeicherte Dateien, ohne Projekte zu löschen.
-- Ein Skip-Link und ein Offline-Indikator halten das Layout für Tastatur und Touch zugänglich; das Badge erscheint, sobald der Browser die Verbindung verliert.
-- Die globale Suche springt zu Funktionen, Geräteselektoren oder Hilfethemen; drücke Enter für das markierte Ergebnis, / oder Strg+K (⌘K auf macOS) zum sofortigen Fokussieren (auf kleinen Displays öffnet sich das Seitenmenü automatisch) und Escape oder × zum Zurücksetzen.
-- Oben findest du Sprachumschaltung, Toggles für dunkles und pinkes Theme sowie den Einstellungsdialog mit Akzentfarbe, Schriftgröße, Schriftfamilie, High-Contrast-Schalter und Logo-Upload plus Backup-, Restore- und Werkseinstellungen-Tools, die vor dem Löschen eine Sicherung anlegen.
-- Die Hilfe-Schaltfläche öffnet einen durchsuchbaren Dialog mit Schritt-für-Schritt-Anleitungen, Tastenkürzeln, FAQ und optionalem Hover-Hilfemodus; erreichbar auch mit ?, H, F1 oder Strg+/ – selbst während der Eingabe.
-- Die Aktualisieren-Schaltfläche (🔄) löscht zwischengespeicherte Service-Worker-Dateien, damit sich die Offline-Anwendung erneuert, ohne Projekte oder Geräte zu verlieren.
-- Auf kleineren Bildschirmen spiegelt ein einklappbares Seitenmenü alle wichtigen Bereiche für schnellen Zugriff.
+- **Moderne Evergreen-Browser.** Validiert mit aktuellen Chromium-, Firefox- und Safari-Versionen. Service Worker, IndexedDB und persistenter Speicher müssen aktiv sein.
+- **Offline-freundliche Geräte.** Laptops/Tablets sollten dauerhaften Speicher erlauben. Starte die App einmal online, damit der Service Worker alle Assets cacht, und übe den Offline-Reload vor der Reise.
+- **Ausreichender lokaler Speicher.** Große Produktionen erzeugen viele Projekte, Backups und Gerätelisten. Beobachte den Speicherplatz deines Browserprofils und exportiere regelmäßig auf redundante Medien.
+- **Keine externen Abhängigkeiten.** Alle Icons, Fonts und Hilfsskripte liegen im Repository. Kopiere Ordner wie `animated icons 3/` und lokale Uicons mit, damit Optik und Scripts identisch bleiben.
 
-### ♿ Anpassung & Barrierefreiheit
-- Theme-Optionen umfassen Dunkelmodus, spielerische pinke Akzente und einen High-Contrast-Schalter für bessere Lesbarkeit.
-- Änderungen an Akzentfarbe, Grundschriftgröße und Schriftfamilie greifen sofort und bleiben im Browser gespeichert – ideal für Markenfarben oder Barrierefreiheit.
-- Eingebaute Tastenkürzel decken globale Suche (/ oder Strg+K/⌘K), Hilfe ( ?, H, F1, Strg+/ ), Speichern (Enter oder Strg+S/⌘S), Dunkelmodus (D) und Rosa-Modus (P) ab.
-- Der Hover-Hilfemodus macht jede Schaltfläche, jedes Feld, Dropdown und jede Überschrift zur Sofort-Hilfe – perfekt für neue Teammitglieder.
-- Tippen zum Filtern, sichtbare Fokusmarken und Sternsymbole neben Auswahllisten erleichtern das Durchsuchen langer Listen und das Fixieren von Favoriten.
-- Lade ein individuelles Logo für Ausdrucke hoch, konfiguriere Standard-Monitorrollen und passe Vorgaben für Projektanforderungen an, damit Exporte zum Produktionsbranding passen.
-- Gabel-Symbole duplizieren Formularzeilen sofort, und angepinnte Favoriten halten beliebte Geräte oben in der Liste – ideal für schnelle Eingaben am Set.
+## Speicher-, Teil- & Import-Drill
 
-### 📋 Geräteliste
-Der Generator verwandelt deine Auswahl in eine nach Kategorien sortierte Packliste:
+Dieser kurze Ablauf sollte bei neuen Teammitgliedern, frisch eingerichteten Workstations oder größeren Updates durchgeführt werden. Er zeigt, dass Speichern, Teilen, Import, Backup und Restore ohne Netzwerk funktionieren.
 
-- Klicke auf **Geräteliste erstellen**, um ausgewähltes Equipment und Projektanforderungen in einer Tabelle zu bündeln.
-- Die Tabelle aktualisiert sich automatisch, sobald Geräteauswahl oder Anforderungen wechseln.
-- Einträge werden nach Kategorien gruppiert (Kamera, Optik, Strom, Monitoring, Rigging, Grip, Zubehör, Verbrauchsmaterial) und Duplikate zusammengeführt.
-- Benötigte Kabel, Rigging und Zubehör für Monitore, Motoren, Gimbals und Wetterszenarien werden automatisch ergänzt.
-- Szenario-Auswahlen ergänzen passendes Equipment:
-  - *Handheld* + *Easyrig* ergänzt einen teleskopischen Griff für stabilen Halt.
-  - *Gimbal* fügt den gewählten Gimbal, Magic-Arms, Spigots sowie Sonnenblenden oder Filtersets hinzu.
-  - *Outdoor* liefert Spigots, Schirme und CapIt-Regenhauben.
-  - Die Szenarien *Vehicle* und *Steadicam* bringen Halterungen, Iso-Arme und Saugnäpfe mit, wo nötig.
-- Objektiv-Auswahlen listen Frontdurchmesser, Gewicht, Rod-Daten und Mindestfokus, ergänzen Linsensupports und Matte-Box-Adapter und warnen vor inkompatiblen Rod-Standards.
-- Akkuzeilen spiegeln die Mengen aus dem Stromrechner und berücksichtigen Hotswap-Platten oder ausgewählte Hotswap-Geräte.
-- Monitoring-Präferenzen weisen Standardmonitore für jede Rolle (Regie, DoP, Fokus usw.) mit Kabelsets und Funkempfängern zu.
-- Das Formular **Projektanforderungen** liefert die Daten für die Liste:
-  - **Projektname**, **Produktion**, **Verleih** und **DoP** erscheinen in der Kopfzeile der gedruckten Anforderungen.
-  - **Crew**-Einträge erfassen Namen, Rollen und E-Mail-Adressen, damit Kontaktdaten mit dem Projekt reisen.
-  - **Prep-Tage** und **Drehtage** liefern Planungsnotizen und empfehlen bei Außenszenarien Wetter-Equipment.
-  - **Verpflichtende Szenarien** fügen passendes Rigging, Gimbals und Wetterschutz hinzu.
-  - **Kameragriff** und **Sucher-Erweiterung** tragen die gewählten Komponenten oder Verlängerungen ein.
-  - Optionen für **Matte Box** und **Filter** ergänzen das gewünschte System samt nötiger Trays, Clamp-Adapter oder Filter.
-  - Einstellungen für **Monitoring**, **Videoverteilung** und **Sucher** fügen Monitore, Kabel und Overlays für jede Rolle hinzu.
-  - **User Buttons** und **Stativ-Präferenzen** werden für schnellen Zugriff aufgeführt.
-- Innerhalb der Kategorien sind die Einträge alphabetisch sortiert und zeigen beim Hover Tooltips an.
-- Die Geräteliste ist Teil der druckbaren Übersichten und der exportierten Projektdateien.
-- Gerätelisten werden automatisch mit dem Projekt gespeichert und sowohl in Exporten als auch in Backups abgelegt.
-- **Geräteliste löschen** entfernt die gespeicherte Liste und blendet die Ausgabe aus.
-- In den Formularen stehen Gabel-Schaltflächen bereit, um Benutzereinträge sofort zu duplizieren.
+1. **Baseline-Save.** Aktuelles Projekt öffnen, manuell speichern und den Zeitstempel merken. Innerhalb von zehn Minuten sollte ein Auto-Backup erscheinen.
+2. **Redundanz-Export.** Planner-Backup und Projekt-Bundle exportieren, ggf. `.cpproject`-Konvention nutzen, auf getrennten Medien sichern.
+3. **Restore-Generalprobe.** In einem privaten Profil oder zweiten Gerät Backup importieren, danach das Bundle. Gerätelisten, Dashboards, Regeln und Favoriten prüfen.
+4. **Offline-Verifikation.** Im Testprofil Netzwerk trennen, `index.html` neu laden und prüfen, ob Offline-Indikator, Uicons und Hilfsskripte sauber geladen werden.
+5. **Archivieren.** Testprofil löschen, Exporte beschriften und in die Produktions-Checkliste aufnehmen.
 
-### 📦 Gerätekategorien
-- **Kamera** (1)
-- **Monitor** (optional)
-- **Funk-Transmitter** (optional)
-- **FIZ-Motoren** (0–4)
-- **FIZ-Controller** (0–4)
-- **Distanzsensor** (0–1)
-- **Akkuplatte** (nur bei Kameras mit V‑ oder B‑Mount)
-- **V‑Mount-Akku** (0–1)
+## Täglicher Ablauf
 
-### ⚙️ Stromberechnung
-- Gesamtverbrauch in Watt
-- Stromstärke bei 14,4 V und 12 V
-- Geschätzte Akkulaufzeit in Stunden basierend auf gewichteten Community-Werten
-- Benötigte Akkumenge für einen 10-Stunden-Dreh
-- Temperaturhinweis zur Anpassung der Laufzeit bei Hitze oder Kälte
+1. **Projekt laden oder erstellen.** Namen eingeben, **Enter** oder **Speichern** drücken – der aktive Name taucht in Listen und Exporten auf.
+2. **Geräte hinzufügen.** Kameras, Strom und Zubehör aus kategorisierten Dropdowns wählen. Tippen zum Filtern, Favoriten und der Shortcut `/` (`Strg+K`/`⌘K`) beschleunigen die Auswahl.
+3. **Strom & Laufzeit prüfen.** Warnungen beobachten, Akkus vergleichen und das Laufzeit-Dashboard analysieren.
+4. **Anforderungen erfassen.** Crew, Szenarien, Handles, Matteboxen und Monitoring eintragen. Fork-Buttons duplizieren Einträge. **Einstellungen → Automatische Gear-Regeln** ergänzen Szenario-spezifische Anpassungen.
+5. **Plan exportieren.** Geräteliste generieren, Backup oder Projekt-Bundle herunterladen, bevor es ans Set geht. Backups enthalten eigene Geräte, Laufzeitdaten und Favoriten.
+6. **Offline-Bereitschaft bestätigen.** Netzwerk trennen, App neu laden und sicherstellen, dass alles erreichbar bleibt. Bei Abweichungen aus dem letzten Backup wiederherstellen.
 
-### 🔋 Akkuausgang prüfen
-- Warnt, wenn die Stromaufnahme den Akku-Ausgang (Pin oder D‑Tap) übersteigt
-- Zeigt an, wenn der Verbrauch in die Nähe des Limits (80 %) rückt
+## Speichern & Projektverwaltung
 
-### 📊 Akkuvergleich (optional)
-- Vergleicht Laufzeitschätzungen aller Akkus
-- Balkendiagramme für einen schnellen Überblick
+- **Manuelle Saves halten Versionen bewusst.** Projektnamen eingeben und **Enter**/**Speichern** drücken. Jede Version bewahrt Geräte, Anforderungen, Listen, Favoriten, Diagramm-Layouts und Laufzeitbeobachtungen.
+- **Auto-Saves schützen Fortschritt.** Während ein Projekt aktiv ist, schreibt die App Änderungen im Hintergrund. `auto-backup-…`-Einträge erscheinen alle zehn Minuten.
+- **Auto-Backups bei Bedarf einblenden.** Über **Einstellungen → Backup & Wiederherstellung → Auto-Backups anzeigen** lassen sich die Zeitstempel im Selector sichtbar machen.
+- **Umbenennen erzeugt Duplikate.** Namen ändern und **Enter** drücken erstellt eine Abzweigung – ideal für Vergleichsversionen.
+- **Projektwechsel ist verlustfrei.** Auswahl im Menü lädt sofort, Scrollposition und unsaved Inputs werden übernommen.
+- **Löschen mit Bestätigung.** Papierkorb-Symbol fragt nach, bevor Einträge entfernt werden.
 
-### 🖼 Projekt-Diagramm
-- Visualisiert Strom- und Videosignale der ausgewählten Geräte
-- Warnt, wenn FIZ-Marken nicht kompatibel sind
-- Ziehe Knoten, um das Layout neu zu ordnen, zoome mit den Schaltflächen und exportiere das Diagramm als SVG oder JPG
-- Halte Umschalt gedrückt, während du auf Download klickst, um ein JPG statt eines SVG zu exportieren
-- Fahre mit der Maus oder tippe auf Geräte, um Popover-Details zu sehen
-- Nutzt OpenMoji-Icons, wenn eine Verbindung besteht, und greift sonst auf Emoji zurück: 🔋 Akku, 🎥 Kamera, 🖥️ Monitor, 📡 Video, ⚙️ Motor, 🎮 Controller, 📐 Distanz, 🎮 Griff und 🔌 Akkuplatte
+## Teilen & Importe
 
-### 🧮 Gewichtung der Laufzeitdaten
-- Von Nutzenden gemeldete Laufzeiten verfeinern die Schätzung
-- Jeder Eintrag wird temperaturabhängig skaliert – von ×1 bei 25 °C auf:
-  - ×1,25 bei 0 °C
-  - ×1,6 bei −10 °C
-  - ×2 bei −20 °C
-- Kameraeinstellungen beeinflussen das Gewicht:
-  - Auflösungsfaktoren: ≥12K ×3, ≥8K ×2, ≥4K ×1,5, ≥1080p ×1; niedrigere Werte werden auf 1080p skaliert
-  - Bildrate skaliert linear ab 24 fps (z. B. 48 fps = ×2)
-  - Aktiviertes WLAN erhöht das Gewicht um 10 %
-  - Codec-Faktoren: RAW/BRAW/ARRIRAW/R3D/CinemaDNG/Canon RAW/X‑OCN ×1; ProRes ×1,1; DNx/AVID ×1,2; All‑Intra ×1,3; H.264/AVC ×1,5; H.265/HEVC ×1,7
-  - Monitor-Einträge unterhalb der angegebenen Helligkeit werden gemäß ihrem Helligkeitsverhältnis gewichtet
-- Das Endgewicht spiegelt den Anteil jedes Geräts am Gesamtverbrauch wider, sodass passende Projekte stärker zählen
-- Der gewichtete Durchschnitt kommt zum Einsatz, sobald mindestens drei Einträge verfügbar sind
-- Ein Dashboard sortiert die Einträge nach Gewicht und zeigt den prozentualen Anteil für den schnellen Vergleich
+- **Projekt-Bundles bleiben leichtgewichtig.** **Projekt exportieren** speichert `project-name.json` mit Projekt, Favoriten und Custom-Geräten. Optional zu `.cpproject` umbenennen und über sichere Kanäle teilen.
+- **Automatische Gear-Regeln reisen mit.** Toggle **Automatische Gear-Regeln einschließen** entscheidet, ob Regeln im Bundle landen; beim Import können Teams sie getrennt übernehmen.
+- **Standalone-Regelimporte validieren offline.** Beim Import von `auto-gear-rules-*.json` prüft der Planner Dateityp, Semver und Zeitstempel, bevor Regeln überschrieben werden. Alte/neue Builds lösen Warnungen aus; bei Fehlern wird der vorherige Snapshot automatisch wiederhergestellt.
+- **Restores sind doppelt gepuffert.** Vor jedem Import wird ein Backup des aktuellen Zustands erzwungen. Danach wird das Bundle validiert und oben in der Liste platziert.
+- **Cross-Device bleibt offline.** Kopiere `index.html`, `script.js`, `devices/` sowie Backups/Bundles auf Wechseldatenträger, öffne von dort und arbeite ohne Netzwerk.
+- **Exporte prüfen.** JSON vor dem Teilen sichten, um unerwünschte Inhalte auszuschließen. Struktur ist lesbar und kann bei Bedarf redigiert werden.
+- **Mit Checklisten synchronisieren.** Bei neuen Bundles `Updated at`-Zeitstempel prüfen und alte JSONs archivieren.
+- **Kontext bewahren.** Bundles merken Sprache, Theme, Logos und Personalisierungen, damit Empfänger vertraut starten – auch offline.
 
-### 🔍 Suche & Filter
-- Tippe in Dropdowns, um Einträge schnell zu finden
-- Filtere Gerätelisten über ein Suchfeld
-- Nutze die globale Suche oben, um zu Funktionen, Geräten oder Hilfethemen zu springen; drücke Enter zum Navigieren, / oder Strg+K (⌘K auf macOS) zum sofortigen Fokussieren und Escape oder × zum Löschen
-- Drücke „/" oder Strg+F (⌘F auf macOS), um das nächstgelegene Suchfeld sofort zu fokussieren
-- Klicke auf den Stern neben einer Auswahl, um Favoriten oben zu pinnen und in Backups mitzunehmen
+## Projekt- & Backup-Dateiformate
 
-### 🛠 Geräte-Datenbank-Editor
-- Geräte in allen Kategorien hinzufügen, bearbeiten oder löschen
-- Gesamte Datenbank als JSON importieren oder exportieren
-- Zur Standarddatenbank aus `src/data/index.js` zurückkehren
+- **`project-name.json` (Projekt-Bundle).** Enthält ein Projekt, Favoriten und referenzierte Custom-Geräte. `.cpproject` wird gleich behandelt.
+- **`planner-backup.json` (Vollbackup).** **Einstellungen → Backup & Wiederherstellung → Backup** speichert alle Projekte, Auto-Backups, Favoriten, Laufzeitfeedback, Regeln, UI-Präferenzen, Fonts und Branding.
+- **`auto-gear-rules-*.json` (Regel-Exports).** Zeitgestempelte Sicherungen der Automations-Setups inklusive Metadaten zur Offline-Validierung.
 
-### 🌓 Dunkelmodus
-- Über die Mondschaltfläche neben dem Sprachmenü umschalten
-- Die Einstellung wird im Browser gespeichert
+## Interface-Rundgang
 
-### 🦄 Rosa Modus
-- Auf den Einhorn-Button klicken (im aktiven Pinkmodus wechseln die Einhorn-Icons alle 30 Sekunden mit einer sanften Pop-Animation und beim Verlassen erscheint wieder das Pferd) oder **P** drücken, um den spielerischen rosa Akzent zu aktivieren
-- Funktioniert im hellen und dunklen Theme und bleibt zwischen Besuchen erhalten
+### Schnellüberblick
 
-### ⚫ High-Contrast-Modus
-- Aktiviert ein kontrastreiches Theme für bessere Lesbarkeit
+- **Globale Suche** (`/`, `Strg+K`, `⌘K`) springt zu Features, Selektoren oder Hilfethemen – selbst bei versteckter Navigation.
+- **Help-Center** (`?`, `H`, `F1`, `Strg+/`) liefert Guides, Shortcuts, FAQs und Hover-Hilfe.
+- **Projektdiagramm** visualisiert Strom- und Signalpfade; mit gedrückter Umschalttaste als JPG exportieren.
+- **Akkuvergleich** zeigt Leistung kompatibler Packs und warnt vor Überlast.
+- **Gerätelistengenerator** erstellt kategorisierte Tabellen mit Metadaten, Crew-E-Mails und Szenario-Zubehör.
+- **Offline-Badge & Neu laden erzwingen** zeigen Verbindungsstatus und aktualisieren Assets ohne Datenverlust.
 
-### 📝 Laufzeit-Feedback
-- Klicke unter der Laufzeit auf <strong>Nutzer-Laufzeit-Feedback senden</strong>, um eigene Messungen hinzuzufügen
-- Optional Temperatur eintragen, um die Gewichtung zu verfeinern
-- Einträge werden im Browser gespeichert und verbessern künftige Schätzungen
-- Ein Dashboard sortiert Beiträge nach Gewicht, zeigt prozentuale Anteile und hebt Ausreißer hervor, damit Crews Feedback schneller bewerten können
+### Top-Bar-Steuerung
 
-### ❓ Durchsuchbare Hilfe
-- Über die Schaltfläche <strong>?</strong> oder per <kbd>?</kbd>, <kbd>H</kbd>, <kbd>F1</kbd> oder <kbd>Strg+/</kbd> öffnen
-- Mit dem Suchfeld Themen sofort filtern; die Eingabe wird beim Schließen zurückgesetzt
-- Mit <kbd>Escape</kbd> oder Klick außerhalb des Dialogs schließen
+- Skip-Link, Offline-Indikator und responsive Branding halten die Navigation zugänglich.
+- Globale Suche fokussiert mit `/` oder `Strg+K` (`⌘K`), öffnet auf Mobilgeräten das Menü und lässt sich mit Escape leeren.
+- Sprachwechsel, Dark/Pink-Theme und Einstellungen sitzen in der Kopfleiste; dort lassen sich Akzentfarbe, Schriftgröße, Schriftart, High-Contrast, Custom-Logo sowie Backup-, Restore- und Factory-Reset-Tools (immer mit Sicherung) steuern.
+- Hilfe-Button öffnet den Suchdialog und reagiert jederzeit auf `?`, `H`, `F1` oder `Strg+/`.
+- Der 🔄-Button entfernt gecachte Assets und lädt die App ohne Projektdaten zu löschen.
 
----
+### Navigation & Suche
 
-## ▶️ So nutzt du die Anwendung
-1. **Anwendung starten:** Öffne `index.html` in einem modernen Browser – kein Server nötig.
-2. **Top-Bar erkunden:** Sprache wechseln, Dunkel- oder Rosa-Theme umschalten, Einstellungen für Akzent und Typografie öffnen und den Hilfedialog mit ? oder Strg+/ starten.
-3. **Geräte auswählen:** Wähle über Dropdowns das Equipment je Kategorie; tippe zum Filtern, pinne Favoriten mit dem Stern und lass Szenario-Voreinstellungen Zubehör automatisch ergänzen.
-4. **Berechnungen ansehen:** Gesamtverbrauch, Strom und Laufzeit erscheinen, sobald ein Akku gewählt ist; Warnungen markieren überschrittene Grenzen.
-5. **Projekte speichern & exportieren:** Benenne und speichere deine Konfiguration, Auto-Backups erstellen Schnappschüsse und die Export-Schaltfläche lädt ein JSON-Paket für das Team, während Import alles wiederherstellt.
-6. **Geräteliste generieren:** Drücke **Geräteliste erstellen**, um Anforderungen in eine kategorisierte Packliste mit Tooltips und Zubehör zu verwandeln.
-7. **Gerätedaten verwalten:** Über „Gerätedaten bearbeiten…" den Editor öffnen, Geräte anpassen, JSON exportieren/importieren oder auf Standardwerte zurücksetzen.
-8. **Laufzeit-Feedback senden:** Mit „Nutzer-Laufzeit-Feedback senden" Messwerte aus der Praxis erfassen und die Gewichtung verbessern.
+- Auf kleinen Bildschirmen spiegelt ein einklappbares Seitenmenü alle Hauptsektionen.
+- Dropdowns und Editorlisten unterstützen Inline-Suche und Tippen zum Filtern. `/` oder `Strg+F` (`⌘F`) fokussiert das nächste Suchfeld.
+- Sterne pinnen Favoriten in Selektoren und sichern sie in Backups.
 
-## 📱 Als Anwendung installieren
+## Anpassung & Barrierefreiheit
 
-Cine Power Planner ist eine Progressive-Web-App und lässt sich direkt aus dem Browser installieren:
+- Wechsel zwischen Light, Dark, Pink und High-Contrast; Akzentfarbe, Basis-Schriftgröße und Typografie bleiben offline gespeichert.
+- Skip-Link, sichtbare Fokuszustände und responsives Layout unterstützen Tastatur, Tablet und Phone.
+- Tastenkürzel decken Suche (`/`, `Strg+K`, `⌘K`), Hilfe (`?`, `H`, `F1`, `Strg+/`), Speichern (`Enter`, `Strg+S`, `⌘S`), Dark Mode (`D`) und Pink Theme (`P`) ab.
+- Hover-Hilfe verwandelt Buttons, Felder, Dropdowns und Header in Tooltips.
+- Lade ein eigenes Logo für Overviews, setze Monitoring-Defaults und Anforderungspresets.
+- Fork-Buttons duplizieren Einträge, Favoriten halten häufige Geräte griffbereit.
 
-- **Chrome/Edge (Desktop):** Auf das Installationssymbol in der Adressleiste klicken.
-- **Android:** Browsermenü öffnen und *Zum Startbildschirm hinzufügen* wählen.
-- **iOS/iPadOS Safari:** Auf *Teilen* tippen und *Zum Home-Bildschirm* auswählen.
+## Datensicherheit & Offline-Betrieb
 
-Nach der Installation startet die Anwendung vom Startbildschirm, funktioniert offline und aktualisiert sich automatisch.
+- Service Worker cached alle Assets, Updates warten auf deine Freigabe via **Neu laden erzwingen**.
+- Projekte, Laufzeitdaten, Favoriten, Custom-Geräte, Themes und Listen liegen im Browser-Speicher. Unterstützte Browser erhalten Persistenz-Anfragen, um Löschrisiken zu mindern.
+- Repository lokal öffnen oder intern hosten, damit sensible Daten nicht nach außen gelangen. Exporte sind menschenlesbar und auditierbar.
+- Kopfzeile zeigt Offline-Indikator, Force-Reload aktualisiert Assets ohne Saves anzutasten.
+- **Werkseinstellungen** oder das Löschen der Website-Daten erfolgt erst nach einem automatischen Backup.
+- Service-Worker-Updates laden im Hintergrund und warten auf deine Bestätigung. Bei **Update bereit**: Änderungen abschließen, Backup erstellen, dann **Neu laden erzwingen**.
+- Speicherung erfolgt in IndexedDB, kleine Präferenzen spiegeln nach `localStorage`. Entwickler-Tools können Rohdaten exportieren.
 
-## 📡 Offline-Nutzung & Datenspeicherung
+## Daten- & Speicherübersicht
 
-Beim Ausliefern über HTTP(S) installiert sich ein Service Worker, der alle Dateien zwischenspeichert, sodass Cine Power Planner vollständig offline läuft und Updates im Hintergrund lädt. Projekte, Laufzeit-Einreichungen und Einstellungen (Sprache, Theme, Rosa-Modus, gespeicherte Gerätelisten) liegen im `localStorage` deines Browsers. Das Löschen der Seitendaten entfernt alle Informationen; im Einstellungsdialog gibt es dafür den Workflow **Werkseinstellungen**, der vor dem Leeren automatisch eine Sicherung speichert. Die Kopfzeile blendet ein Offline-Badge ein, sobald die Verbindung wegfällt, und die Aktion 🔄 **Neu laden erzwingen** aktualisiert gecachte Assets, ohne Projekte anzutasten.
+- **Einstellungen → Daten & Speicher** listet gespeicherte Projekte, Auto-Backups, Gerätelisten, Custom-Geräte, Favoriten, Laufzeitfeedback und Session-Cache mit Live-Zahlen.
+- Einträge erklären ihre Inhalte; leere Bereiche bleiben verborgen, damit du den Zustand sofort siehst.
+- Die Übersicht schätzt die Backup-Größe basierend auf dem jüngsten Export.
 
----
+## Speicherbudget & Wartung
 
-## 🗂️ Verzeichnisstruktur
-```bash
-index.html                 # Zentrales HTML-Layout
-src/styles/style.css       # Styles und Layout
-src/styles/overview.css    # Gestaltung der Übersicht
-src/styles/overview-print.css # Druck-Styles für die Übersicht
-src/scripts/script.js        # Anwendungslogik
-src/scripts/storage.js       # Hilfsfunktionen für LocalStorage
-src/scripts/static-theme.js  # Gemeinsame Theme-Logik für die Rechtstexte
-src/data/index.js       # Standard-Geräteliste
-src/data/devices/       # Gerätekataloge nach Kategorie
-src/data/schema.json    # Generiertes Schema für Auswahllisten
-src/vendor/             # Gebündelte Drittanbieter-Bibliotheken
-legal/                     # Offline-Rechtstexte
-tools/                     # Skripte zur Datenpflege
-tests/                     # Jest-Test-Suite
-```
-Schriftarten werden lokal über `fonts.css` eingebunden; sobald die Assets im Cache liegen, funktioniert die Anwendung komplett offline.
+- **Persistenten Speicher prüfen.** Auf jeder Workstation den Status unter **Einstellungen → Daten & Speicher** kontrollieren. Bei Ablehnung häufiger exportieren.
+- **Quota im Blick behalten.** Speicher-Dashboard oder Browser-Inspector nutzen. Bei wenig Platz ältere Backups archivieren, `auto-backup-…`-Einträge bereinigen und neue Exporte testen.
+- **Caches nach Updates vorbereiten.** Nach **Neu laden erzwingen** Hilfe-Dialog, Legal-Seiten und häufig genutzte Ansichten öffnen, damit Uicons, OpenMoji und Fonts erneut lokal vorliegen.
+- **Speicherstatus dokumentieren.** Checks in Prep- und Wrap-Logs aufnehmen: Persistenz-Status, freier Speicher, Speicherort der aktuellen Backups.
 
-## 🛠️ Entwicklung
-Benötigt Node.js 18 oder neuer.
+## Backup & Wiederherstellung
 
-```bash
-npm install
-npm run lint     # führt nur ESLint aus
-npm test         # startet Linting, Datenprüfungen und Jest-Tests
-```
+- **Gespeicherte Projektsnapshots** – Projektliste speichert alle Saves und erzeugt alle zehn Minuten `auto-backup-…`.
+- **Vollbackups** – **Einstellungen → Backup & Wiederherstellung → Backup** erstellt `planner-backup.json` inkl. aller Projekte, Geräte, Regeln und UI-States; vor jeder Wiederherstellung wird ein Sicherheitsbackup angelegt.
+- **Verborgene Migrations-Backups** – Vor Überschreibungen wird der vorige JSON-Snapshot im geschützten `__legacyMigrationBackup` abgelegt und bei Fehlern automatisch wiederhergestellt.
+- **Automatische Regel-Snapshots** – Änderungen in **Automatische Gear-Regeln** erzeugen alle zehn Minuten Sicherheitskopien.
+- **Factory Reset** – löscht Daten erst nach automatischem Backup.
+- **Stündliche Erinnerungen** – Hintergrundroutine fordert stündlich zu Backups auf.
+- **Verifikation** – Nach jedem kritischen Backup Import in einem Testprofil prüfen.
+- **Sichere Aufbewahrung** – Backups mit Projektname/Zeitstempel beschriften und auf redundanten Medien lagern.
+- **Vor Überschreiben vergleichen** – Vor Restores frisches Backup ziehen und Unterschiede prüfen.
 
-Nach Änderungen an den Gerätedaten die normalisierte Datenbank neu erzeugen:
+## Datenintegritäts-Drills
+
+- **Pre-Flight (täglich/vor größeren Änderungen).** Manuell speichern, Backup und Bundle exportieren, in Testprofil importieren, prüfen, löschen.
+- **Offline-Probe (wöchentlich/vor Reisen).** Planner laden, Backup erstellen, offline gehen, `index.html` neu laden und auf klare Assets achten.
+- **Change-Control (nach Daten-/Script-Updates).** `npm test` laufen lassen und danach Pre-Flight wiederholen; Backup mit Changelog archivieren.
+- **Redundanz-Rotation (monatlich/vor Archivierung).** Neueste Backups, Bundle (ggf. `.cpproject`) und Repository-ZIP auf zwei Medien lagern und abwechselnd testen.
+
+## Operative Checklisten
+
+Print-freundliche Versionen findest du in `docs/operations-checklist.md`; der Travel-Guide `docs/offline-readiness.md` vertieft die Abläufe.
+
+### Pre-Shoot-Readiness
+
+1. Richtige Repository-Version prüfen, **Neu laden erzwingen**, Version in **Einstellungen → Info** vergleichen, Legal-Seiten öffnen um Uicons/OpenMoji/Fonds zu cachen.
+2. Kritische Projekte und aktuelles `auto-backup-…` öffnen, Gearlisten, Feedback und Favoriten prüfen.
+3. Änderung vornehmen, `Enter` oder `Strg+S`/`⌘S` speichern, `planner-backup.json` exportieren, in Testprofil importieren und Liste vergleichen.
+4. `project-name.json` exportieren, importieren, Regeln/Custom-Geräte/Offline-Badge prüfen, Profil löschen.
+5. Netzwerk trennen, Offline-Badge prüfen, Icons betrachten, Projekte öffnen.
+6. Verifizierte Backups/Bundles plus Repository-ZIP redundant sichern.
+
+### Wrap-Day-Handoff
+
+1. Letztes Backup und Bundle exportieren, mit Datum/Ort/Unit beschriften.
+2. Im Verifikationsgerät importieren und auf Fehler prüfen, Gerät offline halten.
+3. Änderungen dokumentieren (welche Auto-Backups befördert wurden, neue Geräte, Regeländerungen) und den Notizen beilegen.
+4. Nach Archivierung **Neu laden erzwingen**, Hilfe-Dialog und Legal-Seiten öffnen, damit Caches aktuell sind.
+5. Redundante Medien an Storage-Team übergeben und zweiten Satz gemäß Datenrichtlinie aufbewahren.
+
+## Notfall-Wiederherstellungsplan
+
+1. **Stoppen und Zustand sichern.** Tab offen lassen, Netzwerk trennen, Zeit und Offline-Status notieren, nicht neu laden.
+2. **Vorhandenes exportieren.** **Einstellungen → Backup & Wiederherstellung → Backup** auslösen und `planner-backup.json` sichern – enthält Auto-Backups, Favoriten, Laufzeitdaten und Regeln.
+3. **Auto-Backups duplizieren.** `auto-backup-…`-Einträge einblenden, jüngste Snapshots zu manuellen Saves hochstufen und mit Incident-ID versehen.
+4. **Verifikations-Bundle prüfen.** Letztes gutes Bundle (`project-name.json`/`.cpproject`) in privatem Profil oder zweitem Gerät offline importieren und Daten vergleichen.
+5. **Sorgfältig wiederherstellen.** Wenn Verifikation passt, frisches Backup im Hauptprofil importieren. Vorheriges Backup bleibt für JSON-Diff-Vergleiche erhalten.
+6. **Caches erneuern & dokumentieren.** Danach **Neu laden erzwingen**, Hilfe- und Legal-Seiten öffnen, Vorfall protokollieren (Zeit, Exporte, Speicherorte, Prüfgerät) und Log zum Backup legen.
+
+## Gerätelisten & Reporting
+
+- **Geräteliste erzeugen** wandelt Auswahl und Anforderungen in kategorisierte Tabellen um; Aktualisierung erfolgt automatisch bei Änderungen.
+- Einträge gruppieren nach Kategorie, Duplikate werden zusammengeführt. Szenarien ergänzen passende Rigs, Wetter- oder Spezialzubehör.
+- Automatische Regeln laufen nach dem Generator und fügen szenariospezifische Anpassungen hinzu.
+- Objektivreihen enthalten Frontdurchmesser, Gewicht, Naheinstellgrenze, Rod-Anforderungen und Mattebox-Komponenten. Akkureihen berücksichtigen Rechnercounts und Hot-Swap-Hardware.
+- Crewdetails, Monitoring, Verteilung und Notizen erscheinen in Exporten.
+- Listen werden mit dem Projekt gespeichert, erscheinen in Overviews, Bundles und lassen sich mit **Geräteliste löschen** zurücksetzen.
+
+## Automatische Gear-Regeln
+
+**Einstellungen → Automatische Gear-Regeln** ermöglicht Feintuning ohne JSON-Bearbeitung:
+
+- Regeln nur aktivieren, wenn bestimmte **Pflichtszenarien** gewählt sind; optionale Labels erleichtern das Scannen.
+- Equipment mit Kategorie und Anzahl hinzufügen oder **Custom Additions** für Hinweise/Spezialkits verwenden. Entfernen-Regeln blenden bestimmte Zeilen aus.
+- Regeln laufen nach den Standardpaketen, greifen nahtlos in Gearlisten, Backups und Bundles ein.
+- Gespeicherte Listen behalten die aktive Regelmenge; beim Laden oder Import bleibt der Regelkontext erhalten.
+- Regelsets als JSON exportieren/importieren, auf Werkseinstellungen zurücksetzen oder auf die automatische Historie (alle zehn Minuten) zurückgreifen.
+
+## Runtime-Intelligenz
+
+Von Nutzer:innen gemeldete Laufzeiten fließen in ein gewichtetetes Modell:
+
+- Temperaturfaktoren: ×1 bei 25 °C, ×1,25 bei 0 °C, ×1,6 bei −10 °C, ×2 bei −20 °C.
+- Auflösung: ≥12K ×3, ≥8K ×2, ≥4K ×1,5, ≥1080p ×1, darunter proportional.
+- Framerate skaliert linear ab 24 fps (48 fps = ×2).
+- WLAN aktiv +10 %.
+- Codec-Faktoren: RAW/BRAW/ARRIRAW/R3D/CinemaDNG/Canon RAW/X‑OCN ×1; ProRes ×1,1; DNx/AVID ×1,2; All-Intra ×1,3; H.264/AVC ×1,5; H.265/HEVC ×1,7.
+- Monitor-Werte werden nach Helligkeitsverhältnis gewichtet.
+- Finale Gewichtung reflektiert den Anteil am Gesamtdraw, damit ähnliche Rigs mehr Einfluss haben.
+- Dashboard sortiert nach Gewicht, zeigt Prozentanteile und markiert Ausreißer.
+
+## Tastenkürzel
+
+| Shortcut | Aktion | Hinweise |
+| --- | --- | --- |
+| `/`, `Strg+K`, `⌘K` | Globale Suche fokussieren | Funktioniert auch bei eingeklappter Navigation, `Esc` löscht |
+| `Enter`, `Strg+S`, `⌘S` | Aktives Projekt speichern | Button bleibt deaktiviert bis ein Name gesetzt ist |
+| `?`, `H`, `F1`, `Strg+/` | Hilfe öffnen | Dialog bleibt durchsuchtbar |
+| `D` | Dark Mode umschalten | Ebenfalls in **Einstellungen → Themes** |
+| `P` | Pinkes Theme umschalten | Funktioniert mit Light, Dark, High-Contrast |
+| 🔄 | Gecachte Assets neu laden | Auch über **Einstellungen → Neu laden erzwingen** |
+
+## Lokalisierung
+
+Neue Sprachen lassen sich sofort testen – kein Build nötig:
+
+1. README duplizieren und übersetzen (`README.<lang>.md`).
+2. UI-Strings in `translations.js` ergänzen; Platzhalter wie `%s` erhalten.
+3. Statische Seiten (Privacy, Impressum) kopieren und übersetzen.
+4. `npm test` ausführen, bevor ein Pull Request entsteht.
+
+## Als App installieren
+
+Cine Power Planner ist eine Progressive Web App:
+
+1. `index.html` in einem unterstützten Browser öffnen.
+2. Über **Installieren** oder **Zum Home-Bildschirm hinzufügen** installieren.
+   - **Chrome/Edge (Desktop):** Installationssymbol in der Adressleiste.
+   - **Android:** Menü → *Zum Startbildschirm hinzufügen*.
+   - **iOS Safari:** Teilen → *Zum Home-Bildschirm*.
+3. App aus dem Launcher starten. Die Installation funktioniert offline und aktualisiert sich automatisch nach deiner Freigabe.
+
+## Gerätedaten-Workflow
+
+Gerätekataloge liegen unter `devices/`. Jede Datei bündelt verwandte Ausrüstung, damit Änderungen in Versionierung und App nachvollziehbar bleiben. Vor Commits helfen folgende Skripte:
 
 ```bash
 npm run normalize
@@ -323,9 +355,75 @@ npm run check-consistency
 npm run generate-schema
 ```
 
-Mit `--help` zeigen die Skripte weitere Optionen an.
+`npm run normalize` bereinigt Steckverbinder und Kurzschreibweisen. `npm run unify-ports` vereinheitlicht Ports. `npm run check-consistency` prüft Pflichtfelder, `npm run generate-schema` aktualisiert `schema.json`. Datenspezifische Tests laufen mit:
 
-`npm run help` liefert eine kompakte Übersicht der Wartungsskripte und ihrer empfohlenen Reihenfolge.
+```bash
+npm run test:data
+```
 
-## 🤝 Mitmachen
-Beiträge sind jederzeit willkommen! Eröffne gerne ein Issue oder sende einen Pull Request. Für Datenkorrekturen helfen angehängte Projekt-Backups oder Laufzeitbeispiele, damit der Gerätekatalog für alle verlässlich bleibt.
+`npm run help` listet alle Skripte, `--help` liefert Details.
+
+## Entwicklung
+
+Node.js 18 oder neuer installieren, dann:
+
+```bash
+npm install
+npm run lint
+npm test
+```
+
+`npm test` führt ESLint, Datenprüfungen und Jest nacheinander aus (`--runInBand`, `maxWorkers=1`). Spezielle Suites beim Entwickeln:
+
+```bash
+npm run test:unit
+npm run test:data
+npm run test:dom
+npm run test:script
+```
+
+### Legacy-Browser-Bundle
+
+Nach Änderungen in `src/scripts/` oder `src/data/` `npm run build:legacy` ausführen. Dadurch wird das ES5-Bundle unter `legacy/` neu erzeugt und lokale Polyfills bleiben aktuell.
+
+### Struktur
+
+```
+index.html
+src/styles/style.css
+src/styles/overview.css
+src/styles/overview-print.css
+src/scripts/script.js
+src/scripts/storage.js
+src/scripts/static-theme.js
+src/data/index.js
+src/data/devices/
+src/data/schema.json
+src/vendor/
+legal/
+tools/
+tests/
+```
+
+## Fehlerbehebung
+
+- **Service Worker hängt?** **Neu laden erzwingen** oder Hard Reload aus Entwickler-Tools.
+- **Daten fehlen nach Tab-Schluss?** Speichereinstellungen prüfen; Private Mode kann Persistenz blockieren.
+- **Downloads blockiert?** Mehrfachdownloads erlauben.
+- **CLI-Skripte fehlschlagen?** Node.js 18+, `npm install`, dann Skript erneut. Bei Memory-Errors gezielt `npm run test:unit` etc. nutzen.
+
+## Feedback & Support
+
+Bitte Issues anlegen, wenn Probleme auftreten, Fragen bestehen oder Feature-Ideen auftauchen. Exporte oder Laufzeit-Beispiele helfen dabei, den Katalog korrekt zu halten.
+
+## Mitwirken
+
+Beiträge sind willkommen! Nach dem Lesen von `CONTRIBUTING.md` Issues eröffnen oder Pull Requests stellen. Vorab `npm test` ausführen.
+
+## Danksagungen
+
+Die App liefert lokale Uicons, OpenMoji-Assets und weitere gebündelte Grafiken, damit Icons auch offline verfügbar sind, und nutzt lz-string zum kompakten Speichern in URLs und Backups.
+
+## Lizenz
+
+Veröffentlicht unter der ISC-Lizenz. Details siehe `package.json`.

--- a/README.en.md
+++ b/README.en.md
@@ -1,353 +1,730 @@
-# 🎥 Cine Power Planner
+# Cine Power Planner
 
-This browser based tool helps plan professional camera projects powered by V‑Mount, B‑Mount or Gold-Mount batteries. It calculates **total power consumption**, **current draw** (at 14.4 V and 12 V) and **estimated battery runtime** while checking that the battery can safely supply the required power.
+![Cine Power Planner icon](src/icons/app-icon.svg)
 
-All planning, inputs and exports stay on the device in front of you. Language
-choice, projects, custom equipment, favorites and runtime feedback live in your
-browser, and service worker updates are driven directly by this repository. Run
-the planner offline from disk or host it internally so every department uses the
-same audited version.
+Cine Power Planner is a standalone web app for building, auditing and sharing
+professional camera power plans that never leave your machine. Plan V‑Mount,
+B‑Mount or Gold‑Mount rigs, model runtime expectations, capture project
+requirements and export shareable bundles—entirely inside your browser, even
+when you are offline. Every dependency lives in this repository so the same
+experience runs on a stage workstation, a field laptop or an air-gapped archive
+drive without phoning home.
 
-## At a glance
+## At a Glance
 
-- **Plan without a network.** Every icon, font and helper script ships inside this repository so you can open `index.html`
-  directly and work offline.
-- **Keep projects on-device.** Saves, runtime feedback, custom devices, favorites and gear lists remain local; backups and
-  shareable bundles are human-readable JSON.
-- **Stay in control of updates.** The service worker only refreshes after you press **Force reload**, keeping crews on a trusted
-  build during travel.
-- **Rely on layered safety nets.** Manual saves, auto-saves and timestamped auto-backups make it easy to rehearse recovery before
-  a shoot.
+- **Plan offline-first.** Build V‑Mount, B‑Mount or Gold‑Mount setups directly
+  in your browser. Every icon, font and helper script ships with the
+  repository so nothing relies on external CDNs or network access. Clone the
+  repo, unplug the network cable and the interface keeps working exactly as it
+  did online.
+- **Keep data on-device.** Projects, runtime feedback, favorites, custom
+  devices, gear lists and settings stay local. Backups and shareable bundles are
+  human-readable JSON files you control.
+- **Verify safety nets quickly.** Manual saves, background auto-saves and
+  timestamped auto-backups layer together so you can rehearse recovery before
+  leaving for set. Practicing the save → backup → bundle → restore loop is part
+  of the recommended first-run routine so crews confirm every safeguard.
+- **Approve updates intentionally.** The service worker waits for you to
+  confirm a refresh, keeping teams on a known-good revision during travel or
+  low-connectivity shoots.
 
-## Quick start
+## Overview
 
-1. Download or clone the repository and open `index.html` in a modern browser.
-2. (Optional) Serve the folder locally (for example with `npx http-server` or `python -m http.server`) so the service worker
-   registers and caches assets for offline use.
-3. Load the planner once, close the tab, go offline and reopen `index.html`. The offline badge should flash briefly while the
-   cached interface loads.
-4. Create a project, press **Enter** (or **Ctrl+S**/`⌘S`) to save and watch for the automatic backup that appears after a few
-   minutes.
-5. Export **Settings → Backup & Restore → Backup**, import the file in a private browser profile and confirm every project,
-   favorite and custom device restores correctly.
-6. Practice exporting a `.cpproject` bundle and importing it on another machine or profile so the save → share → import loop is
-   proven before you arrive on set.
+### Built for crews
 
-## Core workflows
+The planner was designed with ACs, data wranglers and DoPs in mind. As you add
+or swap bodies, battery plates, wireless links and accessories, the total draw
+and runtime estimates update instantly. Safety warnings flag overloaded packs,
+and gear lists stay tied to project context so nothing slips through when you
+hand off prep notes.
 
-- **Plan a rig.** Combine cameras, plates, wireless links, monitors, motors and accessories while watching draw calculations and
-  runtime estimates update instantly.
-- **Save versions.** Maintain explicit project snapshots and let timestamped auto-backups capture in-progress work every 10
-  minutes.
-- **Share securely.** Export `.cpproject` bundles that stay offline, validate schema on import and optionally include automatic
-  gear rules.
-- **Back up everything.** Full planner backups include projects, favorites, custom devices, runtime data and UI preferences so no
-  context is lost.
-- **Hidden migration backups.** Before overwriting planners, setups or
-  preferences, the app preserves the previous JSON snapshot inside the protected
-  `__legacyMigrationBackup` slot. If a write ever fails or produces corrupt
-  data, the recovery tools automatically fall back to that safety copy so no
-  user data disappears.
+### Designed to travel
 
-## Protecting data offline
+Open `index.html` directly from disk or host the repository on your internal
+network—no build process, server dependencies or accounts required. A service
+worker keeps the whole app available offline, remembers every preference and
+only updates when you approve a refresh. Saving, sharing, import, backup and
+restore tools are always available and always run locally so user data stays
+safe.
 
-- Verify offline readiness regularly: load the app, disconnect, refresh and confirm your projects stay accessible.
-- Keep redundant backups on labelled storage and re-import them in a secondary profile after every export.
-- Before applying updates or major data edits, capture a manual backup and confirm it restores cleanly.
+### Why offline-first matters
 
----
+Film sets rarely have guaranteed connectivity, and studios frequently require
+air-gapped planning tools. Cine Power Planner delivers the exact same
+capabilities regardless of connection status: every asset is bundled, every
+workflow runs locally and every save creates artifacts you can archive on
+redundant media. Validating those workflows before a shoot becomes a standard
+checklist item so nothing relies on an external service in the middle of a
+production day.
 
-## 🌍 Languages
+### Feature pillars
+
+- **Plan with confidence.** Calculate draw at 14.4 V/12 V (and 33.6 V/21.6 V for
+  B‑Mount), compare compatible batteries and visualize runtime impact through a
+  weighted feedback dashboard.
+- **Stay production-ready.** Projects capture devices, requirements, scenarios,
+  crew details and gear lists; auto-backups, shareable bundles and forced
+  refreshes keep data current without sacrificing stability.
+- **Work the way you prefer.** Language detection, dark, pink and high-contrast
+  themes, typography controls, custom logos and hover help make the interface
+  approachable on set and in prep.
+
+## Core Principles
+
+- **Offline always.** The full application, including icons, legal pages and
+  helper tools, ships in this repository. Open `index.html` from disk or a
+  private intranet and the service worker keeps every locally stored asset in
+  sync so you are never forced online.
+- **No hidden data paths.** Saves, shareable bundles, imports, backups and
+  restores all happen inside the browser. Nothing leaves your machine unless
+  you export it.
+- **Redundant safety nets.** Manual saves, background auto-saves, periodic
+  auto-backups, forced pre-restore backups and human-readable JSON exports work
+  together so user data cannot disappear silently.
+- **Predictable updates.** Refreshes only apply when you trigger them. Cached
+  versions remain available until you approve a **Force reload**, keeping
+  planning sessions stable even when crews stay offline for extended periods.
+- **Consistent presentation.** Locally bundled Uicons, OpenMoji assets and
+  typography files guarantee identical visuals whether you run the planner on a
+  stage workstation or a field laptop with no connectivity.
+
+## Table of Contents
+
+- [At a Glance](#at-a-glance)
+- [Overview](#overview)
+- [Core Principles](#core-principles)
+- [Translations](#translations)
+- [What’s New](#whats-new)
+- [Quick Start](#quick-start)
+- [System Requirements & Browser Support](#system-requirements--browser-support)
+- [Save, Share & Import Drill](#save-share--import-drill)
+- [Everyday Workflow](#everyday-workflow)
+- [Saving & Project Management](#saving--project-management)
+- [Sharing & Imports](#sharing--imports)
+- [Project & Backup File Formats](#project--backup-file-formats)
+- [Interface Tour](#interface-tour)
+- [Customization & Accessibility](#customization--accessibility)
+- [Data Safety & Offline Operation](#data-safety--offline-operation)
+- [Data & Storage Overview](#data--storage-overview)
+- [Storage Quota & Maintenance](#storage-quota--maintenance)
+- [Backup & Recovery](#backup--recovery)
+- [Data Integrity Drills](#data-integrity-drills)
+- [Operational Checklists](#operational-checklists)
+- [Emergency Recovery Playbook](#emergency-recovery-playbook)
+- [Gear Lists & Reporting](#gear-lists--reporting)
+- [Automatic Gear Rules](#automatic-gear-rules)
+- [Runtime Intelligence](#runtime-intelligence)
+- [Keyboard Shortcuts](#keyboard-shortcuts)
+- [Localization](#localization)
+- [Install as an App](#install-as-an-app)
+- [Device Data Workflow](#device-data-workflow)
+- [Development](#development)
+- [Troubleshooting](#troubleshooting)
+- [Feedback & Support](#feedback--support)
+- [Contributing](#contributing)
+- [Acknowledgements](#acknowledgements)
+- [License](#license)
+
+## Translations
+
+Documentation is available in multiple languages. The app automatically detects
+your browser language on the first launch and you can switch at any time from
+the top-right language menu or through **Settings**.
+
 - 🇬🇧 [English](README.en.md)
 - 🇩🇪 [Deutsch](README.de.md)
 - 🇪🇸 [Español](README.es.md)
 - 🇮🇹 [Italiano](README.it.md)
 - 🇫🇷 [Français](README.fr.md)
 
-The app automatically uses your browser language on first load, and you can switch the language in the top right corner. The choice is remembered for your next visit.
+Follow the translation guide in `docs/translation-guide.md` for detailed
+localization steps.
 
----
+## What’s New
 
-## 🆕 Recent Features
-- Backup version comparisons let you pick any manual save or timestamped auto-backup to review diffs, add incident notes and export a log before rolling a change back or handing footage to post.
-- Backups now normalize legacy data bundles saved as JSON strings or entry arrays so older exports restore correctly.
-- Restore rehearsals load a full-app backup or project bundle into an isolated sandbox so you can confirm its contents match live data without touching production profiles.
-- Automatic gear rules let you design scenario-driven additions or removals, export the configuration and restore it alongside project bundles.
-- Data & storage dashboard audits saved projects, gear lists, custom devices, favorites and runtime feedback directly inside Settings.
-- Autosave status overlay mirrors the latest autosave note inside Settings so crews can see background activity while practicing recovery drills.
-- Monitoring-aware gear editor surfaces extra monitoring and video accessories only when scenarios demand them so rule authoring stays focused.
-- Accent and typography controls in Settings let you adjust the accent color, base font size and typeface alongside dark, pink and high contrast themes.
-- Keyboard shortcuts for the global search let you press / or Ctrl+K (⌘K on macOS) to focus the feature search instantly, even when it sits inside the collapsed mobile side menu.
-- Force reload button clears cached service worker files so the offline app refreshes without deleting saved projects or devices.
-- Star icons in every selector pin favorite cameras, batteries and accessories to the top of the list and keep them in backups.
-- Factory reset workflow automatically downloads a backup before wiping stored projects, custom devices and settings.
-- Gear list and printable overview display the project name for quick reference.
-- Upload a custom logo for printed overviews and backups.
-- Backups include favorites and create an automatic backup before restore.
-- Crew list entries now feature an email field.
-- High contrast, reduced motion, and relaxed spacing accessibility options for improved readability and comfort.
-- Device forms populate category fields dynamically based on schema attributes.
-- Revamped interface design with improved contrast and spacing for a cleaner experience on any device.
-- Simplified project sharing – download a JSON project file that bundles selections, requirements, gear lists, runtime feedback and custom devices, then load it to restore the full setup.
-- Unique icons for required scenarios to distinguish project requirements.
-- Interactive project diagram that lets you drag devices, zoom, snap nodes to a grid and export the layout as SVG or JPG.
-- Playful pink accent theme that persists between visits.
-- Searchable help dialog with step-by-step sections and a FAQ; open with ?, H, F1 or Ctrl+/.
-- Contextual hover help for buttons, fields, dropdowns and headers.
-- Global search bar to jump to features, device selectors or help topics.
-- Support for cameras with V-, B- or Gold-Mount battery plates.
-- Submit user runtime feedback with temperature for better estimates.
-- Visual runtime weighting dashboard to inspect how settings influence each report, now sorted by weight and showing exact share percentages.
-- Generate gear lists to compile selected gear and project requirements.
-- Save project requirements with each project so gear lists retain full context.
-- Duplicate user entries in gear list forms using fork buttons to copy fields instantly.
+- **Backup version comparisons** – pick any manual save or timestamped
+  auto-backup to review diffs, add incident notes and export a log before you
+  roll a change back or hand footage to post.
+- **Restore rehearsals** – load a full-app backup or project bundle into an
+  isolated sandbox to confirm its contents match live data without touching
+  production profiles.
+- **Automatic gear rules** – design scenario-triggered additions or removals
+  that apply after the generator runs, complete with import/export controls
+  and timed backups.
+- **Data & storage dashboard** – audit stored projects, gear lists, custom
+  devices, favorites and runtime feedback, and review approximate backup size
+  without leaving the Settings dialog.
+- **Autosave status overlay** – mirror the latest autosave note inside the
+  settings dialog so crews see background activity while rehearsing recovery
+  drills.
+- **Monitoring-aware gear editor** – surface additional monitor and video
+  distribution selectors only when scenarios demand them, keeping rule
+  authoring focused.
+- **Accent and typography controls** – adjust accent color, font size and
+  typeface while dark, pink and high-contrast themes persist between visits.
+- **Global search shortcuts** – press `/` or `Ctrl+K` (`⌘K` on macOS) to focus
+  the feature search instantly, even when the mobile navigation is collapsed.
+- **Force reload button** – refresh cached service worker assets without
+  deleting projects or devices.
+- **Pinned favorites** – star dropdown entries to keep go-to cameras, batteries
+  and accessories at the top of selectors and inside backups.
+- **Factory reset safeguards** – capture an automatic backup before wiping
+  saved projects, custom devices and settings.
 
----
+See the language-specific README files for release details in other locales.
 
-## 🔧 Features
+## Quick Start
 
-### ✨ Expanded highlights
+Run this checklist the first time you install or update the planner. It proves
+that every save, share, import, backup and restore workflow works exactly the
+same online or offline.
 
-- **Build complex rigs without guesswork.** Combine cameras, battery plates,
-  wireless links, monitors, motors and accessories while tracking total draw at
-  14.4 V/12 V (and 33.6 V/21.6 V for B‑Mount) plus realistic runtimes from
-  weighted field data. The battery comparison panel flags overloads before the
-  wrong kit goes on the truck.
-- **Keep every department aligned.** Save multiple projects with requirements,
-  crew contacts, scenarios and notes. Printable gear lists group equipment by
-  category, merge duplicates, surface technical metadata and include
-  scenario-driven accessories so camera, lighting and grip teams stay synced.
-- **Work confidently anywhere.** Open `index.html` directly or serve the folder
-  over HTTPS to enable the service worker. Offline caching preserves language,
-  themes, favorites and projects, and **Force reload** refreshes cached assets
-  without touching stored data.
-- **Tailor the planner to your crew.** Switch instantly between English,
-  Deutsch, Español, Italiano and Français, adjust font size and typeface, pick a
-  custom accent color, upload a print logo and toggle dark, pink or
-  high-contrast themes. Type-to-search selectors, pinned favorites, fork buttons
-  and hover help keep on-set workflows fast.
+1. Download or clone this repository.
+2. Open `index.html` in any modern browser.
+3. (Optional) Serve the folder over HTTP(S) to install the service worker and
+   Progressive Web App features:
+   ```bash
+   npx http-server
+   # or
+   python -m http.server
+   ```
+   The app then caches itself for offline use and applies updates when you
+   approve them.
+4. Load the planner once, close the tab, disconnect from the network (or toggle
+   Airplane Mode) and reopen `index.html`. The offline indicator in the header
+   should flash briefly while cached files load. Confirm the interface mirrors
+   the last session exactly, including any locally stored Uicons or helper
+   assets.
+5. Create your first project, press **Enter** (or **Ctrl+S**/`⌘S`) to capture a
+   manual save and review the project selector to see the timestamped
+   auto-backup that appears after a few minutes.
+6. Export **Settings → Backup & Restore → Backup** and import the resulting
+   `planner-backup.json` file into a private browser profile. Verifying the
+   restore path early proves that no saves are stranded on a single machine and
+   demonstrates the forced pre-restore backup safeguard.
+7. Practice exporting a project bundle (the download defaults to
+   `project-name.json`) and re-importing it on a secondary machine or profile.
+   Rehearsing the full save → share → import loop keeps crews confident that
+   offline workflows are airtight and that locally stored Uicons, fonts and
+   helper scripts follow the project.
+8. Archive the verified backup and project bundle alongside the repository copy
+   you opened. This keeps save, share, import, backup and restore workflows
+   provably in sync from the first session and gives you redundant recovery
+   media for travel days.
 
-### ✅ Project Management
-- Save, load and delete multiple camera projects (press Enter or Ctrl+S/⌘S to save quickly; the Save button stays disabled until a name is entered).
-- Automatic snapshots are created every 10 minutes while the planner is open, and the Settings dialog can trigger hourly backup exports as a reminder to archive data.
-- Download a JSON project file that bundles selections, requirements, gear lists, runtime feedback and custom devices—flip the **Include automatic gear rules** toggle if you also want your automations embedded; load it through the Import Project picker to restore everything in one step.
-- Data is stored locally via `localStorage` and favorites are preserved in backups; use the **Factory reset** option in Settings to capture a backup automatically before wiping cached projects and device edits.
-- Generate printable overviews for any saved project and add a custom logo so exports and backups match your production branding.
-- Save project requirements along with each project so gear lists retain full context.
-- Works fully offline with the installed service worker—language, theme, device data and favorites persist between sessions.
-- Responsive layout adapts seamlessly across desktops, tablets and phones.
-- Choose **V‑Mount**, **B‑Mount** or **Gold‑Mount** plates on supported cameras; the battery list adapts automatically.
+## System Requirements & Browser Support
 
-### 🧭 Interface Overview
-- **Quick reference:**
-  - **Global search** (`/` or `Ctrl+K`/`⌘K`) jumps to features, selectors or help
-    topics even when the side drawer is collapsed.
-  - **Help center** (`?`, `H`, `F1` or `Ctrl+/`) surfaces searchable guides,
-    FAQs, shortcuts and the optional hover-help mode.
-  - **Project diagram** visualizes connections; hold Shift when downloading to
-    save a JPG snapshot instead of SVG while seeing compatibility notices.
-  - **Battery comparison** reveals how compatible packs perform and highlights
-    overload risks before call time.
-  - **Gear list generator** outputs categorized tables with metadata, crew
-    emails and scenario-driven accessories ready for print or PDF.
-  - **Offline badge & Force reload** show connectivity status and refresh cached
-    assets without clearing projects.
-- A skip link and offline indicator keep the layout accessible on keyboard and touch devices—the badge appears whenever the browser loses its connection.
-- The global search bar jumps to features, device selectors or help topics; press Enter to activate the highlighted result, use / or Ctrl+K (⌘K on macOS) to focus it from anywhere (the side menu opens automatically on small screens) and press Escape or tap × to clear the query.
-- Top bar controls provide language switching, dark and pink theme toggles plus a Settings dialog that exposes accent color, font size, font family, high contrast and custom logo uploads alongside backup, restore and Factory reset tools that back up data before wiping it.
-- The Help button opens a searchable dialog with step-by-step sections, keyboard shortcuts, FAQs and an optional hover-help mode; it can also be triggered with ?, H, F1 or Ctrl+/ even while typing.
-- The Force reload button (🔄) clears cached service worker files so the offline app updates without deleting saved projects or custom devices.
-- On smaller screens a collapsible side menu mirrors every major section for quick navigation.
+- **Modern evergreen browsers.** The planner is validated on the latest
+  releases of Chromium, Firefox and Safari on desktop and mobile. Enable
+  service workers, IndexedDB and persistent storage to unlock the full offline
+  workflow.
+- **Offline-friendly devices.** Laptops and tablets must allow persistent
+  storage so backups and auto-saves stay available. When running from removable
+  media or a field workstation, launch the planner once while online so the
+  service worker can cache every asset, then rehearse the offline reload
+  routine before travel.
+- **Sufficient local storage.** Large productions can accumulate many projects,
+  backups and gear lists. Monitor available disk space in your browser profile
+  and export archives regularly to redundant media to avoid storage eviction.
+- **No external dependencies.** All icons, fonts and helper scripts ship with
+  the repository. Keep the folder intact (including `animated icons 3/` and
+  locally stored Uicons) when copying it between machines so visuals and
+  scripts match exactly.
 
-### ♿ Customization & Accessibility
-- Theme preferences include dark mode, playful pink accents and a dedicated high contrast switch for improved readability.
-- Accent color, base font size and typeface changes apply instantly and persist in the browser, letting you match studio branding or accessibility needs.
-- Built-in keyboard shortcuts cover global search (/ or Ctrl+K/⌘K), help ( ?, H, F1, Ctrl+/ ), saving (Enter or Ctrl+S/⌘S), dark mode (D) and pink mode (P).
-- Hover-help mode turns every button, field, dropdown and header into an on-demand tooltip so new users can learn the interface quickly.
-- Type-to-search inputs, focus-visible controls and star icons beside selectors let you filter long lists quickly and pin favourite devices to the top.
-- Upload a custom logo for printouts, configure default monitoring roles and tweak project requirement presets so exports match your production branding.
-- Fork buttons duplicate gear list rows instantly, and pinned favourites keep go-to equipment at the top of selectors for faster data entry on set.
+## Save, Share & Import Drill
 
-### 📋 Gear List
-The generator turns your selections into a categorized packing list:
+Run this short rehearsal whenever a new crew member joins, a workstation is
+provisioned or a significant update ships. The routine proves that saving,
+sharing, importing, backup and restore all behave as expected without network
+access.
 
-- Click **Generate Gear List and Project Requirements** to compile chosen gear and project requirements into a table.
-- The table updates automatically when device selections or requirements change.
-- Items are grouped by category (camera, lens, power, monitoring, rigging, grip, accessories, consumables) and duplicates are merged with counts.
-- Required cables, rigging and accessories are added for monitors, motors, gimbals and weather scenarios.
-- Scenario selections inject related gear:
-  - *Handheld* + *Easyrig* inserts a telescopic handle for stable support.
-  - *Gimbal* adds the selected gimbal, friction arms, spigots and sunshades or filter kits.
-  - *Outdoor* supplies spigots, umbrellas and CapIt rain covers.
-  - *Vehicle* and *Steadicam* scenarios pack in mounts, isolation arms and suction gear where applicable.
-- Lens selections append front diameter, weight, rod data and minimum focus, add lens supports and matte box adapters, and warn about incompatible rod standards.
-- Battery rows mirror counts from the power calculator and include hotswap plates or chosen hotswap devices when required.
-- Monitoring preferences assign default monitors for each role (Director, DoP, Focus, etc.) with cable sets and wireless receivers.
-- The **Project Requirements** form feeds the list:
-  - **Project Name**, **Production Company**, **Rental House** and **DoP** appear in the heading of the printed requirements.
-  - **Crew** entries capture names, roles and email addresses so contact info travels with the project.
-  - **Prep Days** and **Shooting Days** supply schedule notes and, when paired with outdoor scenarios, suggest weather gear.
-  - **Required Scenarios** append matching rigging, gimbals and weather protection.
-  - **Camera Handle** and **Viewfinder Extension** insert the chosen handle parts or extension brackets.
-  - **Matte Box** and **Filter** choices inject the selected system with any needed trays, clamp adapters or filters.
-  - **Monitoring Configuration**, **Video Distribution** and **Viewfinder** settings add monitors, cables and overlays for each role.
-  - **User Button** selections and **Tripod Preferences** are listed for quick reference.
-- Items inside each category are sorted alphabetically and display tooltips on hover.
-- The gear list is included in printable overviews and exported project files.
-- Gear lists save automatically with the project and are included in exported project files and backups.
-- **Delete Gear List** removes the saved list and hides the output.
-- Gear list forms provide fork buttons to duplicate user entries instantly.
+1. **Baseline save.** Open the current project, trigger a manual save and note
+   the timestamp that appears in the selector. Confirm an auto-backup joins the
+   list within ten minutes while you continue editing.
+2. **Export redundancy.** Create a planner backup and a project bundle. Rename
+   the bundle if you follow a `.cpproject` convention, then store both files on
+   separate physical media.
+3. **Restore dress rehearsal.** Switch to a private browser profile (or a
+   second machine), import the planner backup, then import the project bundle.
+   Inspect gear lists, runtime dashboards, automatic gear rules and favorites
+   to confirm they survived the round-trip.
+4. **Offline verification.** While still in the rehearsal profile, disconnect
+   from the network and reload `index.html`. Ensure the offline indicator shows,
+   the interface matches the source machine and locally stored Uicons plus
+   helper scripts load without flicker.
+5. **Archive with confidence.** Delete the rehearsal profile after confirming
+   everything restored cleanly, then label and file the verified exports with
+   your production’s archival checklist.
 
-### 📦 Device Categories
-- **Camera** (1)
-- **Monitor** (optional)
-- **Wireless Transmitter** (optional)
-- **FIZ Motors** (0–4)
-- **FIZ Controllers** (0–4)
-- **Distance Sensor** (0–1)
-- **Battery Plate** (only on cameras that accept V‑ or B‑Mount)
-- **V‑Mount Battery** (0–1)
+## Everyday Workflow
 
-### ⚙️ Power Calculations
-- Total consumption in watts
-- Current draw at 14.4 V and 12 V
-- Estimated battery runtime in hours using weighted user feedback
-- Required battery count for a 10 h shoot
-- Temperature note to adjust runtime for hot or cold conditions
+Use Cine Power Planner end-to-end with the following routine:
 
-### 🔋 Battery Output Check
-- Warns if current draw exceeds the battery output (Pin or D‑Tap)
-- Indicates when draw is close to the limit (80 % usage)
+1. **Create or load a project.** Select an existing setup or type a new project
+   name and press Enter (or click **Save**). The active project name appears in
+   gear lists, printable overviews and exports.
+2. **Add cameras, power and accessories.** Choose devices from categorized
+   dropdowns. Type-to-filter search, pinned favorites and the global shortcut
+   `/` (or `Ctrl+K`/`⌘K`) jump straight to the gear or feature you need.
+3. **Verify power and runtime.** Monitor draw warnings, compare compatible
+   batteries and review the runtime dashboard to see how temperature, codec,
+   frame rate and other factors influence field data.
+4. **Capture project requirements.** Fill out crew details, scenarios, handles,
+   matte box preferences and monitoring layouts so generated lists reflect the
+   full production context. Fork buttons duplicate entries for faster data
+   entry. When specific scenarios demand bespoke kits, open **Settings →
+   Automatic Gear Rules** to layer custom additions or removals before
+   generating exports.
+5. **Export or archive the plan.** Generate the gear list, export a planner
+   backup or download an exportable project bundle before heading to set.
+   Backups include custom devices, runtime feedback and favorites.
+6. **Verify offline readiness.** Toggle the offline switch on your router or
+   device, refresh the planner and confirm that the project, settings and gear
+   lists all remain accessible. Restore from the most recent backup if anything
+   looks out of sync.
 
-### 📊 Battery Comparison (optional)
-- Compare runtime estimates across all batteries
-- Visual bar graph for quick reference
+## Saving & Project Management
 
-### 🖼 Project Diagram
-- Visualize power and video connections for the selected devices
-- Warns when FIZ brands are incompatible
-- Drag nodes to rearrange the layout, zoom with the buttons and download the diagram as SVG or JPG
-- Hold Shift while clicking Download to export a JPG snapshot instead of SVG
-- Hover or tap devices to see popup details
-- Uses [OpenMoji](https://openmoji.org/) icons when online, falling back to emoji:
-  🔋 battery, 🎥 camera, 🖥️ monitor, 📡 video, ⚙️ motor,
-  🎮 controller, 📐 distance, 🎮 handle and 🔌 battery plate
+- **Manual saves keep versions explicit.** Enter a project name in the header
+  field and press **Enter** or click **Save** to capture the current state. Each
+  manual save preserves devices, requirements, gear lists, favorites, diagram
+  layouts and runtime observations.
+- **Auto-saves protect in-progress work.** While a project is open the planner
+  writes incremental changes in the background. Timestamped `auto-backup-…`
+  versions appear in the project selector every 10 minutes so you can roll back
+  without leaving the interface.
+- **Reveal auto backup snapshots on demand.** Toggle **Settings → Backup &
+  Restore → Show auto backups** to temporarily display the timestamped safety
+  copies in the project selector when you need to restore one manually.
+- **Renaming duplicates on purpose.** Editing the active project name and
+  pressing **Enter** creates a branched copy. Use this when you want to compare
+  alternate builds or keep both day and night configurations side by side.
+- **Switching projects is non-destructive.** Select another entry from the
+  project menu to load it instantly. The planner preserves scroll position and
+  unsaved form inputs for the new project so you can review or edit without
+  re-entering data.
+- **Deletion requires confirmation.** Use the trash icon in the selector to
+  remove unused versions. You’ll be asked to confirm before anything leaves the
+  browser, ensuring you do not lose a project by accident.
 
-### 🧮 Runtime data weighting
-- User-submitted battery runtimes refine the runtime estimate.
-- Each entry is adjusted for temperature, scaling from ×1 at 25 °C to:
-  - ×1.25 at 0 °C
-  - ×1.6 at −10 °C
-  - ×2 at −20 °C
-- Camera settings influence the weight:
-  - Resolution multipliers: ≥12K ×3, ≥8K ×2, ≥4K ×1.5, ≥1080p ×1, lower scaled to 1080p
-  - Frame rate scales linearly from 24 fps (e.g. 48 fps = ×2)
-  - Wi‑Fi enabled adds 10 %
-  - Codec factors: RAW/BRAW/ARRIRAW/R3D/CinemaDNG/Canon RAW/X‑OCN ×1; ProRes ×1.1; DNx/AVID ×1.2; All‑Intra ×1.3; H.264/AVC ×1.5; H.265/HEVC ×1.7
-  - Monitor entries below the specified brightness are weighted by their brightness ratio
-- The final weight reflects each device's share of the total power draw, so matching projects count more.
-- The weighted average is used once at least three entries are available.
-- A dashboard orders entries by weight and displays each one's share percentage for quick comparison.
+## Sharing & Imports
 
-### 🔍 Search & Filtering
-- Type inside dropdowns to quickly find entries
-- Filter device lists with a search box
-- Use the global search bar at the top to jump to features, devices or help topics; press Enter to navigate, use / or Ctrl+K (⌘K on macOS) to focus it instantly and press Escape or × to clear.
-- Press '/' or Ctrl+F (⌘F on macOS) to focus the nearest search box instantly.
-- Click the star beside any selector to pin favourites so they stay at the top of the list and sync with backups.
+- **Project bundles travel light.** Click **Export Project** to download a
+  `project-name.json` file containing the active project, favorites and any
+  referenced custom devices. Rename the file if your archiving standards call
+  for a `.cpproject` extension, then send it via your preferred secure channel;
+  recipients can import without needing internet access.
+- **Automatic gear rules travel with bundles.** Flip the **Include automatic
+  gear rules** toggle during export to decide whether your automations ship with
+  the bundle; teammates who import the file can ignore them, apply them only to
+  the imported project or merge them into their global ruleset.
+- **Standalone rule imports validate metadata offline.** When you import an
+  `auto-gear-rules-*.json` file, the planner now checks the file type, semantic
+  version and timestamp metadata before touching your saved rules—even without
+  connectivity. You’ll see a warning if the payload came from an older or newer
+  build or if required fields were removed, and the previous snapshot is restored
+  automatically if validation fails.
+- **Restores are double-buffered.** Importing a bundle prompts you to save a
+  backup of your current environment first. After choosing the bundle file, the
+  planner validates its JSON schema, merges new devices and places the restored
+  project at the top of the selector.
+- **Cross-device workflows stay offline.** To move a plan to a workstation with
+  no connectivity, copy `index.html`, `script.js`, `devices/` and your backup or
+  bundle files onto removable media. Launch from disk, import the bundle and
+  continue planning without touching external networks.
+- **Export responsibly.** Review the exported JSON before distributing it to
+  make sure no extra projects or notes are included. The structure is human
+  readable so you can redact or duplicate entries as needed, and the file stays
+  portable even when renamed to `.cpproject` for filing.
+- **Synchronize with checklists.** When a teammate sends you an updated bundle,
+  import it, review the `Updated at` timestamps in the sidebar and archive the
+  previous JSON (or `.cpproject`) bundle in your storage system to maintain a
+  clear history.
+- **Share without losing context.** Bundles remember language, theme, custom
+  logo and other personalization choices so the recipient opens the project in a
+  familiar state even if they stay offline.
 
-### 🛠 Device Database Editor
-- Add, edit or delete devices in all categories
-- Import or export the full database as JSON
-- Revert to the default database from `src/data/index.js`
+## Project & Backup File Formats
 
-### 🌓 Dark Mode
-- Toggle via the moon button next to the language selector.
-- Preference is stored in your browser.
+- **`project-name.json` (project bundle).** Exported from **Export Project**,
+  this JSON bundle stores one project, favorites and any referenced custom
+  devices. Rename it to `.cpproject` if your workflow expects that extension;
+  the planner treats both identically during import.
+- **`planner-backup.json` (full backup).** Created via **Settings → Backup &
+  Restore → Backup**, this archive captures every project, auto-backup,
+  favorite, runtime submission, automatic gear rule, UI preference, custom
+  font and branding asset so a restore never loses context.
+- **`auto-gear-rules-*.json` (rule exports).** Optional downloads from
+  **Automatic Gear Rules** provide timestamped copies of your automation setup.
+  They now embed file type, semantic version and timestamp metadata so the
+  importer can validate payloads offline. Store them alongside full backups so
+  custom presets never disappear during cross-team handoffs, and keep an eye on
+  import warnings if you restore them on a different build.
 
-### 🦄 Pink Mode
-- Click the unicorn button (pink mode cycles through unicorn icons every 30 seconds with a gentle pop animation and switches back to the horse icon when you leave the theme) or press **P** for a playful pink accent.
-- Works in both light and dark themes and persists between visits.
+## Interface Tour
 
-### ⚫ High Contrast Mode
-- Toggle a high contrast theme for improved readability.
+### Quick reference
 
-### 📝 User Runtime Feedback
-- Click <strong>Submit User Runtime Feedback</strong> below the runtime to add your own measurement.
-- Optionally include temperature for more accurate weighting.
-- Entries are saved in your browser and improve future estimates.
-- A dashboard orders submissions by weight, shows contribution percentages and
-  highlights outliers so crews can review field data quickly.
+- **Global search** (`/`, `Ctrl+K`, `⌘K`) jumps to any feature, selector or help
+  topic—even when the side navigation is hidden on smaller screens.
+- **Help center** (`?`, `H`, `F1`, `Ctrl+/`) provides searchable guides,
+  shortcuts, FAQs and an optional hover-help mode so every control explains
+  itself.
+- **Project diagram** visualizes power and signal paths. Hold Shift while
+  exporting to save a JPG snapshot instead of SVG.
+- **Battery comparison panel** reveals how each compatible pack performs and
+  flags overload risks before you leave prep.
+- **Gear list generator** turns selections into categorized tables with tooltips
+  for specs, crew emails and scenario-driven accessories.
+- **Offline indicator and Force reload** badges show connectivity status and
+  refresh cached assets without touching saved data.
 
-### ❓ Searchable Help
-- Open via the <strong>?</strong> button or press <kbd>?</kbd>, <kbd>H</kbd>, <kbd>F1</kbd> or <kbd>Ctrl+/</kbd>.
-- Use the search field to filter topics instantly; the query resets when the dialog closes.
-- Close with <kbd>Escape</kbd> or by clicking outside the dialog.
+### Top bar controls
 
----
+- A keyboard-friendly skip link, offline indicator and responsive branding keep
+  navigation accessible across devices.
+- The global search bar focuses with `/` or `Ctrl+K` (`⌘K` on macOS), opens the
+  side menu on mobile and clears with Escape.
+- Language, dark mode and pink mode toggles sit beside the Settings dialog,
+  which exposes accent color, font size, font family, high-contrast mode, custom
+  logo uploads plus backup, restore and factory reset tools that always save a
+  backup first.
+- The Help button opens a searchable dialog and can be triggered at any time
+  with `?`, `H`, `F1` or `Ctrl+/`.
+- The 🔄 **Force reload** button removes cached assets and reloads the app
+  without erasing projects or runtime data.
 
-## ▶️ How to Use
-1. **Launch App:** Open `index.html` in any modern browser – no server required.
-2. **Explore the Top Bar:** Switch language, toggle dark or pink themes, open Settings for accent and typography options, and start the searchable help dialog with ? or Ctrl+/.
-3. **Select Devices:** Choose gear from each category using the dropdowns—type to filter, click the star to pin favourites and let scenario presets fill in accessories automatically.
-4. **View Calculations:** See total draw, current and runtime once a battery is selected; warnings highlight when output limits are exceeded.
-5. **Save & Export Projects:** Name and save your configuration, auto-backups capture snapshots, and the Export button downloads a JSON bundle for collaborators while the Import button restores them.
-6. **Generate Gear Lists:** Press **Generate Gear List and Project Requirements** to turn project requirements into a categorized packing list with tooltips and accessory packs.
-7. **Manage Device Data:** Click “Edit Device Data…” to open the database editor, modify devices, export/import JSON or revert to the defaults.
-8. **Submit Runtime Feedback:** Use “Submit User Runtime Feedback” to record field measurements and refine weighted estimates.
+### Navigation and search
 
-## 📱 Install as an App
+- On small screens, a collapsible side menu mirrors the main sections for quick
+  navigation.
+- Every dropdown and editor list includes inline search and supports type-to-
+  filter interactions. `/` or `Ctrl+F` (`⌘F` on macOS) focuses the nearest
+  search field.
+- Star icons pin favorite devices so they stay at the top of selectors and
+  persist across sessions and backups.
 
-The planner is a Progressive Web App and can be installed directly from your browser:
+## Customization & Accessibility
 
-- **Chrome/Edge (desktop):** Click the install icon in the address bar.
-- **Android:** Open the browser menu and choose *Add to Home Screen*.
-- **iOS/iPadOS Safari:** Tap the *Share* button and select *Add to Home Screen*.
+- Switch among light, dark, pink and high-contrast themes; accent color, base
+  font size and typeface can be tuned in Settings and persist offline.
+- A skip link, focus-visible controls and responsive layout keep navigation
+  smooth on keyboards, tablets and phones.
+- Keyboard shortcuts cover global search (`/`, `Ctrl+K`, `⌘K`), help (`?`, `H`,
+  `F1`, `Ctrl+/`), saving (`Enter`, `Ctrl+S`, `⌘S`), dark mode (`D`) and the pink
+  accent (`P`).
+- Hover-help mode turns every button, field, dropdown and header into an
+  on-demand tooltip so new users can self-teach the interface.
+- Upload a custom logo for printed overviews, configure monitoring defaults and
+  set preferred requirement presets so deliverables match production branding.
+- Fork buttons in gear list forms duplicate entries, while favorites keep
+  frequently used devices in reach.
 
-Once installed, the app launches from your home screen, works offline and updates itself automatically.
+## Data Safety & Offline Operation
 
-## 📡 Offline Use & Data Storage
+- A service worker caches every asset so the planner runs offline and applies
+  updates only when you approve them via **Force reload**.
+- Projects, runtime submissions, favorites, custom devices, theme selections and
+  gear lists live in browser storage. Browsers that support persistent storage
+  receive an automatic retention request to reduce eviction risk.
+- Opening the repository directly from disk or serving it internally keeps
+  sensitive data off external networks. All exports are human-readable JSON so
+  you can audit what leaves the machine.
+- The header shows an offline indicator whenever connectivity drops, and the
+  Force reload control refreshes cached files without touching saved work.
+- Clearing the site’s data or using **Factory reset** removes local entries only
+  after exporting a backup automatically, ensuring nothing disappears without a
+  copy.
+- Service worker updates download in the background and wait for your approval.
+  When the **Update ready** toast appears, finish your current edits, trigger a
+  manual backup, then click **Force reload** so fresh assets load alongside your
+  preserved data.
+- Storage lives inside IndexedDB with small preferences mirrored to
+  `localStorage`. Use your browser’s developer tools to inspect or export raw
+  records before making experimental changes or clearing caches.
 
-Serving the app over HTTP(S) installs a service worker that caches every file
-so Cine Power Planner works fully offline and updates in the background. Projects,
-runtime submissions and preferences (language, theme, pink mode and saved gear
-lists) live in your browser's `localStorage`. Clearing the site's data in the
-browser removes all stored information, and the Settings dialog includes a
-**Factory reset** workflow that saves a backup automatically before clearing everything. The header shows an
-offline badge whenever connectivity drops, and the 🔄 **Force reload** action
-refreshes cached assets without disturbing saved projects.
+## Data & Storage Overview
 
----
+- Open **Settings → Data & Storage** to review everything the planner keeps on
+  the current device—saved projects, timestamped auto backups, gear list
+  snapshots, custom devices, favorites, runtime feedback and the unsaved session
+  cache all appear with live counts.
+- Each entry clarifies what it represents and, when relevant, lists affected
+  categories or whether the session data is currently stored. Empty sections stay
+  hidden so you know at a glance when the planner is pristine.
+- The summary also estimates backup size using the most recent export, giving you
+  a quick check that archives will fit on the storage you bring to set.
 
-## 🗂️ File Structure
-```bash
-index.html                 # Main HTML layout
-src/styles/style.css       # Core styles and layout
-src/styles/overview.css    # Printable overview styling
-src/styles/overview-print.css # Print overrides for the overview
-src/scripts/script.js        # Application logic
-src/scripts/storage.js       # LocalStorage helpers
-src/scripts/static-theme.js  # Shared theme logic for legal pages
-src/data/index.js       # Default device list
-src/data/devices/       # Device catalogs by category
-src/data/schema.json    # Generated schema for selectors
-src/vendor/             # Bundled third-party libraries
-legal/                     # Offline legal documents
-tools/                     # Data maintenance scripts
-tests/                     # Jest test suite
-```
-Fonts are bundled locally via `fonts.css`, so once the assets are cached the application works entirely offline.
+## Storage Quota & Maintenance
 
-## 🛠️ Development
-Requires Node.js 18 or later.
+- **Confirm persistent storage access.** Visit **Settings → Data & Storage** on
+  every workstation you provision. The panel reports whether the browser granted
+  persistent storage; if it did not, request access from the settings dialog or
+  manually via developer tools before loading large projects. Browsers that
+  reject the request should trigger a contingency plan—schedule more frequent
+  manual exports so nothing depends on eviction-prone storage.
+- **Watch quota headroom.** Use the same dashboard (or your browser’s storage
+  inspector) to review how much space projects, backups and cached assets
+  consume. If available space drops below your comfort margin, archive older
+  backups to encrypted external media, delete redundant `auto-backup-…` entries
+  from the project selector and confirm fresh exports still complete without
+  warnings.
+- **Prime caches after updates.** Any time you click **Force reload**, reopen the
+  help dialog, legal pages and high-traffic screens such as the device catalog so
+  locally bundled Uicons, OpenMoji artwork and typography files repopulate the
+  cache. Confirm the offline indicator flickers only briefly on the next load.
+- **Document storage health.** Add storage checks to your prep and wrap logs. A
+  quick note about granted persistent storage status, remaining quota and where
+  the latest backups live makes audits easier and guards against accidental data
+  loss when the project transitions to another crew.
 
-```bash
-npm install
-npm run lint     # run ESLint alone
-npm test         # runs linting, data checks and Jest tests
-```
+## Backup & Recovery
 
-After editing device data, regenerate the normalized database:
+- **Saved project snapshots** – the selector keeps every plan you save and
+  creates timestamped `auto-backup-…` entries every 10 minutes while the app is
+  open so you can roll back without losing changes.
+- **Full planner backups** – **Settings → Backup & Restore → Backup** downloads
+  `planner-backup.json` with projects, custom devices, runtime feedback,
+  favorites, automatic gear rules and UI state. Restores create a safety copy
+  before importing and warn if the file was produced on another version.
+- **Hidden migration backups** – before overwriting stored planners, setups or
+  preferences, the app now preserves the previous JSON snapshot in a protected
+  `__legacyMigrationBackup` slot. If a write ever fails or produces corrupt
+  data, the recovery tools automatically fall back to that safety copy so no
+  user data disappears.
+- **Automatic gear snapshots** – rule changes trigger timestamped safety copies
+  every 10 minutes in **Settings → Automatic Gear Rules**, and you can restore or
+  export them if a customization misfires.
+- **Factory reset** – wipes stored data only after downloading a backup. Use it
+  when you need a clean slate.
+- **Hourly reminders** – a background routine prompts an additional backup each
+  hour so crews always have a recent snapshot ready to archive.
+- **Verification loop** – after every critical backup, re-import it into a
+  separate browser profile or private window, confirm projects and gear lists
+  match expectations, then delete the temporary profile. This routine catches
+  corrupted files before they matter.
+- **Secure storage habits** – label exported backups with the project name and
+  timestamp, then store them on redundant media (RAID volume, encrypted thumb
+  drive, optical disc) according to your production’s data policy.
+- **Compare before overwriting** – when restoring from an older file, download a
+  fresh backup of the current state first. Use a JSON-aware diff tool to review
+  differences so you can merge notes manually if needed.
+
+## Data Integrity Drills
+
+Treat data protection as an ongoing habit so no crew member ever wonders whether
+the latest save or export is trustworthy. Pair the backup options above with a
+repeatable verification loop:
+
+- **Pre-flight validation (daily or before major edits).** Create a manual save,
+  export both a planner backup and a `project-name.json` bundle, then import each
+  file into a private browser profile. Confirm projects, automatic gear rules,
+  favorites and runtime dashboards match the source machine before deleting the
+  verification profile. This proves the full save → share → import chain is
+  intact.
+- **Offline rehearsal (weekly or before travel).** Launch the planner, trigger a
+  manual backup, disconnect from all networks and reload `index.html`. Verify
+  the offline indicator appears, locally stored Uicons and other assets stay
+  crisp and the imported verification project opens without errors. Reconnect
+  only after the restored project is confirmed.
+- **Change control check (after updating data or scripts).** When devices,
+  automatic rules or helper tools change, run `npm test` to rebuild confidence,
+  then repeat the pre-flight validation above. Archive the passing backup with a
+  changelog entry so future crews know which revisions were certified for
+  offline work.
+- **Redundancy rotation (monthly or before archiving).** Store the most recent
+  planner backup, a verified `project-name.json` bundle (rename to `.cpproject`
+  if your asset tracker expects it) and a ZIP of the repository on at least two
+  physical media. Rotate which copy you open for spot-checks so you
+  catch media degradation before it causes data loss.
+
+## Operational Checklists
+
+Use the following repeatable routines to keep projects, backups and offline
+assets in sync on every machine that runs Cine Power Planner. Each checklist is
+designed so crews can confirm that saving, sharing, importing, backup and
+restore paths all function before heading to set and again before wrapping. A
+print-friendly version lives in `docs/operations-checklist.md`, and the travel-
+focused `docs/offline-readiness.md` runbook expands on these steps for crews
+preparing hardware that will operate without connectivity for extended periods.
+
+### Pre-shoot readiness
+
+1. **Confirm the right repository revision.** Open `index.html`, press the
+   **Force reload** button and verify the app reports the expected version in
+   **Settings → About**. Launch the legal pages once to warm up locally stored
+   Uicons, OpenMoji artwork and typography files.
+2. **Load critical projects.** Open the active production plan plus a recent
+   `auto-backup-…` snapshot. Confirm gear lists, runtime feedback and favorites
+   appear correctly in both.
+3. **Exercise the save pipeline.** Make a small edit, press `Enter` or
+   `Ctrl+S`/`⌘S` to save, then export a `planner-backup.json` file. Restore that
+   backup into a private browsing window or secondary profile and confirm the
+   project selector matches the source machine.
+4. **Test sharing flows.** Export a `project-name.json` bundle, import it into
+   the verification profile and ensure automatic gear rules, custom devices and
+   the offline indicator load as expected. Delete the profile afterwards.
+5. **Simulate no-connectivity operation.** Disconnect from the network or toggle
+   Airplane Mode, refresh the planner and confirm the offline badge appears,
+   icons stay crisp and previously verified projects remain accessible.
+6. **Archive sign-off artifacts.** Store the verified backup, bundle and a copy
+   of the repository ZIP on redundant media so the crew can rebuild the exact
+   environment even without internet access.
+
+### Wrap-day handoff
+
+1. **Capture a final manual backup.** With the project still open, export a
+   `planner-backup.json` file plus the latest `project-name.json` bundle (rename
+   to `.cpproject` if needed) and label them with the date, location and shoot
+   day.
+2. **Validate imports.** Restore both files on a verification machine to ensure
+   no corruption occurred during export. Keep the verification instance offline
+   to mimic field conditions.
+3. **Log changes for the archive.** Record which auto backups were promoted to
+   manual saves, which custom devices were added and which automatic gear rules
+   changed. Store the notes alongside the backups so future crews understand the
+   delta.
+4. **Refresh cached assets intentionally.** Once everything is archived, trigger
+   **Force reload** so the next session starts with current assets, then open the
+   help dialog and legal pages to recache any large documents before going
+   offline again.
+5. **Hand off redundant media.** Deliver encrypted copies of the backups,
+   bundles and repository snapshot to the production’s storage team and retain a
+   second copy per your organization’s data retention policy.
+
+## Emergency Recovery Playbook
+
+Follow these steps immediately if something feels wrong—missing gear lists,
+unexpected validation warnings or a suspected storage issue. The goal is to
+stabilize the environment, capture evidence and restore service without losing
+data.
+
+1. **Pause and preserve the current state.** Keep the tab open, disconnect from
+   the network (if possible) and note the time plus the offline indicator state.
+   Avoid reloading until you record what happened.
+2. **Export what still exists.** Trigger **Settings → Backup & Restore → Backup**
+   and download the resulting `planner-backup.json`. Even if the project list
+   looks wrong, the export captures auto backups, favorites, runtime feedback and
+   automatic gear rules for forensic review.
+3. **Duplicate auto backups.** In the project selector, reveal `auto-backup-…`
+   entries (if hidden) and promote the most recent snapshots to manual saves so
+   they cannot be pruned automatically. Rename each copy with an incident ID or
+   timestamp.
+4. **Inspect the verification bundle.** Import the latest known-good
+   `project-name.json` (or `.cpproject`) bundle into a private browser profile or
+   secondary machine that stays offline. Confirm projects, gear lists and
+   settings appear as expected there before touching the production environment.
+5. **Restore carefully.** Once the verification import passes, restore the fresh
+   backup on the primary machine. The workflow saves a safety copy first, letting
+   you compare the incident snapshot against the restored state with a JSON diff
+   tool if needed.
+6. **Recache and document.** After recovery, click **Force reload**, reopen the
+   help dialog and legal pages to rehydrate caches, then log the incident: what
+   happened, which files were exported, where redundant copies were stored and
+   which workstation verified the fix. Store the incident log alongside the
+   backup so future crews can audit the resolution.
+
+## Gear Lists & Reporting
+
+- Click **Generate Gear List and Project Requirements** to expand selections and project requirements into
+  categorized packing tables. Lists refresh automatically when data changes.
+- Entries are grouped by category with duplicates merged. Scenario selections add
+  matching rigging, weather protection and specialty accessories so the printed
+  kit reflects reality.
+- Automatic gear rules execute after the generator finishes, inserting
+  scenario-specific additions or removals so exports reflect bespoke crew
+  preferences without editing JSON by hand.
+- Lens rows include front diameter, weight, minimum focus, rod requirements and
+  matte box components. Battery rows account for calculator counts and required
+  hot-swap hardware.
+- Crew details, monitoring configurations, video distribution preferences and
+  custom notes appear in exports so departments stay aligned.
+- Gear lists save with the project, appear in printable overviews, live inside
+  shareable project files and can be removed with **Delete Gear List** if you
+  want a fresh start.
+
+## Automatic Gear Rules
+
+Settings → **Automatic Gear Rules** lets you fine-tune every generated packing
+list without editing JSON exports manually:
+
+- Build rules that only trigger when selected **Required Scenarios** are active.
+  Each rule can have an optional label for quick scanning in the settings list.
+- Add equipment with explicit category and quantity values or pick **Custom
+  Additions** for reminders, specialty kits or callouts. Matching remove rules
+  hide specific rows the generator would normally include.
+- Rules run after built-in accessory packs so they stack cleanly with default
+  planner logic and flow through to printable gear lists, project backups and
+  shareable bundles.
+- Saving a gear list stores the active rule set with the project. Loading that
+  project—or importing a bundle—restores its rule scope so scenario tweaks stay
+  attached to the plan.
+- Export or import the rule set as JSON, reset to the factory additions when you
+  need a clean baseline and fall back to the automatic history captured every 10
+  minutes if edits go sideways.
+
+## Runtime Intelligence
+
+User-submitted runtimes feed a weighted model so estimates match field
+experience:
+
+- Temperature adjustments scale from ×1 at 25 °C to ×1.25 at 0 °C, ×1.6 at −10 °C
+  and ×2 at −20 °C.
+- Resolution multipliers: ≥12K ×3, ≥8K ×2, ≥4K ×1.5, ≥1080p ×1, lower scaled
+  relative to 1080p.
+- Frame rate scales linearly from 24 fps (for example, 48 fps = ×2).
+- Wi‑Fi enabled adds 10 %.
+- Codec factors: RAW/BRAW/ARRIRAW/R3D/CinemaDNG/Canon RAW/X‑OCN ×1; ProRes ×1.1;
+  DNx/AVID ×1.2; All-Intra ×1.3; H.264/AVC ×1.5; H.265/HEVC ×1.7.
+- Monitor entries below specified brightness are weighted by their brightness
+  ratio.
+- Final weighting reflects how much of the total draw comes from each component
+  so similar rigs carry more influence.
+- A dashboard sorts entries by weight, shows contribution percentages and flags
+  outliers for quick evaluation.
+
+## Keyboard Shortcuts
+
+| Shortcut | Action | Notes |
+| --- | --- | --- |
+| `/`, `Ctrl+K`, `⌘K` | Focus the global search field. | Works even when navigation is collapsed; press `Esc` to clear. |
+| `Enter`, `Ctrl+S`, `⌘S` | Save the active project. | The Save button stays disabled until a project name is entered. |
+| `?`, `H`, `F1`, `Ctrl+/` | Open the help dialog. | The dialog stays searchable while you type elsewhere. |
+| `D` | Toggle dark mode. | Also available from **Settings → Themes**. |
+| `P` | Toggle the pink accent theme. | Works alongside light, dark or high-contrast modes. |
+| 🔄 button | Force reload cached assets. | Also accessible via **Settings → Force reload** without erasing projects. |
+
+## Localization
+
+New locales can be previewed immediately—no build step required. To translate
+the planner:
+
+1. Duplicate the closest language README as `README.<lang>.md` and translate the
+   documentation.
+2. Add UI strings to `translations.js` by copying an existing language block and
+   translating each value. Preserve formatting placeholders such as `%s`.
+3. Provide translated static pages (privacy policy, imprint) by copying the
+   relevant HTML files.
+4. Run `npm test` to ensure linting, data validation and Jest suites pass before
+   submitting a pull request.
+
+## Install as an App
+
+Cine Power Planner is a Progressive Web App:
+
+1. Open `index.html` in a supported browser.
+2. Use the browser’s **Install** or **Add to Home Screen** option.
+   - **Chrome/Edge (desktop):** Click the install icon in the address bar.
+   - **Android:** Open the browser menu and choose *Add to Home screen*.
+   - **iOS Safari:** Tap the share icon and select *Add to Home Screen*.
+3. Launch the app from your applications list. The installed version works
+   offline and updates automatically once you approve a refresh.
+
+## Device Data Workflow
+
+Device catalogs live under `devices/`. Each file groups related equipment so
+changes are easy to audit in version control and inside the app. When editing
+the dataset, run helper scripts before committing:
 
 ```bash
 npm run normalize
@@ -356,11 +733,100 @@ npm run check-consistency
 npm run generate-schema
 ```
 
-Add `--help` to any of the above scripts for usage details.
+`npm run normalize` cleans connector names and expands shorthand entries.
+`npm run unify-ports` standardizes connector labels. `npm run
+check-consistency` confirms required fields are present, and `npm run
+generate-schema` rebuilds `schema.json` so the interface reflects the latest
+data. Iterate quickly with the data-focused Jest project:
 
-Run `npm run help` whenever you need a quick reminder of the maintenance commands and their suggested order.
+```bash
+npm run test:data
+```
 
-## 🤝 Contributing
-Contributions are welcome! Feel free to open an issue or submit a pull request on GitHub.
-When reporting data corrections, attaching project backups or runtime samples
-helps keep the catalog accurate for everyone.
+Add `--help` to any helper command for usage notes and review generated JSON
+diffs before opening a pull request. `npm run help` prints a summary of all
+available scripts.
+
+## Development
+
+Set up with Node.js 18 or later. After cloning the repository:
+
+```bash
+npm install
+npm run lint     # run ESLint alone
+npm test
+```
+
+`npm test` runs ESLint, data consistency checks and the Jest suite sequentially
+(`--runInBand`, `maxWorkers=1`) to reduce memory usage while still failing fast.
+Run targeted suites while iterating:
+
+```bash
+npm run test:unit   # module-level logic and storage helpers (1 GB heap cap)
+npm run test:data   # static dataset validations (1 GB heap cap)
+npm run test:dom    # lightweight DOM utilities (1.5 GB heap cap)
+npm run test:script # reduced smoke checks for script.js (3 GB heap cap)
+```
+
+### Legacy browser bundle
+
+Run `npm run build:legacy` after modifying files in `src/scripts/` or `src/data/`
+to regenerate the transpiled ES5 bundle served to older browsers. The command
+rebuilds everything inside `legacy/` and refreshes the local polyfill copies so
+offline usage stays reliable.
+
+### File structure
+
+```
+index.html                 # Main HTML layout
+src/styles/style.css       # Core styles and layout
+src/styles/overview.css    # Printable overview styling
+src/styles/overview-print.css # Print overrides for the overview dialog
+src/scripts/script.js        # Application logic
+src/scripts/storage.js       # Local storage helpers
+src/scripts/static-theme.js  # Shared theme logic for legal pages
+src/data/index.js       # Default device list
+src/data/devices/       # Device catalogs by category
+src/data/schema.json    # Schema used for validation
+src/vendor/             # Bundled third-party libraries
+legal/                     # Offline legal documents
+tools/                     # Data maintenance scripts
+tests/                     # Jest test suites
+```
+
+## Troubleshooting
+
+- **Service worker stuck on an old version?** Click **Force reload** or perform a
+  hard reload in your browser’s developer tools to update cached assets without
+  deleting saved projects.
+- **Missing data after closing the tab?** Ensure the site has storage access.
+  Private browsing modes or restrictive tracking protections can block
+  persistence.
+- **Downloads blocked?** Allow multiple downloads so backups and shareable
+  bundles can save to disk.
+- **Command-line scripts failing?** Confirm Node.js 18+ is installed, run
+  `npm install` and rerun the requested npm script. Memory errors usually mean a
+  suite exceeded its cap—retry with a narrower target like `npm run test:unit`.
+
+## Feedback & Support
+
+Open an issue if you encounter problems, have questions or want to suggest new
+features. Including project exports or runtime samples helps keep the catalog
+accurate for future shoots.
+
+## Contributing
+
+Contributions are welcome! Open an issue or submit a pull request after reading
+`CONTRIBUTING.md`. Run `npm test` before submitting to ensure linting, data
+consistency checks and unit tests all pass.
+
+## Acknowledgements
+
+The planner ships with locally stored Uicons, OpenMoji assets and other bundled
+artwork so icons stay available without a network connection, and relies on
+lz-string to compactly store projects in URLs and backups.
+
+## License
+
+Distributed under the ISC license. See `package.json` for details.
+

--- a/README.es.md
+++ b/README.es.md
@@ -1,323 +1,352 @@
-# 🎥 Cine Power Planner
+# Cine Power Planner
 
-Esta herramienta basada en navegador ayuda a planificar proyectos de cámara profesionales alimentados con baterías V‑Mount, B‑Mount o Gold-Mount. Calcula el **consumo total de energía**, la **corriente demandada** (a 14,4 V y 12 V) y la **autonomía estimada** mientras comprueba que la batería pueda suministrar con seguridad la potencia necesaria.
+![Icono de Cine Power Planner](src/icons/app-icon.svg)
 
-Toda la planificación, los datos introducidos y las exportaciones permanecen en el dispositivo que tienes delante. El idioma, los proyectos, el equipo personalizado, los favoritos y los comentarios de autonomía se guardan en tu navegador, y las actualizaciones del service worker llegan directamente desde este repositorio. Ejecuta Cine Power Planner sin conexión desde el disco o aloja la carpeta internamente para que todos los departamentos trabajen con la misma versión auditada.
+Cine Power Planner es una aplicación web independiente para crear, auditar y compartir planes de alimentación profesional que nunca abandonan tu equipo. Diseña rigs V‑Mount, B‑Mount o Gold-Mount, modela tiempos de autonomía, documenta requisitos del proyecto y exporta paquetes compartibles, todo dentro del navegador, incluso sin conexión. Cada dependencia vive en este repositorio para que la experiencia sea idéntica en un estudio, un portátil de rodaje o un disco aislado.
 
 ## De un vistazo
 
-- **Planifica sin conexión.** Todos los iconos, tipografías y scripts auxiliares están incluidos en este repositorio; abre
-  `index.html` directamente y trabaja sin conexión.
-- **Los proyectos se quedan en tu dispositivo.** Las copias guardadas, los datos de autonomía, el equipo personalizado, los
-  favoritos y las listas de equipo permanecen locales; las copias de seguridad y los paquetes compartibles son archivos JSON
-  legibles.
-- **Controla las actualizaciones.** El service worker solo se renueva cuando pulsas **Forzar recarga**, de modo que el equipo se
-  mantiene en una versión fiable incluso durante los traslados.
-- **Red de seguridad en capas.** Guardados manuales, auto guardados y copias de seguridad automáticas con marca de tiempo
-  facilitan ensayar la recuperación antes del rodaje.
+- **Planifica sin conexión.** Construye configuraciones V‑Mount, B‑Mount o Gold-Mount directamente en el navegador. Todos los Uicons, fuentes y scripts auxiliares están incluidos, sin depender de CDNs ni de la red. Clona el repositorio, desconecta el cable y la interfaz seguirá funcionando igual.
+- **Mantén los datos en el dispositivo.** Proyectos, comentarios de autonomía, favoritos, equipos personalizados, listas y ajustes permanecen locales. Las copias de seguridad y los paquetes compartibles son archivos JSON legibles.
+- **Pon a prueba las redes de seguridad.** Guardados manuales, auto-guardados en segundo plano y copias automáticas con sello horario se combinan para que practiques la rutina Guardar → Copia → Paquete → Restaurar desde el primer día.
+- **Aprueba actualizaciones a conciencia.** El service worker espera tu confirmación antes de actualizar, de modo que el equipo se mantiene en una versión auditada incluso durante viajes o con conectividad limitada.
 
-## Puesta en marcha rápida
+## Panorama general
 
-1. Descarga o clona el repositorio y abre `index.html` en un navegador moderno.
-2. (Opcional) Sirve la carpeta en local (por ejemplo con `npx http-server` o `python -m http.server`) para que el service worker
-   se registre y almacene en caché los recursos para el uso sin conexión.
-3. Carga el planner una vez, cierra la pestaña, desconéctate de la red y vuelve a abrir `index.html`. El indicador sin conexión
-   parpadeará brevemente mientras se carga la interfaz almacenada.
-4. Crea un proyecto, pulsa **Intro** (o **Ctrl+S**/`⌘S`) para guardar y comprueba la copia de seguridad automática que aparece
-   en el selector tras unos minutos.
-5. Exporta **Ajustes → Copia de seguridad y restauración → Copia de seguridad**, importa el archivo en un perfil privado del
-   navegador y confirma que todos los proyectos, favoritos y equipos personalizados se restauran correctamente.
-6. Practica exportar un paquete `.cpproject` e importarlo en otra máquina o perfil para validar la cadena guardar → compartir →
-   importar antes de llegar al set.
+### Construido para equipos
 
-## Flujos de trabajo clave
+El planner se diseñó para foquistas, data wranglers y directores de fotografía. Cuando añades cuerpos, placas de batería, enlaces inalámbricos o accesorios, el consumo total y las estimaciones de autonomía se actualizan al instante. Las advertencias señalan packs sobrecargados y las listas de equipos permanecen ligadas al contexto del proyecto para que nada se pierda al compartir el plan.
 
-- **Planifica un rig.** Combina cámaras, placas, enlaces inalámbricos, monitores, motores y accesorios mientras las cifras de
-  consumo y autonomía se actualizan al instante.
-- **Guarda versiones.** Mantén instantáneas explícitas de los proyectos y deja que las copias de seguridad automáticas con marca
-  de tiempo capturen el trabajo en curso cada 10 minutos.
-- **Comparte con seguridad.** Exporta paquetes `.cpproject` que permanecen sin conexión, validan el esquema al importar e
-  incluyen reglas automáticas de equipo si lo necesitas.
-- **Haz copia de todo.** Las copias de seguridad completas del planner incluyen proyectos, favoritos, equipos personalizados,
-  datos de autonomía y preferencias de la interfaz para no perder contexto.
-- **Copias de migración ocultas.** Antes de sobrescribir planificadores, ajustes
-  o preferencias guardados, la aplicación conserva la instantánea JSON anterior
-  en el espacio protegido `__legacyMigrationBackup`. Si una escritura falla o
-  genera datos corruptos, las herramientas de recuperación recurren
-  automáticamente a esa copia de seguridad para que no se pierdan datos de
-  usuario.
+### Listo para viajar
 
-## Protección de datos sin conexión
+Abre `index.html` directamente desde disco o aloja el repositorio en tu red interna, sin builds, servidores ni cuentas. Un service worker mantiene la aplicación disponible offline, recuerda las preferencias y sólo se actualiza cuando lo autorizas. Guardar, compartir, importar, respaldar y restaurar siempre se ejecutan localmente, protegiendo los datos.
 
-- Verifica con regularidad que todo está listo para trabajar sin conexión: carga la aplicación, desconéctate, actualiza y
-  comprueba que tus proyectos siguen disponibles.
-- Conserva copias redundantes en soportes etiquetados e impórtalas en un segundo perfil después de cada exportación.
-- Antes de aplicar actualizaciones o modificar datos importantes, genera una copia de seguridad manual y confirma que se restaura
-  correctamente.
+### Por qué importa el enfoque offline-first
 
----
+Los rodajes raramente tienen conectividad garantizada y muchos estudios exigen herramientas desconectadas. Cine Power Planner ofrece las mismas capacidades con o sin red: todos los recursos están empaquetados, cada flujo funciona localmente y cada guardado genera artefactos que puedes archivar en medios redundantes. Practicar estos flujos antes de filmar forma parte de la lista de comprobación para no depender de servicios externos en pleno rodaje.
 
-## 🌍 Idiomas
+### Pilares de funciones
+
+- **Planifica con confianza.** Calcula la demanda a 14,4 V/12 V (y 33,6 V/21,6 V para B‑Mount), compara baterías compatibles y visualiza el impacto en un panel ponderado de retroalimentación.
+- **Mantente listo para producción.** Los proyectos capturan dispositivos, requisitos, escenarios, detalles de equipo y listas; los auto-backups, paquetes y actualizaciones controladas mantienen la información vigente sin perder estabilidad.
+- **Trabaja como prefieras.** Detección de idioma, temas oscuro, rosa y de alto contraste, controles tipográficos, logotipos personalizados y ayuda contextual hacen que la interfaz sea cómoda en rodajes y en preparación.
+
+## Principios clave
+
+- **Siempre offline.** Toda la aplicación, incluidos iconos, páginas legales y herramientas, vive en el repositorio. Abre `index.html` desde disco o una intranet y el service worker sincroniza los recursos sin obligarte a conectarte.
+- **Sin rutas ocultas de datos.** Guardados, paquetes, importaciones, copias de seguridad y restauraciones suceden íntegramente en el navegador. Nada sale del equipo a menos que lo exportes.
+- **Redes redundantes.** Guardados manuales, auto-guardados en segundo plano, copias periódicas, respaldos previos a la restauración y exportaciones legibles garantizan que ningún dato desaparezca.
+- **Actualizaciones previsibles.** Sólo se aplican cuando tú las activas. Las versiones en caché siguen disponibles hasta que confirmas **Forzar recarga**.
+- **Presentación consistente.** Uicons locales, recursos OpenMoji y tipografías integradas aseguran la misma apariencia en un estudio o en un portátil desconectado.
+
+## Tabla de contenidos
+
+- [De un vistazo](#de-un-vistazo)
+- [Panorama general](#panorama-general)
+- [Principios clave](#principios-clave)
+- [Traducciones](#traducciones)
+- [Novedades](#novedades)
+- [Guía rápida](#guía-rápida)
+- [Requisitos del sistema y navegadores](#requisitos-del-sistema-y-navegadores)
+- [Ensayo de guardado, compartido e importación](#ensayo-de-guardado-compartido-e-importación)
+- [Flujo cotidiano](#flujo-cotidiano)
+- [Gestión de proyectos y guardados](#gestión-de-proyectos-y-guardados)
+- [Compartir e importar](#compartir-e-importar)
+- [Formatos de archivos](#formatos-de-archivos)
+- [Recorrido por la interfaz](#recorrido-por-la-interfaz)
+- [Personalización y accesibilidad](#personalización-y-accesibilidad)
+- [Seguridad de datos y operación offline](#seguridad-de-datos-y-operación-offline)
+- [Resumen de datos y almacenamiento](#resumen-de-datos-y-almacenamiento)
+- [Cuotas y mantenimiento](#cuotas-y-mantenimiento)
+- [Copias de seguridad y recuperación](#copias-de-seguridad-y-recuperación)
+- [Ensayos de integridad](#ensayos-de-integridad)
+- [Listas operativas](#listas-operativas)
+- [Plan de recuperación de emergencia](#plan-de-recuperación-de-emergencia)
+- [Listas de equipo e informes](#listas-de-equipo-e-informes)
+- [Reglas automáticas](#reglas-automáticas)
+- [Inteligencia de autonomía](#inteligencia-de-autonomía)
+- [Atajos de teclado](#atajos-de-teclado)
+- [Localización](#localización)
+- [Instalación como app](#instalación-como-app)
+- [Flujo de datos de dispositivos](#flujo-de-datos-de-dispositivos)
+- [Desarrollo](#desarrollo)
+- [Resolución de problemas](#resolución-de-problemas)
+- [Comentarios y soporte](#comentarios-y-soporte)
+- [Contribuir](#contribuir)
+- [Agradecimientos](#agradecimientos)
+- [Licencia](#licencia)
+
+## Traducciones
+
+La documentación está disponible en varios idiomas. La aplicación detecta automáticamente el idioma del navegador al primer inicio y puedes cambiarlo en cualquier momento desde el menú superior derecho o en **Configuración**.
+
 - 🇬🇧 [English](README.en.md)
 - 🇩🇪 [Deutsch](README.de.md)
 - 🇪🇸 [Español](README.es.md)
 - 🇮🇹 [Italiano](README.it.md)
 - 🇫🇷 [Français](README.fr.md)
 
-La aplicación adopta automáticamente el idioma de tu navegador en la primera visita y puedes cambiarlo desde la esquina superior derecha. El ajuste se guarda para la siguiente sesión.
+Consulta `docs/translation-guide.md` para más detalles sobre la localización.
 
----
+## Novedades
 
-## 🆕 Novedades recientes
-- Las comparaciones de versiones de respaldos permiten elegir cualquier guardado manual o copia automática con marca de tiempo para revisar diferencias, añadir notas de incidentes y exportar un registro antes de revertir cambios o entregar material a postproducción.
-- Las copias de seguridad ahora normalizan los paquetes de datos heredados guardados como cadenas JSON o como matrices de entradas para que los archivos antiguos se restauren correctamente.
-- Los ensayos de restauración cargan una copia completa de la aplicación o un paquete de proyecto en un entorno aislado para confirmar que su contenido coincide con los datos en vivo sin tocar los perfiles de producción.
-- Las reglas automáticas de equipo permiten diseñar adiciones o retiradas según el escenario, exportar la configuración y restaurarla junto con los paquetes de proyecto.
-- El panel Datos y almacenamiento audita proyectos guardados, listas de equipo, dispositivos personalizados, favoritos y comentarios de autonomía directamente desde Ajustes y muestra el tamaño aproximado del respaldo.
-- La superposición del estado de auto-guardado refleja la nota más reciente dentro de Ajustes para que los equipos vean la actividad en segundo plano mientras practican los ejercicios de recuperación.
-- El editor de equipo consciente del monitoreo muestra accesorios adicionales de monitor y video solo cuando los escenarios lo requieren para mantener enfocado el diseño de reglas.
-- Los controles de acento y tipografía en Ajustes permiten ajustar el color de acento, el tamaño base de la fuente y la familia tipográfica junto a los temas oscuro, rosa y de alto contraste.
-- Los atajos de teclado de la búsqueda global enfocan la búsqueda de funciones al instante con / o Ctrl+K (⌘K en macOS), incluso cuando está dentro del menú lateral móvil contraído.
-- El botón **Forzar recarga** borra los archivos del service worker en caché para que la aplicación sin conexión se actualice sin eliminar proyectos ni dispositivos guardados.
-- Las estrellas de cada selector fijan cámaras, baterías y accesorios favoritos en la parte superior de la lista y los mantienen en las copias de seguridad.
-- El flujo de **Restablecimiento de fábrica** descarga automáticamente una copia de seguridad antes de eliminar proyectos, dispositivos y ajustes almacenados.
-- La lista de equipo y la vista imprimible muestran el nombre del proyecto para consultarlo de un vistazo.
-- Sube un logotipo personalizado para que aparezca en las vistas imprimibles y en las copias de seguridad.
-- Las copias de seguridad incluyen los favoritos y crean automáticamente una copia antes de restaurar.
-- Las fichas del equipo incluyen ahora un campo de correo electrónico.
-- Opciones de accesibilidad con alto contraste, animación reducida y espaciado relajado mejoran la legibilidad y la comodidad.
-- Los formularios de dispositivos rellenan los campos de categoría dinámicamente a partir de los atributos del esquema.
-- Interfaz rediseñada con mayor contraste y espaciado para una experiencia más limpia en cualquier dispositivo.
-- Compartir proyectos es más sencillo: descarga un archivo JSON que agrupa selecciones, requisitos, listas de equipo, comentarios de autonomía y dispositivos personalizados, e impórtalo para restaurarlo todo. Activa el interruptor **Incluir reglas automáticas de equipo** cuando quieras que tus automatizaciones viajen en el archivo o déjalo desmarcado para mantenerlas locales.
-- Iconos exclusivos para los escenarios obligatorios distinguen los requisitos del proyecto.
-- Diagrama de proyecto interactivo para arrastrar dispositivos, hacer zoom, ajustar los nodos a la cuadrícula y exportar el plano como SVG o JPG.
-- Tema rosa divertido que se mantiene entre visitas.
-- Diálogo de ayuda con búsqueda, secciones paso a paso y FAQ; ábrelo con ?, H, F1 o Ctrl+/.
-- Ayudas contextuales al pasar el cursor por botones, campos, menús y encabezados.
-- Barra de búsqueda global para saltar a funciones, selectores de dispositivos o temas de ayuda.
-- Compatibilidad con cámaras con placas de batería V‑, B‑ o Gold-Mount.
-- Envía comentarios de autonomía con temperatura para afinar las estimaciones.
-- Panel visual de ponderación de autonomías que muestra cómo influyen los ajustes en cada informe, ahora ordenado por peso y con porcentajes exactos.
-- Generador de listas de equipo que reúne el material seleccionado y los requisitos del proyecto.
-- Guarda los requisitos del proyecto con cada proyecto para conservar todo el contexto en las listas de equipo.
-- Duplica al instante las entradas personalizadas en los formularios de lista de equipo con los botones en forma de horquilla.
+- **Comparación de copias de seguridad** – Selecciona guardados manuales o auto-backups, revisa diferencias, añade notas de incidente y exporta un registro antes de revertir cambios o entregar material a postproducción.
+- **Ensayos de restauración** – Carga copias completas o paquetes de proyectos en un entorno aislado para comprobar su contenido sin tocar perfiles de producción.
+- **Reglas automáticas de equipo** – Define añadidos o retiradas activados por escenarios, con controles de importación/exportación y copias temporizadas.
+- **Panel de datos y almacenamiento** – Audita proyectos, listas, equipos personalizados, favoritos y comentarios de autonomía desde Configuración y estima el tamaño del backup.
+- **Superposición de estado de auto-guardado** – Refleja la nota más reciente dentro del diálogo de ajustes para que el equipo vea la actividad de fondo durante los ensayos.
+- **Editor sensible al monitoreo** – Sólo muestra campos extra de monitores y distribución cuando el escenario lo requiere.
+- **Controles de acento y tipografía** – Ajusta color de acento, tamaño y familia de fuente; los temas oscuro, rosa y alto contraste persisten entre sesiones.
+- **Atajos de búsqueda global** – Pulsa `/` o `Ctrl+K` (`⌘K` en macOS) para enfocar la búsqueda aunque el menú móvil esté plegado.
+- **Botón de forzar recarga** – Actualiza los recursos del service worker sin borrar proyectos ni dispositivos.
+- **Favoritos anclados** – Marca opciones con estrella para mantener cámaras, baterías y accesorios habituales arriba y en las copias de seguridad.
+- **Reseteo de fábrica con respaldo** – Descarga automáticamente una copia antes de borrar proyectos, dispositivos y ajustes guardados.
 
----
+Consulta los README específicos para ver detalles por idioma.
 
-## 🔧 Funciones
+## Guía rápida
 
-### ✨ Destacados ampliados
+Ejecuta esta lista tras instalar o actualizar el planner. Confirma que guardado, compartido, importación, respaldo y restauración funcionan igual en línea y sin red.
 
-- **Diseña rigs complejos sin adivinar.** Combina cámaras, placas de batería, enlaces inalámbricos, monitores, motores y accesorios mientras supervisas el consumo total a 14,4 V/12 V (y 33,6 V/21,6 V en B‑Mount) junto a autonomías realistas basadas en datos de campo ponderados. El panel de comparación de baterías avisa de sobrecargas antes de que el equipo salga al rodaje.
-- **Mantén coordinados a todos los departamentos.** Guarda varios proyectos con requisitos, contactos del equipo, escenarios y notas. Las listas imprimibles agrupan el material por categoría, fusionan duplicados, muestran metadatos técnicos e incluyen accesorios condicionados por los escenarios para que cámara, iluminación y grip trabajen con el mismo contexto.
-- **Trabaja con seguridad estés donde estés.** Abre `index.html` directamente o sirve la carpeta por HTTPS para activar el service worker. La caché sin conexión conserva idioma, temas, favoritos y proyectos, y **Forzar recarga** actualiza los recursos almacenados sin tocar tus datos.
-- **Ajusta Cine Power Planner a tu equipo.** Cambia al instante entre español, inglés, alemán, italiano y francés, ajusta el tamaño de la fuente y la tipografía, define un color de acento, sube un logotipo para impresión y alterna entre temas claro, oscuro, rosa o de alto contraste. Los selectores con búsqueda, los favoritos fijados, los botones de duplicar y las ayudas flotantes mantienen ágil el trabajo en set.
+1. Descarga o clona el repositorio.
+2. Abre `index.html` en un navegador moderno.
+3. (Opcional) Sirve la carpeta por HTTP(S) para instalar el service worker:
+   ```bash
+   npx http-server
+   # o
+   python -m http.server
+   ```
+   La aplicación se almacenará en caché para uso offline y aplicará actualizaciones cuando las apruebes.
+4. Carga el planner, cierra la pestaña, desconecta la red (o activa modo avión) y vuelve a abrir `index.html`. El indicador offline debe parpadear mientras se cargan los recursos en caché, incluidos los Uicons locales.
+5. Crea un proyecto, pulsa **Enter** (o **Ctrl+S**/`⌘S`) para guardar manualmente y revisa el selector para ver el auto-backup con sello horario que aparece a los pocos minutos.
+6. Exporta **Configuración → Copia de seguridad y restauración → Copia de seguridad** e importa el archivo `planner-backup.json` en un perfil privado. Verificar la ruta de restauración demuestra que ninguna copia queda atrapada y que la salvaguarda previa funciona.
+7. Practica la exportación de un paquete (`project-name.json`) y su importación en otro equipo o perfil. Ensayar el flujo Guardar → Compartir → Importar asegura que los recursos locales acompañan al proyecto.
+8. Archiva la copia verificada y el paquete junto a la versión del repositorio usada. Así mantienes sincronizados los flujos y tienes medios redundantes para viajar.
 
-### ✅ Gestión de proyectos
-- Guarda, carga y elimina múltiples proyectos (pulsa Enter o Ctrl+S/⌘S para guardar rápido; el botón Guardar permanece desactivado hasta introducir un nombre).
-- Se generan instantáneas automáticas cada 10 minutos mientras Cine Power Planner está abierto, y el cuadro de Ajustes puede lanzar exportaciones de copias de seguridad cada hora como recordatorio.
-- Descarga un archivo JSON que reúne selecciones, requisitos, listas de equipo, comentarios de autonomía y dispositivos personalizados; impórtalo mediante el selector de proyectos para recuperarlo todo de una vez.
-- Los datos se guardan localmente mediante `localStorage`, y los favoritos se incluyen en las copias de seguridad; usa la opción **Restablecimiento de fábrica** para descargar automáticamente una copia antes de limpiar proyectos y dispositivos guardados.
-- Genera vistas imprimibles de cualquier proyecto y añade un logotipo personalizado para que exportaciones y copias coincidan con tu identidad de producción.
-- Los requisitos de proyecto se guardan junto a cada proyecto, de modo que la lista de equipo mantiene todo el contexto.
-- Funciona íntegramente sin conexión gracias al service worker: idioma, tema, datos de dispositivos y favoritos persisten entre sesiones.
-- El diseño adaptable responde sin esfuerzo en ordenadores, tabletas y teléfonos.
-- En las cámaras compatibles puedes elegir placas **V‑Mount**, **B‑Mount** o **Gold-Mount**; la lista de baterías se actualiza automáticamente.
+## Requisitos del sistema y navegadores
 
-### 🧭 Descripción de la interfaz
-- **Resumen rápido:**
-  - **Búsqueda global** (`/` o `Ctrl+K`/`⌘K`) salta a funciones, selectores o temas de ayuda incluso con el menú lateral plegado.
-  - **Centro de ayuda** (`?`, `H`, `F1` o `Ctrl+/`) ofrece guías filtrables, preguntas frecuentes, atajos y el modo de ayuda flotante.
-  - **Diagrama del proyecto** muestra las conexiones; mantén pulsada Mayús al descargar para guardar un JPG en lugar de un SVG y ver avisos de compatibilidad.
-  - **Comparador de baterías** revela el rendimiento de cada pack compatible y resalta riesgos de sobrecarga.
-  - **Generador de listas** crea tablas por categoría con metadatos, correos del equipo y accesorios según escenario listos para imprimir.
-  - **Indicador sin conexión y Forzar recarga** reflejan el estado de la conexión y renuevan los archivos en caché sin borrar proyectos.
-- Un enlace de salto y un indicador sin conexión mantienen la interfaz accesible para teclado y pantallas táctiles; la insignia aparece cuando el navegador pierde la conexión.
-- La barra de búsqueda global salta a funciones, selectores de dispositivos o temas de ayuda; pulsa Enter para abrir el resultado destacado, usa / o Ctrl+K (⌘K en macOS) para enfocarla desde cualquier lugar (el menú lateral se abre automáticamente en pantallas pequeñas) y pulsa Escape o × para limpiar la consulta.
-- Los controles superiores permiten cambiar de idioma, alternar los temas oscuro y rosa y abrir Ajustes con opciones de color de acento, tamaño y familia tipográfica, modo de alto contraste y carga de logotipo, además de herramientas para copia de seguridad, restauración y Restablecimiento de fábrica que guardan una copia antes de borrar datos.
-- El botón de Ayuda abre un diálogo con búsqueda, secciones guiadas, atajos de teclado, FAQ y un modo de ayuda emergente opcional; también puedes abrirlo con ?, H, F1 o Ctrl+/ incluso mientras escribes.
-- El botón de recarga forzada (🔄) borra los archivos del service worker almacenados en caché para que la aplicación sin conexión se actualice sin perder proyectos ni dispositivos.
-- En pantallas pequeñas, un menú lateral plegable replica cada sección principal para navegar con rapidez.
+- **Navegadores modernos.** Validado en las últimas versiones de Chromium, Firefox y Safari. Activa service workers, IndexedDB y almacenamiento persistente.
+- **Dispositivos orientados a offline.** Portátiles y tabletas deben permitir almacenamiento persistente. Ejecuta la app una vez en línea para que el service worker almacene todos los recursos y practica la recarga offline antes de viajar.
+- **Espacio local suficiente.** Las producciones grandes acumulan proyectos, backups y listas. Vigila el espacio del perfil y exporta regularmente a medios redundantes.
+- **Sin dependencias externas.** Todos los iconos, fuentes y scripts se entregan con el repositorio. Copia también `animated icons 3/` y los Uicons locales al mover la carpeta.
 
-### ♿ Personalización y accesibilidad
-- Los temas incluyen modo oscuro, acentos rosas lúdicos y un interruptor de alto contraste para mejorar la legibilidad.
-- Los cambios de color de acento, tamaño base y tipografía se aplican al instante y se conservan en el navegador, ideales para adaptarse a la identidad visual o a necesidades de accesibilidad.
-- Los atajos integrados cubren la búsqueda global (/ o Ctrl+K/⌘K), la ayuda ( ?, H, F1, Ctrl+/ ), el guardado (Enter o Ctrl+S/⌘S), el modo oscuro (D) y el modo rosa (P).
-- El modo de ayuda emergente convierte botones, campos, menús y encabezados en descripciones bajo demanda para que el equipo se familiarice rápido.
-- Las entradas con búsqueda incremental, los estados visibles al enfocar y las estrellas junto a los selectores permiten filtrar listas largas y fijar los favoritos.
-- Sube un logotipo para impresiones, configura roles de monitorización predeterminados y ajusta los presets de requisitos del proyecto para que las exportaciones respeten la identidad de la producción.
-- Los botones de bifurcación duplican filas al instante, y los favoritos fijados mantienen el equipo habitual en la parte superior de cada selector.
+## Ensayo de guardado, compartido e importación
 
-### 📋 Lista de equipo
-El generador convierte tus selecciones en una lista de empaque categorizada:
+Repite esta rutina cuando se incorpore personal, se prepare una estación nueva o se publique una actualización importante. Verifica que los flujos de guardado, compartido, importación, copia de seguridad y restauración funcionan sin conexión.
 
-- Haz clic en **Generar lista de equipo** para combinar el equipo elegido y los requisitos del proyecto en una tabla.
-- La tabla se actualiza en cuanto cambian las selecciones o los requisitos.
-- Los elementos se agrupan por categoría (cámara, óptica, alimentación, monitorización, rigging, grip, accesorios, consumibles) y los duplicados se fusionan con sus cantidades.
-- Se añaden cables, rigging y accesorios necesarios para monitores, motores, gimbals y escenarios meteorológicos.
-- Las selecciones de escenarios agregan el equipo relacionado:
-  - *Handheld* + *Easyrig* incorpora una empuñadura telescópica para un soporte estable.
-  - *Gimbal* suma el gimbal seleccionado, brazos articulados, espigas y parasoles o kits de filtros.
-  - *Outdoor* aporta espigas, paraguas y fundas de lluvia CapIt.
-  - Los escenarios *Vehicle* y *Steadicam* incluyen montajes, brazos de aislamiento y ventosas cuando corresponde.
-- Las selecciones de óptica aportan diámetro frontal, peso, datos de varillas y enfoque mínimo, añaden soportes de lente y adaptadores de matte box y avisan de estándares incompatibles.
-- Las filas de baterías reflejan los cálculos del módulo de potencia e incluyen placas o dispositivos de hotswap cuando son necesarios.
-- Las preferencias de monitorización asignan monitores predeterminados para cada rol (director, DoP, foco, etc.) con juegos de cables y receptores inalámbricos.
-- El formulario de **Requisitos del proyecto** nutre la lista:
-  - **Nombre del proyecto**, **productora**, **casa de alquiler** y **DoP** aparecen en el encabezado de los requisitos impresos.
-  - Las entradas de **equipo** recogen nombres, roles y correos electrónicos para que la información de contacto acompañe al proyecto.
-  - **Días de preparación** y **días de rodaje** aportan notas de calendario y, combinados con escenarios exteriores, proponen equipo para la climatología.
-  - Los **escenarios obligatorios** añaden rigging, gimbals y protección climática adecuada.
-  - **Empuñadura de cámara** y **extensión de visor** incluyen las piezas o soportes seleccionados.
-  - Las opciones de **matte box** y **filtros** agregan el sistema elegido con bandejas, adaptadores de pinza o filtros necesarios.
-  - Las configuraciones de **monitorización**, **distribución de vídeo** y **visor** añaden monitores, cables y overlays para cada rol.
-  - Las selecciones de **botones de usuario** y **preferencias de trípode** se listan para referencia rápida.
-- Los elementos de cada categoría se ordenan alfabéticamente y muestran descripciones emergentes al pasar el cursor.
-- La lista de equipo se incluye en las vistas imprimibles y en los archivos de proyecto exportados.
-- Las listas de equipo se guardan automáticamente con el proyecto y se incluyen tanto en los archivos exportados como en las copias de seguridad.
-- **Eliminar lista de equipo** borra la lista guardada y oculta la salida.
-- Los formularios incluyen botones de bifurcación para duplicar entradas personalizadas al instante.
+1. **Guardado base.** Abre el proyecto actual, realiza un guardado manual y observa el sello horario. Un auto-backup debería añadirse en menos de diez minutos.
+2. **Exporta redundancias.** Genera una copia completa y un paquete del proyecto. Renómbralo a `.cpproject` si lo requiere tu flujo y guarda ambos en medios distintos.
+3. **Ensayo de restauración.** Cambia a un perfil privado (o segunda máquina), importa la copia completa y después el paquete. Comprueba listas, paneles, reglas y favoritos.
+4. **Verificación offline.** En el perfil de ensayo, desconecta la red y recarga `index.html`. Confirma que aparece el indicador offline y que los Uicons y scripts locales cargan correctamente.
+5. **Archiva con confianza.** Borra el perfil de ensayo tras confirmar la restauración y etiqueta los archivos verificados según el protocolo del proyecto.
 
-### 📦 Categorías de dispositivos
-- **Cámara** (1)
-- **Monitor** (opcional)
-- **Transmisor inalámbrico** (opcional)
-- **Motores FIZ** (0–4)
-- **Controladores FIZ** (0–4)
-- **Sensor de distancia** (0–1)
-- **Placa de batería** (solo en cámaras que aceptan V‑ o B‑Mount)
-- **Batería V‑Mount** (0–1)
+## Flujo cotidiano
 
-### ⚙️ Cálculos de energía
-- Consumo total en vatios
-- Corriente demandada a 14,4 V y 12 V
-- Autonomía estimada en horas usando la media ponderada de la comunidad
-- Número de baterías necesario para un rodaje de 10 h
-- Nota de temperatura para ajustar la autonomía en condiciones extremas
+1. **Crea o abre un proyecto.** Escribe un nombre y pulsa **Enter**/**Guardar**. El nombre activo aparece en listas e impresiones.
+2. **Añade cámaras, energía y accesorios.** Selecciona equipos en menús categorizados. La búsqueda al escribir, los favoritos y el atajo `/` (`Ctrl+K`/`⌘K`) aceleran la selección.
+3. **Revisa potencia y autonomía.** Observa las alertas, compara baterías y usa el panel de autonomía para evaluar cómo influyen temperatura, códec, fps, etc.
+4. **Documenta requisitos.** Introduce equipo, escenarios, agarres, matte boxes y configuraciones de monitoreo. Los botones de bifurcar duplican entradas. Usa **Configuración → Reglas automáticas** para agregar o quitar elementos según escenarios antes de exportar.
+5. **Exporta o archiva el plan.** Genera la lista de equipo, descarga una copia o un paquete antes de salir al set. Los respaldos incluyen dispositivos personalizados, comentarios y favoritos.
+6. **Confirma la preparación offline.** Desconecta la red, recarga la app y verifica que todo siga accesible. Restaura la copia más reciente si algo parece fuera de lugar.
 
-### 🔋 Comprobación de entrega de batería
-- Avisa si la corriente demandada supera la salida de la batería (pin o D‑Tap)
-- Indica cuando el consumo se acerca al límite (80 % de uso)
+## Gestión de proyectos y guardados
 
-### 📊 Comparación de baterías (opcional)
-- Compara estimaciones de autonomía entre todas las baterías
-- Gráficos de barras para consulta rápida
+- **Guardados manuales para versiones explícitas.** Introduce el nombre y pulsa **Enter**/**Guardar**. Cada guardado preserva dispositivos, requisitos, listas, favoritos, diagramas y observaciones.
+- **Auto-guardados para progreso en curso.** Mientras el proyecto está abierto, la app escribe cambios en segundo plano. Las entradas `auto-backup-…` aparecen cada diez minutos.
+- **Mostrar auto-backups bajo demanda.** Activa **Configuración → Copia de seguridad y restauración → Mostrar auto-backups** para ver los sellos temporales.
+- **Renombrar crea bifurcaciones.** Cambia el nombre y pulsa **Enter** para duplicar la versión. Útil para comparar variantes.
+- **Cambiar de proyecto no destruye datos.** Selecciona otro elemento en el menú; la app conserva la posición de scroll y campos no guardados.
+- **Eliminación con confirmación.** Usa el icono de papelera; siempre se solicita confirmación antes de borrar.
 
-### 🖼 Diagrama del proyecto
-- Visualiza las conexiones de alimentación y vídeo de los dispositivos seleccionados
-- Advierte cuando las marcas FIZ son incompatibles
-- Arrastra nodos para reorganizar el esquema, usa los botones de zoom y exporta el diagrama como SVG o JPG
-- Mantén pulsada Mayús al descargar para exportar una instantánea JPG en lugar de un SVG
-- Pasa el cursor o toca los dispositivos para ver detalles emergentes
-- Utiliza iconos OpenMoji cuando hay conexión, con emoji como alternativa: 🔋 batería, 🎥 cámara, 🖥️ monitor, 📡 vídeo, ⚙️ motor, 🎮 controlador, 📐 distancia, 🎮 empuñadura y 🔌 placa de batería
+## Compartir e importar
 
-### 🧮 Ponderación de datos de autonomía
-- Los tiempos enviados por la comunidad refinan la estimación
-- Cada registro se ajusta por temperatura, escalando desde ×1 a 25 °C hasta:
-  - ×1,25 a 0 °C
-  - ×1,6 a −10 °C
-  - ×2 a −20 °C
-- Los ajustes de cámara influyen en el peso:
-  - Multiplicadores de resolución: ≥12K ×3, ≥8K ×2, ≥4K ×1,5, ≥1080p ×1; resoluciones menores se escalan a 1080p
-  - La frecuencia de cuadro escala linealmente desde 24 fps (por ejemplo, 48 fps = ×2)
-  - Wi‑Fi activado suma un 10 %
-  - Factores de códec: RAW/BRAW/ARRIRAW/R3D/CinemaDNG/Canon RAW/X‑OCN ×1; ProRes ×1,1; DNx/AVID ×1,2; All‑Intra ×1,3; H.264/AVC ×1,5; H.265/HEVC ×1,7
-  - Las entradas de monitores por debajo del brillo especificado se ponderan según su relación de brillo
-- El peso final refleja la cuota de consumo de cada dispositivo, de modo que los proyectos similares cuentan más
-- Se usa la media ponderada cuando hay al menos tres entradas disponibles
-- Un panel ordena los registros por peso y muestra el porcentaje de cada uno para compararlos al instante
+- **Paquetes de proyecto ligeros.** **Exportar proyecto** descarga `project-name.json` con el proyecto activo, favoritos y dispositivos personalizados. Renómbralo a `.cpproject` si tu archivo maestro lo requiere.
+- **Reglas automáticas junto al paquete.** Activa **Incluir reglas automáticas** durante la exportación para que viajen; al importar se pueden aplicar sólo al proyecto o fusionarse con las reglas globales.
+- **Importaciones validadas offline.** Al importar `auto-gear-rules-*.json`, la app verifica tipo, versión semántica y metadatos antes de sobrescribir. Las discrepancias muestran avisos y, si algo falla, se restaura el snapshot anterior automáticamente.
+- **Restauraciones con doble buffer.** Antes de importar, se solicita guardar una copia del estado actual. Tras validar el paquete, el proyecto restaurado aparece arriba en el selector.
+- **Flujos entre dispositivos sin red.** Copia `index.html`, `script.js`, `devices/` y tus archivos de respaldo a un medio externo. Lanza la app desde disco, importa el paquete y continúa trabajando sin conectarte.
+- **Exporta con responsabilidad.** Revisa el JSON antes de compartirlo para asegurarte de que sólo incluye lo necesario. El formato es legible para editar o depurar entradas.
+- **Sincroniza con checklists.** Cuando recibas un paquete actualizado, impórtalo, revisa los sellos `Actualizado` en la barra lateral y archiva el JSON anterior para mantener el historial.
+- **Comparte sin perder contexto.** Los paquetes recuerdan idioma, tema, logotipo y preferencias para que quien lo abra vea el proyecto como tú, incluso offline.
 
-### 🔍 Búsqueda y filtrado
-- Escribe en los menús desplegables para encontrar entradas rápidamente
-- Filtra las listas de dispositivos con un cuadro de búsqueda
-- Utiliza la barra de búsqueda global en la parte superior para saltar a funciones, dispositivos o temas de ayuda; pulsa Enter para navegar, usa / o Ctrl+K (⌘K en macOS) para enfocarla y pulsa Escape o × para limpiar
-- Pulsa “/” o Ctrl+F (⌘F en macOS) para enfocar al instante el cuadro de búsqueda más cercano
-- Haz clic en la estrella junto a cualquier selector para fijar favoritos y sincronizarlos con las copias de seguridad
+## Formatos de archivos
 
-### 🛠 Editor de la base de datos
-- Añade, edita o elimina dispositivos en todas las categorías
-- Importa o exporta la base completa como JSON
-- Vuelve a la base predeterminada de `src/data/index.js`
+- **`project-name.json` (paquete).** Incluye un proyecto, favoritos y dispositivos personalizados. Cambiar la extensión a `.cpproject` no altera la importación.
+- **`planner-backup.json` (respaldo completo).** **Configuración → Copia de seguridad y restauración → Copia de seguridad** captura proyectos, auto-backups, favoritos, comentarios, reglas, ajustes, fuentes y branding.
+- **`auto-gear-rules-*.json` (reglas).** Exportaciones opcionales desde **Reglas automáticas** con tipo de archivo, versión y metadatos para validar offline. Guarda estas copias junto a los respaldos completos.
 
-### 🌓 Modo oscuro
-- Actívalo con el botón de la luna junto al selector de idioma
-- La preferencia se guarda en tu navegador
+## Recorrido por la interfaz
 
-### 🦄 Modo rosa
-- Haz clic en el botón del unicornio (el modo rosa rota iconos cada 30 segundos con una animación suave y vuelve al caballo cuando sales) o pulsa **P** para activar un acento rosa lúdico
-- Funciona en los temas claro y oscuro y persiste entre visitas
+### Referencia rápida
 
-### ⚫ Modo de alto contraste
-- Activa un tema de alto contraste para mejorar la legibilidad
+- **Búsqueda global** (`/`, `Ctrl+K`, `⌘K`) salta a funciones, selectores o temas de ayuda, incluso con navegación oculta.
+- **Centro de ayuda** (`?`, `H`, `F1`, `Ctrl+/`) ofrece guías, atajos, preguntas frecuentes y modo de ayuda flotante.
+- **Diagrama de proyecto** visualiza rutas de energía y señal; mantén Shift al exportar para guardar JPG.
+- **Panel de comparación de baterías** muestra rendimiento de packs compatibles y alerta sobre sobrecargas.
+- **Generador de listas** crea tablas categorizadas con metadatos, correos de equipo y accesorios según escenarios.
+- **Indicador offline y Forzar recarga** muestran el estado de conexión y actualizan recursos sin tocar los datos.
 
-### 📝 Comentarios de autonomía
-- Haz clic en <strong>Enviar comentarios de autonomía</strong> debajo de la estimación para añadir tu medición
-- Incluye la temperatura para obtener una ponderación más precisa
-- Las entradas se guardan en tu navegador y mejoran estimaciones futuras
-- Un panel dedicado ordena los envíos por peso, muestra porcentajes de contribución y resalta valores atípicos para analizarlos rápidamente
+### Controles superiores
 
-### ❓ Ayuda con búsqueda
-- Ábrela mediante el botón <strong>?</strong> o pulsa <kbd>?</kbd>, <kbd>H</kbd>, <kbd>F1</kbd> o <kbd>Ctrl+/</kbd>
-- Usa el campo de búsqueda para filtrar temas al instante; la consulta se restablece al cerrar el diálogo
-- Cierra con <kbd>Escape</kbd> o haciendo clic fuera del diálogo
+- Un enlace para saltar, el indicador offline y la marca responsiva mantienen la navegación accesible.
+- La barra de búsqueda se enfoca con `/` o `Ctrl+K` (`⌘K`), abre el menú lateral en móviles y se limpia con Escape.
+- El cambio de idioma, los modos oscuro/rosa y el diálogo de Configuración permiten ajustar color de acento, tamaño y familia de fuente, alto contraste, logotipo personalizado y acceder a herramientas de respaldo, restauración y restablecimiento (siempre con copia previa).
+- El botón de ayuda abre el diálogo buscable y responde a `?`, `H`, `F1` o `Ctrl+/` en cualquier momento.
+- El botón 🔄 elimina recursos en caché y recarga la app sin borrar proyectos ni datos de autonomía.
 
----
+### Navegación y búsqueda
 
-## ▶️ Cómo usarlo
-1. **Inicia la aplicación:** abre `index.html` en cualquier navegador moderno; no necesita servidor.
-2. **Explora la barra superior:** cambia de idioma, alterna los temas oscuro o rosa, abre Ajustes para modificar acento y tipografía y lanza la ayuda con ? o Ctrl+/.
-3. **Selecciona los dispositivos:** elige el equipo de cada categoría en los menús desplegables; escribe para filtrar, fija favoritos con la estrella y deja que los escenarios rellenen los accesorios automáticamente.
-4. **Consulta los cálculos:** verás consumo, corriente y autonomía en cuanto elijas una batería; las alertas señalan cuando se superan los límites.
-5. **Guarda y exporta proyectos:** pon nombre y guarda la configuración, las copias automáticas capturan instantáneas y el botón Exportar descarga un paquete JSON mientras Importar lo restaura.
-6. **Genera listas de equipo:** pulsa **Generar lista de equipo** para convertir los requisitos en una lista categorizada con descripciones y accesorios.
-7. **Gestiona los datos de dispositivos:** haz clic en “Editar datos de dispositivos…” para abrir el editor, ajustar el catálogo, exportar/importar JSON o volver a los valores predeterminados.
-8. **Envía comentarios de autonomía:** usa “Enviar comentarios de autonomía” para registrar mediciones reales y refinar los promedios ponderados.
+- En pantallas pequeñas, un menú lateral plegable replica las secciones principales.
+- Cada lista y desplegable permite buscar escribiendo y filtrar al vuelo. `/` o `Ctrl+F` (`⌘F`) enfocan el campo más cercano.
+- Los iconos de estrella fijan dispositivos favoritos en la parte superior y los preservan en las copias de seguridad.
 
-## 📱 Instalar como aplicación
+## Personalización y accesibilidad
 
-Cine Power Planner es una aplicación web progresiva y puede instalarse directamente desde el navegador:
+- Cambia entre temas claro, oscuro, rosa y alto contraste; el color de acento, el tamaño base y la tipografía persisten offline.
+- El enlace de salto, los estados de foco visibles y el diseño responsivo facilitan la navegación con teclado, tablet o móvil.
+- Atajos disponibles: búsqueda (`/`, `Ctrl+K`, `⌘K`), ayuda (`?`, `H`, `F1`, `Ctrl+/`), guardado (`Enter`, `Ctrl+S`, `⌘S`), modo oscuro (`D`) y tema rosa (`P`).
+- El modo de ayuda flotante convierte botones, campos y cabeceras en tooltips bajo demanda.
+- Sube un logotipo personalizado para las vistas imprimibles, define valores por defecto de monitoreo y conjuntos de requisitos.
+- Los botones de bifurcar duplican campos rápidamente y los favoritos mantienen a mano los dispositivos recurrentes.
 
-- **Chrome/Edge (escritorio):** haz clic en el icono de instalación de la barra de direcciones.
-- **Android:** abre el menú del navegador y elige *Añadir a pantalla de inicio*.
-- **iOS/iPadOS Safari:** toca *Compartir* y selecciona *Añadir a pantalla de inicio*.
+## Seguridad de datos y operación offline
 
-Una vez instalada, la aplicación se abre desde la pantalla de inicio, funciona sin conexión y se actualiza automáticamente.
+- Un service worker almacena todos los recursos, ejecuta la app sin conexión y aplica actualizaciones sólo tras **Forzar recarga**.
+- Proyectos, comentarios, favoritos, dispositivos, temas y listas viven en el almacenamiento del navegador. Se solicita persistencia cuando está disponible para reducir riesgos de expulsión.
+- Ejecutar la app desde disco o una red interna mantiene los datos sensibles fuera de servicios externos. Las exportaciones en JSON son auditables.
+- La cabecera muestra el indicador offline cuando cae la conexión; **Forzar recarga** actualiza archivos sin tocar el trabajo guardado.
+- **Restablecer fábrica** o borrar datos del sitio sólo se permite tras generar automáticamente una copia.
+- Las actualizaciones del service worker se descargan en segundo plano y esperan tu aprobación. Al ver **Actualización lista**, termina los cambios, crea un backup y pulsa **Forzar recarga**.
+- El almacenamiento reside en IndexedDB con preferencias pequeñas reflejadas en `localStorage`. Usa las herramientas del navegador para inspeccionar o exportar datos antes de limpiar cachés.
 
-## 📡 Uso sin conexión y almacenamiento
+## Resumen de datos y almacenamiento
 
-Servir la aplicación mediante HTTP(S) instala un service worker que almacena en caché cada archivo, de modo que Cine Power Planner funciona completamente sin conexión y se actualiza en segundo plano. Los proyectos, los comentarios de autonomía y las preferencias (idioma, tema, modo rosa y listas guardadas) se almacenan en el `localStorage` del navegador. Borrar los datos del sitio elimina toda la información, y el cuadro de Ajustes incluye un flujo de **Restablecimiento de fábrica** que guarda automáticamente una copia antes de efectuar la limpieza. La cabecera muestra un indicador sin conexión cuando la red falla y la acción 🔄 **Forzar recarga** actualiza los recursos en caché sin tocar los proyectos guardados.
+- Abre **Configuración → Datos y almacenamiento** para revisar proyectos, auto-backups, listas, dispositivos personalizados, favoritos, comentarios y la caché de sesión con recuentos en vivo.
+- Cada entrada explica qué representa; las secciones vacías permanecen ocultas para que identifiques el estado rápidamente.
+- El resumen estima el tamaño del backup usando la exportación más reciente.
 
----
+## Cuotas y mantenimiento
 
-## 🗂️ Estructura de archivos
-```bash
-index.html                 # Estructura principal en HTML
-src/styles/style.css       # Estilos base y diseño
-src/styles/overview.css    # Estilos de la vista general
-src/styles/overview-print.css # Ajustes de impresión para la vista general
-src/scripts/script.js        # Lógica de la aplicación
-src/scripts/storage.js       # Utilidades para LocalStorage
-src/scripts/static-theme.js  # Lógica de tema compartida para las páginas legales
-src/data/index.js       # Lista predeterminada de dispositivos
-src/data/devices/       # Catálogos de dispositivos por categoría
-src/data/schema.json    # Esquema generado para los selectores
-src/vendor/             # Bibliotecas de terceros incluidas
-legal/                     # Documentación legal sin conexión
-tools/                     # Scripts de mantenimiento de datos
-tests/                     # Suite de pruebas con Jest
-```
-Las fuentes se incluyen localmente mediante `fonts.css`; una vez en caché, la aplicación funciona completamente sin conexión.
+- **Confirma el almacenamiento persistente.** Revisa el panel en cada estación. Si el navegador lo deniega, solicita acceso de nuevo o planifica exportaciones manuales más frecuentes.
+- **Vigila el espacio disponible.** Usa el panel o el inspector de almacenamiento. Si el margen se reduce, archiva backups antiguos, elimina entradas `auto-backup-…` redundantes y verifica que los nuevos archivos se descargan sin avisos.
+- **Prepara las cachés tras actualizar.** Después de **Forzar recarga**, abre el diálogo de ayuda, las páginas legales y las vistas habituales para volver a almacenar Uicons, OpenMoji y fuentes.
+- **Documenta la salud del almacenamiento.** Añade estas comprobaciones a tus registros de preparación y cierre: estado de persistencia, espacio libre y ubicación de las copias más recientes.
 
-## 🛠️ Desarrollo
-Se requiere Node.js 18 o posterior.
+## Copias de seguridad y recuperación
 
-```bash
-npm install
-npm run lint     # ejecuta solo ESLint
-npm test         # realiza linting, comprobaciones de datos y pruebas de Jest
-```
+- **Instantáneas guardadas** – El selector conserva cada plan manual y crea `auto-backup-…` cada diez minutos mientras la app está abierta.
+- **Copias completas** – **Configuración → Copia de seguridad y restauración → Copia de seguridad** descarga `planner-backup.json` con proyectos, dispositivos, comentarios, reglas y estado de UI. Antes de restaurar se crea un respaldo de seguridad y se muestran avisos si el archivo proviene de otra versión.
+- **Resguardos ocultos de migración** – Antes de sobrescribir planners, configuraciones o preferencias, la app guarda el JSON anterior en `__legacyMigrationBackup`. Si algo falla, la recuperación vuelve automáticamente a esa copia.
+- **Historial automático de reglas** – Los cambios en **Reglas automáticas** generan copias con sello horario cada diez minutos.
+- **Restablecimiento de fábrica** – Borra datos sólo después de descargar un backup.
+- **Recordatorios por hora** – Una rutina en segundo plano sugiere realizar una copia adicional cada hora.
+- **Bucle de verificación** – Tras cada backup crítico, impórtalo en un perfil separado y confirma que coincide antes de eliminar el perfil.
+- **Hábitos de almacenamiento seguro** – Etiqueta los archivos con nombre del proyecto y fecha y guárdalos en medios redundantes (RAID, USB cifrado, disco óptico).
+- **Compara antes de sobrescribir** – Descarga un backup nuevo antes de restaurar y revisa diferencias con una herramienta de diff JSON.
 
-Tras editar los datos de dispositivos, regenera la base normalizada:
+## Ensayos de integridad
+
+- **Validación previa (diaria o antes de cambios mayores).** Guarda manualmente, exporta copia completa y paquete, impórtalos en un perfil privado y comprueba proyectos, reglas, favoritos y paneles antes de borrarlo.
+- **Ensayo offline (semanal o antes de viajar).** Ejecuta la app, crea un backup, desconecta toda red y recarga `index.html`. Verifica el indicador offline, los Uicons y la apertura del proyecto verificado.
+- **Control de cambios (tras editar datos o scripts).** Corre `npm test` para recuperar confianza y repite la validación previa. Archiva el backup aprobado con una nota de cambios.
+- **Rotación de redundancia (mensual o antes de archivar).** Guarda el backup más reciente, un paquete verificado (renombrado a `.cpproject` si es necesario) y un ZIP del repositorio en al menos dos medios. Alterna cuál se inspecciona para detectar degradación.
+
+## Listas operativas
+
+Rutinas repetibles para mantener proyectos, respaldos y recursos offline sincronizados en cada equipo que usa Cine Power Planner. Existe una versión imprimible en `docs/operations-checklist.md` y la guía `docs/offline-readiness.md` amplía los pasos para viajes largos sin conectividad.
+
+### Preparación previa al rodaje
+
+1. **Confirma la revisión correcta.** Abre `index.html`, pulsa **Forzar recarga** y verifica la versión en **Configuración → Acerca de**. Abre las páginas legales para precargar Uicons, OpenMoji y tipografías.
+2. **Carga proyectos críticos.** Abre el plan activo y un `auto-backup-…` reciente. Comprueba listas, comentarios y favoritos en ambos.
+3. **Ejercita la cadena de guardado.** Realiza un cambio, guarda con `Enter` o `Ctrl+S`/`⌘S`, exporta `planner-backup.json`, impórtalo en un perfil privado y compara el selector.
+4. **Prueba el flujo de compartido.** Exporta `project-name.json`, impórtalo, revisa reglas automáticas, dispositivos y el indicador offline. Elimina el perfil después.
+5. **Simula operación sin red.** Desconecta el equipo, recarga la app y confirma que el indicador offline aparece, los iconos se ven nítidos y los proyectos siguen accesibles.
+6. **Archiva los artefactos.** Guarda el backup verificado, el paquete y un ZIP del repositorio en medios redundantes para reconstruir el entorno sin internet.
+
+### Entrega al finalizar
+
+1. **Captura un backup final.** Con el proyecto abierto, exporta `planner-backup.json` y el último `project-name.json` (renómbralo a `.cpproject` si procede) y etiquétalos con fecha, localización y jornada.
+2. **Valida importaciones.** Restaura ambos archivos en una máquina de verificación y asegúrate de que no haya corrupción. Mantén esa instancia offline.
+3. **Registra los cambios.** Documenta qué auto-backups se promovieron, qué dispositivos personalizados se añadieron y qué reglas cambiaron. Guarda las notas junto a los respaldos.
+4. **Actualiza cachés con intención.** Tras archivar, pulsa **Forzar recarga**, abre el diálogo de ayuda y las páginas legales para recargar documentos antes de volver a trabajar offline.
+5. **Entrega medios redundantes.** Proporciona copias cifradas a la unidad de almacenamiento y conserva un segundo juego según la política de retención.
+
+## Plan de recuperación de emergencia
+
+1. **Pausa y preserva el estado.** Deja la pestaña abierta, desconecta la red si puedes y registra la hora y el estado del indicador offline. Evita recargar.
+2. **Exporta lo que queda.** Ejecuta **Configuración → Copia de seguridad y restauración → Copia de seguridad** y descarga `planner-backup.json`. Aun si la lista parece incorrecta, captura auto-backups, favoritos, comentarios y reglas para análisis.
+3. **Duplica auto-backups.** Muestra las entradas `auto-backup-…`, promueve los snapshots recientes a guardados manuales y renómbralos con el ID del incidente o un sello temporal.
+4. **Inspecciona el paquete verificado.** Importa el último `project-name.json`/`.cpproject` confiable en un perfil privado o máquina secundaria sin conexión y compara proyectos, listas y ajustes.
+5. **Restaura con cuidado.** Si la verificación es correcta, restaura el backup fresco en la máquina principal. El flujo guarda primero una copia de seguridad para comparar con herramientas de diff si fuera necesario.
+6. **Recarga y documenta.** Tras recuperarte, pulsa **Forzar recarga**, abre el diálogo de ayuda y las páginas legales para rehidratar cachés, luego registra el incidente (qué ocurrió, qué archivos se exportaron, dónde se guardaron y qué estación validó la solución). Almacena el informe junto a la copia.
+
+## Listas de equipo e informes
+
+- **Generar lista de equipo y requisitos** crea tablas categorizadas que se actualizan automáticamente cuando cambian los datos.
+- Los elementos se agrupan por categoría y fusionan duplicados. Los escenarios añaden rigging, protección climática y accesorios especializados para reflejar la realidad del rodaje.
+- Las reglas automáticas se ejecutan tras el generador para añadir o quitar elementos específicos sin editar JSON a mano.
+- Las filas de lentes incluyen diámetro frontal, peso, mínimo enfoque, necesidad de varillas y componentes de matte box. Las filas de baterías consideran cantidades y hardware para hot-swap.
+- Detalles del equipo, configuraciones de monitoreo, preferencias de distribución de vídeo y notas personalizadas aparecen en las exportaciones.
+- Las listas se guardan con el proyecto, aparecen en las vistas imprimibles y en los paquetes; puedes reiniciarlas con **Eliminar lista de equipo**.
+
+## Reglas automáticas
+
+Desde **Configuración → Reglas automáticas** puedes ajustar cada lista sin editar JSON manualmente:
+
+- Activa reglas sólo cuando ciertos **Escenarios requeridos** estén marcados; añade etiquetas opcionales para identificarlas rápidamente.
+- Agrega equipo con categoría y cantidad o utiliza **Adiciones personalizadas** para recordatorios, kits especiales o avisos. Las reglas de eliminación ocultan filas que el generador incluiría.
+- Las reglas se ejecutan después de los paquetes predeterminados para integrarse con la lógica base y fluyen a las listas, backups y paquetes.
+- Guardar una lista almacena el conjunto de reglas activo con el proyecto. Al cargarlo o importar un paquete, se recupera el alcance correcto.
+- Exporta o importa el conjunto como JSON, restablécelo a los valores de fábrica cuando necesites un punto limpio y recurre al historial automático (cada diez minutos) si un ajuste falla.
+
+## Inteligencia de autonomía
+
+Los tiempos aportados por usuarios alimentan un modelo ponderado para aproximarse a la experiencia real:
+
+- Ajustes de temperatura: ×1 a 25 °C, ×1,25 a 0 °C, ×1,6 a −10 °C y ×2 a −20 °C.
+- Resolución: ≥12K ×3, ≥8K ×2, ≥4K ×1,5, ≥1080p ×1; menores se escalan en relación a 1080p.
+- Fotogramas: escala lineal a partir de 24 fps (48 fps = ×2).
+- Wi‑Fi activado suma 10 %.
+- Códecs: RAW/BRAW/ARRIRAW/R3D/CinemaDNG/Canon RAW/X‑OCN ×1; ProRes ×1,1; DNx/AVID ×1,2; All-Intra ×1,3; H.264/AVC ×1,5; H.265/HEVC ×1,7.
+- Monitores ponderados según la relación de brillo.
+- El peso final refleja cuánta energía aporta cada componente para que rigs similares influyan más.
+- Un panel ordena por peso, muestra porcentajes y destaca valores atípicos para análisis rápido.
+
+## Atajos de teclado
+
+| Atajo | Acción | Notas |
+| --- | --- | --- |
+| `/`, `Ctrl+K`, `⌘K` | Enfocar la búsqueda global | Funciona incluso con navegación plegada; `Esc` limpia |
+| `Enter`, `Ctrl+S`, `⌘S` | Guardar el proyecto activo | El botón Guardar se habilita tras introducir un nombre |
+| `?`, `H`, `F1`, `Ctrl+/` | Abrir la ayuda | El diálogo sigue siendo buscable mientras escribes |
+| `D` | Cambiar a modo oscuro | También disponible en **Configuración → Temas** |
+| `P` | Alternar tema rosa | Compatible con temas claro, oscuro o alto contraste |
+| 🔄 | Forzar recarga de recursos | También desde **Configuración → Forzar recarga** |
+
+## Localización
+
+Puedes previsualizar nuevas traducciones sin build:
+
+1. Duplica el README más cercano como `README.<lang>.md` y tradúcelo.
+2. Añade cadenas en `translations.js`, manteniendo los marcadores como `%s`.
+3. Copia y traduce las páginas estáticas (privacidad, aviso legal).
+4. Ejecuta `npm test` antes de enviar un pull request.
+
+## Instalación como app
+
+Cine Power Planner es una aplicación web progresiva:
+
+1. Abre `index.html` en un navegador compatible.
+2. Usa la opción **Instalar** o **Añadir a la pantalla de inicio**.
+   - **Chrome/Edge (escritorio):** Haz clic en el icono de instalación en la barra de direcciones.
+   - **Android:** Menú del navegador → *Añadir a pantalla de inicio*.
+   - **iOS Safari:** Botón compartir → *Añadir a pantalla de inicio*.
+3. Inicia la app desde tu lista de aplicaciones. Funciona offline y se actualiza automáticamente tras aprobar una recarga.
+
+## Flujo de datos de dispositivos
+
+Los catálogos viven en `devices/`. Cada archivo agrupa equipos relacionados para facilitar las auditorías. Ejecuta los siguientes scripts antes de hacer commit:
 
 ```bash
 npm run normalize
@@ -326,9 +355,75 @@ npm run check-consistency
 npm run generate-schema
 ```
 
-Añade `--help` a cualquiera de los scripts anteriores para ver las opciones disponibles.
+`npm run normalize` limpia nombres y abreviaturas de conectores. `npm run unify-ports` estandariza etiquetas. `npm run check-consistency` verifica campos obligatorios y `npm run generate-schema` reconstruye `schema.json`. Para iterar rápido con datos:
 
-Ejecuta `npm run help` para obtener un recordatorio rápido de los scripts de mantenimiento y del orden recomendado.
+```bash
+npm run test:data
+```
 
-## 🤝 Contribuciones
-Las contribuciones son bienvenidas. Abre una incidencia o envía un pull request. Si informas de correcciones de datos, adjuntar copias de seguridad o mediciones de autonomía ayuda a mantener el catálogo fiable para todos.
+Añade `--help` a cualquier comando para ver instrucciones y revisa los diffs generados antes de abrir un pull request. `npm run help` resume los scripts disponibles.
+
+## Desarrollo
+
+Configura Node.js 18 o superior. Tras clonar:
+
+```bash
+npm install
+npm run lint
+npm test
+```
+
+`npm test` ejecuta ESLint, comprobaciones de datos y Jest de forma secuencial (`--runInBand`, `maxWorkers=1`). Ejecuta suites específicas mientras iteras:
+
+```bash
+npm run test:unit
+npm run test:data
+npm run test:dom
+npm run test:script
+```
+
+### Bundle para navegadores legacy
+
+Después de modificar `src/scripts/` o `src/data/`, ejecuta `npm run build:legacy` para regenerar el bundle ES5 que sirve a navegadores antiguos. El comando también actualiza los polyfills locales para preservar la experiencia offline.
+
+### Estructura de archivos
+
+```
+index.html
+src/styles/style.css
+src/styles/overview.css
+src/styles/overview-print.css
+src/scripts/script.js
+src/scripts/storage.js
+src/scripts/static-theme.js
+src/data/index.js
+src/data/devices/
+src/data/schema.json
+src/vendor/
+legal/
+tools/
+tests/
+```
+
+## Resolución de problemas
+
+- **¿El service worker está bloqueado en una versión antigua?** Pulsa **Forzar recarga** o realiza una recarga dura desde las herramientas de desarrollador.
+- **¿Faltan datos tras cerrar la pestaña?** Asegúrate de que el sitio tenga acceso a almacenamiento; la navegación privada puede bloquearlo.
+- **¿Descargas bloqueadas?** Permite descargas múltiples para guardar copias y paquetes.
+- **¿Fallo en scripts de línea de comandos?** Verifica que Node.js 18+ esté instalado, ejecuta `npm install` y vuelve a probar. Si hay errores de memoria, usa una suite más pequeña como `npm run test:unit`.
+
+## Comentarios y soporte
+
+Abre un issue si encuentras problemas, tienes preguntas o quieres proponer funciones. Incluir exportaciones o muestras de autonomía ayuda a mantener el catálogo preciso.
+
+## Contribuir
+
+¡Se aceptan contribuciones! Abre un issue o envía un pull request tras leer `CONTRIBUTING.md`. Ejecuta `npm test` antes de enviarlo.
+
+## Agradecimientos
+
+El planner incluye Uicons locales, recursos OpenMoji y otros elementos para disponer de iconografía sin conexión, y utiliza lz-string para almacenar proyectos de forma compacta en URLs y respaldos.
+
+## Licencia
+
+Distribuido bajo la licencia ISC. Consulta `package.json` para más detalles.

--- a/README.fr.md
+++ b/README.fr.md
@@ -1,321 +1,352 @@
-# 🎥 Cine Power Planner
+# Cine Power Planner
 
-Cet outil basé sur le navigateur aide à planifier des projets caméra professionnels alimentés par des batteries V‑Mount, B‑Mount ou Gold-Mount. Il calcule la **consommation totale**, l’**intensité demandée** (à 14,4 V et 12 V) et l’**autonomie estimée**, tout en vérifiant que la batterie peut fournir la puissance requise en toute sécurité.
+![Icône Cine Power Planner](src/icons/app-icon.svg)
 
-L’ensemble de la planification, des saisies et des exports reste sur votre appareil. La langue, les projets, les appareils personnalisés, les favoris et les retours d’autonomie sont stockés dans votre navigateur, et les mises à jour du service worker proviennent directement de ce dépôt. Lancez Cine Power Planner hors ligne depuis le disque ou hébergez-le en interne pour que chaque département exploite la même version auditée.
+Cine Power Planner est une application web autonome pour créer, auditer et partager des plans d’alimentation professionnels qui ne quittent jamais votre machine. Configurez des rigs V‑Mount, B‑Mount ou Gold-Mount, modélisez les autonomies, consignez les exigences du projet et exportez des lots partageables, entièrement dans le navigateur, même hors ligne. Toutes les dépendances résident dans ce dépôt, garantissant la même expérience sur un poste de plateau, un ordinateur portable de tournage ou un disque isolé.
 
-## En bref
+## En résumé
 
-- **Planifiez sans réseau.** Toutes les icônes, polices et scripts d’assistance sont fournis dans ce dépôt ; ouvrez simplement
-  `index.html` pour travailler hors ligne.
-- **Les projets restent sur l’appareil.** Sauvegardes, retours d’autonomie, appareils personnalisés, favoris et listes de
-  matériel demeurent locaux ; les sauvegardes et paquets partageables sont des JSON lisibles.
-- **Gardez la main sur les mises à jour.** Le service worker ne se met à jour qu’après avoir cliqué sur **Forcer le rechargement**,
-  maintenant l’équipe sur une version fiable en déplacement.
-- **Filets de sécurité en cascade.** Sauvegardes manuelles, enregistrements automatiques et copies horodatées facilitent les
-  exercices de restauration avant le tournage.
+- **Planification hors ligne en priorité.** Concevez des configurations V‑Mount, B‑Mount ou Gold-Mount directement dans le navigateur. Tous les Uicons, polices et scripts auxiliaires sont fournis localement, sans dépendre de CDNs ni du réseau. Clonez le dépôt, débranchez le câble et l’interface reste identique.
+- **Données conservées sur l’appareil.** Projets, retours d’autonomie, favoris, équipements personnalisés, listes et préférences restent locaux. Les sauvegardes et lots partageables sont des fichiers JSON lisibles.
+- **Réseaux de sécurité éprouvés.** Sauvegardes manuelles, enregistrements automatiques en arrière-plan et backups horodatés se complètent pour répéter la boucle Sauvegarder → Backup → Bundle → Restaurer dès la première utilisation.
+- **Mises à jour sous contrôle.** Le service worker attend votre validation avant d’actualiser afin que les équipes restent sur une version vérifiée, même en déplacement ou avec une connectivité limitée.
 
-## Démarrage rapide
+## Vue d’ensemble
 
-1. Téléchargez ou clonez le dépôt et ouvrez `index.html` dans un navigateur moderne.
-2. (Optionnel) Servez le dossier en local (par exemple avec `npx http-server` ou `python -m http.server`) pour que le service
-   worker s’enregistre et mette en cache les ressources pour l’usage hors ligne.
-3. Chargez le planner une fois, fermez l’onglet, coupez la connexion et rouvrez `index.html`. L’indicateur hors ligne doit
-   clignoter brièvement pendant le chargement de l’interface en cache.
-4. Créez un projet, appuyez sur **Entrée** (ou **Ctrl+S**/`⌘S`) pour sauvegarder et surveillez la sauvegarde automatique qui
-   apparaît dans le sélecteur après quelques minutes.
-5. Exportez **Paramètres → Sauvegarde & Restauration → Sauvegarder**, importez le fichier dans un profil de navigation privé et
-   confirmez que projets, favoris et appareils personnalisés se restaurent correctement.
-6. Entraînez-vous à exporter un paquet `.cpproject` et à l’importer sur un autre appareil ou profil pour valider la chaîne
-   sauvegarde → partage → import avant d’arriver sur le plateau.
+### Pensé pour les équipes
 
-## Flux de travail essentiels
+Le planner a été conçu pour les 1ers assistants caméra, data managers et chefs opérateurs. À chaque ajout de corps caméra, plaque batterie, lien sans fil ou accessoire, la consommation totale et les estimations d’autonomie se mettent à jour instantanément. Des alertes signalent les packs surchargés et les listes d’équipement restent liées au contexte du projet pour éviter toute perte lors du passage de relais.
 
-- **Planifier un rig.** Combinez caméras, plaques, liaisons sans fil, moniteurs, moteurs et accessoires tout en suivant en temps
-  réel la consommation et les estimations d’autonomie.
-- **Sauvegarder des versions.** Conservez des instantanés explicites et laissez les sauvegardes automatiques horodatées capturer
-  le travail en cours toutes les 10 minutes.
-- **Partager en toute sécurité.** Exportez des paquets `.cpproject` hors ligne qui valident le schéma à l’import et peuvent inclure
-  des règles automatiques de matériel.
-- **Sauvegarder l’ensemble.** Les sauvegardes complètes incluent projets, favoris, appareils personnalisés, données d’autonomie
-  et préférences d’interface pour ne perdre aucun contexte.
-- **Sauvegardes de migration invisibles.** Avant d’écraser les planificateurs,
-  configurations ou préférences enregistrés, l’application conserve l’instantané
-  JSON précédent dans l’emplacement protégé `__legacyMigrationBackup`. Si une
-  écriture échoue ou produit des données corrompues, les outils de récupération
-  reviennent automatiquement à cette copie de sécurité afin qu’aucune donnée
-  utilisateur ne disparaisse.
+### Prêt à voyager
 
-## Protéger les données hors ligne
+Ouvrez `index.html` directement depuis le disque ou hébergez le dépôt sur votre réseau interne, sans build, serveur ni compte. Un service worker garde l’application disponible hors ligne, mémorise les préférences et n’applique les mises à jour que sur validation. Sauvegarde, partage, import, backup et restauration restent locaux pour protéger les données utilisateur.
 
-- Vérifiez régulièrement la préparation hors ligne : chargez l’application, coupez la connexion, actualisez et assurez-vous que
-  vos projets restent accessibles.
-- Conservez des sauvegardes redondantes sur des supports étiquetés et réimportez-les dans un deuxième profil après chaque export.
-- Avant toute mise à jour ou modification importante, créez une sauvegarde manuelle et vérifiez que la restauration est propre.
+### Pourquoi l’offline-first est crucial
 
----
+Les plateaux disposent rarement d’une connectivité fiable et les studios exigent souvent des outils déconnectés. Cine Power Planner offre les mêmes capacités avec ou sans réseau : chaque ressource est incluse, chaque workflow fonctionne localement et chaque sauvegarde crée des artefacts que vous pouvez archiver sur des supports redondants. Vérifier ces workflows avant le tournage fait partie de la checklist pour ne dépendre d’aucun service externe en pleine production.
 
-## 🌍 Langues
+### Piliers fonctionnels
+
+- **Planifier en confiance.** Calculez la consommation à 14,4 V/12 V (et 33,6 V/21,6 V pour le B‑Mount), comparez les batteries compatibles et visualisez l’impact dans un tableau de bord pondéré.
+- **Rester prêt pour la production.** Les projets capturent équipements, exigences, scénarios, détails d’équipe et listes ; backups automatiques, bundles et mises à jour contrôlées gardent les données à jour sans sacrifier la stabilité.
+- **Travailler à votre manière.** Détection de langue, thèmes sombre, rose et contraste élevé, contrôles typographiques, logos personnalisés et aide contextuelle rendent l’interface accessible en préparation comme sur le plateau.
+
+## Principes fondamentaux
+
+- **Toujours hors ligne.** L’application complète — icônes, pages légales et outils — est livrée dans le dépôt. Ouvrez `index.html` depuis le disque ou un intranet privé et le service worker synchronise les ressources sans imposer de connexion.
+- **Pas de chemins cachés.** Sauvegardes, bundles, imports, backups et restaurations se déroulent intégralement dans le navigateur. Rien ne quitte la machine sauf export explicite.
+- **Filets redondants.** Sauvegardes manuelles, autosaves en arrière-plan, backups périodiques, sauvegardes forcées avant restauration et exports lisibles empêchent toute disparition silencieuse.
+- **Mises à jour prévisibles.** Elles ne s’appliquent que sur votre action. Les versions en cache restent disponibles jusqu’à ce que vous confirmiez **Forcer le rechargement**.
+- **Présentation cohérente.** Uicons locaux, ressources OpenMoji et polices intégrées garantissent la même apparence en studio ou sur un poste déconnecté.
+
+## Table des matières
+
+- [En résumé](#en-résumé)
+- [Vue d’ensemble](#vue-densemble)
+- [Principes fondamentaux](#principes-fondamentaux)
+- [Traductions](#traductions)
+- [Nouveautés](#nouveautés)
+- [Démarrage rapide](#démarrage-rapide)
+- [Prérequis système et navigateurs](#prérequis-système-et-navigateurs)
+- [Exercice sauvegarde/partage/import](#exercice-sauvegardepartageimport)
+- [Routine quotidienne](#routine-quotidienne)
+- [Sauvegarde et gestion de projet](#sauvegarde-et-gestion-de-projet)
+- [Partage et imports](#partage-et-imports)
+- [Formats de fichiers](#formats-de-fichiers)
+- [Visite de l’interface](#visite-de-linterface)
+- [Personnalisation et accessibilité](#personnalisation-et-accessibilité)
+- [Sécurité des données et mode hors ligne](#sécurité-des-données-et-mode-hors-ligne)
+- [Vue d’ensemble des données et du stockage](#vue-densemble-des-données-et-du-stockage)
+- [Gestion des quotas et maintenance](#gestion-des-quotas-et-maintenance)
+- [Backup et restauration](#backup-et-restauration)
+- [Exercices d’intégrité](#exercices-dintégrité)
+- [Check-lists opérationnelles](#check-lists-opérationnelles)
+- [Plan de récupération d’urgence](#plan-de-récupération-durgence)
+- [Listes de matériel et rapports](#listes-de-matériel-et-rapports)
+- [Règles automatiques](#règles-automatiques)
+- [Intelligence d’autonomie](#intelligence-dautonomie)
+- [Raccourcis clavier](#raccourcis-clavier)
+- [Localisation](#localisation)
+- [Installer comme application](#installer-comme-application)
+- [Flux de données matériel](#flux-de-données-matériel)
+- [Développement](#développement)
+- [Dépannage](#dépannage)
+- [Retours et support](#retours-et-support)
+- [Contribuer](#contribuer)
+- [Remerciements](#remerciements)
+- [Licence](#licence)
+
+## Traductions
+
+La documentation existe en plusieurs langues. L’application détecte automatiquement celle du navigateur lors du premier lancement et vous pouvez la modifier à tout moment depuis le menu en haut à droite ou via **Paramètres**.
+
 - 🇬🇧 [English](README.en.md)
 - 🇩🇪 [Deutsch](README.de.md)
 - 🇪🇸 [Español](README.es.md)
 - 🇮🇹 [Italiano](README.it.md)
 - 🇫🇷 [Français](README.fr.md)
 
-L’application adopte automatiquement la langue de votre navigateur lors de la première visite. Vous pouvez ensuite changer de langue à tout moment depuis l’angle supérieur droit, et le choix est mémorisé pour la prochaine session.
+Consultez `docs/translation-guide.md` pour le guide de localisation.
 
----
+## Nouveautés
 
-## 🆕 Nouveautés
-- Les comparaisons de versions de sauvegarde permettent de sélectionner n’importe quel enregistrement manuel ou sauvegarde automatique horodatée pour analyser les différences, ajouter des notes d’incident et exporter un journal avant un retour arrière ou une remise d’images à la post-production.
-- Les sauvegardes normalisent désormais les anciens paquets de données enregistrés en chaînes JSON ou en tableaux d’entrées afin que les exports historiques se restaurent correctement.
-- Les répétitions de restauration chargent une sauvegarde complète de l’application ou un bundle de projet dans un bac à sable isolé pour confirmer que son contenu correspond aux données actives sans toucher aux profils de production.
-- Les règles automatiques d’équipement ajoutent ou retirent du matériel selon le scénario, avec export/import aux côtés des bundles partagés.
-- Le tableau de bord Données & stockage audite projets enregistrés, listes de matériel, appareils personnalisés, favoris et retours d’autonomie depuis les Réglages et affiche la taille approximative des sauvegardes.
-- Une superposition d’état d’enregistrement automatique reflète la dernière note dans Paramètres afin que les équipes visualisent l’activité en arrière-plan pendant les exercices de récupération.
-- Un éditeur d’équipement sensible au monitoring affiche des accessoires supplémentaires de monitoring et de vidéo uniquement lorsque les scénarios l’exigent, pour garder la conception des règles focalisée.
-- Les réglages d’accent et de typographie dans Paramètres permettent d’ajuster couleur d’accent, taille de base et famille de police, aux côtés des thèmes sombre, rose et à fort contraste.
-- Les raccourcis clavier de la recherche globale placent le focus sur le champ instantanément avec / ou Ctrl+K (⌘K sur macOS), même lorsqu’il se trouve dans le menu latéral replié.
-- Le bouton **Forcer le rechargement** vide les fichiers mis en cache par le service worker afin de mettre à jour l’application hors ligne sans effacer projets ou appareils.
-- Les icônes en forme d’étoile fixent caméras, batteries et accessoires favoris en haut des listes et les incluent dans les sauvegardes.
-- Le flux de **Réinitialisation d’usine** télécharge automatiquement une sauvegarde avant de supprimer projets, appareils et paramètres stockés.
-- La liste de matériel et l’aperçu imprimable affichent le nom du projet pour une référence immédiate.
-- Importez un logo personnalisé pour les aperçus imprimables et les sauvegardes.
-- Les sauvegardes incluent les favoris et génèrent une copie automatique avant chaque restauration.
-- Les fiches équipe disposent désormais d’un champ e-mail.
-- Nouveau thème à fort contraste pour améliorer la lisibilité.
-- Les formulaires d’appareils complètent les catégories dynamiquement à partir du schéma.
-- Interface repensée avec contraste renforcé et espacements plus généreux pour une expérience plus nette sur tout appareil.
-- Partage simplifié : téléchargez un fichier JSON regroupant sélections, exigences, liste de matériel, retours d’autonomie et appareils personnalisés, puis importez-le pour tout restaurer. Activez l’option **Inclure les règles automatiques d’équipement** si vous souhaitez embarquer vos automatisations ou laissez-la désactivée pour les conserver en local.
-- Des icônes dédiées pour les scénarios obligatoires mettent en évidence les contraintes du projet.
-- Diagramme de projet interactif pour déplacer les appareils, zoomer, aligner sur la grille et exporter en SVG ou JPG.
-- Thème rose ludique qui persiste entre les visites.
-- Boîte d’aide avec recherche, sections guidées et FAQ ; ouvrez-la avec ?, H, F1 ou Ctrl+/.
-- Aides contextuelles au survol des boutons, champs, menus et en-têtes.
-- Barre de recherche globale pour rejoindre rapidement fonctionnalités, sélecteurs ou rubriques d’aide.
-- Compatibilité avec les caméras équipées de plaques V‑, B‑ ou Gold-Mount.
-- Soumettez des retours d’autonomie avec la température pour affiner les estimations.
-- Tableau de pondération visuel pour analyser l’impact des réglages sur chaque mesure, trié par poids avec pourcentages précis.
-- Générateur de liste de matériel qui agrège équipements choisis et exigences du projet.
-- Les exigences de projet sont sauvegardées avec chaque configuration pour conserver tout le contexte.
-- Les boutons en forme de fourche dupliquent désormais instantanément les entrées personnalisées dans les formulaires de liste de matériel.
+- **Comparaison de sauvegardes** – Sélectionnez un enregistrement manuel ou un auto-backup, analysez les différences, ajoutez des notes d’incident et exportez un rapport avant toute restauration ou remise au montage.
+- **Simulations de restauration** – Chargez un backup complet ou un bundle projet dans une sandbox isolée pour vérifier le contenu sans toucher aux profils de production.
+- **Règles automatiques de matériel** – Définissez des ajouts/suppressions déclenchés par scénario avec contrôle d’import/export et backups horodatés.
+- **Tableau de bord données & stockage** – Auditez projets, listes, matériels personnalisés, favoris et retours d’autonomie directement depuis Paramètres et estimez la taille du backup.
+- **Superposition d’état d’autosave** – Réplique la dernière note d’autosave dans la boîte de dialogue des paramètres afin que les équipes voient l’activité de fond pendant les exercices.
+- **Éditeur sensible au monitoring** – Affiche les champs de monitoring supplémentaires uniquement lorsque les scénarios l’exigent pour garder la création de règles focalisée.
+- **Contrôles d’accent et typographie** – Ajustez couleur d’accent, taille et famille de police ; les thèmes sombre, rose et contraste élevé persistent entre les sessions.
+- **Raccourcis de recherche globale** – Pressez `/` ou `Ctrl+K` (`⌘K` sur macOS) pour cibler la recherche instantanément, même avec la navigation mobile repliée.
+- **Bouton Forcer le rechargement** – Rafraîchit les ressources du service worker sans effacer projets ni appareils.
+- **Favoris épinglés** – Étoile les entrées pour garder caméras, batteries et accessoires préférés en tête de liste et inclus dans les backups.
+- **Réinitialisation usine sécurisée** – Télécharge automatiquement un backup avant toute suppression de projets, appareils ou préférences.
 
----
+Voir les README traduits pour les notes locales.
 
-## 🔧 Fonctionnalités
+## Démarrage rapide
 
-### ✨ Points forts détaillés
+Appliquez cette checklist lors de l’installation ou après une mise à jour pour prouver que sauvegarde, partage, import, backup et restauration fonctionnent en ligne comme hors ligne.
 
-- **Construisez des rigs complexes sans tâtonner.** Combinez caméras, plaques batteries, liaisons sans fil, moniteurs, moteurs et accessoires tout en visualisant la consommation totale à 14,4 V/12 V (et 33,6 V/21,6 V pour B‑Mount) avec des autonomies réalistes issues de données terrain pondérées. Le panneau de comparaison des batteries signale les surcharges avant le départ du matériel.
-- **Gardez chaque département aligné.** Enregistrez plusieurs projets avec exigences, contacts équipe, scénarios et notes. Les listes imprimables regroupent le matériel par catégorie, fusionnent les doublons, affichent les métadonnées techniques et ajoutent les accessoires dictés par les scénarios pour que caméra, lumière et machinerie restent synchronisées.
-- **Travaillez sereinement partout.** Ouvrez `index.html` directement ou servez le dossier via HTTPS pour activer le service worker. La mise en cache hors ligne conserve langue, thèmes, favoris et projets, et **Forcer le rechargement** actualise les fichiers sans toucher aux données.
-- **Adaptez l’outil à votre équipe.** Basculez instantanément entre français, anglais, allemand, espagnol et italien, ajustez taille et police, choisissez une couleur d’accent personnalisée, importez un logo d’impression et alternez thème clair, sombre, rose ou à fort contraste. Menus filtrables, favoris épinglés, boutons de duplication et aides contextuelles gardent un rythme rapide sur le plateau.
+1. Téléchargez ou clonez le dépôt.
+2. Ouvrez `index.html` dans un navigateur moderne.
+3. (Optionnel) Servez le dossier en HTTP(S) pour installer le service worker :
+   ```bash
+   npx http-server
+   # ou
+   python -m http.server
+   ```
+   L’application se met ensuite en cache pour un usage hors ligne et n’applique les mises à jour qu’après validation.
+4. Chargez le planner, fermez l’onglet, coupez la connexion (ou activez le mode avion) puis rouvrez `index.html`. L’indicateur hors ligne doit clignoter brièvement pendant le chargement des ressources mises en cache, y compris les Uicons locaux.
+5. Créez un projet, appuyez sur **Entrée** (ou **Ctrl+S**/`⌘S`) pour déclencher une sauvegarde manuelle et vérifiez l’apparition de l’auto-backup horodaté dans le sélecteur après quelques minutes.
+6. Exportez **Paramètres → Backup & Restauration → Backup** et importez le fichier `planner-backup.json` dans un profil privé. Cette vérification garantit qu’aucune sauvegarde ne reste isolée et démontre le backup forcé avant restauration.
+7. Entraînez-vous à exporter un bundle (`project-name.json`) puis à l’importer sur une seconde machine ou profil pour valider la chaîne Sauvegarder → Partager → Importer et s’assurer que les ressources locales suivent le projet hors ligne.
+8. Archivez le backup vérifié et le bundle avec la copie du dépôt. Les flux restent synchronisés et vous disposez de médias redondants pour les déplacements.
 
-### ✅ Gestion de projet
-- Enregistrez, chargez et supprimez plusieurs projets caméra (appuyez sur Entrée ou Ctrl+S/⌘S pour sauvegarder rapidement ; le bouton reste inactif tant qu’aucun nom n’est saisi).
-- Des instantanés automatiques se créent toutes les 10 minutes tant que Cine Power Planner est ouvert, et la boîte de dialogue Paramètres peut déclencher des exports de sauvegarde horaires en guise de rappel.
-- Téléchargez un fichier JSON qui regroupe sélections, exigences, liste de matériel, retours d’autonomie et appareils personnalisés ; importez-le via le sélecteur de projet pour tout restaurer d’un coup.
-- Les données se stockent localement via `localStorage` et les favoris sont inclus dans les sauvegardes ; utilisez l’option **Réinitialisation d’usine** pour enregistrer automatiquement une copie avant d’effacer projets et modifications d’appareils.
-- Générez des aperçus imprimables pour chaque projet et ajoutez un logo personnalisé afin d’aligner exports et sauvegardes sur l’identité de votre production.
-- Les exigences de projet sont enregistrées avec chaque projet afin que la liste de matériel conserve l’intégralité du contexte.
-- Fonctionne intégralement hors ligne grâce au service worker : langue, thème, données d’appareil et favoris persistent entre les sessions.
-- Mise en page responsive qui s’adapte aux ordinateurs, tablettes et téléphones.
-- Sur les caméras compatibles, choisissez des plaques **V‑Mount**, **B‑Mount** ou **Gold-Mount** ; la liste des batteries se met à jour automatiquement.
+## Prérequis système et navigateurs
 
-### 🧭 Aperçu de l’interface
-- **Rappel express :**
-  - **Recherche globale** (`/` ou `Ctrl+K`/`⌘K`) rejoint fonctionnalités, sélecteurs ou rubriques d’aide même avec le menu replié.
-  - **Centre d’aide** (`?`, `H`, `F1` ou `Ctrl+/`) propose des guides filtrables, une FAQ, des raccourcis et le mode d’aide contextuelle.
-  - **Diagramme de projet** visualise les connexions ; maintenez Maj au téléchargement pour obtenir un JPG plutôt qu’un SVG et afficher les alertes de compatibilité.
-  - **Comparateur de batteries** montre les performances des packs compatibles et met en évidence les risques de surcharge.
-  - **Générateur de liste** crée des tableaux catégorisés avec métadonnées, e-mails de l’équipe et compléments liés aux scénarios prêts pour l’impression.
-  - **Badge hors ligne et Forcer le rechargement** reflètent l’état de la connexion et renouvellent les fichiers en cache sans supprimer les projets.
-- Un lien d’évitement et un indicateur hors ligne maintiennent l’interface accessible au clavier et au tactile ; le badge apparaît dès que la connexion tombe.
-- La barre de recherche globale permet d’atteindre fonctionnalités, sélecteurs ou rubriques d’aide ; appuyez sur Entrée pour valider le résultat en surbrillance, utilisez / ou Ctrl+K (⌘K sur macOS) pour focaliser le champ instantanément (le menu latéral s’ouvre automatiquement sur petit écran) et appuyez sur Échap ou × pour effacer la requête.
-- Les commandes supérieures offrent le changement de langue, les thèmes sombre et rose, ainsi qu’un dialogue Paramètres avec couleur d’accent, taille et famille de police, mode à fort contraste et import de logo, sans oublier les outils de sauvegarde, restauration et Réinitialisation d’usine qui créent une copie avant effacement.
-- Le bouton Aide ouvre une boîte de dialogue recherchable avec sections pas à pas, raccourcis clavier, FAQ et mode d’aide contextuelle optionnel ; vous pouvez aussi l’ouvrir avec ?, H, F1 ou Ctrl+/ même pendant la saisie.
-- Le bouton de rechargement forcé (🔄) efface les fichiers du service worker en cache pour mettre à jour l’application hors ligne sans perdre projets ni appareils.
-- Sur petits écrans, un menu latéral repliable reflète chaque section principale pour une navigation rapide.
+- **Navigateurs modernes.** Validé sur les dernières versions de Chromium, Firefox et Safari. Activez service workers, IndexedDB et stockage persistant.
+- **Appareils adaptés au hors ligne.** Laptops et tablettes doivent autoriser le stockage persistant. Lancez l’application une fois en ligne pour mettre en cache toutes les ressources puis répétez la procédure de rechargement hors ligne avant le départ.
+- **Espace local suffisant.** Les productions importantes accumulent projets, backups et listes. Surveillez l’espace disponible du profil navigateur et exportez régulièrement vers des supports redondants.
+- **Aucune dépendance externe.** Tous les icônes, polices et scripts sont fournis. Copiez également `animated icons 3/` et les Uicons locaux lors du transfert du dossier.
 
-### ♿ Personnalisation et accessibilité
-- Les thèmes incluent mode sombre, accent rose ludique et interrupteur dédié à fort contraste pour une meilleure lisibilité.
-- Les modifications de couleur d’accent, taille de police et typographie s’appliquent instantanément et restent mémorisées dans le navigateur – idéal pour respecter charte graphique ou besoins d’accessibilité.
-- Les raccourcis intégrés couvrent recherche globale (/ ou Ctrl+K/⌘K), aide ( ?, H, F1, Ctrl+/ ), enregistrement (Entrée ou Ctrl+S/⌘S), mode sombre (D) et mode rose (P).
-- Le mode d’aide au survol transforme chaque bouton, champ, menu et en-tête en infobulle à la demande pour accélérer l’apprentissage.
-- Les champs avec recherche incrémentale, les styles visibles au focus et les icônes étoilées facilitent le filtrage des longues listes et l’épinglage des favoris.
-- Importez un logo d’impression, définissez des rôles de monitoring par défaut et ajustez les préréglages d’exigences afin que les exports restent conformes à l’identité de production.
-- Les boutons de duplication dupliquent instantanément les lignes de formulaire, et les favoris épinglés maintiennent le matériel clé en tête de liste – pratique quand le temps est compté.
+## Exercice sauvegarde/partage/import
 
-### 📋 Liste de matériel
-Le générateur transforme vos sélections en une liste de préparation classée par catégorie :
+Cette routine prouve que sauvegarde, partage, import, backup et restauration fonctionnent hors ligne lorsqu’un nouveau membre rejoint l’équipe, qu’un poste est préparé ou qu’une mise à jour majeure arrive.
 
-- Cliquez sur **Générer la liste de matériel** pour compiler équipement choisi et exigences du projet dans un tableau.
-- Le tableau se met à jour dès que sélections ou exigences évoluent.
-- Les éléments sont regroupés par catégorie (caméra, optique, alimentation, monitoring, rigging, machinerie, accessoires, consommables) et les doublons sont fusionnés avec leur quantité.
-- Câbles, structures et accessoires requis pour moniteurs, moteurs, gimbals et scénarios météo sont ajoutés automatiquement.
-- Les scénarios sélectionnés ajoutent l’équipement associé :
-  - *Handheld* + *Easyrig* ajoute une poignée télescopique pour un soutien stable.
-  - *Gimbal* ajoute le gimbal choisi, des bras articulés, des spigots et des pare-soleil ou kits de filtres.
-  - *Outdoor* fournit spigots, parapluies et housses de pluie CapIt.
-  - Les scénarios *Vehicle* et *Steadicam* ajoutent fixations, bras isolants et ventouses selon le besoin.
-- Les sélections d’optique incluent diamètre frontal, poids, données de rods et mise au point minimale, ajoutent supports d’objectif et adaptateurs de matte box, et signalent les standards incompatibles.
-- Les lignes de batteries reprennent les quantités calculées et incluent plaques ou appareils de hotswap lorsque nécessaire.
-- Les préférences de monitoring attribuent des moniteurs par défaut pour chaque rôle (réalisateur, DoP, pointeur, etc.) avec jeux de câbles et récepteurs sans fil.
-- Le formulaire **Exigences du projet** alimente la liste :
-  - **Nom du projet**, **société de production**, **loueur** et **DoP** apparaissent dans l’en-tête des exigences imprimées.
-  - Les entrées **Équipe** collectent noms, rôles et adresses e-mail pour que les contacts suivent le projet.
-  - **Jours de préparation** et **jours de tournage** fournissent des notes de calendrier et, associés à des scénarios extérieurs, suggèrent l’équipement météo.
-  - Les **scénarios requis** ajoutent rigging, gimbals et protections climatiques adaptés.
-  - **Poignée caméra** et **extension viseur** ajoutent les composants sélectionnés ou leurs supports.
-  - Les options de **matte box** et de **filtres** ajoutent le système choisi avec plateaux, adaptateurs à collier ou filtres nécessaires.
-  - Les réglages de **monitoring**, **distribution vidéo** et **viseur** ajoutent moniteurs, câbles et incrustations pour chaque rôle.
-  - Les sélections de **boutons utilisateur** et **préférences trépied** sont listées pour référence rapide.
-- Les éléments de chaque catégorie sont triés alphabétiquement et affichent une info-bulle au survol.
-- La liste de matériel est incluse dans les aperçus imprimables et les fichiers de projet exportés.
-- Les listes sont enregistrées automatiquement avec le projet et incluses dans exports et sauvegardes.
-- **Supprimer la liste de matériel** efface la liste enregistrée et masque la sortie.
-- Les formulaires fournissent des boutons en forme de fourche pour dupliquer instantanément les entrées.
+1. **Sauvegarde de base.** Ouvrez le projet courant, effectuez une sauvegarde manuelle et notez l’horodatage. Un auto-backup doit apparaître en moins de dix minutes.
+2. **Export redondant.** Produisez un backup du planner et un bundle projet. Renommez-le en `.cpproject` si nécessaire et stockez les deux sur des supports distincts.
+3. **Répétition de restauration.** Passez sur un profil privé (ou une seconde machine), importez d’abord le backup complet, puis le bundle. Vérifiez listes, tableaux de bord, règles et favoris.
+4. **Vérification hors ligne.** Sur le profil d’essai, coupez la connexion et rechargez `index.html`. Confirmez l’affichage de l’indicateur hors ligne et le chargement des Uicons et scripts locaux.
+5. **Archivage.** Supprimez le profil de test après validation et étiquetez les exports selon le protocole de production.
 
-### 📦 Catégories d’appareils
-- **Caméra** (1)
-- **Moniteur** (optionnel)
-- **Transmetteur sans fil** (optionnel)
-- **Moteurs FIZ** (0–4)
-- **Contrôleurs FIZ** (0–4)
-- **Capteur de distance** (0–1)
-- **Plaque batterie** (sur les caméras compatibles V‑ ou B‑Mount)
-- **Batterie V‑Mount** (0–1)
+## Routine quotidienne
 
-### ⚙️ Calculs de puissance
-- Consommation totale en watts
-- Intensité à 14,4 V et 12 V
-- Autonomie estimée en heures via la moyenne pondérée des retours
-- Nombre de batteries nécessaire pour un tournage de 10 h
-- Note de température pour ajuster l’autonomie par temps chaud ou froid
+1. **Créer ou charger un projet.** Saisissez un nom et appuyez sur **Entrée**/**Sauvegarder**. Le nom actif apparaît dans les listes et exports.
+2. **Ajouter caméras, alimentation et accessoires.** Sélectionnez les équipements via des menus catégorisés. Recherche incrémentale, favoris et raccourci `/` (`Ctrl+K`/`⌘K`) accélèrent la sélection.
+3. **Contrôler puissance et autonomie.** Surveillez les alertes, comparez les batteries et consultez le tableau de bord d’autonomie pour comprendre l’impact de la température, du codec, de la cadence, etc.
+4. **Rassembler les exigences.** Renseignez équipe, scénarios, poignées, matte box et configuration de monitoring. Les boutons dupliquer accélèrent la saisie. Utilisez **Paramètres → Règles automatiques** pour ajouter/retraiter du matériel spécifique avant export.
+5. **Exporter ou archiver.** Générez la liste de matériel, exportez un backup ou téléchargez un bundle avant de partir sur le plateau. Les backups incluent équipements personnalisés, retours et favoris.
+6. **Valider la préparation hors ligne.** Coupez le réseau, rechargez l’application et vérifiez que projets, réglages et listes restent accessibles. Restaurez le dernier backup en cas d’écart.
 
-### 🔋 Vérification de la sortie batterie
-- Avertit si l’intensité dépasse la sortie de la batterie (pin ou D‑Tap)
-- Indique lorsque la consommation se rapproche de la limite (80 % d’utilisation)
+## Sauvegarde et gestion de projet
 
-### 📊 Comparaison des batteries (optionnel)
-- Compare les estimations d’autonomie de toutes les batteries
-- Graphiques à barres pour une lecture immédiate
+- **Sauvegardes manuelles pour des versions explicites.** Entrez le nom et appuyez sur **Entrée**/**Sauvegarder**. Chaque version conserve équipements, exigences, listes, favoris, schémas et observations.
+- **Autosaves pour le travail en cours.** Tant qu’un projet est ouvert, l’application écrit les changements en arrière-plan. Des entrées `auto-backup-…` apparaissent toutes les dix minutes.
+- **Afficher les auto-backups à la demande.** Activez **Paramètres → Backup & Restauration → Afficher les auto-backups** pour visualiser les horodatages.
+- **Renommer crée une branche.** Modifier le nom puis valider duplique le projet — pratique pour comparer des variantes.
+- **Changer de projet n’efface rien.** Sélectionnez un autre élément dans le menu ; la position et les saisies non sauvegardées se propagent.
+- **Suppression avec confirmation.** L’icône corbeille demande toujours une validation avant d’effacer.
 
-### 🖼 Diagramme du projet
-- Visualise les connexions d’alimentation et de vidéo des appareils sélectionnés
-- Signale les marques FIZ incompatibles
-- Faites glisser les nœuds pour réorganiser le schéma, zoomez avec les boutons et exportez le diagramme en SVG ou JPG
-- Maintenez Shift enfoncé lors du clic sur Télécharger pour exporter une image JPG plutôt qu’un SVG
-- Survolez ou touchez un appareil pour afficher ses détails
-- Utilise les icônes OpenMoji lorsqu’une connexion est disponible et se replie sur les emoji : 🔋 batterie, 🎥 caméra, 🖥️ moniteur, 📡 vidéo, ⚙️ moteur, 🎮 contrôleur, 📐 distance, 🎮 poignée et 🔌 plaque batterie
+## Partage et imports
 
-### 🧮 Pondération des données d’autonomie
-- Les autonomies remontées par les utilisateurs affinent l’estimation
-- Chaque mesure est ajustée selon la température, en passant de ×1 à 25 °C à :
-  - ×1,25 à 0 °C
-  - ×1,6 à −10 °C
-  - ×2 à −20 °C
-- Les réglages caméra influencent la pondération :
-  - Multiplicateurs de résolution : ≥12K ×3, ≥8K ×2, ≥4K ×1,5, ≥1080p ×1 ; les résolutions inférieures sont ramenées à 1080p
-  - La cadence est pondérée linéairement à partir de 24 i/s (par ex. 48 i/s = ×2)
-  - Le Wi-Fi activé ajoute 10 %
-  - Facteurs codecs : RAW/BRAW/ARRIRAW/R3D/CinemaDNG/Canon RAW/X‑OCN ×1 ; ProRes ×1,1 ; DNx/AVID ×1,2 ; All‑Intra ×1,3 ; H.264/AVC ×1,5 ; H.265/HEVC ×1,7
-  - Les entrées moniteur en dessous de la luminosité spécifiée sont pondérées selon leur ratio de luminosité
-- La pondération finale reflète la part de consommation de chaque appareil, de sorte que les projets similaires comptent davantage
-- La moyenne pondérée est utilisée dès que trois entrées minimum sont disponibles
-- Un tableau de bord classe les mesures par poids et affiche le pourcentage associé pour comparer d’un coup d’œil
+- **Bundles compacts.** **Exporter le projet** télécharge `project-name.json` avec le projet actif, les favoris et les équipements personnalisés. Renommez-le en `.cpproject` si votre flux le requiert.
+- **Règles automatiques incluses.** Activez **Inclure les règles automatiques** pour qu’elles voyagent ; à l’import, vos collègues peuvent les ignorer, les appliquer uniquement au projet ou les fusionner au jeu global.
+- **Imports validés hors ligne.** Lors de l’import d’un `auto-gear-rules-*.json`, le planner vérifie type, version sémantique et métadonnées avant d’écraser vos règles. Les fichiers provenant d’une autre version déclenchent des avertissements et l’ancienne capture est restaurée automatiquement en cas d’échec.
+- **Restaurations double tampon.** Avant tout import, une sauvegarde du contexte courant est demandée. Une fois le bundle validé, le projet restauré apparaît en tête du sélecteur.
+- **Workflows inter-appareils hors ligne.** Copiez `index.html`, `script.js`, `devices/` et vos fichiers de backup/bundle sur un support amovible, lancez depuis le disque et continuez sans connexion.
+- **Exporter en conscience.** Relisez le JSON avant partage pour vérifier le contenu. Le format étant lisible, vous pouvez supprimer ou dupliquer les entrées nécessaires.
+- **Synchroniser avec les check-lists.** Lorsqu’un collaborateur vous envoie un bundle mis à jour, importez-le, vérifiez les horodatages `Mis à jour` et archivez le JSON précédent pour garder l’historique.
+- **Partager sans perdre le contexte.** Les bundles mémorisent langue, thème, logo et préférences pour que le destinataire retrouve un environnement familier même hors ligne.
 
-### 🔍 Recherche et filtrage
-- Tapez dans les menus déroulants pour trouver rapidement une entrée
-- Filtrez les listes d’appareils via un champ de recherche
-- Utilisez la barre de recherche globale pour rejoindre fonctionnalités, appareils ou sujets d’aide ; appuyez sur Entrée pour naviguer, / ou Ctrl+K (⌘K sur macOS) pour focaliser instantanément et Échap ou × pour effacer
-- Appuyez sur « / » ou Ctrl+F (⌘F sur macOS) pour atteindre immédiatement le champ de recherche le plus proche
-- Cliquez sur l’étoile à côté d’un sélecteur pour épingler vos favoris et les synchroniser avec les sauvegardes
+## Formats de fichiers
 
-### 🛠 Éditeur de la base d’appareils
-- Ajoutez, modifiez ou supprimez des appareils dans toutes les catégories
-- Importez ou exportez la base complète au format JSON
-- Revenez à la base par défaut depuis `src/data/index.js`
+- **`project-name.json` (bundle).** Contient un projet, les favoris et équipements personnalisés. Renommer en `.cpproject` ne change rien à l’import.
+- **`planner-backup.json` (backup complet).** Généré via **Paramètres → Backup & Restauration → Backup**, il capture projets, auto-backups, favoris, retours, règles, préférences, polices et éléments de branding.
+- **`auto-gear-rules-*.json` (règles).** Export optionnel depuis **Règles automatiques** avec métadonnées de type, version et horodatage pour validation hors ligne. Stockez-les avec les backups complets.
 
-### 🌓 Mode sombre
-- Activez-le via le bouton lune près du sélecteur de langue
-- La préférence est mémorisée dans votre navigateur
+## Visite de l’interface
 
-### 🦄 Mode rose
-- Cliquez sur le bouton licorne (le mode rose fait défiler des icônes toutes les 30 secondes avec une douce animation pop et revient au cheval quand vous quittez le thème) ou appuyez sur **P** pour activer un accent rose ludique
-- Fonctionne avec les thèmes clair et sombre et persiste entre les visites
+### Référence rapide
 
-### ⚫ Mode à fort contraste
-- Active un thème à contraste élevé pour améliorer la lisibilité
+- **Recherche globale** (`/`, `Ctrl+K`, `⌘K`) pour accéder à toute fonctionnalité, liste ou thème d’aide, même navigation repliée.
+- **Centre d’aide** (`?`, `H`, `F1`, `Ctrl+/`) proposant guides, raccourcis, FAQ et mode aide au survol.
+- **Diagramme de projet** pour visualiser alimentation et signal ; maintenez Maj lors de l’export pour enregistrer un JPG.
+- **Comparateur de batteries** affichant les performances et alertant sur les surcharges.
+- **Générateur de listes** qui produit des tableaux catégorisés avec métadonnées, emails et accessoires liés aux scénarios.
+- **Indicateur hors ligne et Forcer le rechargement** montrant l’état de connexion et rafraîchissant les ressources sans toucher aux données.
 
-### 📝 Retours d’autonomie
-- Cliquez sur <strong>Soumettre un retour d’autonomie</strong> sous l’autonomie pour ajouter votre mesure
-- Ajoutez la température pour une pondération plus précise
-- Les entrées sont sauvegardées dans votre navigateur et améliorent les estimations futures
-- Un tableau de bord classe les retours selon leur poids, affiche les pourcentages de contribution et met en évidence les valeurs atypiques pour une analyse rapide
+### Barre supérieure
 
-### ❓ Aide avec recherche
-- Ouvrez-la via le bouton <strong>?</strong> ou avec <kbd>?</kbd>, <kbd>H</kbd>, <kbd>F1</kbd> ou <kbd>Ctrl+/</kbd>
-- Utilisez le champ de recherche pour filtrer instantanément les sujets ; la requête est réinitialisée à la fermeture
-- Fermez avec <kbd>Échap</kbd> ou en cliquant hors de la boîte de dialogue
+- Lien d’évitement, indicateur hors ligne et branding responsive assurent l’accessibilité.
+- La recherche se focalise avec `/` ou `Ctrl+K` (`⌘K`), ouvre la navigation sur mobile et se vide avec Échap.
+- Les contrôles de langue, thèmes sombre/rose et le dialogue Paramètres permettent d’ajuster couleur d’accent, taille et police, contraste élevé, logo personnalisé ainsi que d’accéder aux outils de backup, restauration et réinitialisation (avec sauvegarde automatique).
+- Le bouton d’aide ouvre un dialogue consultable et répond à `?`, `H`, `F1` ou `Ctrl+/` à tout moment.
+- Le bouton 🔄 supprime les ressources mises en cache et recharge l’application sans effacer les projets ou données d’autonomie.
 
----
+### Navigation et recherche
 
-## ▶️ Guide d’utilisation
-1. **Lancez l’application :** ouvrez `index.html` dans un navigateur moderne – aucun serveur requis.
-2. **Explorez la barre supérieure :** changez de langue, activez les thèmes sombre ou rose, ouvrez Paramètres pour régler accent et typographie et lancez l’aide avec ? ou Ctrl+/.
-3. **Sélectionnez les appareils :** choisissez l’équipement par catégorie via les menus déroulants ; saisissez pour filtrer, épinglez vos favoris et laissez les scénarios préconfigurés ajouter automatiquement les accessoires.
-4. **Consultez les calculs :** dès qu’une batterie est sélectionnée, consommation, intensité et autonomie apparaissent ; des alertes signalent les limites dépassées.
-5. **Enregistrez et exportez les projets :** nommez et sauvegardez votre configuration, les sauvegardes automatiques capturent des instantanés et le bouton Exporter télécharge un bundle JSON tandis qu’Importer le restaure.
-6. **Générez la liste de matériel :** cliquez sur **Générer la liste de matériel** pour transformer les exigences en liste catégorisée avec infobulles et accessoires.
-7. **Gérez les données d’appareils :** sélectionnez « Modifier les données d’appareils… » pour ouvrir l’éditeur, ajuster les appareils, exporter/importer du JSON ou revenir aux valeurs par défaut.
-8. **Soumettez des retours d’autonomie :** utilisez « Soumettre un retour d’autonomie » pour enregistrer vos mesures terrain et enrichir la pondération.
+- Sur petits écrans, un menu latéral pliable réplique les sections principales.
+- Chaque liste et éditeur propose une recherche inline et un filtrage instantané. `/` ou `Ctrl+F` (`⌘F`) ciblent le champ le plus proche.
+- Les icônes étoile épinglent les favoris en tête de liste et les conservent dans les sauvegardes.
 
-## 📱 Installer l’application
+## Personnalisation et accessibilité
 
-Cine Power Planner est une application web progressive installable directement depuis le navigateur :
+- Basculez entre thèmes clair, sombre, rose et contraste élevé ; couleur d’accent, taille et typographie persistent hors ligne.
+- Lien d’évitement, focus visibles et mise en page responsive facilitent la navigation clavier, tablette et mobile.
+- Raccourcis couverts : recherche (`/`, `Ctrl+K`, `⌘K`), aide (`?`, `H`, `F1`, `Ctrl+/`), sauvegarde (`Entrée`, `Ctrl+S`, `⌘S`), mode sombre (`D`) et thème rose (`P`).
+- Le mode aide au survol transforme boutons, champs, menus et titres en infobulles à la demande.
+- Téléchargez un logo personnalisé pour les impressions, définissez des valeurs de monitoring et des préréglages d’exigences.
+- Les boutons dupliquer accélèrent la saisie et les favoris conservent les équipements récurrents à portée.
 
-- **Chrome/Edge (bureau) :** cliquez sur l’icône d’installation dans la barre d’adresse.
-- **Android :** ouvrez le menu du navigateur et choisissez *Ajouter à l’écran d’accueil*.
-- **iOS/iPadOS Safari :** touchez *Partager* puis *Ajouter à l’écran d’accueil*.
+## Sécurité des données et mode hors ligne
 
-Une fois installée, l’application se lance depuis l’écran d’accueil, fonctionne hors ligne et se met à jour automatiquement.
+- Le service worker met en cache chaque ressource pour une utilisation hors ligne et n’applique les mises à jour qu’après **Forcer le rechargement**.
+- Projets, retours d’autonomie, favoris, équipements personnalisés, thèmes et listes résident dans le stockage du navigateur. Une demande de persistance est effectuée pour réduire le risque d’éviction.
+- Ouvrir le dépôt depuis le disque ou un réseau interne évite toute fuite vers l’extérieur. Les exports JSON sont lisibles pour audit.
+- L’en-tête affiche un indicateur hors ligne lorsqu’il n’y a pas de connexion ; **Forcer le rechargement** rafraîchit les fichiers sans toucher aux sauvegardes.
+- **Réinitialisation usine** ou nettoyage des données ne s’exécutent qu’après génération d’un backup automatique.
+- Les mises à jour du service worker se téléchargent en tâche de fond et attendent votre accord. À l’apparition de **Mise à jour prête**, terminez vos modifications, créez un backup puis cliquez sur **Forcer le rechargement**.
+- Le stockage principal est IndexedDB, avec préférences légères reflétées dans `localStorage`. Les outils développeur peuvent inspecter ou exporter les enregistrements avant nettoyage.
 
-## 📡 Utilisation hors ligne & stockage
+## Vue d’ensemble des données et du stockage
 
-Servir l’application via HTTP(S) installe un service worker qui met en cache chaque fichier pour que Cine Power Planner fonctionne totalement hors ligne et se mette à jour en arrière-plan. Projets, retours d’autonomie et préférences (langue, thème, mode rose et listes enregistrées) sont stockés dans le `localStorage` du navigateur. Effacer les données du site supprime toutes les informations, et la boîte de dialogue Paramètres propose un flux de **Réinitialisation d’usine** qui sauvegarde automatiquement une copie avant le nettoyage complet. L’en-tête affiche un badge hors ligne dès que la connexion tombe, et l’action 🔄 **Forcer le rechargement** actualise les fichiers en cache sans toucher aux projets enregistrés.
+- Ouvrez **Paramètres → Données & stockage** pour consulter projets, auto-backups, listes, équipements personnalisés, favoris, retours et cache de session avec des compteurs en temps réel.
+- Chaque section précise son contenu ; les sections vides restent masquées pour identifier rapidement l’état du planner.
+- Le résumé estime la taille d’un backup à partir de la dernière exportation.
 
----
+## Gestion des quotas et maintenance
 
-## 🗂️ Structure des fichiers
-```bash
-index.html                 # Mise en page HTML principale
-src/styles/style.css       # Styles et mise en page
-src/styles/overview.css    # Styles de l’aperçu imprimable
-src/styles/overview-print.css # Ajustements d’impression pour l’aperçu
-src/scripts/script.js        # Logique applicative
-src/scripts/storage.js       # Helpers LocalStorage
-src/scripts/static-theme.js  # Logique de thème partagée pour les pages légales
-src/data/index.js       # Liste d’appareils par défaut
-src/data/devices/       # Catalogues d’appareils par catégorie
-src/data/schema.json    # Schéma généré pour les sélecteurs
-src/vendor/             # Bibliothèques tierces incluses
-legal/                     # Pages légales hors ligne
-tools/                     # Scripts de maintenance des données
-tests/                     # Suite de tests Jest
-```
-Les polices sont intégrées localement via `fonts.css`, ce qui permet à l’application de fonctionner entièrement hors ligne une fois les ressources en cache.
+- **Valider l’accès au stockage persistant.** Vérifiez le statut sur chaque poste. Si le navigateur refuse, refaites la demande ou planifiez plus d’exports manuels.
+- **Surveiller la marge disponible.** Utilisez le tableau de bord ou l’inspecteur du navigateur. En cas de place limitée, archivez les backups anciens, supprimez les entrées `auto-backup-…` redondantes et vérifiez que les nouveaux exports aboutissent.
+- **Recharger les caches après mise à jour.** Après **Forcer le rechargement**, ouvrez le centre d’aide, les pages légales et les écrans les plus utilisés pour recharger Uicons, OpenMoji et polices.
+- **Documenter l’état du stockage.** Ajoutez ces vérifications à vos rapports de préparation et de clôture : statut de persistance, espace restant et emplacement des derniers backups.
 
-## 🛠️ Développement
-Nécessite Node.js 18 ou version ultérieure.
+## Backup et restauration
 
-```bash
-npm install
-npm run lint     # exécute uniquement ESLint
-npm test         # lance le linting, les vérifications de données et les tests Jest
-```
+- **Instantanés enregistrés** – Le sélecteur conserve chaque sauvegarde manuelle et crée un `auto-backup-…` toutes les dix minutes.
+- **Backups complets** – **Paramètres → Backup & Restauration → Backup** télécharge `planner-backup.json` avec projets, équipements personnalisés, retours, favoris, règles automatiques et état UI. Les restaurations créent une copie de sécurité et avertissent si le fichier provient d’une autre version.
+- **Backups de migration cachés** – Avant d’écraser planners, configurations ou préférences, l’application enregistre le JSON précédent dans `__legacyMigrationBackup`. En cas d’échec, les outils de récupération reviennent automatiquement à cette copie.
+- **Snapshots automatiques des règles** – Les modifications dans **Règles automatiques** génèrent des copies horodatées toutes les dix minutes.
+- **Réinitialisation usine** – Efface les données uniquement après téléchargement d’un backup.
+- **Rappels horaires** – Une tâche de fond invite à créer un backup toutes les heures pour disposer d’une capture récente.
+- **Boucle de vérification** – Après chaque backup critique, importez-le dans un profil séparé pour confirmer le résultat avant de supprimer l’instance de test.
+- **Habitudes de stockage sécurisées** – Étiquetez les backups avec nom de projet et horodatage puis stockez-les sur des supports redondants (RAID, clé chiffrée, disque optique).
+- **Comparer avant d’écraser** – Téléchargez un backup du contexte actuel avant toute restauration et examinez les différences avec un outil diff JSON pour fusionner manuellement si besoin.
 
-Après modification des données d’appareils, régénérez la base normalisée :
+## Exercices d’intégrité
+
+- **Validation pré-vol (quotidienne ou avant changements majeurs).** Sauvegardez manuellement, exportez un backup complet et un bundle, importez-les dans un profil privé, vérifiez projets, règles, favoris et tableaux puis supprimez le profil.
+- **Répétition hors ligne (hebdomadaire ou avant déplacement).** Lancez le planner, déclenchez un backup, coupez tout réseau et rechargez `index.html`. Vérifiez l’indicateur, la netteté des Uicons et l’ouverture du projet vérifié.
+- **Contrôle de changement (après mise à jour des données ou scripts).** Exécutez `npm test` puis répétez la validation pré-vol. Archivez le backup validé avec une note de changement.
+- **Rotation de redondance (mensuelle ou avant archivage).** Stockez le backup le plus récent, un bundle vérifié (renommé `.cpproject` si besoin) et une archive ZIP du dépôt sur au moins deux supports. Alternez celui que vous testez pour détecter toute dégradation.
+
+## Check-lists opérationnelles
+
+Ces routines garantissent que projets, backups et ressources hors ligne restent synchronisés sur chaque machine utilisant Cine Power Planner. Une version imprimable se trouve dans `docs/operations-checklist.md` et le guide de déplacement `docs/offline-readiness.md` détaille les étapes supplémentaires pour les opérations prolongées sans connexion.
+
+### Préparation avant tournage
+
+1. **Valider la bonne révision.** Ouvrez `index.html`, cliquez sur **Forcer le rechargement** et vérifiez la version dans **Paramètres → À propos**. Ouvrez les pages légales pour précharger Uicons, OpenMoji et polices.
+2. **Charger les projets critiques.** Ouvrez le plan en cours et un `auto-backup-…` récent. Vérifiez listes, retours et favoris dans les deux cas.
+3. **Tester la chaîne de sauvegarde.** Apportez une modification, sauvegardez avec `Entrée` ou `Ctrl+S`/`⌘S`, exportez `planner-backup.json`, importez-le dans un profil privé et comparez le sélecteur.
+4. **Valider le partage.** Exportez `project-name.json`, importez-le, vérifiez règles automatiques, équipements personnalisés et indicateur hors ligne. Supprimez ensuite le profil.
+5. **Simuler l’absence de réseau.** Coupez la connexion ou activez le mode avion, rechargez le planner et vérifiez l’indicateur, la netteté des icônes et l’accès aux projets.
+6. **Archiver les artefacts de validation.** Conservez le backup vérifié, le bundle et une archive du dépôt sur des supports redondants pour reconstruire l’environnement sans Internet.
+
+### Handoff de fin de journée
+
+1. **Capturer un backup final.** Avec le projet ouvert, exportez `planner-backup.json` et le dernier `project-name.json` (renommé `.cpproject` si besoin) et étiquetez-les (date, lieu, journée).
+2. **Valider les imports.** Restaurez les deux fichiers sur une machine de vérification hors ligne pour détecter toute corruption.
+3. **Consigner les changements.** Notez quels auto-backups ont été promus, quels équipements personnalisés ont été ajoutés et quelles règles ont changé. Archivez ces notes avec les backups.
+4. **Actualiser les caches volontairement.** Après archivage, cliquez sur **Forcer le rechargement**, ouvrez le centre d’aide et les pages légales pour recharger les ressources avant la prochaine session hors ligne.
+5. **Transmettre les supports redondants.** Fournissez des copies chiffrées à l’équipe stockage et conservez un second jeu selon la politique de rétention.
+
+## Plan de récupération d’urgence
+
+1. **Mettre en pause et préserver l’état.** Laissez l’onglet ouvert, coupez la connexion si possible et notez l’heure ainsi que l’état de l’indicateur hors ligne. Évitez de recharger.
+2. **Exporter l’existant.** Lancez **Paramètres → Backup & Restauration → Backup** et téléchargez `planner-backup.json`. Même si la liste semble incorrecte, ce fichier capture auto-backups, favoris, retours et règles pour analyse.
+3. **Dupliquer les auto-backups.** Affichez les entrées `auto-backup-…`, promouvez les snapshots récents en sauvegardes manuelles et renommez-les avec un identifiant d’incident ou l’horodatage.
+4. **Examiner le bundle de vérification.** Importez le dernier `project-name.json`/`.cpproject` validé dans un profil privé ou une machine secondaire hors ligne pour vérifier projets, listes et paramètres.
+5. **Restaurer avec soin.** Après validation, restaurez le backup récent sur la machine principale. Le processus crée d’abord une copie de sécurité, ce qui permet de comparer avec un diff JSON si nécessaire.
+6. **Réhydrater et documenter.** Une fois la récupération terminée, cliquez sur **Forcer le rechargement**, ouvrez le centre d’aide et les pages légales pour réchauffer les caches, puis consignez l’incident (symptômes, fichiers exportés, emplacements, machine de vérification). Archivez ce rapport avec le backup.
+
+## Listes de matériel et rapports
+
+- **Générer la liste de matériel et des exigences** transforme la sélection et les exigences en tableaux catégorisés qui se mettent à jour automatiquement.
+- Les entrées sont regroupées par catégorie et les doublons fusionnés. Les scénarios ajoutent rigging, protections météo et accessoires spécifiques pour refléter la réalité terrain.
+- Les règles automatiques s’exécutent après le générateur pour ajouter ou retirer des éléments sans modifier le JSON à la main.
+- Les lignes d’objectifs incluent diamètre frontal, poids, mise au point minimale, besoin de rods et composants matte box. Les lignes batteries tiennent compte du nombre et du matériel de bascule à chaud.
+- Détails de l’équipe, configurations de monitoring, distribution vidéo et notes personnalisées apparaissent dans les exports.
+- Les listes sont sauvegardées avec le projet, visibles dans les aperçus imprimables et incluses dans les bundles ; utilisez **Supprimer la liste** pour repartir de zéro.
+
+## Règles automatiques
+
+Via **Paramètres → Règles automatiques**, ajustez chaque liste sans éditer le JSON manuellement :
+
+- Déclenchez des règles uniquement lorsque des **Scénarios requis** spécifiques sont actifs ; ajoutez un libellé facultatif pour les identifier rapidement.
+- Ajoutez du matériel avec catégorie et quantité ou utilisez **Ajouts personnalisés** pour des rappels, kits spécialisés ou notes. Les règles de retrait masquent certaines lignes générées automatiquement.
+- Les règles s’exécutent après les packs intégrés pour se combiner proprement et sont incluses dans listes, backups et bundles.
+- Sauvegarder une liste conserve l’ensemble de règles actif ; charger le projet ou importer un bundle restaure son périmètre.
+- Exporte/importez l’ensemble en JSON, revenez aux paramètres d’usine ou utilisez l’historique automatique (toutes les dix minutes) si une modification pose problème.
+
+## Intelligence d’autonomie
+
+Les autonomies remontées par les utilisateurs alimentent un modèle pondéré reflétant l’expérience terrain :
+
+- Ajustements de température : ×1 à 25 °C, ×1,25 à 0 °C, ×1,6 à −10 °C, ×2 à −20 °C.
+- Résolution : ≥12K ×3, ≥8K ×2, ≥4K ×1,5, ≥1080p ×1, valeurs inférieures proportionnelles.
+- Cadence : échelle linéaire à partir de 24 fps (48 fps = ×2).
+- Wi‑Fi activé : +10 %.
+- Codecs : RAW/BRAW/ARRIRAW/R3D/CinemaDNG/Canon RAW/X‑OCN ×1 ; ProRes ×1,1 ; DNx/AVID ×1,2 ; All-Intra ×1,3 ; H.264/AVC ×1,5 ; H.265/HEVC ×1,7.
+- Les moniteurs sont pondérés selon le ratio de luminosité.
+- Le poids final reflète la contribution de chaque composant afin que des rigs similaires influencent davantage le modèle.
+- Un tableau de bord trie par poids, affiche les pourcentages et souligne les valeurs atypiques.
+
+## Raccourcis clavier
+
+| Raccourci | Action | Notes |
+| --- | --- | --- |
+| `/`, `Ctrl+K`, `⌘K` | Focaliser la recherche globale | Fonctionne même navigation repliée ; `Échap` efface |
+| `Entrée`, `Ctrl+S`, `⌘S` | Sauvegarder le projet actif | Le bouton reste inactif tant qu’aucun nom n’est saisi |
+| `?`, `H`, `F1`, `Ctrl+/` | Ouvrir l’aide | La boîte de dialogue reste consultable |
+| `D` | Basculer en mode sombre | Aussi disponible dans **Paramètres → Thèmes** |
+| `P` | Activer le thème rose | Compatible avec clair, sombre ou contraste élevé |
+| 🔄 | Recharger les ressources en cache | Également via **Paramètres → Forcer le rechargement** |
+
+## Localisation
+
+Prévisualisez immédiatement de nouvelles langues :
+
+1. Dupliquez le README le plus proche en `README.<lang>.md` et traduisez-le.
+2. Ajoutez les chaînes dans `translations.js` en conservant les placeholders (`%s`).
+3. Copiez et traduisez les pages statiques (confidentialité, mentions légales).
+4. Exécutez `npm test` avant de soumettre une pull request.
+
+## Installer comme application
+
+Cine Power Planner est une Progressive Web App :
+
+1. Ouvrez `index.html` dans un navigateur compatible.
+2. Utilisez l’option **Installer** ou **Ajouter à l’écran d’accueil**.
+   - **Chrome/Edge (desktop)** : icône d’installation dans la barre d’adresse.
+   - **Android** : menu du navigateur → *Ajouter à l’écran d’accueil*.
+   - **Safari iOS** : bouton partager → *Ajouter à l’écran d’accueil*.
+3. Lancez l’application depuis votre liste de programmes. La version installée fonctionne hors ligne et se met à jour automatiquement après validation.
+
+## Flux de données matériel
+
+Les catalogues se trouvent dans `devices/`. Chaque fichier regroupe des équipements associés pour faciliter l’audit. Avant de valider une modification, exécutez :
 
 ```bash
 npm run normalize
@@ -324,9 +355,75 @@ npm run check-consistency
 npm run generate-schema
 ```
 
-Ajoutez `--help` à l’un de ces scripts pour afficher les options disponibles.
+`npm run normalize` nettoie les noms de connecteurs, `npm run unify-ports` unifie les libellés, `npm run check-consistency` vérifie les champs requis et `npm run generate-schema` régénère `schema.json`. Pour itérer sur les données :
 
-Exécutez `npm run help` pour obtenir un rappel rapide des scripts de maintenance et de l’ordre recommandé.
+```bash
+npm run test:data
+```
 
-## 🤝 Contribuer
-Les contributions sont les bienvenues ! Ouvrez un ticket ou proposez une pull request. Lors de corrections de données, joignez des sauvegardes de projet ou des mesures d’autonomie pour aider à maintenir un catalogue fiable pour tous.
+Ajoutez `--help` à n’importe quelle commande pour obtenir de l’aide et consultez les diffs générés avant d’ouvrir une pull request. `npm run help` récapitule les scripts disponibles.
+
+## Développement
+
+Installez Node.js 18 ou supérieur. Après clonage :
+
+```bash
+npm install
+npm run lint
+npm test
+```
+
+`npm test` exécute ESLint, les vérifications de données et Jest séquentiellement (`--runInBand`, `maxWorkers=1`). Pendant l’itération, lancez des suites ciblées :
+
+```bash
+npm run test:unit
+npm run test:data
+npm run test:dom
+npm run test:script
+```
+
+### Bundle pour navigateurs anciens
+
+Après modification de `src/scripts/` ou `src/data/`, lancez `npm run build:legacy` pour régénérer le bundle ES5 servi aux navigateurs plus anciens et maintenir les polyfills locaux à jour.
+
+### Structure des fichiers
+
+```
+index.html
+src/styles/style.css
+src/styles/overview.css
+src/styles/overview-print.css
+src/scripts/script.js
+src/scripts/storage.js
+src/scripts/static-theme.js
+src/data/index.js
+src/data/devices/
+src/data/schema.json
+src/vendor/
+legal/
+tools/
+tests/
+```
+
+## Dépannage
+
+- **Service worker bloqué sur une ancienne version ?** Cliquez sur **Forcer le rechargement** ou faites un hard reload via les outils développeur.
+- **Données manquantes après fermeture d’onglet ?** Vérifiez l’accès au stockage ; la navigation privée peut le bloquer.
+- **Téléchargements bloqués ?** Autorisez les téléchargements multiples pour sauvegardes et bundles.
+- **Scripts en ligne de commande en échec ?** Assurez-vous d’utiliser Node.js 18+, exécutez `npm install` et relancez. En cas d’erreur mémoire, ciblez une suite plus légère (`npm run test:unit`).
+
+## Retours et support
+
+Ouvrez une issue si vous rencontrez un problème, avez une question ou souhaitez proposer une fonctionnalité. Joindre des exports ou des exemples d’autonomie aide à maintenir un catalogue précis.
+
+## Contribuer
+
+Les contributions sont bienvenues ! Lisez `CONTRIBUTING.md`, puis ouvrez une issue ou soumettez une pull request. Lancez `npm test` avant envoi.
+
+## Remerciements
+
+Le planner inclut des Uicons locaux, des ressources OpenMoji et d’autres visuels empaquetés pour disposer d’icônes hors ligne, et utilise lz-string pour stocker les projets de façon compacte dans les URLs et backups.
+
+## Licence
+
+Distribué sous licence ISC. Voir `package.json` pour les détails.

--- a/README.it.md
+++ b/README.it.md
@@ -1,320 +1,352 @@
-# 🎥 Cine Power Planner
+# Cine Power Planner
 
-Questo strumento basato sul browser ti aiuta a pianificare progetti camera professionali alimentati da batterie V‑Mount, B‑Mount o Gold-Mount. Calcola il **consumo totale**, la **corrente assorbita** (a 14,4 V e 12 V) e l’**autonomia stimata**, verificando che il pacco batteria possa erogare in sicurezza la potenza richiesta.
+![Icona di Cine Power Planner](src/icons/app-icon.svg)
 
-Tutta la pianificazione, gli input e gli export restano sul dispositivo davanti a te. Lingua, progetti, dispositivi personalizzati, preferiti e feedback sulle autonomie vivono nel browser, e gli aggiornamenti del service worker arrivano direttamente da questo repository. Avvia Cine Power Planner offline dal disco o ospitalo internamente così che ogni reparto utilizzi la stessa versione verificata.
+Cine Power Planner è un’applicazione web autonoma pensata per creare, verificare e condividere piani di alimentazione professionali senza che i dati lascino mai il tuo dispositivo. Progetta rig V‑Mount, B‑Mount o Gold-Mount, stima le autonomie, raccogli i requisiti di progetto ed esporta pacchetti condivisibili – tutto nel browser, anche offline. Ogni dipendenza vive in questo repository, così l’esperienza resta identica in studio, sul portatile di campo o su un disco isolato.
 
-## A colpo d'occhio
+## In breve
 
-- **Pianifica senza rete.** Tutte le icone, i font e gli script ausiliari sono inclusi in questo repository; apri `index.html`
-  direttamente e lavora offline.
-- **I progetti restano sul dispositivo.** Salvataggi, feedback sulle autonomie, attrezzature personalizzate, preferiti e liste
-  di attrezzatura restano locali; backup e pacchetti condivisibili sono file JSON leggibili.
-- **Controlla gli aggiornamenti.** Il service worker si aggiorna solo dopo aver premuto **Forza ricarica**, mantenendo la
-  produzione su una versione affidabile durante gli spostamenti.
-- **Rete di sicurezza a più livelli.** Salvataggi manuali, auto-save e backup automatici con timestamp rendono semplice provare
-  il ripristino prima delle riprese.
+- **Pianifica offline-first.** Costruisci configurazioni V‑Mount, B‑Mount o Gold-Mount direttamente dal browser. Uicons, font e script di supporto sono inclusi localmente, senza affidarsi a CDN o alla rete. Clona il repository, scollega il cavo e l’interfaccia continua a funzionare allo stesso modo.
+- **Dati sempre sul dispositivo.** Progetti, feedback sulle autonomie, preferiti, dispositivi personalizzati, liste e impostazioni restano locali. Backup e pacchetti condivisibili sono file JSON leggibili.
+- **Metti alla prova le reti di sicurezza.** Salvataggi manuali, auto-save in background e backup automatici con timestamp si sommano per esercitarsi fin da subito nel ciclo Salva → Backup → Bundle → Ripristina.
+- **Aggiornamenti sotto controllo.** Il service worker attende la tua conferma prima di aggiornarsi, mantenendo la troupe su una versione certificata anche in viaggio o con connettività limitata.
 
-## Avvio rapido
+## Panoramica
 
-1. Scarica o clona il repository e apri `index.html` in un browser moderno.
-2. (Opzionale) Servi la cartella in locale (ad esempio con `npx http-server` o `python -m http.server`) così il service worker
-   si registra e memorizza nella cache le risorse per l'uso offline.
-3. Carica il planner una volta, chiudi la scheda, disconnettiti dalla rete e riapri `index.html`. L'indicatore offline dovrebbe
-   lampeggiare brevemente mentre viene caricata l'interfaccia in cache.
-4. Crea un progetto, premi **Invio** (o **Ctrl+S**/`⌘S`) per salvare e controlla il backup automatico che appare nel selettore
-   dopo qualche minuto.
-5. Esporta **Impostazioni → Backup e ripristino → Backup**, importa il file in un profilo privato del browser e verifica che
-   progetti, preferiti e attrezzature personalizzate si ripristinino correttamente.
-6. Esercitati a esportare un pacchetto `.cpproject` e a importarlo su un'altra macchina o profilo per validare la catena salvataggio →
-   condivisione → importazione prima di arrivare sul set.
+### Progettato per le troupe
 
-## Flussi di lavoro principali
+Il planner è stato ideato per 1st AC, data wrangler e direttori della fotografia. Quando aggiungi corpi camera, piastre, link wireless o accessori, consumo totale e stime di autonomia si aggiornano all’istante. Gli avvisi segnalano batterie sovraccariche e le liste restano legate al contesto di progetto per evitare perdite durante i passaggi di consegne.
 
-- **Pianificare un rig.** Combina camere, piastre, collegamenti wireless, monitor, motori e accessori osservando aggiornarsi
-  all'istante consumi e stime di autonomia.
-- **Salvare versioni.** Mantieni istantanee esplicite dei progetti e lascia che backup automatici con timestamp catturino il
-  lavoro in corso ogni 10 minuti.
-- **Condividere in sicurezza.** Esporta pacchetti `.cpproject` che restano offline, convalidano lo schema in import e possono
-  includere regole automatiche per l'attrezzatura.
-- **Eseguire backup completi.** I backup del planner includono progetti, preferiti, attrezzature personalizzate, dati sulle
-  autonomie e preferenze dell'interfaccia in modo da non perdere contesto.
-- **Backup di migrazione nascosti.** Prima di sovrascrivere planner, set o
-  preferenze salvate, l’app conserva lo snapshot JSON precedente nello slot
-  protetto `__legacyMigrationBackup`. Se una scrittura fallisce o produce dati
-  danneggiati, gli strumenti di ripristino tornano automaticamente a quella
-  copia di sicurezza così da non perdere alcun dato utente.
+### Nato per viaggiare
 
-## Proteggere i dati offline
+Apri `index.html` direttamente dal disco o ospita il repository sulla tua rete interna, senza build, server o account. Un service worker mantiene l’app disponibile offline, memorizza le preferenze e applica aggiornamenti solo con la tua approvazione. Salvataggi, condivisioni, import, backup e ripristini avvengono sempre in locale per proteggere i dati.
 
-- Verifica regolarmente la prontezza offline: carica l'applicazione, disconnettiti, aggiorna e assicurati che i progetti restino
-  accessibili.
-- Conserva copie ridondanti su supporti etichettati e importale in un secondo profilo dopo ogni esportazione.
-- Prima di applicare aggiornamenti o modifiche importanti ai dati, crea un backup manuale e assicurati che il ripristino sia pulito.
+### Perché l’offline-first è fondamentale
 
----
+Sul set la connettività non è garantita e molti studi richiedono strumenti isolati. Cine Power Planner offre le stesse funzionalità con o senza rete: tutte le risorse sono incluse, ogni flusso gira in locale e ogni salvataggio produce artefatti che puoi archiviare su supporti ridondanti. Verificare questi flussi prima delle riprese fa parte della checklist, così niente dipende da servizi esterni in piena produzione.
 
-## 🌍 Lingue
+### Pilastri funzionali
+
+- **Pianifica con sicurezza.** Calcola l’assorbimento a 14,4 V/12 V (e 33,6 V/21,6 V per B‑Mount), confronta batterie compatibili e visualizza l’impatto in un cruscotto ponderato.
+- **Resta pronto per la produzione.** I progetti includono dispositivi, requisiti, scenari, dettagli della troupe e liste; auto-backup, bundle e aggiornamenti controllati mantengono i dati aggiornati senza perdere stabilità.
+- **Lavora come preferisci.** Rilevamento lingua, temi scuro, rosa e alto contrasto, controlli tipografici, logo personalizzato e aiuto contestuale rendono l’interfaccia accogliente sia in preparazione sia sul set.
+
+## Principi chiave
+
+- **Sempre offline.** L’intera applicazione – icone, pagine legali e strumenti – è inclusa nel repository. Apri `index.html` dal disco o da una intranet privata e il service worker sincronizza le risorse senza richiedere connessione.
+- **Nessun percorso nascosto.** Salvataggi, bundle, import, backup e ripristini avvengono esclusivamente nel browser. Nulla lascia il dispositivo se non tramite un export volontario.
+- **Reti ridondanti.** Salvataggi manuali, auto-save, backup periodici, backup forzati prima dei ripristini ed export leggibili lavorano insieme per evitare perdite silenziose.
+- **Aggiornamenti prevedibili.** Si applicano solo quando li attivi. Le versioni in cache restano disponibili finché non confermi **Forza ricarica**.
+- **Presentazione coerente.** Uicons locali, risorse OpenMoji e font inclusi garantiscono la stessa resa visiva in studio o su un portatile offline.
+
+## Indice
+
+- [In breve](#in-breve)
+- [Panoramica](#panoramica)
+- [Principi chiave](#principi-chiave)
+- [Traduzioni](#traduzioni)
+- [Novità](#novità)
+- [Avvio rapido](#avvio-rapido)
+- [Requisiti di sistema e browser](#requisiti-di-sistema-e-browser)
+- [Drill di salvataggio, condivisione e import](#drill-di-salvataggio-condivisione-e-import)
+- [Flusso quotidiano](#flusso-quotidiano)
+- [Gestione di salvataggi e progetti](#gestione-di-salvataggi-e-progetti)
+- [Condivisione e import](#condivisione-e-import)
+- [Formati di file](#formati-di-file)
+- [Tour dell’interfaccia](#tour-dellinterfaccia)
+- [Personalizzazione e accessibilità](#personalizzazione-e-accessibilità)
+- [Sicurezza dei dati e uso offline](#sicurezza-dei-dati-e-uso-offline)
+- [Panoramica dati e archiviazione](#panoramica-dati-e-archiviazione)
+- [Gestione quote e manutenzione](#gestione-quote-e-manutenzione)
+- [Backup e ripristino](#backup-e-ripristino)
+- [Drill di integrità](#drill-di-integrità)
+- [Checklist operative](#checklist-operative)
+- [Piano di emergenza](#piano-di-emergenza)
+- [Liste attrezzatura e report](#liste-attrezzatura-e-report)
+- [Regole automatiche](#regole-automatiche)
+- [Intelligenza sulle autonomie](#intelligenza-sulle-autonomie)
+- [Scorciatoie da tastiera](#scorciatoie-da-tastiera)
+- [Localizzazione](#localizzazione)
+- [Installazione come app](#installazione-come-app)
+- [Workflow dati dispositivi](#workflow-dati-dispositivi)
+- [Sviluppo](#sviluppo)
+- [Risoluzione dei problemi](#risoluzione-dei-problemi)
+- [Feedback e supporto](#feedback-e-supporto)
+- [Contribuire](#contribuire)
+- [Ringraziamenti](#ringraziamenti)
+- [Licenza](#licenza)
+
+## Traduzioni
+
+La documentazione è disponibile in più lingue. L’app rileva automaticamente la lingua del browser al primo avvio e puoi cambiarla in qualsiasi momento dal menu in alto a destra o da **Impostazioni**.
+
 - 🇬🇧 [English](README.en.md)
 - 🇩🇪 [Deutsch](README.de.md)
 - 🇪🇸 [Español](README.es.md)
 - 🇮🇹 [Italiano](README.it.md)
 - 🇫🇷 [Français](README.fr.md)
 
-Al primo avvio l’applicazione adotta la lingua del browser; puoi cambiarla dall’angolo in alto a destra e la scelta viene ricordata per la visita successiva.
+Consulta `docs/translation-guide.md` per i dettagli sulla localizzazione.
 
----
+## Novità
 
-## 🆕 Novità
-- I confronti delle versioni dei backup permettono di scegliere qualsiasi salvataggio manuale o backup automatico con timestamp per rivedere le differenze, aggiungere note sugli incidenti ed esportare un registro prima di annullare una modifica o consegnare il materiale alla post.
-- I backup ora normalizzano i pacchetti di dati legacy salvati come stringhe JSON o array di voci, così gli export storici si ripristinano correttamente.
-- Le prove di ripristino caricano un backup completo dell’app o un bundle di progetto in una sandbox isolata così puoi confermare che il contenuto corrisponde ai dati live senza toccare i profili di produzione.
-- Le regole automatiche dell'attrezzatura consentono di definire aggiunte o rimozioni guidate dallo scenario, esportarle e ripristinarle insieme ai bundle condivisi.
-- Il cruscotto Dati e archiviazione controlla progetti salvati, elenchi, dispositivi personalizzati, preferiti e feedback sulle autonomie direttamente nelle Impostazioni e mostra la dimensione approssimativa del backup.
-- Un overlay di stato dell'autosalvataggio riporta l’ultima nota di autosalvataggio dentro alle Impostazioni così le squadre vedono l’attività in background mentre provano le procedure di recupero.
-- Un editor dell'attrezzatura sensibile al monitoraggio mette in evidenza accessori aggiuntivi per monitor e video solo quando gli scenari lo richiedono, mantenendo la creazione delle regole concentrata.
-- I controlli di accento e tipografia nelle Impostazioni consentono di regolare colore, dimensione base e famiglia del font insieme ai temi scuro, rosa e ad alto contrasto.
-- Le scorciatoie della ricerca globale portano il focus sul campo all’istante con / o Ctrl+K (⌘K su macOS), anche quando è nascosto nel menu laterale compresso.
-- Il pulsante **Forza ricarica** cancella i file del service worker in cache per aggiornare l’applicazione offline senza eliminare progetti o dispositivi salvati.
-- Le icone a stella di ogni selettore fissano videocamere, batterie e accessori preferiti in cima alla lista e li includono nei backup.
-- Il flusso di **Ripristino di fabbrica** scarica automaticamente una copia di sicurezza prima di rimuovere progetti, dispositivi e impostazioni memorizzati.
-- La lista attrezzatura e l’anteprima stampabile mostrano il nome del progetto per un riferimento veloce.
-- Puoi caricare un logo personalizzato che apparirà nelle stampe e nei backup.
-- I backup includono i preferiti e creano automaticamente una copia prima del ripristino.
-- Le schede della troupe includono ora un campo e-mail dedicato.
-- Nuovo tema ad alto contrasto per migliorare la leggibilità.
-- I moduli dei dispositivi compilano le categorie in modo dinamico partendo dallo schema.
-- Interfaccia ridisegnata con contrasto maggiore e spaziature più generose per un’esperienza più pulita su qualsiasi dispositivo.
-- Condividere i progetti è più semplice: scarica un file JSON con selezioni, requisiti, lista attrezzatura, feedback di autonomia e dispositivi personalizzati, quindi importalo per ripristinare tutto. Attiva l'interruttore **Includi regole automatiche dell'attrezzatura** se vuoi che le automazioni viaggino con l'export oppure lascialo disattivato per mantenerle locali.
-- Icone dedicate per gli scenari obbligatori evidenziano subito i requisiti del progetto.
-- Diagramma del progetto interattivo per trascinare i dispositivi, fare zoom, allineare alla griglia ed esportare in SVG o JPG.
-- Tema rosa giocoso che resta attivo tra una visita e l’altra.
-- Finestra di aiuto ricercabile con sezioni guidate e FAQ; aprila con ?, H, F1 o Ctrl+/.
-- Suggerimenti contestuali al passaggio del mouse su pulsanti, campi, menu e intestazioni.
-- Barra di ricerca globale per raggiungere rapidamente funzioni, selettori di dispositivi o argomenti di aiuto.
-- Supporto per videocamere con piastre V‑, B‑ o Gold-Mount.
-- Invia feedback di autonomia indicando la temperatura per affinare le stime.
-- Dashboard visiva per la ponderazione delle autonomie che mostra l’impatto delle impostazioni su ogni misura, ordinata per peso con percentuali precise.
-- Generatore di liste attrezzatura che riunisce l’equipaggiamento selezionato e i requisiti del progetto.
-- I requisiti di progetto vengono salvati insieme a ogni configurazione così la lista mantiene tutto il contesto.
-- I pulsanti a forchetta duplicano all’istante le voci personalizzate nei moduli della lista attrezzatura.
+- **Confronto backup** – Seleziona salvataggi manuali o auto-backup, analizza i diff, aggiungi note e esporta un log prima di ripristinare o consegnare il materiale.
+- **Prove di ripristino** – Carica un backup completo o un bundle in una sandbox isolata per verificarne il contenuto senza toccare i profili di produzione.
+- **Regole automatiche per l’attrezzatura** – Definisci aggiunte o rimozioni attivate dagli scenari con controlli di import/export e backup programmati.
+- **Dashboard dati e archiviazione** – Audita progetti, liste, dispositivi personalizzati, preferiti e feedback sulle autonomie direttamente da Impostazioni e stima la dimensione del backup.
+- **Overlay stato auto-save** – Replica l’ultima nota di auto-save nel dialogo Impostazioni così la troupe vede l’attività in background durante gli esercizi.
+- **Editor sensibile al monitoring** – Mostra campi aggiuntivi per monitor e distribuzione video solo quando richiesti dagli scenari.
+- **Controlli di accento e tipografia** – Regola colore di accento, dimensione e famiglia di font; i temi scuro, rosa e alto contrasto restano attivi tra le sessioni.
+- **Scorciatoie di ricerca globale** – Premi `/` o `Ctrl+K` (`⌘K` su macOS) per focalizzare subito la ricerca anche con navigazione mobile chiusa.
+- **Pulsante Forza ricarica** – Aggiorna le risorse del service worker senza eliminare progetti o dispositivi.
+- **Preferiti fissati** – Aggiungi una stella alle voci per mantenere camere, batterie e accessori principali in cima e inclusi nei backup.
+- **Ripristino alle impostazioni di fabbrica con salvaguardia** – Scarica automaticamente un backup prima di cancellare progetti, dispositivi e preferenze.
 
----
+Consulta i README localizzati per ulteriori dettagli.
 
-## 🔧 Funzionalità
+## Avvio rapido
 
-### ✨ Punti salienti
+Segui questa checklist all’installazione o dopo un aggiornamento: dimostra che salvataggio, condivisione, import, backup e ripristino funzionano identici online e offline.
 
-- **Progetta rig complessi senza tentativi.** Combina camere, piastre batteria, link wireless, monitor, motori e accessori tenendo sotto controllo il consumo totale a 14,4 V/12 V (e 33,6 V/21,6 V per B‑Mount) e autonomie realistiche basate su dati di campo ponderati. Il pannello di confronto batterie segnala eventuali sovraccarichi prima che l’attrezzatura parta.
-- **Mantieni allineati tutti i reparti.** Salva più progetti con requisiti, contatti della troupe, scenari e note. Le liste stampabili raggruppano il materiale per categoria, uniscono i duplicati, mostrano metadati tecnici e aggiungono accessori legati agli scenari così che camera, luce e grip condividano lo stesso contesto.
-- **Lavora con serenità ovunque.** Apri `index.html` direttamente oppure servi la cartella via HTTPS per attivare il service worker. La cache offline conserva lingua, temi, preferiti e progetti, e **Forza ricarica** aggiorna gli asset senza toccare i dati salvati.
-- **Adatta Cine Power Planner alla tua troupe.** Passa subito tra italiano, inglese, tedesco, spagnolo e francese, regola dimensione e font, scegli un colore accento personale, carica un logo per la stampa e alterna tema chiaro, scuro, rosa o ad alto contrasto. Selettori con ricerca, preferiti fissati, pulsanti di duplicazione e guide contestuali mantengono il ritmo sul set.
+1. Clona o scarica il repository.
+2. Apri `index.html` in un browser moderno.
+3. (Opzionale) Servi la cartella via HTTP(S) per installare il service worker:
+   ```bash
+   npx http-server
+   # oppure
+   python -m http.server
+   ```
+   L’app viene messa in cache per l’uso offline e applica gli update solo con il tuo consenso.
+4. Carica il planner, chiudi la scheda, disconnettiti (o attiva la modalità aereo) e riapri `index.html`. L’indicatore offline dovrebbe lampeggiare brevemente mentre carica le risorse memorizzate, inclusi gli Uicons locali.
+5. Crea un progetto, premi **Invio** (o **Ctrl+S**/`⌘S`) per un salvataggio manuale e controlla che nel selettore compaia il backup automatico con timestamp dopo pochi minuti.
+6. Esporta **Impostazioni → Backup e ripristino → Backup** e importa il file `planner-backup.json` in un profilo privato. Così verifichi che nessuna copia resti isolata e che il backup forzato prima del ripristino funzioni.
+7. Esercitati a esportare un bundle (`project-name.json`) e importarlo su un altro dispositivo o profilo per collaudare il flusso Salva → Condividi → Importa e assicurarti che risorse locali seguano il progetto.
+8. Archivia backup e bundle verificati insieme alla copia del repository utilizzato. In questo modo mantieni sincronizzati i flussi e hai supporti ridondanti in viaggio.
 
-### ✅ Gestione dei progetti
-- Salva, carica e cancella più progetti (premi Invio o Ctrl+S/⌘S per salvare rapidamente; il pulsante rimane disattivato finché non inserisci un nome).
-- Vengono creati snapshot automatici ogni 10 minuti mentre Cine Power Planner è aperto, e nelle Impostazioni puoi attivare export orari di backup come promemoria.
-- Scarica un file JSON che raggruppa selezioni, requisiti, lista attrezzatura, feedback di autonomia e dispositivi personalizzati; importalo dal selettore per ripristinare tutto in un passo.
-- I dati si salvano localmente tramite `localStorage` e i preferiti vengono inclusi nei backup; l’opzione **Ripristino di fabbrica** scarica automaticamente una copia prima di cancellare progetti e modifiche ai dispositivi.
-- Genera anteprime stampabili per ogni progetto e aggiungi un logo personalizzato così esportazioni e backup rispettano l’identità della produzione.
-- I requisiti di progetto vengono salvati con il progetto, così la lista attrezzatura conserva il contesto completo.
-- Funziona interamente offline grazie al service worker: lingua, tema, dati dei dispositivi e preferiti persistono tra le sessioni.
-- Il layout responsive si adatta a desktop, tablet e smartphone.
-- Sulle videocamere compatibili puoi scegliere piastre **V‑Mount**, **B‑Mount** o **Gold-Mount**; l’elenco delle batterie si aggiorna automaticamente.
+## Requisiti di sistema e browser
 
-### 🧭 Panoramica dell’interfaccia
-- **Promemoria rapido:**
-  - **Ricerca globale** (`/` o `Ctrl+K`/`⌘K`) salta a funzioni, selettori o argomenti di aiuto anche con il menu laterale chiuso.
-  - **Centro assistenza** (`?`, `H`, `F1` o `Ctrl+/`) offre guide filtrabili, FAQ, scorciatoie e la modalità di aiuto al passaggio del mouse.
-  - **Diagramma del progetto** visualizza le connessioni; tieni premuto Maiusc durante il download per salvare un JPG al posto di un SVG e vedere gli avvisi di compatibilità.
-  - **Confronto batterie** mostra le prestazioni dei pack compatibili ed evidenzia i rischi di sovraccarico.
-  - **Generatore di liste** produce tabelle per categoria con metadati, e-mail della troupe e aggiunte basate sugli scenari pronte per la stampa.
-  - **Badge offline e Forza ricarica** indicano lo stato della connessione e aggiornano i file in cache senza eliminare i progetti.
-- Un collegamento di salto e un indicatore offline mantengono l’interfaccia accessibile con tastiera e touch; il badge appare ogni volta che il browser perde la rete.
-- La barra di ricerca globale consente di raggiungere funzioni, selettori o argomenti di aiuto; premi Invio per aprire il risultato evidenziato, usa / o Ctrl+K (⌘K su macOS) per focalizzarla subito (su schermi piccoli il menu laterale si apre automaticamente) e premi Esc o × per cancellare la ricerca.
-- I controlli della barra superiore offrono cambio lingua, temi scuro e rosa e la finestra Impostazioni con colore accento, dimensione e famiglia del font, modalità ad alto contrasto e caricamento del logo, oltre agli strumenti di backup, ripristino e Ripristino di fabbrica che salvano una copia prima di cancellare i dati.
-- Il pulsante di aiuto apre un dialogo ricercabile con sezioni guidate, scorciatoie da tastiera, FAQ e una modalità di suggerimenti al passaggio del mouse; lo puoi aprire anche con ?, H, F1 o Ctrl+/ mentre digiti.
-- Il pulsante di ricarica forzata (🔄) elimina i file del service worker in cache così l’applicazione offline si aggiorna senza perdere progetti o dispositivi.
-- Su schermi piccoli un menu laterale a scomparsa replica ogni sezione principale per navigare rapidamente.
+- **Browser moderni.** Validato sulle ultime versioni di Chromium, Firefox e Safari. Attiva service worker, IndexedDB e archiviazione persistente.
+- **Dispositivi orientati all’offline.** Laptop e tablet devono consentire storage persistente. Avvia l’app una volta online per mettere in cache tutte le risorse e ripeti la procedura di ricarica offline prima di partire.
+- **Spazio locale adeguato.** Produzioni grandi accumulano progetti, backup e liste. Monitora lo spazio del profilo e esporta regolarmente su supporti ridondanti.
+- **Zero dipendenze esterne.** Tutte le icone, i font e gli script sono inclusi. Copia anche `animated icons 3/` e gli Uicons locali quando trasferisci la cartella.
 
-### ♿ Personalizzazione e accessibilità
-- Le preferenze di tema includono modalità scura, accento rosa giocoso e un interruttore dedicato ad alto contrasto.
-- Le modifiche a colore accento, dimensione e tipografia si applicano subito e restano memorizzate nel browser, ideali per rispettare il brand o esigenze di accessibilità.
-- Le scorciatoie integrate coprono ricerca globale (/ o Ctrl+K/⌘K), aiuto ( ?, H, F1, Ctrl+/ ), salvataggio (Invio o Ctrl+S/⌘S), modalità scura (D) e modalità rosa (P).
-- La modalità di aiuto al passaggio del mouse trasforma pulsanti, campi, menu e intestazioni in tooltip su richiesta, perfetta per chi è alle prime armi.
-- Gli input con ricerca incrementale, il focus visibile e le icone a stella accanto ai selettori consentono di filtrare elenchi lunghi e fissare i preferiti.
-- Carica un logo per la stampa, configura i ruoli di monitoraggio predefiniti e regola i preset dei requisiti di progetto così gli export rispettano l’identità della produzione.
-- I pulsanti a forchetta duplicano le righe dei moduli all’istante e i preferiti fissati mantengono l’attrezzatura abituale in cima alle liste, utile quando il tempo è limitato.
+## Drill di salvataggio, condivisione e import
 
-### 📋 Lista attrezzatura
-Il generatore trasforma le tue scelte in una lista di carico ordinata per categorie:
+Ripeti questa routine quando arriva un nuovo membro, allestisci una postazione o pubblichi un aggiornamento importante per confermare che salvataggio, condivisione, import, backup e ripristino funzionano senza rete.
 
-- Clicca su **Genera lista attrezzatura** per raccogliere l’equipaggiamento selezionato e i requisiti del progetto in una tabella.
-- La tabella si aggiorna non appena cambiano selezioni o requisiti.
-- Gli elementi sono raggruppati per categoria (camera, ottiche, alimentazione, monitoraggio, rigging, grip, accessori, consumabili) e i duplicati sono uniti con la quantità corretta.
-- Cavi, rigging e accessori necessari per monitor, motori, gimbal e scenari meteo vengono aggiunti automaticamente.
-- Gli scenari selezionati aggiungono l’attrezzatura correlata:
-  - *Handheld* + *Easyrig* inserisce una maniglia telescopica per un supporto stabile.
-  - *Gimbal* aggiunge il gimbal scelto, bracci articolati, spigot e paraluce o kit filtri.
-  - *Outdoor* fornisce spigot, ombrelli e coperture antipioggia CapIt.
-  - Gli scenari *Vehicle* e *Steadicam* includono staffe, bracci di isolamento e ventose quando necessari.
-- Le selezioni delle ottiche riportano diametro frontale, peso, dati dei rod e fuoco minimo, aggiungono i supporti per lenti e gli adattatori matte box e segnalano eventuali standard incompatibili.
-- Le righe delle batterie riprendono i conteggi del calcolatore di potenza e includono piastre o dispositivi di hotswap quando richiesti.
-- Le preferenze di monitoraggio assegnano monitor predefiniti a ogni ruolo (regista, DoP, fuochista, ecc.) con set di cavi e ricevitori wireless.
-- Il modulo **Requisiti del progetto** alimenta la lista:
-  - **Nome del progetto**, **casa di produzione**, **noleggio** e **DoP** compaiono nell’intestazione delle specifiche stampate.
-  - Le voci **Troupe** raccolgono nomi, ruoli ed e-mail così i contatti viaggiano con il progetto.
-  - **Giorni di preparazione** e **giorni di ripresa** aggiungono note di pianificazione e, con scenari outdoor, suggeriscono attrezzatura per il meteo.
-  - Gli **scenari obbligatori** inseriscono rigging, gimbal e protezioni climatiche adeguati.
-  - **Impugnatura camera** ed **estensione mirino** includono i componenti selezionati o i relativi supporti.
-  - Le opzioni di **matte box** e **filtri** aggiungono il sistema scelto con cassetti, adattatori a clamp o filtri necessari.
-  - Le configurazioni di **monitoraggio**, **distribuzione video** e **mirino** aggiungono monitor, cavi e overlay per ciascun ruolo.
-  - Le scelte dei **pulsanti personalizzati** e delle **preferenze treppiede** vengono elencate per riferimento rapido.
-- All’interno di ogni categoria gli elementi sono ordinati alfabeticamente e mostrano un tooltip al passaggio del mouse.
-- La lista attrezzatura è inclusa nelle anteprime stampabili e nei file di progetto esportati.
-- Le liste vengono salvate automaticamente insieme al progetto e sono incluse sia negli export sia nei backup.
-- **Elimina lista attrezzatura** cancella la lista salvata e nasconde l’output.
-- I moduli includono pulsanti a forchetta per duplicare le voci inserite al volo.
+1. **Salvataggio base.** Apri il progetto attuale, esegui un salvataggio manuale e annota l’orario. Un auto-backup dovrebbe comparire entro dieci minuti.
+2. **Export ridondanti.** Crea un backup completo e un bundle di progetto. Rinominalo in `.cpproject` se richiesto e salva entrambi su supporti diversi.
+3. **Prova di ripristino.** Passa a un profilo privato (o seconda macchina), importa il backup completo e poi il bundle. Controlla liste, dashboard, regole e preferiti.
+4. **Verifica offline.** Nel profilo di test, disconnetti la rete e ricarica `index.html`. Assicurati che l’indicatore offline appaia e che Uicons e script locali si carichino correttamente.
+5. **Archiviazione sicura.** Elimina il profilo di test dopo la verifica e etichetta gli export secondo la procedura di produzione.
 
-### 📦 Categorie dei dispositivi
-- **Camera** (1)
-- **Monitor** (opzionale)
-- **Trasmettitore wireless** (opzionale)
-- **Motori FIZ** (0–4)
-- **Controller FIZ** (0–4)
-- **Sensore di distanza** (0–1)
-- **Piastra batteria** (solo sulle camere compatibili con V‑ o B‑Mount)
-- **Batteria V‑Mount** (0–1)
+## Flusso quotidiano
 
-### ⚙️ Calcoli di potenza
-- Consumo totale in watt
-- Corrente a 14,4 V e 12 V
-- Autonomia stimata in ore utilizzando la media ponderata della community
-- Numero di batterie necessario per 10 h di riprese
-- Nota sulla temperatura per adattare l’autonomia in condizioni estreme
+1. **Crea o carica un progetto.** Inserisci un nome e premi **Invio**/**Salva**. Il nome attivo compare in liste e export.
+2. **Aggiungi camere, alimentazione e accessori.** Scegli dispositivi da menu categorizzati. Ricerca digitando, preferiti e scorciatoia `/` (`Ctrl+K`/`⌘K`) velocizzano la selezione.
+3. **Controlla potenza e autonomia.** Monitora gli avvisi, confronta le batterie e consulta il cruscotto per capire l’impatto di temperatura, codec, fps, ecc.
+4. **Documenta i requisiti.** Inserisci dati della troupe, scenari, maniglie, matte box e setup di monitoraggio. I pulsanti duplica replicano le voci. **Impostazioni → Regole automatiche** aggiunge o rimuove elementi specifici prima dell’export.
+5. **Esporta o archivia il piano.** Genera la lista attrezzatura, scarica un backup o un bundle prima di andare sul set. I backup includono dispositivi personalizzati, feedback e preferiti.
+6. **Conferma la preparazione offline.** Disconnetti, ricarica l’app e verifica che tutto resti accessibile. Ripristina dall’ultimo backup se qualcosa non torna.
 
-### 🔋 Controllo dell’erogazione
-- Avvisa se la corrente richiesta supera l’uscita della batteria (pin o D‑Tap)
-- Indica quando il carico raggiunge l’80 % della capacità
+## Gestione di salvataggi e progetti
 
-### 📊 Confronto batterie (opzionale)
-- Confronta le stime di autonomia fra tutte le batterie
-- Grafici a barre per un colpo d’occhio immediato
+- **Salvataggi manuali per versioni esplicite.** Inserisci il nome e premi **Invio**/**Salva**. Ogni salvataggio conserva dispositivi, requisiti, liste, preferiti, diagrammi e osservazioni.
+- **Auto-save per il lavoro in corso.** Con un progetto aperto, l’app scrive i cambiamenti in background. Le voci `auto-backup-…` compaiono ogni dieci minuti.
+- **Mostra gli auto-backup su richiesta.** Attiva **Impostazioni → Backup e ripristino → Mostra auto-backup** per vedere gli orari.
+- **Rinominare crea una copia.** Modifica il nome e premi **Invio** per duplicare il progetto, utile per confrontare varianti.
+- **Cambiare progetto è sicuro.** Seleziona un’altra voce: posizione di scroll e campi non salvati si aggiornano senza perdere dati.
+- **Eliminazione con conferma.** L’icona cestino chiede sempre conferma prima di rimuovere elementi.
 
-### 🖼 Diagramma del progetto
-- Visualizza le connessioni di alimentazione e video dei dispositivi selezionati
-- Avvisa quando i brand FIZ non sono compatibili
-- Trascina i nodi per riordinare il layout, usa i pulsanti per zoomare ed esporta il diagramma in SVG o JPG
-- Tieni premuto Shift mentre clicchi Download per esportare uno snapshot JPG invece di un SVG
-- Passa il mouse o tocca un dispositivo per vedere i dettagli in popover
-- Utilizza icone OpenMoji quando è disponibile la connessione e passa agli emoji in assenza: 🔋 batteria, 🎥 camera, 🖥️ monitor, 📡 video, ⚙️ motore, 🎮 controller, 📐 distanza, 🎮 impugnatura e 🔌 piastra batteria
+## Condivisione e import
 
-### 🧮 Ponderazione dei dati di autonomia
-- I feedback inviati dagli utenti migliorano la stima finale
-- Ogni voce viene corretta in base alla temperatura, passando da ×1 a 25 °C a:
-  - ×1,25 a 0 °C
-  - ×1,6 a −10 °C
-  - ×2 a −20 °C
-- Le impostazioni della camera influiscono sul peso:
-  - Moltiplicatori di risoluzione: ≥12K ×3, ≥8K ×2, ≥4K ×1,5, ≥1080p ×1; risoluzioni inferiori scalate a 1080p
-  - Il frame rate scala linearmente da 24 fps (es. 48 fps = ×2)
-  - Wi‑Fi attivo aggiunge il 10 %
-  - Fattori codec: RAW/BRAW/ARRIRAW/R3D/CinemaDNG/Canon RAW/X‑OCN ×1; ProRes ×1,1; DNx/AVID ×1,2; All‑Intra ×1,3; H.264/AVC ×1,5; H.265/HEVC ×1,7
-  - Le voci dei monitor sotto la luminosità indicata vengono pesate in base al loro rapporto di luminosità
-- Il peso finale riflette la quota di consumo di ciascun dispositivo, così i progetti simili contano di più
-- La media ponderata viene applicata quando sono disponibili almeno tre voci
-- Una dashboard ordina i contributi per peso e mostra la percentuale di ciascuno per un confronto immediato
+- **Bundle leggeri.** **Esporta progetto** scarica `project-name.json` con progetto attivo, preferiti e dispositivi personalizzati. Puoi rinominarlo `.cpproject`.
+- **Regole automatiche insieme al bundle.** Attiva **Includi regole automatiche** per inserirle; all’import il destinatario può applicarle solo al progetto o fonderle con le proprie.
+- **Import offline validati.** Importando `auto-gear-rules-*.json`, il planner controlla tipo, versione semantica e metadati prima di modificare le tue regole. Se qualcosa non torna, avvisa e ripristina lo snapshot precedente.
+- **Ripristini a doppio buffer.** Prima dell’import viene richiesto un backup del contesto corrente. Dopo la validazione il progetto ripristinato appare in cima al selettore.
+- **Flussi cross-device senza rete.** Copia `index.html`, `script.js`, `devices/` e i tuoi file di backup/bundle su un supporto removibile, avvia dal disco e continua senza internet.
+- **Esporta con attenzione.** Controlla il JSON prima di condividerlo per verificare che contenga solo ciò che serve. Il formato è leggibile per eventuali modifiche.
+- **Sincronizza con le checklist.** Quando ricevi un bundle aggiornato, importalo, verifica i timestamp `Aggiornato` e archivia il JSON precedente per mantenere la storia.
+- **Condividi senza perdere contesto.** I bundle ricordano lingua, tema, logo e preferenze, offrendo al destinatario un ambiente familiare anche offline.
 
-### 🔍 Ricerca e filtri
-- Digita nei menu a discesa per trovare rapidamente un elemento
-- Filtra le liste di dispositivi tramite un campo di ricerca
-- Usa la barra di ricerca globale in alto per saltare a funzioni, dispositivi o argomenti di aiuto; premi Invio per navigare, / o Ctrl+K (⌘K su macOS) per focalizzarla al volo ed Esc o × per cancellare
-- Premi “/” o Ctrl+F (⌘F su macOS) per portare subito il focus sul campo di ricerca più vicino
-- Clicca sulla stella accanto a qualsiasi selettore per fissare i preferiti in cima e sincronizzarli con i backup
+## Formati di file
 
-### 🛠 Editor del database
-- Aggiungi, modifica o elimina dispositivi in tutte le categorie
-- Importa o esporta l’intero database in formato JSON
-- Ripristina il database predefinito da `src/data/index.js`
+- **`project-name.json` (bundle).** Include un progetto, preferiti e dispositivi personalizzati. L’estensione `.cpproject` è equivalente.
+- **`planner-backup.json` (backup completo).** Da **Impostazioni → Backup e ripristino → Backup** ottieni tutti i progetti, auto-backup, preferiti, feedback, regole, preferenze, font e branding.
+- **`auto-gear-rules-*.json` (regole).** Export opzionali da **Regole automatiche** con metadati per la validazione offline; conservali insieme ai backup completi.
 
-### 🌓 Modalità scura
-- Attivala con il pulsante a forma di luna accanto al selettore della lingua
-- La preferenza viene salvata nel browser
+## Tour dell’interfaccia
 
-### 🦄 Modalità rosa
-- Clicca sul pulsante con l’unicorno (la modalità rosa alterna icone ogni 30 secondi con una delicata animazione pop e torna al cavallo quando esci) o premi **P** per attivare un accento rosa giocoso
-- Funziona sia nel tema chiaro sia in quello scuro e persiste fra le visite
+### Riferimenti rapidi
 
-### ⚫ Modalità ad alto contrasto
-- Attiva un tema ad alto contrasto per una migliore leggibilità
+- **Ricerca globale** (`/`, `Ctrl+K`, `⌘K`) per saltare a funzioni, menu o argomenti di aiuto anche con navigazione nascosta.
+- **Centro assistenza** (`?`, `H`, `F1`, `Ctrl+/`) con guide, scorciatoie, FAQ e modalità aiuto al passaggio.
+- **Diagramma di progetto** per visualizzare alimentazione e segnali; tieni premuto Shift durante l’export per salvare un JPG.
+- **Confronto batterie** che mostra le prestazioni dei pack compatibili e avvisa in caso di sovraccarichi.
+- **Generatore di liste** che produce tabelle categorizzate con metadati, email e accessori basati sugli scenari.
+- **Indicatore offline e Forza ricarica** per mostrare lo stato e aggiornare le risorse senza toccare i dati.
 
-### 📝 Feedback di autonomia
-- Clicca su <strong>Invia feedback di autonomia</strong> sotto la stima per aggiungere la tua misurazione
-- Includi la temperatura per una ponderazione più accurata
-- Le voci vengono salvate nel browser e migliorano le stime future
-- Un cruscotto dedicato ordina i contributi in base al peso, mostra le percentuali e mette in evidenza gli outlier per valutarli rapidamente
+### Barra superiore
 
-### ❓ Aiuto ricercabile
-- Apri il dialogo con il pulsante <strong>?</strong> o con <kbd>?</kbd>, <kbd>H</kbd>, <kbd>F1</kbd> o <kbd>Ctrl+/</kbd>
-- Usa il campo di ricerca per filtrare subito gli argomenti; la query viene azzerata alla chiusura
-- Chiudi con <kbd>Esc</kbd> o cliccando all’esterno del dialogo
+- Link di salto, indicatore offline e branding responsive garantiscono accessibilità.
+- La ricerca si focalizza con `/` o `Ctrl+K` (`⌘K`), apre il menu laterale su mobile e si azzera con Esc.
+- Switch lingua, temi scuro/rosa e dialogo Impostazioni consentono di regolare colore di accento, dimensione e font, modalità alto contrasto, logo personalizzato e accedere a backup, ripristino e reset (sempre preceduti da backup automatico).
+- Il pulsante Aiuto apre un dialogo ricercabile e risponde a `?`, `H`, `F1` o `Ctrl+/` in qualsiasi momento.
+- Il pulsante 🔄 cancella le risorse in cache e ricarica l’app senza eliminare progetti o dati runtime.
 
----
+### Navigazione e ricerca
 
-## ▶️ Come usarlo
-1. **Avvia l’applicazione:** apri `index.html` in un browser moderno; non serve alcun server.
-2. **Esplora la barra superiore:** cambia lingua, alterna i temi scuro o rosa, apri Impostazioni per regolare accento e tipografia e lancia l’aiuto con ? o Ctrl+/.
-3. **Seleziona i dispositivi:** scegli l’attrezzatura per ogni categoria dai menu; digita per filtrare, fissa i preferiti con la stella e lascia che gli scenari compilino gli accessori.
-4. **Consulta i calcoli:** dopo aver scelto una batteria vedrai consumo, corrente e autonomia; gli avvisi evidenziano eventuali superamenti dei limiti.
-5. **Salva ed esporta i progetti:** assegna un nome e salva la configurazione, i backup automatici creano snapshot e il pulsante Esporta scarica un bundle JSON mentre Importa lo ripristina.
-6. **Genera la lista attrezzatura:** premi **Genera lista attrezzatura** per trasformare i requisiti in una lista categorizzata con tooltip e accessori.
-7. **Gestisci i dati dei dispositivi:** clicca su “Modifica dati dispositivi…” per aprire l’editor, aggiornare il catalogo, esportare/importare JSON o tornare ai valori predefiniti.
-8. **Invia feedback di autonomia:** usa “Invia feedback di autonomia” per registrare misurazioni reali e perfezionare le medie ponderate.
+- Su schermi piccoli un menu laterale collassabile replica le sezioni principali.
+- Liste e editor supportano la ricerca inline e il filtraggio digitando. `/` o `Ctrl+F` (`⌘F`) mettono a fuoco il campo più vicino.
+- Le icone a stella fissano i dispositivi preferiti in cima e li mantengono nei backup.
 
-## 📱 Installare come applicazione
+## Personalizzazione e accessibilità
 
-Cine Power Planner è un’applicazione web progressiva installabile direttamente dal browser:
+- Passa tra temi chiaro, scuro, rosa e alto contrasto; colore di accento, dimensione di base e font persistono offline.
+- Link di salto, focus visibile e layout responsive rendono la navigazione fluida con tastiera, tablet e smartphone.
+- Scorciatoie disponibili: ricerca (`/`, `Ctrl+K`, `⌘K`), aiuto (`?`, `H`, `F1`, `Ctrl+/`), salvataggio (`Invio`, `Ctrl+S`, `⌘S`), dark mode (`D`) e tema rosa (`P`).
+- La modalità aiuto al passaggio trasforma pulsanti, campi, menu e intestazioni in tooltip on demand.
+- Carica un logo personalizzato per le overview stampabili, imposta default di monitoraggio e preset di requisiti.
+- I pulsanti duplica replicano i campi, mentre i preferiti tengono a portata i dispositivi ricorrenti.
 
-- **Chrome/Edge (desktop):** fai clic sull’icona di installazione nella barra degli indirizzi.
-- **Android:** apri il menu del browser e scegli *Aggiungi alla schermata Home*.
-- **iOS/iPadOS Safari:** tocca *Condividi* e seleziona *Aggiungi alla schermata Home*.
+## Sicurezza dei dati e uso offline
 
-Una volta installata, l’applicazione si avvia dalla schermata Home, funziona offline e si aggiorna automaticamente.
+- Un service worker mette in cache ogni risorsa per l’uso offline e applica gli aggiornamenti solo dopo **Forza ricarica**.
+- Progetti, feedback runtime, preferiti, dispositivi personalizzati, temi e liste vivono nello storage del browser. Quando possibile viene richiesta la persistenza per ridurre i rischi di cancellazione.
+- Aprire il repository dal disco o da una rete interna mantiene i dati sensibili lontani da servizi esterni. Gli export JSON sono leggibili e auditabili.
+- L’header mostra l’indicatore offline quando manca connessione; **Forza ricarica** aggiorna gli asset senza toccare i salvataggi.
+- **Ripristino impostazioni di fabbrica** o pulizia dei dati del sito avviene solo dopo aver generato automaticamente un backup.
+- Gli aggiornamenti del service worker vengono scaricati in background e attendono la tua approvazione. Quando compare **Aggiornamento pronto**, completa le modifiche, crea un backup e poi premi **Forza ricarica**.
+- Lo storage principale è IndexedDB, con preferenze leggere replicate in `localStorage`. Usa gli strumenti del browser per ispezionare o esportare i record prima di cancellare cache.
 
-## 📡 Uso offline e archiviazione
+## Panoramica dati e archiviazione
 
-Servire l’applicazione via HTTP(S) installa un service worker che memorizza in cache ogni file, così Cine Power Planner funziona completamente offline e si aggiorna in background. Progetti, feedback di autonomia e preferenze (lingua, tema, modalità rosa e liste salvate) risiedono nel `localStorage` del browser. Cancellare i dati del sito elimina tutte le informazioni e il menu Impostazioni offre un flusso di **Ripristino di fabbrica** che salva automaticamente un backup prima della stessa pulizia completa. L’intestazione mostra un badge offline quando la connessione cade e l’azione 🔄 **Forza ricarica** aggiorna i file in cache senza toccare i progetti.
+- Apri **Impostazioni → Dati e archiviazione** per vedere progetti salvati, auto-backup, liste, dispositivi personalizzati, preferiti, feedback e cache di sessione con conteggi in tempo reale.
+- Ogni sezione descrive il proprio contenuto; quelle vuote restano nascoste per riconoscere subito lo stato del planner.
+- Il riepilogo stima la dimensione del backup basandosi sull’export più recente.
 
----
+## Gestione quote e manutenzione
 
-## 🗂️ Struttura dei file
-```bash
-index.html                 # Layout HTML principale
-src/styles/style.css       # Stili e layout di base
-src/styles/overview.css    # Stili della panoramica stampabile
-src/styles/overview-print.css # Regole di stampa per la panoramica
-src/scripts/script.js        # Logica dell’applicazione
-src/scripts/storage.js       # Helper per LocalStorage
-src/scripts/static-theme.js  # Logica di tema condivisa per le pagine legali
-src/data/index.js       # Elenco dispositivi predefinito
-src/data/devices/       # Cataloghi dei dispositivi per categoria
-src/data/schema.json    # Schema generato per i selettori
-src/vendor/             # Librerie di terze parti incluse
-legal/                     # Pagine legali offline
-tools/                     # Script di manutenzione dei dati
-tests/                     # Suite di test Jest
-```
-I font sono inclusi localmente tramite `fonts.css`; una volta in cache, l’applicazione funziona interamente offline.
+- **Conferma l’accesso allo storage persistente.** Controlla il pannello su ogni workstation. Se il browser rifiuta, richiedi nuovamente o pianifica export manuali più frequenti.
+- **Monitora lo spazio disponibile.** Usa il dashboard o l’inspector del browser. Se la soglia si riduce, archivia i backup vecchi, rimuovi voci `auto-backup-…` ridondanti e verifica che i nuovi export vadano a buon fine.
+- **Prepara le cache dopo gli aggiornamenti.** Dopo **Forza ricarica**, apri il centro assistenza, le pagine legali e le viste principali per ricaricare Uicons, OpenMoji e font.
+- **Documenta lo stato dello storage.** Aggiungi queste verifiche ai log di preparazione e chiusura: stato della persistenza, spazio residuo e posizione degli ultimi backup.
 
-## 🛠️ Sviluppo
-Richiede Node.js 18 o successivo.
+## Backup e ripristino
 
-```bash
-npm install
-npm run lint     # esegue solo ESLint
-npm test         # esegue linting, controlli dati e test Jest
-```
+- **Snapshot salvati** – Il selettore conserva ogni salvataggio manuale e crea `auto-backup-…` ogni dieci minuti mentre l’app è aperta.
+- **Backup completi** – **Impostazioni → Backup e ripristino → Backup** scarica `planner-backup.json` con progetti, dispositivi, feedback, preferiti, regole automatiche e stato UI. I ripristini creano un backup di sicurezza e avvisano se il file proviene da un’altra versione.
+- **Backup di migrazione nascosti** – Prima di sovrascrivere planner, setup o preferenze, l’app salva il precedente JSON in `__legacyMigrationBackup`. In caso di errore, gli strumenti di recupero tornano automaticamente a quella copia.
+- **Snapshot automatici delle regole** – Le modifiche in **Regole automatiche** generano copie con timestamp ogni dieci minuti.
+- **Ripristino impostazioni di fabbrica** – Cancella i dati solo dopo aver scaricato un backup.
+- **Promemoria orari** – Una routine in background suggerisce un backup aggiuntivo ogni ora per avere sempre una copia recente.
+- **Loop di verifica** – Dopo ogni backup critico, importalo in un profilo separato per confermare il risultato prima di eliminare l’istanza di test.
+- **Abitudini di archiviazione sicura** – Etichetta backup con nome progetto e orario, poi conserva su supporti ridondanti (RAID, USB cifrato, disco ottico).
+- **Confronta prima di sovrascrivere** – Scarica un backup dello stato corrente prima di ripristinare e confronta le differenze con un diff JSON per eventuali fusioni manuali.
 
-Dopo aver modificato i dati dei dispositivi, rigenera il database normalizzato:
+## Drill di integrità
+
+- **Validazione pre-flight (quotidiana o prima di modifiche importanti).** Salva manualmente, esporta backup completo e bundle, importali in un profilo privato, verifica progetti, regole, preferiti e dashboard, poi elimina il profilo.
+- **Esercizio offline (settimanale o prima di viaggi).** Avvia il planner, genera un backup, disconnettiti e ricarica `index.html`. Controlla indicatore offline, nitidezza degli Uicons e apertura del progetto verificato.
+- **Controllo cambi (dopo modifiche a dati o script).** Esegui `npm test`, ripeti la validazione pre-flight e archivia il backup approvato con una nota di modifica.
+- **Rotazione della ridondanza (mensile o prima dell’archiviazione).** Conserva l’ultimo backup, un bundle verificato (rinominato `.cpproject` se serve) e uno ZIP del repository su almeno due supporti e alterna quale controllare per individuare degrado.
+
+## Checklist operative
+
+Queste routine mantengono progetti, backup e risorse offline sincronizzati su ogni macchina che usa Cine Power Planner. Una versione stampabile è in `docs/operations-checklist.md` e la guida `docs/offline-readiness.md` approfondisce i passaggi per periodi prolungati senza connessione.
+
+### Preparazione pre-shoot
+
+1. **Verifica la revisione corretta.** Apri `index.html`, premi **Forza ricarica** e controlla la versione in **Impostazioni → Informazioni**. Apri le pagine legali per precaricare Uicons, OpenMoji e font.
+2. **Carica i progetti critici.** Apri il piano attivo e un `auto-backup-…` recente. Controlla liste, feedback e preferiti in entrambi.
+3. **Testa la catena di salvataggio.** Apporta una modifica, salva con `Invio` o `Ctrl+S`/`⌘S`, esporta `planner-backup.json`, importalo in un profilo privato e confronta il selettore.
+4. **Verifica la condivisione.** Esporta `project-name.json`, importalo, controlla regole automatiche, dispositivi e indicatore offline. Elimina poi il profilo.
+5. **Simula l’assenza di rete.** Disconnetti il dispositivo o attiva la modalità aereo, ricarica il planner e verifica indicatore, icone e accesso ai progetti.
+6. **Archivia gli artefatti.** Conserva backup, bundle e un ZIP del repository su supporti ridondanti per ricostruire l’ambiente senza internet.
+
+### Handoff di fine giornata
+
+1. **Cattura un backup finale.** Con il progetto aperto, esporta `planner-backup.json` e l’ultimo `project-name.json` (rinominalo `.cpproject` se serve) e etichettali con data, luogo e giornata.
+2. **Valida gli import.** Ripristina entrambi i file su una macchina di verifica offline per assicurarti che non ci siano corruzioni.
+3. **Registra le modifiche.** Annota quali auto-backup sono stati promossi, quali dispositivi personalizzati aggiunti e quali regole cambiate. Archivia le note con i backup.
+4. **Aggiorna le cache intenzionalmente.** Dopo l’archiviazione, premi **Forza ricarica**, apri centro assistenza e pagine legali per ricaricare le risorse prima della prossima sessione offline.
+5. **Consegnare i supporti ridondanti.** Fornisci copie cifrate al team archiviazione e conserva un secondo set secondo la policy.
+
+## Piano di emergenza
+
+1. **Metti in pausa e preserva lo stato.** Lascia la scheda aperta, disconnetti la rete se possibile e annota ora e stato dell’indicatore offline. Evita di ricaricare.
+2. **Esporta ciò che resta.** Avvia **Impostazioni → Backup e ripristino → Backup** e scarica `planner-backup.json`. Anche se l’elenco sembra errato, cattura auto-backup, preferiti, feedback e regole per l’analisi.
+3. **Duplica gli auto-backup.** Mostra le voci `auto-backup-…`, promuovi gli snapshot più recenti a salvataggi manuali e rinominali con ID o timestamp.
+4. **Controlla il bundle verificato.** Importa l’ultimo `project-name.json`/`.cpproject` noto in un profilo privato o su una seconda macchina offline per confrontare progetti, liste e impostazioni.
+5. **Ripristina con attenzione.** Dopo la verifica, ripristina il backup recente sulla macchina principale. Il flusso salva prima una copia di sicurezza così puoi confrontarla tramite diff JSON se serve.
+6. **Ricarica e documenta.** Al termine, premi **Forza ricarica**, apri centro assistenza e pagine legali per rigenerare le cache, poi documenta l’incidente (cosa è successo, file esportati, dove sono conservati e quale macchina ha verificato). Archivia il report con il backup.
+
+## Liste attrezzatura e report
+
+- **Genera lista attrezzatura e requisiti** trasforma selezioni e requisiti in tabelle categorizzate che si aggiornano automaticamente.
+- Le voci sono raggruppate per categoria e i duplicati fusi. Gli scenari aggiungono rigging, protezioni meteo e accessori specialistici per rispecchiare il lavoro reale.
+- Le regole automatiche si eseguono dopo il generatore per aggiungere o rimuovere elementi specifici senza toccare il JSON.
+- Le righe obiettivi includono diametro frontale, peso, minima di fuoco, necessità di aste e componenti della matte box. Le righe batterie considerano quantità e hardware per l’hot swap.
+- Dettagli troupe, configurazioni di monitoraggio, distribuzione video e note personalizzate appaiono negli export.
+- Le liste vengono salvate con il progetto, compaiono nelle overview stampabili e nei bundle; puoi azzerarle con **Elimina lista attrezzatura**.
+
+## Regole automatiche
+
+Da **Impostazioni → Regole automatiche** puoi affinare ogni lista senza modificare JSON a mano:
+
+- Attiva regole solo quando determinati **Scenari obbligatori** sono selezionati; aggiungi etichette opzionali per riconoscerle a colpo d’occhio.
+- Aggiungi attrezzatura con categoria e quantità oppure usa **Aggiunte personalizzate** per promemoria, kit speciali o note. Le regole di rimozione nascondono righe che il generatore includerebbe.
+- Le regole girano dopo i pacchetti predefiniti così si integrano con la logica di base e confluiscono in liste, backup e bundle.
+- Salvare una lista memorizza l’insieme di regole attivo; caricando il progetto o importando un bundle si ripristina lo stesso perimetro.
+- Esporta/importa l’insieme in JSON, ripristina le impostazioni di fabbrica o usa la cronologia automatica (ogni dieci minuti) se un editing va storto.
+
+## Intelligenza sulle autonomie
+
+Le autonomie fornite dagli utenti alimentano un modello ponderato per riflettere l’esperienza reale:
+
+- Temperature: ×1 a 25 °C, ×1,25 a 0 °C, ×1,6 a −10 °C, ×2 a −20 °C.
+- Risoluzione: ≥12K ×3, ≥8K ×2, ≥4K ×1,5, ≥1080p ×1; risoluzioni inferiori scalate rispetto a 1080p.
+- Frame rate: scala lineare da 24 fps (48 fps = ×2).
+- Wi‑Fi attivo: +10 %.
+- Codec: RAW/BRAW/ARRIRAW/R3D/CinemaDNG/Canon RAW/X‑OCN ×1; ProRes ×1,1; DNx/AVID ×1,2; All-Intra ×1,3; H.264/AVC ×1,5; H.265/HEVC ×1,7.
+- I monitor sono ponderati in base al rapporto di luminosità.
+- Il peso finale riflette il contributo di ciascun componente, così rig simili influenzano maggiormente il modello.
+- Un dashboard ordina per peso, mostra percentuali e segnala outlier.
+
+## Scorciatoie da tastiera
+
+| Scorciatoia | Azione | Note |
+| --- | --- | --- |
+| `/`, `Ctrl+K`, `⌘K` | Focalizza la ricerca globale | Funziona anche con navigazione collassata; `Esc` svuota |
+| `Invio`, `Ctrl+S`, `⌘S` | Salva il progetto attivo | Il pulsante resta disabilitato finché non inserisci un nome |
+| `?`, `H`, `F1`, `Ctrl+/` | Apri il centro assistenza | Il dialogo resta ricercabile |
+| `D` | Attiva/disattiva il tema scuro | Disponibile anche in **Impostazioni → Temi** |
+| `P` | Attiva il tema rosa | Compatibile con i temi chiaro, scuro o alto contrasto |
+| 🔄 | Ricarica le risorse in cache | Anche tramite **Impostazioni → Forza ricarica** |
+
+## Localizzazione
+
+Puoi provare subito una nuova lingua senza build:
+
+1. Duplica il README più simile come `README.<lang>.md` e traducilo.
+2. Aggiungi le stringhe in `translations.js`, mantenendo i placeholder come `%s`.
+3. Copia e traduci le pagine statiche (privacy, note legali).
+4. Esegui `npm test` prima di inviare una pull request.
+
+## Installazione come app
+
+Cine Power Planner è una Progressive Web App:
+
+1. Apri `index.html` in un browser supportato.
+2. Usa l’opzione **Installa** o **Aggiungi alla schermata Home**.
+   - **Chrome/Edge (desktop):** icona di installazione nella barra degli indirizzi.
+   - **Android:** menu del browser → *Aggiungi alla schermata Home*.
+   - **Safari iOS:** pulsante condividi → *Aggiungi alla schermata Home*.
+3. Avvia l’app dall’elenco applicazioni. Funziona offline e si aggiorna automaticamente dopo che approvi la ricarica.
+
+## Workflow dati dispositivi
+
+I cataloghi risiedono in `devices/`. Ogni file raggruppa attrezzatura correlata per semplificare le revisioni. Prima di eseguire commit, lancia:
 
 ```bash
 npm run normalize
@@ -323,9 +355,75 @@ npm run check-consistency
 npm run generate-schema
 ```
 
-Aggiungi `--help` a uno qualsiasi degli script per visualizzare le opzioni disponibili.
+`npm run normalize` pulisce nomi e abbreviazioni dei connettori. `npm run unify-ports` uniforma le etichette. `npm run check-consistency` verifica i campi obbligatori e `npm run generate-schema` rigenera `schema.json`. Per iterare rapidamente sui dati:
 
-Esegui `npm run help` per un riepilogo rapido dei comandi di manutenzione e dell’ordine consigliato.
+```bash
+npm run test:data
+```
 
-## 🤝 Contribuire
-Contributi di ogni tipo sono benvenuti! Apri una issue o invia una pull request. Per correzioni sui dati, allega backup di progetto o misure di autonomia per mantenere un catalogo accurato per tutti.
+Aggiungi `--help` a ogni comando per avere istruzioni e controlla i diff generati prima di aprire una pull request. `npm run help` riepiloga tutti gli script disponibili.
+
+## Sviluppo
+
+Installa Node.js 18 o superiore. Dopo il clone:
+
+```bash
+npm install
+npm run lint
+npm test
+```
+
+`npm test` esegue ESLint, controlli sui dati e Jest in sequenza (`--runInBand`, `maxWorkers=1`). Durante lo sviluppo usa suite dedicate:
+
+```bash
+npm run test:unit
+npm run test:data
+npm run test:dom
+npm run test:script
+```
+
+### Bundle legacy
+
+Dopo modifiche in `src/scripts/` o `src/data/`, esegui `npm run build:legacy` per rigenerare il bundle ES5 destinato ai browser datati e mantenere aggiornati i polyfill locali.
+
+### Struttura dei file
+
+```
+index.html
+src/styles/style.css
+src/styles/overview.css
+src/styles/overview-print.css
+src/scripts/script.js
+src/scripts/storage.js
+src/scripts/static-theme.js
+src/data/index.js
+src/data/devices/
+src/data/schema.json
+src/vendor/
+legal/
+tools/
+tests/
+```
+
+## Risoluzione dei problemi
+
+- **Service worker bloccato su una versione vecchia?** Premi **Forza ricarica** o esegui un hard reload dagli strumenti per sviluppatori.
+- **Dati mancanti dopo la chiusura della scheda?** Assicurati che il sito abbia accesso allo storage; la navigazione privata può bloccarlo.
+- **Download bloccati?** Consenti download multipli per backup e bundle.
+- **Script da CLI in errore?** Verifica di usare Node.js 18+, esegui `npm install` e riprova. Con errori di memoria, avvia una suite più piccola come `npm run test:unit`.
+
+## Feedback e supporto
+
+Apri un’issue se incontri problemi, hai domande o vuoi proporre nuove funzionalità. Allegare export o campioni di autonomia aiuta a mantenere il catalogo accurato.
+
+## Contribuire
+
+Le contribuzioni sono benvenute! Dopo aver letto `CONTRIBUTING.md`, apri un’issue o invia una pull request. Esegui `npm test` prima dell’invio.
+
+## Ringraziamenti
+
+Il planner include Uicons locali, asset OpenMoji e altre grafiche pacchettizzate per avere icone offline, e usa lz-string per memorizzare i progetti in modo compatto in URL e backup.
+
+## Licenza
+
+Distribuito con licenza ISC. Dettagli in `package.json`.


### PR DESCRIPTION
## Summary
- replaced the English README translation with the full offline-first documentation that matches the canonical README
- refreshed German, Spanish, French, and Italian READMEs with up-to-date guidance on offline workflows, safety nets, and operational checklists

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d4ecf4c67483209d0aaba20569dd6f