### PR TITLE
Add mobile sidebar layout for settings tabs

### DIFF
--- a/index.html
+++ b/index.html
@@ -815,127 +815,131 @@
   <dialog id="settingsDialog" class="app-modal" role="dialog" aria-modal="true" aria-labelledby="settingsTitle" hidden>
     <div class="modal-surface modal-surface-scrollable settings-content">
       <h2 id="settingsTitle">Settings</h2>
-      <div
-        id="settingsTablist"
-        class="settings-tabs"
-        role="tablist"
-        aria-label="Settings sections"
-        aria-orientation="horizontal"
-      >
-        <button
-          type="button"
-          class="settings-tab"
-          id="settingsTab-general"
-          role="tab"
-          aria-controls="settingsPanel-general"
-          aria-selected="true"
-        >
-          <span
-            class="settings-tab-icon icon-glyph"
-            aria-hidden="true"
-            data-icon-font="uicons"
+      <div class="settings-layout">
+        <div class="settings-sidebar">
+          <div
+            id="settingsTablist"
+            class="settings-tabs"
+            role="tablist"
+            aria-label="Settings sections"
+            aria-orientation="horizontal"
           >
-            &#xE5A3;
-          </span>
-          <span class="settings-tab-label">General</span>
-        </button>
-        <button
-          type="button"
-          class="settings-tab"
-          id="settingsTab-autoGear"
-          role="tab"
-          aria-controls="settingsPanel-autoGear"
-          aria-selected="false"
-          tabindex="-1"
-        >
-          <span
-            class="settings-tab-icon icon-glyph"
-            aria-hidden="true"
-            data-icon-font="uicons"
+            <button
+              type="button"
+              class="settings-tab"
+              id="settingsTab-general"
+              role="tab"
+              aria-controls="settingsPanel-general"
+              aria-selected="true"
+            >
+              <span
+                class="settings-tab-icon icon-glyph"
+                aria-hidden="true"
+                data-icon-font="uicons"
+              >
+                &#xE5A3;
+              </span>
+              <span class="settings-tab-label">General</span>
+            </button>
+            <button
+              type="button"
+              class="settings-tab"
+              id="settingsTab-autoGear"
+              role="tab"
+              aria-controls="settingsPanel-autoGear"
+              aria-selected="false"
+              tabindex="-1"
+            >
+              <span
+                class="settings-tab-icon icon-glyph"
+                aria-hidden="true"
+                data-icon-font="uicons"
+              >
+                &#xE8AF;
+              </span>
+              <span class="settings-tab-label">Automatic Gear</span>
+            </button>
+            <button
+              type="button"
+              class="settings-tab"
+              id="settingsTab-accessibility"
+              role="tab"
+              aria-controls="settingsPanel-accessibility"
+              aria-selected="false"
+              tabindex="-1"
+            >
+              <span
+                class="settings-tab-icon icon-glyph"
+                aria-hidden="true"
+                data-icon-font="uicons"
+              >
+                &#xF392;
+              </span>
+              <span class="settings-tab-label">Accessibility</span>
+            </button>
+            <button
+              type="button"
+              class="settings-tab"
+              id="settingsTab-backup"
+              role="tab"
+              aria-controls="settingsPanel-backup"
+              aria-selected="false"
+              tabindex="-1"
+            >
+              <span
+                class="settings-tab-icon icon-glyph"
+                aria-hidden="true"
+                data-icon-font="uicons"
+              >
+                &#xE5BD;
+              </span>
+              <span class="settings-tab-label">Backup &amp; Restore</span>
+            </button>
+            <button
+              type="button"
+              class="settings-tab"
+              id="settingsTab-data"
+              role="tab"
+              aria-controls="settingsPanel-data"
+              aria-selected="false"
+              tabindex="-1"
+            >
+              <span
+                class="settings-tab-icon icon-glyph"
+                aria-hidden="true"
+                data-icon-font="uicons"
+              >
+                &#xE5C7;
+              </span>
+              <span class="settings-tab-label">Data &amp; Storage</span>
+            </button>
+            <button
+              type="button"
+              class="settings-tab"
+              id="settingsTab-about"
+              role="tab"
+              aria-controls="settingsPanel-about"
+              aria-selected="false"
+              tabindex="-1"
+            >
+              <span
+                class="settings-tab-icon icon-glyph"
+                aria-hidden="true"
+                data-icon-font="uicons"
+              >
+                &#xEA4F;
+              </span>
+              <span class="settings-tab-label">About &amp; Support</span>
+            </button>
+          </div>
+        </div>
+        <div class="settings-panels">
+          <section
+            id="settingsPanel-general"
+            class="settings-panel"
+            role="tabpanel"
+            aria-labelledby="settingsTab-general generalSettingsHeading"
           >
