### PR TITLE
Update help docs for backup workflows

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -186,6 +186,8 @@ Dieser kurze Ablauf sollte bei neuen Teammitgliedern, frisch eingerichteten Work
 - **Projektdiagramm** visualisiert Strom- und Signalpfade; mit gedrückter Umschalttaste als JPG exportieren.
 - **Akkuvergleich** zeigt Leistung kompatibler Packs und warnt vor Überlast.
 - **Gerätelistengenerator** erstellt kategorisierte Tabellen mit Metadaten, Crew-E-Mails und Szenario-Zubehör.
+- **Versionsvergleich** (**Einstellungen → Backup & Wiederherstellung → Versionen vergleichen**) hebt Unterschiede zwischen manuellen Saves oder Auto-Backups hervor, erlaubt Vorfallsnotizen und exportiert Prüfprotokolle vor der Archivierung.
+- **Wiederherstellungsprobe** lädt Backups in eine Sandbox, damit du jeden Datensatz offline prüfen kannst, bevor Live-Daten überschrieben werden.
 - **Offline-Badge & Neu laden erzwingen** zeigen Verbindungsstatus und aktualisieren Assets ohne Datenverlust.
 
 ### Top-Bar-Steuerung
@@ -215,6 +217,10 @@ Dieser kurze Ablauf sollte bei neuen Teammitgliedern, frisch eingerichteten Work
 
 - Service Worker cached alle Assets, Updates warten auf deine Freigabe via **Neu laden erzwingen**.
 - Projekte, Laufzeitdaten, Favoriten, Custom-Geräte, Themes und Listen liegen im Browser-Speicher. Unterstützte Browser erhalten Persistenz-Anfragen, um Löschrisiken zu mindern.
+- Automatische Sicherungen stapeln Projektsnapshots alle zehn Minuten, stündliche Voll-Backups und Hintergrundarchive der Auto-Gear-Regeln. Aktiviere **Einstellungen → Backup & Wiederherstellung → Auto-Backups in Projektliste anzeigen**, um die Timeline einzublenden, die Aufbewahrung zu steuern und Snapshots ohne Verbindung wiederherzustellen.
+- Blockiert der Browser Downloads, öffnet die App einen Tab **Manueller Download** mit dem JSON, damit du es in eine `.json`-Datei kopierst und auf vertrauenswürdigen Offline-Medien ablegst.
+- Nutze **Einstellungen → Backup & Wiederherstellung → Versionen vergleichen**, um zwei Stände zu vergleichen, Kontext in **Vorfallsnotizen** festzuhalten und ein Prüfprotokoll für Übergaben zu exportieren.
+- Starte **Wiederherstellungsprobe** in **Einstellungen → Backup & Wiederherstellung**, lade das Backup in eine Wegwerf-Sandbox, prüfe die Vergleichstabelle und bestätige die Integrität, bevor du **Wiederherstellen** auf die Live-Daten anwendest.
 - Repository lokal öffnen oder intern hosten, damit sensible Daten nicht nach außen gelangen. Exporte sind menschenlesbar und auditierbar.
 - Kopfzeile zeigt Offline-Indikator, Force-Reload aktualisiert Assets ohne Saves anzutasten.
 - **Werkseinstellungen** oder das Löschen der Website-Daten erfolgt erst nach einem automatischen Backup.

--- a/README.en.md
+++ b/README.en.md
@@ -383,6 +383,11 @@ Use Cine Power Planner end-to-end with the following routine:
   flags overload risks before you leave prep.
 - **Gear list generator** turns selections into categorized tables with tooltips
   for specs, crew emails and scenario-driven accessories.
+- **Version comparison** (**Settings → Backup & Restore → Compare versions**)
+  highlights changes between manual saves or automatic backups, captures
+  incident notes and exports audit logs before you archive revisions.
+- **Restore rehearsal** loads backups into a sandbox so you can verify every
+  record offline before running a full restore on production data.
 - **Offline indicator and Force reload** badges show connectivity status and
   refresh cached assets without touching saved data.
 
