### PR TITLE
Add top bar toggles to legal pages

### DIFF
--- a/legal/datenschutz-en.html
+++ b/legal/datenschutz-en.html
@@ -13,33 +13,76 @@
   <link rel="apple-touch-icon" href="../src/icons/app-icon.png" />
   <link rel="stylesheet" href="../src/styles/style.css" />
   <script src="../src/scripts/static-theme.js" defer></script>
+  <script src="../src/scripts/legal-topbar.js" defer></script>
 </head>
 <body class="static-page">
   <a href="#mainContent" class="skip-link">Skip to content</a>
   <div id="offlineIndicator" role="status" aria-live="polite">Offline</div>
   <header id="topBar">
-    <div class="branding">
+    <a class="branding" href="../index.html">
       <span id="logo" class="logo-wrapper" aria-hidden="true">
         <img src="../Icon Bluenew.svg" class="logo-img logo-default" alt="" />
         <img src="../Icon Pinknew.svg" class="logo-img logo-pink" alt="" />
       </span>
       <h1 id="mainTitle">Cine Power Planner</h1>
-    </div>
+    </a>
     <nav class="static-nav" aria-label="Secondary navigation">
       <a class="button-link" href="../index.html">Back to the app</a>
+    </nav>
+    <nav class="controls" aria-label="Page settings">
+      <select
+        id="languageSelect"
+        aria-label="Select language"
+        data-current-value="datenschutz-en.html"
+      >
+        <option value="datenschutz.html" lang="de">Deutsch</option>
+        <option value="datenschutz-en.html" lang="en">English</option>
+        <option value="datenschutz-es.html" lang="es">Español</option>
+        <option value="datenschutz-fr.html" lang="fr">Français</option>
+        <option value="datenschutz-it.html" lang="it">Italiano</option>
+      </select>
+      <button
+        id="darkModeToggle"
+        title="Toggle dark mode"
+        aria-label="Toggle dark mode"
+        aria-pressed="false"
+      >
+        <span class="icon-glyph" aria-hidden="true" data-icon-font="uicons">&#xEC7E;</span>
+      </button>
+      <button
+        id="pinkModeToggle"
+        title="Toggle pink mode"
+        aria-label="Toggle pink mode"
+        aria-pressed="false"
+      >
+        <span class="icon-glyph icon-svg pink-mode-icon" aria-hidden="true">
+          <svg viewBox="0 0 60 60" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+            <path
+              d="m1 40c0-8 3-17 3-17a4.84 4.84 0 0 0-1.829-3.064 1 1 0 0 1 .45-1.716 19.438 19.438 0 0 1 4.379-.22c.579-2.317-1.19-3.963-2.782-4.938a1 1 0 0 1 .393-1.85 14.128 14.128 0 0 1 6.389.788c0-.958-1.147-2.145-2.342-3.122a1 1 0 0 1 .708-1.773 40.655 40.655 0 0 1 6.634.895 3.723 3.723 0 0 0-1.049-2.264 1 1 0 0 1 .823-1.652c6.151.378 9.226 1.916 9.226 1.916l10-1s8.472-2.311 15.954.5a1 1 0 0 1-.084 1.9c-1.455.394-2.87 1.143-2.87 2.6 0 0 4.426.738 5.675 4.114a1 1 0 0 1-1.228 1.317c-1.64-.48-4.273-.88-6.447.569Z"
+              fill="#805333"
+            />
+            <path
+              d="m30.18 42.82c1.073 2.7 2.6 9.993 3.357 13.8a2 2 0 0 1-1.964 2.38h-28.573a2 2 0 0 1-2-2v-18c0-2.55 10.03-22.11 23.99-23.87Z"
+              fill="#a56a43"
+            />
+            <path
+              d="m55.67 48.46-6.34 2.97a6 6 0 0 1-7.98-2.88l-.25-.54-.76-1.6a4.956 4.956 0 0 0-4.68-2.87c-.22.01-.44.02-.66.02a16.019 16.019 0 0 1-8.28-29.66c-1.81-2.97-3.45-8.03 2.03-12.49a2.1 2.1 0 0 1 2.5 0c4.23 3.45 4.21 7.25 3.16 10.17a16 16 0 0 1 15.91 11.36l5.31 11.31 2.92 6.22a6.008 6.008 0 0 1-2.88 7.99Z"
+              fill="#cb8252"
+            />
+            <circle cx="42" cy="26" r="3" fill="#2c2f38" />
+            <circle cx="54" cy="43" r="1" fill="#805333" />
+            <path
+              d="m58.55 40.47-2.92-6.22-14.53 13.76.25.54a6 6 0 0 0 7.98 2.88l6.34-2.97a6.008 6.008 0 0 0 2.88-7.99Zm-4.55 3.53a1 1 0 1 1 1-1 1 1 0 0 1-1 1Z"
+              fill="#cf976a"
+            />
+            <circle cx="41" cy="25" r="1.25" fill="#ecf0f1" />
+          </svg>
+        </span>
+      </button>
     </nav>
   </header>
   <main id="mainContent" class="legal-content" tabindex="-1">
     <h1>Privacy Policy</h1>
-    <nav class="legal-language-nav" aria-label="Language selection">
-      <ul>
-        <li><a href="datenschutz.html" lang="de">Deutsch</a></li>
-        <li><a href="datenschutz-en.html" lang="en" aria-current="page">English</a></li>
-        <li><a href="datenschutz-es.html" lang="es">Español</a></li>
-        <li><a href="datenschutz-fr.html" lang="fr">Français</a></li>
-        <li><a href="datenschutz-it.html" lang="it">Italiano</a></li>
-      </ul>
-    </nav>
     <div class="legal-card">
       <h2>Controller</h2>
       <p>Luca Zanner<br>Brünnsteinstraße 5<br>81541 Munich<br>Germany<br>E-mail: <a href="mailto:info@lucazanner.com">info@lucazanner.com</a></p>

--- a/legal/datenschutz-es.html
+++ b/legal/datenschutz-es.html
@@ -13,33 +13,76 @@
   <link rel="apple-touch-icon" href="../src/icons/app-icon.png" />
   <link rel="stylesheet" href="../src/styles/style.css" />
   <script src="../src/scripts/static-theme.js" defer></script>
+  <script src="../src/scripts/legal-topbar.js" defer></script>
 </head>
 <body class="static-page">
   <a href="#mainContent" class="skip-link">Saltar al contenido</a>
   <div id="offlineIndicator" role="status" aria-live="polite">Sin conexión</div>
   <header id="topBar">
-    <div class="branding">
+    <a class="branding" href="../index.html">
       <span id="logo" class="logo-wrapper" aria-hidden="true">
         <img src="../Icon Bluenew.svg" class="logo-img logo-default" alt="" />
         <img src="../Icon Pinknew.svg" class="logo-img logo-pink" alt="" />
       </span>
       <h1 id="mainTitle">Cine Power Planner</h1>
-    </div>
+    </a>
     <nav class="static-nav" aria-label="Navegación secundaria">
       <a class="button-link" href="../index.html">Volver a la aplicación</a>
