### PR TITLE
Document backup ledger and runtime guard

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -92,9 +92,11 @@ Folge `docs/translation-guide.md` für Details zur Lokalisierung.
 
 - **Backup-Vergleiche** – Wähle manuelle Saves oder Auto-Backups, prüfe Diffs, ergänze Vorfallnotizen und exportiere Protokolle, bevor du Änderungen zurückrollst oder Daten an die Post übergibst.
 - **Restore-Proben** – Lade komplette Backups oder Projekt-Bundles in eine isolierte Sandbox, um Inhalte gegen Live-Daten zu checken, ohne Produktionsprofile anzurühren.
+- **Backup-Verlaufsprotokoll** – Jeder Vollbackup-Download speichert Zeitstempel und Dateinamen lokal. In **Einstellungen → Daten & Speicher** kannst du die Zählung prüfen oder das Protokoll zusammen mit deinen Archiven exportieren, um Offline-Aufbewahrung nachzuweisen.
 - **Automatische Gear-Regeln** – Definiere szenariobasierte Ergänzungen oder Entfernungen mit Import/Export-Kontrollen und zeitgesteuerten Backups.
 - **Regelabdeckungs-Dashboard** – Fasse doppelte Auslöser, Netto-Zu-/Abgänge, Konflikte und ungedeckte Szenarien direkt in den automatischen Gear-Regeln zusammen, setze Fokus-Filter offline und gib dieselben Einblicke in Exporten und Druckansichten weiter.
 - **Daten- & Speicher-Dashboard** – Prüfe gespeicherte Projekte, Gerätelisten, eigene Geräte, Favoriten und Laufzeitfeedback direkt in den Einstellungen und schätze die Backup-Größe.
+- **Runtime-Schutzprüfung** – Das Runtime-Bundle protokolliert Prüfergebnisse unter `window.__cineRuntimeIntegrity` und stellt `window.cineRuntime.verifyCriticalFlows()` bereit, damit Teams Speicher-, Teil- und Restore-Pfade vor der Abreise bestätigen können.
 - **Autosave-Status-Overlay** – Spiegelt die letzte Autosave-Notiz im Einstellungsdialog, damit Teams Hintergrundaktivitäten während Recovery-Drills sehen.
 - **Monitoring-sensitiver Gear-Editor** – Blendet zusätzliche Monitor- und Videoverteilungsoptionen nur ein, wenn Szenarien sie verlangen.
 - **Akzent- & Typografie-Regler** – Passe Akzentfarbe, Schriftgröße und Schriftart an; Dark-, Pink- und High-Contrast-Themes bleiben zwischen Besuchen erhalten.
@@ -122,7 +124,8 @@ Führe diese Checkliste beim ersten Setup oder nach Updates aus. Sie beweist, da
 5. Erstes Projekt anlegen, **Enter** (oder **Strg+S**/`⌘S`) drücken und im Projektmenü das zeitgestempelte Auto-Backup prüfen, das nach wenigen Minuten erscheint.
 6. **Einstellungen → Backup & Wiederherstellung → Backup** exportieren und die `planner-backup.json` in einem privaten Profil importieren. So stellst du sicher, dass keine Sicherung auf einem Gerät festsitzt und der erzwungene Pre-Restore-Export funktioniert.
 7. Projekt-Bundle exportieren (`project-name.json`) und auf einem zweiten Gerät/Profil importieren. Das trainiert die komplette Kette Speichern → Teilen → Importieren und stellt sicher, dass Uicons, Fonts und Scripts offline mitreisen.
-8. Verifiziertes Backup und Projekt-Bundle zusammen mit der Repository-Kopie archivieren. So bleiben alle Workflows synchron und du hast redundante Medien für Reisen.
+8. Verifiziertes Backup und Projekt-Bundle zusammen mit der Repository-Kopie archivieren. Datum, Rechner und Operator protokollieren, damit nachvollziehbar bleibt, wann der Drill erfolgreich war und alle Workflows synchron blieben.
+9. Entwicklerkonsole öffnen und einen Screenshot von `window.__cineRuntimeIntegrity` festhalten (oder `window.cineRuntime.verifyCriticalFlows()` erneut ausführen und das Protokoll speichern). So dokumentierst du, dass die Runtime-Wache die Speicher-/Teilen-/Restore-Wege während der Offline-Probe bestätigt hat.
 
 ## Systemanforderungen & Browser-Support
 
@@ -140,6 +143,7 @@ Dieser kurze Ablauf sollte bei neuen Teammitgliedern, frisch eingerichteten Work
 3. **Restore-Generalprobe.** In einem privaten Profil oder zweiten Gerät Backup importieren, danach das Bundle. Gerätelisten, Dashboards, Regeln und Favoriten prüfen.
 4. **Offline-Verifikation.** Im Testprofil Netzwerk trennen, `index.html` neu laden und prüfen, ob Offline-Indikator, Uicons und Hilfsskripte sauber geladen werden.
 5. **Archivieren.** Testprofil löschen, Exporte beschriften und in die Produktions-Checkliste aufnehmen.
