### PR TITLE
Add persistent storage status card

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -232,6 +232,7 @@ Dieser kurze Ablauf sollte bei neuen Teammitgliedern, frisch eingerichteten Work
 ## Daten- & Speicherübersicht
 
 - **Einstellungen → Daten & Speicher** listet gespeicherte Projekte, Auto-Backups, Gerätelisten, Custom-Geräte, Favoriten, Laufzeitfeedback und Session-Cache mit Live-Zahlen.
+- Eine **Speicherschutz**-Karte zeigt, ob der Browser dauerhaften Speicher gewährt hat und erlaubt eine erneute Anfrage, damit Teams den Schutz vor dem Offline-Einsatz absichern können.
 - Einträge erklären ihre Inhalte; leere Bereiche bleiben verborgen, damit du den Zustand sofort siehst.
 - Die Übersicht schätzt die Backup-Größe basierend auf dem jüngsten Export.
 

--- a/README.en.md
+++ b/README.en.md
@@ -480,6 +480,9 @@ Use Cine Power Planner end-to-end with the following routine:
   the current device—saved projects, timestamped auto backups, gear list
   snapshots, custom devices, favorites, runtime feedback and the unsaved session
   cache all appear with live counts.
+- A **Storage protection** card shows whether the browser granted persistent
+  storage and provides a retry button when approval is pending so crews can lock
+  data retention before going offline.
 - Each entry clarifies what it represents and, when relevant, lists affected
   categories or whether the session data is currently stored. Empty sections stay
   hidden so you know at a glance when the planner is pristine.

--- a/README.es.md
+++ b/README.es.md
@@ -232,6 +232,7 @@ Repite esta rutina cuando se incorpore personal, se prepare una estación nueva 
 ## Resumen de datos y almacenamiento
 
 - Abre **Configuración → Datos y almacenamiento** para revisar proyectos, auto-backups, listas, dispositivos personalizados, favoritos, comentarios y la caché de sesión con recuentos en vivo.
+- Una tarjeta de **Protección de almacenamiento** indica si el navegador concedió almacenamiento persistente y permite volver a solicitarlo cuando falta aprobación, de modo que el equipo asegure la retención antes de trabajar sin conexión.
 - Cada entrada explica qué representa; las secciones vacías permanecen ocultas para que identifiques el estado rápidamente.
 - El resumen estima el tamaño del backup usando la exportación más reciente.
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -232,6 +232,7 @@ Cette routine prouve que sauvegarde, partage, import, backup et restauration fon
 ## Vue d’ensemble des données et du stockage
 
 - Ouvrez **Paramètres → Données & stockage** pour consulter projets, auto-backups, listes, équipements personnalisés, favoris, retours et cache de session avec des compteurs en temps réel.
+- Une carte **Protection du stockage** indique si le navigateur a accordé un stockage persistant et permet de renouveler la demande lorsque l’accès est en attente, afin de sécuriser les données avant de travailler hors ligne.
 - Chaque section précise son contenu ; les sections vides restent masquées pour identifier rapidement l’état du planner.
 - Le résumé estime la taille d’un backup à partir de la dernière exportation.
 

--- a/README.it.md
+++ b/README.it.md
@@ -232,6 +232,7 @@ Ripeti questa routine quando arriva un nuovo membro, allestisci una postazione o
 ## Panoramica dati e archiviazione
 
 - Apri **Impostazioni → Dati e archiviazione** per vedere progetti salvati, auto-backup, liste, dispositivi personalizzati, preferiti, feedback e cache di sessione con conteggi in tempo reale.
+- Una scheda **Protezione dell’archiviazione** indica se il browser ha concesso l’archiviazione persistente e permette di richiederla di nuovo quando serve approvazione, così il team mette al sicuro i dati prima di lavorare offline.
 - Ogni sezione descrive il proprio contenuto; quelle vuote restano nascoste per riconoscere subito lo stato del planner.
 - Il riepilogo stima la dimensione del backup basandosi sull’export più recente.
 

--- a/README.md
+++ b/README.md
@@ -485,6 +485,9 @@ Use Cine Power Planner end-to-end with the following routine:
   the current device—saved projects, timestamped auto backups, gear list
   snapshots, custom devices, favorites, runtime feedback and the unsaved session
   cache all appear with live counts.
+- A **Storage protection** card shows whether the browser granted persistent
+  storage and provides a retry button when approval is pending so crews can lock
+  data retention before going offline.
 - Each entry clarifies what it represents and, when relevant, lists affected
   categories or whether the session data is currently stored. Empty sections stay
   hidden so you know at a glance when the planner is pristine.

