### PR TITLE
Create automatic backups when overwriting projects

### DIFF
--- a/docs/backup-rotation-guide.md
+++ b/docs/backup-rotation-guide.md
@@ -7,6 +7,11 @@ known-good snapshot. Pair these routines with the [Operational Checklist](operat
 and the [Offline Readiness Runbook](offline-readiness.md) so every workstation ships with
 a validated recovery plan.
 
+Every time you overwrite an existing project the planner now captures a timestamped
+`auto-backup-…` snapshot of the previous state before committing the new data. These
+automatic backups follow the same retention rules described below, ensuring that even
+manual saves keep an additional recovery point without requiring operator action.
+
 ## 1. Naming conventions that survive handoffs
 
 Adopt a predictable naming scheme before creating your first backup or bundle. Consistent


### PR DESCRIPTION
## Summary
- ensure saveProject snapshots the prior state before overwriting an existing project entry
- add coverage for overwrite scenarios and document the new automatic backup behaviour in the rotation guide

## Testing
- npm run test:unit

------
https://chatgpt.com/codex/tasks/task_e_68d71598ad748320b22cc57399f279c7