+    </nav>
+    <nav class="controls" aria-label="Ajustes de la página">
+      <select
+        id="languageSelect"
+        aria-label="Seleccionar idioma"
+        data-current-value="datenschutz-es.html"
+      >
+        <option value="datenschutz.html" lang="de">Deutsch</option>
+        <option value="datenschutz-en.html" lang="en">English</option>
+        <option value="datenschutz-es.html" lang="es">Español</option>
+        <option value="datenschutz-fr.html" lang="fr">Français</option>
+        <option value="datenschutz-it.html" lang="it">Italiano</option>
+      </select>
+      <button
+        id="darkModeToggle"
+        title="Alternar modo oscuro"
+        aria-label="Alternar modo oscuro"
+        aria-pressed="false"
+      >
+        <span class="icon-glyph" aria-hidden="true" data-icon-font="uicons">&#xEC7E;</span>
+      </button>
+      <button
+        id="pinkModeToggle"
+        title="Alternar modo rosa"
+        aria-label="Alternar modo rosa"
+        aria-pressed="false"
+      >
+        <span class="icon-glyph icon-svg pink-mode-icon" aria-hidden="true">
+          <svg viewBox="0 0 60 60" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+            <path
+              d="m1 40c0-8 3-17 3-17a4.84 4.84 0 0 0-1.829-3.064 1 1 0 0 1 .45-1.716 19.438 19.438 0 0 1 4.379-.22c.579-2.317-1.19-3.963-2.782-4.938a1 1 0 0 1 .393-1.85 14.128 14.128 0 0 1 6.389.788c0-.958-1.147-2.145-2.342-3.122a1 1 0 0 1 .708-1.773 40.655 40.655 0 0 1 6.634.895 3.723 3.723 0 0 0-1.049-2.264 1 1 0 0 1 .823-1.652c6.151.378 9.226 1.916 9.226 1.916l10-1s8.472-2.311 15.954.5a1 1 0 0 1-.084 1.9c-1.455.394-2.87 1.143-2.87 2.6 0 0 4.426.738 5.675 4.114a1 1 0 0 1-1.228 1.317c-1.64-.48-4.273-.88-6.447.569Z"
+              fill="#805333"
+            />
+            <path
+              d="m30.18 42.82c1.073 2.7 2.6 9.993 3.357 13.8a2 2 0 0 1-1.964 2.38h-28.573a2 2 0 0 1-2-2v-18c0-2.55 10.03-22.11 23.99-23.87Z"
+              fill="#a56a43"
+            />
+            <path
+              d="m55.67 48.46-6.34 2.97a6 6 0 0 1-7.98-2.88l-.25-.54-.76-1.6a4.956 4.956 0 0 0-4.68-2.87c-.22.01-.44.02-.66.02a16.019 16.019 0 0 1-8.28-29.66c-1.81-2.97-3.45-8.03 2.03-12.49a2.1 2.1 0 0 1 2.5 0c4.23 3.45 4.21 7.25 3.16 10.17a16 16 0 0 1 15.91 11.36l5.31 11.31 2.92 6.22a6.008 6.008 0 0 1-2.88 7.99Z"
+              fill="#cb8252"
+            />
+            <circle cx="42" cy="26" r="3" fill="#2c2f38" />
+            <circle cx="54" cy="43" r="1" fill="#805333" />
+            <path
+              d="m58.55 40.47-2.92-6.22-14.53 13.76.25.54a6 6 0 0 0 7.98 2.88l6.34-2.97a6.008 6.008 0 0 0 2.88-7.99Zm-4.55 3.53a1 1 0 1 1 1-1 1 1 0 0 1-1 1Z"
+              fill="#cf976a"
+            />
+            <circle cx="41" cy="25" r="1.25" fill="#ecf0f1" />
+          </svg>
+        </span>
+      </button>
     </nav>
   </header>
   <main id="mainContent" class="legal-content" tabindex="-1">
     <h1>Política de privacidad</h1>
-    <nav class="legal-language-nav" aria-label="Selección de idioma">
-      <ul>
-        <li><a href="datenschutz.html" lang="de">Deutsch</a></li>
-        <li><a href="datenschutz-en.html" lang="en">English</a></li>
-        <li><a href="datenschutz-es.html" lang="es" aria-current="page">Español</a></li>
-        <li><a href="datenschutz-fr.html" lang="fr">Français</a></li>
-        <li><a href="datenschutz-it.html" lang="it">Italiano</a></li>
-      </ul>
-    </nav>
     <div class="legal-card">
       <h2>Responsable del tratamiento</h2>
       <p>Luca Zanner<br>Brünnsteinstraße 5<br>81541 Múnich<br>Alemania<br>Correo electrónico: <a href="mailto:info@lucazanner.com">info@lucazanner.com</a></p>

--- a/legal/datenschutz-fr.html
+++ b/legal/datenschutz-fr.html
@@ -13,33 +13,76 @@
   <link rel="apple-touch-icon" href="../src/icons/app-icon.png" />
   <link rel="stylesheet" href="../src/styles/style.css" />
   <script src="../src/scripts/static-theme.js" defer></script>
+  <script src="../src/scripts/legal-topbar.js" defer></script>
 </head>
 <body class="static-page">
   <a href="#mainContent" class="skip-link">Aller au contenu</a>
   <div id="offlineIndicator" role="status" aria-live="polite">Hors ligne</div>
   <header id="topBar">
-    <div class="branding">
+    <a class="branding" href="../index.html">
       <span id="logo" class="logo-wrapper" aria-hidden="true">
         <img src="../Icon Bluenew.svg" class="logo-img logo-default" alt="" />
         <img src="../Icon Pinknew.svg" class="logo-img logo-pink" alt="" />
       </span>
       <h1 id="mainTitle">Cine Power Planner</h1>
-    </div>
+    </a>
     <nav class="static-nav" aria-label="Navigation secondaire">
       <a class="button-link" href="../index.html">Retour à l’application</a>
+    </nav>
+    <nav class="controls" aria-label="Paramètres de la page">
+      <select
+        id="languageSelect"
+        aria-label="Choisir la langue"
+        data-current-value="datenschutz-fr.html"
+      >
+        <option value="datenschutz.html" lang="de">Deutsch</option>
+        <option value="datenschutz-en.html" lang="en">English</option>
+        <option value="datenschutz-es.html" lang="es">Español</option>
+        <option value="datenschutz-fr.html" lang="fr">Français</option>
+        <option value="datenschutz-it.html" lang="it">Italiano</option>
+      </select>
+      <button
+        id="darkModeToggle"
+        title="Activer/désactiver le mode sombre"
+        aria-label="Activer/désactiver le mode sombre"
+        aria-pressed="false"
+      >
+        <span class="icon-glyph" aria-hidden="true" data-icon-font="uicons">&#xEC7E;</span>
+      </button>
+      <button
+        id="pinkModeToggle"
+        title="Activer/désactiver le mode rose"
+        aria-label="Activer/désactiver le mode rose"
+        aria-pressed="false"
+      >
+        <span class="icon-glyph icon-svg pink-mode-icon" aria-hidden="true">
+          <svg viewBox="0 0 60 60" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+            <path
+              d="m1 40c0-8 3-17 3-17a4.84 4.84 0 0 0-1.829-3.064 1 1 0 0 1 .45-1.716 19.438 19.438 0 0 1 4.379-.22c.579-2.317-1.19-3.963-2.782-4.938a1 1 0 0 1 .393-1.85 14.128 14.128 0 0 1 6.389.788c0-.958-1.147-2.145-2.342-3.122a1 1 0 0 1 .708-1.773 40.655 40.655 0 0 1 6.634.895 3.723 3.723 0 0 0-1.049-2.264 1 1 0 0 1 .823-1.652c6.151.378 9.226 1.916 9.226 1.916l10-1s8.472-2.311 15.954.5a1 1 0 0 1-.084 1.9c-1.455.394-2.87 1.143-2.87 2.6 0 0 4.426.738 5.675 4.114a1 1 0 0 1-1.228 1.317c-1.64-.48-4.273-.88-6.447.569Z"
+              fill="#805333"
+            />
+            <path
+              d="m30.18 42.82c1.073 2.7 2.6 9.993 3.357 13.8a2 2 0 0 1-1.964 2.38h-28.573a2 2 0 0 1-2-2v-18c0-2.55 10.03-22.11 23.99-23.87Z"
+              fill="#a56a43"
+            />
+            <path
+              d="m55.67 48.46-6.34 2.97a6 6 0 0 1-7.98-2.88l-.25-.54-.76-1.6a4.956 4.956 0 0 0-4.68-2.87c-.22.01-.44.02-.66.02a16.019 16.019 0 0 1-8.28-29.66c-1.81-2.97-3.45-8.03 2.03-12.49a2.1 2.1 0 0 1 2.5 0c4.23 3.45 4.21 7.25 3.16 10.17a16 16 0 0 1 15.91 11.36l5.31 11.31 2.92 6.22a6.008 6.008 0 0 1-2.88 7.99Z"
+              fill="#cb8252"
+            />
+            <circle cx="42" cy="26" r="3" fill="#2c2f38" />
+            <circle cx="54" cy="43" r="1" fill="#805333" />
+            <path
+              d="m58.55 40.47-2.92-6.22-14.53 13.76.25.54a6 6 0 0 0 7.98 2.88l6.34-2.97a6.008 6.008 0 0 0 2.88-7.99Zm-4.55 3.53a1 1 0 1 1 1-1 1 1 0 0 1-1 1Z"
+              fill="#cf976a"
+            />
+            <circle cx="41" cy="25" r="1.25" fill="#ecf0f1" />
+          </svg>
+        </span>
+      </button>
     </nav>
   </header>
   <main id="mainContent" class="legal-content" tabindex="-1">
     <h1>Politique de confidentialité</h1>