--- a/docs/offline-readiness.md
+++ b/docs/offline-readiness.md
@@ -27,7 +27,8 @@ time:
    timestamped `auto-backup-…` snapshot once the autosave routine runs. Open **Settings →
    Backup & Restore** to confirm the autosave status overlay reflects the same timestamp,
    then review **Settings → Data & Storage** to verify project, backup and gear counts
-   updated as expected.
+   updated as expected. Confirm the **Storage protection** card reports a granted state
+   (or retry the request) so eviction-safe storage stays active for the trip.
 4. **Capture baseline exports.** While still offline, export both a planner backup
    (`planner-backup.json`) and a project bundle (`project-name.json`). Import the files into
    a private browser profile that also stays offline. Once you confirm the restore loop

--- a/docs/operations-checklist.md
+++ b/docs/operations-checklist.md
@@ -36,7 +36,9 @@ update the repository or hand off a project at the end of the day.
    removals and scenario scope changes are confirmed without touching live
    storage. Delete the temporary profile after confirmation.
 5. **Review data & storage dashboard.** Open **Settings → Data & Storage** to
-   ensure counts for projects, backups and custom devices match expectations.
+   ensure counts for projects, backups and custom devices match expectations and
+   confirm the **Storage protection** card is green or re-request persistence if
+   needed.
 6. **Check draft impact preview.** Open the automatic gear rule editor, review
    the draft impact preview for quantity deltas and warnings, then cancel to
    confirm the live generator stays unchanged.

--- a/docs/testing-plan.md
+++ b/docs/testing-plan.md
@@ -50,7 +50,9 @@ you prepare a release candidate or validate a workstation:
    **Settings → Backup & Restore** and ensure the autosave status overlay mirrors
    the same timestamp before continuing.
 3. **Inspect data inventory.** Visit **Settings → Data & Storage** to confirm
-   project, backup, gear list and custom device counts match expectations. This
+   project, backup, gear list and custom device counts match expectations. Check
+   the **Storage protection** card for a granted state (or trigger another
+   request) so the browser locks planner data before you leave the network. This
    step catches storage issues before they risk user data.
 4. **Exercise backups and bundles.** Export a planner backup and a
    `project-name.json` bundle, import both into an offline private profile and

--- a/index.html
+++ b/index.html
@@ -2088,6 +2088,29 @@
         </p>
         <ul id="storageSummaryList" class="storage-summary" aria-live="polite"></ul>
         <p id="storageSummaryEmpty" class="storage-summary-note" hidden>No planner data stored yet.</p>
+        <section
+          id="storagePersistenceSection"
+          class="storage-persistence"
+          aria-live="polite"
+        >
+          <h4 id="storagePersistenceHeading">Storage protection</h4>
+          <p id="storagePersistenceStatus" class="storage-persistence-status">
+            Checking storage protection…
+          </p>
+          <div class="storage-persistence-actions">
+            <button
+              type="button"
+              id="storagePersistenceRequest"
+              data-feature-search="true"
+              data-feature-search-keywords="storage persistent quota data eviction"
+            >
+              Request persistent storage
+            </button>
+          </div>
+          <p id="storagePersistenceHelp" class="storage-summary-note">
+            Persistent storage asks the browser not to clear planner data automatically.
+          </p>
+        </section>
         <p id="storageSummaryFootnote" class="storage-summary-note">
           Backups export each entry as human-readable JSON.
         </p>

