### PR TITLE
Make top bar language selector use light font weight

### DIFF
--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -4611,6 +4611,7 @@ body.pink-mode #topBar #logo .logo-pink {
   height: var(--select-height);
   margin: 0;
   font-size: var(--font-size-relative-base);
+  font-weight: var(--font-weight-light);
   padding: 2px 4px;
   text-align: center;
   text-align-last: center;
@@ -4651,7 +4652,7 @@ body.light-mode #topBar .controls button:focus-visible {
 
 body.light-mode #topBar select {
   color: var(--accent-color);
-  font-weight: var(--font-weight-medium);
+  font-weight: var(--font-weight-light);
 }
 
 body.light-mode #topBar select:hover,


### PR DESCRIPTION
## Summary
- set the top bar controls select element to use the light font weight so the language selector appears lighter
- keep the light mode language selector styling aligned with the new lighter weight

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d82fc9636c8320924ddc9c25072354