### PR TITLE
Fix runtime initialization order for split core bundle

### DIFF
--- a/legacy/scripts/app-core-new-1.js
+++ b/legacy/scripts/app-core-new-1.js
@@ -41,6 +41,28 @@ function resolveCoreShared() {
   return null;
 }
 var CORE_SHARED = resolveCoreShared() || {};
+var CORE_BOOT_QUEUE_KEY = '__coreRuntimeBootQueue';
+var CORE_BOOT_QUEUE = function () {
+  if (CORE_SHARED && _typeof(CORE_SHARED) === 'object') {
+    if (!Array.isArray(CORE_SHARED[CORE_BOOT_QUEUE_KEY])) {
+      CORE_SHARED[CORE_BOOT_QUEUE_KEY] = [];
+    }
+    return CORE_SHARED[CORE_BOOT_QUEUE_KEY];
+  }
+  if (CORE_GLOBAL_SCOPE) {
+    var shared = CORE_GLOBAL_SCOPE.cineCoreShared || (CORE_GLOBAL_SCOPE.cineCoreShared = {});
+    if (!Array.isArray(shared[CORE_BOOT_QUEUE_KEY])) {
+      shared[CORE_BOOT_QUEUE_KEY] = [];
+    }
+    return shared[CORE_BOOT_QUEUE_KEY];
+  }
+  return [];
+}();
+function enqueueCoreBootTask(task) {
+  if (typeof task === 'function') {
+    CORE_BOOT_QUEUE.push(task);
+  }
+}
 function fallbackStableStringify(value) {
   if (value === null) return 'null';
   if (value === undefined) return 'undefined';
@@ -1879,12 +1901,14 @@ var initialAutoGearRulesSignature = getAutoGearConfigurationSignature(autoGearRu
 var autoGearRulesLastBackupSignature = autoGearBackups.length ? getAutoGearConfigurationSignature(autoGearBackups[0].rules, autoGearBackups[0].monitorDefaults) : initialAutoGearRulesSignature;
 var autoGearRulesLastPersistedSignature = initialAutoGearRulesSignature;
 var autoGearRulesDirtySinceBackup = autoGearRulesLastPersistedSignature !== autoGearRulesLastBackupSignature;
-reconcileAutoGearAutoPresetState({
-  persist: true,
-  skipRender: true
-});
-alignActiveAutoGearPreset({
-  skipRender: true
+enqueueCoreBootTask(function () {
+  reconcileAutoGearAutoPresetState({
+    persist: true,
+    skipRender: true
+  });
+  alignActiveAutoGearPreset({
+    skipRender: true
+  });
 });
 function assignAutoGearRules(rules) {
   autoGearRules = Array.isArray(rules) ? rules.map(normalizeAutoGearRule).filter(Boolean) : [];

--- a/legacy/scripts/app-core-new-2.js
+++ b/legacy/scripts/app-core-new-2.js
@@ -36,6 +36,42 @@ function resolveCoreSharedPart2() {
   return null;
 }
 var CORE_SHARED_LOCAL = typeof CORE_SHARED !== 'undefined' && CORE_SHARED ? CORE_SHARED : resolveCoreSharedPart2() || {};
+var CORE_BOOT_QUEUE_KEY = '__coreRuntimeBootQueue';
+var CORE_BOOT_QUEUE = function () {
+  if (CORE_SHARED_LOCAL && _typeof(CORE_SHARED_LOCAL) === 'object') {
+    if (!Array.isArray(CORE_SHARED_LOCAL[CORE_BOOT_QUEUE_KEY])) {
+      CORE_SHARED_LOCAL[CORE_BOOT_QUEUE_KEY] = [];
+    }
+    return CORE_SHARED_LOCAL[CORE_BOOT_QUEUE_KEY];
+  }
+  if (CORE_SHARED_SCOPE_PART2) {
+    var shared = CORE_SHARED_SCOPE_PART2.cineCoreShared || (CORE_SHARED_SCOPE_PART2.cineCoreShared = {});
+    if (!Array.isArray(shared[CORE_BOOT_QUEUE_KEY])) {
+      shared[CORE_BOOT_QUEUE_KEY] = [];
+    }
+    return shared[CORE_BOOT_QUEUE_KEY];
+  }
+  return [];
+}();
+function flushCoreBootQueue() {
+  if (!Array.isArray(CORE_BOOT_QUEUE) || !CORE_BOOT_QUEUE.length) {
+    return;
+  }
+  var pending = CORE_BOOT_QUEUE.splice(0, CORE_BOOT_QUEUE.length);
+  for (var index = 0; index < pending.length; index += 1) {
+    var task = pending[index];
+    if (typeof task !== 'function') {
+      continue;
+    }
+    try {
+      task();
+    } catch (taskError) {
+      if (typeof console !== 'undefined' && typeof console.error === 'function') {
+        console.error('Core boot task failed', taskError);
+      }
+    }
+  }
+}
 function fallbackStableStringify(value) {
   if (value === null) return 'null';
   if (value === undefined) return 'undefined';
@@ -13237,6 +13273,7 @@ function refreshDeviceLists() {
     filterDeviceList(list, filterValue);
   });
 }
+flushCoreBootQueue();
 refreshDeviceLists();
 if (typeof module !== 'undefined' && module.exports) {
   module.exports = {


### PR DESCRIPTION
## Summary
- add a shared boot queue so the first runtime segment defers work that depends on later scripts
- flush the queued boot tasks once the second segment loads in both the modern and legacy bundles to keep initialisation intact

## Testing
- npm test -- --watch=false *(fails: eslint reports "generateConnectorSummary" is not defined in src/scripts/modules/core-shared.js)*

------
https://chatgpt.com/codex/tasks/task_e_68d6eb9873748320b93d11ffeda83e92