### PR TITLE
Adjust mobile button spacing in project overview

### DIFF
--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -1120,7 +1120,7 @@ main.legal-content {
   #setup-config .form-row:not(.form-row-actions) > button:not(.clear-input-btn):not(.favorite-toggle) {
     flex: 1 0 100%;
     width: 100%;
-    margin: 5px 0 0 0;
+    margin: var(--gap-size) 0 0 0;
   }
   #setup-manager .form-row.form-row-actions {
     flex-direction: column;
@@ -5690,12 +5690,12 @@ body.dark-mode.dark-accent-boost:not(.pink-mode) .settings-content.modal-surface
 
   .form-row > button {
     width: 100%;
-    margin: 5px 0 0 0;
+    margin: var(--gap-size) 0 0 0;
   }
 
   .form-row > button + button {
     margin-left: 0;
-    margin-top: 5px;
+    margin-top: var(--gap-size);
   }
 
   .share-import-group {


### PR DESCRIPTION
## Summary
- align the stacked project overview action buttons on small screens by reusing the global gap spacing
- ensure consecutive project overview buttons keep the same vertical separation when the layout stacks in a column

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d5c2767e848320bdfe67581e539071