### PR TITLE
Remove duplicate cancel icon in feedback dialog

### DIFF
--- a/index.html
+++ b/index.html
@@ -5533,7 +5533,7 @@
 
       <div class="form-row button-row">
         <button type="submit" id="fbSubmit">Save &amp; Submit</button>
-        <button type="button" id="fbCancel"><span class="btn-icon icon-glyph" aria-hidden="true" data-icon-font="essential">&#xF131;</span>Cancel</button>
+        <button type="button" id="fbCancel">Cancel</button>
       </div>
     </form>
 


### PR DESCRIPTION
## Summary
- remove redundant static icon markup from the feedback cancel button so only one icon is rendered

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d70ff53aec8320b9a97f1315401d75