### PR TITLE
Improve global search coverage for critical actions

### DIFF
--- a/index.html
+++ b/index.html
@@ -208,19 +208,32 @@
           <option value="">-- New Project --</option>
         </select>
       </div>
-      <button id="deleteSetupBtn" title="Delete selected project">
+      <button
+        id="deleteSetupBtn"
+        title="Delete selected project"
+        data-feature-search="true"
+        data-feature-search-keywords="delete remove project clear"
+      >
         <span class="btn-icon icon-glyph" aria-hidden="true" data-icon-font="essential">&#xF254;</span>Delete
       </button>
     </div>
     <div class="form-row">
       <label for="setupName" id="setupNameLabel">Project Name:</label>
       <input type="text" id="setupName" placeholder="Project name" aria-labelledby="setupNameLabel" />
-      <button id="saveSetupBtn"><span class="btn-icon icon-glyph" aria-hidden="true" data-icon-font="essential">&#xF207;</span>Save</button>
+      <button
+        id="saveSetupBtn"
+        data-feature-search="true"
+        data-feature-search-keywords="save project store backup autosave offline"
+      ><span class="btn-icon icon-glyph" aria-hidden="true" data-icon-font="essential">&#xF207;</span>Save</button>
     </div>
     <div class="form-row form-row-actions" role="group" aria-label="Project actions">
       <span class="form-label-spacer" aria-hidden="true"></span>
       <div class="form-actions">
-        <button id="shareSetupBtn">
+        <button
+          id="shareSetupBtn"
+          data-feature-search="true"
+          data-feature-search-keywords="export share download backup archive"
+        >
           <span class="btn-icon icon-glyph" aria-hidden="true" data-icon-font="uicons">&#xE7AB;</span>
           Export Project
         </button>
@@ -234,7 +247,11 @@
             tabindex="-1"
             class="visually-hidden"
           />
-          <button id="applySharedLinkBtn">
+          <button
+            id="applySharedLinkBtn"
+            data-feature-search="true"
+            data-feature-search-keywords="import project load restore file"
+          >
             <span class="btn-icon icon-glyph" aria-hidden="true" data-icon-font="uicons">&#xE7C7;</span>
             Import Project
           </button>
@@ -245,11 +262,20 @@
     <div class="form-row form-row-actions" role="group" aria-label="Project exports">
       <span class="form-label-spacer" aria-hidden="true"></span>
       <div class="form-actions">
-        <button id="generateOverviewBtn">
+        <button
+          id="generateOverviewBtn"
+          data-feature-search="true"
+          data-feature-search-keywords="overview summary pdf print report"
+        >
           <span class="btn-icon icon-glyph" aria-hidden="true" data-icon-font="uicons">&#xF1F5;</span>
           Generate Overview
         </button>
-        <button id="generateGearListBtn" type="button">
+        <button
+          id="generateGearListBtn"
+          type="button"
+          data-feature-search="true"
+          data-feature-search-keywords="gear list requirements export print"
+        >
           <span class="btn-icon icon-glyph" aria-hidden="true" data-icon-font="uicons">&#xE467;</span>
           Generate Gear List and Project Requirements
         </button>
@@ -1801,6 +1827,8 @@
               class="inline-form-button"
               aria-expanded="false"
               aria-controls="backupDiffSection"
+              data-feature-search="true"
+              data-feature-search-keywords="compare backups versions diff changes log"
             >
               Compare versions
             </button>
@@ -1840,7 +1868,14 @@
             ></textarea>
           </div>
           <div class="button-row diff-actions">
-            <button type="button" id="backupDiffExport">Export log</button>
+            <button
+              type="button"
+              id="backupDiffExport"
+              data-feature-search="true"
+              data-feature-search-keywords="export log backup diff report"
+            >
+              Export log
+            </button>
             <button type="button" id="backupDiffClose">Close</button>
           </div>
         </section>
@@ -1855,11 +1890,35 @@
             Create complete archives, rehearse restores in a sandbox, or reset the planner safely.
           </p>
           <div class="button-row full-backup-actions">
-            <button id="backupSettings">Backup</button>
+            <button
+              id="backupSettings"
+              data-feature-search="true"
+              data-feature-search-keywords="backup download archive safety full"
+            >
+              Backup
+            </button>
             <input type="file" id="restoreSettingsInput" accept="application/json" hidden />
-            <button id="restoreSettings">Restore</button>
-            <button id="restoreRehearsalButton">Restore rehearsal</button>
-            <button id="factoryResetButton">Factory reset</button>
+            <button
+              id="restoreSettings"
+              data-feature-search="true"
+              data-feature-search-keywords="restore recover backup import full"
+            >
+              Restore
+            </button>
+            <button
+              id="restoreRehearsalButton"
+              data-feature-search="true"
+              data-feature-search-keywords="restore rehearsal sandbox verify test backup"
+            >
+              Restore rehearsal
+            </button>
+            <button
+              id="factoryResetButton"
+              data-feature-search="true"
+              data-feature-search-keywords="factory reset clear wipe safety backup"
+            >
+              Factory reset
+            </button>
           </div>
           <section
             id="restoreRehearsalSection"
