### PR TITLE
Normalize stored boolean preferences during export

### DIFF
--- a/src/scripts/storage.js
+++ b/src/scripts/storage.js
@@ -4833,9 +4833,40 @@ function clearAllData() {
   }
 
   function parseStoredBoolean(value) {
-    if (value === null) return null;
-    if (value === 'true' || value === '1') return true;
-    if (value === 'false' || value === '0') return false;
+    if (value === null || value === undefined) {
+      return null;
+    }
+
+    if (typeof value === 'boolean') {
+      return value;
+    }
+
+    if (typeof value === 'number') {
+      if (Number.isNaN(value)) {
+        return null;
+      }
+      return value !== 0;
+    }
+
+    const normalized = String(value).trim().toLowerCase();
+    if (!normalized) {
+      return null;
+    }
+
+    if (normalized === 'true'
+        || normalized === '1'
+        || normalized === 'yes'
+        || normalized === 'on') {
+      return true;
+    }
+
+    if (normalized === 'false'
+        || normalized === '0'
+        || normalized === 'no'
+        || normalized === 'off') {
+      return false;
+    }
+
     return null;
   }
 

--- a/tests/unit/storage.test.js
+++ b/tests/unit/storage.test.js
@@ -1263,6 +1263,22 @@ describe('export/import all data', () => {
     });
   });
 
+  test('exportAllData normalizes stored boolean preference strings', () => {
+    localStorage.setItem('darkMode', ' TRUE ');
+    localStorage.setItem('pinkMode', 'false');
+    localStorage.setItem('highContrast', 'Yes');
+    localStorage.setItem('reduceMotion', ' OFF ');
+
+    const exported = exportAllData();
+
+    expect(exported.preferences).toEqual({
+      darkMode: true,
+      pinkMode: false,
+      highContrast: true,
+      reduceMotion: false,
+    });
+  });
+
   test('exportAllData filters invalid custom font entries', () => {
     const invalidEntries = [
       { id: 'font-keep', name: 'Keep', data: 'data:font/woff;base64,AAAA' },


### PR DESCRIPTION
## Summary
- normalize stored boolean preference strings before building the export payload so backups capture legacy values with whitespace, different casing, or alternate yes/no markers
- add a regression test proving exportAllData preserves these boolean preferences when they were stored with varied formatting

## Testing
- npm run test:jest -- tests/unit/storage.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d713197d048320b024f95014b7fcd1