### PR TITLE
Fix auto gear retention constant conflicts and rule diff ordering

### DIFF
--- a/src/scripts/app-session.js
+++ b/src/scripts/app-session.js
@@ -857,7 +857,20 @@ function buildRestoreRehearsalRuleDiff(liveRules, sandboxRules) {
     ? (a, b) => localeSort(a, b)
     : (a, b) => a.localeCompare(b);
 
-  return differences.sort((a, b) => compareStrings(a.label || '', b.label || ''));
+  const statusPriority = {
+    changed: 0,
+    removed: 1,
+    added: 2,
+  };
+
+  return differences.sort((a, b) => {
+    const priorityA = statusPriority[a.status] ?? Number.MAX_SAFE_INTEGER;
+    const priorityB = statusPriority[b.status] ?? Number.MAX_SAFE_INTEGER;
+    if (priorityA !== priorityB) {
+      return priorityA - priorityB;
+    }
+    return compareStrings(a.label || '', b.label || '');
+  });
 }
 
 function formatRestoreRehearsalRuleScenarioLines(rule, langTexts) {

--- a/src/scripts/storage.js
+++ b/src/scripts/storage.js
@@ -117,6 +117,16 @@ const MAX_FULL_BACKUP_HISTORY_ENTRIES = 200;
 const AUTO_GEAR_BACKUP_RETENTION_DEFAULT = 12;
 const AUTO_GEAR_BACKUP_RETENTION_MIN = 1;
 
+if (GLOBAL_SCOPE && typeof GLOBAL_SCOPE.AUTO_GEAR_BACKUP_RETENTION_MIN !== 'number') {
+  try {
+    GLOBAL_SCOPE.AUTO_GEAR_BACKUP_RETENTION_MIN = AUTO_GEAR_BACKUP_RETENTION_MIN;
+  } catch (error) {
+    if (typeof console !== 'undefined' && typeof console.warn === 'function') {
+      console.warn('Unable to expose auto gear backup retention minimum globally.', error);
+    }
+  }
+}
+
 const STORAGE_BACKUP_SUFFIX = '__backup';
 const MAX_SAVE_ATTEMPTS = 3;
 const MAX_QUOTA_RECOVERY_STEPS = 100;


### PR DESCRIPTION
## Summary
- expose the auto gear backup retention minimum from storage so it is only defined once across scripts
- resolve the retention minimum from shared scopes in app-core and reuse it when clamping values and configuring the UI input
- prioritize changed and removed entries ahead of additions in restore rehearsal rule diffs for predictable ordering

## Testing
- npm run test:script

------
https://chatgpt.com/codex/tasks/task_e_68d4f0c4b0708320b6a24440952e7f00