### PR TITLE
Clarify storage architecture in documentation

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -125,7 +125,7 @@ Führe diese Checkliste beim ersten Setup oder nach Updates aus. Sie beweist, da
 
 ## Systemanforderungen & Browser-Support
 
-- **Moderne Evergreen-Browser.** Validiert mit aktuellen Chromium-, Firefox- und Safari-Versionen. Service Worker, IndexedDB und persistenter Speicher müssen aktiv sein.
+- **Moderne Evergreen-Browser.** Validiert mit aktuellen Chromium-, Firefox- und Safari-Versionen. Service Worker, Zugriff auf `localStorage` (Website-Speicher) und persistenter Speicher müssen aktiv sein.
 - **Offline-freundliche Geräte.** Laptops/Tablets sollten dauerhaften Speicher erlauben. Starte die App einmal online, damit der Service Worker alle Assets cacht, und übe den Offline-Reload vor der Reise.
 - **Ausreichender lokaler Speicher.** Große Produktionen erzeugen viele Projekte, Backups und Gerätelisten. Beobachte den Speicherplatz deines Browserprofils und exportiere regelmäßig auf redundante Medien.
 - **Keine externen Abhängigkeiten.** Alle Icons, Fonts und Hilfsskripte liegen im Repository. Kopiere Ordner wie `animated icons 3/` und lokale Uicons mit, damit Optik und Scripts identisch bleiben.
@@ -218,7 +218,7 @@ Dieser kurze Ablauf sollte bei neuen Teammitgliedern, frisch eingerichteten Work
 - Kopfzeile zeigt Offline-Indikator, Force-Reload aktualisiert Assets ohne Saves anzutasten.
 - **Werkseinstellungen** oder das Löschen der Website-Daten erfolgt erst nach einem automatischen Backup.
 - Service-Worker-Updates laden im Hintergrund und warten auf deine Bestätigung. Bei **Update bereit**: Änderungen abschließen, Backup erstellen, dann **Neu laden erzwingen**.
-- Speicherung erfolgt in IndexedDB, kleine Präferenzen spiegeln nach `localStorage`. Entwickler-Tools können Rohdaten exportieren.
+- Daten liegen in gehärtetem `localStorage`; gesperrte Profile weichen auf `sessionStorage` aus. Jeder Schreibvorgang legt zusätzlich einen `__legacyMigrationBackup`-Schnappschuss an, damit sich Quota- oder Schemafehler verlustfrei beheben lassen. Entwickler-Tools können Rohdaten exportieren, bevor Caches geleert oder Tests gefahren werden.
 
 ## Daten- & Speicherübersicht
 

--- a/README.en.md
+++ b/README.en.md
@@ -216,8 +216,8 @@ same online or offline.
 
 - **Modern evergreen browsers.** The planner is validated on the latest
   releases of Chromium, Firefox and Safari on desktop and mobile. Enable
-  service workers, IndexedDB and persistent storage to unlock the full offline
-  workflow.
+  service workers, `localStorage` (site storage) access and persistent storage
+  to unlock the full offline workflow.
 - **Offline-friendly devices.** Laptops and tablets must allow persistent
   storage so backups and auto-saves stay available. When running from removable
   media or a field workstation, launch the planner once while online so the
@@ -443,9 +443,11 @@ Use Cine Power Planner end-to-end with the following routine:
   When the **Update ready** toast appears, finish your current edits, trigger a
   manual backup, then click **Force reload** so fresh assets load alongside your
   preserved data.
-- Storage lives inside IndexedDB with small preferences mirrored to
-  `localStorage`. Use your browser’s developer tools to inspect or export raw
-  records before making experimental changes or clearing caches.
+- Storage lives inside hardened `localStorage` with a `sessionStorage` fallback
+  when browsers restrict long-term writes. Every save also creates a
+  `__legacyMigrationBackup` snapshot so you can recover even if the browser
+  reports a quota or schema error. Use your browser’s storage inspector to
+  export or audit records before clearing caches or experimenting with data.
 
 ## Data & Storage Overview
 

--- a/README.es.md
+++ b/README.es.md
@@ -125,7 +125,7 @@ Ejecuta esta lista tras instalar o actualizar el planner. Confirma que guardado,
 
 ## Requisitos del sistema y navegadores
 