@@ -434,6 +439,19 @@ Use Cine Power Planner end-to-end with the following routine:
 - Projects, runtime submissions, favorites, custom devices, theme selections and
   gear lists live in browser storage. Browsers that support persistent storage
   receive an automatic retention request to reduce eviction risk.
+- Automatic safety copies layer 10-minute project snapshots, hourly full-app
+  downloads and background auto-gear archives. Enable **Settings → Backup &
+  Restore → Show auto backups in project list** to surface the timeline, tune
+  retention and restore snapshots without connectivity.
+- If a browser blocks downloads, the planner opens a **Manual download** tab
+  with the JSON payload so you can copy it into a `.json` file and store it on
+  trusted offline media before closing the tab.
+- Use **Settings → Backup & Restore → Compare versions** to diff two saves,
+  record context in **Incident notes** and export an audit log for your
+  handover records.
+- Run **Restore rehearsal** from **Settings → Backup & Restore** to load a
+  backup inside a disposable sandbox, review the comparison table for changes
+  and confirm the archive is healthy before applying **Restore** to live data.
 - Opening the repository directly from disk or serving it internally keeps
   sensitive data off external networks. All exports are human-readable JSON so
   you can audit what leaves the machine.

--- a/README.es.md
+++ b/README.es.md
@@ -186,6 +186,8 @@ Repite esta rutina cuando se incorpore personal, se prepare una estación nueva 
 - **Diagrama de proyecto** visualiza rutas de energía y señal; mantén Shift al exportar para guardar JPG.
 - **Panel de comparación de baterías** muestra rendimiento de packs compatibles y alerta sobre sobrecargas.
 - **Generador de listas** crea tablas categorizadas con metadatos, correos de equipo y accesorios según escenarios.
+- **Comparación de versiones** (**Configuración → Copia de seguridad y restauración → Comparar versiones**) resalta cambios entre guardados manuales o auto-backups, permite tomar notas del incidente y exportar registros antes de archivar.
+- **Ensayo de restauración** carga respaldos en un entorno aislado para validar cada registro sin conexión antes de restaurar los datos de producción.
 - **Indicador offline y Forzar recarga** muestran el estado de conexión y actualizan recursos sin tocar los datos.
 
 ### Controles superiores
@@ -215,6 +217,10 @@ Repite esta rutina cuando se incorpore personal, se prepare una estación nueva 
 
 - Un service worker almacena todos los recursos, ejecuta la app sin conexión y aplica actualizaciones sólo tras **Forzar recarga**.
 - Proyectos, comentarios, favoritos, dispositivos, temas y listas viven en el almacenamiento del navegador. Se solicita persistencia cuando está disponible para reducir riesgos de expulsión.
+- Las copias automáticas encadenan instantáneas de proyectos cada diez minutos, descargas completas cada hora y archivos de reglas automáticas en segundo plano. Activa **Configuración → Copia de seguridad y restauración → Mostrar auto-backups en la lista** para ver la línea de tiempo, ajustar la retención y recuperar instantáneas sin conectividad.
+- Si el navegador bloquea descargas, la app abre una pestaña de **Descarga manual** con el JSON para que lo copies en un archivo `.json` y lo guardes en medios offline de confianza antes de cerrarla.
+- Usa **Configuración → Copia de seguridad y restauración → Comparar versiones** para diferenciar dos guardados, anotar contexto en **Notas del incidente** y exportar un registro para el traspaso.
+- Ejecuta **Ensayo de restauración** desde **Configuración → Copia de seguridad y restauración** para cargar un backup en un espacio desechable, revisar la tabla comparativa y confirmar que está íntegro antes de aplicar **Restaurar** sobre los datos activos.
 - Ejecutar la app desde disco o una red interna mantiene los datos sensibles fuera de servicios externos. Las exportaciones en JSON son auditables.
 - La cabecera muestra el indicador offline cuando cae la conexión; **Forzar recarga** actualiza archivos sin tocar el trabajo guardado.
 - **Restablecer fábrica** o borrar datos del sitio sólo se permite tras generar automáticamente una copia.