+6. **Runtime protokollieren.** Im Testprofil die Entwicklerkonsole öffnen, `window.__cineRuntimeIntegrity.ok` auf `true` prüfen und bei Bedarf `window.cineRuntime.verifyCriticalFlows({ warnOnFailure: true })` ausführen. Das Ergebnis zusammen mit den Drill-Notizen archivieren.
 
 ## Täglicher Ablauf
 
@@ -234,6 +238,7 @@ Dieser kurze Ablauf sollte bei neuen Teammitgliedern, frisch eingerichteten Work
 - **Einstellungen → Daten & Speicher** listet gespeicherte Projekte, Auto-Backups, Gerätelisten, Custom-Geräte, Favoriten, Laufzeitfeedback und Session-Cache mit Live-Zahlen.
 - Einträge erklären ihre Inhalte; leere Bereiche bleiben verborgen, damit du den Zustand sofort siehst.
 - Die Übersicht schätzt die Backup-Größe basierend auf dem jüngsten Export.
+- Vollbackups zeigen ihre aktuelle Anzahl und speisen das Backup-Protokoll, damit du vor dem Archivieren kontrollieren kannst, ob die stündlichen Sicherungen erfasst wurden.
 
 ## Speicherbudget & Wartung
 
@@ -246,10 +251,12 @@ Dieser kurze Ablauf sollte bei neuen Teammitgliedern, frisch eingerichteten Work
 
 - **Gespeicherte Projektsnapshots** – Projektliste speichert alle Saves und erzeugt alle zehn Minuten `auto-backup-…`.
 - **Vollbackups** – **Einstellungen → Backup & Wiederherstellung → Backup** erstellt `planner-backup.json` inkl. aller Projekte, Geräte, Regeln und UI-States; vor jeder Wiederherstellung wird ein Sicherheitsbackup angelegt.
+- **Backup-Verlauf** – Jede Vollsicherung schreibt einen Eintrag, der sich in **Einstellungen → Daten & Speicher** prüfen oder zusammen mit dem Archiv exportieren lässt. Zeitstempel und Dateinamen bleiben so auch offline nachvollziehbar.
 - **Verborgene Migrations-Backups** – Vor Überschreibungen wird der vorige JSON-Snapshot im geschützten `__legacyMigrationBackup` abgelegt und bei Fehlern automatisch wiederhergestellt.
 - **Automatische Regel-Snapshots** – Änderungen in **Automatische Gear-Regeln** erzeugen alle zehn Minuten Sicherheitskopien.
 - **Factory Reset** – löscht Daten erst nach automatischem Backup.
 - **Stündliche Erinnerungen** – Hintergrundroutine fordert stündlich zu Backups auf.
+- **Runtime-Integritätswache** – Vor Abfahrt in der Konsole `window.__cineRuntimeIntegrity.ok` auf `true` prüfen oder `window.cineRuntime.verifyCriticalFlows({ warnOnFailure: true })` ausführen. Der Bericht bestätigt, dass Speichern/Teilen/Wiederherstellen offline geschützt ist.
 - **Verifikation** – Nach jedem kritischen Backup Import in einem Testprofil prüfen.
 - **Sichere Aufbewahrung** – Backups mit Projektname/Zeitstempel beschriften und auf redundanten Medien lagern.
 - **Vor Überschreiben vergleichen** – Vor Restores frisches Backup ziehen und Unterschiede prüfen.

--- a/README.en.md
+++ b/README.en.md
@@ -152,6 +152,10 @@ localization steps.
 - **Restore rehearsals** – load a full-app backup or project bundle into an
   isolated sandbox to confirm its contents match live data without touching
   production profiles.
+- **Backup history ledger** – every full-app backup download records its
+  timestamp and filename locally. Review counts in **Settings → Data & Storage**
+  or export the log alongside your archives so you can prove retention while
+  staying offline.
 - **Automatic gear rules** – design scenario-triggered additions or removals
   that apply after the generator runs, complete with import/export controls
   and timed backups.
@@ -161,6 +165,10 @@ localization steps.
 - **Data & storage dashboard** – audit stored projects, gear lists, custom
   devices, favorites and runtime feedback, and review approximate backup size
   without leaving the Settings dialog.
+- **Runtime safeguard inspector** – the runtime bundle now records verification
+  results on `window.__cineRuntimeIntegrity` and exposes
+  `window.cineRuntime.verifyCriticalFlows()` so crews can confirm save/share/
+  restore gateways before leaving for set.
 - **Autosave status overlay** – mirror the latest autosave note inside the
   settings dialog so crews see background activity while rehearsing recovery
   drills.
@@ -215,9 +223,13 @@ same online or offline.
    offline workflows are airtight and that locally stored Uicons, fonts and
    helper scripts follow the project.
 8. Archive the verified backup and project bundle alongside the repository copy
-   you opened. This keeps save, share, import, backup and restore workflows
-   provably in sync from the first session and gives you redundant recovery
-   media for travel days.
+   you opened. Log the verification date, machine name and operator so crews can
+   prove when the drill succeeded, keeping save, share, import, backup and
+   restore workflows provably in sync from the first session.
+9. Capture a console screenshot of `window.__cineRuntimeIntegrity` (or rerun
+   `window.cineRuntime.verifyCriticalFlows()` and store the report) to document
+   that the runtime guard validated every save/share/restore gateway while you
+   rehearsed offline.
 
 ## Key Workflow Reference
 
