### PR TITLE
Add runtime integrity guard and document diagnostic hook

### DIFF
--- a/docs/documentation-maintenance.md
+++ b/docs/documentation-maintenance.md
@@ -17,7 +17,12 @@ dialog names documented in code.【F:src/scripts/modules/ui.js†L1-L192】
 The new integration suite (`tests/dom/runtimeIntegration.test.js`) ensures these modules
 continue to cooperate. When updating help text or translations, keep the assertions in that
 test in mind—they describe the critical APIs (`cineOffline`, `cinePersistence`, `cineUi`) that
-must remain available to avoid data loss.【F:tests/dom/runtimeIntegration.test.js†L1-L51】
+must remain available to avoid data loss.【F:tests/dom/runtimeIntegration.test.js†L1-L64】
+
+The runtime bundle also stores the most recent verification result on
+`__cineRuntimeIntegrity`, giving documentation reviewers a quick signal that the
+save/share/import safeguards initialised correctly before they start editing
+copy offline.【F:src/scripts/script.js†L92-L183】
 
 ## 1. Identify every surface that needs an update
 

--- a/docs/modularization/step-5-integration.md
+++ b/docs/modularization/step-5-integration.md
@@ -10,11 +10,14 @@ future refactors catch mismatches immediately.
 * `tests/dom/runtimeIntegration.test.js` boots the application runtime inside the
   Jest + jsdom environment. The test asserts that `cineOffline`, `cinePersistence` and
   `cineUi` are all exposed with the APIs needed to reload the planner, persist projects,
-  create backups and apply shared setups.【F:tests/dom/runtimeIntegration.test.js†L1-L51】
+  create backups and apply shared setups.【F:tests/dom/runtimeIntegration.test.js†L1-L64】
 * The integration suite also confirms that the Node-oriented bundle (`script.js`) continues to
   export the helpers used by existing tests (`collectProjectFormData`, backup utilities and
   sharing helpers). This guards the split core from accidentally dropping functionality when
-  the bundling strategy evolves.【F:tests/dom/runtimeIntegration.test.js†L35-L51】【F:tests/helpers/runtimeLoader.js†L1-L36】
+  the bundling strategy evolves.【F:tests/dom/runtimeIntegration.test.js†L50-L63】【F:tests/helpers/runtimeLoader.js†L1-L36】
+* During startup the bundle now captures the `cineRuntime.verifyCriticalFlows()` result on
+  `__cineRuntimeIntegrity` so regressions surface immediately in both automated logs and
+  manual offline rehearsals.【F:src/scripts/script.js†L92-L183】
 
 ## Documentation updates
 

--- a/docs/testing-plan.md
+++ b/docs/testing-plan.md
@@ -22,6 +22,9 @@ exploratory testing without risking data loss.
 * **Runtime integration guard** – `tests/dom/runtimeIntegration.test.js` boots the modular
   runtime and verifies that `cineOffline`, `cinePersistence` and `cineUi` expose the
   workflows required for saving, sharing, importing, backing up and restoring data.
+  The startup bundle now records the verification outcome on
+  `__cineRuntimeIntegrity`, making it easy to audit the integrity status during
+  manual rehearsals or when reviewing automated logs.【F:src/scripts/script.js†L92-L183】
 * **Runtime and backup automation (opt-in)** – Heavyweight script-level tests are now
   opt-in. Setting `RUN_HEAVY_TESTS=true` before invoking Jest will re-enable the
   integration suite that exercises the modular runtime loader, backup/restore flows,

--- a/tests/dom/runtimeIntegration.test.js
+++ b/tests/dom/runtimeIntegration.test.js
@@ -54,4 +54,11 @@ describe('critical workflow integration', () => {
     expect(typeof utils.downloadSharedProject).toBe('function');
     expect(typeof utils.autoBackup).toBe('function');
   });
+
+  test('records runtime integrity results for diagnostics', () => {
+    const integrity = global.__cineRuntimeIntegrity;
+    expect(integrity).toBeDefined();
+    expect(integrity.ok).toBe(true);
+    expect(Array.isArray(integrity.missing)).toBe(true);
+  });
 });

--- a/tests/helpers/scriptEnvironment.js
+++ b/tests/helpers/scriptEnvironment.js
@@ -154,6 +154,11 @@ function setupScriptEnvironment(options = {}) {
       delete global[key];
     }
     delete window.defaultDevices;
+    try {
+      delete global.__cineRuntimeIntegrity;
+    } catch (error) {
+      void error;
+    }
     jest.clearAllMocks();
     document.body.innerHTML = '';
   };


### PR DESCRIPTION
## Summary
- run cineRuntime.verifyCriticalFlows() during startup and persist the result on __cineRuntimeIntegrity so failures surface immediately
- update the runtime integration test helpers to validate and reset the recorded integrity status
- document the new diagnostic hook in the testing and maintenance guides for release reviewers

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d5d639919c8320a79de10e6a2f71a7