### PR TITLE
Hoist stable helpers to avoid module ReferenceErrors

### DIFF
--- a/legacy/scripts/app-core-new-1.js
+++ b/legacy/scripts/app-core-new-1.js
@@ -80,6 +80,13 @@
  * Do not trim these notes unless the tooling issue has been resolved.
  */
 
+// Legacy bundle hoists these helpers to keep strict-mode environments from
+// throwing before the globals are patched in. Without explicit declarations the
+// assignments inside the compatibility shims fail under module evaluation and
+// risk breaking persistence flows during offline restores.
+var stableStringify;
+var humanizeKey;
+
 (function ensureSharedCoreUtilitiesLegacy() {
   var GLOBAL_SCOPE =
     typeof globalThis !== 'undefined'
@@ -145,7 +152,6 @@
 
   try {
     if (typeof stableStringify !== 'function') {
-      // eslint-disable-next-line no-global-assign
       stableStringify = GLOBAL_SCOPE.stableStringify;
     }
   } catch (error) {
@@ -154,7 +160,6 @@
 
   try {
     if (typeof humanizeKey !== 'function') {
-      // eslint-disable-next-line no-global-assign
       humanizeKey = GLOBAL_SCOPE.humanizeKey;
     }
   } catch (error) {

--- a/legacy/scripts/app-core-new-2.js
+++ b/legacy/scripts/app-core-new-2.js
@@ -1,3 +1,9 @@
+// Mirror the shared helper declarations for the legacy bundle so runtime
+// wrappers that run under strict evaluation can still assign to these
+// fallbacks without tripping ReferenceErrors before the globals are ready.
+var stableStringify;
+var humanizeKey;
+
 var SHARED_GLOBAL_SCOPE =
   typeof globalThis !== 'undefined'
     ? globalThis

--- a/src/scripts/app-core-new-1.js
+++ b/src/scripts/app-core-new-1.js
@@ -80,6 +80,14 @@
  * Do not trim these notes unless the tooling issue has been resolved.
  */
 
+// Hoist shared helpers so both halves of the split runtime can safely assign
+// to them even when the scripts are evaluated in strict or module contexts.
+// Without these declarations browsers that treat the files as modules throw a
+// ReferenceError before the fallback wiring attaches the helpers to the global
+// scope, which breaks autosave and offline persistence.
+var stableStringify;
+var humanizeKey;
+
 (function ensureSharedCoreUtilities() {
   const GLOBAL_SCOPE =
     typeof globalThis !== 'undefined'
@@ -143,7 +151,6 @@
 
   try {
     if (typeof stableStringify !== 'function') {
-      // eslint-disable-next-line no-global-assign
       stableStringify = GLOBAL_SCOPE.stableStringify;
     }
   } catch (error) {
@@ -152,7 +159,6 @@
 
   try {
     if (typeof humanizeKey !== 'function') {
-      // eslint-disable-next-line no-global-assign
       humanizeKey = GLOBAL_SCOPE.humanizeKey;
     }
   } catch (error) {

--- a/src/scripts/app-core-new-2.js
+++ b/src/scripts/app-core-new-2.js
@@ -1,3 +1,10 @@
+// Declare shared helpers upfront so assignments inside try/catch blocks never
+// trigger strict-mode ReferenceErrors when the module executes in isolation.
+// The runtime still prefers the globally shared implementations once they are
+// attached in the first core bundle.
+var stableStringify;
+var humanizeKey;
+
 const SHARED_GLOBAL_SCOPE =
   typeof globalThis !== 'undefined'
     ? globalThis
@@ -69,7 +76,6 @@ if (SHARED_GLOBAL_SCOPE) {
 
 try {
   if (typeof stableStringify !== 'function') {
-    // eslint-disable-next-line no-global-assign
     stableStringify = SHARED_GLOBAL_SCOPE?.stableStringify || fallbackStableStringify;
   }
 } catch (error) {
@@ -78,7 +84,6 @@ try {
 
 try {
   if (typeof humanizeKey !== 'function') {
-    // eslint-disable-next-line no-global-assign
     humanizeKey = SHARED_GLOBAL_SCOPE?.humanizeKey || fallbackHumanizeKey;
   }
 } catch (error) {


### PR DESCRIPTION
## Summary
- declare shared stableStringify and humanizeKey helpers up front in both modern and legacy core bundles so strict/module execution keeps autosave and persistence intact

## Testing
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68d6dbb8aee0832098ef9940b2408094