-- **Navegadores modernos.** Validado en las últimas versiones de Chromium, Firefox y Safari. Activa service workers, IndexedDB y almacenamiento persistente.
+- **Navegadores modernos.** Validado en las últimas versiones de Chromium, Firefox y Safari. Activa service workers, acceso a `localStorage` (almacenamiento del sitio) y almacenamiento persistente.
 - **Dispositivos orientados a offline.** Portátiles y tabletas deben permitir almacenamiento persistente. Ejecuta la app una vez en línea para que el service worker almacene todos los recursos y practica la recarga offline antes de viajar.
 - **Espacio local suficiente.** Las producciones grandes acumulan proyectos, backups y listas. Vigila el espacio del perfil y exporta regularmente a medios redundantes.
 - **Sin dependencias externas.** Todos los iconos, fuentes y scripts se entregan con el repositorio. Copia también `animated icons 3/` y los Uicons locales al mover la carpeta.
@@ -218,7 +218,7 @@ Repite esta rutina cuando se incorpore personal, se prepare una estación nueva 
 - La cabecera muestra el indicador offline cuando cae la conexión; **Forzar recarga** actualiza archivos sin tocar el trabajo guardado.
 - **Restablecer fábrica** o borrar datos del sitio sólo se permite tras generar automáticamente una copia.
 - Las actualizaciones del service worker se descargan en segundo plano y esperan tu aprobación. Al ver **Actualización lista**, termina los cambios, crea un backup y pulsa **Forzar recarga**.
-- El almacenamiento reside en IndexedDB con preferencias pequeñas reflejadas en `localStorage`. Usa las herramientas del navegador para inspeccionar o exportar datos antes de limpiar cachés.
+- Los datos residen en un `localStorage` reforzado; los perfiles restringidos recurren a `sessionStorage`. Cada escritura genera una instantánea `__legacyMigrationBackup` para recuperarse sin pérdidas si aparece un error de cuota o de esquema. Usa las herramientas del navegador para inspeccionar o exportar datos antes de limpiar cachés o realizar pruebas.
 
 ## Resumen de datos y almacenamiento
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -125,7 +125,7 @@ Appliquez cette checklist lors de l’installation ou après une mise à jour po
 
 ## Prérequis système et navigateurs
 
-- **Navigateurs modernes.** Validé sur les dernières versions de Chromium, Firefox et Safari. Activez service workers, IndexedDB et stockage persistant.
+- **Navigateurs modernes.** Validé sur les dernières versions de Chromium, Firefox et Safari. Activez service workers, l’accès à `localStorage` (stockage du site) et le stockage persistant.
 - **Appareils adaptés au hors ligne.** Laptops et tablettes doivent autoriser le stockage persistant. Lancez l’application une fois en ligne pour mettre en cache toutes les ressources puis répétez la procédure de rechargement hors ligne avant le départ.
 - **Espace local suffisant.** Les productions importantes accumulent projets, backups et listes. Surveillez l’espace disponible du profil navigateur et exportez régulièrement vers des supports redondants.
 - **Aucune dépendance externe.** Tous les icônes, polices et scripts sont fournis. Copiez également `animated icons 3/` et les Uicons locaux lors du transfert du dossier.
@@ -218,7 +218,7 @@ Cette routine prouve que sauvegarde, partage, import, backup et restauration fon
 - L’en-tête affiche un indicateur hors ligne lorsqu’il n’y a pas de connexion ; **Forcer le rechargement** rafraîchit les fichiers sans toucher aux sauvegardes.
 - **Réinitialisation usine** ou nettoyage des données ne s’exécutent qu’après génération d’un backup automatique.
 - Les mises à jour du service worker se téléchargent en tâche de fond et attendent votre accord. À l’apparition de **Mise à jour prête**, terminez vos modifications, créez un backup puis cliquez sur **Forcer le rechargement**.
-- Le stockage principal est IndexedDB, avec préférences légères reflétées dans `localStorage`. Les outils développeur peuvent inspecter ou exporter les enregistrements avant nettoyage.
+- Les données résident dans un `localStorage` renforcé ; les profils restreints basculent sur `sessionStorage`. Chaque écriture crée un instantané `__legacyMigrationBackup` pour restaurer sans perte en cas d’erreur de quota ou de schéma. Les outils développeur peuvent inspecter ou exporter les enregistrements avant de vider les caches ou de lancer des tests.
 
 ## Vue d’ensemble des données et du stockage
 