-    <nav class="legal-language-nav" aria-label="Sélection de la langue">
-      <ul>
-        <li><a href="datenschutz.html" lang="de">Deutsch</a></li>
-        <li><a href="datenschutz-en.html" lang="en">English</a></li>
-        <li><a href="datenschutz-es.html" lang="es">Español</a></li>
-        <li><a href="datenschutz-fr.html" lang="fr" aria-current="page">Français</a></li>
-        <li><a href="datenschutz-it.html" lang="it">Italiano</a></li>
-      </ul>
-    </nav>
     <div class="legal-card">
       <h2>Responsable du traitement</h2>
       <p>Luca Zanner<br>Brünnsteinstraße 5<br>81541 Munich<br>Allemagne<br>E-mail : <a href="mailto:info@lucazanner.com">info@lucazanner.com</a></p>

--- a/legal/datenschutz-it.html
+++ b/legal/datenschutz-it.html
@@ -13,33 +13,76 @@
   <link rel="apple-touch-icon" href="../src/icons/app-icon.png" />
   <link rel="stylesheet" href="../src/styles/style.css" />
   <script src="../src/scripts/static-theme.js" defer></script>
+  <script src="../src/scripts/legal-topbar.js" defer></script>
 </head>
 <body class="static-page">
   <a href="#mainContent" class="skip-link">Vai al contenuto</a>
   <div id="offlineIndicator" role="status" aria-live="polite">Offline</div>
   <header id="topBar">
-    <div class="branding">
+    <a class="branding" href="../index.html">
       <span id="logo" class="logo-wrapper" aria-hidden="true">
         <img src="../Icon Bluenew.svg" class="logo-img logo-default" alt="" />
         <img src="../Icon Pinknew.svg" class="logo-img logo-pink" alt="" />
       </span>
       <h1 id="mainTitle">Cine Power Planner</h1>
-    </div>
+    </a>
     <nav class="static-nav" aria-label="Navigazione secondaria">
       <a class="button-link" href="../index.html">Torna all’app</a>
+    </nav>
+    <nav class="controls" aria-label="Impostazioni della pagina">
+      <select
+        id="languageSelect"
+        aria-label="Seleziona lingua"
+        data-current-value="datenschutz-it.html"
+      >
+        <option value="datenschutz.html" lang="de">Deutsch</option>
+        <option value="datenschutz-en.html" lang="en">English</option>
+        <option value="datenschutz-es.html" lang="es">Español</option>
+        <option value="datenschutz-fr.html" lang="fr">Français</option>
+        <option value="datenschutz-it.html" lang="it">Italiano</option>
+      </select>
+      <button
+        id="darkModeToggle"
+        title="Attiva/disattiva la modalità scura"
+        aria-label="Attiva/disattiva la modalità scura"
+        aria-pressed="false"
+      >
+        <span class="icon-glyph" aria-hidden="true" data-icon-font="uicons">&#xEC7E;</span>
+      </button>
+      <button
+        id="pinkModeToggle"
+        title="Attiva/disattiva la modalità rosa"
+        aria-label="Attiva/disattiva la modalità rosa"
+        aria-pressed="false"
+      >
+        <span class="icon-glyph icon-svg pink-mode-icon" aria-hidden="true">
+          <svg viewBox="0 0 60 60" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+            <path
+              d="m1 40c0-8 3-17 3-17a4.84 4.84 0 0 0-1.829-3.064 1 1 0 0 1 .45-1.716 19.438 19.438 0 0 1 4.379-.22c.579-2.317-1.19-3.963-2.782-4.938a1 1 0 0 1 .393-1.85 14.128 14.128 0 0 1 6.389.788c0-.958-1.147-2.145-2.342-3.122a1 1 0 0 1 .708-1.773 40.655 40.655 0 0 1 6.634.895 3.723 3.723 0 0 0-1.049-2.264 1 1 0 0 1 .823-1.652c6.151.378 9.226 1.916 9.226 1.916l10-1s8.472-2.311 15.954.5a1 1 0 0 1-.084 1.9c-1.455.394-2.87 1.143-2.87 2.6 0 0 4.426.738 5.675 4.114a1 1 0 0 1-1.228 1.317c-1.64-.48-4.273-.88-6.447.569Z"
+              fill="#805333"
+            />
+            <path
+              d="m30.18 42.82c1.073 2.7 2.6 9.993 3.357 13.8a2 2 0 0 1-1.964 2.38h-28.573a2 2 0 0 1-2-2v-18c0-2.55 10.03-22.11 23.99-23.87Z"
+              fill="#a56a43"
+            />
+            <path
+              d="m55.67 48.46-6.34 2.97a6 6 0 0 1-7.98-2.88l-.25-.54-.76-1.6a4.956 4.956 0 0 0-4.68-2.87c-.22.01-.44.02-.66.02a16.019 16.019 0 0 1-8.28-29.66c-1.81-2.97-3.45-8.03 2.03-12.49a2.1 2.1 0 0 1 2.5 0c4.23 3.45 4.21 7.25 3.16 10.17a16 16 0 0 1 15.91 11.36l5.31 11.31 2.92 6.22a6.008 6.008 0 0 1-2.88 7.99Z"
+              fill="#cb8252"
+            />
+            <circle cx="42" cy="26" r="3" fill="#2c2f38" />
+            <circle cx="54" cy="43" r="1" fill="#805333" />
+            <path
+              d="m58.55 40.47-2.92-6.22-14.53 13.76.25.54a6 6 0 0 0 7.98 2.88l6.34-2.97a6.008 6.008 0 0 0 2.88-7.99Zm-4.55 3.53a1 1 0 1 1 1-1 1 1 0 0 1-1 1Z"
+              fill="#cf976a"
+            />
+            <circle cx="41" cy="25" r="1.25" fill="#ecf0f1" />
+          </svg>
+        </span>
+      </button>
     </nav>
   </header>
   <main id="mainContent" class="legal-content" tabindex="-1">
     <h1>Informativa sulla privacy</h1>
-    <nav class="legal-language-nav" aria-label="Selezione della lingua">
-      <ul>
-        <li><a href="datenschutz.html" lang="de">Deutsch</a></li>
-        <li><a href="datenschutz-en.html" lang="en">English</a></li>
-        <li><a href="datenschutz-es.html" lang="es">Español</a></li>
-        <li><a href="datenschutz-fr.html" lang="fr">Français</a></li>
-        <li><a href="datenschutz-it.html" lang="it" aria-current="page">Italiano</a></li>
-      </ul>
-    </nav>
     <div class="legal-card">
       <h2>Titolare del trattamento</h2>
       <p>Luca Zanner<br>Brünnsteinstraße 5<br>81541 Monaco di Baviera<br>Germania<br>E-mail: <a href="mailto:info@lucazanner.com">info@lucazanner.com</a></p>

--- a/legal/datenschutz.html
+++ b/legal/datenschutz.html
@@ -13,6 +13,7 @@
   <link rel="apple-touch-icon" href="../src/icons/app-icon.png" />
   <link rel="stylesheet" href="../src/styles/style.css" />
   <script src="../src/scripts/static-theme.js" defer></script>
+  <script src="../src/scripts/legal-topbar.js" defer></script>
 </head>
 <body class="static-page">
   <a href="#mainContent" class="skip-link">Zum Inhalt springen</a>