@@ -1899,7 +1958,14 @@
             <div class="form-row restore-rehearsal-file">
               <label for="restoreRehearsalInput" id="restoreRehearsalFileLabel">Select file</label>
               <input type="file" id="restoreRehearsalInput" accept="application/json" hidden />
-              <button type="button" id="restoreRehearsalBrowse">Choose file</button>
+              <button
+                type="button"
+                id="restoreRehearsalBrowse"
+                data-feature-search="true"
+                data-feature-search-keywords="choose file select backup import"
+              >
+                Choose file
+              </button>
               <p id="restoreRehearsalFileName" class="settings-hint" aria-live="polite">
                 No file selected yet.
               </p>
@@ -1932,8 +1998,22 @@
               <ul id="restoreRehearsalRuleList" class="diff-list"></ul>
             </section>
             <div id="restoreRehearsalActions" class="button-row restore-rehearsal-actions" hidden>
-              <button type="button" id="restoreRehearsalProceed">Continue rehearsal restore</button>
-              <button type="button" id="restoreRehearsalAbort">Abort rehearsal</button>
+              <button
+                type="button"
+                id="restoreRehearsalProceed"
+                data-feature-search="true"
+                data-feature-search-keywords="apply rehearsal restore commit backup"
+              >
+                Continue rehearsal restore
+              </button>
+              <button
+                type="button"
+                id="restoreRehearsalAbort"
+                data-feature-search="true"
+                data-feature-search-keywords="abort rehearsal restore cancel backup"
+              >
+                Abort rehearsal
+              </button>
             </div>
           </section>
         </section>

--- a/src/scripts/app-core.js
+++ b/src/scripts/app-core.js
@@ -17444,6 +17444,28 @@ const featureList     = document.getElementById("featureList");
 const featureMap      = new Map();
 const normalizeSearchValue = value =>
   typeof value === 'string' ? value.trim().toLowerCase() : '';
+const FEATURE_SEARCH_EXTRA_SELECTOR = '[data-feature-search]';
+
+const getFeatureSearchLabel = element => {
+  if (!element) return '';
+  const { dataset } = element;
+  const dataLabel = dataset?.featureSearchLabel || element.getAttribute('data-feature-search-label');
+  if (dataLabel && dataLabel.trim()) return dataLabel.trim();
+  const ariaLabel = element.getAttribute('aria-label');
+  if (ariaLabel && ariaLabel.trim()) return ariaLabel.trim();
+  const title = element.getAttribute('title');
+  if (title && title.trim()) return title.trim();
+  const text = element.textContent;
+  return text && text.trim() ? text.trim() : '';
+};
+
+const getFeatureSearchKeywords = element => {
+  if (!element) return '';
+  const { dataset } = element;
+  const dataValue = dataset?.featureSearchKeywords || element.getAttribute('data-feature-search-keywords');
+  return dataValue && dataValue.trim() ? dataValue.trim() : '';
+};
+
 const updateFeatureSearchValue = (newValue, originalNormalized) => {
   if (!featureSearch || typeof newValue !== 'string') return;
   const trimmed = newValue.trim();
@@ -19305,6 +19327,24 @@ function populateFeatureSearch() {
         value: entry
       });
     });
