### PR TITLE
Shift install guide modal below install banner

### DIFF
--- a/src/scripts/app-core.js
+++ b/src/scripts/app-core.js
@@ -16136,7 +16136,12 @@ function shouldShowInstallBanner() {
 
 function updateInstallBannerVisibility() {
   if (!installPromptBanner) return;
-  if (shouldShowInstallBanner()) {
+  const shouldShow = shouldShowInstallBanner();
+  const root = typeof document !== 'undefined' ? document.documentElement : null;
+  if (root && typeof root.classList !== 'undefined') {
+    root.classList.toggle('install-banner-visible', shouldShow);
+  }
+  if (shouldShow) {
     installPromptBanner.removeAttribute('hidden');
     updateInstallBannerColors();
     updateInstallBannerPosition();

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -1739,6 +1739,10 @@ body.high-contrast .diff-value-changed {
   overscroll-behavior: contain;
 }
 
+html.install-banner-visible .app-modal[open] {
+  padding-top: calc(20px + var(--install-banner-offset, 0px));
+}
+
 .modal-surface {
   background: var(--surface-color);
   color: var(--text-color);


### PR DESCRIPTION
## Summary
- toggle a root class while the install banner is visible to coordinate layout adjustments
- add CSS padding so open modals sit below the banner height when it is shown

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d4f143c9988320b629de53cd667324