### PR TITLE
Fix runtime integration loading and stabilize tests

### DIFF
--- a/docs/documentation-maintenance.md
+++ b/docs/documentation-maintenance.md
@@ -14,6 +14,11 @@ workflow diagrams and troubleshooting notes to reference the registered controll
 interactions and help entries so offline operators can cross-check the exact button or
 dialog names documented in code.【F:src/scripts/modules/ui.js†L1-L192】
 
+The new integration suite (`tests/dom/runtimeIntegration.test.js`) ensures these modules
+continue to cooperate. When updating help text or translations, keep the assertions in that
+test in mind—they describe the critical APIs (`cineOffline`, `cinePersistence`, `cineUi`) that
+must remain available to avoid data loss.【F:tests/dom/runtimeIntegration.test.js†L1-L51】
+
 ## 1. Identify every surface that needs an update
 
 1. **Help dialog topics.** Review contextual help entries, FAQ answers and hover-help copy in

--- a/docs/modularization/step-5-integration.md
+++ b/docs/modularization/step-5-integration.md
@@ -1,0 +1,29 @@
+# Step 5 – Integration, Testing & Documentation Pass
+
+The final stage verifies that the newly modularised services operate together without
+regressing the offline-first promises of the Camera Power Planner. Rather than introducing
+another coordinator layer, we exercise the existing modules in a single integration suite so
+future refactors catch mismatches immediately.
+
+## Runtime integration checks
+
+* `tests/dom/runtimeIntegration.test.js` boots the application runtime inside the
+  Jest + jsdom environment. The test asserts that `cineOffline`, `cinePersistence` and
+  `cineUi` are all exposed with the APIs needed to reload the planner, persist projects,
+  create backups and apply shared setups.【F:tests/dom/runtimeIntegration.test.js†L1-L51】
+* The integration suite also confirms that the Node-oriented bundle (`script.js`) continues to
+  export the helpers used by existing tests (`collectProjectFormData`, backup utilities and
+  sharing helpers). This guards the split core from accidentally dropping functionality when
+  the bundling strategy evolves.【F:tests/dom/runtimeIntegration.test.js†L35-L51】【F:tests/helpers/runtimeLoader.js†L1-L36】
+
+## Documentation updates
+
+* `docs/documentation-maintenance.md` references the integration suite so contributors keep
+  the new coverage in mind while updating help or translation content.
+* `docs/testing-plan.md` highlights the runtime integration test in the “What still runs by
+  default” section, pairing it with the existing regression drills.
+
+These additions close the modularisation plan by proving that the persistence, offline and
+UI modules cooperate in a single runtime session. The integration test now acts as a
+sentinel—any future change that risks data loss, breaks backups or hides sharing workflows
+will fail quickly, keeping the offline crews protected.

--- a/docs/testing-plan.md
+++ b/docs/testing-plan.md
@@ -19,6 +19,9 @@ exploratory testing without risking data loss.
 * **Critical DOM flows** – The DOM project still executes tests that exercise
   autosave, sharing, deleting, and loading project data to ensure users never lose their
   work, even while offline.
+* **Runtime integration guard** – `tests/dom/runtimeIntegration.test.js` boots the modular
+  runtime and verifies that `cineOffline`, `cinePersistence` and `cineUi` expose the
+  workflows required for saving, sharing, importing, backing up and restoring data.
 * **Runtime and backup automation (opt-in)** – Heavyweight script-level tests are now
   opt-in. Setting `RUN_HEAVY_TESTS=true` before invoking Jest will re-enable the
   integration suite that exercises the modular runtime loader, backup/restore flows,

--- a/src/scripts/app-events.js
+++ b/src/scripts/app-events.js
@@ -55,7 +55,7 @@ function resolveCineUi() {
   return null;
 }
 