@@ -279,6 +291,10 @@ access.
 5. **Archive with confidence.** Delete the rehearsal profile after confirming
    everything restored cleanly, then label and file the verified exports with
    your production’s archival checklist.
+6. **Log the runtime guard.** In the same profile, open the developer console
+   and confirm `window.__cineRuntimeIntegrity.ok` is `true`. If you need a fresh
+   report, run `window.cineRuntime.verifyCriticalFlows({ warnOnFailure: true })`
+   and archive the output alongside your rehearsal notes.
 
 ## Everyday Workflow
 
@@ -504,6 +520,9 @@ Use Cine Power Planner end-to-end with the following routine:
   hidden so you know at a glance when the planner is pristine.
 - The summary also estimates backup size using the most recent export, giving you
   a quick check that archives will fit on the storage you bring to set.
+- Full-app backups report their running total and feed the backup history ledger
+  so you can confirm hourly safety copies are captured before archiving them
+  offline.
 
 ## Storage Quota & Maintenance
 
@@ -537,6 +556,10 @@ Use Cine Power Planner end-to-end with the following routine:
   `planner-backup.json` with projects, custom devices, runtime feedback,
   favorites, automatic gear rules and UI state. Restores create a safety copy
   before importing and warn if the file was produced on another version.
+- **Backup history ledger** – each full-app backup writes an entry that you can
+  audit from **Settings → Data & Storage** or export with the archive. It keeps
+  timestamps and filenames aligned with your paper trail even when you rotate
+  media offline.
 - **Hidden migration backups** – before overwriting stored planners, setups or
   preferences, the app now preserves the previous JSON snapshot in a protected
   `__legacyMigrationBackup` slot. If a write ever fails or produces corrupt
@@ -549,6 +572,10 @@ Use Cine Power Planner end-to-end with the following routine:
   when you need a clean slate.
 - **Hourly reminders** – a background routine prompts an additional backup each
   hour so crews always have a recent snapshot ready to archive.
+- **Runtime integrity guard** – open the developer console and confirm
+  `window.__cineRuntimeIntegrity.ok` is `true` (or rerun
+  `window.cineRuntime.verifyCriticalFlows({ warnOnFailure: true })`) before
+  travel. The report proves the offline save/share/restore gateways are intact.
 - **Verification loop** – after every critical backup, re-import it into a
   separate browser profile or private window, confirm projects and gear lists
   match expectations, then delete the temporary profile. This routine catches

--- a/README.es.md
+++ b/README.es.md
@@ -92,9 +92,11 @@ Consulta `docs/translation-guide.md` para más detalles sobre la localización.
 
 - **Comparación de copias de seguridad** – Selecciona guardados manuales o auto-backups, revisa diferencias, añade notas de incidente y exporta un registro antes de revertir cambios o entregar material a postproducción.
 - **Ensayos de restauración** – Carga copias completas o paquetes de proyectos en un entorno aislado para comprobar su contenido sin tocar perfiles de producción.
+- **Libro de historial de copias** – Cada descarga de copia completa registra su marca de tiempo y nombre de archivo localmente. Revísalo en **Configuración → Datos y almacenamiento** o exporta el registro junto con tus archivos para demostrar retención sin conexión.
 - **Reglas automáticas de equipo** – Define añadidos o retiradas activados por escenarios, con controles de importación/exportación y copias temporizadas.
 - **Panel de cobertura de reglas** – Resume disparadores duplicados, cambios netos, conflictos y escenarios sin cubrir dentro de Reglas automáticas de equipo, aplica filtros de foco sin conexión y comparte los mismos datos en exportaciones e impresiones.
 - **Panel de datos y almacenamiento** – Audita proyectos, listas, equipos personalizados, favoritos y comentarios de autonomía desde Configuración y estima el tamaño del backup.
+- **Inspector de salvaguardas en tiempo de ejecución** – El runtime guarda el resultado en `window.__cineRuntimeIntegrity` y ofrece `window.cineRuntime.verifyCriticalFlows()` para que el equipo confirme las rutas de guardado/compartido/restauración antes de viajar.
 - **Superposición de estado de auto-guardado** – Refleja la nota más reciente dentro del diálogo de ajustes para que el equipo vea la actividad de fondo durante los ensayos.
 - **Editor sensible al monitoreo** – Sólo muestra campos extra de monitores y distribución cuando el escenario lo requiere.
 - **Controles de acento y tipografía** – Ajusta color de acento, tamaño y familia de fuente; los temas oscuro, rosa y alto contraste persisten entre sesiones.
@@ -122,7 +124,8 @@ Ejecuta esta lista tras instalar o actualizar el planner. Confirma que guardado,
 5. Crea un proyecto, pulsa **Enter** (o **Ctrl+S**/`⌘S`) para guardar manualmente y revisa el selector para ver el auto-backup con sello horario que aparece a los pocos minutos.
 6. Exporta **Configuración → Copia de seguridad y restauración → Copia de seguridad** e importa el archivo `planner-backup.json` en un perfil privado. Verificar la ruta de restauración demuestra que ninguna copia queda atrapada y que la salvaguarda previa funciona.
 7. Practica la exportación de un paquete (`project-name.json`) y su importación en otro equipo o perfil. Ensayar el flujo Guardar → Compartir → Importar asegura que los recursos locales acompañan al proyecto.