--- a/src/scripts/translations.js
+++ b/src/scripts/translations.js
@@ -636,6 +636,24 @@ const texts = {
     storageSummaryFootnote:
       "Backups download human-readable JSON with each entry.",
     storageSummaryEmpty: "No planner data is currently stored.",
+    storagePersistenceHeading: "Storage protection",
+    storagePersistenceHelp:
+      "Persistent storage asks the browser not to clear planner data automatically.",
+    storagePersistenceStatusChecking: "Checking storage protection…",
+    storagePersistenceStatusGranted:
+      "Persistent storage is active. The browser keeps planner data even when space runs low.",
+    storagePersistenceStatusPrompt:
+      "Request persistent storage so the browser keeps planner data safe from automatic clearing.",
+    storagePersistenceStatusDenied:
+      "Persistent storage is unavailable or was declined. Keep manual backups and try again after freeing space.",
+    storagePersistenceStatusUnsupported:
+      "This browser cannot lock planner data in persistent storage. Maintain external backups.",
+    storagePersistenceStatusError:
+      "Unable to confirm persistent storage. Keep manual backups and try again.",
+    storagePersistenceRequest: "Request persistent storage",
+    storagePersistenceRequestRetry: "Try again",
+    storagePersistenceRequestWorking: "Requesting…",
+    storagePersistenceRequestGranted: "Persistent storage granted",
     storageKeyProjects: "Saved projects",
     storageKeyProjectsDesc: "Configurations saved from Manage Project.",
     storageProjectsCountOne: "%s project",
@@ -2307,6 +2325,24 @@ const texts = {
     storageSummaryFootnote:
       "I backup scaricano ogni voce in JSON leggibile.",
     storageSummaryEmpty: "Nessun dato dell’app è attualmente salvato.",
+    storagePersistenceHeading: "Protezione dell’archiviazione",
+    storagePersistenceHelp:
+      "L’archiviazione persistente chiede al browser di non cancellare automaticamente i dati del planner.",
+    storagePersistenceStatusChecking: "Verifica della protezione dell’archiviazione…",
+    storagePersistenceStatusGranted:
+      "L’archiviazione persistente è attiva. Il browser conserva i dati del planner anche quando lo spazio libero è ridotto.",
+    storagePersistenceStatusPrompt:
+      "Richiedi l’archiviazione persistente per mantenere al sicuro i dati del planner da cancellazioni automatiche.",
+    storagePersistenceStatusDenied:
+      "L’archiviazione persistente non è disponibile o è stata rifiutata. Esegui backup manuali e riprova dopo aver liberato spazio.",
+    storagePersistenceStatusUnsupported:
+      "Questo browser non può bloccare i dati del planner in archiviazione persistente. Mantieni backup esterni.",
+    storagePersistenceStatusError:
+      "Impossibile confermare la protezione dell’archiviazione. Esegui backup manuali e riprova.",
+    storagePersistenceRequest: "Richiedi archiviazione persistente",
+    storagePersistenceRequestRetry: "Richiedi di nuovo",
+    storagePersistenceRequestWorking: "Richiesta in corso…",
+    storagePersistenceRequestGranted: "Archiviazione persistente concessa",
     storageKeyProjects: "Progetti salvati",
     storageKeyProjectsDesc: "Configurazioni salvate da Gestione progetto.",
     storageProjectsCountOne: "%s progetto",
@@ -3555,6 +3591,24 @@ const texts = {
     storageSummaryFootnote:
       "Las copias de seguridad descargan cada elemento en JSON legible.",
     storageSummaryEmpty: "No hay datos del planificador guardados actualmente.",
+    storagePersistenceHeading: "Protección de almacenamiento",
+    storagePersistenceHelp:
+      "El almacenamiento persistente pide al navegador que no borre los datos del planificador automáticamente.",
+    storagePersistenceStatusChecking: "Comprobando la protección de almacenamiento…",
+    storagePersistenceStatusGranted:
+      "El almacenamiento persistente está activo. El navegador conserva los datos del planificador incluso cuando queda poco espacio.",
+    storagePersistenceStatusPrompt:
+      "Solicita almacenamiento persistente para que el navegador mantenga los datos del planificador a salvo de borrados automáticos.",
+    storagePersistenceStatusDenied:
+      "El almacenamiento persistente no está disponible o fue rechazado. Haz copias de seguridad manuales y vuelve a intentarlo tras liberar espacio.",
+    storagePersistenceStatusUnsupported:
+      "Este navegador no puede bloquear los datos del planificador en almacenamiento persistente. Mantén copias de seguridad externas.",
+    storagePersistenceStatusError:
+      "No se pudo confirmar la protección de almacenamiento. Haz copias de seguridad manuales e inténtalo de nuevo.",
+    storagePersistenceRequest: "Solicitar almacenamiento persistente",
+    storagePersistenceRequestRetry: "Volver a solicitar",
+    storagePersistenceRequestWorking: "Solicitando…",
+    storagePersistenceRequestGranted: "Almacenamiento persistente concedido",
     storageKeyProjects: "Proyectos guardados",
     storageKeyProjectsDesc: "Configuraciones guardadas desde Gestionar proyecto.",
     storageProjectsCountOne: "%s proyecto",
@@ -4813,6 +4867,24 @@ const texts = {
     storageSummaryFootnote:
       "Les sauvegardes téléchargent chaque élément en JSON lisible.",
     storageSummaryEmpty: "Aucune donnée du planificateur n'est actuellement enregistrée.",
+    storagePersistenceHeading: "Protection du stockage",
+    storagePersistenceHelp:
+      "Le stockage persistant demande au navigateur de ne pas effacer automatiquement les données du planificateur.",
+    storagePersistenceStatusChecking: "Vérification de la protection du stockage…",
+    storagePersistenceStatusGranted:
+      "Le stockage persistant est actif. Le navigateur conserve les données du planificateur même lorsque l’espace libre diminue.",
+    storagePersistenceStatusPrompt:
+      "Demandez un stockage persistant pour éviter que le navigateur n’efface les données du planificateur.",
+    storagePersistenceStatusDenied:
+      "Le stockage persistant est indisponible ou a été refusé. Réalisez des sauvegardes manuelles et réessayez après avoir libéré de l’espace.",
+    storagePersistenceStatusUnsupported:
+      "Ce navigateur ne peut pas verrouiller les données du planificateur dans un stockage persistant. Conservez des sauvegardes externes.",
+    storagePersistenceStatusError:
+      "Impossible de confirmer la protection du stockage. Réalisez des sauvegardes manuelles puis réessayez.",
+    storagePersistenceRequest: "Demander le stockage persistant",
+    storagePersistenceRequestRetry: "Redemander",
+    storagePersistenceRequestWorking: "Demande en cours…",
+    storagePersistenceRequestGranted: "Stockage persistant accordé",
     storageKeyProjects: "Projets enregistrés",
     storageKeyProjectsDesc: "Configurations enregistrées depuis Gestion du projet.",
     storageProjectsCountOne: "%s projet",
@@ -6077,6 +6149,24 @@ const texts = {
     storageSummaryFootnote:
       "Backups laden jede Position als gut lesbares JSON herunter.",
     storageSummaryEmpty: "Derzeit sind keine Planer-Daten gespeichert.",
+    storagePersistenceHeading: "Speicherschutz",
+    storagePersistenceHelp:
+      "Dauerhafter Speicher sorgt dafür, dass der Browser Planerdaten nicht automatisch löscht.",
+    storagePersistenceStatusChecking: "Speicherschutz wird geprüft…",
+    storagePersistenceStatusGranted:
+      "Dauerhafter Speicher ist aktiv. Der Browser behält Planerdaten auch bei wenig freiem Speicher.",
+    storagePersistenceStatusPrompt:
+      "Fordern Sie dauerhaften Speicher an, damit der Browser Planerdaten vor automatischem Löschen schützt.",
+    storagePersistenceStatusDenied:
+      "Dauerhafter Speicher ist nicht verfügbar oder wurde abgelehnt. Erstellen Sie manuelle Sicherungen und versuchen Sie es nach etwas freiem Speicher erneut.",
+    storagePersistenceStatusUnsupported:
+      "Dieser Browser kann Planerdaten nicht dauerhaft speichern. Verlassen Sie sich auf externe Sicherungen.",
+    storagePersistenceStatusError:
+      "Speicherschutz konnte nicht bestätigt werden. Erstellen Sie manuelle Sicherungen und versuchen Sie es erneut.",
+    storagePersistenceRequest: "Dauerhaften Speicher anfordern",
+    storagePersistenceRequestRetry: "Erneut anfordern",
+    storagePersistenceRequestWorking: "Anfrage läuft…",
+    storagePersistenceRequestGranted: "Dauerhafter Speicher gewährt",
     storageKeyProjects: "Gespeicherte Projekte",
     storageKeyProjectsDesc: "Konfigurationen aus Projekt verwalten.",
     storageProjectsCountOne: "%s Projekt",

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -3146,6 +3146,54 @@ body.pink-mode:not(.dark-mode) #settingsPanel-autoGear .auto-gear-rule-items-lab
   padding-left: 0;
 }
 
+.storage-persistence {
+  margin-top: 20px;
+  padding: 12px;
+  border-radius: 10px;
+  border: 1px solid var(--panel-border);
+  background: color-mix(in srgb, var(--surface-color) 94%, var(--panel-bg) 6%);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.storage-persistence-status {
+  margin: 0;
+  font-weight: var(--font-weight-medium);
+}
+
+.storage-persistence-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--cluster-gap);
+}
+
+.storage-persistence button[disabled] {
+  opacity: 0.65;
+  cursor: not-allowed;
+}
+
+.storage-persistence--granted {
+  border-color: color-mix(in srgb, var(--success-color) 55%, var(--panel-border) 45%);
+  background: color-mix(in srgb, var(--surface-color) 88%, var(--success-color) 12%);
+}
+
+.storage-persistence--warning {
+  border-color: color-mix(in srgb, var(--warning-color) 55%, var(--panel-border) 45%);
+  background: color-mix(in srgb, var(--surface-color) 92%, var(--warning-color) 8%);
+}
+
+.storage-persistence--error {
+  border-color: color-mix(in srgb, var(--danger-color) 55%, var(--panel-border) 45%);
+  background: color-mix(in srgb, var(--surface-color) 90%, var(--danger-color) 10%);
+}
+
+.storage-persistence--unsupported {
+  border-style: dashed;
+  opacity: 0.85;
+}
+
 .settings-content .button-row {
   display: flex;
   gap: var(--cluster-gap);


### PR DESCRIPTION
## Summary
- add a Storage protection card to Settings → Data & Storage so crews can verify and re-request persistent storage before going offline
- implement persistent storage status helpers, UI state handling and localization for all supported languages
- document the new workflow in the multilingual READMEs and operational guides

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d5a18123dc8320bfa7c43001461d18