-            &#xE8AF;
-          </span>
-          <span class="settings-tab-label">Automatic Gear</span>
-        </button>
-        <button
-          type="button"
-          class="settings-tab"
-          id="settingsTab-accessibility"
-          role="tab"
-          aria-controls="settingsPanel-accessibility"
-          aria-selected="false"
-          tabindex="-1"
-        >
-          <span
-            class="settings-tab-icon icon-glyph"
-            aria-hidden="true"
-            data-icon-font="uicons"
-          >
-            &#xF392;
-          </span>
-          <span class="settings-tab-label">Accessibility</span>
-        </button>
-        <button
-          type="button"
-          class="settings-tab"
-          id="settingsTab-backup"
-          role="tab"
-          aria-controls="settingsPanel-backup"
-          aria-selected="false"
-          tabindex="-1"
-        >
-          <span
-            class="settings-tab-icon icon-glyph"
-            aria-hidden="true"
-            data-icon-font="uicons"
-          >
-            &#xE5BD;
-          </span>
-          <span class="settings-tab-label">Backup &amp; Restore</span>
-        </button>
-        <button
-          type="button"
-          class="settings-tab"
-          id="settingsTab-data"
-          role="tab"
-          aria-controls="settingsPanel-data"
-          aria-selected="false"
-          tabindex="-1"
-        >
-          <span
-            class="settings-tab-icon icon-glyph"
-            aria-hidden="true"
-            data-icon-font="uicons"
-          >
-            &#xE5C7;
-          </span>
-          <span class="settings-tab-label">Data &amp; Storage</span>
-        </button>
-        <button
-          type="button"
-          class="settings-tab"
-          id="settingsTab-about"
-          role="tab"
-          aria-controls="settingsPanel-about"
-          aria-selected="false"
-          tabindex="-1"
-        >
-          <span
-            class="settings-tab-icon icon-glyph"
-            aria-hidden="true"
-            data-icon-font="uicons"
-          >
-            &#xEA4F;
-          </span>
-          <span class="settings-tab-label">About &amp; Support</span>
-        </button>
-      </div>
-      <section
-        id="settingsPanel-general"
-        class="settings-panel"
-        role="tabpanel"
-        aria-labelledby="settingsTab-general generalSettingsHeading"
-      >
         <h3 id="generalSettingsHeading">General</h3>
         <div class="form-row">
           <label for="settingsLanguage" id="settingsLanguageLabel">Language</label>
@@ -1011,13 +1015,14 @@
           </div>
         </div>
       </section>
-      <section
-        id="settingsPanel-autoGear"
-        class="settings-panel"
-        role="tabpanel"
-        aria-labelledby="settingsTab-autoGear autoGearHeading"
-        hidden
-      >
+          </section>
+          <section
+            id="settingsPanel-autoGear"
+            class="settings-panel"
+            role="tabpanel"
+            aria-labelledby="settingsTab-autoGear autoGearHeading"
+            hidden
+          >
         <h3 id="autoGearHeading">Automatic Gear Rules</h3>
         <p id="autoGearDescription" class="settings-hint"></p>
         <section
@@ -1933,13 +1938,14 @@
           </section>
         </section>
       </section>
-      <section
-        id="settingsPanel-data"
-        class="settings-panel"
-        role="tabpanel"
-        aria-labelledby="settingsTab-data dataHeading"
-        hidden
-      >
+          </section>
+          <section
+            id="settingsPanel-data"
+            class="settings-panel"
+            role="tabpanel"
+            aria-labelledby="settingsTab-data dataHeading"
+            hidden
+          >
         <h3 id="dataHeading">Data &amp; Storage</h3>
         <p id="storageSummaryIntro" class="storage-summary-note">
           Everything below stays on this device.
@@ -1950,20 +1956,22 @@
           Backups export each entry as human-readable JSON.
         </p>
       </section>
-      <section
-        id="settingsPanel-about"
-        class="settings-panel"
-        role="tabpanel"
-        aria-labelledby="settingsTab-about aboutHeading"
-        hidden
-      >
+          <section
+            id="settingsPanel-about"
+            class="settings-panel"
+            role="tabpanel"
+            aria-labelledby="settingsTab-about aboutHeading"
+            hidden
+          >
         <h3 id="aboutHeading">About &amp; Support</h3>
         <p id="aboutVersion">Version 1.0.9</p>
         <p><a href="https://github.com" id="supportLink" target="_blank">Support</a></p>
       </section>
