### PR TITLE
Improve feature search coverage with help text tokens

### DIFF
--- a/src/scripts/app-core.js
+++ b/src/scripts/app-core.js
@@ -19624,6 +19624,65 @@ const collectFeatureContexts = (element, baseLabelLower) => {
   return contexts.reverse();
 };
 
+const collectFeatureSearchHelpTexts = element => {
+  if (!element) return [];
+  const texts = new Set();
+  const MAX_TEXTS = 4;
+  const clean = value => {
+    if (typeof value !== 'string') return '';
+    const normalized = value.replace(/\s+/g, ' ').trim();
+    if (!normalized) return '';
+    if (normalized.length > 160) {
+      return normalized.slice(0, 160);
+    }
+    return normalized;
+  };
+  const add = value => {
+    if (texts.size >= MAX_TEXTS) return;
+    const cleaned = clean(value);
+    if (cleaned) {
+      texts.add(cleaned);
+    }
+  };
+  const addFromElement = el => {
+    if (!el) return;
+    add(el.getAttribute('data-help'));
+    add(el.getAttribute('aria-description'));
+    add(el.getAttribute('title'));
+  };
+
+  add(element.getAttribute('data-help'));
+  add(element.getAttribute('aria-description'));
+  add(element.getAttribute('title'));
+
+  const ownerDoc = element.ownerDocument || (typeof document !== 'undefined' ? document : null);
+
+  const processIdRefs = (attrName, collector) => {
+    if (!ownerDoc) return;
+    const attrValue = element.getAttribute(attrName);
+    if (!attrValue) return;
+    attrValue
+      .split(/\s+/)
+      .map(id => id && ownerDoc.getElementById(id))
+      .filter(Boolean)
+      .forEach(collector);
+  };
+
+  processIdRefs('aria-describedby', addFromElement);
+  processIdRefs('aria-labelledby', addFromElement);
+
+  if (element.labels && typeof element.labels === 'object') {
+    Array.from(element.labels).forEach(addFromElement);
+  }
+
+  if (typeof element.closest === 'function') {
+    const wrappingLabel = element.closest('label');
+    if (wrappingLabel) addFromElement(wrappingLabel);
+  }
+
+  return Array.from(texts);
+};
+
 const buildFeatureSearchEntry = (element, { label, keywords = '' }) => {
   if (!element || !label) return null;
   const baseLabel = label.trim();
@@ -19632,11 +19691,19 @@ const buildFeatureSearchEntry = (element, { label, keywords = '' }) => {
   if (!baseKey) return null;
   const baseLabelLower = baseLabel.toLowerCase();
   const contextLabels = collectFeatureContexts(element, baseLabelLower);
+  const shouldCollectHelp =
+    typeof element.hasAttribute === 'function' && element.hasAttribute('data-feature-search');
+  const helpTexts = shouldCollectHelp ? collectFeatureSearchHelpTexts(element) : [];
   let combinedLabel = baseLabel;
   if (contextLabels.length) {
     combinedLabel = `${baseLabel} (${contextLabels.join(' › ')})`;
   }
-  const combinedKeywords = [baseLabel, contextLabels.join(' '), keywords]
+  const combinedKeywords = [
+    baseLabel,
+    contextLabels.join(' '),
+    keywords,
+    helpTexts.join(' ')
+  ]
     .filter(Boolean)
     .join(' ');
   const entry = {
@@ -19647,7 +19714,8 @@ const buildFeatureSearchEntry = (element, { label, keywords = '' }) => {
     context: contextLabels,
     tokens: searchTokens(combinedKeywords),
     key: baseKey,
-    optionValue: combinedLabel
+    optionValue: combinedLabel,
+    helpTexts
   };
   const existing = featureMap.get(baseKey);
   if (!existing) {

--- a/src/scripts/translations.js
+++ b/src/scripts/translations.js
@@ -92,7 +92,7 @@ const texts = {
     featureSearchPlaceholder: "Search features or devices...",
     featureSearchLabel: "Search features, devices and help",
     featureSearchHelp:
-      "Type to jump to features, devices, quick actions like Save or Backup, or help topics. Suggestions prioritize direct feature and device matches before help topics so navigation lands on controls first. Each entry shows whether it opens a Feature, Action, Device or Help topic so you know what happens before pressing Enter. Press Enter to navigate, / or Ctrl+K (Cmd+K on Mac) to focus the search from anywhere, and use Escape or × to clear the query.",
+      "Type to jump to features, devices, quick actions like Save or Backup, or help topics. Suggestions prioritize direct feature and device matches before help topics so navigation lands on controls first. Each entry shows whether it opens a Feature, Action, Device or Help topic so you know what happens before pressing Enter. Search also reads the same tooltip and help text shown around controls, so words like \"JSON\" or \"autosave\" still land on the right button even if the label differs. Press Enter to navigate, / or Ctrl+K (Cmd+K on Mac) to focus the search from anywhere, and use Escape or × to clear the query.",
     featureSearchClear: "Clear search",
     featureSearchClearHelp: "Clear the search box and show all results again. Press Escape to clear quickly.",
     featureSearchTypeFeature: "Feature",
@@ -1315,7 +1315,7 @@ const texts = {
     featureSearchPlaceholder: "Cerca funzionalità o dispositivi...",
     featureSearchLabel: "Cerca funzionalità, dispositivi e aiuto",
     featureSearchHelp:
-      "Digita per andare alle funzionalità, ai dispositivi, alle azioni rapide come Salva o Backup o aprire gli argomenti di aiuto correlati. I suggerimenti ora danno priorità alle corrispondenze dirette di funzionalità e dispositivi prima degli argomenti di aiuto, così raggiungi subito i controlli. Ogni voce indica se aprirà una Funzione, un'Azione, un Dispositivo o un argomento di Supporto, così sai cosa succede prima di premere Invio. Premi Invio per navigare, / o Ctrl+K (Cmd+K su Mac) per mettere a fuoco la ricerca ovunque e usa Esc o × per cancellare la ricerca.",
+      "Digita per andare alle funzionalità, ai dispositivi, alle azioni rapide come Salva o Backup o aprire gli argomenti di aiuto correlati. I suggerimenti danno priorità alle corrispondenze dirette di funzionalità e dispositivi prima degli argomenti di aiuto, così raggiungi subito i controlli. Ogni voce indica se aprirà una Funzione, un'Azione, un Dispositivo o un argomento di Supporto, così sai cosa succede prima di premere Invio. La ricerca analizza anche gli stessi testi di aiuto mostrati nelle descrizioni, quindi termini come \"JSON\" o \"salvataggio automatico\" portano comunque al pulsante giusto anche se l'etichetta è diversa. Premi Invio per navigare, / o Ctrl+K (Cmd+K su Mac) per mettere a fuoco la ricerca ovunque e usa Esc o × per cancellare la ricerca.",
     featureSearchClear: "Cancella ricerca",
     featureSearchClearHelp: "Cancella il campo di ricerca e mostra di nuovo tutti i risultati. Premi Esc per cancellare rapidamente.",
     featureSearchTypeFeature: "Funzione",
@@ -2521,7 +2521,7 @@ const texts = {
     featureSearchPlaceholder: "Buscar funciones o dispositivos...",
     featureSearchLabel: "Buscar funciones, dispositivos y ayuda",
     featureSearchHelp:
-      "Escribe para ir a funciones, dispositivos, acciones rápidas como Guardar o Copia de seguridad, o temas de ayuda relacionados. Las sugerencias ahora dan prioridad a las coincidencias directas de funciones y dispositivos antes que a los temas de ayuda, para llevarte primero a los controles. Cada sugerencia indica si abre una Función, una Acción, un Dispositivo o un tema de Ayuda para que sepas qué ocurrirá antes de pulsar Enter. Pulsa Enter para navegar, / o Ctrl+K (Cmd+K en Mac) para enfocar la búsqueda desde cualquier lugar y usa Esc o × para borrar la búsqueda.",
+      "Escribe para ir a funciones, dispositivos, acciones rápidas como Guardar o Copia de seguridad, o temas de ayuda relacionados. Las sugerencias dan prioridad a las coincidencias directas de funciones y dispositivos antes que a los temas de ayuda, para llevarte primero a los controles. Cada sugerencia indica si abre una Función, una Acción, un Dispositivo o un tema de Ayuda para que sepas qué ocurrirá antes de pulsar Enter. La búsqueda también tiene en cuenta los mismos textos de ayuda que aparecen en las descripciones emergentes, de modo que palabras como \"JSON\" o \"autoguardado\" te llevan igualmente al botón correcto aunque la etiqueta sea distinta. Pulsa Enter para navegar, / o Ctrl+K (Cmd+K en Mac) para enfocar la búsqueda desde cualquier lugar y usa Esc o × para borrar la búsqueda.",
     featureSearchClear: "Borrar búsqueda",
     featureSearchClearHelp: "Limpia el campo de búsqueda y muestra todos los resultados de nuevo. Pulsa Esc para borrar rápidamente.",
     featureSearchTypeFeature: "Función",
@@ -3740,7 +3740,7 @@ const texts = {
     featureSearchPlaceholder: "Rechercher des fonctionnalités ou des appareils...",
     featureSearchLabel: "Rechercher des fonctionnalités, des appareils et de l’aide",
     featureSearchHelp:
-      "Saisissez du texte pour retrouver des fonctionnalités, des appareils, des actions rapides comme Enregistrer ou Sauvegarder et les sujets d’aide associés. Les suggestions privilégient désormais les correspondances directes avec les fonctionnalités et les appareils avant les sujets d’aide afin de vous amener en priorité sur les commandes. Chaque suggestion précise s’il s’agit d’une Fonctionnalité, d’une Action, d’un Appareil ou d’un sujet d’Aide afin que vous sachiez ce qui s’ouvrira avant d’appuyer sur Entrée. Appuyez sur Entrée pour ouvrir l’élément sélectionné, sur / ou Ctrl+K (Cmd+K sur Mac) pour activer la recherche à tout moment, puis sur Échap ou × pour effacer la requête.",
+      "Saisissez du texte pour retrouver des fonctionnalités, des appareils, des actions rapides comme Enregistrer ou Sauvegarder et les sujets d’aide associés. Les suggestions privilégient les correspondances directes avec les fonctionnalités et les appareils avant les sujets d’aide afin de vous amener en priorité sur les commandes. Chaque suggestion précise s’il s’agit d’une Fonctionnalité, d’une Action, d’un Appareil ou d’un sujet d’Aide afin que vous sachiez ce qui s’ouvrira avant d’appuyer sur Entrée. La recherche lit aussi les mêmes textes d’aide affichés dans les info-bulles, ainsi des mots comme \"JSON\" ou \"sauvegarde auto\" mènent quand même au bon bouton même si son libellé est différent. Appuyez sur Entrée pour ouvrir l’élément sélectionné, sur / ou Ctrl+K (Cmd+K sur Mac) pour activer la recherche à tout moment, puis sur Échap ou × pour effacer la requête.",
     featureSearchClear: "Effacer la recherche",
     featureSearchClearHelp: "Efface le champ de recherche et affiche à nouveau tous les résultats. Appuyez sur Échap pour effacer rapidement.",
     featureSearchTypeFeature: "Fonctionnalité",
@@ -4970,7 +4970,7 @@ const texts = {
     featureSearchPlaceholder: "Funktionen oder Geräte durchsuchen...",
     featureSearchLabel: "Funktionen, Geräte und Hilfe durchsuchen",
     featureSearchHelp:
-      "Tippen, um zu Funktionen, Geräten, Schnellaktionen wie Speichern oder Backup oder zu passenden Hilfethemen zu springen. Vorschläge priorisieren jetzt direkte Treffer für Funktionen und Geräte vor Hilfethemen, damit du zuerst bei den Bedienelementen landest. Jeder Vorschlag zeigt, ob er eine Funktion, Aktion, ein Gerät oder ein Hilfethema öffnet, damit du vor dem Drücken von Enter weißt, was passiert. Drücke Enter zum Navigieren, / oder Strg+K (Cmd+K auf dem Mac), um die Suche überall zu fokussieren, und verwende Esc oder ×, um die Eingabe zu löschen.",
+      "Tippe, um zu Funktionen, Geräten, Schnellaktionen wie Speichern oder Backup oder zu passenden Hilfethemen zu springen. Vorschläge priorisieren direkte Treffer für Funktionen und Geräte vor Hilfethemen, damit du zuerst bei den Bedienelementen landest. Jeder Vorschlag zeigt, ob er eine Funktion, Aktion, ein Gerät oder ein Hilfethema öffnet, damit du vor dem Drücken von Enter weißt, was passiert. Die Suche berücksichtigt außerdem die gleichen Hilfetexte aus Tooltips, sodass Begriffe wie \"JSON\" oder \"Autospeichern\" trotzdem zum richtigen Button führen, selbst wenn die Beschriftung anders lautet. Drücke Enter zum Navigieren, / oder Strg+K (Cmd+K auf dem Mac), um die Suche überall zu fokussieren, und verwende Esc oder ×, um die Eingabe zu löschen.",
     featureSearchClear: "Suche löschen",
     featureSearchClearHelp: "Suchfeld leeren und alle Ergebnisse wieder anzeigen. Drücke Esc, um schnell zu löschen.",
     featureSearchTypeFeature: "Funktion",

--- a/tests/dom/globalFeatureSearch.test.js
+++ b/tests/dom/globalFeatureSearch.test.js
@@ -1,5 +1,7 @@
 const { setupScriptEnvironment } = require('../helpers/scriptEnvironment');
 
+jest.setTimeout(20000);
+
 describe('global feature search help navigation', () => {
   let env;
   let featureSearch;
@@ -130,6 +132,25 @@ describe('global feature search help navigation', () => {
     ).toBe(true);
     expect(
       options.some(opt => typeof opt.label === 'string' && opt.label.includes('Help'))
+    ).toBe(true);
+  });
+
+  test('search suggestions include help text keywords', async () => {
+    expect(featureSearch).toBeTruthy();
+
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    const featureList = document.getElementById('featureList');
+    expect(featureList).toBeTruthy();
+
+    featureSearch.value = 'JSON';
+    featureSearch.dispatchEvent(new Event('input', { bubbles: true }));
+
+    const options = Array.from(featureList.options);
+    expect(options.length).toBeGreaterThan(0);
+    expect(
+      options.some(opt => /Export Project/i.test(opt.value || '') || /Export Project/i.test(opt.label || ''))
     ).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- index tooltip/help descriptions for feature search entries so queries like "JSON" match the right control
- clarify feature search guidance across supported languages to mention help text matching
- extend and stabilise global feature search DOM tests for the new behaviour

## Testing
- npm run lint
- npm run test:dom

------
https://chatgpt.com/codex/tasks/task_e_68d58c17fecc8320ae558f410073be61