-8. Archiva la copia verificada y el paquete junto a la versión del repositorio usada. Así mantienes sincronizados los flujos y tienes medios redundantes para viajar.
+8. Archiva la copia verificada y el paquete junto a la versión del repositorio usada. Registra fecha, equipo y operador para dejar constancia de cuándo se validó el ensayo y mantener los flujos sincronizados desde la primera sesión.
+9. Abre la consola del navegador y captura `window.__cineRuntimeIntegrity` (o vuelve a ejecutar `window.cineRuntime.verifyCriticalFlows()` y guarda el informe). Ese registro demuestra que la guarda en tiempo de ejecución validó las rutas de guardado/compartido/restauración durante la práctica offline.
 
 ## Requisitos del sistema y navegadores
 
@@ -140,6 +143,7 @@ Repite esta rutina cuando se incorpore personal, se prepare una estación nueva 
 3. **Ensayo de restauración.** Cambia a un perfil privado (o segunda máquina), importa la copia completa y después el paquete. Comprueba listas, paneles, reglas y favoritos.
 4. **Verificación offline.** En el perfil de ensayo, desconecta la red y recarga `index.html`. Confirma que aparece el indicador offline y que los Uicons y scripts locales cargan correctamente.
 5. **Archiva con confianza.** Borra el perfil de ensayo tras confirmar la restauración y etiqueta los archivos verificados según el protocolo del proyecto.
+6. **Registra la guarda runtime.** En el mismo perfil, abre la consola y confirma que `window.__cineRuntimeIntegrity.ok` vale `true`. Si necesitas un informe nuevo, ejecuta `window.cineRuntime.verifyCriticalFlows({ warnOnFailure: true })` y guarda el resultado junto con tus notas.
 
 ## Flujo cotidiano
 
@@ -234,6 +238,7 @@ Repite esta rutina cuando se incorpore personal, se prepare una estación nueva 
 - Abre **Configuración → Datos y almacenamiento** para revisar proyectos, auto-backups, listas, dispositivos personalizados, favoritos, comentarios y la caché de sesión con recuentos en vivo.
 - Cada entrada explica qué representa; las secciones vacías permanecen ocultas para que identifiques el estado rápidamente.
 - El resumen estima el tamaño del backup usando la exportación más reciente.
+- Las copias completas muestran su total acumulado y alimentan el registro de historial, así puedes confirmar que las copias horarias quedaron capturadas antes de archivarlas sin conexión.
 
 ## Cuotas y mantenimiento
 
@@ -246,10 +251,12 @@ Repite esta rutina cuando se incorpore personal, se prepare una estación nueva 
 
 - **Instantáneas guardadas** – El selector conserva cada plan manual y crea `auto-backup-…` cada diez minutos mientras la app está abierta.
 - **Copias completas** – **Configuración → Copia de seguridad y restauración → Copia de seguridad** descarga `planner-backup.json` con proyectos, dispositivos, comentarios, reglas y estado de UI. Antes de restaurar se crea un respaldo de seguridad y se muestran avisos si el archivo proviene de otra versión.
+- **Libro de historial** – Cada copia completa añade una entrada que puedes auditar en **Configuración → Datos y almacenamiento** o exportar junto al archivo. Mantiene sellos horarios y nombres alineados con tu bitácora aunque trabajes sin conexión.
 - **Resguardos ocultos de migración** – Antes de sobrescribir planners, configuraciones o preferencias, la app guarda el JSON anterior en `__legacyMigrationBackup`. Si algo falla, la recuperación vuelve automáticamente a esa copia.
 - **Historial automático de reglas** – Los cambios en **Reglas automáticas** generan copias con sello horario cada diez minutos.
 - **Restablecimiento de fábrica** – Borra datos sólo después de descargar un backup.
 - **Recordatorios por hora** – Una rutina en segundo plano sugiere realizar una copia adicional cada hora.
+- **Guardia de integridad runtime** – Antes de viajar, abre la consola y verifica que `window.__cineRuntimeIntegrity.ok` sea `true` (o ejecuta `window.cineRuntime.verifyCriticalFlows({ warnOnFailure: true })`). El informe demuestra que los caminos de guardado/compartido/restauración siguen protegidos offline.
 - **Bucle de verificación** – Tras cada backup crítico, impórtalo en un perfil separado y confirma que coincide antes de eliminar el perfil.
 - **Hábitos de almacenamiento seguro** – Etiqueta los archivos con nombre del proyecto y fecha y guárdalos en medios redundantes (RAID, USB cifrado, disco óptico).
 - **Compara antes de sobrescribir** – Descarga un backup nuevo antes de restaurar y revisa diferencias con una herramienta de diff JSON.

--- a/README.fr.md
+++ b/README.fr.md
@@ -92,9 +92,11 @@ Consultez `docs/translation-guide.md` pour le guide de localisation.
 
 - **Comparaison de sauvegardes** – Sélectionnez un enregistrement manuel ou un auto-backup, analysez les différences, ajoutez des notes d’incident et exportez un rapport avant toute restauration ou remise au montage.
 - **Simulations de restauration** – Chargez un backup complet ou un bundle projet dans une sandbox isolée pour vérifier le contenu sans toucher aux profils de production.
