### PR TITLE
Improve automatic gear backup guidance in help

### DIFF
--- a/docs/offline-readiness.md
+++ b/docs/offline-readiness.md
@@ -46,7 +46,9 @@ connectivity:
    help dialog, legal pages and the device catalog.
 2. **Review current data.** Load active projects plus their latest `auto-backup-…`
    entries. Confirm gear lists, runtime dashboards, favorites and automatic gear rules all
-   match the production log.
+   match the production log. In **Settings → Automatic Gear Rules** reveal the automatic
+   backup timeline, review the retention summary and adjust the limit if you need a longer
+   runway of snapshots before travelling.
 3. **Generate redundancy.** Export a fresh planner backup and project bundle, then import
    both files into an isolated browser profile. Document the validation date, machine name
    and any notes about data changes since the last rehearsal. Include a standalone

--- a/docs/translation-guide.md
+++ b/docs/translation-guide.md
@@ -46,6 +46,13 @@ You can run targeted suites while iterating if you only touched translation file
 npm run test:unit
 ```
 
+## Recent interface updates
+
+- Automatic Gear Rules now include an automatic backup timeline and a **Backup retention**
+  control with live warnings inside the help dialog. Translate the related labels in
+  `index.html` and the retention status strings in `translations.js` so crews understand how
+  many snapshots stay on each device.
+
 ## Step 5: Open a pull request
 
 Commit your changes, describe the new language in the pull request summary and mention any remaining untranslated phrases so maintainers can help. Linking to this guide from your PR helps other contributors follow the same process.

--- a/index.html
+++ b/index.html
@@ -3685,7 +3685,19 @@
                 Background automatic backups capture rule changes every 10 minutes. Toggle
                 <a class="help-link button-link" href="#autoGearShowBackups" data-help-target="#autoGearShowBackups"><strong>Show automatic
                     backups</strong></a>
-                to reveal the timeline inside Automatic Gear Rules.
+                to reveal the timeline inside Automatic Gear Rules; when you hide it again the status notice under the toggle confirms
+                snapshots are still running in the background and how many entries remain so you can bring them back before restoring.
+              </li>
+              <li>
+                Tune the
+                <a
+                  class="help-link button-link"
+                  href="#autoGearBackupRetention"
+                  data-help-target="#autoGearBackupRetention"
+                  data-help-highlight="#autoGearBackupsSection"
+                ><strong>Backup retention</strong></a>
+                field to decide how many automatic snapshots stay available on this device. The live summary warns before trimming older
+                versions so you can export rule sets you still need.
               </li>
               <li>
                 When backups are visible, pick a timestamped snapshot from the


### PR DESCRIPTION
## Summary
- expand the Automatic Gear Rules help article with guidance on hiding the timeline and tuning the Backup retention control
- extend the offline readiness runbook so crews review the automatic gear backup timeline and retention limit before travelling
- add a translation guide note reminding contributors to localize the new backup retention help content

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d4fae5d9c8832084df3b0e17fef549