### PR TITLE
Ensure battery selection persists across reloads and setup loads

### DIFF
--- a/src/scripts/app-session.js
+++ b/src/scripts/app-session.js
@@ -1964,6 +1964,10 @@ function restoreSessionState() {
     }
     setSelectValue(batterySelect, state.battery);
     setSelectValue(hotswapSelect, state.batteryHotswap);
+    if ((state && typeof state.battery === 'string' && state.battery.trim())
+      || (state && typeof state.batteryHotswap === 'string' && state.batteryHotswap.trim())) {
+      updateBatteryOptions();
+    }
     setSelectValue(setupSelect, state.setupSelect);
     currentProjectInfo = state.projectInfo || null;
     if (projectForm) populateProjectForm(currentProjectInfo || {});
@@ -2179,6 +2183,10 @@ function applySharedSetup(shared, options = {}) {
     }
     setSelectValue(batterySelect, decoded.battery);
     setSelectValue(hotswapSelect, decoded.batteryHotswap);
+    if ((typeof decoded.battery === 'string' && decoded.battery.trim())
+      || (typeof decoded.batteryHotswap === 'string' && decoded.batteryHotswap.trim())) {
+      updateBatteryOptions();
+    }
     if (typeof setManualDiagramPositions === 'function') {
       let sharedDiagramPositions = {};
       if (typeof normalizeDiagramPositionsInput === 'function' && decoded.diagramPositions) {

--- a/tests/dom/batteryPersistence.test.js
+++ b/tests/dom/batteryPersistence.test.js
@@ -1,0 +1,104 @@
+const { setupScriptEnvironment } = require('../helpers/scriptEnvironment');
+
+const SESSION_KEY = 'cameraPowerPlanner_session';
+
+function createDeviceData() {
+  return {
+    cameras: {
+      'Test Cam': {
+        power: {
+          batteryPlateSupport: [
+            { type: 'V-Mount', mount: 'native' }
+          ]
+        }
+      }
+    },
+    batteries: {
+      'Test Battery': {
+        mount_type: 'V-Mount',
+        capacity: 98,
+        pinA: 12
+      }
+    },
+    batteryHotswaps: {
+      'Test Swap': {
+        mount_type: 'V-Mount',
+        pinA: 12
+      }
+    }
+  };
+}
+
+describe('battery persistence', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    sessionStorage.clear();
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+    sessionStorage.clear();
+  });
+
+  test('restores battery selection from session state on reload', () => {
+    localStorage.setItem(SESSION_KEY, JSON.stringify({
+      camera: 'Test Cam',
+      batteryPlate: 'V-Mount',
+      battery: 'Test Battery',
+      batteryHotswap: 'Test Swap'
+    }));
+
+    const env = setupScriptEnvironment({
+      devices: createDeviceData(),
+      globals: {
+        saveSetups: jest.fn(),
+        loadSetups: jest.fn(() => ({})),
+      }
+    });
+
+    require('../../src/scripts/storage.js');
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+
+    const batterySelect = document.getElementById('batterySelect');
+    const hotswapSelect = document.getElementById('batteryHotswapSelect');
+
+    expect(batterySelect.value).toBe('Test Battery');
+    expect(hotswapSelect.value).toBe('Test Swap');
+
+    env.cleanup();
+  });
+
+  test('loads saved battery choices when switching setups', () => {
+    const storedSetups = {
+      'Project A': {
+        camera: 'Test Cam',
+        batteryPlate: 'V-Mount',
+        battery: 'Test Battery',
+        batteryHotswap: 'Test Swap'
+      }
+    };
+
+    const env = setupScriptEnvironment({
+      devices: createDeviceData(),
+      globals: {
+        saveSetups: jest.fn(),
+        loadSetups: jest.fn(() => ({ ...storedSetups })),
+      }
+    });
+
+    require('../../src/scripts/storage.js');
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+
+    const setupSelect = document.getElementById('setupSelect');
+    setupSelect.value = 'Project A';
+    setupSelect.dispatchEvent(new Event('change'));
+
+    const batterySelect = document.getElementById('batterySelect');
+    const hotswapSelect = document.getElementById('batteryHotswapSelect');
+
+    expect(batterySelect.value).toBe('Test Battery');
+    expect(hotswapSelect.value).toBe('Test Swap');
+
+    env.cleanup();
+  });
+});


### PR DESCRIPTION
## Summary
- rerun battery option refresh after session and shared setup restores so stored battery and hotswap selections persist
- add DOM regression tests covering session reload and saved setup switching to guard against regressions

## Testing
- npx jest tests/dom/batteryPersistence.test.js --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68d4fe4fa9388320bcfcb6d577e7e8d8