### PR TITLE
Fix global auto-backup flag collisions

### DIFF
--- a/src/scripts/app-events.js
+++ b/src/scripts/app-events.js
@@ -5,7 +5,7 @@
           normalizeSetupName, createProjectInfoSnapshotForStorage,
           applyDynamicFieldValues, applyBatteryPlateSelectionFromBattery */
 
-const AUTO_BACKUP_RENAMED_FLAG =
+const APP_EVENTS_AUTO_BACKUP_RENAMED_FLAG =
   (typeof globalThis !== 'undefined' && globalThis.__CINE_AUTO_BACKUP_RENAMED_FLAG)
     ? globalThis.__CINE_AUTO_BACKUP_RENAMED_FLAG
     : '__cineAutoBackupRenamed';
@@ -15,14 +15,14 @@ function markAutoBackupDataAsRenamed(value) {
     return;
   }
   try {
-    value[AUTO_BACKUP_RENAMED_FLAG] = true;
+    value[APP_EVENTS_AUTO_BACKUP_RENAMED_FLAG] = true;
   } catch (assignmentError) {
     void assignmentError;
   }
   const info = value.projectInfo;
   if (info && typeof info === 'object') {
     try {
-      info[AUTO_BACKUP_RENAMED_FLAG] = true;
+      info[APP_EVENTS_AUTO_BACKUP_RENAMED_FLAG] = true;
     } catch (infoError) {
       void infoError;
     }

--- a/src/scripts/storage.js
+++ b/src/scripts/storage.js
@@ -111,7 +111,7 @@ const AUTO_GEAR_BACKUP_RETENTION_STORAGE_KEY = 'cameraPowerPlanner_autoGearBacku
 const FULL_BACKUP_HISTORY_STORAGE_KEY = 'cameraPowerPlanner_fullBackups';
 const STORAGE_AUTO_BACKUP_NAME_PREFIX = 'auto-backup-';
 const STORAGE_AUTO_BACKUP_DELETION_PREFIX = 'auto-backup-before-delete-';
-const AUTO_BACKUP_RENAMED_FLAG = '__cineAutoBackupRenamed';
+const STORAGE_AUTO_BACKUP_RENAMED_FLAG = '__cineAutoBackupRenamed';
 
 if (GLOBAL_SCOPE && typeof GLOBAL_SCOPE === 'object') {
   try {
@@ -119,13 +119,13 @@ if (GLOBAL_SCOPE && typeof GLOBAL_SCOPE === 'object') {
       Object.defineProperty(GLOBAL_SCOPE, '__CINE_AUTO_BACKUP_RENAMED_FLAG', {
         configurable: true,
         writable: false,
-        value: AUTO_BACKUP_RENAMED_FLAG,
+        value: STORAGE_AUTO_BACKUP_RENAMED_FLAG,
       });
     }
   } catch (error) {
     void error;
     try {
-      GLOBAL_SCOPE.__CINE_AUTO_BACKUP_RENAMED_FLAG = AUTO_BACKUP_RENAMED_FLAG;
+      GLOBAL_SCOPE.__CINE_AUTO_BACKUP_RENAMED_FLAG = STORAGE_AUTO_BACKUP_RENAMED_FLAG;
     } catch (assignmentError) {
       void assignmentError;
     }
@@ -1298,11 +1298,11 @@ function markAutoBackupValueAsRenamed(value) {
   }
 
   try {
-    value[AUTO_BACKUP_RENAMED_FLAG] = true;
+    value[STORAGE_AUTO_BACKUP_RENAMED_FLAG] = true;
   } catch (assignmentError) {
     void assignmentError;
     try {
-      Object.defineProperty(value, AUTO_BACKUP_RENAMED_FLAG, {
+      Object.defineProperty(value, STORAGE_AUTO_BACKUP_RENAMED_FLAG, {
         configurable: true,
         enumerable: true,
         writable: true,
@@ -1315,7 +1315,7 @@ function markAutoBackupValueAsRenamed(value) {
 
   if (isPlainObject(value.projectInfo)) {
     try {
-      value.projectInfo[AUTO_BACKUP_RENAMED_FLAG] = true;
+      value.projectInfo[STORAGE_AUTO_BACKUP_RENAMED_FLAG] = true;
     } catch (infoError) {
       void infoError;
     }
@@ -1326,12 +1326,12 @@ function isAutoBackupValueRenamed(value) {
   if (!value || typeof value !== 'object') {
     return false;
   }
-  if (value[AUTO_BACKUP_RENAMED_FLAG] === true) {
+  if (value[STORAGE_AUTO_BACKUP_RENAMED_FLAG] === true) {
     return true;
   }
   if (
     isPlainObject(value.projectInfo)
-    && value.projectInfo[AUTO_BACKUP_RENAMED_FLAG] === true
+    && value.projectInfo[STORAGE_AUTO_BACKUP_RENAMED_FLAG] === true
   ) {
     return true;
   }

--- a/tests/unit/storage.test.js
+++ b/tests/unit/storage.test.js
@@ -88,7 +88,7 @@ const BACKUP_SUFFIX = '__backup';
 const MIGRATION_BACKUP_SUFFIX = '__legacyMigrationBackup';
 const backupKeyFor = (key) => `${key}${BACKUP_SUFFIX}`;
 const migrationBackupKeyFor = (key) => `${key}${MIGRATION_BACKUP_SUFFIX}`;
-const AUTO_BACKUP_RENAMED_FLAG =
+const TEST_AUTO_BACKUP_RENAMED_FLAG =
   (typeof globalThis !== 'undefined' && globalThis.__CINE_AUTO_BACKUP_RENAMED_FLAG)
     ? globalThis.__CINE_AUTO_BACKUP_RENAMED_FLAG
     : '__cineAutoBackupRenamed';
@@ -511,14 +511,14 @@ describe('setup storage', () => {
     expect(result).toBe(renamedKey);
 
     const stored = JSON.parse(localStorage.getItem(SETUP_KEY));
-    expect(stored[renamedKey][AUTO_BACKUP_RENAMED_FLAG]).toBe(true);
+    expect(stored[renamedKey][TEST_AUTO_BACKUP_RENAMED_FLAG]).toBe(true);
   });
 
   test('saveSetups keeps renamed auto backups when a new snapshot shares the label', () => {
     const renamedKey = 'auto-backup-2024-01-01-00-00-Project Alpha';
     const newKey = 'auto-backup-2024-02-01-00-00-Project Alpha';
     const setups = {
-      [renamedKey]: { camera: 'A', [AUTO_BACKUP_RENAMED_FLAG]: true },
+      [renamedKey]: { camera: 'A', [TEST_AUTO_BACKUP_RENAMED_FLAG]: true },
       [newKey]: { camera: 'A' },
     };
 


### PR DESCRIPTION
## Summary
- rename the auto-backup flag constants in modern scripts to scoped identifiers so multiple bundles no longer collide
- keep the shared flag value via the existing global property while preserving data integrity and backup metadata
- update unit tests to reflect the new scoped identifier name

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d5a155258c8320aa3187ffdcc3ca85