@@ -26,20 +27,62 @@
       <h1 id="mainTitle">Cine Power Planner</h1>
     </a>
     <nav class="static-nav" aria-label="Sekundärnavigation">
-      <a class="button-link" href="index.html">Zurück zur App</a>
+      <a class="button-link" href="../index.html">Zurück zur App</a>
+    </nav>
+    <nav class="controls" aria-label="Seiteneinstellungen">
+      <select
+        id="languageSelect"
+        aria-label="Sprache auswählen"
+        data-current-value="datenschutz.html"
+      >
+        <option value="datenschutz.html" lang="de">Deutsch</option>
+        <option value="datenschutz-en.html" lang="en">English</option>
+        <option value="datenschutz-es.html" lang="es">Español</option>
+        <option value="datenschutz-fr.html" lang="fr">Français</option>
+        <option value="datenschutz-it.html" lang="it">Italiano</option>
+      </select>
+      <button
+        id="darkModeToggle"
+        title="Dunkelmodus umschalten"
+        aria-label="Dunkelmodus umschalten"
+        aria-pressed="false"
+      >
+        <span class="icon-glyph" aria-hidden="true" data-icon-font="uicons">&#xEC7E;</span>
+      </button>
+      <button
+        id="pinkModeToggle"
+        title="Pink-Modus umschalten"
+        aria-label="Pink-Modus umschalten"
+        aria-pressed="false"
+      >
+        <span class="icon-glyph icon-svg pink-mode-icon" aria-hidden="true">
+          <svg viewBox="0 0 60 60" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+            <path
+              d="m1 40c0-8 3-17 3-17a4.84 4.84 0 0 0-1.829-3.064 1 1 0 0 1 .45-1.716 19.438 19.438 0 0 1 4.379-.22c.579-2.317-1.19-3.963-2.782-4.938a1 1 0 0 1 .393-1.85 14.128 14.128 0 0 1 6.389.788c0-.958-1.147-2.145-2.342-3.122a1 1 0 0 1 .708-1.773 40.655 40.655 0 0 1 6.634.895 3.723 3.723 0 0 0-1.049-2.264 1 1 0 0 1 .823-1.652c6.151.378 9.226 1.916 9.226 1.916l10-1s8.472-2.311 15.954.5a1 1 0 0 1-.084 1.9c-1.455.394-2.87 1.143-2.87 2.6 0 0 4.426.738 5.675 4.114a1 1 0 0 1-1.228 1.317c-1.64-.48-4.273-.88-6.447.569Z"
+              fill="#805333"
+            />
+            <path
+              d="m30.18 42.82c1.073 2.7 2.6 9.993 3.357 13.8a2 2 0 0 1-1.964 2.38h-28.573a2 2 0 0 1-2-2v-18c0-2.55 10.03-22.11 23.99-23.87Z"
+              fill="#a56a43"
+            />
+            <path
+              d="m55.67 48.46-6.34 2.97a6 6 0 0 1-7.98-2.88l-.25-.54-.76-1.6a4.956 4.956 0 0 0-4.68-2.87c-.22.01-.44.02-.66.02a16.019 16.019 0 0 1-8.28-29.66c-1.81-2.97-3.45-8.03 2.03-12.49a2.1 2.1 0 0 1 2.5 0c4.23 3.45 4.21 7.25 3.16 10.17a16 16 0 0 1 15.91 11.36l5.31 11.31 2.92 6.22a6.008 6.008 0 0 1-2.88 7.99Z"
+              fill="#cb8252"
+            />
+            <circle cx="42" cy="26" r="3" fill="#2c2f38" />
+            <circle cx="54" cy="43" r="1" fill="#805333" />
+            <path
+              d="m58.55 40.47-2.92-6.22-14.53 13.76.25.54a6 6 0 0 0 7.98 2.88l6.34-2.97a6.008 6.008 0 0 0 2.88-7.99Zm-4.55 3.53a1 1 0 1 1 1-1 1 1 0 0 1-1 1Z"
+              fill="#cf976a"
+            />
+            <circle cx="41" cy="25" r="1.25" fill="#ecf0f1" />
+          </svg>
+        </span>
+      </button>
     </nav>
   </header>
   <main id="mainContent" class="legal-content" tabindex="-1">
     <h1>Datenschutzerklärung</h1>
-    <nav class="legal-language-nav" aria-label="Sprachauswahl">
-      <ul>
-        <li><a href="datenschutz.html" lang="de" aria-current="page">Deutsch</a></li>
-        <li><a href="datenschutz-en.html" lang="en">English</a></li>
-        <li><a href="datenschutz-es.html" lang="es">Español</a></li>
-        <li><a href="datenschutz-fr.html" lang="fr">Français</a></li>
-        <li><a href="datenschutz-it.html" lang="it">Italiano</a></li>
-      </ul>
-    </nav>
     <div class="legal-card">
       <h2>Verantwortliche Stelle</h2>
       <p>Luca Zanner<br>Brünnsteinstraße 5<br>81541 München<br>Deutschland<br>E-Mail: <a href="mailto:info@lucazanner.com">info@lucazanner.com</a></p>

--- a/legal/impressum-en.html
+++ b/legal/impressum-en.html
@@ -13,33 +13,76 @@
   <link rel="apple-touch-icon" href="../src/icons/app-icon.png" />
   <link rel="stylesheet" href="../src/styles/style.css" />
   <script src="../src/scripts/static-theme.js" defer></script>
+  <script src="../src/scripts/legal-topbar.js" defer></script>
 </head>
 <body class="static-page">
   <a href="#mainContent" class="skip-link">Skip to content</a>
   <div id="offlineIndicator" role="status" aria-live="polite">Offline</div>
   <header id="topBar">
-    <div class="branding">
+    <a class="branding" href="../index.html">
       <span id="logo" class="logo-wrapper" aria-hidden="true">
         <img src="../Icon Bluenew.svg" class="logo-img logo-default" alt="" />
         <img src="../Icon Pinknew.svg" class="logo-img logo-pink" alt="" />
       </span>
       <h1 id="mainTitle">Cine Power Planner</h1>
-    </div>
+    </a>
     <nav class="static-nav" aria-label="Secondary navigation">
       <a class="button-link" href="../index.html">Back to the app</a>
+    </nav>
+    <nav class="controls" aria-label="Page settings">
+      <select
+        id="languageSelect"
+        aria-label="Select language"
+        data-current-value="impressum-en.html"
+      >
+        <option value="impressum.html" lang="de">Deutsch</option>
+        <option value="impressum-en.html" lang="en">English</option>
+        <option value="impressum-es.html" lang="es">Español</option>
+        <option value="impressum-fr.html" lang="fr">Français</option>
+        <option value="impressum-it.html" lang="it">Italiano</option>
+      </select>
+      <button
+        id="darkModeToggle"
+        title="Toggle dark mode"
+        aria-label="Toggle dark mode"
+        aria-pressed="false"
+      >
+        <span class="icon-glyph" aria-hidden="true" data-icon-font="uicons">&#xEC7E;</span>
+      </button>
+      <button
+        id="pinkModeToggle"
+        title="Toggle pink mode"
+        aria-label="Toggle pink mode"
+        aria-pressed="false"
+      >
+        <span class="icon-glyph icon-svg pink-mode-icon" aria-hidden="true">
+          <svg viewBox="0 0 60 60" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+            <path
+              d="m1 40c0-8 3-17 3-17a4.84 4.84 0 0 0-1.829-3.064 1 1 0 0 1 .45-1.716 19.438 19.438 0 0 1 4.379-.22c.579-2.317-1.19-3.963-2.782-4.938a1 1 0 0 1 .393-1.85 14.128 14.128 0 0 1 6.389.788c0-.958-1.147-2.145-2.342-3.122a1 1 0 0 1 .708-1.773 40.655 40.655 0 0 1 6.634.895 3.723 3.723 0 0 0-1.049-2.264 1 1 0 0 1 .823-1.652c6.151.378 9.226 1.916 9.226 1.916l10-1s8.472-2.311 15.954.5a1 1 0 0 1-.084 1.9c-1.455.394-2.87 1.143-2.87 2.6 0 0 4.426.738 5.675 4.114a1 1 0 0 1-1.228 1.317c-1.64-.48-4.273-.88-6.447.569Z"
+              fill="#805333"
+            />
+            <path
+              d="m30.18 42.82c1.073 2.7 2.6 9.993 3.357 13.8a2 2 0 0 1-1.964 2.38h-28.573a2 2 0 0 1-2-2v-18c0-2.55 10.03-22.11 23.99-23.87Z"
+              fill="#a56a43"
+            />
+            <path
+              d="m55.67 48.46-6.34 2.97a6 6 0 0 1-7.98-2.88l-.25-.54-.76-1.6a4.956 4.956 0 0 0-4.68-2.87c-.22.01-.44.02-.66.02a16.019 16.019 0 0 1-8.28-29.66c-1.81-2.97-3.45-8.03 2.03-12.49a2.1 2.1 0 0 1 2.5 0c4.23 3.45 4.21 7.25 3.16 10.17a16 16 0 0 1 15.91 11.36l5.31 11.31 2.92 6.22a6.008 6.008 0 0 1-2.88 7.99Z"
+              fill="#cb8252"
+            />
+            <circle cx="42" cy="26" r="3" fill="#2c2f38" />
+            <circle cx="54" cy="43" r="1" fill="#805333" />
+            <path
+              d="m58.55 40.47-2.92-6.22-14.53 13.76.25.54a6 6 0 0 0 7.98 2.88l6.34-2.97a6.008 6.008 0 0 0 2.88-7.99Zm-4.55 3.53a1 1 0 1 1 1-1 1 1 0 0 1-1 1Z"
+              fill="#cf976a"
+            />
+            <circle cx="41" cy="25" r="1.25" fill="#ecf0f1" />
+          </svg>
+        </span>
+      </button>
     </nav>
   </header>
   <main id="mainContent" class="legal-content" tabindex="-1">
     <h1>Imprint</h1>