--- a/README.it.md
+++ b/README.it.md
@@ -125,7 +125,7 @@ Segui questa checklist all’installazione o dopo un aggiornamento: dimostra che
 
 ## Requisiti di sistema e browser
 
-- **Browser moderni.** Validato sulle ultime versioni di Chromium, Firefox e Safari. Attiva service worker, IndexedDB e archiviazione persistente.
+- **Browser moderni.** Validato sulle ultime versioni di Chromium, Firefox e Safari. Attiva service worker, accesso a `localStorage` (archiviazione del sito) e archiviazione persistente.
 - **Dispositivi orientati all’offline.** Laptop e tablet devono consentire storage persistente. Avvia l’app una volta online per mettere in cache tutte le risorse e ripeti la procedura di ricarica offline prima di partire.
 - **Spazio locale adeguato.** Produzioni grandi accumulano progetti, backup e liste. Monitora lo spazio del profilo e esporta regolarmente su supporti ridondanti.
 - **Zero dipendenze esterne.** Tutte le icone, i font e gli script sono inclusi. Copia anche `animated icons 3/` e gli Uicons locali quando trasferisci la cartella.
@@ -218,7 +218,7 @@ Ripeti questa routine quando arriva un nuovo membro, allestisci una postazione o
 - L’header mostra l’indicatore offline quando manca connessione; **Forza ricarica** aggiorna gli asset senza toccare i salvataggi.
 - **Ripristino impostazioni di fabbrica** o pulizia dei dati del sito avviene solo dopo aver generato automaticamente un backup.
 - Gli aggiornamenti del service worker vengono scaricati in background e attendono la tua approvazione. Quando compare **Aggiornamento pronto**, completa le modifiche, crea un backup e poi premi **Forza ricarica**.
-- Lo storage principale è IndexedDB, con preferenze leggere replicate in `localStorage`. Usa gli strumenti del browser per ispezionare o esportare i record prima di cancellare cache.
+- I dati risiedono in un `localStorage` rinforzato; i profili bloccati ricadono su `sessionStorage`. Ogni scrittura crea anche uno snapshot `__legacyMigrationBackup` per recuperare senza perdite eventuali errori di quota o di schema. Usa gli strumenti del browser per ispezionare o esportare i record prima di svuotare cache o fare prove.
 
 ## Panoramica dati e archiviazione
 

--- a/README.md
+++ b/README.md
@@ -216,8 +216,8 @@ same online or offline.
 
 - **Modern evergreen browsers.** The planner is validated on the latest
   releases of Chromium, Firefox and Safari on desktop and mobile. Enable
-  service workers, IndexedDB and persistent storage to unlock the full offline
-  workflow.
+  service workers, `localStorage` (site storage) access and persistent storage
+  to unlock the full offline workflow.
 - **Offline-friendly devices.** Laptops and tablets must allow persistent
   storage so backups and auto-saves stay available. When running from removable
   media or a field workstation, launch the planner once while online so the
@@ -439,9 +439,11 @@ Use Cine Power Planner end-to-end with the following routine:
   When the **Update ready** toast appears, finish your current edits, trigger a
   manual backup, then click **Force reload** so fresh assets load alongside your
   preserved data.
-- Storage lives inside IndexedDB with small preferences mirrored to
-  `localStorage`. Use your browser’s developer tools to inspect or export raw
-  records before making experimental changes or clearing caches.
+- Storage lives inside hardened `localStorage` with a `sessionStorage` fallback
+  when browsers restrict long-term writes. Every save also creates a
+  `__legacyMigrationBackup` snapshot so you can recover even if the browser
+  reports a quota or schema error. Use your browser’s storage inspector to
+  export or audit records before clearing caches or experimenting with data.
 
 ## Data & Storage Overview
 


### PR DESCRIPTION
## Summary
- clarify the English documentation to explain the planner’s hardened `localStorage` storage layer, session fallback and migration safety copies
- update the browser requirements note to reference enabling `localStorage` access alongside persistent storage
- sync the German, Spanish, French and Italian READMEs with the same storage guidance

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d4fb79db5c83208dcb4e6fa9604c4f