### PR TITLE
docs: add maintenance guide for help and translations

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ production day.
 - [Localization](#localization)
 - [Install as an App](#install-as-an-app)
 - [Device Data Workflow](#device-data-workflow)
+- [Documentation, Help & Translation Maintenance](#documentation-help--translation-maintenance)
 - [Development](#development)
 - [Troubleshooting](#troubleshooting)
 - [Feedback & Support](#feedback--support)
@@ -799,6 +800,22 @@ npm run test:data
 Add `--help` to any helper command for usage notes and review generated JSON
 diffs before opening a pull request. `npm run help` prints a summary of all
 available scripts.
+
+## Documentation, Help & Translation Maintenance
+
+Keeping the help center, printable manuals and localized READMEs current is part of every
+feature change. Follow the [Documentation, Help & Translation Maintenance Guide](docs/documentation-maintenance.md)
+whenever you ship a new workflow so offline crews inherit accurate drills, translation
+coverage and recovery instructions. Each update should:
+
+- Refresh help dialog topics and hover-help text so shortcuts, save routines and offline
+  indicators match the live build.
+- Mirror the same adjustments in every localized README and static legal page, preserving
+  guidance on saving, sharing, importing, backing up and restoring.
+- Update translation keys and selectors so language options stay synchronized with the UI
+  and remain fully functional without connectivity.
+- Rehearse the save → share → import loop after documentation edits to guarantee the printed
+  instructions, help content and offline behavior still align.
 
 ## Development
 

--- a/docs/documentation-maintenance.md
+++ b/docs/documentation-maintenance.md
@@ -1,0 +1,62 @@
+# Documentation, Help & Translation Maintenance Guide
+
+Cine Power Planner treats documentation as a core feature of the product. Help content,
+offline manuals and translations must reflect the current behavior of the app so crews can
+trust every save, share, import, backup and restore workflow even when they are far from an
+internet connection. Use this guide whenever you add, remove or adjust functionality.
+
+## 1. Identify every surface that needs an update
+
+1. **Help dialog topics.** Review contextual help entries, FAQ answers and hover-help copy in
+   `src/scripts/help/` before landing a feature change. Update screenshots, keyboard
+   shortcuts and workflow descriptions so crews see accurate instructions while offline.
+2. **README family.** Revise the primary `README.md` plus each localized README under the
+   project root. Ensure new workflows appear in the *Save, Share & Import Drill*, *Backup &
+   Recovery* and *Emergency Recovery Playbook* sections so every language documents the same
+   safety routines.
+3. **Operations manuals.** Confirm `docs/offline-readiness.md`,
+   `docs/operations-checklist.md`, `docs/backup-rotation-guide.md` and `docs/testing-plan.md`
+   include the new logic. These printable guides travel with field kits, so add or update
+   drills that prove autosave, backup rotation and restore rehearsals still behave exactly
+   as the latest build.
+4. **In-app legal and static pages.** If the change surfaces on legal disclosures or other
+   static pages in `legal/`, mirror the update in every localized HTML file so offline
+   references stay consistent.
+
+## 2. Update translations in lockstep
+
+1. **Add UI strings.** Extend `translations.js` with any new labels. Copy the English source
+   to all supported locales if you do not have an immediate translation so the UI keeps
+   rendering legibly offline.
+2. **Localize documentation.** Translate adjustments made to each localized README and any
+   static HTML page. When time is limited, add translator notes to the relevant pull request
+   so the community can help close gaps quickly.
+3. **Verify selector entries.** Add new language options to every selector in `index.html`
+   and the settings dialog so crews can access the translation without editing storage by
+   hand.
+
+## 3. Prove offline readiness after doc updates
+
+1. **Prime caches.** Open `index.html`, launch the help dialog, visit legal pages and toggle
+   each theme so the service worker caches the updated documentation, locally stored Uicons
+   and other bundled assets.
+2. **Run the save rehearsal.** Follow the [Save, Share & Import Drill](../README.md#save-share--import-drill)
+   to confirm the documented steps still match the product. Capture manual saves, export a
+   planner backup and a shareable bundle, then rehearse the restore in an offline browser
+   profile.
+3. **Archive verification artifacts.** Store the validated backup, bundle and a ZIP of the
+   repository alongside a short verification log. Note which documentation changes shipped
+   so crews can trace when instructions last matched the product.
+
+## 4. Testing checklist before release
+
+- `npm test` – ensures linting, data integrity checks and Jest suites continue to protect
+  persistence logic.
+- Manual offline rehearsal – confirms help topics, documentation callouts and translations
+  render correctly without connectivity.
+- Screenshot or export updates (as required) – regenerate any documentation images or
+  printable PDFs referenced in manuals so crews see the latest UI states while offline.
+
+Maintaining this cadence guarantees the planner’s guidance, translations and offline-first
+workflows stay in sync, keeping user data safe even in the most isolated production
+environments.


### PR DESCRIPTION
## Summary
- add a comprehensive documentation, help, and translation maintenance guide that keeps offline workflows safe
- link the new guide from the README and outline the expectations for refreshing help content and localized manuals

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d5868f3ea883209ac59faafe8ddd5e