### PR TITLE
Document verification logging for offline drills

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,9 +212,11 @@ same online or offline.
    offline workflows are airtight and that locally stored Uicons, fonts and
    helper scripts follow the project.
 8. Archive the verified backup and project bundle alongside the repository copy
-   you opened. This keeps save, share, import, backup and restore workflows
-   provably in sync from the first session and gives you redundant recovery
-   media for travel days.
+   you opened. Log the verification date, machine name and operator in the same
+   folder (mirroring the recommendations in `docs/backup-rotation-guide.md`) so
+   every crew can prove when the drill succeeded. This keeps save, share,
+   import, backup and restore workflows provably in sync from the first session
+   and gives you redundant recovery media for travel days.
 
 ## System Requirements & Browser Support
 
@@ -257,8 +259,11 @@ access.
    the interface matches the source machine and locally stored Uicons plus
    helper scripts load without flicker.
 5. **Archive with confidence.** Delete the rehearsal profile after confirming
-   everything restored cleanly, then label and file the verified exports with
-   your production’s archival checklist.
+   everything restored cleanly. Label and file the verified exports with your
+   production’s archival checklist and add a short verification log (timestamp,
+   machine, operator and notes). The paper trail makes it easy to prove that
+   save, share, import, backup and restore workflows were validated end-to-end
+   before anyone relies on them in the field.
 
 ## Everyday Workflow
 

--- a/docs/offline-readiness.md
+++ b/docs/offline-readiness.md
@@ -104,3 +104,26 @@ this triage list:
 
 Keeping this runbook nearby ensures crews can prove offline readiness, preserve user data
 and rehearse recovery workflows without relying on an internet connection.
+
+## 5. Verification logging & audits
+
+Every successful drill should leave a trail operators can reference later. After each
+rehearsal, append a short note to your verification log (or create one alongside the
+exported artifacts if it does not already exist) with:
+
+- **Timestamp and workstation.** Note the local time, browser version and machine name so
+  future crews can trace which environment proved the offline workflow.
+- **Exports inspected.** List the filenames for the planner backup, project bundle and any
+  automatic gear rule exports you validated. Include checksum values when available to
+  make integrity checks trivial.
+- **Share and restore results.** Record whether manual saves, autosaves, shareable bundles,
+  imports and automatic rollbacks behaved as expected. Document anything that required a
+  retry so auditors know what to watch during the next drill.
+- **Cache status.** Confirm the help dialog, legal pages and other locally stored Uicons or
+  helper scripts rendered correctly while offline. A quick note here proves the service
+  worker cache stayed intact.
+
+Store the log in the same folder as the verified exports on both redundant media sets. The
+auditable paper trail makes it obvious when the last offline rehearsal occurred and which
+assets were inspected, keeping save, share, import, backup and restore workflows trusted by
+every crew member.

--- a/docs/operations-checklist.md
+++ b/docs/operations-checklist.md
@@ -40,6 +40,10 @@ update the repository or hand off a project at the end of the day.
 6. **Check draft impact preview.** Open the automatic gear rule editor, review
    the draft impact preview for quantity deltas and warnings, then cancel to
    confirm the live generator stays unchanged.
+7. **Log the drill.** Append a verification note (timestamp, machine, operator
+   and files inspected) to your archival log or create one beside the exports
+   if it does not exist yet. Pair the note with checksum manifests so every
+   crew member can prove when the save → share → import rehearsal succeeded.
 
 ## 3. Offline confidence checks
 

--- a/docs/testing-plan.md
+++ b/docs/testing-plan.md
@@ -59,6 +59,10 @@ you prepare a release candidate or validate a workstation:
 5. **Simulate loss of connectivity.** While the verification profile stays
    offline, refresh the planner and make sure the offline indicator appears,
    cached assets render instantly and the restored project remains intact.
+6. **Document the outcome.** Note the timestamp, machine, browser version and
+   files inspected in your verification log. Include any checksum manifests so
+   release managers can trace which rehearsal proved the save → share → import
+   loop remained reliable.
 
 Document the drill results alongside your automated test logs so every release
 carries evidence that saving, sharing, importing, backup and restore routines


### PR DESCRIPTION
## Summary
- extend the README quick-start and rehearsal checklists with guidance for recording verification logs alongside backups
- add a new verification logging and audit section to the offline readiness runbook so crews capture share/import results and cache health
- update the operations checklist and testing plan to require timestamped notes and checksums after each offline drill

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d56663e86c83208164d13f1f052fcd