### PR TITLE
Ensure auto gear monitor defaults are exported

### DIFF
--- a/src/scripts/storage.js
+++ b/src/scripts/storage.js
@@ -4476,6 +4476,7 @@ function clearAllData() {
       autoGearBackups: loadAutoGearBackups(),
       autoGearSeeded: loadAutoGearSeedFlag(),
       autoGearPresets: loadAutoGearPresets(),
+      autoGearMonitorDefaults: loadAutoGearMonitorDefaults(),
       autoGearActivePresetId: loadAutoGearActivePresetId(),
       autoGearAutoPresetId: loadAutoGearAutoPresetId(),
       autoGearShowBackups: loadAutoGearBackupVisibility(),

--- a/tests/unit/exportAllData.test.js
+++ b/tests/unit/exportAllData.test.js
@@ -1,0 +1,48 @@
+const originalWindow = global.window;
+const originalNavigator = global.navigator;
+
+describe('exportAllData', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    localStorage.clear();
+    sessionStorage.clear();
+
+    global.window = {
+      localStorage,
+      sessionStorage,
+    };
+    delete global.navigator;
+  });
+
+  afterEach(() => {
+    jest.resetModules();
+    if (typeof originalWindow === 'undefined') {
+      delete global.window;
+    } else {
+      global.window = originalWindow;
+    }
+    if (typeof originalNavigator === 'undefined') {
+      delete global.navigator;
+    } else {
+      global.navigator = originalNavigator;
+    }
+  });
+
+  test('includes auto gear monitor defaults in export payload', () => {
+    const {
+      saveAutoGearMonitorDefaults,
+      exportAllData,
+    } = require('../../src/scripts/storage');
+
+    const defaults = {
+      exposure: 'Rec709',
+      color: 'Warm',
+    };
+
+    saveAutoGearMonitorDefaults(defaults);
+
+    const exported = exportAllData();
+
+    expect(exported.autoGearMonitorDefaults).toEqual(defaults);
+  });
+});

--- a/tests/unit/storage.test.js
+++ b/tests/unit/storage.test.js
@@ -1144,6 +1144,8 @@ describe('export/import all data', () => {
       { id: 'preset-1', label: 'Outdoor tweaks', rules }
     ];
     saveAutoGearPresets(presets);
+    const monitorDefaults = { waveform: 'RGB', lut: 'False Color' };
+    saveAutoGearMonitorDefaults(monitorDefaults);
     saveAutoGearActivePresetId('preset-1');
     saveAutoGearAutoPresetId('preset-auto');
     saveAutoGearBackupVisibility(true);
@@ -1159,6 +1161,7 @@ describe('export/import all data', () => {
       autoGearBackups: backups,
       autoGearSeeded: true,
       autoGearPresets: presets,
+      autoGearMonitorDefaults: monitorDefaults,
       autoGearActivePresetId: 'preset-1',
       autoGearAutoPresetId: 'preset-auto',
       autoGearBackupRetention: 20,


### PR DESCRIPTION
## Summary
- include the saved auto gear monitor defaults in the export payload so backups capture all user preferences
- add unit coverage for exporting monitor defaults and update existing storage export expectations

## Testing
- npm test --silent

------
https://chatgpt.com/codex/tasks/task_e_68d4fd9533648320a0973020591000c4