-    <nav class="legal-language-nav" aria-label="Language selection">
-      <ul>
-        <li><a href="impressum.html" lang="de">Deutsch</a></li>
-        <li><a href="impressum-en.html" lang="en" aria-current="page">English</a></li>
-        <li><a href="impressum-es.html" lang="es">Español</a></li>
-        <li><a href="impressum-fr.html" lang="fr">Français</a></li>
-        <li><a href="impressum-it.html" lang="it">Italiano</a></li>
-      </ul>
-    </nav>
     <div class="legal-card">
       <h2>Provider identification pursuant to Section&nbsp;5 German Telemedia Act (TMG)</h2>
       <p>Luca Zanner<br>Brünnsteinstraße 5<br>81541 Munich<br>Germany</p>

--- a/legal/impressum-es.html
+++ b/legal/impressum-es.html
@@ -13,33 +13,76 @@
   <link rel="apple-touch-icon" href="../src/icons/app-icon.png" />
   <link rel="stylesheet" href="../src/styles/style.css" />
   <script src="../src/scripts/static-theme.js" defer></script>
+  <script src="../src/scripts/legal-topbar.js" defer></script>
 </head>
 <body class="static-page">
   <a href="#mainContent" class="skip-link">Saltar al contenido</a>
   <div id="offlineIndicator" role="status" aria-live="polite">Sin conexión</div>
   <header id="topBar">
-    <div class="branding">
+    <a class="branding" href="../index.html">
       <span id="logo" class="logo-wrapper" aria-hidden="true">
         <img src="../Icon Bluenew.svg" class="logo-img logo-default" alt="" />
         <img src="../Icon Pinknew.svg" class="logo-img logo-pink" alt="" />
       </span>
       <h1 id="mainTitle">Cine Power Planner</h1>
-    </div>
+    </a>
     <nav class="static-nav" aria-label="Navegación secundaria">
       <a class="button-link" href="../index.html">Volver a la aplicación</a>
+    </nav>
+    <nav class="controls" aria-label="Ajustes de la página">
+      <select
+        id="languageSelect"
+        aria-label="Seleccionar idioma"
+        data-current-value="impressum-es.html"
+      >
+        <option value="impressum.html" lang="de">Deutsch</option>
+        <option value="impressum-en.html" lang="en">English</option>
+        <option value="impressum-es.html" lang="es">Español</option>
+        <option value="impressum-fr.html" lang="fr">Français</option>
+        <option value="impressum-it.html" lang="it">Italiano</option>
+      </select>
+      <button
+        id="darkModeToggle"
+        title="Alternar modo oscuro"
+        aria-label="Alternar modo oscuro"
+        aria-pressed="false"
+      >
+        <span class="icon-glyph" aria-hidden="true" data-icon-font="uicons">&#xEC7E;</span>
+      </button>
+      <button
+        id="pinkModeToggle"
+        title="Alternar modo rosa"
+        aria-label="Alternar modo rosa"
+        aria-pressed="false"
+      >
+        <span class="icon-glyph icon-svg pink-mode-icon" aria-hidden="true">
+          <svg viewBox="0 0 60 60" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+            <path
+              d="m1 40c0-8 3-17 3-17a4.84 4.84 0 0 0-1.829-3.064 1 1 0 0 1 .45-1.716 19.438 19.438 0 0 1 4.379-.22c.579-2.317-1.19-3.963-2.782-4.938a1 1 0 0 1 .393-1.85 14.128 14.128 0 0 1 6.389.788c0-.958-1.147-2.145-2.342-3.122a1 1 0 0 1 .708-1.773 40.655 40.655 0 0 1 6.634.895 3.723 3.723 0 0 0-1.049-2.264 1 1 0 0 1 .823-1.652c6.151.378 9.226 1.916 9.226 1.916l10-1s8.472-2.311 15.954.5a1 1 0 0 1-.084 1.9c-1.455.394-2.87 1.143-2.87 2.6 0 0 4.426.738 5.675 4.114a1 1 0 0 1-1.228 1.317c-1.64-.48-4.273-.88-6.447.569Z"
+              fill="#805333"
+            />
+            <path
+              d="m30.18 42.82c1.073 2.7 2.6 9.993 3.357 13.8a2 2 0 0 1-1.964 2.38h-28.573a2 2 0 0 1-2-2v-18c0-2.55 10.03-22.11 23.99-23.87Z"
+              fill="#a56a43"
+            />
+            <path
+              d="m55.67 48.46-6.34 2.97a6 6 0 0 1-7.98-2.88l-.25-.54-.76-1.6a4.956 4.956 0 0 0-4.68-2.87c-.22.01-.44.02-.66.02a16.019 16.019 0 0 1-8.28-29.66c-1.81-2.97-3.45-8.03 2.03-12.49a2.1 2.1 0 0 1 2.5 0c4.23 3.45 4.21 7.25 3.16 10.17a16 16 0 0 1 15.91 11.36l5.31 11.31 2.92 6.22a6.008 6.008 0 0 1-2.88 7.99Z"
+              fill="#cb8252"
+            />
+            <circle cx="42" cy="26" r="3" fill="#2c2f38" />
+            <circle cx="54" cy="43" r="1" fill="#805333" />
+            <path
+              d="m58.55 40.47-2.92-6.22-14.53 13.76.25.54a6 6 0 0 0 7.98 2.88l6.34-2.97a6.008 6.008 0 0 0 2.88-7.99Zm-4.55 3.53a1 1 0 1 1 1-1 1 1 0 0 1-1 1Z"
+              fill="#cf976a"
+            />
+            <circle cx="41" cy="25" r="1.25" fill="#ecf0f1" />
+          </svg>
+        </span>
+      </button>
     </nav>
   </header>
   <main id="mainContent" class="legal-content" tabindex="-1">
     <h1>Aviso legal</h1>
-    <nav class="legal-language-nav" aria-label="Selección de idioma">
-      <ul>
-        <li><a href="impressum.html" lang="de">Deutsch</a></li>
-        <li><a href="impressum-en.html" lang="en">English</a></li>
-        <li><a href="impressum-es.html" lang="es" aria-current="page">Español</a></li>
-        <li><a href="impressum-fr.html" lang="fr">Français</a></li>
-        <li><a href="impressum-it.html" lang="it">Italiano</a></li>
-      </ul>
-    </nav>
     <div class="legal-card">
       <h2>Información según el § 5 de la Ley alemana de Telemedios (TMG)</h2>
       <p>Luca Zanner<br>Brünnsteinstraße 5<br>81541 Múnich<br>Alemania</p>