+- **Journal d’historique des sauvegardes** – Chaque téléchargement de backup complet enregistre localement l’horodatage et le nom de fichier. Consultez-le dans **Paramètres → Données & stockage** ou exportez le journal avec vos archives pour prouver la conservation hors ligne.
 - **Règles automatiques de matériel** – Définissez des ajouts/suppressions déclenchés par scénario avec contrôle d’import/export et backups horodatés.
 - **Tableau de couverture des règles** – Résume déclencheurs dupliqués, bilans nets, conflits et scénarios non couverts depuis Règles automatiques, applique des filtres de focus hors ligne et partage les mêmes informations via exports et impressions.
 - **Tableau de bord données & stockage** – Auditez projets, listes, matériels personnalisés, favoris et retours d’autonomie directement depuis Paramètres et estimez la taille du backup.
+- **Inspecteur de sauvegarde runtime** – Le bundle runtime consigne le résultat dans `window.__cineRuntimeIntegrity` et expose `window.cineRuntime.verifyCriticalFlows()` afin que l’équipe confirme les parcours de sauvegarde/partage/restauration avant le départ.
 - **Superposition d’état d’autosave** – Réplique la dernière note d’autosave dans la boîte de dialogue des paramètres afin que les équipes voient l’activité de fond pendant les exercices.
 - **Éditeur sensible au monitoring** – Affiche les champs de monitoring supplémentaires uniquement lorsque les scénarios l’exigent pour garder la création de règles focalisée.
 - **Contrôles d’accent et typographie** – Ajustez couleur d’accent, taille et famille de police ; les thèmes sombre, rose et contraste élevé persistent entre les sessions.
@@ -122,7 +124,8 @@ Appliquez cette checklist lors de l’installation ou après une mise à jour po
 5. Créez un projet, appuyez sur **Entrée** (ou **Ctrl+S**/`⌘S`) pour déclencher une sauvegarde manuelle et vérifiez l’apparition de l’auto-backup horodaté dans le sélecteur après quelques minutes.
 6. Exportez **Paramètres → Backup & Restauration → Backup** et importez le fichier `planner-backup.json` dans un profil privé. Cette vérification garantit qu’aucune sauvegarde ne reste isolée et démontre le backup forcé avant restauration.
 7. Entraînez-vous à exporter un bundle (`project-name.json`) puis à l’importer sur une seconde machine ou profil pour valider la chaîne Sauvegarder → Partager → Importer et s’assurer que les ressources locales suivent le projet hors ligne.
-8. Archivez le backup vérifié et le bundle avec la copie du dépôt. Les flux restent synchronisés et vous disposez de médias redondants pour les déplacements.
+8. Archivez le backup vérifié et le bundle avec la copie du dépôt. Consignez date, machine et opérateur pour attester du succès de l’exercice et garder les flux synchronisés dès la première session.
+9. Ouvrez la console du navigateur et capturez `window.__cineRuntimeIntegrity` (ou relancez `window.cineRuntime.verifyCriticalFlows()` puis enregistrez le rapport). Cette trace prouve que la sentinelle runtime a validé les parcours de sauvegarde/partage/restauration durant la répétition hors ligne.
 
 ## Prérequis système et navigateurs
 
@@ -140,6 +143,7 @@ Cette routine prouve que sauvegarde, partage, import, backup et restauration fon
 3. **Répétition de restauration.** Passez sur un profil privé (ou une seconde machine), importez d’abord le backup complet, puis le bundle. Vérifiez listes, tableaux de bord, règles et favoris.
 4. **Vérification hors ligne.** Sur le profil d’essai, coupez la connexion et rechargez `index.html`. Confirmez l’affichage de l’indicateur hors ligne et le chargement des Uicons et scripts locaux.
 5. **Archivage.** Supprimez le profil de test après validation et étiquetez les exports selon le protocole de production.
+6. **Consignez la sentinelle runtime.** Dans le même profil, ouvrez la console et vérifiez que `window.__cineRuntimeIntegrity.ok` vaut `true`. Si besoin d’un nouveau rapport, exécutez `window.cineRuntime.verifyCriticalFlows({ warnOnFailure: true })` et archivez le résultat avec vos notes.
 
 ## Routine quotidienne
 
@@ -234,6 +238,7 @@ Cette routine prouve que sauvegarde, partage, import, backup et restauration fon
 - Ouvrez **Paramètres → Données & stockage** pour consulter projets, auto-backups, listes, équipements personnalisés, favoris, retours et cache de session avec des compteurs en temps réel.
 - Chaque section précise son contenu ; les sections vides restent masquées pour identifier rapidement l’état du planner.
 - Le résumé estime la taille d’un backup à partir de la dernière exportation.
+- Les backups complets affichent leur total cumulé et alimentent le journal d’historique afin que vous confirmiez la capture des copies horaires avant archivage hors ligne.
 
 ## Gestion des quotas et maintenance
 
