### PR TITLE
Refine mobile sidebar navigation drawer

### DIFF
--- a/index.html
+++ b/index.html
@@ -68,7 +68,7 @@
       </span>
       <h1 id="mainTitle">Cine Power Planner</h1>
     </a>
-    <button id="menuToggle" aria-label="Menu" aria-expanded="false">
+    <button id="menuToggle" aria-label="Menu" aria-expanded="false" aria-controls="sideMenu">
       <span class="icon-glyph" aria-hidden="true" data-icon-font="uicons">&#xE198;</span>
     </button>
     <div class="feature-search">
@@ -158,7 +158,25 @@
     </nav>
   </header>
 
-  <nav id="sideMenu" class="side-menu" aria-label="Sidebar navigation" hidden>
+  <nav
+    id="sideMenu"
+    class="side-menu"
+    aria-label="Sidebar navigation"
+    aria-labelledby="sideMenuTitle"
+    hidden
+  >
+    <div class="sidebar-header">
+      <h2 id="sideMenuTitle">Planner sections</h2>
+      <button
+        type="button"
+        id="closeMenuButton"
+        class="sidebar-close"
+        aria-label="Close menu"
+      >
+        <span id="closeMenuLabel" class="visually-hidden">Close navigation</span>
+        <span class="icon-glyph" aria-hidden="true" data-icon-font="uicons">&#xF131;</span>
+      </button>
+    </div>
     <div class="sidebar-controls"></div>
     <ul>
       <li><a href="#setup-manager" data-nav-key="setupManageHeading">Project Overview</a></li>