--- a/legal/impressum-fr.html
+++ b/legal/impressum-fr.html
@@ -13,33 +13,76 @@
   <link rel="apple-touch-icon" href="../src/icons/app-icon.png" />
   <link rel="stylesheet" href="../src/styles/style.css" />
   <script src="../src/scripts/static-theme.js" defer></script>
+  <script src="../src/scripts/legal-topbar.js" defer></script>
 </head>
 <body class="static-page">
   <a href="#mainContent" class="skip-link">Aller au contenu</a>
   <div id="offlineIndicator" role="status" aria-live="polite">Hors ligne</div>
   <header id="topBar">
-    <div class="branding">
+    <a class="branding" href="../index.html">
       <span id="logo" class="logo-wrapper" aria-hidden="true">
         <img src="../Icon Bluenew.svg" class="logo-img logo-default" alt="" />
         <img src="../Icon Pinknew.svg" class="logo-img logo-pink" alt="" />
       </span>
       <h1 id="mainTitle">Cine Power Planner</h1>
-    </div>
+    </a>
     <nav class="static-nav" aria-label="Navigation secondaire">
       <a class="button-link" href="../index.html">Retour à l'application</a>
+    </nav>
+    <nav class="controls" aria-label="Paramètres de la page">
+      <select
+        id="languageSelect"
+        aria-label="Choisir la langue"
+        data-current-value="impressum-fr.html"
+      >
+        <option value="impressum.html" lang="de">Deutsch</option>
+        <option value="impressum-en.html" lang="en">English</option>
+        <option value="impressum-es.html" lang="es">Español</option>
+        <option value="impressum-fr.html" lang="fr">Français</option>
+        <option value="impressum-it.html" lang="it">Italiano</option>
+      </select>
+      <button
+        id="darkModeToggle"
+        title="Activer/désactiver le mode sombre"
+        aria-label="Activer/désactiver le mode sombre"
+        aria-pressed="false"
+      >
+        <span class="icon-glyph" aria-hidden="true" data-icon-font="uicons">&#xEC7E;</span>
+      </button>
+      <button
+        id="pinkModeToggle"
+        title="Activer/désactiver le mode rose"
+        aria-label="Activer/désactiver le mode rose"
+        aria-pressed="false"
+      >
+        <span class="icon-glyph icon-svg pink-mode-icon" aria-hidden="true">
+          <svg viewBox="0 0 60 60" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+            <path
+              d="m1 40c0-8 3-17 3-17a4.84 4.84 0 0 0-1.829-3.064 1 1 0 0 1 .45-1.716 19.438 19.438 0 0 1 4.379-.22c.579-2.317-1.19-3.963-2.782-4.938a1 1 0 0 1 .393-1.85 14.128 14.128 0 0 1 6.389.788c0-.958-1.147-2.145-2.342-3.122a1 1 0 0 1 .708-1.773 40.655 40.655 0 0 1 6.634.895 3.723 3.723 0 0 0-1.049-2.264 1 1 0 0 1 .823-1.652c6.151.378 9.226 1.916 9.226 1.916l10-1s8.472-2.311 15.954.5a1 1 0 0 1-.084 1.9c-1.455.394-2.87 1.143-2.87 2.6 0 0 4.426.738 5.675 4.114a1 1 0 0 1-1.228 1.317c-1.64-.48-4.273-.88-6.447.569Z"
+              fill="#805333"
+            />
+            <path
+              d="m30.18 42.82c1.073 2.7 2.6 9.993 3.357 13.8a2 2 0 0 1-1.964 2.38h-28.573a2 2 0 0 1-2-2v-18c0-2.55 10.03-22.11 23.99-23.87Z"
+              fill="#a56a43"
+            />
+            <path
+              d="m55.67 48.46-6.34 2.97a6 6 0 0 1-7.98-2.88l-.25-.54-.76-1.6a4.956 4.956 0 0 0-4.68-2.87c-.22.01-.44.02-.66.02a16.019 16.019 0 0 1-8.28-29.66c-1.81-2.97-3.45-8.03 2.03-12.49a2.1 2.1 0 0 1 2.5 0c4.23 3.45 4.21 7.25 3.16 10.17a16 16 0 0 1 15.91 11.36l5.31 11.31 2.92 6.22a6.008 6.008 0 0 1-2.88 7.99Z"
+              fill="#cb8252"
+            />
+            <circle cx="42" cy="26" r="3" fill="#2c2f38" />
+            <circle cx="54" cy="43" r="1" fill="#805333" />
+            <path
+              d="m58.55 40.47-2.92-6.22-14.53 13.76.25.54a6 6 0 0 0 7.98 2.88l6.34-2.97a6.008 6.008 0 0 0 2.88-7.99Zm-4.55 3.53a1 1 0 1 1 1-1 1 1 0 0 1-1 1Z"
+              fill="#cf976a"
+            />
+            <circle cx="41" cy="25" r="1.25" fill="#ecf0f1" />
+          </svg>
+        </span>
+      </button>
     </nav>
   </header>
   <main id="mainContent" class="legal-content" tabindex="-1">
     <h1>Mentions légales</h1>
-    <nav class="legal-language-nav" aria-label="Choix de la langue">
-      <ul>
-        <li><a href="impressum.html" lang="de">Deutsch</a></li>
-        <li><a href="impressum-en.html" lang="en">English</a></li>
-        <li><a href="impressum-es.html" lang="es">Español</a></li>
-        <li><a href="impressum-fr.html" lang="fr" aria-current="page">Français</a></li>
-        <li><a href="impressum-it.html" lang="it">Italiano</a></li>
-      </ul>
-    </nav>
     <div class="legal-card">
       <h2>Informations conformément à l'article 5 de la loi allemande sur les télémédias (TMG)</h2>
       <p>Luca Zanner<br>Brünnsteinstraße 5<br>81541 Munich<br>Allemagne</p>

--- a/legal/impressum-it.html
+++ b/legal/impressum-it.html
@@ -13,33 +13,76 @@
   <link rel="apple-touch-icon" href="../src/icons/app-icon.png" />
   <link rel="stylesheet" href="../src/styles/style.css" />
   <script src="../src/scripts/static-theme.js" defer></script>
+  <script src="../src/scripts/legal-topbar.js" defer></script>
 </head>
 <body class="static-page">
   <a href="#mainContent" class="skip-link">Vai al contenuto</a>
   <div id="offlineIndicator" role="status" aria-live="polite">Offline</div>
   <header id="topBar">
-    <div class="branding">
+    <a class="branding" href="../index.html">
       <span id="logo" class="logo-wrapper" aria-hidden="true">
         <img src="../Icon Bluenew.svg" class="logo-img logo-default" alt="" />
         <img src="../Icon Pinknew.svg" class="logo-img logo-pink" alt="" />
       </span>
       <h1 id="mainTitle">Cine Power Planner</h1>
-    </div>
+    </a>
     <nav class="static-nav" aria-label="Navigazione secondaria">
       <a class="button-link" href="../index.html">Torna all'app</a>