-const cineUi = resolveCineUi();
+const eventsCineUi = resolveCineUi();
 
 // Language selection
 languageSelect.addEventListener("change", (event) => {
@@ -958,10 +958,10 @@ if (toggleDeviceBtn) {
   toggleDeviceBtn.addEventListener('click', toggleDeviceManagerSection);
 }
 
-if (cineUi) {
+if (eventsCineUi) {
   try {
-    if (cineUi.controllers && typeof cineUi.controllers.register === 'function') {
-      cineUi.controllers.register('deviceManagerSection', {
+    if (eventsCineUi.controllers && typeof eventsCineUi.controllers.register === 'function') {
+      eventsCineUi.controllers.register('deviceManagerSection', {
         show: showDeviceManagerSection,
         hide: hideDeviceManagerSection,
         toggle: toggleDeviceManagerSection,
@@ -972,17 +972,17 @@ if (cineUi) {
   }
 
   try {
-    if (cineUi.interactions && typeof cineUi.interactions.register === 'function') {
-      cineUi.interactions.register('saveSetup', handleSaveSetupClick);
-      cineUi.interactions.register('deleteSetup', handleDeleteSetupClick);
+    if (eventsCineUi.interactions && typeof eventsCineUi.interactions.register === 'function') {
+      eventsCineUi.interactions.register('saveSetup', handleSaveSetupClick);
+      eventsCineUi.interactions.register('deleteSetup', handleDeleteSetupClick);
     }
   } catch (error) {
     console.warn('cineUi interaction registration failed', error);
   }
 
   try {
-    if (cineUi.help && typeof cineUi.help.register === 'function') {
-      cineUi.help.register('saveSetup', () => {
+    if (eventsCineUi.help && typeof eventsCineUi.help.register === 'function') {
+      eventsCineUi.help.register('saveSetup', () => {
         const langTexts = texts[currentLang] || {};
         const fallbackTexts = texts.en || {};
         return (
@@ -992,7 +992,7 @@ if (cineUi) {
         );
       });
 
-      cineUi.help.register('autoBackupBeforeDeletion', () => {
+      eventsCineUi.help.register('autoBackupBeforeDeletion', () => {
         const langTexts = texts[currentLang] || {};
         const fallbackTexts = texts.en || {};
         return (

--- a/src/scripts/app-session.js
+++ b/src/scripts/app-session.js
@@ -31,7 +31,7 @@
 /* global getDiagramManualPositions, setManualDiagramPositions,
           normalizeDiagramPositionsInput, ensureAutoBackupsFromProjects */
 
-const cineUi =
+const sessionCineUi =
   (typeof globalThis !== 'undefined' && globalThis.cineUi)
   || (typeof window !== 'undefined' && window.cineUi)
   || (typeof self !== 'undefined' && self.cineUi)
@@ -6562,14 +6562,14 @@ if (restoreSettings && restoreSettingsInput) {
   restoreSettingsInput.addEventListener('change', handleRestoreSettingsInputChange);
 }
 
-if (cineUi) {
+if (sessionCineUi) {
   try {
-    if (cineUi.controllers && typeof cineUi.controllers.register === 'function') {
-      cineUi.controllers.register('backupSettings', {
+    if (sessionCineUi.controllers && typeof sessionCineUi.controllers.register === 'function') {
+      sessionCineUi.controllers.register('backupSettings', {
         execute: createSettingsBackup,
       });
 
-      cineUi.controllers.register('restoreSettings', {
+      sessionCineUi.controllers.register('restoreSettings', {
         openPicker: handleRestoreSettingsClick,
         processFile: handleRestoreSettingsInputChange,
       });
@@ -6579,18 +6579,18 @@ if (cineUi) {
   }
 
   try {
-    if (cineUi.interactions && typeof cineUi.interactions.register === 'function') {
-      cineUi.interactions.register('performBackup', createSettingsBackup);
-      cineUi.interactions.register('openRestorePicker', handleRestoreSettingsClick);
-      cineUi.interactions.register('applyRestoreFile', handleRestoreSettingsInputChange);
+    if (sessionCineUi.interactions && typeof sessionCineUi.interactions.register === 'function') {
+      sessionCineUi.interactions.register('performBackup', createSettingsBackup);
+      sessionCineUi.interactions.register('openRestorePicker', handleRestoreSettingsClick);
+      sessionCineUi.interactions.register('applyRestoreFile', handleRestoreSettingsInputChange);
     }
   } catch (error) {
     console.warn('cineUi interaction registration (session) failed', error);
   }
 
   try {
-    if (cineUi.help && typeof cineUi.help.register === 'function') {
-      cineUi.help.register('backupSettings', () => {
+    if (sessionCineUi.help && typeof sessionCineUi.help.register === 'function') {
+      sessionCineUi.help.register('backupSettings', () => {
         const langTexts = texts[currentLang] || {};
         const fallbackTexts = texts.en || {};
         return (
@@ -6600,7 +6600,7 @@ if (cineUi) {
         );
       });
 
-      cineUi.help.register('restoreSettings', () => {
+      sessionCineUi.help.register('restoreSettings', () => {
         const langTexts = texts[currentLang] || {};
         const fallbackTexts = texts.en || {};
         return (

--- a/src/scripts/app-setups.js
+++ b/src/scripts/app-setups.js
@@ -6,7 +6,7 @@
 
 // --- NEW SETUP MANAGEMENT FUNCTIONS ---
 
-const cineUi =
+const setupsCineUi =
   (typeof globalThis !== 'undefined' && globalThis.cineUi)
   || (typeof window !== 'undefined' && window.cineUi)
   || (typeof self !== 'undefined' && self.cineUi)
@@ -434,17 +434,17 @@ if (sharedImportDialog) {
   sharedImportDialog.addEventListener('cancel', handleSharedImportDialogCancel);
 }
 
-if (cineUi) {
+if (setupsCineUi) {
   try {
-    if (cineUi.controllers && typeof cineUi.controllers.register === 'function') {
-      cineUi.controllers.register('shareDialog', {
+    if (setupsCineUi.controllers && typeof setupsCineUi.controllers.register === 'function') {
+      setupsCineUi.controllers.register('shareDialog', {
         open: handleShareSetupClick,
         submit: handleShareFormSubmit,
         cancel: handleShareCancelClick,
         dismiss: handleShareDialogCancel,
       });
 
-      cineUi.controllers.register('sharedImportDialog', {
+      setupsCineUi.controllers.register('sharedImportDialog', {
         submit: handleSharedImportSubmit,
         cancel: handleSharedImportCancel,
         dismiss: handleSharedImportDialogCancel,
@@ -456,22 +456,22 @@ if (cineUi) {
   }
 
   try {
-    if (cineUi.interactions && typeof cineUi.interactions.register === 'function') {
-      cineUi.interactions.register('shareOpen', handleShareSetupClick);
-      cineUi.interactions.register('shareSubmit', handleShareFormSubmit);
-      cineUi.interactions.register('shareCancel', handleShareCancelClick);
-      cineUi.interactions.register('shareApplyFile', handleApplySharedLinkClick);
-      cineUi.interactions.register('shareInputChange', handleSharedLinkInputChange);
-      cineUi.interactions.register('sharedImportSubmit', handleSharedImportSubmit);
-      cineUi.interactions.register('sharedImportCancel', handleSharedImportCancel);
+    if (setupsCineUi.interactions && typeof setupsCineUi.interactions.register === 'function') {
+      setupsCineUi.interactions.register('shareOpen', handleShareSetupClick);
+      setupsCineUi.interactions.register('shareSubmit', handleShareFormSubmit);
+      setupsCineUi.interactions.register('shareCancel', handleShareCancelClick);
+      setupsCineUi.interactions.register('shareApplyFile', handleApplySharedLinkClick);
+      setupsCineUi.interactions.register('shareInputChange', handleSharedLinkInputChange);
+      setupsCineUi.interactions.register('sharedImportSubmit', handleSharedImportSubmit);
+      setupsCineUi.interactions.register('sharedImportCancel', handleSharedImportCancel);
     }
   } catch (error) {
     console.warn('cineUi interaction registration (setups) failed', error);
   }
 
   try {
-    if (cineUi.help && typeof cineUi.help.register === 'function') {
-      cineUi.help.register('shareProject', () => {
+    if (setupsCineUi.help && typeof setupsCineUi.help.register === 'function') {
+      setupsCineUi.help.register('shareProject', () => {
         const langTexts = texts[currentLang] || {};
         const fallbackTexts = texts.en || {};
         return (
@@ -481,7 +481,7 @@ if (cineUi) {
         );
       });
 
-      cineUi.help.register('sharedImport', () => {
+      setupsCineUi.help.register('sharedImport', () => {
         const langTexts = texts[currentLang] || {};
         const fallbackTexts = texts.en || {};
         return (

--- a/src/scripts/modules/runtime.js
+++ b/src/scripts/modules/runtime.js
@@ -1,0 +1,514 @@
+(function () {
+  const GLOBAL_SCOPE =
+    typeof globalThis !== 'undefined'
+      ? globalThis
+      : typeof window !== 'undefined'
+        ? window
+        : typeof self !== 'undefined'
+          ? self
+          : typeof global !== 'undefined'
+            ? global
+            : {};
+
+  const MODULE_NAMES = ['cinePersistence', 'cineOffline', 'cineUi'];
+
+  const REQUIRED_PERSISTENCE_FUNCTIONS = [
+    'storage.loadDeviceData',
+    'storage.saveDeviceData',
+    'storage.loadSetups',
+    'storage.saveSetups',
+    'storage.saveSetup',
+    'storage.loadSetup',
+    'storage.deleteSetup',
+    'storage.renameSetup',
+    'storage.loadSessionState',
+    'storage.saveSessionState',
+    'storage.saveProject',
+    'storage.loadProject',
+    'storage.deleteProject',
+    'storage.exportAllData',
+    'storage.importAllData',
+    'storage.loadFavorites',
+    'storage.saveFavorites',
+    'storage.loadAutoGearRules',
+    'storage.saveAutoGearRules',
+    'storage.loadAutoGearBackups',
+    'storage.saveAutoGearBackups',
+    'storage.loadAutoGearBackupRetention',
+    'storage.saveAutoGearBackupRetention',
+    'storage.loadAutoGearPresets',
+    'storage.saveAutoGearPresets',
+    'storage.loadAutoGearActivePresetId',
+    'storage.saveAutoGearActivePresetId',
+    'storage.loadAutoGearAutoPresetId',
+    'storage.saveAutoGearAutoPresetId',
+    'storage.loadAutoGearMonitorDefaults',
+    'storage.saveAutoGearMonitorDefaults',
+    'storage.loadAutoGearBackupVisibility',
+    'storage.saveAutoGearBackupVisibility',
+    'storage.loadFullBackupHistory',
+    'storage.saveFullBackupHistory',
+    'storage.recordFullBackupHistoryEntry',
+    'autosave.saveSession',
+    'autosave.autoSaveSetup',
+    'autosave.saveGearList',
+    'autosave.restoreSessionState',
+    'backups.collectFullBackupData',
+    'backups.createSettingsBackup',
+    'backups.captureStorageSnapshot',
+    'backups.sanitizeBackupPayload',
+    'backups.autoBackup',
+    'backups.formatFullBackupFilename',
+    'backups.downloadPayload',
+    'backups.recordFullBackupHistoryEntry',
+    'restore.proceed',
+    'restore.abort',
+    'share.downloadProject',
+    'share.encodeSharedSetup',
+    'share.decodeSharedSetup',
+    'share.applySharedSetup',
+    'share.applySharedSetupFromUrl'
+  ];
+
+  const REQUIRED_OFFLINE_FUNCTIONS = [
+    'registerServiceWorker',
+    'reloadApp'
+  ];
+
+  const REQUIRED_UI_CONTROLLERS = [
+    { name: 'deviceManagerSection', actions: ['show', 'hide', 'toggle'] },
+    { name: 'shareDialog', actions: ['open', 'submit', 'cancel', 'dismiss'] },
+    { name: 'sharedImportDialog', actions: ['submit', 'cancel', 'dismiss', 'changeMode'] },
+    { name: 'backupSettings', actions: ['execute'] },
+    { name: 'restoreSettings', actions: ['openPicker', 'processFile'] }
+  ];
+
+  const REQUIRED_UI_INTERACTIONS = [
+    'saveSetup',
+    'deleteSetup',
+    'shareOpen',
+    'shareSubmit',
+    'shareCancel',
+    'shareApplyFile',
+    'shareInputChange',
+    'sharedImportSubmit',
+    'sharedImportCancel',
+    'performBackup',
+    'openRestorePicker',
+    'applyRestoreFile'
+  ];
+
+  const REQUIRED_UI_HELP_ENTRIES = [
+    'saveSetup',
+    'autoBackupBeforeDeletion',
+    'shareProject',
+    'sharedImport',
+    'backupSettings',
+    'restoreSettings'
+  ];
+
+  function safeWarn(message, detail) {
+    if (typeof console !== 'undefined' && typeof console.warn === 'function') {
+      try {
+        if (typeof detail === 'undefined') {
+          console.warn(message);
+        } else {
+          console.warn(message, detail);
+        }
+      } catch (error) {
+        void error;
+      }
+    }
+  }
+
+  function tryRequire(modulePath) {
+    if (typeof require !== 'function') {
+      return null;
+    }
+
+    try {
+      return require(modulePath);
+    } catch (error) {
+      void error;
+      return null;
+    }
+  }
+
+  function freezeDeep(value, seen = new WeakSet()) {
+    if (!value || typeof value !== 'object') {
+      return value;
+    }
+
+    if (seen.has(value)) {
+      return value;
+    }
+
+    seen.add(value);
+
+    const keys = Object.getOwnPropertyNames(value);
+    for (let index = 0; index < keys.length; index += 1) {
+      const key = keys[index];
+      const descriptor = Object.getOwnPropertyDescriptor(value, key);
+      if (!descriptor || ('get' in descriptor) || ('set' in descriptor)) {
+        continue;
+      }
+      freezeDeep(descriptor.value, seen);
+    }
+
+    return Object.freeze(value);
+  }
+
+  function resolveModule(name) {
+    if (!name || !MODULE_NAMES.includes(name)) {
+      throw new TypeError(`cineRuntime cannot resolve unknown module "${name}".`);
+    }
+
+    if (GLOBAL_SCOPE && typeof GLOBAL_SCOPE === 'object') {
+      try {
+        const existing = GLOBAL_SCOPE[name];
+        if (existing) {
+          return existing;
+        }
+      } catch (error) {
+        void error;
+      }
+    }
+
+    switch (name) {
+      case 'cinePersistence':
+        return tryRequire('./persistence.js');
+      case 'cineOffline':
+        return tryRequire('./offline.js');
+      case 'cineUi':
+        return tryRequire('./ui.js');
+      default:
+        return null;
+    }
+  }
+
+  function ensureModule(name, options = {}) {
+    const resolved = resolveModule(name);
+    if (!resolved && options.optional) {
+      return null;
+    }
+    if (!resolved) {
+      throw new Error(`cineRuntime could not locate ${name}.`);
+    }
+    return resolved;
+  }
+
+  function parsePath(path) {
+    if (Array.isArray(path)) {
+      return path.slice();
+    }
+    if (typeof path === 'string' && path.trim()) {
+      return path.split('.');
+    }
+    throw new TypeError('cineRuntime expected check paths to be strings or arrays.');
+  }
+
+  function inspectFunctionPath(root, path, missing, detailMap, prefix) {
+    const segments = parsePath(path);
+    let current = root;
+    let traversed = prefix ? `${prefix}` : '';
+
+    for (let index = 0; index < segments.length; index += 1) {
+      const segment = segments[index];
+      traversed = traversed ? `${traversed}.${segment}` : segment;
+      if (!current || (typeof current !== 'object' && typeof current !== 'function')) {
+        missing.push(traversed);
+        detailMap[traversed] = false;
+        return;
+      }
+      current = current[segment];
+    }
+
+    const finalPath = prefix ? `${prefix}.${segments.join('.')}` : segments.join('.');
+    const ok = typeof current === 'function';
+    if (!ok) {
+      missing.push(finalPath);
+    }
+    detailMap[finalPath] = ok;
+  }
+
+  function inspectOfflineFunctions(module, missing, detailMap) {
+    for (let index = 0; index < REQUIRED_OFFLINE_FUNCTIONS.length; index += 1) {
+      const name = REQUIRED_OFFLINE_FUNCTIONS[index];
+      const fn = module ? module[name] : null;
+      const path = `cineOffline.${name}`;
+      const ok = typeof fn === 'function';
+      if (!ok) {
+        missing.push(path);
+      }
+      detailMap[path] = ok;
+    }
+  }
+
+  function inspectUiControllers(uiModule, missing, detailMap) {
+    const controllers = uiModule && uiModule.controllers;
+    const getter = controllers && typeof controllers.get === 'function'
+      ? controllers.get.bind(controllers)
+      : null;
+
+    for (let index = 0; index < REQUIRED_UI_CONTROLLERS.length; index += 1) {
+      const descriptor = REQUIRED_UI_CONTROLLERS[index];
+      const pathPrefix = `cineUi.controllers.${descriptor.name}`;
+
+      if (!getter) {
+        missing.push(pathPrefix);
+        detailMap[pathPrefix] = false;
+        continue;
+      }
+
+      let entry = null;
+      try {
+        entry = getter(descriptor.name);
+      } catch (error) {
+        void error;
+        entry = null;
+      }
+
+      const entryOk = !!entry && typeof entry === 'object';
+      if (!entryOk) {
+        missing.push(pathPrefix);
+        detailMap[pathPrefix] = false;
+        continue;
+      }
+
+      detailMap[pathPrefix] = true;
+
+      for (let actionIndex = 0; actionIndex < descriptor.actions.length; actionIndex += 1) {
+        const actionName = descriptor.actions[actionIndex];
+        const actionPath = `${pathPrefix}.${actionName}`;
+        const action = entry[actionName];
+        const actionOk = typeof action === 'function';
+        if (!actionOk) {
+          missing.push(actionPath);
+        }
+        detailMap[actionPath] = actionOk;
+      }
+    }
+  }
+
+  function inspectUiInteractions(uiModule, missing, detailMap) {
+    const interactions = uiModule && uiModule.interactions;
+    const getter = interactions && typeof interactions.get === 'function'
+      ? interactions.get.bind(interactions)
+      : null;
+
+    for (let index = 0; index < REQUIRED_UI_INTERACTIONS.length; index += 1) {
+      const name = REQUIRED_UI_INTERACTIONS[index];
+      const path = `cineUi.interactions.${name}`;
+
+      if (!getter) {
+        missing.push(path);
+        detailMap[path] = false;
+        continue;
+      }
+
+      let handler = null;
+      try {
+        handler = getter(name);
+      } catch (error) {
+        void error;
+        handler = null;
+      }
+
+      const ok = typeof handler === 'function';
+      if (!ok) {
+        missing.push(path);
+      }
+      detailMap[path] = ok;
+    }
+  }
+
+  function inspectUiHelp(uiModule, missing, detailMap) {
+    const help = uiModule && uiModule.help;
+    const resolver = help && typeof help.resolve === 'function'
+      ? help.resolve.bind(help)
+      : null;
+
+    for (let index = 0; index < REQUIRED_UI_HELP_ENTRIES.length; index += 1) {
+      const name = REQUIRED_UI_HELP_ENTRIES[index];
+      const path = `cineUi.help.${name}`;
+
+      if (!resolver) {
+        missing.push(path);
+        detailMap[path] = false;
+        continue;
+      }
+
+      let value = null;
+      try {
+        value = resolver(name);
+      } catch (error) {
+        void error;
+        value = null;
+      }
+
+      const ok = typeof value === 'string' && !!value.trim();
+      if (!ok) {
+        missing.push(path);
+      }
+      detailMap[path] = ok;
+    }
+  }
+
+  function listCriticalChecks() {
+    return freezeDeep({
+      cinePersistence: REQUIRED_PERSISTENCE_FUNCTIONS.slice(),
+      cineOffline: REQUIRED_OFFLINE_FUNCTIONS.slice(),
+      cineUi: {
+        controllers: REQUIRED_UI_CONTROLLERS.map(entry => ({
+          name: entry.name,
+          actions: entry.actions.slice()
+        })),
+        interactions: REQUIRED_UI_INTERACTIONS.slice(),
+        help: REQUIRED_UI_HELP_ENTRIES.slice(),
+      },
+    });
+  }
+
+  function verifyCriticalFlows(options = {}) {
+    const missing = [];
+    const detailMap = {};
+
+    const persistence = resolveModule('cinePersistence');
+    const offline = resolveModule('cineOffline');
+    const ui = resolveModule('cineUi');
+
+    const modulePresence = {
+      cinePersistence: !!persistence,
+      cineOffline: !!offline,
+      cineUi: !!ui,
+    };
+
+    if (!persistence) {
+      missing.push('cinePersistence');
+      detailMap.cinePersistence = false;
+    } else {
+      detailMap.cinePersistence = true;
+      if (!Object.isFrozen(persistence)) {
+        missing.push('cinePersistence (not frozen)');
+        detailMap['cinePersistence.frozen'] = false;
+      } else {
+        detailMap['cinePersistence.frozen'] = true;
+      }
+
+      for (let index = 0; index < REQUIRED_PERSISTENCE_FUNCTIONS.length; index += 1) {
+        inspectFunctionPath(persistence, REQUIRED_PERSISTENCE_FUNCTIONS[index], missing, detailMap, 'cinePersistence');
+      }
+    }
+
+    if (!offline) {
+      missing.push('cineOffline');
+      detailMap.cineOffline = false;
+    } else {
+      detailMap.cineOffline = true;
+      if (!Object.isFrozen(offline)) {
+        missing.push('cineOffline (not frozen)');
+        detailMap['cineOffline.frozen'] = false;
+      } else {
+        detailMap['cineOffline.frozen'] = true;
+      }
+      inspectOfflineFunctions(offline, missing, detailMap);
+    }
+
+    if (!ui) {
+      missing.push('cineUi');
+      detailMap.cineUi = false;
+    } else {
+      detailMap.cineUi = true;
+      if (!Object.isFrozen(ui)) {
+        missing.push('cineUi (not frozen)');
+        detailMap['cineUi.frozen'] = false;
+      } else {
+        detailMap['cineUi.frozen'] = true;
+      }
+
+      inspectUiControllers(ui, missing, detailMap);
+      inspectUiInteractions(ui, missing, detailMap);
+      inspectUiHelp(ui, missing, detailMap);
+    }
+
+    const ok = missing.length === 0;
+    const result = freezeDeep({
+      ok,
+      missing: missing.slice(),
+      modules: freezeDeep(modulePresence),
+      details: freezeDeep(detailMap),
+      checks: listCriticalChecks(),
+    });
+
+    if (!ok) {
+      if (options.warnOnFailure) {
+        safeWarn('cineRuntime.verifyCriticalFlows() detected missing safeguards.', missing);
+      }
+      if (options.throwOnFailure) {
+        const error = new Error('cineRuntime integrity verification failed.');
+        error.details = result;
+        throw error;
+      }
+    }
+
+    return result;
+  }
+
+  const runtimeAPI = freezeDeep({
+    getPersistence(options) {
+      return ensureModule('cinePersistence', options);
+    },
+    getOffline(options) {
+      return ensureModule('cineOffline', options);
+    },
+    getUi(options) {
+      return ensureModule('cineUi', options);
+    },
+    listCriticalChecks,
+    verifyCriticalFlows,
+    __internal: freezeDeep({
+      resolveModule,
+      ensureModule,
+      listCriticalChecks,
+    }),
+  });
+
+  if (GLOBAL_SCOPE && typeof GLOBAL_SCOPE === 'object') {
+    try {
+      if (GLOBAL_SCOPE.cineRuntime !== runtimeAPI) {
+        Object.defineProperty(GLOBAL_SCOPE, 'cineRuntime', {
+          configurable: true,
+          enumerable: false,
+          value: runtimeAPI,
+          writable: false,
+        });
+      }
+    } catch (error) {
+      safeWarn('Unable to expose cineRuntime globally.', error);
+    }
+  }
+
+  if (typeof module !== 'undefined' && module && module.exports) {
+    if (
+      module.exports
+      && module.exports !== runtimeAPI
+      && typeof module.exports === 'object'
+      && Object.keys(module.exports).length > 0
+    ) {
+      try {
+        if (module.exports.cineRuntime !== runtimeAPI) {
+          Object.defineProperty(module.exports, 'cineRuntime', {
+            configurable: true,
+            enumerable: false,
+            value: runtimeAPI,
+            writable: false,
+          });
+        }
+      } catch (attachmentError) {
+        safeWarn('Unable to attach cineRuntime to existing module.exports.', attachmentError);
+      }
+    } else {
+      module.exports = runtimeAPI;
+    }
+  }
+})();

--- a/src/scripts/script.js
+++ b/src/scripts/script.js
@@ -62,6 +62,18 @@ if (typeof require === 'function' && typeof module !== 'undefined' && module && 
       || this;
   wrapper.call(globalScope, module.exports, require, module, __filename, __dirname, globalScope);
 
+  const ensureModule = relativePath => {
+    const resolvedPath = path.join(__dirname, relativePath);
+    const moduleId = require.resolve(resolvedPath);
+    if (require.cache[moduleId]) {
+      delete require.cache[moduleId];
+    }
+    return require(resolvedPath);
+  };
+
+  ensureModule('modules/persistence.js');
+  ensureModule('modules/runtime.js');
+
   const aggregatedExports = module.exports;
   const combinedAppVersion = aggregatedExports && aggregatedExports.APP_VERSION;
   const APP_VERSION = "1.0.9"; // Version marker for consistency checks

--- a/tests/dom/globalFeatureSearch.test.js
+++ b/tests/dom/globalFeatureSearch.test.js
@@ -1,6 +1,6 @@
 const { setupScriptEnvironment } = require('../helpers/scriptEnvironment');
 
-jest.setTimeout(20000);
+jest.setTimeout(45000);
 
 describe('global feature search help navigation', () => {
   let env;

--- a/tests/dom/runtimeIntegration.test.js
+++ b/tests/dom/runtimeIntegration.test.js
@@ -1,0 +1,57 @@
+const { setupScriptEnvironment } = require('../helpers/scriptEnvironment');
+describe('critical workflow integration', () => {
+  let env;
+  let utils;
+
+  beforeEach(() => {
+    env = setupScriptEnvironment();
+    ({ utils } = env);
+  });
+
+  afterEach(() => {
+    env.cleanup();
+  });
+
+  test('exposes offline reload helpers and persistence gateways', () => {
+    expect(global.cineOffline).toBeDefined();
+    expect(typeof global.cineOffline.reloadApp).toBe('function');
+    expect(typeof global.cineOffline.registerServiceWorker).toBe('function');
+
+    expect(global.cinePersistence).toBeDefined();
+    expect(typeof global.cinePersistence.storage.saveProject).toBe('function');
+    expect(typeof global.cinePersistence.storage.importAllData).toBe('function');
+    expect(typeof global.cinePersistence.backups.createSettingsBackup).toBe('function');
+    expect(typeof global.cinePersistence.restore.proceed).toBe('function');
+    expect(typeof global.cinePersistence.share.applySharedSetup).toBe('function');
+  });
+
+  test('provides ui registry access for save, share and restore flows', () => {
+    const { cineUi } = global;
+    expect(cineUi).toBeDefined();
+    expect(typeof cineUi.controllers.get).toBe('function');
+
+    const backupController = cineUi.controllers.get('backupSettings');
+    const restoreController = cineUi.controllers.get('restoreSettings');
+
+    expect(backupController).not.toBeNull();
+    expect(typeof backupController.execute).toBe('function');
+    expect(restoreController).not.toBeNull();
+    expect(typeof restoreController.openPicker).toBe('function');
+    expect(typeof restoreController.processFile).toBe('function');
+
+    expect(typeof cineUi.interactions.get).toBe('function');
+    expect(typeof cineUi.interactions.get('performBackup')).toBe('function');
+    expect(typeof cineUi.interactions.get('applyRestoreFile')).toBe('function');
+
+    expect(typeof cineUi.help.resolve).toBe('function');
+    expect(typeof cineUi.help.resolve('shareProject')).toBe('string');
+  });
+
+  test('exports integration utilities for tests via runtime bundle', () => {
+    expect(utils).toBeDefined();
+    expect(typeof utils.collectProjectFormData).toBe('function');
+    expect(typeof utils.createSettingsBackup).toBe('function');
+    expect(typeof utils.downloadSharedProject).toBe('function');
+    expect(typeof utils.autoBackup).toBe('function');
+  });
+});

--- a/tests/unit/runtimeModule.test.js
+++ b/tests/unit/runtimeModule.test.js
@@ -1,0 +1,257 @@
+const path = require('path');
+
+describe('cineRuntime module', () => {
+  let runtime;
+  let persistenceStub;
+  let offlineStub;
+  let uiStub;
+
+  function buildPersistenceStub() {
+    const noop = () => {};
+    const storage = {
+      loadDeviceData: noop,
+      saveDeviceData: noop,
+      loadSetups: noop,
+      saveSetups: noop,
+      saveSetup: noop,
+      loadSetup: noop,
+      deleteSetup: noop,
+      renameSetup: noop,
+      loadSessionState: noop,
+      saveSessionState: noop,
+      saveProject: noop,
+      loadProject: noop,
+      deleteProject: noop,
+      exportAllData: noop,
+      importAllData: noop,
+      loadFavorites: noop,
+      saveFavorites: noop,
+      loadAutoGearRules: noop,
+      saveAutoGearRules: noop,
+      loadAutoGearBackups: noop,
+      saveAutoGearBackups: noop,
+      loadAutoGearBackupRetention: noop,
+      saveAutoGearBackupRetention: noop,
+      loadAutoGearPresets: noop,
+      saveAutoGearPresets: noop,
+      loadAutoGearActivePresetId: noop,
+      saveAutoGearActivePresetId: noop,
+      loadAutoGearAutoPresetId: noop,
+      saveAutoGearAutoPresetId: noop,
+      loadAutoGearMonitorDefaults: noop,
+      saveAutoGearMonitorDefaults: noop,
+      loadAutoGearBackupVisibility: noop,
+      saveAutoGearBackupVisibility: noop,
+      loadFullBackupHistory: noop,
+      saveFullBackupHistory: noop,
+      recordFullBackupHistoryEntry: noop,
+    };
+
+    const autosave = {
+      saveSession: noop,
+      autoSaveSetup: noop,
+      saveGearList: noop,
+      restoreSessionState: noop,
+    };
+
+    const backups = {
+      collectFullBackupData: noop,
+      createSettingsBackup: noop,
+      captureStorageSnapshot: noop,
+      sanitizeBackupPayload: noop,
+      autoBackup: noop,
+      formatFullBackupFilename: noop,
+      downloadPayload: noop,
+      recordFullBackupHistoryEntry: noop,
+    };
+
+    const restore = {
+      proceed: noop,
+      abort: noop,
+    };
+
+    const share = {
+      downloadProject: noop,
+      encodeSharedSetup: noop,
+      decodeSharedSetup: noop,
+      applySharedSetup: noop,
+      applySharedSetupFromUrl: noop,
+    };
+
+    return Object.freeze({
+      storage: Object.freeze(storage),
+      autosave: Object.freeze(autosave),
+      backups: Object.freeze(backups),
+      restore: Object.freeze(restore),
+      share: Object.freeze(share),
+    });
+  }
+
+  function buildOfflineStub() {
+    return Object.freeze({
+      registerServiceWorker: () => Promise.resolve(),
+      reloadApp: () => Promise.resolve({}),
+    });
+  }
+
+  function buildUiStub() {
+    const controllers = new Map();
+    const interactions = new Map();
+    const helpEntries = new Map();
+
+    const controllerApi = {
+      register(name, descriptor) {
+        controllers.set(name, Object.freeze({ ...descriptor }));
+      },
+      get(name) {
+        return controllers.get(name) || null;
+      },
+    };
+
+    controllerApi.register('deviceManagerSection', {
+      show: () => {},
+      hide: () => {},
+      toggle: () => {},
+    });
+    controllerApi.register('shareDialog', {
+      open: () => {},
+      submit: () => {},
+      cancel: () => {},
+      dismiss: () => {},
+    });
+    controllerApi.register('sharedImportDialog', {
+      submit: () => {},
+      cancel: () => {},
+      dismiss: () => {},
+      changeMode: () => {},
+    });
+    controllerApi.register('backupSettings', {
+      execute: () => {},
+    });
+    controllerApi.register('restoreSettings', {
+      openPicker: () => {},
+      processFile: () => {},
+    });
+
+    const interactionApi = {
+      register(name, handler) {
+        interactions.set(name, handler);
+      },
+      get(name) {
+        return interactions.get(name) || null;
+      },
+    };
+
+    [
+      'saveSetup',
+      'deleteSetup',
+      'shareOpen',
+      'shareSubmit',
+      'shareCancel',
+      'shareApplyFile',
+      'shareInputChange',
+      'sharedImportSubmit',
+      'sharedImportCancel',
+      'performBackup',
+      'openRestorePicker',
+      'applyRestoreFile',
+    ].forEach(name => interactionApi.register(name, () => {}));
+
+    const helpApi = {
+      register(name, resolver) {
+        helpEntries.set(name, resolver);
+      },
+      resolve(name) {
+        const entry = helpEntries.get(name);
+        return entry ? entry() : null;
+      },
+    };
+
+    helpApi.register('saveSetup', () => 'Save projects.');
+    helpApi.register('autoBackupBeforeDeletion', () => 'Backups run before deletion.');
+    helpApi.register('shareProject', () => 'Share the current planner state.');
+    helpApi.register('sharedImport', () => 'Import a shared planner file.');
+    helpApi.register('backupSettings', () => 'Create a full backup.');
+    helpApi.register('restoreSettings', () => 'Restore from a full backup.');
+
+    return Object.freeze({
+      controllers: Object.freeze({
+        register: controllerApi.register,
+        get: controllerApi.get,
+      }),
+      interactions: Object.freeze({
+        register: interactionApi.register,
+        get: interactionApi.get,
+      }),
+      help: Object.freeze({
+        register: helpApi.register,
+        resolve: helpApi.resolve,
+      }),
+    });
+  }
+
+  beforeEach(() => {
+    jest.resetModules();
+    persistenceStub = buildPersistenceStub();
+    offlineStub = buildOfflineStub();
+    uiStub = buildUiStub();
+
+    global.cinePersistence = persistenceStub;
+    global.cineOffline = offlineStub;
+    global.cineUi = uiStub;
+
+    runtime = require(path.join('..', '..', 'src', 'scripts', 'modules', 'runtime.js'));
+  });
+
+  afterEach(() => {
+    delete global.cinePersistence;
+    delete global.cineOffline;
+    delete global.cineUi;
+    delete global.cineRuntime;
+  });
+
+  test('exposes frozen runtime API and module getters', () => {
+    expect(Object.isFrozen(runtime)).toBe(true);
+    expect(runtime.getPersistence()).toBe(persistenceStub);
+    expect(runtime.getOffline()).toBe(offlineStub);
+    expect(runtime.getUi()).toBe(uiStub);
+  });
+
+  test('lists critical checks across persistence, offline and UI layers', () => {
+    const checks = runtime.listCriticalChecks();
+    expect(Object.isFrozen(checks)).toBe(true);
+    expect(checks.cinePersistence).toEqual(expect.arrayContaining(['storage.saveProject', 'share.applySharedSetupFromUrl']));
+    expect(checks.cineOffline).toEqual(expect.arrayContaining(['registerServiceWorker', 'reloadApp']));
+    expect(checks.cineUi.controllers).toEqual(expect.arrayContaining([
+      expect.objectContaining({ name: 'backupSettings' }),
+    ]));
+  });
+
+  test('verifies critical flows when safeguards are present', () => {
+    const result = runtime.verifyCriticalFlows();
+    expect(result.ok).toBe(true);
+    expect(result.missing).toEqual([]);
+    expect(result.modules).toEqual({
+      cinePersistence: true,
+      cineOffline: true,
+      cineUi: true,
+    });
+  });
+
+  test('reports missing safeguards and can throw when requested', () => {
+    const mutated = { ...persistenceStub.storage };
+    delete mutated.saveProject;
+    global.cinePersistence = Object.freeze({
+      ...persistenceStub,
+      storage: Object.freeze(mutated),
+    });
+
+    const result = runtime.verifyCriticalFlows();
+    expect(result.ok).toBe(false);
+    expect(result.missing).toContain('cinePersistence.storage.saveProject');
+
+    expect(() => runtime.verifyCriticalFlows({ throwOnFailure: true })).toThrow(
+      /cineRuntime integrity verification failed/
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- rename module-local cineUi references in the setups, session, and events scripts to prevent redeclaration errors when the runtime bundle is reloaded in tests
- teach the Node bundler in `script.js` to reload the persistence and runtime modules so `cinePersistence`, `cineOffline`, and `cineUi` stay available for integration checks
- add runtime integration/unit tests, document the new guard, and extend the feature search timeout to accommodate the heavier initialization

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d5c210a9c48320a202fdee03d98d73