@@ -246,10 +251,12 @@ Cette routine prouve que sauvegarde, partage, import, backup et restauration fon
 
 - **Instantanés enregistrés** – Le sélecteur conserve chaque sauvegarde manuelle et crée un `auto-backup-…` toutes les dix minutes.
 - **Backups complets** – **Paramètres → Backup & Restauration → Backup** télécharge `planner-backup.json` avec projets, équipements personnalisés, retours, favoris, règles automatiques et état UI. Les restaurations créent une copie de sécurité et avertissent si le fichier provient d’une autre version.
+- **Journal d’historique** – Chaque backup complet ajoute une entrée consultable via **Paramètres → Données & stockage** ou exportable avec l’archive. Horodatages et noms restent alignés avec votre documentation même hors ligne.
 - **Backups de migration cachés** – Avant d’écraser planners, configurations ou préférences, l’application enregistre le JSON précédent dans `__legacyMigrationBackup`. En cas d’échec, les outils de récupération reviennent automatiquement à cette copie.
 - **Snapshots automatiques des règles** – Les modifications dans **Règles automatiques** génèrent des copies horodatées toutes les dix minutes.
 - **Réinitialisation usine** – Efface les données uniquement après téléchargement d’un backup.
 - **Rappels horaires** – Une tâche de fond invite à créer un backup toutes les heures pour disposer d’une capture récente.
+- **Sentinelle d’intégrité runtime** – Avant un déplacement, ouvrez la console et vérifiez que `window.__cineRuntimeIntegrity.ok` vaut `true` (ou exécutez `window.cineRuntime.verifyCriticalFlows({ warnOnFailure: true })`). Le rapport démontre que les parcours de sauvegarde/partage/restauration restent protégés hors ligne.
 - **Boucle de vérification** – Après chaque backup critique, importez-le dans un profil séparé pour confirmer le résultat avant de supprimer l’instance de test.
 - **Habitudes de stockage sécurisées** – Étiquetez les backups avec nom de projet et horodatage puis stockez-les sur des supports redondants (RAID, clé chiffrée, disque optique).
 - **Comparer avant d’écraser** – Téléchargez un backup du contexte actuel avant toute restauration et examinez les différences avec un outil diff JSON pour fusionner manuellement si besoin.

--- a/README.it.md
+++ b/README.it.md
@@ -92,9 +92,11 @@ Consulta `docs/translation-guide.md` per i dettagli sulla localizzazione.
 
 - **Confronto backup** – Seleziona salvataggi manuali o auto-backup, analizza i diff, aggiungi note e esporta un log prima di ripristinare o consegnare il materiale.
 - **Prove di ripristino** – Carica un backup completo o un bundle in una sandbox isolata per verificarne il contenuto senza toccare i profili di produzione.
+- **Registro storico dei backup** – Ogni download del backup completo salva localmente timestamp e nome file. Controllalo in **Impostazioni → Dati e archiviazione** o esporta il registro insieme agli archivi per dimostrare la conservazione offline.
 - **Regole automatiche per l’attrezzatura** – Definisci aggiunte o rimozioni attivate dagli scenari con controlli di import/export e backup programmati.
 - **Dashboard di copertura regole** – Riassume trigger duplicati, variazioni nette, conflitti e scenari scoperti nelle Regole automatiche, applica filtri di focus offline e condivide le stesse informazioni in export e stampe.
 - **Dashboard dati e archiviazione** – Audita progetti, liste, dispositivi personalizzati, preferiti e feedback sulle autonomie direttamente da Impostazioni e stima la dimensione del backup.
+- **Ispettore di salvaguardia runtime** – Il bundle runtime registra il risultato su `window.__cineRuntimeIntegrity` ed espone `window.cineRuntime.verifyCriticalFlows()` così la troupe può confermare i percorsi di salvataggio/condivisione/ripristino prima di partire.
 - **Overlay stato auto-save** – Replica l’ultima nota di auto-save nel dialogo Impostazioni così la troupe vede l’attività in background durante gli esercizi.
 - **Editor sensibile al monitoring** – Mostra campi aggiuntivi per monitor e distribuzione video solo quando richiesti dagli scenari.
 - **Controlli di accento e tipografia** – Regola colore di accento, dimensione e famiglia di font; i temi scuro, rosa e alto contrasto restano attivi tra le sessioni.
@@ -122,7 +124,8 @@ Segui questa checklist all’installazione o dopo un aggiornamento: dimostra che
 5. Crea un progetto, premi **Invio** (o **Ctrl+S**/`⌘S`) per un salvataggio manuale e controlla che nel selettore compaia il backup automatico con timestamp dopo pochi minuti.
 6. Esporta **Impostazioni → Backup e ripristino → Backup** e importa il file `planner-backup.json` in un profilo privato. Così verifichi che nessuna copia resti isolata e che il backup forzato prima del ripristino funzioni.
 7. Esercitati a esportare un bundle (`project-name.json`) e importarlo su un altro dispositivo o profilo per collaudare il flusso Salva → Condividi → Importa e assicurarti che risorse locali seguano il progetto.
-8. Archivia backup e bundle verificati insieme alla copia del repository utilizzato. In questo modo mantieni sincronizzati i flussi e hai supporti ridondanti in viaggio.
+8. Archivia backup e bundle verificati insieme alla copia del repository utilizzato. Annota data, macchina e operatore per documentare quando l’esercizio è stato convalidato e mantenere i flussi sincronizzati fin dalla prima sessione.
+9. Apri la console del browser e acquisisci `window.__cineRuntimeIntegrity` (oppure riesegui `window.cineRuntime.verifyCriticalFlows()` e salva il report). In questo modo dimostri che la sentinella runtime ha validato i percorsi di salvataggio/condivisione/ripristino durante la prova offline.
 
 ## Requisiti di sistema e browser
 
