### PR TITLE
Improve diagram font scaling on mobile

### DIFF
--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -162,6 +162,22 @@
     padding-bottom: 0.3em;
   }
 }
+
+@media (max-width: 768px) {
+  :root {
+    --font-scale-diagram-text: 0.7;
+    --font-scale-diagram-label: 0.6;
+    --font-scale-icon-lg: 1.35;
+  }
+}
+
+@media (max-width: 480px) {
+  :root {
+    --font-scale-diagram-text: 0.6;
+    --font-scale-diagram-label: 0.5;
+    --font-scale-icon-lg: 1.2;
+  }
+}
 html.pink-mode,
 body.pink-mode {
   --accent-color: #ff69b4;


### PR DESCRIPTION
## Summary
- adjust diagram font and icon scale variables for medium and small screens
- ensure project diagram labels and legends shrink on phones to avoid overflow

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d82bd155b08320b3b86715f97eaaf6