### PR TITLE
Fix auto gear coverage omission in shared setup encoding

### DIFF
--- a/legacy/scripts/app-core-new-1.js
+++ b/legacy/scripts/app-core-new-1.js
@@ -9020,6 +9020,7 @@ var sharedKeyMap = {
   changedDevices: "x",
   feedback: "f",
   autoGearRules: "a",
+  autoGearCoverage: "z",
   diagramPositions: "y"
 };
 var lastSharedSetupData = null;

--- a/src/scripts/app-core-new-1.js
+++ b/src/scripts/app-core-new-1.js
@@ -10377,6 +10377,7 @@ const sharedKeyMap = {
   changedDevices: "x",
   feedback: "f",
   autoGearRules: "a",
+  autoGearCoverage: "z",
   diagramPositions: "y"
 };
 

--- a/tests/dom/sharedProjectGearList.test.js
+++ b/tests/dom/sharedProjectGearList.test.js
@@ -38,6 +38,25 @@ describe('shared project gear list handling', () => {
     expect(decoded.projectInfo).toEqual(payload.projectInfo);
   });
 
+  test('encodeSharedSetup preserves auto gear coverage snapshots', () => {
+    const { utils } = env;
+    const payload = {
+      autoGearCoverage: {
+        summary: { totalRules: 3, duplicates: 1 },
+        categories: [
+          { id: 'camera', coverage: ['cameraSelect'], rules: ['rule-1'] },
+          { id: 'monitor', coverage: ['monitorSelect'], rules: ['rule-2', 'rule-3'] }
+        ]
+      }
+    };
+
+    const encoded = utils.encodeSharedSetup(payload);
+    expect(encoded.z).toEqual(payload.autoGearCoverage);
+
+    const decoded = utils.decodeSharedSetup(encoded);
+    expect(decoded.autoGearCoverage).toEqual(payload.autoGearCoverage);
+  });
+
   test('applySharedSetup persists imported gear list', () => {
     const { utils } = env;
     const sharedData = {


### PR DESCRIPTION
## Summary
- ensure the shared setup key map includes auto gear coverage for both modern and legacy bundles so coverage data survives sharing
- add a regression test that proves encode/decode keeps the auto gear coverage snapshot intact

## Testing
- npm run test:dom -- sharedProjectGearList
- npm run test:unit
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d7161b1144832095c69ef45afe4b6d