--- a/README.fr.md
+++ b/README.fr.md
@@ -186,6 +186,8 @@ Cette routine prouve que sauvegarde, partage, import, backup et restauration fon
 - **Diagramme de projet** pour visualiser alimentation et signal ; maintenez Maj lors de l’export pour enregistrer un JPG.
 - **Comparateur de batteries** affichant les performances et alertant sur les surcharges.
 - **Générateur de listes** qui produit des tableaux catégorisés avec métadonnées, emails et accessoires liés aux scénarios.
+- **Comparaison de versions** (**Paramètres → Sauvegarde & Restauration → Comparer les versions**) met en évidence les écarts entre sauvegardes manuelles ou automatiques, permet de consigner l’incident et d’exporter un journal avant archivage.
+- **Répétition de restauration** charge les sauvegardes dans un bac à sable pour vérifier chaque enregistrement hors ligne avant de restaurer les données de production.
 - **Indicateur hors ligne et Forcer le rechargement** montrant l’état de connexion et rafraîchissant les ressources sans toucher aux données.
 
 ### Barre supérieure
@@ -215,6 +217,10 @@ Cette routine prouve que sauvegarde, partage, import, backup et restauration fon
 
 - Le service worker met en cache chaque ressource pour une utilisation hors ligne et n’applique les mises à jour qu’après **Forcer le rechargement**.
 - Projets, retours d’autonomie, favoris, équipements personnalisés, thèmes et listes résident dans le stockage du navigateur. Une demande de persistance est effectuée pour réduire le risque d’éviction.
+- Les sauvegardes automatiques enchaînent des instantanés de projet toutes les dix minutes, des archives complètes horaires et des copies des règles automatiques en arrière-plan. Activez **Paramètres → Sauvegarde & Restauration → Afficher les auto-sauvegardes dans la liste** pour afficher la chronologie, ajuster la rétention et restaurer des instantanés sans connexion.
+- Si le navigateur bloque les téléchargements, l’application ouvre un onglet **Téléchargement manuel** contenant le JSON afin de le copier dans un fichier `.json` et de le stocker sur un support hors ligne de confiance avant de fermer l’onglet.
+- Utilisez **Paramètres → Sauvegarde & Restauration → Comparer les versions** pour confronter deux sauvegardes, consigner le contexte dans **Notes d’incident** et exporter un journal pour vos transmissions.
+- Lancez **Répétition de restauration** depuis **Paramètres → Sauvegarde & Restauration** pour charger une sauvegarde dans un bac à sable jetable, revoir le tableau comparatif et confirmer son intégrité avant d’appliquer **Restaurer** aux données actives.
 - Ouvrir le dépôt depuis le disque ou un réseau interne évite toute fuite vers l’extérieur. Les exports JSON sont lisibles pour audit.
 - L’en-tête affiche un indicateur hors ligne lorsqu’il n’y a pas de connexion ; **Forcer le rechargement** rafraîchit les fichiers sans toucher aux sauvegardes.
 - **Réinitialisation usine** ou nettoyage des données ne s’exécutent qu’après génération d’un backup automatique.

--- a/README.it.md
+++ b/README.it.md
@@ -186,6 +186,8 @@ Ripeti questa routine quando arriva un nuovo membro, allestisci una postazione o
 - **Diagramma di progetto** per visualizzare alimentazione e segnali; tieni premuto Shift durante l’export per salvare un JPG.
 - **Confronto batterie** che mostra le prestazioni dei pack compatibili e avvisa in caso di sovraccarichi.
 - **Generatore di liste** che produce tabelle categorizzate con metadati, email e accessori basati sugli scenari.
+- **Confronto versioni** (**Impostazioni → Backup e ripristino → Confronta versioni**) evidenzia le differenze tra salvataggi manuali o auto-backup, permette di annotare l’incidente ed esporta i log prima dell’archiviazione.
+- **Prova di ripristino** carica i backup in un ambiente isolato così da verificare ogni record offline prima di ripristinare i dati di produzione.
 - **Indicatore offline e Forza ricarica** per mostrare lo stato e aggiornare le risorse senza toccare i dati.
 
 ### Barra superiore