@@ -140,6 +143,7 @@ Ripeti questa routine quando arriva un nuovo membro, allestisci una postazione o
 3. **Prova di ripristino.** Passa a un profilo privato (o seconda macchina), importa il backup completo e poi il bundle. Controlla liste, dashboard, regole e preferiti.
 4. **Verifica offline.** Nel profilo di test, disconnetti la rete e ricarica `index.html`. Assicurati che l’indicatore offline appaia e che Uicons e script locali si carichino correttamente.
 5. **Archiviazione sicura.** Elimina il profilo di test dopo la verifica e etichetta gli export secondo la procedura di produzione.
+6. **Registra la sentinella runtime.** Nello stesso profilo apri la console, verifica che `window.__cineRuntimeIntegrity.ok` sia `true` e, se serve un report aggiornato, esegui `window.cineRuntime.verifyCriticalFlows({ warnOnFailure: true })`, archiviando l’output con le note dell’esercizio.
 
 ## Flusso quotidiano
 
@@ -234,6 +238,7 @@ Ripeti questa routine quando arriva un nuovo membro, allestisci una postazione o
 - Apri **Impostazioni → Dati e archiviazione** per vedere progetti salvati, auto-backup, liste, dispositivi personalizzati, preferiti, feedback e cache di sessione con conteggi in tempo reale.
 - Ogni sezione descrive il proprio contenuto; quelle vuote restano nascoste per riconoscere subito lo stato del planner.
 - Il riepilogo stima la dimensione del backup basandosi sull’export più recente.
+- I backup completi mostrano il totale corrente e alimentano il registro storico, così puoi verificare che le copie orarie siano state registrate prima di archiviare offline.
 
 ## Gestione quote e manutenzione
 
@@ -246,10 +251,12 @@ Ripeti questa routine quando arriva un nuovo membro, allestisci una postazione o
 
 - **Snapshot salvati** – Il selettore conserva ogni salvataggio manuale e crea `auto-backup-…` ogni dieci minuti mentre l’app è aperta.
 - **Backup completi** – **Impostazioni → Backup e ripristino → Backup** scarica `planner-backup.json` con progetti, dispositivi, feedback, preferiti, regole automatiche e stato UI. I ripristini creano un backup di sicurezza e avvisano se il file proviene da un’altra versione.
+- **Registro storico** – Ogni backup completo aggiunge una voce consultabile in **Impostazioni → Dati e archiviazione** o esportabile insieme al file. Mantiene timestamp e nomi allineati alla documentazione anche offline.
 - **Backup di migrazione nascosti** – Prima di sovrascrivere planner, setup o preferenze, l’app salva il precedente JSON in `__legacyMigrationBackup`. In caso di errore, gli strumenti di recupero tornano automaticamente a quella copia.
 - **Snapshot automatici delle regole** – Le modifiche in **Regole automatiche** generano copie con timestamp ogni dieci minuti.
 - **Ripristino impostazioni di fabbrica** – Cancella i dati solo dopo aver scaricato un backup.
 - **Promemoria orari** – Una routine in background suggerisce un backup aggiuntivo ogni ora per avere sempre una copia recente.
+- **Sentinella di integrità runtime** – Prima di partire, apri la console e assicurati che `window.__cineRuntimeIntegrity.ok` sia `true` (o esegui `window.cineRuntime.verifyCriticalFlows({ warnOnFailure: true })`). Il report dimostra che i percorsi di salvataggio/condivisione/ripristino restano protetti offline.
 - **Loop di verifica** – Dopo ogni backup critico, importalo in un profilo separato per confermare il risultato prima di eliminare l’istanza di test.
 - **Abitudini di archiviazione sicura** – Etichetta backup con nome progetto e orario, poi conserva su supporti ridondanti (RAID, USB cifrato, disco ottico).
 - **Confronta prima di sovrascrivere** – Scarica un backup dello stato corrente prima di ripristinare e confronta le differenze con un diff JSON per eventuali fusioni manuali.

--- a/README.md
+++ b/README.md
@@ -154,6 +154,10 @@ localization steps.
 - **Restore rehearsals** – load a full-app backup or project bundle into an
   isolated sandbox to confirm its contents match live data without touching
   production profiles.
+- **Backup history ledger** – every full-app backup download records its
+  timestamp and filename locally. Review counts in **Settings → Data & Storage**
+  or export the log alongside your archives so you can prove retention while
+  staying offline.
 - **Automatic gear rules** – design scenario-triggered additions or removals
   that apply after the generator runs, complete with import/export controls
   and timed backups.
@@ -163,6 +167,10 @@ localization steps.
 - **Data & storage dashboard** – audit stored projects, gear lists, custom
   devices, favorites and runtime feedback, and review approximate backup size
   without leaving the Settings dialog.