+  document.querySelectorAll(FEATURE_SEARCH_EXTRA_SELECTOR).forEach(el => {
+    if (!el || (helpDialog && helpDialog.contains(el))) return;
+    const label = getFeatureSearchLabel(el);
+    if (!label) return;
+    const keywords = getFeatureSearchKeywords(el);
+    const entry = buildFeatureSearchEntry(el, { label, keywords });
+    if (!entry || !entry.key) return;
+    const display = entry.optionValue || entry.displayLabel || entry.baseLabel;
+    if (!display) return;
+    registerOption(display);
+    featureSearchEntries.push({
+      type: 'feature',
+      key: entry.key,
+      display,
+      tokens: Array.isArray(entry.tokens) ? entry.tokens : [],
+      value: entry
+    });
+  });
   if (helpDialog) {
     helpDialog.querySelectorAll('section[data-help-section]').forEach(section => {
       const heading = section.querySelector('h3');

--- a/src/scripts/translations.js
+++ b/src/scripts/translations.js
@@ -92,7 +92,7 @@ const texts = {
     featureSearchPlaceholder: "Search features or devices...",
     featureSearchLabel: "Search features, devices and help",
     featureSearchHelp:
-      "Type to jump to features, devices or help topics. Press Enter to navigate, / or Ctrl+K (Cmd+K on Mac) to focus the search from anywhere, and use Escape or × to clear the query.",
+      "Type to jump to features, devices, quick actions like Save or Backup, or help topics. Press Enter to navigate, / or Ctrl+K (Cmd+K on Mac) to focus the search from anywhere, and use Escape or × to clear the query.",
     featureSearchClear: "Clear search",
     featureSearchClearHelp: "Clear the search box and show all results again. Press Escape to clear quickly.",
     darkModeHelp:
@@ -1262,7 +1262,7 @@ const texts = {
     featureSearchPlaceholder: "Cerca funzionalità o dispositivi...",
     featureSearchLabel: "Cerca funzionalità, dispositivi e aiuto",
     featureSearchHelp:
-      "Digita per andare alle funzionalità, ai dispositivi o aprire gli argomenti di aiuto correlati. Premi Invio per navigare, / o Ctrl+K (Cmd+K su Mac) per mettere a fuoco la ricerca ovunque e usa Esc o × per cancellare la ricerca.",
+      "Digita per andare alle funzionalità, ai dispositivi, alle azioni rapide come Salva o Backup o aprire gli argomenti di aiuto correlati. Premi Invio per navigare, / o Ctrl+K (Cmd+K su Mac) per mettere a fuoco la ricerca ovunque e usa Esc o × per cancellare la ricerca.",
     featureSearchClear: "Cancella ricerca",
     featureSearchClearHelp: "Cancella il campo di ricerca e mostra di nuovo tutti i risultati. Premi Esc per cancellare rapidamente.",
     darkModeHelp:
@@ -2415,7 +2415,7 @@ const texts = {
     featureSearchPlaceholder: "Buscar funciones o dispositivos...",
     featureSearchLabel: "Buscar funciones, dispositivos y ayuda",
     featureSearchHelp:
-      "Escribe para ir a funciones, dispositivos o temas de ayuda relacionados. Pulsa Enter para navegar, / o Ctrl+K (Cmd+K en Mac) para enfocar la búsqueda desde cualquier lugar y usa Esc o × para borrar la búsqueda.",
+      "Escribe para ir a funciones, dispositivos, acciones rápidas como Guardar o Copia de seguridad, o temas de ayuda relacionados. Pulsa Enter para navegar, / o Ctrl+K (Cmd+K en Mac) para enfocar la búsqueda desde cualquier lugar y usa Esc o × para borrar la búsqueda.",
     featureSearchClear: "Borrar búsqueda",
     featureSearchClearHelp: "Limpia el campo de búsqueda y muestra todos los resultados de nuevo. Pulsa Esc para borrar rápidamente.",
     darkModeHelp:
@@ -3581,7 +3581,7 @@ const texts = {
     featureSearchPlaceholder: "Rechercher des fonctionnalités ou des appareils...",
     featureSearchLabel: "Rechercher des fonctionnalités, des appareils et de l’aide",
     featureSearchHelp:
-      "Tapez pour accéder aux fonctionnalités, appareils ou sujets d’aide associés. Appuyez sur Entrée pour naviguer, sur / ou Ctrl+K (Cmd+K sur Mac) pour placer le focus sur la recherche où que vous soyez, puis sur Échap ou × pour effacer la requête.",
+      "Tapez pour accéder aux fonctionnalités, appareils, actions rapides comme Enregistrer ou Sauvegarde, ou aux sujets d’aide associés. Appuyez sur Entrée pour naviguer, sur / ou Ctrl+K (Cmd+K sur Mac) pour placer le focus sur la recherche où que vous soyez, puis sur Échap ou × pour effacer la requête.",
     featureSearchClear: "Effacer la recherche",
     featureSearchClearHelp: "Efface le champ de recherche et affiche à nouveau tous les résultats. Appuyez sur Échap pour effacer rapidement.",
     darkModeHelp:
@@ -4758,7 +4758,7 @@ const texts = {
     featureSearchPlaceholder: "Funktionen oder Geräte durchsuchen...",
     featureSearchLabel: "Funktionen, Geräte und Hilfe durchsuchen",
     featureSearchHelp:
-      "Tippen, um zu Funktionen, Geräten oder Hilfethemen zu springen. Drücke Enter zum Navigieren, / oder Strg+K (Cmd+K auf dem Mac), um die Suche überall zu fokussieren, und verwende Esc oder ×, um die Eingabe zu löschen.",
+      "Tippen, um zu Funktionen, Geräten, Schnellaktionen wie Speichern oder Backup oder zu passenden Hilfethemen zu springen. Drücke Enter zum Navigieren, / oder Strg+K (Cmd+K auf dem Mac), um die Suche überall zu fokussieren, und verwende Esc oder ×, um die Eingabe zu löschen.",
     featureSearchClear: "Suche löschen",
     featureSearchClearHelp: "Suchfeld leeren und alle Ergebnisse wieder anzeigen. Drücke Esc, um schnell zu löschen.",
     darkModeHelp:


### PR DESCRIPTION
## Summary
- include controls flagged with `data-feature-search` when building the global search index so quick actions are suggested
- tag save, share, import, backup, restore and related safety controls with search metadata for reliable discovery
- update feature search help text in all supported languages to mention quick action coverage

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d4faebea308320ba92ff20860f9f64