### PR TITLE
Document manual download fallback in help

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -166,6 +166,7 @@ Dieser kurze Ablauf sollte bei neuen Teammitgliedern, frisch eingerichteten Work
 - **Restores sind doppelt gepuffert.** Vor jedem Import wird ein Backup des aktuellen Zustands erzwungen. Danach wird das Bundle validiert und oben in der Liste platziert.
 - **Cross-Device bleibt offline.** Kopiere `index.html`, `script.js`, `devices/` sowie Backups/Bundles auf Wechseldatenträger, öffne von dort und arbeite ohne Netzwerk.
 - **Exporte prüfen.** JSON vor dem Teilen sichten, um unerwünschte Inhalte auszuschließen. Struktur ist lesbar und kann bei Bedarf redigiert werden.
+- **Manueller Download sichert Exporte ab.** Wenn Browser oder Content-Blocker den Download verhindern, öffnet der Planner einen "Manual download"-Tab mit dem JSON-Inhalt. Drücke `Strg+A`/`Strg+C` (`⌘A`/`⌘C` auf macOS), füge den Text in eine `.json`-Datei ein und archiviere sie mit deinen Backups, bevor du den Tab schließt.
 - **Mit Checklisten synchronisieren.** Bei neuen Bundles `Updated at`-Zeitstempel prüfen und alte JSONs archivieren.
 - **Kontext bewahren.** Bundles merken Sprache, Theme, Logos und Personalisierungen, damit Empfänger vertraut starten – auch offline.
 

--- a/README.en.md
+++ b/README.en.md
@@ -336,6 +336,10 @@ Use Cine Power Planner end-to-end with the following routine:
   make sure no extra projects or notes are included. The structure is human
   readable so you can redact or duplicate entries as needed, and the file stays
   portable even when renamed to `.cpproject` for filing.
+- **Manual download fallback safeguards exports.** If a browser or content
+  blocker stops an export, the planner opens a Manual download tab with the JSON
+  contents. Press `Ctrl+A`/`Ctrl+C` (`⌘A`/`⌘C` on macOS) to copy everything into
+  a `.json` file and store it with your backups before closing the tab.
 - **Synchronize with checklists.** When a teammate sends you an updated bundle,
   import it, review the `Updated at` timestamps in the sidebar and archive the
   previous JSON (or `.cpproject`) bundle in your storage system to maintain a

--- a/README.es.md
+++ b/README.es.md
@@ -166,6 +166,7 @@ Repite esta rutina cuando se incorpore personal, se prepare una estación nueva 
 - **Restauraciones con doble buffer.** Antes de importar, se solicita guardar una copia del estado actual. Tras validar el paquete, el proyecto restaurado aparece arriba en el selector.
 - **Flujos entre dispositivos sin red.** Copia `index.html`, `script.js`, `devices/` y tus archivos de respaldo a un medio externo. Lanza la app desde disco, importa el paquete y continúa trabajando sin conectarte.
 - **Exporta con responsabilidad.** Revisa el JSON antes de compartirlo para asegurarte de que sólo incluye lo necesario. El formato es legible para editar o depurar entradas.
+- **La descarga manual protege los archivos.** Si el navegador o un bloqueador impide la descarga, el planner abre una pestaña «Manual download» con el contenido JSON. Pulsa `Ctrl+A`/`Ctrl+C` (`⌘A`/`⌘C` en macOS), pega el texto en un archivo `.json` y guárdalo junto a tus copias de seguridad antes de cerrar la pestaña.
 - **Sincroniza con checklists.** Cuando recibas un paquete actualizado, impórtalo, revisa los sellos `Actualizado` en la barra lateral y archiva el JSON anterior para mantener el historial.
 - **Comparte sin perder contexto.** Los paquetes recuerdan idioma, tema, logotipo y preferencias para que quien lo abra vea el proyecto como tú, incluso offline.
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -166,6 +166,7 @@ Cette routine prouve que sauvegarde, partage, import, backup et restauration fon
 - **Restaurations double tampon.** Avant tout import, une sauvegarde du contexte courant est demandée. Une fois le bundle validé, le projet restauré apparaît en tête du sélecteur.
 - **Workflows inter-appareils hors ligne.** Copiez `index.html`, `script.js`, `devices/` et vos fichiers de backup/bundle sur un support amovible, lancez depuis le disque et continuez sans connexion.
 - **Exporter en conscience.** Relisez le JSON avant partage pour vérifier le contenu. Le format étant lisible, vous pouvez supprimer ou dupliquer les entrées nécessaires.