+- **Runtime safeguard inspector** – the runtime bundle now records verification
+  results on `window.__cineRuntimeIntegrity` and exposes
+  `window.cineRuntime.verifyCriticalFlows()` so crews can confirm save/share/
+  restore gateways before leaving for set.
 - **Autosave status overlay** – mirror the latest autosave note inside the
   settings dialog so crews see background activity while rehearsing recovery
   drills.
@@ -224,6 +232,10 @@ same online or offline.
    every crew can prove when the drill succeeded. This keeps save, share,
    import, backup and restore workflows provably in sync from the first session
    and gives you redundant recovery media for travel days.
+9. Capture a console screenshot of `window.__cineRuntimeIntegrity` (or rerun
+   `window.cineRuntime.verifyCriticalFlows()` and store the report) to document
+   that the runtime guard validated every save/share/restore gateway while you
+   rehearsed offline.
 
 ## Key Workflow Reference
 
@@ -288,6 +300,10 @@ access.
    machine, operator and notes). The paper trail makes it easy to prove that
    save, share, import, backup and restore workflows were validated end-to-end
    before anyone relies on them in the field.
+6. **Log the runtime guard.** In the same profile, open the developer console
+   and confirm `window.__cineRuntimeIntegrity.ok` is `true`. If you need a fresh
+   report, run `window.cineRuntime.verifyCriticalFlows({ warnOnFailure: true })`
+   and archive the output alongside your rehearsal notes.
 
 ## Everyday Workflow
 
@@ -509,6 +525,9 @@ Use Cine Power Planner end-to-end with the following routine:
   hidden so you know at a glance when the planner is pristine.
 - The summary also estimates backup size using the most recent export, giving you
   a quick check that archives will fit on the storage you bring to set.
+- Full-app backups report their running total and feed the backup history ledger
+  so you can confirm hourly safety copies are captured before archiving them
+  offline.
 
 ## Storage Quota & Maintenance
 
@@ -542,6 +561,10 @@ Use Cine Power Planner end-to-end with the following routine:
   `planner-backup.json` with projects, custom devices, runtime feedback,
   favorites, automatic gear rules and UI state. Restores create a safety copy
   before importing and warn if the file was produced on another version.
+- **Backup history ledger** – each full-app backup writes an entry that you can
+  audit from **Settings → Data & Storage** or export with the archive. It keeps
+  timestamps and filenames aligned with your paper trail even when you rotate
+  media offline.
 - **Hidden migration backups** – before overwriting stored planners, setups or
   preferences, the app now preserves the previous JSON snapshot in a protected
   `__legacyMigrationBackup` slot. If a write ever fails or produces corrupt
@@ -554,6 +577,10 @@ Use Cine Power Planner end-to-end with the following routine:
   when you need a clean slate.
 - **Hourly reminders** – a background routine prompts an additional backup each
   hour so crews always have a recent snapshot ready to archive.
+- **Runtime integrity guard** – open the developer console and confirm
+  `window.__cineRuntimeIntegrity.ok` is `true` (or rerun
+  `window.cineRuntime.verifyCriticalFlows({ warnOnFailure: true })`) before
+  travel. The report proves the offline save/share/restore gateways are intact.
 - **Verification loop** – after every critical backup, re-import it into a
   separate browser profile or private window, confirm projects and gear lists
   match expectations, then delete the temporary profile. This routine catches

--- a/index.html
+++ b/index.html
@@ -3148,6 +3148,17 @@
                 edits, preferences, favorites and runtime logs so you can copy them to external storage for offline safekeeping.
               </li>
               <li>
+                <strong>Backup history ledger</strong> tracks every full-app download inside
+                <a
+                  class="help-link"
+                  href="#dataHeading"
+                  data-help-target="#dataHeading"
+                  data-help-highlight="#settingsPanel-data"
+                >Settings → Data &amp; Storage</a>
+                . Export the log alongside your archives so audit trails show the same timestamps even when you rotate media
+                offline.
+              </li>
+              <li>
                 <strong>Restore safeguards</strong> always create a brand-new safety backup before applying the file you choose,
                 giving you an immediate rollback point if you need to undo the
                 <a class="help-link button-link" href="#restoreSettings" data-help-target="#restoreSettings"><strong>Restore</strong></a>
@@ -3328,6 +3339,12 @@
                 <a class="help-link button-link" href="#restoreSettings" data-help-target="#restoreSettings"><strong>Restore</strong></a>
                 once the sandbox checks out—the planner still creates a fresh safety snapshot beforehand so you can revert
                 instantly if needed. Log which backup you restored and where the validation copy lives.
+              </li>
+              <li>
+                Capture the runtime guard during every rehearsal. Open the developer console, confirm
+                <code>window.__cineRuntimeIntegrity.ok</code> is <code>true</code> (or rerun
+                <code>window.cineRuntime.verifyCriticalFlows({ warnOnFailure: true })</code>) and store the output with your
+                verification notes so the audit trail proves every save/share/restore gateway stayed online-free.
               </li>
             </ol>
             <p class="help-callout-note">


### PR DESCRIPTION
## Summary
- describe the backup history ledger and runtime guard features in every README, including localized copies
- extend quick start and rehearsal drills with runtime verification steps and mention ledger counts in the data overview
- update in-app help to highlight the backup ledger and capturing runtime integrity reports during rehearsals

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d71905087083208eb4b26a2cb97d5b