### PR TITLE
Preserve renamed auto backups when pruning duplicates

### DIFF
--- a/src/scripts/app-events.js
+++ b/src/scripts/app-events.js
@@ -1,9 +1,22 @@
+const AUTO_BACKUP_NAME_PREFIX = 'auto-backup-';
+const AUTO_BACKUP_DELETION_PREFIX = 'auto-backup-before-delete-';
+
+function isAutoBackupKey(name) {
+  return (
+    typeof name === 'string'
+    && (
+      name.startsWith(AUTO_BACKUP_NAME_PREFIX)
+      || name.startsWith(AUTO_BACKUP_DELETION_PREFIX)
+    )
+  );
+}
+
 // --- EVENT LISTENERS ---
 /* global updateCageSelectOptions, updateGlobalDevicesReference, scheduleProjectAutoSave,
           ensureAutoBackupsFromProjects, getDiagramManualPositions,
           setManualDiagramPositions, normalizeDiagramPositionsInput,
           normalizeSetupName, createProjectInfoSnapshotForStorage,
-          applyDynamicFieldValues */
+          applyDynamicFieldValues, markAutoBackupEntryRenamed */
 
 // Language selection
 languageSelect.addEventListener("change", (event) => {
@@ -57,6 +70,16 @@ saveSetupBtn.addEventListener("click", () => {
         storedProjectSnapshot = loadProject(selectedName);
       } catch (error) {
         console.warn('Failed to load project data while renaming setup', error);
+      }
+      if (
+        storedProjectSnapshot
+        && isAutoBackupKey(selectedName)
+        && typeof markAutoBackupEntryRenamed === 'function'
+      ) {
+        storedProjectSnapshot = markAutoBackupEntryRenamed(
+          storedProjectSnapshot,
+          selectedName,
+        );
       }
     }
 
@@ -679,7 +702,7 @@ function autoBackup(options = {}) {
     : '';
   const normalizedSelectedName = normalizeProjectName(selectedName);
   const normalizedTypedName = normalizeProjectName(typedName);
-  const isAutoBackupName = (name) => typeof name === 'string' && name.startsWith('auto-backup-');
+  const isAutoBackupName = (name) => isAutoBackupKey(name);
 
   let nameForBackup = '';
   if (overrideName !== null && overrideName !== undefined) {


### PR DESCRIPTION
## Summary
- track auto backup rename metadata so duplicate pruning skips snapshots marked by the user
- flag renamed backups when retitling entries and when copying project snapshots to keep their metadata intact
- add unit coverage ensuring renamed backups remain available alongside newer auto saves

## Testing
- npm run test:unit

------
https://chatgpt.com/codex/tasks/task_e_68d571dc1dec8320b8da54dbf7a1344e