### PR TITLE
Fix boot queue redeclaration in core runtime split

### DIFF
--- a/src/scripts/app-core-new-1.js
+++ b/src/scripts/app-core-new-1.js
@@ -107,8 +107,15 @@ function resolveCoreShared() {
 
 const CORE_SHARED = resolveCoreShared() || {};
 
-const CORE_BOOT_QUEUE_KEY = '__coreRuntimeBootQueue';
-const CORE_BOOT_QUEUE = (() => {
+var CORE_BOOT_QUEUE_KEY = typeof CORE_BOOT_QUEUE_KEY !== 'undefined'
+  ? CORE_BOOT_QUEUE_KEY
+  : '__coreRuntimeBootQueue';
+
+var CORE_BOOT_QUEUE = (function bootstrapCoreBootQueue(existingQueue) {
+  if (Array.isArray(existingQueue)) {
+    return existingQueue;
+  }
+
   if (CORE_SHARED && typeof CORE_SHARED === 'object') {
     if (!Array.isArray(CORE_SHARED[CORE_BOOT_QUEUE_KEY])) {
       CORE_SHARED[CORE_BOOT_QUEUE_KEY] = [];
@@ -125,7 +132,11 @@ const CORE_BOOT_QUEUE = (() => {
   }
 
   return [];
-})();
+})(CORE_GLOBAL_SCOPE && CORE_GLOBAL_SCOPE.CORE_BOOT_QUEUE);
+
+if (CORE_GLOBAL_SCOPE && CORE_GLOBAL_SCOPE.CORE_BOOT_QUEUE !== CORE_BOOT_QUEUE) {
+  CORE_GLOBAL_SCOPE.CORE_BOOT_QUEUE = CORE_BOOT_QUEUE;
+}
 
 function enqueueCoreBootTask(task) {
   if (typeof task === 'function') {

--- a/src/scripts/app-core-new-2.js
+++ b/src/scripts/app-core-new-2.js
@@ -30,8 +30,15 @@ const CORE_SHARED_LOCAL =
     ? CORE_SHARED
     : resolveCoreSharedPart2() || {};
 
-const CORE_BOOT_QUEUE_KEY = '__coreRuntimeBootQueue';
-const CORE_BOOT_QUEUE = (() => {
+var CORE_BOOT_QUEUE_KEY = typeof CORE_BOOT_QUEUE_KEY !== 'undefined'
+  ? CORE_BOOT_QUEUE_KEY
+  : '__coreRuntimeBootQueue';
+
+var CORE_BOOT_QUEUE = (function bootstrapCoreBootQueuePart2(existingQueue) {
+  if (Array.isArray(existingQueue)) {
+    return existingQueue;
+  }
+
   if (CORE_SHARED_LOCAL && typeof CORE_SHARED_LOCAL === 'object') {
     if (!Array.isArray(CORE_SHARED_LOCAL[CORE_BOOT_QUEUE_KEY])) {
       CORE_SHARED_LOCAL[CORE_BOOT_QUEUE_KEY] = [];
@@ -48,7 +55,11 @@ const CORE_BOOT_QUEUE = (() => {
   }
 
   return [];
-})();
+})(CORE_SHARED_SCOPE_PART2 && CORE_SHARED_SCOPE_PART2.CORE_BOOT_QUEUE);
+
+if (CORE_SHARED_SCOPE_PART2 && CORE_SHARED_SCOPE_PART2.CORE_BOOT_QUEUE !== CORE_BOOT_QUEUE) {
+  CORE_SHARED_SCOPE_PART2.CORE_BOOT_QUEUE = CORE_BOOT_QUEUE;
+}
 
 function flushCoreBootQueue() {
   if (!Array.isArray(CORE_BOOT_QUEUE) || CORE_BOOT_QUEUE.length === 0) {


### PR DESCRIPTION
## Summary
- reuse the existing core boot queue key when either runtime half loads
- share the same queue array across both app-core modules to prevent duplicate initialization errors

## Testing
- npm run lint *(fails: `generateConnectorSummary` is not defined in src/scripts/modules/core-shared.js)*

------
https://chatgpt.com/codex/tasks/task_e_68d6f1f183248320aa5fef3cee3e58ed