### PR TITLE
Fix snapshot import for preference-only data

### DIFF
--- a/src/scripts/storage.js
+++ b/src/scripts/storage.js
@@ -5218,9 +5218,68 @@ function convertStorageSnapshotToData(snapshot) {
     return null;
   }
 
+  const exportStructureKeys = [
+    'devices',
+    'setups',
+    'session',
+    'feedback',
+    'favorites',
+    'preferences',
+    'project',
+    'projects',
+    'autoGearRules',
+    'autoGearBackups',
+    'autoGearPresets',
+    'autoGearMonitorDefaults',
+    'autoGearSeeded',
+    'autoGearActivePresetId',
+    'autoGearAutoPresetId',
+    'autoGearBackupRetention',
+    'autoGearShowBackups',
+    'fullBackupHistory',
+    'fullBackups',
+  ];
+
+  const resemblesExportPayload = exportStructureKeys.some((key) =>
+    Object.prototype.hasOwnProperty.call(snapshot, key),
+  );
+
+  if (resemblesExportPayload) {
+    return null;
+  }
+
   const data = {};
   let hasAssignments = false;
   let hasSnapshotKeys = false;
+
+  const preferenceKeys = [
+    'darkMode',
+    'pinkMode',
+    'highContrast',
+    'reduceMotion',
+    'relaxedSpacing',
+    'showAutoBackups',
+    'accentColor',
+    'fontSize',
+    'fontFamily',
+    'language',
+    'iosPwaHelpShown',
+  ];
+
+  const simpleSnapshotKeys = new Set([
+    CUSTOM_LOGO_STORAGE_KEY,
+    ...preferenceKeys,
+  ]);
+
+  const booleanPreferenceKeys = new Set([
+    'darkMode',
+    'pinkMode',
+    'highContrast',
+    'reduceMotion',
+    'relaxedSpacing',
+    'showAutoBackups',
+    'iosPwaHelpShown',
+  ]);
 
   const markSnapshotEntry = (entry) => {
     if (!entry || typeof entry.key !== 'string') {
@@ -5232,6 +5291,12 @@ function convertStorageSnapshotToData(snapshot) {
       entry.key.endsWith(STORAGE_BACKUP_SUFFIX) ||
       entry.key.endsWith(STORAGE_MIGRATION_BACKUP_SUFFIX)
     ) {
+      hasSnapshotKeys = true;
+      return;
+    }
+
+    const normalizedKey = entry.key.replace(/(?:__backup|__legacyMigrationBackup)$/u, '');
+    if (simpleSnapshotKeys.has(normalizedKey)) {
       hasSnapshotKeys = true;
     }
   };
@@ -5320,28 +5385,6 @@ function convertStorageSnapshotToData(snapshot) {
     hasAssignments = true;
   }
 
-  const preferenceKeys = [
-    'darkMode',
-    'pinkMode',
-    'highContrast',
-    'reduceMotion',
-    'relaxedSpacing',
-    'showAutoBackups',
-    'accentColor',
-    'fontSize',
-    'fontFamily',
-    'language',
-    'iosPwaHelpShown',
-  ];
-  const booleanPreferenceKeys = new Set([
-    'darkMode',
-    'pinkMode',
-    'highContrast',
-    'reduceMotion',
-    'relaxedSpacing',
-    'showAutoBackups',
-    'iosPwaHelpShown',
-  ]);
   const preferences = {};
 
   preferenceKeys.forEach((key) => {

--- a/tests/unit/storage.test.js
+++ b/tests/unit/storage.test.js
@@ -1884,6 +1884,34 @@ describe('migration backups before overwriting data', () => {
   });
 });
 
+describe('storage snapshot conversion', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    sessionStorage.clear();
+  });
+
+  test('imports preferences stored under simple keys from a snapshot object', () => {
+    const { importAllData, exportAllData } = require('../../src/scripts/storage');
+
+    const snapshot = {
+      darkMode: 'true',
+      accentColor: 'Ocean',
+      customLogo: 'data:image/png;base64,AAA',
+    };
+
+    importAllData(snapshot);
+
+    const exported = exportAllData();
+    expect(exported.preferences).toEqual(
+      expect.objectContaining({
+        darkMode: true,
+        accentColor: 'Ocean',
+      }),
+    );
+    expect(exported.customLogo).toBe('data:image/png;base64,AAA');
+  });
+});
+
 afterAll(() => {
   localStorage.clear();
   sessionStorage.clear();


### PR DESCRIPTION
## Summary
- make storage snapshot conversion ignore export-style payloads while recognizing known simple keys like custom logo and preferences
- update snapshot handling to treat preference-only storage dumps as valid imports without misclassifying normal export data
- add a regression test that ensures preference and logo entries imported from snapshots are preserved in exports

## Testing
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68d56682ed40832096cc10e85ccb17fa