+- **Le téléchargement manuel sécurise les exports.** Si le navigateur ou un bloqueur empêche la sauvegarde, le planner ouvre un onglet « Manual download » avec le contenu JSON. Appuyez sur `Ctrl+A`/`Ctrl+C` (`⌘A`/`⌘C` sur macOS), collez le texte dans un fichier `.json` et rangez-le avec vos sauvegardes avant de fermer l’onglet.
 - **Synchroniser avec les check-lists.** Lorsqu’un collaborateur vous envoie un bundle mis à jour, importez-le, vérifiez les horodatages `Mis à jour` et archivez le JSON précédent pour garder l’historique.
 - **Partager sans perdre le contexte.** Les bundles mémorisent langue, thème, logo et préférences pour que le destinataire retrouve un environnement familier même hors ligne.
 

--- a/README.it.md
+++ b/README.it.md
@@ -166,6 +166,7 @@ Ripeti questa routine quando arriva un nuovo membro, allestisci una postazione o
 - **Ripristini a doppio buffer.** Prima dell’import viene richiesto un backup del contesto corrente. Dopo la validazione il progetto ripristinato appare in cima al selettore.
 - **Flussi cross-device senza rete.** Copia `index.html`, `script.js`, `devices/` e i tuoi file di backup/bundle su un supporto removibile, avvia dal disco e continua senza internet.
 - **Esporta con attenzione.** Controlla il JSON prima di condividerlo per verificare che contenga solo ciò che serve. Il formato è leggibile per eventuali modifiche.
+- **Il download manuale tutela gli export.** Se il browser o un blocco impedisce lo scaricamento, il planner apre una scheda «Manual download» con il JSON. Premi `Ctrl+A`/`Ctrl+C` (`⌘A`/`⌘C` su macOS), incolla il testo in un file `.json` e archivialo con i backup prima di chiudere la scheda.
 - **Sincronizza con le checklist.** Quando ricevi un bundle aggiornato, importalo, verifica i timestamp `Aggiornato` e archivia il JSON precedente per mantenere la storia.
 - **Condividi senza perdere contesto.** I bundle ricordano lingua, tema, logo e preferenze, offrendo al destinatario un ambiente familiare anche offline.
 

--- a/index.html
+++ b/index.html
@@ -2874,6 +2874,12 @@
               add extra insurance without disrupting your workflow.
             </li>
             <li>
+              If your browser blocks automatic downloads, the planner opens a Manual download tab with the JSON payload so you
+              can still capture it. Press <kbd>Ctrl</kbd>+<kbd>A</kbd> then <kbd>Ctrl</kbd>+<kbd>C</kbd> (<kbd>⌘</kbd>+<kbd>A</kbd>,
+              <kbd>⌘</kbd>+<kbd>C</kbd> on macOS) and paste the contents into a <code>.json</code> file stored with your backups
+              before closing the tab.
+            </li>
+            <li>
               After each major milestone, run through the
               <a
                 class="help-link"


### PR DESCRIPTION
## Summary
- Clarify that the manual download fallback tab provides a safe way to copy backup JSON when browsers block automatic downloads
- Update the English, German, Spanish, French and Italian READMEs to document the manual download workflow for consistent guidance across languages

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d4f11f12708320b9181b798dc15000