### PR TITLE
Ensure core boot queue key is single-sourced across runtime splits

### DIFF
--- a/legacy/scripts/app-core-new-1.js
+++ b/legacy/scripts/app-core-new-1.js
@@ -41,23 +41,80 @@ function resolveCoreShared() {
   return null;
 }
 var CORE_SHARED = resolveCoreShared() || {};
-var CORE_BOOT_QUEUE_KEY = '__coreRuntimeBootQueue';
-var CORE_BOOT_QUEUE = function () {
-  if (CORE_SHARED && _typeof(CORE_SHARED) === 'object') {
-    if (!Array.isArray(CORE_SHARED[CORE_BOOT_QUEUE_KEY])) {
-      CORE_SHARED[CORE_BOOT_QUEUE_KEY] = [];
+var CORE_BOOT_QUEUE_KEY = function resolveLegacyCoreBootQueueKey(scope) {
+  var fallbackKey = '__coreRuntimeBootQueue';
+
+  if (scope && _typeof(scope) === 'object') {
+    var existingPublic = scope.CORE_BOOT_QUEUE_KEY;
+    var existingHidden = scope.__cineCoreBootQueueKey;
+
+    if (typeof existingPublic === 'string' && existingPublic) {
+      try {
+        scope.__cineCoreBootQueueKey = existingPublic;
+      } catch (syncError) {
+        void syncError;
+        scope.__cineCoreBootQueueKey = existingPublic;
+      }
+      return existingPublic;
     }
-    return CORE_SHARED[CORE_BOOT_QUEUE_KEY];
+
+    if (typeof existingHidden === 'string' && existingHidden) {
+      if (typeof scope.CORE_BOOT_QUEUE_KEY !== 'string' || !scope.CORE_BOOT_QUEUE_KEY) {
+        try {
+          scope.CORE_BOOT_QUEUE_KEY = existingHidden;
+        } catch (shadowError) {
+          void shadowError;
+          scope.CORE_BOOT_QUEUE_KEY = existingHidden;
+        }
+      }
+      return existingHidden;
+    }
   }
-  if (CORE_GLOBAL_SCOPE) {
-    var shared = CORE_GLOBAL_SCOPE.cineCoreShared || (CORE_GLOBAL_SCOPE.cineCoreShared = {});
-    if (!Array.isArray(shared[CORE_BOOT_QUEUE_KEY])) {
-      shared[CORE_BOOT_QUEUE_KEY] = [];
+
+  if (scope && _typeof(scope) === 'object') {
+    try {
+      scope.__cineCoreBootQueueKey = fallbackKey;
+    } catch (hiddenAssignError) {
+      void hiddenAssignError;
+      scope.__cineCoreBootQueueKey = fallbackKey;
     }
-    return shared[CORE_BOOT_QUEUE_KEY];
+
+    if (typeof scope.CORE_BOOT_QUEUE_KEY !== 'string' || !scope.CORE_BOOT_QUEUE_KEY) {
+      try {
+        scope.CORE_BOOT_QUEUE_KEY = fallbackKey;
+      } catch (publicAssignError) {
+        void publicAssignError;
+        scope.CORE_BOOT_QUEUE_KEY = fallbackKey;
+      }
+    }
+  }
+
+  return fallbackKey;
+}(CORE_GLOBAL_SCOPE);
+var CORE_BOOT_QUEUE = function () {
+  if (CORE_GLOBAL_SCOPE && _typeof(CORE_GLOBAL_SCOPE) === 'object') {
+    var shared = CORE_GLOBAL_SCOPE.cineCoreShared;
+    if (shared && _typeof(shared) === 'object') {
+      var sharedQueue = shared[CORE_BOOT_QUEUE_KEY];
+      if (Array.isArray(sharedQueue)) {
+        return sharedQueue;
+      }
+      var sharedExtensible = typeof Object.isExtensible === 'function' ? Object.isExtensible(shared) : true;
+      if (sharedExtensible) {
+        shared[CORE_BOOT_QUEUE_KEY] = [];
+        return shared[CORE_BOOT_QUEUE_KEY];
+      }
+    }
+    if (!Array.isArray(CORE_GLOBAL_SCOPE.CORE_BOOT_QUEUE)) {
+      CORE_GLOBAL_SCOPE.CORE_BOOT_QUEUE = [];
+    }
+    return CORE_GLOBAL_SCOPE.CORE_BOOT_QUEUE;
   }
   return [];
 }();
+if (CORE_GLOBAL_SCOPE && CORE_GLOBAL_SCOPE.CORE_BOOT_QUEUE !== CORE_BOOT_QUEUE) {
+  CORE_GLOBAL_SCOPE.CORE_BOOT_QUEUE = CORE_BOOT_QUEUE;
+}
 function enqueueCoreBootTask(task) {
   if (typeof task === 'function') {
     CORE_BOOT_QUEUE.push(task);
@@ -6766,9 +6823,10 @@ function setLanguage(lang) {
       if (_noneLabel2) viewfinderExtensionSelect.options[0].textContent = _noneLabel2;
       if (yesLabel) viewfinderExtensionSelect.options[1].textContent = yesLabel;
     }
-    var cancelText = projectFormTexts.cancel || fallbackProjectForm.cancel || (projectCancelBtn ? projectCancelBtn.textContent : projectDialogCloseBtn === null || projectDialogCloseBtn === void 0 ? void 0 : projectDialogCloseBtn.getAttribute('aria-label')) || 'Cancel';
-    if (projectCancelBtn) {
-      setButtonLabelWithIcon(projectCancelBtn, cancelText, ICON_GLYPHS.circleX);
+    var projectCancelButton = typeof document !== 'undefined' ? document.getElementById('projectCancel') : null;
+    var cancelText = projectFormTexts.cancel || fallbackProjectForm.cancel || (projectCancelButton ? projectCancelButton.textContent : projectDialogCloseBtn === null || projectDialogCloseBtn === void 0 ? void 0 : projectDialogCloseBtn.getAttribute('aria-label')) || 'Cancel';
+    if (projectCancelButton) {
+      setButtonLabelWithIcon(projectCancelButton, cancelText, ICON_GLYPHS.circleX);
     }
     if (projectDialogCloseBtn) {
       projectDialogCloseBtn.innerHTML = iconMarkup(ICON_GLYPHS.circleX, 'btn-icon');

--- a/legacy/scripts/app-core-new-2.js
+++ b/legacy/scripts/app-core-new-2.js
@@ -36,28 +36,51 @@ function resolveCoreSharedPart2() {
   return null;
 }
 var CORE_SHARED_LOCAL = typeof CORE_SHARED !== 'undefined' && CORE_SHARED ? CORE_SHARED : resolveCoreSharedPart2() || {};
-var CORE_BOOT_QUEUE_KEY = '__coreRuntimeBootQueue';
-var CORE_BOOT_QUEUE = function () {
-  if (CORE_SHARED_LOCAL && _typeof(CORE_SHARED_LOCAL) === 'object') {
-    if (!Array.isArray(CORE_SHARED_LOCAL[CORE_BOOT_QUEUE_KEY])) {
-      CORE_SHARED_LOCAL[CORE_BOOT_QUEUE_KEY] = [];
+var CORE_BOOT_QUEUE_KEY_PART2 = function resolveLegacyBootQueueKeyPart2(scope) {
+  if (scope && _typeof(scope) === 'object') {
+    var existingPublic = scope.CORE_BOOT_QUEUE_KEY;
+    var existingHidden = scope.__cineCoreBootQueueKey;
+
+    if (typeof existingPublic === 'string' && existingPublic) {
+      return existingPublic;
     }
-    return CORE_SHARED_LOCAL[CORE_BOOT_QUEUE_KEY];
+
+    if (typeof existingHidden === 'string' && existingHidden) {
+      return existingHidden;
+    }
   }
-  if (CORE_SHARED_SCOPE_PART2) {
-    var shared = CORE_SHARED_SCOPE_PART2.cineCoreShared || (CORE_SHARED_SCOPE_PART2.cineCoreShared = {});
-    if (!Array.isArray(shared[CORE_BOOT_QUEUE_KEY])) {
-      shared[CORE_BOOT_QUEUE_KEY] = [];
+
+  return '__coreRuntimeBootQueue';
+}(CORE_SHARED_SCOPE_PART2);
+var CORE_BOOT_QUEUE_PART2 = function () {
+  if (CORE_SHARED_SCOPE_PART2 && _typeof(CORE_SHARED_SCOPE_PART2) === 'object') {
+    var shared = CORE_SHARED_SCOPE_PART2.cineCoreShared;
+    if (shared && _typeof(shared) === 'object') {
+      var sharedQueue = shared[CORE_BOOT_QUEUE_KEY_PART2];
+      if (Array.isArray(sharedQueue)) {
+        return sharedQueue;
+      }
+      var sharedExtensible = typeof Object.isExtensible === 'function' ? Object.isExtensible(shared) : true;
+      if (sharedExtensible) {
+        shared[CORE_BOOT_QUEUE_KEY_PART2] = [];
+        return shared[CORE_BOOT_QUEUE_KEY_PART2];
+      }
     }
-    return shared[CORE_BOOT_QUEUE_KEY];
+    if (!Array.isArray(CORE_SHARED_SCOPE_PART2.CORE_BOOT_QUEUE)) {
+      CORE_SHARED_SCOPE_PART2.CORE_BOOT_QUEUE = [];
+    }
+    return CORE_SHARED_SCOPE_PART2.CORE_BOOT_QUEUE;
   }
   return [];
 }();
+if (CORE_SHARED_SCOPE_PART2 && CORE_SHARED_SCOPE_PART2.CORE_BOOT_QUEUE !== CORE_BOOT_QUEUE_PART2) {
+  CORE_SHARED_SCOPE_PART2.CORE_BOOT_QUEUE = CORE_BOOT_QUEUE_PART2;
+}
 function flushCoreBootQueue() {
-  if (!Array.isArray(CORE_BOOT_QUEUE) || !CORE_BOOT_QUEUE.length) {
+  if (!Array.isArray(CORE_BOOT_QUEUE_PART2) || !CORE_BOOT_QUEUE_PART2.length) {
     return;
   }
-  var pending = CORE_BOOT_QUEUE.splice(0, CORE_BOOT_QUEUE.length);
+  var pending = CORE_BOOT_QUEUE_PART2.splice(0, CORE_BOOT_QUEUE_PART2.length);
   for (var index = 0; index < pending.length; index += 1) {
     var task = pending[index];
     if (typeof task !== 'function') {

--- a/legacy/scripts/app-setups.js
+++ b/legacy/scripts/app-setups.js
@@ -57,15 +57,16 @@ if (deleteGearListProjectBtn) {
     deleteCurrentGearList();
   });
 }
-if (projectCancelBtn) {
-  projectCancelBtn.addEventListener('click', function () {
+var projectCancelBtnRef = typeof projectCancelBtn !== 'undefined' ? projectCancelBtn : null;
+if (projectCancelBtnRef) {
+  projectCancelBtnRef.addEventListener('click', function () {
     closeDialog(projectDialog);
   });
 }
 if (projectDialogCloseBtn) {
   projectDialogCloseBtn.addEventListener('click', function () {
-    if (projectCancelBtn) {
-      projectCancelBtn.click();
+    if (projectCancelBtnRef) {
+      projectCancelBtnRef.click();
     } else {
       closeDialog(projectDialog);
     }

--- a/legacy/scripts/modules/core-shared.js
+++ b/legacy/scripts/modules/core-shared.js
@@ -108,8 +108,8 @@ function _typeof(o) { "@babel/helpers - typeof"; return _typeof = "function" == 
         return cachedConnectorSummaryGenerator;
       }
     }
-    if (typeof generateConnectorSummary === 'function') {
-      cachedConnectorSummaryGenerator = generateConnectorSummary;
+    if (GLOBAL_SCOPE && typeof GLOBAL_SCOPE.generateConnectorSummary === 'function') {
+      cachedConnectorSummaryGenerator = GLOBAL_SCOPE.generateConnectorSummary;
       connectorSummaryCachePrimed = true;
       return cachedConnectorSummaryGenerator;
     }

--- a/src/scripts/app-core-new-2.js
+++ b/src/scripts/app-core-new-2.js
@@ -30,43 +30,60 @@ const CORE_SHARED_LOCAL =
     ? CORE_SHARED
     : resolveCoreSharedPart2() || {};
 
-var CORE_BOOT_QUEUE_KEY = typeof CORE_BOOT_QUEUE_KEY !== 'undefined'
-  ? CORE_BOOT_QUEUE_KEY
-  : '__coreRuntimeBootQueue';
+const CORE_BOOT_QUEUE_KEY_PART2 = (function resolveBootQueueKeyPart2(scope) {
+  if (scope && typeof scope === 'object') {
+    const existingPublic = scope.CORE_BOOT_QUEUE_KEY;
+    const existingHidden = scope.__cineCoreBootQueueKey;
 
-var CORE_BOOT_QUEUE = (function bootstrapCoreBootQueuePart2(existingQueue) {
+    if (typeof existingPublic === 'string' && existingPublic) {
+      return existingPublic;
+    }
+
+    if (typeof existingHidden === 'string' && existingHidden) {
+      return existingHidden;
+    }
+  }
+
+  return '__coreRuntimeBootQueue';
+})(CORE_SHARED_SCOPE_PART2);
+
+const CORE_BOOT_QUEUE_PART2 = (function bootstrapCoreBootQueuePart2(existingQueue) {
   if (Array.isArray(existingQueue)) {
     return existingQueue;
   }
 
-  if (CORE_SHARED_LOCAL && typeof CORE_SHARED_LOCAL === 'object') {
-    if (!Array.isArray(CORE_SHARED_LOCAL[CORE_BOOT_QUEUE_KEY])) {
-      CORE_SHARED_LOCAL[CORE_BOOT_QUEUE_KEY] = [];
+  if (CORE_SHARED_SCOPE_PART2 && typeof CORE_SHARED_SCOPE_PART2 === 'object') {
+    const shared = CORE_SHARED_SCOPE_PART2.cineCoreShared;
+    if (shared && typeof shared === 'object') {
+      const sharedQueue = shared[CORE_BOOT_QUEUE_KEY_PART2];
+      if (Array.isArray(sharedQueue)) {
+        return sharedQueue;
+      }
+      if (Object.isExtensible(shared)) {
+        shared[CORE_BOOT_QUEUE_KEY_PART2] = [];
+        return shared[CORE_BOOT_QUEUE_KEY_PART2];
+      }
     }
-    return CORE_SHARED_LOCAL[CORE_BOOT_QUEUE_KEY];
-  }
 
-  if (CORE_SHARED_SCOPE_PART2) {
-    const shared = CORE_SHARED_SCOPE_PART2.cineCoreShared || (CORE_SHARED_SCOPE_PART2.cineCoreShared = {});
-    if (!Array.isArray(shared[CORE_BOOT_QUEUE_KEY])) {
-      shared[CORE_BOOT_QUEUE_KEY] = [];
+    if (!Array.isArray(CORE_SHARED_SCOPE_PART2.CORE_BOOT_QUEUE)) {
+      CORE_SHARED_SCOPE_PART2.CORE_BOOT_QUEUE = [];
     }
-    return shared[CORE_BOOT_QUEUE_KEY];
+    return CORE_SHARED_SCOPE_PART2.CORE_BOOT_QUEUE;
   }
 
   return [];
 })(CORE_SHARED_SCOPE_PART2 && CORE_SHARED_SCOPE_PART2.CORE_BOOT_QUEUE);
 
-if (CORE_SHARED_SCOPE_PART2 && CORE_SHARED_SCOPE_PART2.CORE_BOOT_QUEUE !== CORE_BOOT_QUEUE) {
-  CORE_SHARED_SCOPE_PART2.CORE_BOOT_QUEUE = CORE_BOOT_QUEUE;
+if (CORE_SHARED_SCOPE_PART2 && CORE_SHARED_SCOPE_PART2.CORE_BOOT_QUEUE !== CORE_BOOT_QUEUE_PART2) {
+  CORE_SHARED_SCOPE_PART2.CORE_BOOT_QUEUE = CORE_BOOT_QUEUE_PART2;
 }
 
 function flushCoreBootQueue() {
-  if (!Array.isArray(CORE_BOOT_QUEUE) || CORE_BOOT_QUEUE.length === 0) {
+  if (!Array.isArray(CORE_BOOT_QUEUE_PART2) || CORE_BOOT_QUEUE_PART2.length === 0) {
     return;
   }
 
-  const pending = CORE_BOOT_QUEUE.splice(0, CORE_BOOT_QUEUE.length);
+  const pending = CORE_BOOT_QUEUE_PART2.splice(0, CORE_BOOT_QUEUE_PART2.length);
   for (let index = 0; index < pending.length; index += 1) {
     const task = pending[index];
     if (typeof task !== 'function') {

--- a/src/scripts/app-setups.js
+++ b/src/scripts/app-setups.js
@@ -64,16 +64,17 @@ if (deleteGearListProjectBtn) {
     });
 }
 
-if (projectCancelBtn) {
-    projectCancelBtn.addEventListener('click', () => {
+const projectCancelBtnRef = typeof projectCancelBtn !== 'undefined' ? projectCancelBtn : null;
+if (projectCancelBtnRef) {
+    projectCancelBtnRef.addEventListener('click', () => {
         closeDialog(projectDialog);
     });
 }
 
 if (projectDialogCloseBtn) {
     projectDialogCloseBtn.addEventListener('click', () => {
-        if (projectCancelBtn) {
-            projectCancelBtn.click();
+        if (projectCancelBtnRef) {
+            projectCancelBtnRef.click();
         } else {
             closeDialog(projectDialog);
         }

--- a/src/scripts/modules/core-shared.js
+++ b/src/scripts/modules/core-shared.js
@@ -132,8 +132,8 @@
       }
     }
 
-    if (typeof generateConnectorSummary === 'function') {
-      cachedConnectorSummaryGenerator = generateConnectorSummary;
+    if (GLOBAL_SCOPE && typeof GLOBAL_SCOPE.generateConnectorSummary === 'function') {
+      cachedConnectorSummaryGenerator = GLOBAL_SCOPE.generateConnectorSummary;
       connectorSummaryCachePrimed = true;
       return cachedConnectorSummaryGenerator;
     }


### PR DESCRIPTION
## Summary
- stabilize the boot queue key by persisting it on the shared global scope in the modern runtime bootstrap
- adjust the second runtime split to reference the shared boot queue without redefining conflicting globals
- mirror the boot queue key and queue handling changes in the legacy bundles to maintain parity

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d6f404eb088320b1331887ac58993e