### PR TITLE
Handle migration backup quota with compression fallback

### DIFF
--- a/tests/unit/storage.test.js
+++ b/tests/unit/storage.test.js
@@ -16,6 +16,9 @@ if (!('sessionStorage' in global.window)) {
   });
 }
 
+const lzString = require('lz-string/libs/lz-string');
+global.LZString = lzString;
+
 const {
   loadDeviceData,
   saveDeviceData,


### PR DESCRIPTION
## Summary
- add a compression-based fallback when storage quota blocks migration backup creation and log when compressed payloads are written
- teach migration backup recovery and snapshot readers to understand the compressed format and update the legacy bundle accordingly
- expose the lz-string helpers to the test environment so the new compression paths stay exercised

## Testing
- npm run test:unit

------
https://chatgpt.com/codex/tasks/task_e_68d50aef4da08320ae35603318fd73f1