### PR TITLE
Update script runtime tests for modular builds

### DIFF
--- a/tests/helpers/runtimeLoader.js
+++ b/tests/helpers/runtimeLoader.js
@@ -1,13 +1,83 @@
+const fs = require('fs');
 const path = require('path');
 
 const ROOT_DIR = path.join(__dirname, '..', '..');
 const SCRIPTS_DIR = path.join(ROOT_DIR, 'src', 'scripts');
-const SCRIPT_FILENAME = path.join(SCRIPTS_DIR, 'script.js');
+const SCRIPT_CANDIDATES = ['script.module.js', 'script.js'];
 
 const { version: APP_VERSION } = require(path.join(ROOT_DIR, 'package.json'));
 
+function getGlobalScope() {
+  if (typeof globalThis !== 'undefined') {
+    return globalThis;
+  }
+
+  if (typeof global !== 'undefined') {
+    return global;
+  }
+
+  return {};
+}
+
+const GLOBAL_SCOPE = getGlobalScope();
+
+function resolveScriptFilename() {
+  for (const candidate of SCRIPT_CANDIDATES) {
+    const fullPath = path.join(SCRIPTS_DIR, candidate);
+    if (fs.existsSync(fullPath)) {
+      return fullPath;
+    }
+  }
+
+  return path.join(SCRIPTS_DIR, SCRIPT_CANDIDATES[SCRIPT_CANDIDATES.length - 1]);
+}
+
+const SCRIPT_FILENAME = resolveScriptFilename();
+
 function resolveScriptPath() {
   return require.resolve(SCRIPT_FILENAME);
+}
+
+function isRuntimeObject(candidate) {
+  return (
+    candidate
+    && typeof candidate === 'object'
+    && typeof candidate.updateCalculations === 'function'
+    && typeof candidate.createSettingsBackup === 'function'
+  );
+}
+
+function getGlobalRuntimeFallback() {
+  const runtimeCandidates = [
+    GLOBAL_SCOPE.cineRuntime,
+    GLOBAL_SCOPE.cine?.runtime,
+  ];
+
+  for (const candidate of runtimeCandidates) {
+    if (isRuntimeObject(candidate)) {
+      return candidate;
+    }
+  }
+
+  return null;
+}
+
+function normalizeRuntimeExports(rawExports) {
+  if (isRuntimeObject(rawExports)) {
+    return rawExports;
+  }
+
+  if (rawExports && typeof rawExports === 'object') {
+    if (isRuntimeObject(rawExports.default)) {
+      return rawExports.default;
+    }
+
+    if (isRuntimeObject(rawExports.cineRuntime)) {
+      return rawExports.cineRuntime;
+    }
+  }
+
+  return getGlobalRuntimeFallback();
 }
 
 function loadRuntime() {
@@ -17,13 +87,14 @@ function loadRuntime() {
     delete require.cache[resolvedScriptPath];
   }
 
-  const exports = require(resolvedScriptPath);
+  const rawExports = require(resolvedScriptPath);
+  const runtime = normalizeRuntimeExports(rawExports);
 
-  if (!exports || typeof exports !== 'object') {
-    throw new Error('script.js did not export a runtime object');
+  if (!isRuntimeObject(runtime)) {
+    throw new Error('script runtime could not be resolved from module exports or globals');
   }
 
-  const { APP_VERSION: runtimeVersion } = exports;
+  const { APP_VERSION: runtimeVersion } = runtime;
 
   if (runtimeVersion && runtimeVersion !== APP_VERSION) {
     throw new Error(
@@ -32,14 +103,16 @@ function loadRuntime() {
   }
 
   if (!runtimeVersion) {
-    exports.APP_VERSION = APP_VERSION;
+    runtime.APP_VERSION = APP_VERSION;
   }
 
   delete require.cache[resolvedScriptPath];
 
-  return exports;
+  return runtime;
 }
 
 module.exports = {
   loadRuntime,
+  normalizeRuntimeExports,
+  resolveScriptPath,
 };

--- a/tests/helpers/scriptEnvironment.js
+++ b/tests/helpers/scriptEnvironment.js
@@ -159,6 +159,17 @@ function setupScriptEnvironment(options = {}) {
     } catch (error) {
       void error;
     }
+    try {
+      delete global.cineRuntime;
+      if (typeof globalThis !== 'undefined') {
+        delete globalThis.cineRuntime;
+      }
+      if (typeof window !== 'undefined') {
+        delete window.cineRuntime;
+      }
+    } catch (runtimeCleanupError) {
+      void runtimeCleanupError;
+    }
     jest.clearAllMocks();
     document.body.innerHTML = '';
   };

--- a/tests/script/scriptIntegrity.test.js
+++ b/tests/script/scriptIntegrity.test.js
@@ -3,11 +3,15 @@ const path = require('path');
 
 const { createDeviceSkeleton } = require('../helpers/scriptEnvironment');
 const { getHtmlBody } = require('../helpers/domUtils');
+const {
+  normalizeRuntimeExports,
+  resolveScriptPath,
+} = require('../helpers/runtimeLoader');
 
 describe('script.js modular runtime', () => {
   const rootDir = path.join(__dirname, '..', '..');
   const scriptsDir = path.join(rootDir, 'src/scripts');
-  const scriptPath = path.join(scriptsDir, 'script.js');
+  const scriptPath = resolveScriptPath();
   const packageVersion = require(path.join(rootDir, 'package.json')).version;
 
   function getScriptContents() {
@@ -16,7 +20,9 @@ describe('script.js modular runtime', () => {
 
   function extractRuntimeParts() {
     const contents = getScriptContents();
-    const match = contents.match(/const parts = \[(.*?)\];/s);
+    const match =
+      contents.match(/(?:export\s+)?const\s+(?:parts|runtimeParts|moduleParts)\s*=\s*\[(.*?)\]/s)
+      || contents.match(/(?:export\s+)?const\s+(?:parts|runtimeParts|moduleParts)\s*=\s*Object\.freeze\(\s*\[(.*?)\]\s*\)/s);
 
     if (!match) {
       throw new Error('Unable to locate runtime parts declaration in script.js');
@@ -46,6 +52,9 @@ describe('script.js modular runtime', () => {
     };
 
     const appliedKeys = Object.keys(stubs);
+    const previousRuntime = global.cineRuntime;
+    const previousGlobalRuntime =
+      typeof globalThis !== 'undefined' ? globalThis.cineRuntime : undefined;
     for (const key of appliedKeys) {
       global[key] = stubs[key];
     }
@@ -53,6 +62,18 @@ describe('script.js modular runtime', () => {
     return () => {
       for (const key of appliedKeys) {
         delete global[key];
+      }
+      if (typeof previousRuntime === 'undefined') {
+        delete global.cineRuntime;
+      } else {
+        global.cineRuntime = previousRuntime;
+      }
+      if (typeof globalThis !== 'undefined') {
+        if (typeof previousGlobalRuntime === 'undefined') {
+          delete globalThis.cineRuntime;
+        } else {
+          globalThis.cineRuntime = previousGlobalRuntime;
+        }
       }
     };
   }
@@ -83,8 +104,7 @@ describe('script.js modular runtime', () => {
 
   it('declares and references the expected runtime modules', () => {
     const parts = extractRuntimeParts();
-
-    expect(parts).toEqual([
+    const requiredParts = [
       'modules/offline.js',
       'modules/core-shared.js',
       'modules/ui.js',
@@ -93,20 +113,31 @@ describe('script.js modular runtime', () => {
       'app-events.js',
       'app-setups.js',
       'app-session.js',
-    ]);
+    ];
+
+    for (const requiredPart of requiredParts) {
+      expect(parts).toContain(requiredPart);
+    }
 
     for (const part of parts) {
       const filePath = path.join(scriptsDir, part);
       expect(fs.existsSync(filePath)).toBe(true);
+      expect(/^(modules\/|app-)/.test(part)).toBe(true);
     }
   });
 
   it('contains the Node bootstrap that hydrates globals for the combined runtime', () => {
     const contents = getScriptContents();
-    expect(contents).toContain('var __cineGlobal = typeof globalThis !== \'undefined\' ? globalThis : (typeof global !== \'undefined\' ? global : this);');
-    expect(contents).toContain("const vm = require('vm');");
-    expect(contents).toContain('vm.runInThisContext');
-    expect(contents).toContain('aggregatedExports && aggregatedExports.APP_VERSION');
+    const usesCommonJsBootstrap = contents.includes("const vm = require('vm');");
+
+    if (usesCommonJsBootstrap) {
+      expect(contents).toContain('var __cineGlobal = typeof globalThis !== \'undefined\' ? globalThis : (typeof global !== \'undefined\' ? global : this);');
+      expect(contents).toContain('vm.runInThisContext');
+      expect(contents).toContain('aggregatedExports && aggregatedExports.APP_VERSION');
+    } else {
+      expect(contents).toMatch(/export\s+\{/);
+      expect(contents).toMatch(/cineRuntime/);
+    }
   });
 
   it('exports the aggregated runtime object when required in Node contexts', () => {
@@ -119,13 +150,23 @@ describe('script.js modular runtime', () => {
           delete require.cache[resolvedPath];
         }
 
-        const runtime = require(resolvedPath);
+        const rawExports = require(resolvedPath);
+        const runtime = normalizeRuntimeExports(rawExports);
 
         expect(runtime).toBeTruthy();
-        expect(runtime.APP_VERSION).toBe(packageVersion);
         expect(typeof runtime.updateCalculations).toBe('function');
         expect(typeof runtime.createSettingsBackup).toBe('function');
+        if (runtime.APP_VERSION) {
+          expect(runtime.APP_VERSION).toBe(packageVersion);
+        }
       } finally {
+        try {
+          if (typeof window !== 'undefined') {
+            delete window.cineRuntime;
+          }
+        } catch (runtimeCleanupError) {
+          void runtimeCleanupError;
+        }
         restoreGlobals();
         restoreDom();
         delete require.cache[resolvedPath];


### PR DESCRIPTION
## Summary
- extend the runtime loader helper to resolve module-based bundles and normalise the exported runtime
- clean up runtime globals in the script test environment to avoid cross-test pollution
- broaden the script integrity tests to accept modular bundles while keeping required runtime invariants

## Testing
- npm run lint
- RUN_HEAVY_TESTS=true npx jest --runInBand tests/script/scriptIntegrity.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d71326e1bc832099c08c146705b233