--- a/src/scripts/app-core.js
+++ b/src/scripts/app-core.js
@@ -3568,12 +3568,19 @@ function closeSideMenu() {
   const menu = document.getElementById('sideMenu');
   const overlay = document.getElementById('menuOverlay');
   const toggle = document.getElementById('menuToggle');
+  const body = typeof document !== 'undefined' ? document.body : null;
   if (!menu || !overlay || !toggle) return;
   menu.classList.remove('open');
+  menu.scrollTop = 0;
   menu.setAttribute('hidden', '');
   overlay.classList.add('hidden');
+  const menuLabel = toggle.dataset?.menuLabel || 'Menu';
+  const menuHelp = toggle.dataset?.menuHelp || menuLabel;
   toggle.setAttribute('aria-expanded', 'false');
-  toggle.setAttribute('aria-label', 'Menu');
+  toggle.setAttribute('aria-label', menuLabel);
+  toggle.setAttribute('title', menuLabel);
+  toggle.setAttribute('data-help', menuHelp);
+  body?.classList.remove('menu-open');
 }
 
 /**
@@ -3583,13 +3590,26 @@ function openSideMenu() {
   const menu = document.getElementById('sideMenu');
   const overlay = document.getElementById('menuOverlay');
   const toggle = document.getElementById('menuToggle');
+  const closeButton = document.getElementById('closeMenuButton');
+  const body = typeof document !== 'undefined' ? document.body : null;
   if (!menu || !overlay || !toggle) return;
   if (menu.classList.contains('open')) return;
   menu.classList.add('open');
   menu.removeAttribute('hidden');
   overlay.classList.remove('hidden');
   toggle.setAttribute('aria-expanded', 'true');
-  toggle.setAttribute('aria-label', 'Close menu');
+  const closeLabel =
+    toggle.dataset?.closeLabel ||
+    closeButton?.getAttribute('aria-label') ||
+    'Close menu';
+  const closeHelp =
+    toggle.dataset?.closeHelp ||
+    closeButton?.getAttribute('data-help') ||
+    closeLabel;
+  toggle.setAttribute('aria-label', closeLabel);
+  toggle.setAttribute('title', closeLabel);
+  toggle.setAttribute('data-help', closeHelp);
+  body?.classList.add('menu-open');
 }
 
 /**
@@ -3599,6 +3619,7 @@ function setupSideMenu() {
   const toggle = document.getElementById('menuToggle');
   const menu = document.getElementById('sideMenu');
   const overlay = document.getElementById('menuOverlay');
+  const closeButton = document.getElementById('closeMenuButton');
   if (!toggle || !menu || !overlay) return;
 
   toggle.addEventListener('click', () => {
@@ -3610,6 +3631,18 @@ function setupSideMenu() {
   });
 
   overlay.addEventListener('click', closeSideMenu);
+  closeButton?.addEventListener('click', () => {
+    closeSideMenu();
+    toggle.focus();
+  });
+  if (typeof window !== 'undefined' && typeof window.matchMedia === 'function') {
+    const mobileQuery = window.matchMedia('(max-width: 768px)');
+    mobileQuery.addEventListener('change', event => {
+      if (!event.matches && menu.classList.contains('open')) {
+        closeSideMenu();
+      }
+    });
+  }
   document.addEventListener('keydown', event => {
     if (event.key === 'Escape' && menu.classList.contains('open')) {
       closeSideMenu();
@@ -7085,10 +7118,20 @@ function setLanguage(lang) {
       texts.en?.menuToggleLabel ||
       menuToggle.getAttribute("aria-label") ||
       "Menu";
+    const closeLabel =
+      texts[lang].sideMenuClose ||
+      texts.en?.sideMenuClose ||
+      menuToggle.dataset.closeLabel ||
+      "Close menu";
+    const closeHelp = texts[lang].sideMenuCloseHelp || closeLabel;
     menuToggle.setAttribute("title", menuLabel);
     menuToggle.setAttribute("aria-label", menuLabel);
     const menuHelp = texts[lang].menuToggleHelp || menuLabel;
     menuToggle.setAttribute("data-help", menuHelp);
+    menuToggle.dataset.menuLabel = menuLabel;
+    menuToggle.dataset.menuHelp = menuHelp;
+    menuToggle.dataset.closeLabel = closeLabel;
+    menuToggle.dataset.closeHelp = closeHelp;
   }
   const sideMenu = document.getElementById("sideMenu");
   if (sideMenu) {
@@ -7097,6 +7140,35 @@ function setLanguage(lang) {
       sideMenu.setAttribute("data-help", sideMenuHelp);
     } else {
       sideMenu.removeAttribute("data-help");
+    }
+  }
+  const sideMenuTitle = document.getElementById("sideMenuTitle");
+  if (sideMenuTitle) {
+    const titleLabel =
+      texts[lang].sideMenuTitle ||
+      texts.en?.sideMenuTitle ||
+      sideMenuTitle.textContent;
+    sideMenuTitle.textContent = titleLabel;
+    const titleHelp =
+      texts[lang].sideMenuTitleHelp ||
+      texts[lang].sideMenuHelp ||
+      titleLabel;
+    sideMenuTitle.setAttribute("data-help", titleHelp);
+  }
+  const closeMenuButton = document.getElementById("closeMenuButton");
+  const closeMenuLabel = document.getElementById("closeMenuLabel");
+  if (closeMenuButton) {
+    const closeLabel =
+      texts[lang].sideMenuClose ||
+      texts.en?.sideMenuClose ||
+      closeMenuButton.getAttribute("aria-label") ||
+      "Close menu";
+    const closeHelp = texts[lang].sideMenuCloseHelp || closeLabel;
+    closeMenuButton.setAttribute("aria-label", closeLabel);
+    closeMenuButton.setAttribute("title", closeHelp);
+    closeMenuButton.setAttribute("data-help", closeHelp);
+    if (closeMenuLabel) {
+      closeMenuLabel.textContent = closeLabel;
     }
   }
   if (reloadButton) {

--- a/src/scripts/translations.js
+++ b/src/scripts/translations.js
@@ -87,6 +87,12 @@ const texts = {
     menuToggleLabel: "Menu",
     menuToggleHelp:
       "Open the sidebar to jump between planner sections or reveal controls on smaller screens. Click again to close it.",
+    sideMenuTitle: "Planner sections",
+    sideMenuTitleHelp:
+      "Swipe up to explore planner sections and mobile controls. Your project keeps saving automatically while you browse.",
+    sideMenuClose: "Close navigation",
+    sideMenuCloseHelp:
+      "Close the navigation drawer and return to the planner. Your data stays saved and ready to restore if needed.",
     sideMenuHelp:
       "Sidebar navigation listing planner sections. Select a section to scroll there and the menu closes automatically.",
     featureSearchPlaceholder: "Search features or devices...",
@@ -1340,6 +1346,12 @@ const texts = {
     menuToggleLabel: "Menu",
     menuToggleHelp:
       "Apri la barra laterale per raggiungere rapidamente le sezioni dell’app o mostrare i controlli sugli schermi piccoli. Premi di nuovo per chiuderla.",
+    sideMenuTitle: "Sezioni del planner",
+    sideMenuTitleHelp:
+      "Scorri per esplorare le sezioni e i controlli del planner sul telefono. Il progetto viene salvato automaticamente mentre navighi.",
+    sideMenuClose: "Chiudi navigazione",
+    sideMenuCloseHelp:
+      "Chiudi il pannello di navigazione e torna al planner. I tuoi dati restano salvati e pronti per il ripristino.",
     sideMenuHelp:
       "Navigazione laterale con le sezioni dell’app. Seleziona una sezione per scorrere fino a essa e chiudere automaticamente il menu.",
     featureSearchPlaceholder: "Cerca funzionalità o dispositivi...",
@@ -2576,6 +2588,12 @@ const texts = {
     menuToggleLabel: "Menú",
     menuToggleHelp:
       "Abre la barra lateral para saltar entre las secciones del planificador o mostrar los controles en pantallas pequeñas. Pulsa de nuevo para cerrarla.",
+    sideMenuTitle: "Secciones del planificador",
+    sideMenuTitleHelp:
+      "Desliza para explorar las secciones y controles del planificador en el móvil. El proyecto se guarda automáticamente mientras navegas.",
+    sideMenuClose: "Cerrar navegación",
+    sideMenuCloseHelp:
+      "Cierra el panel de navegación y vuelve al planificador. Tus datos permanecen guardados y listos para restaurarse.",
     sideMenuHelp:
       "Navegación lateral con las secciones del planificador. Elige una sección para desplazarte allí y cerrar automáticamente el menú.",
     featureSearchPlaceholder: "Buscar funciones o dispositivos...",
@@ -3825,6 +3843,12 @@ const texts = {
     menuToggleLabel: "Menu",
     menuToggleHelp:
       "Ouvre la barre latérale pour passer rapidement d’une section du planificateur à l’autre ou afficher les commandes sur les petits écrans. Cliquez de nouveau pour la fermer.",
+    sideMenuTitle: "Sections du planificateur",
+    sideMenuTitleHelp:
+      "Balayez pour explorer les sections et commandes du planificateur sur mobile. Le projet est enregistré automatiquement pendant la navigation.",
+    sideMenuClose: "Fermer la navigation",
+    sideMenuCloseHelp:
+      "Fermez le tiroir de navigation et retournez au planificateur. Vos données restent enregistrées et prêtes à être restaurées.",
     sideMenuHelp:
       "Navigation latérale listant les sections du planificateur. Choisissez une section pour y faire défiler la page et fermer automatiquement le menu.",
     featureSearchPlaceholder: "Rechercher des fonctionnalités ou des appareils...",
@@ -5085,6 +5109,12 @@ const texts = {
     menuToggleLabel: "Menü",
     menuToggleHelp:
       "Öffnet die Seitenleiste, um schnell zwischen den Planerbereichen zu wechseln oder die Bedienelemente auf kleinen Bildschirmen einzublenden. Nochmal klicken schließt sie wieder.",
+    sideMenuTitle: "Planerbereiche",
+    sideMenuTitleHelp:
+      "Wische, um die Planerbereiche und Steuerungen auf dem Mobilgerät zu erkunden. Dein Projekt wird beim Navigieren automatisch gespeichert.",
+    sideMenuClose: "Navigation schließen",
+    sideMenuCloseHelp:
+      "Schließe den Navigationsbereich und kehre zum Planer zurück. Deine Daten bleiben gesichert und jederzeit wiederherstellbar.",
     sideMenuHelp:
       "Seitenleiste mit den Bereichen des Planers. Wähle einen Bereich aus, um dorthin zu scrollen; das Menü schließt sich dabei automatisch.",
     featureSearchPlaceholder: "Funktionen oder Geräte durchsuchen...",

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -6759,6 +6759,42 @@ body.dark-mode.pink-mode #gearListOutput h2,
   font-size: calc(var(--font-size-relative-base) * var(--font-scale-xxxl));
 }
 
+#sideMenu .sidebar-header {
+  display: none;
+}
+
+#sideMenuTitle {
+  font-size: calc(var(--font-size-relative-base) * var(--font-scale-xl));
+  margin: 0;
+}
+
+#sideMenu .sidebar-close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 6px;
+  border: none;
+  background: none;
+  color: var(--text-color);
+  font: inherit;
+  cursor: pointer;
+  border-radius: 8px;
+  min-width: 44px;
+  min-height: 44px;
+}
+
+#sideMenu .sidebar-close:hover {
+  color: var(--accent-color);
+  background: color-mix(in srgb, var(--accent-color) 12%, transparent);
+}
+
+#sideMenu .sidebar-close:focus-visible {
+  outline: 2px solid var(--accent-color);
+  outline-offset: 2px;
+  background: color-mix(in srgb, var(--accent-color) 16%, transparent);
+}
+
 #sideMenu {
   position: fixed;
   top: 0;
@@ -6878,6 +6914,85 @@ body.pink-mode,
   border-color: var(--accent-color);
 }
 
+@media (max-width: 768px) {
+  body.menu-open {
+    overflow: hidden;
+  }
+
+  #sideMenu {
+    left: 0;
+    right: 0;
+    bottom: 0;
+    top: auto;
+    width: auto;
+    max-width: 100%;
+    max-height: min(80vh, 640px);
+    border-radius: 18px 18px 0 0;
+    box-shadow: 0 -6px 24px rgba(0, 0, 0, 0.35);
+    transform: translateY(100%);
+    padding: clamp(16px, 5vw, 28px);
+    padding-bottom: clamp(20px, 6vw, 32px);
+    overflow-y: auto;
+  }
+
+  #sideMenu.open {
+    transform: translateY(0);
+  }
+
+  #sideMenu .sidebar-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    margin-bottom: clamp(12px, 3vw, 18px);
+  }
+
+  #sideMenuTitle {
+    font-size: calc(var(--font-size-relative-base) * var(--font-scale-lg));
+  }
+
+  #sideMenu .sidebar-controls {
+    margin-bottom: clamp(12px, 3vw, 18px);
+  }
+
+  #sideMenu ul {
+    border: none;
+    border-radius: 14px;
+    padding: clamp(8px, 3vw, 12px) clamp(4px, 2vw, 8px);
+    background: var(--background-color);
+    box-shadow: inset 0 0 0 1px var(--panel-border);
+  }
+
+  #sideMenu li + li {
+    border-top: 1px solid var(--panel-border);
+  }
+
+  body.light-mode #sideMenu ul {
+    background: color-mix(in srgb, var(--surface-color) 92%, white 8%);
+  }
+
+  body.light-mode #sideMenu li + li {
+    border-top: 1px solid color-mix(in srgb, var(--panel-border) 75%, transparent);
+  }
+
+  body.dark-mode #sideMenu ul,
+  .dark-mode #sideMenu ul {
+    background: color-mix(in srgb, var(--surface-color) 78%, black 22%);
+  }
+
+  body.dark-mode #sideMenu li + li,
+  .dark-mode #sideMenu li + li {
+    border-top: 1px solid color-mix(in srgb, var(--panel-border) 65%, transparent);
+  }
+}
+
+@media (max-width: 768px) and (prefers-reduced-motion: reduce) {
+  #sideMenu,
+  #sideMenu.open {
+    transition: none;
+  }
+}
+
 #menuOverlay {
   position: fixed;
   top: 0;
@@ -6889,12 +7004,30 @@ body.pink-mode,
 }
 
 @supports (padding: env(safe-area-inset-top)) {
-  #sideMenu {
-    padding:
-      calc(var(--page-padding) + 10px + env(safe-area-inset-top))
-      calc(var(--page-padding) + 10px + env(safe-area-inset-right))
-      calc(var(--page-padding) + 10px + env(safe-area-inset-bottom))
-      calc(var(--page-padding) + 20px + env(safe-area-inset-left));
+  @media (min-width: 769px) {
+    #sideMenu {
+      padding:
+        calc(var(--page-padding) + 10px + env(safe-area-inset-top))
+        calc(var(--page-padding) + 10px + env(safe-area-inset-right))
+        calc(var(--page-padding) + 10px + env(safe-area-inset-bottom))
+        calc(var(--page-padding) + 20px + env(safe-area-inset-left));
+    }
+  }
+
+  @media (max-width: 768px) {
+    #sideMenu {
+      padding-top: calc(clamp(16px, 5vw, 28px) + env(safe-area-inset-top));
+      padding-right: calc(clamp(16px, 5vw, 28px) + env(safe-area-inset-right));
+      padding-left: calc(clamp(16px, 5vw, 28px) + env(safe-area-inset-left));
+    }
+  }
+}
+
+@supports (padding: env(safe-area-inset-bottom)) {
+  @media (max-width: 768px) {
+    #sideMenu {
+      padding-bottom: calc(clamp(20px, 6vw, 32px) + env(safe-area-inset-bottom));
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- convert the mobile sidebar into a bottom navigation drawer with a dedicated header and close control
- update sidebar toggle logic to manage scroll locking, localization and close button handling
- refresh translations and styling so the drawer matches dark/light themes and mobile safe areas

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d5a1d0a334832098668a10da515a9f