-      <div class="button-row action-buttons">
-        <button id="settingsSave"><span class="btn-icon icon-glyph" aria-hidden="true" data-icon-font="essential">&#xF207;</span>Save</button>
-        <button id="settingsCancel"><span class="btn-icon icon-glyph" aria-hidden="true" data-icon-font="essential">&#xF131;</span>Cancel</button>
+          <div class="button-row action-buttons">
+            <button id="settingsSave"><span class="btn-icon icon-glyph" aria-hidden="true" data-icon-font="essential">&#xF207;</span>Save</button>
+            <button id="settingsCancel"><span class="btn-icon icon-glyph" aria-hidden="true" data-icon-font="essential">&#xF131;</span>Cancel</button>
+          </div>
+        </div>
       </div>
     </div>
   </dialog>

--- a/src/scripts/app-core.js
+++ b/src/scripts/app-core.js
@@ -10730,6 +10730,36 @@ const settingsTabsScrollPrev = document.getElementById('settingsTabsScrollPrev')
 const settingsTabsScrollNext = document.getElementById('settingsTabsScrollNext');
 let settingsTabsOverflowFrame = 0;
 
+const SETTINGS_TABS_SIDEBAR_QUERY = '(max-width: 720px)';
+const settingsTabsOrientationQuery =
+  typeof window !== 'undefined' && typeof window.matchMedia === 'function'
+    ? window.matchMedia(SETTINGS_TABS_SIDEBAR_QUERY)
+    : null;
+
+function applySettingsTabsOrientation(matches) {
+  if (!settingsTablist) return;
+  settingsTablist.setAttribute('aria-orientation', matches ? 'vertical' : 'horizontal');
+  scheduleSettingsTabsOverflowUpdate();
+}
+
+if (settingsTabsOrientationQuery) {
+  try {
+    applySettingsTabsOrientation(settingsTabsOrientationQuery.matches);
+    const handleSettingsTabsOrientationChange = event => {
+      applySettingsTabsOrientation(event.matches);
+    };
+    if (typeof settingsTabsOrientationQuery.addEventListener === 'function') {
+      settingsTabsOrientationQuery.addEventListener('change', handleSettingsTabsOrientationChange);
+    } else if (typeof settingsTabsOrientationQuery.addListener === 'function') {
+      settingsTabsOrientationQuery.addListener(handleSettingsTabsOrientationChange);
+    }
+  } catch {
+    applySettingsTabsOrientation(false);
+  }
+} else if (settingsTablist) {
+  settingsTablist.setAttribute('aria-orientation', 'horizontal');
+}
+
 function updateSettingsTabsOverflowIndicators() {
   if (!settingsTablist || !settingsTabsContainer) {
     if (settingsTabsScrollPrev) {

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -1977,6 +1977,26 @@ body.high-contrast .diff-value-changed {
   gap: 20px;
 }
 
+.settings-layout {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.settings-sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  min-width: 0;
+}
+
+.settings-panels {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  min-width: 0;
+}
+
 .settings-tabs {
   display: flex;
   flex-wrap: nowrap;
@@ -2085,6 +2105,45 @@ body.high-contrast .settings-tab[aria-selected="true"] {
 @media (max-width: 600px) {
   .settings-tab {
     flex-basis: 100%;
+  }
+}
+
+@media (max-width: 720px) {
+  .settings-content {
+    width: min(100vw, 960px);
+    padding: clamp(16px, 4vw, 20px);
+  }
+
+  .settings-layout {
+    flex-direction: row;
+    align-items: stretch;
+    gap: 16px;
+  }
+
+  .settings-sidebar {
+    flex: 0 0 clamp(140px, 38vw, 220px);
+    max-width: clamp(140px, 38vw, 240px);
+  }
+
+  .settings-tabs {
+    flex-direction: column;
+    align-items: stretch;
+    overflow-x: hidden;
+    overflow-y: auto;
+    max-height: min(60vh, 420px);
+    padding-right: 4px;
+  }
+
+  .settings-tab {
+    flex: 0 0 auto;
+    flex-basis: auto;
+    width: 100%;
+    min-width: 0;
+  }
+
+  .settings-panels {
+    flex: 1 1 auto;
+    min-width: 0;
   }
 }
 


### PR DESCRIPTION
## Summary
- wrap the settings dialog content in a sidebar layout so the tablist can live in its own column
- add responsive styles that pivot the tabs into a vertical sidebar on small screens
- update the settings tab logic to flip `aria-orientation` with matchMedia for the new layout

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d4ed76326883208a65b6e4e01e6ed9