### PR TITLE
Guard auto gear refresh routines during boot

### DIFF
--- a/src/scripts/app-core-new-1.js
+++ b/src/scripts/app-core-new-1.js
@@ -3489,10 +3489,10 @@ function normalizeAutoGearMonitorCatalogMode(value) {
   return 'none';
 }
 
-let autoGearMonitorCatalogMode = 'none';
-let autoGearMonitorDefaultGroups = [];
-let autoGearAddMonitorFieldGroup = null;
-let autoGearRemoveMonitorFieldGroup = null;
+var autoGearMonitorCatalogMode = 'none';
+var autoGearMonitorDefaultGroups = [];
+var autoGearAddMonitorFieldGroup = null;
+var autoGearRemoveMonitorFieldGroup = null;
 
 function collectAutoGearMonitorNames(type = autoGearMonitorCatalogMode) {
   const mode = normalizeAutoGearMonitorCatalogMode(type);
@@ -12102,7 +12102,7 @@ const autoGearConditionRefreshers = {
   viewfinderExtension: refreshAutoGearViewfinderExtensionOptions,
   deliveryResolution: refreshAutoGearDeliveryResolutionOptions,
   videoDistribution: refreshAutoGearVideoDistributionOptions,
-  camera: selected => callCoreFunctionIfAvailable('refreshAutoGearCameraOptions', [selected]),
+  camera: selected => callCoreFunctionIfAvailable('refreshAutoGearCameraOptions', [selected], { defer: true }),
   cameraWeight: refreshAutoGearCameraWeightCondition,
   monitor: refreshAutoGearMonitorOptions,
   crewPresent: selected => refreshAutoGearCrewOptions(autoGearCrewPresentSelect, selected, 'crewPresent'),


### PR DESCRIPTION
## Summary
- ensure the automatic gear camera refresher defers until the core handler is available in both modern and legacy bundles
- harden the monitor field visibility state by hoisting its globals to avoid temporal dead zone errors
- add a reusable helper in the legacy bundle so late-loading functions are invoked safely without breaking autosave flows

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d70a83cf4c8320b80bbd9f583171e2