### PR TITLE
Align script integrity test with modular repair plan

### DIFF
--- a/docs/modularization/step-5-integration.md
+++ b/docs/modularization/step-5-integration.md
@@ -11,6 +11,10 @@ future refactors catch mismatches immediately.
   Jest + jsdom environment. The test asserts that `cineOffline`, `cinePersistence` and
   `cineUi` are all exposed with the APIs needed to reload the planner, persist projects,
   create backups and apply shared setups.【F:tests/dom/runtimeIntegration.test.js†L1-L64】
+* `tests/script/scriptIntegrity.test.js` now verifies that the Node bundle stitches together the
+  offline and UI modules before executing the core runtime halves, keeping the five-step repair
+  plan on track by ensuring the offline cache controls and UI registries are always available to
+  tests and automation.【F:tests/script/scriptIntegrity.test.js†L1-L112】
 * The integration suite also confirms that the Node-oriented bundle (`script.js`) continues to
   export the helpers used by existing tests (`collectProjectFormData`, backup utilities and
   sharing helpers). This guards the split core from accidentally dropping functionality when

--- a/tests/script/scriptIntegrity.test.js
+++ b/tests/script/scriptIntegrity.test.js
@@ -85,6 +85,8 @@ describe('script.js modular runtime', () => {
     const parts = extractRuntimeParts();
 
     expect(parts).toEqual([
+      'modules/offline.js',
+      'modules/ui.js',
       'app-core-new-1.js',
       'app-core-new-2.js',
       'app-events.js',


### PR DESCRIPTION
## Summary
- update the script integrity test to expect the offline and UI modules before the core runtime pieces
- document that the script integrity suite now enforces the five-step repair plan during Node bundling

## Testing
- RUN_HEAVY_TESTS=true npx jest --config jest.config.js --runInBand --selectProjects script -- tests/script/scriptIntegrity.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d628cefc3c832096256cd80486f73a