### PR TITLE
Ensure loader migrates new auto gear storage keys

### DIFF
--- a/legacy/scripts/loader.js
+++ b/legacy/scripts/loader.js
@@ -153,6 +153,12 @@ function _typeof(o) { "@babel/helpers - typeof"; return _typeof = "function" == 
       legacy: legacyPrefix + 'autoGearShowBackups',
       modern: 'cameraPowerPlanner_autoGearShowBackups'
     }, {
+      legacy: legacyPrefix + 'autoGearBackupRetention',
+      modern: 'cameraPowerPlanner_autoGearBackupRetention'
+    }, {
+      legacy: legacyPrefix + 'autoGearMonitorDefaults',
+      modern: 'cameraPowerPlanner_autoGearMonitorDefaults'
+    }, {
       legacy: legacyPrefix + 'customFonts',
       modern: 'cameraPowerPlanner_customFonts',
       updateFontKey: true

--- a/src/scripts/loader.js
+++ b/src/scripts/loader.js
@@ -143,6 +143,8 @@
       { legacy: legacyPrefix + 'autoGearActivePreset', modern: 'cameraPowerPlanner_autoGearActivePreset' },
       { legacy: legacyPrefix + 'autoGearAutoPreset', modern: 'cameraPowerPlanner_autoGearAutoPreset' },
       { legacy: legacyPrefix + 'autoGearShowBackups', modern: 'cameraPowerPlanner_autoGearShowBackups' },
+      { legacy: legacyPrefix + 'autoGearBackupRetention', modern: 'cameraPowerPlanner_autoGearBackupRetention' },
+      { legacy: legacyPrefix + 'autoGearMonitorDefaults', modern: 'cameraPowerPlanner_autoGearMonitorDefaults' },
       { legacy: legacyPrefix + 'customFonts', modern: 'cameraPowerPlanner_customFonts', updateFontKey: true }
     ];
 

--- a/tests/unit/loaderScripts.test.js
+++ b/tests/unit/loaderScripts.test.js
@@ -4,6 +4,8 @@ const path = require('path');
 describe('loader script bundles', () => {
   const loaderPath = path.join(__dirname, '..', '..', 'src', 'scripts', 'loader.js');
   const loaderSource = fs.readFileSync(loaderPath, 'utf8');
+  const legacyLoaderPath = path.join(__dirname, '..', '..', 'legacy', 'scripts', 'loader.js');
+  const legacyLoaderSource = fs.readFileSync(legacyLoaderPath, 'utf8');
 
   test('modern bundle loads charger data', () => {
     expect(loaderSource).toMatch(/['"]src\/data\/devices\/chargers\.js['"]/);
@@ -11,5 +13,25 @@ describe('loader script bundles', () => {
 
   test('legacy bundle loads charger data', () => {
     expect(loaderSource).toMatch(/['"]legacy\/data\/devices\/chargers\.js['"]/);
+  });
+
+  test('modern bundle migrates auto gear retention storage keys', () => {
+    expect(loaderSource).toContain("autoGearBackupRetention");
+    expect(loaderSource).toContain("cameraPowerPlanner_autoGearBackupRetention");
+  });
+
+  test('legacy bundle migrates auto gear retention storage keys', () => {
+    expect(legacyLoaderSource).toContain("autoGearBackupRetention");
+    expect(legacyLoaderSource).toContain("cameraPowerPlanner_autoGearBackupRetention");
+  });
+
+  test('modern bundle migrates auto gear monitor defaults keys', () => {
+    expect(loaderSource).toContain("autoGearMonitorDefaults");
+    expect(loaderSource).toContain("cameraPowerPlanner_autoGearMonitorDefaults");
+  });
+
+  test('legacy bundle migrates auto gear monitor defaults keys', () => {
+    expect(legacyLoaderSource).toContain("autoGearMonitorDefaults");
+    expect(legacyLoaderSource).toContain("cameraPowerPlanner_autoGearMonitorDefaults");
   });
 });


### PR DESCRIPTION
## Summary
- update the modern and legacy loader bundles to migrate the auto gear backup retention and monitor defaults storage keys
- extend the loader script unit tests to assert the new storage keys are covered in both bundles

## Testing
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68d56b253844832091096ab8e0110293