@@ -215,6 +217,10 @@ Ripeti questa routine quando arriva un nuovo membro, allestisci una postazione o
 
 - Un service worker mette in cache ogni risorsa per l’uso offline e applica gli aggiornamenti solo dopo **Forza ricarica**.
 - Progetti, feedback runtime, preferiti, dispositivi personalizzati, temi e liste vivono nello storage del browser. Quando possibile viene richiesta la persistenza per ridurre i rischi di cancellazione.
+- Le copie automatiche concatenano snapshot di progetto ogni dieci minuti, backup completi ogni ora e archivi delle regole automatiche in background. Attiva **Impostazioni → Backup e ripristino → Mostra auto-backup nell’elenco** per vedere la timeline, regolare la conservazione e ripristinare le istantanee senza connessione.
+- Se il browser blocca i download, l’app apre una scheda **Download manuale** con il JSON da copiare in un file `.json` e salvare su supporti offline affidabili prima di chiuderla.
+- Usa **Impostazioni → Backup e ripristino → Confronta versioni** per confrontare due salvataggi, annotare il contesto nelle **Note sull’incidente** ed esportare un registro per il passaggio di consegne.
+- Avvia **Prova di ripristino** da **Impostazioni → Backup e ripristino** per caricare un backup in un’area temporanea, rivedere la tabella di confronto e confermare che sia integro prima di applicare **Ripristina** ai dati attivi.
 - Aprire il repository dal disco o da una rete interna mantiene i dati sensibili lontani da servizi esterni. Gli export JSON sono leggibili e auditabili.
 - L’header mostra l’indicatore offline quando manca connessione; **Forza ricarica** aggiorna gli asset senza toccare i salvataggi.
 - **Ripristino impostazioni di fabbrica** o pulizia dei dati del sito avviene solo dopo aver generato automaticamente un backup.

--- a/README.md
+++ b/README.md
@@ -380,6 +380,11 @@ Use Cine Power Planner end-to-end with the following routine:
   flags overload risks before you leave prep.
 - **Gear list generator** turns selections into categorized tables with tooltips
   for specs, crew emails and scenario-driven accessories.
+- **Version comparison** (**Settings → Backup & Restore → Compare versions**)
+  highlights changes between manual saves or automatic backups, captures
+  incident notes and exports audit logs before you archive revisions.
+- **Restore rehearsal** loads backups into a sandbox so you can verify every
+  record offline before running a full restore on production data.
 - **Offline indicator and Force reload** badges show connectivity status and
   refresh cached assets without touching saved data.
 
@@ -431,6 +436,19 @@ Use Cine Power Planner end-to-end with the following routine:
 - Projects, runtime submissions, favorites, custom devices, theme selections and
   gear lists live in browser storage. Browsers that support persistent storage
   receive an automatic retention request to reduce eviction risk.
+- Automatic safety copies layer 10-minute project snapshots, hourly full-app
+  downloads and background auto-gear archives. Enable **Settings → Backup &
+  Restore → Show auto backups in project list** to surface the timeline, tune
+  retention and restore snapshots without connectivity.
+- If a browser blocks downloads, the planner opens a **Manual download** tab
+  with the JSON payload so you can copy it into a `.json` file and store it on
+  trusted offline media before closing the tab.
+- Use **Settings → Backup & Restore → Compare versions** to diff two saves,
+  record context in **Incident notes** and export an audit log for your
+  handover records.
+- Run **Restore rehearsal** from **Settings → Backup & Restore** to load a
+  backup inside a disposable sandbox, review the comparison table for changes
+  and confirm the archive is healthy before applying **Restore** to live data.
 - Opening the repository directly from disk or serving it internally keeps
   sensitive data off external networks. All exports are human-readable JSON so
   you can audit what leaves the machine.


### PR DESCRIPTION
## Summary
- highlight the in-app version comparison and restore rehearsal workflows in the help quick reference across all README languages
- document automatic safety copies, manual download fallback, and diff/export notes in the data safety sections so teams can rehearse restores offline

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d5665b2a9c8320bea13b89dbdd3e6e