### PR TITLE
Improve hover help clarity

### DIFF
--- a/src/scripts/translations.js
+++ b/src/scripts/translations.js
@@ -1169,7 +1169,7 @@ const texts = {
       "Scroll to the “%s” section in the help dialog.",
     hoverHelpButtonLabel: "Hover for help",
     hoverHelpButtonHelp:
-      "Activate hover help so moving the cursor over buttons, fields, dropdowns or headers reveals brief explanations. You can open Settings while hover help is active to explore preferences without leaving this mode.",
+      "Activate hover help so moving the cursor over buttons, fields, dropdowns or headers reveals brief explanations. You can open Settings while hover help is active to explore preferences without leaving this mode. Hovered controls are outlined and the tooltip shows their title alongside any available details.",
     setupSelectHelp:
       "Pick a previously saved configuration or select '-- New Project --' to start from scratch.",
     setupNameHelp:
@@ -2375,7 +2375,7 @@ const texts = {
       "Scorri fino alla sezione “%s” all'interno della guida.",
     hoverHelpButtonLabel: "Aiuto al passaggio",
     hoverHelpButtonHelp:
-      "Attiva i suggerimenti al passaggio del mouse: spostando il cursore su pulsanti, campi, menu a discesa o intestazioni compaiono brevi spiegazioni. Puoi aprire Impostazioni mentre la modalità è attiva per esplorare le preferenze senza uscirne.",
+      "Attiva i suggerimenti al passaggio del mouse: spostando il cursore su pulsanti, campi, menu a discesa o intestazioni compaiono brevi spiegazioni. Puoi aprire Impostazioni mentre la modalità è attiva per esplorare le preferenze senza uscirne. Gli elementi sotto il cursore vengono evidenziati e il tooltip mostra il titolo insieme ai dettagli disponibili.",
     setupSelectHelp:
       "Scegli una configurazione salvata da caricare o inizia una nuova.",
     setupNameHelp: "Inserisci un nome per la configurazione corrente.",
@@ -3587,7 +3587,7 @@ const texts = {
       "Desplázate a la sección “%s” dentro de la guía.",
     hoverHelpButtonLabel: "Ayuda al pasar el cursor",
     hoverHelpButtonHelp:
-      "Activa la ayuda al pasar el cursor para que, al moverlo sobre botones, campos, menús desplegables o encabezados, aparezcan explicaciones breves. Puedes abrir Ajustes mientras el modo está activo para explorar las preferencias sin salir de él.",
+      "Activa la ayuda al pasar el cursor para que, al moverlo sobre botones, campos, menús desplegables o encabezados, aparezcan explicaciones breves. Puedes abrir Ajustes mientras el modo está activo para explorar las preferencias sin salir de él. Los controles bajo el cursor se resaltan y la información emergente muestra el título junto con los detalles disponibles.",
     setupSelectHelp:
       "Elige una configuración guardada para cargarla o comienza una nueva.",
     setupNameHelp: "Introduce un nombre para la configuración actual.",
@@ -4809,7 +4809,7 @@ const texts = {
       "Faites défiler jusqu'à la section « %s » dans la fenêtre d'aide.",
     hoverHelpButtonLabel: "Aide au survol",
     hoverHelpButtonHelp:
-      "Activez l'aide contextuelle au survol : en déplaçant le curseur sur les boutons, champs, menus déroulants ou en-têtes, de brèves explications apparaissent. Vous pouvez ouvrir Paramètres pendant que le mode est actif afin d'explorer les préférences sans quitter cette vue.",
+      "Activez l'aide contextuelle au survol : en déplaçant le curseur sur les boutons, champs, menus déroulants ou en-têtes, de brèves explications apparaissent. Vous pouvez ouvrir Paramètres pendant que le mode est actif afin d'explorer les préférences sans quitter cette vue. Les commandes survolées sont mises en évidence et l'infobulle affiche leur titre ainsi que les détails disponibles.",
     setupSelectHelp:
       "Choisissez une configuration enregistrée à charger ou commencez-en une nouvelle.",
     setupNameHelp: "Saisissez un nom pour la configuration actuelle.",
@@ -6037,7 +6037,7 @@ const texts = {
       "Zum Abschnitt „%s“ im Hilfedialog scrollen.",
     hoverHelpButtonLabel: "Hover-Hilfe aktivieren",
     hoverHelpButtonHelp:
-      "Aktiviere die Hover-Hilfe: Beim Überfahren von Schaltflächen, Feldern, Dropdowns oder Überschriften erscheinen kurze Erklärungen. Du kannst die Einstellungen öffnen, während der Modus aktiv ist, um Optionen zu erkunden, ohne ihn zu verlassen.",
+      "Aktiviere die Hover-Hilfe: Beim Überfahren von Schaltflächen, Feldern, Dropdowns oder Überschriften erscheinen kurze Erklärungen. Du kannst die Einstellungen öffnen, während der Modus aktiv ist, um Optionen zu erkunden, ohne ihn zu verlassen. Überfahrene Elemente werden hervorgehoben und das Tooltip zeigt ihren Titel zusammen mit allen verfügbaren Details.",
     setupSelectHelp:
       "Wähle ein gespeichertes Projekt zum Laden oder starte ein neues.",
     setupNameHelp: "Gib einen Namen für das aktuelle Projekt ein.",

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -3719,10 +3719,41 @@ body.pink-mode .favorite-toggle.favorited:active {
   /* Allow longer hover help descriptions */
   max-width: 320px;
   white-space: normal;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
 }
 
 #hoverHelpTooltip[hidden] {
   display: none;
+}
+
+#hoverHelpTooltip .hover-help-heading {
+  font-weight: 600;
+  letter-spacing: 0.01em;
+}
+
+#hoverHelpTooltip .hover-help-details {
+  line-height: 1.35;
+  font-size: calc(var(--font-size-base) * var(--font-scale-compact));
+}
+
+.hover-help-highlight {
+  outline: 2px solid color-mix(in srgb, var(--accent-color) 75%, transparent);
+  outline-offset: 3px;
+  box-shadow: 0 0 0 4px color-mix(in srgb, var(--accent-color) 18%, transparent);
+  border-radius: 6px;
+  transition: outline-color 120ms ease, box-shadow 120ms ease;
+}
+
+body.dark-mode .hover-help-highlight {
+  outline-color: color-mix(in srgb, var(--accent-color) 80%, black 20%);
+  box-shadow: 0 0 0 4px color-mix(in srgb, var(--accent-color) 30%, transparent);
+}
+
+body.high-contrast .hover-help-highlight {
+  outline-color: var(--accent-color);
+  box-shadow: 0 0 0 4px color-mix(in srgb, var(--accent-color) 40%, transparent);
 }
 
 /* Force help cursor when hover help is active */


### PR DESCRIPTION
## Summary
- refine hover help collection so tooltips show a labelled heading plus descriptive details and highlight the hovered control
- style hover help tooltips with stacked layout and add highlight treatments for light, dark, and high-contrast themes
- update hover help documentation strings across supported languages to mention the new highlight behavior

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d566702a7483209888edd2c4b9853f