### PR TITLE
Fix initialization timing for auto gear retention handlers

### DIFF
--- a/src/scripts/app-core-new-1.js
+++ b/src/scripts/app-core-new-1.js
@@ -2203,6 +2203,13 @@ persistAutoGearBackupRetention(autoGearBackupRetention);
 let factoryAutoGearRulesSnapshot = null;
 let factoryAutoGearSeedContext = null;
 let autoGearBackupRetentionWarningText = '';
+var autoGearEditorDraft = null;
+var autoGearEditorActiveItem = null;
+let autoGearDraftPendingWarnings = null;
+let autoGearSearchQuery = '';
+let autoGearSummaryFocus = 'all';
+let autoGearSummaryLast = null;
+let autoGearScenarioFilter = 'all';
 function getAutoGearBackupEntrySignature(entry) {
   if (!entry || typeof entry !== 'object') return '';
   return stableStringify({
@@ -12769,14 +12776,6 @@ function computeAutoGearMultiSelectSize(optionCount, {
   const boundedMax = Number.isFinite(maxRows) && maxRows >= minRows ? maxRows : minRows;
   return Math.max(minRows, Math.min(optionCount, boundedMax));
 }
-
-var autoGearEditorDraft = null;
-var autoGearEditorActiveItem = null;
-let autoGearDraftPendingWarnings = null;
-let autoGearSearchQuery = '';
-let autoGearSummaryFocus = 'all';
-let autoGearSummaryLast = null;
-let autoGearScenarioFilter = 'all';
 
 function setAutoGearSearchQuery(value) {
   const nextValue = typeof value === 'string' ? value : '';


### PR DESCRIPTION
## Summary
- initialize the auto gear editor and filter state before the first localization pass so handlers are available during boot

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d7141eeb2c83208f7106c636b09f2d