### PR TITLE
Fix shared setup decoding when setup name is empty

### DIFF
--- a/legacy/scripts/app-core-new-1.js
+++ b/legacy/scripts/app-core-new-1.js
@@ -9023,6 +9023,7 @@ var sharedKeyMap = {
   autoGearCoverage: "z",
   diagramPositions: "y"
 };
+var sharedKeyMapKeys = Object.keys(sharedKeyMap);
 var lastSharedSetupData = null;
 var lastSharedAutoGearRules = null;
 var sharedImportPreviousPresetId = '';
@@ -9321,15 +9322,23 @@ function resolveSharedImportMode(sharedRules) {
 }
 function encodeSharedSetup(setup) {
   var out = {};
-  Object.keys(sharedKeyMap).forEach(function (key) {
+  sharedKeyMapKeys.forEach(function (key) {
     if (setup[key] != null) out[sharedKeyMap[key]] = setup[key];
   });
   return out;
 }
 function decodeSharedSetup(setup) {
-  if (setup.setupName || setup.camera) return setup;
+  if (!setup || _typeof(setup) !== "object") return {};
+
+  for (var index = 0; index < sharedKeyMapKeys.length; index += 1) {
+    var key = sharedKeyMapKeys[index];
+    if (Object.prototype.hasOwnProperty.call(setup, key)) {
+      return setup;
+    }
+  }
+
   var out = {};
-  Object.keys(sharedKeyMap).forEach(function (key) {
+  sharedKeyMapKeys.forEach(function (key) {
     var short = sharedKeyMap[key];
     if (setup[short] != null) out[key] = setup[short];
   });

--- a/src/scripts/app-core-new-1.js
+++ b/src/scripts/app-core-new-1.js
@@ -10389,6 +10389,7 @@ const sharedKeyMap = {
   autoGearCoverage: "z",
   diagramPositions: "y"
 };
+const sharedKeyMapKeys = Object.keys(sharedKeyMap);
 
 var lastSharedSetupData = null;
 var lastSharedAutoGearRules = null;
@@ -10717,16 +10718,24 @@ function resolveSharedImportMode(sharedRules) {
 
 function encodeSharedSetup(setup) {
   const out = {};
-  Object.keys(sharedKeyMap).forEach(key => {
+  sharedKeyMapKeys.forEach(key => {
     if (setup[key] != null) out[sharedKeyMap[key]] = setup[key];
   });
   return out;
 }
 
 function decodeSharedSetup(setup) {
-  if (setup.setupName || setup.camera) return setup;
+  if (!setup || typeof setup !== "object") return {};
+
+  for (let index = 0; index < sharedKeyMapKeys.length; index += 1) {
+    const key = sharedKeyMapKeys[index];
+    if (Object.prototype.hasOwnProperty.call(setup, key)) {
+      return setup;
+    }
+  }
+
   const out = {};
-  Object.keys(sharedKeyMap).forEach(key => {
+  sharedKeyMapKeys.forEach(key => {
     const short = sharedKeyMap[key];
     if (setup[short] != null) out[key] = setup[short];
   });

--- a/tests/dom/sharedProjectGearList.test.js
+++ b/tests/dom/sharedProjectGearList.test.js
@@ -38,6 +38,20 @@ describe('shared project gear list handling', () => {
     expect(decoded.projectInfo).toEqual(payload.projectInfo);
   });
 
+  test('decodeSharedSetup preserves modern payloads with empty setup names', () => {
+    const { utils } = env;
+    const payload = {
+      setupName: '',
+      gearList: '<section>Gear</section>',
+      projectInfo: { projectName: 'Untitled' }
+    };
+
+    const decoded = utils.decodeSharedSetup(payload);
+    expect(decoded).toBe(payload);
+    expect(decoded.projectInfo).toEqual(payload.projectInfo);
+    expect(decoded.gearList).toBe(payload.gearList);
+  });
+
   test('encodeSharedSetup preserves auto gear coverage snapshots', () => {
     const { utils } = env;
     const payload = {


### PR DESCRIPTION
## Summary
- ensure modern shared setup payloads are detected even when setup names are empty strings
- reuse shared key metadata for encode/decode in both modern and legacy bundles
- add a regression test covering decoding of empty-named shared setups

## Testing
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68d71be2240883209698a6ce8ec512f8