+    </nav>
+    <nav class="controls" aria-label="Impostazioni della pagina">
+      <select
+        id="languageSelect"
+        aria-label="Seleziona lingua"
+        data-current-value="impressum-it.html"
+      >
+        <option value="impressum.html" lang="de">Deutsch</option>
+        <option value="impressum-en.html" lang="en">English</option>
+        <option value="impressum-es.html" lang="es">Español</option>
+        <option value="impressum-fr.html" lang="fr">Français</option>
+        <option value="impressum-it.html" lang="it">Italiano</option>
+      </select>
+      <button
+        id="darkModeToggle"
+        title="Attiva/disattiva la modalità scura"
+        aria-label="Attiva/disattiva la modalità scura"
+        aria-pressed="false"
+      >
+        <span class="icon-glyph" aria-hidden="true" data-icon-font="uicons">&#xEC7E;</span>
+      </button>
+      <button
+        id="pinkModeToggle"
+        title="Attiva/disattiva la modalità rosa"
+        aria-label="Attiva/disattiva la modalità rosa"
+        aria-pressed="false"
+      >
+        <span class="icon-glyph icon-svg pink-mode-icon" aria-hidden="true">
+          <svg viewBox="0 0 60 60" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+            <path
+              d="m1 40c0-8 3-17 3-17a4.84 4.84 0 0 0-1.829-3.064 1 1 0 0 1 .45-1.716 19.438 19.438 0 0 1 4.379-.22c.579-2.317-1.19-3.963-2.782-4.938a1 1 0 0 1 .393-1.85 14.128 14.128 0 0 1 6.389.788c0-.958-1.147-2.145-2.342-3.122a1 1 0 0 1 .708-1.773 40.655 40.655 0 0 1 6.634.895 3.723 3.723 0 0 0-1.049-2.264 1 1 0 0 1 .823-1.652c6.151.378 9.226 1.916 9.226 1.916l10-1s8.472-2.311 15.954.5a1 1 0 0 1-.084 1.9c-1.455.394-2.87 1.143-2.87 2.6 0 0 4.426.738 5.675 4.114a1 1 0 0 1-1.228 1.317c-1.64-.48-4.273-.88-6.447.569Z"
+              fill="#805333"
+            />
+            <path
+              d="m30.18 42.82c1.073 2.7 2.6 9.993 3.357 13.8a2 2 0 0 1-1.964 2.38h-28.573a2 2 0 0 1-2-2v-18c0-2.55 10.03-22.11 23.99-23.87Z"
+              fill="#a56a43"
+            />
+            <path
+              d="m55.67 48.46-6.34 2.97a6 6 0 0 1-7.98-2.88l-.25-.54-.76-1.6a4.956 4.956 0 0 0-4.68-2.87c-.22.01-.44.02-.66.02a16.019 16.019 0 0 1-8.28-29.66c-1.81-2.97-3.45-8.03 2.03-12.49a2.1 2.1 0 0 1 2.5 0c4.23 3.45 4.21 7.25 3.16 10.17a16 16 0 0 1 15.91 11.36l5.31 11.31 2.92 6.22a6.008 6.008 0 0 1-2.88 7.99Z"
+              fill="#cb8252"
+            />
+            <circle cx="42" cy="26" r="3" fill="#2c2f38" />
+            <circle cx="54" cy="43" r="1" fill="#805333" />
+            <path
+              d="m58.55 40.47-2.92-6.22-14.53 13.76.25.54a6 6 0 0 0 7.98 2.88l6.34-2.97a6.008 6.008 0 0 0 2.88-7.99Zm-4.55 3.53a1 1 0 1 1 1-1 1 1 0 0 1-1 1Z"
+              fill="#cf976a"
+            />
+            <circle cx="41" cy="25" r="1.25" fill="#ecf0f1" />
+          </svg>
+        </span>
+      </button>
     </nav>
   </header>
   <main id="mainContent" class="legal-content" tabindex="-1">
     <h1>Note legali</h1>
-    <nav class="legal-language-nav" aria-label="Selezione della lingua">
-      <ul>
-        <li><a href="impressum.html" lang="de">Deutsch</a></li>
-        <li><a href="impressum-en.html" lang="en">English</a></li>
-        <li><a href="impressum-es.html" lang="es">Español</a></li>
-        <li><a href="impressum-fr.html" lang="fr">Français</a></li>
-        <li><a href="impressum-it.html" lang="it" aria-current="page">Italiano</a></li>
-      </ul>
-    </nav>
     <div class="legal-card">
       <h2>Informazioni ai sensi del § 5 della legge tedesca sui telemedia (TMG)</h2>
       <p>Luca Zanner<br>Brünnsteinstraße 5<br>81541 Monaco di Baviera<br>Germania</p>

--- a/legal/impressum.html
+++ b/legal/impressum.html
@@ -13,6 +13,7 @@
   <link rel="apple-touch-icon" href="../src/icons/app-icon.png" />
   <link rel="stylesheet" href="../src/styles/style.css" />
   <script src="../src/scripts/static-theme.js" defer></script>
+  <script src="../src/scripts/legal-topbar.js" defer></script>
 </head>
 <body class="static-page">
   <a href="#mainContent" class="skip-link">Zum Inhalt springen</a>
@@ -26,20 +27,62 @@
       <h1 id="mainTitle">Cine Power Planner</h1>
     </a>
     <nav class="static-nav" aria-label="Sekundärnavigation">
-      <a class="button-link" href="index.html">Zurück zur App</a>
+      <a class="button-link" href="../index.html">Zurück zur App</a>
+    </nav>
+    <nav class="controls" aria-label="Seiteneinstellungen">
+      <select
+        id="languageSelect"
+        aria-label="Sprache auswählen"
+        data-current-value="impressum.html"
+      >
+        <option value="impressum.html" lang="de">Deutsch</option>
+        <option value="impressum-en.html" lang="en">English</option>
+        <option value="impressum-es.html" lang="es">Español</option>
+        <option value="impressum-fr.html" lang="fr">Français</option>
+        <option value="impressum-it.html" lang="it">Italiano</option>
+      </select>
+      <button
+        id="darkModeToggle"
+        title="Dunkelmodus umschalten"
+        aria-label="Dunkelmodus umschalten"
+        aria-pressed="false"
+      >
+        <span class="icon-glyph" aria-hidden="true" data-icon-font="uicons">&#xEC7E;</span>
+      </button>
+      <button
+        id="pinkModeToggle"
+        title="Pink-Modus umschalten"
+        aria-label="Pink-Modus umschalten"
+        aria-pressed="false"
+      >
+        <span class="icon-glyph icon-svg pink-mode-icon" aria-hidden="true">
+          <svg viewBox="0 0 60 60" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+            <path
+              d="m1 40c0-8 3-17 3-17a4.84 4.84 0 0 0-1.829-3.064 1 1 0 0 1 .45-1.716 19.438 19.438 0 0 1 4.379-.22c.579-2.317-1.19-3.963-2.782-4.938a1 1 0 0 1 .393-1.85 14.128 14.128 0 0 1 6.389.788c0-.958-1.147-2.145-2.342-3.122a1 1 0 0 1 .708-1.773 40.655 40.655 0 0 1 6.634.895 3.723 3.723 0 0 0-1.049-2.264 1 1 0 0 1 .823-1.652c6.151.378 9.226 1.916 9.226 1.916l10-1s8.472-2.311 15.954.5a1 1 0 0 1-.084 1.9c-1.455.394-2.87 1.143-2.87 2.6 0 0 4.426.738 5.675 4.114a1 1 0 0 1-1.228 1.317c-1.64-.48-4.273-.88-6.447.569Z"
+              fill="#805333"
+            />
+            <path
+              d="m30.18 42.82c1.073 2.7 2.6 9.993 3.357 13.8a2 2 0 0 1-1.964 2.38h-28.573a2 2 0 0 1-2-2v-18c0-2.55 10.03-22.11 23.99-23.87Z"
+              fill="#a56a43"
+            />
+            <path
+              d="m55.67 48.46-6.34 2.97a6 6 0 0 1-7.98-2.88l-.25-.54-.76-1.6a4.956 4.956 0 0 0-4.68-2.87c-.22.01-.44.02-.66.02a16.019 16.019 0 0 1-8.28-29.66c-1.81-2.97-3.45-8.03 2.03-12.49a2.1 2.1 0 0 1 2.5 0c4.23 3.45 4.21 7.25 3.16 10.17a16 16 0 0 1 15.91 11.36l5.31 11.31 2.92 6.22a6.008 6.008 0 0 1-2.88 7.99Z"
+              fill="#cb8252"
+            />
+            <circle cx="42" cy="26" r="3" fill="#2c2f38" />
+            <circle cx="54" cy="43" r="1" fill="#805333" />
+            <path
+              d="m58.55 40.47-2.92-6.22-14.53 13.76.25.54a6 6 0 0 0 7.98 2.88l6.34-2.97a6.008 6.008 0 0 0 2.88-7.99Zm-4.55 3.53a1 1 0 1 1 1-1 1 1 0 0 1-1 1Z"
+              fill="#cf976a"
+            />
+            <circle cx="41" cy="25" r="1.25" fill="#ecf0f1" />
+          </svg>
+        </span>
+      </button>
     </nav>
   </header>
   <main id="mainContent" class="legal-content" tabindex="-1">
     <h1>Impressum</h1>
