### PR TITLE
Fix auto gear refresh deferrals before core part 2 loads

### DIFF
--- a/legacy/scripts/app-core-new-1.js
+++ b/legacy/scripts/app-core-new-1.js
@@ -10959,6 +10959,12 @@ var autoGearConditionConfigs = AUTO_GEAR_CONDITION_KEYS.reduce(function (acc, ke
   }
   return acc;
 }, {});
+function createDeferredAutoGearRefresher(functionName) {
+  return function (selected) {
+    return callCoreFunctionIfAvailable(functionName, [selected], { defer: true });
+  };
+}
+
 var autoGearConditionRefreshers = {
   always: null,
   scenarios: refreshAutoGearScenarioOptions,
@@ -10968,21 +10974,19 @@ var autoGearConditionRefreshers = {
   viewfinderExtension: refreshAutoGearViewfinderExtensionOptions,
   deliveryResolution: refreshAutoGearDeliveryResolutionOptions,
   videoDistribution: refreshAutoGearVideoDistributionOptions,
-  camera: function camera(selected) {
-    return callCoreFunctionIfAvailable('refreshAutoGearCameraOptions', [selected], { defer: true });
-  },
+  camera: createDeferredAutoGearRefresher('refreshAutoGearCameraOptions'),
   cameraWeight: refreshAutoGearCameraWeightCondition,
-  monitor: refreshAutoGearMonitorOptions,
+  monitor: createDeferredAutoGearRefresher('refreshAutoGearMonitorOptions'),
   crewPresent: function crewPresent(selected) {
     return refreshAutoGearCrewOptions(autoGearCrewPresentSelect, selected, 'crewPresent');
   },
   crewAbsent: function crewAbsent(selected) {
     return refreshAutoGearCrewOptions(autoGearCrewAbsentSelect, selected, 'crewAbsent');
   },
-  wireless: refreshAutoGearWirelessOptions,
-  motors: refreshAutoGearMotorsOptions,
-  controllers: refreshAutoGearControllersOptions,
-  distance: refreshAutoGearDistanceOptions
+  wireless: createDeferredAutoGearRefresher('refreshAutoGearWirelessOptions'),
+  motors: createDeferredAutoGearRefresher('refreshAutoGearMotorsOptions'),
+  controllers: createDeferredAutoGearRefresher('refreshAutoGearControllersOptions'),
+  distance: createDeferredAutoGearRefresher('refreshAutoGearDistanceOptions')
 };
 var autoGearActiveConditions = new Set();
 function getAutoGearConditionConfig(key) {

--- a/src/scripts/app-core-new-1.js
+++ b/src/scripts/app-core-new-1.js
@@ -12093,6 +12093,9 @@ const autoGearConditionConfigs = AUTO_GEAR_CONDITION_KEYS.reduce((acc, key) => {
   }
   return acc;
 }, {});
+const createDeferredAutoGearRefresher = functionName => selected =>
+  callCoreFunctionIfAvailable(functionName, [selected], { defer: true });
+
 const autoGearConditionRefreshers = {
   always: null,
   scenarios: refreshAutoGearScenarioOptions,
@@ -12102,15 +12105,15 @@ const autoGearConditionRefreshers = {
   viewfinderExtension: refreshAutoGearViewfinderExtensionOptions,
   deliveryResolution: refreshAutoGearDeliveryResolutionOptions,
   videoDistribution: refreshAutoGearVideoDistributionOptions,
-  camera: selected => callCoreFunctionIfAvailable('refreshAutoGearCameraOptions', [selected], { defer: true }),
+  camera: createDeferredAutoGearRefresher('refreshAutoGearCameraOptions'),
   cameraWeight: refreshAutoGearCameraWeightCondition,
-  monitor: refreshAutoGearMonitorOptions,
+  monitor: createDeferredAutoGearRefresher('refreshAutoGearMonitorOptions'),
   crewPresent: selected => refreshAutoGearCrewOptions(autoGearCrewPresentSelect, selected, 'crewPresent'),
   crewAbsent: selected => refreshAutoGearCrewOptions(autoGearCrewAbsentSelect, selected, 'crewAbsent'),
-  wireless: refreshAutoGearWirelessOptions,
-  motors: refreshAutoGearMotorsOptions,
-  controllers: refreshAutoGearControllersOptions,
-  distance: refreshAutoGearDistanceOptions,
+  wireless: createDeferredAutoGearRefresher('refreshAutoGearWirelessOptions'),
+  motors: createDeferredAutoGearRefresher('refreshAutoGearMotorsOptions'),
+  controllers: createDeferredAutoGearRefresher('refreshAutoGearControllersOptions'),
+  distance: createDeferredAutoGearRefresher('refreshAutoGearDistanceOptions'),
 };
 const autoGearActiveConditions = new Set();
 


### PR DESCRIPTION
## Summary
- guard auto-gear condition refresh hooks so they defer to core part 2 before invoking heavy refreshers
- mirror the same deferred refresher helper in the legacy runtime to keep behavior consistent

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d70c149c948320aed9c79929348372