### PR TITLE
Fix auto gear backup retention handler initialization

### DIFF
--- a/legacy/scripts/app-core-new-1.js
+++ b/legacy/scripts/app-core-new-1.js
@@ -11570,9 +11570,19 @@ var storageSummaryList = document.getElementById("storageSummaryList");
 var storageSummaryEmpty = document.getElementById("storageSummaryEmpty");
 var storageSummaryFootnote = document.getElementById("storageSummaryFootnote");
 if (autoGearBackupRetentionInput) {
-  autoGearBackupRetentionInput.addEventListener('input', handleAutoGearBackupRetentionInput);
-  autoGearBackupRetentionInput.addEventListener('blur', handleAutoGearBackupRetentionBlur);
-  autoGearBackupRetentionInput.addEventListener('change', handleAutoGearBackupRetentionChange);
+  var queueAutoGearRetentionHandler = function queueAutoGearRetentionHandler(handlerName) {
+    callCoreFunctionIfAvailable(handlerName, [], { defer: true });
+  };
+
+  autoGearBackupRetentionInput.addEventListener('input', function handleAutoGearRetentionInputEvent() {
+    queueAutoGearRetentionHandler('handleAutoGearBackupRetentionInput');
+  });
+  autoGearBackupRetentionInput.addEventListener('blur', function handleAutoGearRetentionBlurEvent() {
+    queueAutoGearRetentionHandler('handleAutoGearBackupRetentionBlur');
+  });
+  autoGearBackupRetentionInput.addEventListener('change', function handleAutoGearRetentionChangeEvent() {
+    queueAutoGearRetentionHandler('handleAutoGearBackupRetentionChange');
+  });
 }
 function computeAutoGearMultiSelectSize(optionCount) {
   var _ref45 = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {},

--- a/src/scripts/app-core-new-1.js
+++ b/src/scripts/app-core-new-1.js
@@ -12740,9 +12740,19 @@ const storageSummaryEmpty = document.getElementById("storageSummaryEmpty");
 const storageSummaryFootnote = document.getElementById("storageSummaryFootnote");
 
 if (autoGearBackupRetentionInput) {
-  autoGearBackupRetentionInput.addEventListener('input', handleAutoGearBackupRetentionInput);
-  autoGearBackupRetentionInput.addEventListener('blur', handleAutoGearBackupRetentionBlur);
-  autoGearBackupRetentionInput.addEventListener('change', handleAutoGearBackupRetentionChange);
+  const queueAutoGearRetentionHandler = handlerName => {
+    callCoreFunctionIfAvailable(handlerName, [], { defer: true });
+  };
+
+  autoGearBackupRetentionInput.addEventListener('input', () => {
+    queueAutoGearRetentionHandler('handleAutoGearBackupRetentionInput');
+  });
+  autoGearBackupRetentionInput.addEventListener('blur', () => {
+    queueAutoGearRetentionHandler('handleAutoGearBackupRetentionBlur');
+  });
+  autoGearBackupRetentionInput.addEventListener('change', () => {
+    queueAutoGearRetentionHandler('handleAutoGearBackupRetentionChange');
+  });
 }
 
 function computeAutoGearMultiSelectSize(optionCount, {


### PR DESCRIPTION
## Summary
- invoke auto gear backup retention handlers through the core function bridge so listeners register before secondary scripts load
- mirror the same safety change in the legacy bundle to keep behavior consistent

## Testing
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68d712b1d5e4832085faa75385b1655f