-    <nav class="legal-language-nav" aria-label="Sprachauswahl">
-      <ul>
-        <li><a href="impressum.html" lang="de" aria-current="page">Deutsch</a></li>
-        <li><a href="impressum-en.html" lang="en">English</a></li>
-        <li><a href="impressum-es.html" lang="es">Español</a></li>
-        <li><a href="impressum-fr.html" lang="fr">Français</a></li>
-        <li><a href="impressum-it.html" lang="it">Italiano</a></li>
-      </ul>
-    </nav>
     <div class="legal-card">
       <h2>Angaben gemäß § 5 TMG</h2>
       <p>Luca Zanner<br>Brünnsteinstraße 5<br>81541 München<br>Deutschland</p>

--- a/src/scripts/legal-topbar.js
+++ b/src/scripts/legal-topbar.js
@@ -1,0 +1,186 @@
+(function () {
+  'use strict';
+
+  var DEFAULT_ACCENT = '#001589';
+  var HIGH_CONTRAST_ACCENT = '#ffffff';
+  var storageErrorLogged = false;
+
+  function getRoot() {
+    return document.documentElement || document.getElementsByTagName('html')[0];
+  }
+
+  function getBody() {
+    return document.body || document.getElementsByTagName('body')[0];
+  }
+
+  function safeGet(key) {
+    try {
+      if (typeof window !== 'undefined' && window.localStorage) {
+        return window.localStorage.getItem(key);
+      }
+    } catch (error) {
+      if (!storageErrorLogged) {
+        console.warn('Unable to read localStorage preference', error);
+        storageErrorLogged = true;
+      }
+    }
+    return null;
+  }
+
+  function safeSet(key, value) {
+    try {
+      if (typeof window !== 'undefined' && window.localStorage) {
+        window.localStorage.setItem(key, value);
+      }
+    } catch (error) {
+      if (!storageErrorLogged) {
+        console.warn('Unable to store localStorage preference', error);
+        storageErrorLogged = true;
+      }
+    }
+  }
+
+  function updateThemeColor(isDarkMode) {
+    var meta = document.querySelector('meta[name="theme-color"]');
+    if (meta) {
+      meta.setAttribute('content', isDarkMode ? '#1c1c1e' : '#f9f9f9');
+    }
+  }
+
+  function clearAccentStyles(root, body) {
+    if (!root) return;
+    root.style.removeProperty('--accent-color');
+    root.style.removeProperty('--link-color');
+    root.style.removeProperty('--logo-background-color');
+    root.style.removeProperty('--logo-accent-color');
+    if (body) {
+      body.style.removeProperty('--accent-color');
+      body.style.removeProperty('--link-color');
+      body.style.removeProperty('--logo-background-color');
+      body.style.removeProperty('--logo-accent-color');
+    }
+  }
+
+  function applyAccentStyles(color, root, body) {
+    if (!root) return;
+
+    var effectiveRoot = root;
+    var effectiveBody = body;
+
+    var highContrastActive =
+      (effectiveRoot && effectiveRoot.classList.contains('high-contrast')) ||
+      (effectiveBody && effectiveBody.classList.contains('high-contrast'));
+
+    var accentValue = highContrastActive ? HIGH_CONTRAST_ACCENT : color;
+
+    effectiveRoot.style.setProperty('--accent-color', accentValue);
+    if (highContrastActive) {
+      effectiveRoot.style.removeProperty('--link-color');
+    } else {
+      effectiveRoot.style.setProperty('--link-color', color);
+    }
+    effectiveRoot.style.setProperty('--logo-background-color', accentValue);
+    effectiveRoot.style.setProperty('--logo-accent-color', accentValue);
+
+    if (effectiveBody) {
+      effectiveBody.style.setProperty('--accent-color', accentValue);
+      if (highContrastActive) {
+        effectiveBody.style.removeProperty('--link-color');
+      } else {
+        effectiveBody.style.setProperty('--link-color', color);
+      }
+      effectiveBody.style.setProperty('--logo-background-color', accentValue);
+      effectiveBody.style.setProperty('--logo-accent-color', accentValue);
+    }
+  }
+
+  function refreshAccent(root, body) {
+    if (!root) return;
+    var pinkModeActive = root.classList.contains('pink-mode') || (body && body.classList.contains('pink-mode'));
+    if (pinkModeActive) {
+      clearAccentStyles(root, body);
+      return;
+    }
+    var storedAccent = safeGet('accentColor');
+    var accent = storedAccent || DEFAULT_ACCENT;
+    applyAccentStyles(accent, root, body);
+  }
+
+  function setAriaPressed(control, isPressed) {
+    if (control) {
+      control.setAttribute('aria-pressed', isPressed ? 'true' : 'false');
+    }
+  }
+
+  function initTopBarControls() {
+    var root = getRoot();
+    var body = getBody();
+    if (!root) {
+      return;
+    }
+
+    var darkModeToggle = document.getElementById('darkModeToggle');
+    var pinkModeToggle = document.getElementById('pinkModeToggle');
+    var languageSelect = document.getElementById('languageSelect');
+
+    if (darkModeToggle && root && body) {
+      var darkModeActive = root.classList.contains('dark-mode') || body.classList.contains('dark-mode');
+      setAriaPressed(darkModeToggle, darkModeActive);
+      darkModeToggle.addEventListener('click', function (event) {
+        event.preventDefault();
+        var currentlyDark = root.classList.contains('dark-mode') || body.classList.contains('dark-mode');
+        var nextDark = !currentlyDark;
+        root.classList.toggle('dark-mode', nextDark);
+        body.classList.toggle('dark-mode', nextDark);
+        root.classList.toggle('light-mode', !nextDark);
+        body.classList.toggle('light-mode', !nextDark);
+        safeSet('darkMode', nextDark ? 'true' : 'false');
+        setAriaPressed(darkModeToggle, nextDark);
+        updateThemeColor(nextDark);
+      });
+    }
+
+    if (pinkModeToggle && root && body) {
+      var pinkModeActive = root.classList.contains('pink-mode') || body.classList.contains('pink-mode');
+      setAriaPressed(pinkModeToggle, pinkModeActive);
+      pinkModeToggle.addEventListener('click', function (event) {
+        event.preventDefault();
+        var currentlyPink = root.classList.contains('pink-mode') || body.classList.contains('pink-mode');
+        var nextPink = !currentlyPink;
+        root.classList.toggle('pink-mode', nextPink);
+        body.classList.toggle('pink-mode', nextPink);
+        safeSet('pinkMode', nextPink ? 'true' : 'false');
+        setAriaPressed(pinkModeToggle, nextPink);
+        if (nextPink) {
+          clearAccentStyles(root, body);
+        } else {
+          refreshAccent(root, body);
+        }
+      });
+    }
+
+    if (languageSelect) {
+      var currentValue = languageSelect.getAttribute('data-current-value');
+      if (currentValue) {
+        languageSelect.value = currentValue;
+      }
+      languageSelect.addEventListener('change', function (event) {
+        var target = event.target;
+        if (!target) return;
+        var selectedOption = target.selectedOptions && target.selectedOptions[0];
+        var destination = selectedOption ? selectedOption.value : target.value;
+        if (destination) {
+          window.location.href = destination;
+        }
+      });
+    }
+
+    refreshAccent(root, body);
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initTopBarControls);
+  } else {
+    initTopBarControls();
+  }
+})();


### PR DESCRIPTION
## Summary
- update all Impressum and Datenschutz pages to use the standard top bar with the language, dark mode, and pink mode controls
- add a lightweight legal-topbar script to persist toggle state and drive language selection across static pages

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d719360720832089811660eeaa6f56