### PR TITLE
Add runtime guard checks to integration test and offline docs

### DIFF
--- a/docs/offline-readiness.md
+++ b/docs/offline-readiness.md
@@ -28,11 +28,16 @@ time:
    Backup & Restore** to confirm the autosave status overlay reflects the same timestamp,
    then review **Settings → Data & Storage** to verify project, backup and gear counts
    updated as expected.
-4. **Capture baseline exports.** While still offline, export both a planner backup
+4. **Check the runtime guard.** Open the browser console and inspect
+   `window.__cineRuntimeIntegrity`. It should report `{ ok: true }` with an empty
+   `missing` list. Run `window.cineRuntime.verifyCriticalFlows()` if you need a fresh
+   report—the output lists every persistence, offline and UI safeguard that must stay
+   available before crews rely on the workstation.
+5. **Capture baseline exports.** While still offline, export both a planner backup
    (`planner-backup.json`) and a project bundle (`project-name.json`). Import the files into
    a private browser profile that also stays offline. Once you confirm the restore loop
    works end-to-end, delete the verification profile to prevent stale caches.
-5. **Archive the reference set.** Store the verified backup, bundle and a ZIP of the
+6. **Archive the reference set.** Store the verified backup, bundle and a ZIP of the
    repository on redundant encrypted media alongside a checksum manifest. These artifacts
    become your gold-standard comparison point during future audits.
 
@@ -55,10 +60,15 @@ connectivity:
    `auto-gear-rules-*.json` export in this drill—the import flow now verifies the file
    type, semantic version and timestamp metadata entirely offline, warning you about
    mismatches and restoring the pre-import snapshot automatically if validation fails.
-4. **Simulate outages.** With the verification profile still offline, reload the planner
+4. **Confirm safeguards stayed intact.** In the main profile, review
+   `window.__cineRuntimeIntegrity` or rerun
+   `window.cineRuntime.verifyCriticalFlows({ warnOnFailure: true })` to ensure no
+   controller, share helper or backup routine dropped out between rehearsals. If the
+   report lists anything in `missing`, rehearse exports again before travelling.
+5. **Simulate outages.** With the verification profile still offline, reload the planner
    and navigate the interface. Confirm locally stored Uicons, fonts and helper scripts stay
    available and that autosave warnings do not appear.
-5. **Pack verified media.** Copy the newly validated exports plus the repository snapshot
+6. **Pack verified media.** Copy the newly validated exports plus the repository snapshot
    onto at least two encrypted drives that travel separately. Update your inventory list so
    every crew member knows where the redundant copies live.
 

--- a/docs/operations-checklist.md
+++ b/docs/operations-checklist.md
@@ -35,12 +35,17 @@ update the repository or hand off a project at the end of the day.
    review the rule-by-rule diff before you load the snapshot so additions,
    removals and scenario scope changes are confirmed without touching live
    storage. Delete the temporary profile after confirmation.
-5. **Review data & storage dashboard.** Open **Settings → Data & Storage** to
+5. **Inspect the runtime guard.** Back in the primary profile, open the
+   developer console and check `window.__cineRuntimeIntegrity`. It should show
+   `{ ok: true }` with no missing safeguards. When in doubt, run
+   `window.cineRuntime.verifyCriticalFlows()` for a fresh report and confirm the
+   persistence, offline and UI sections all pass before you archive exports.
+6. **Review data & storage dashboard.** Open **Settings → Data & Storage** to
    ensure counts for projects, backups and custom devices match expectations.
-6. **Check draft impact preview.** Open the automatic gear rule editor, review
+7. **Check draft impact preview.** Open the automatic gear rule editor, review
    the draft impact preview for quantity deltas and warnings, then cancel to
    confirm the live generator stays unchanged.
-7. **Log the drill.** Append a verification note (timestamp, machine, operator
+8. **Log the drill.** Append a verification note (timestamp, machine, operator
    and files inspected) to your archival log or create one beside the exports
    if it does not exist yet. Pair the note with checksum manifests so every
    crew member can prove when the save → share → import rehearsal succeeded.

--- a/tests/dom/runtimeIntegration.test.js
+++ b/tests/dom/runtimeIntegration.test.js
@@ -61,4 +61,28 @@ describe('critical workflow integration', () => {
     expect(integrity.ok).toBe(true);
     expect(Array.isArray(integrity.missing)).toBe(true);
   });
+
+  test('exposes the runtime guard so crews can audit safeguards', () => {
+    const { cineRuntime } = global;
+    expect(cineRuntime).toBeDefined();
+    expect(typeof cineRuntime.verifyCriticalFlows).toBe('function');
+
+    const report = cineRuntime.verifyCriticalFlows();
+    expect(report).toBeDefined();
+    expect(report.ok).toBe(true);
+    expect(Array.isArray(report.missing)).toBe(true);
+    expect(report.missing.length).toBe(0);
+
+    expect(report.modules).toEqual(
+      expect.objectContaining({
+        cinePersistence: true,
+        cineOffline: true,
+        cineUi: true,
+      })
+    );
+
+    expect(report.details['cinePersistence.storage.saveProject']).toBe(true);
+    expect(report.details['cineOffline.registerServiceWorker']).toBe(true);
+    expect(report.details['cineUi.controllers.backupSettings']).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary
- document how to inspect the cineRuntime integrity guard in the offline readiness runbook and operational checklist
- extend the runtime integration test to assert cineRuntime.verifyCriticalFlows() reports a clean bill of health

## Testing
- npx jest --runInBand tests/dom/runtimeIntegration.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d62601c3088320b5c3b917171216e2