### PR TITLE
Normalize monitoring category text color

### DIFF
--- a/src/scripts/app-core-new-2.js
+++ b/src/scripts/app-core-new-2.js
@@ -8007,6 +8007,19 @@ function updateGearListButtonVisibility() {
   }
 }
 
+function annotateGearTableCategoryGroups(table) {
+  if (!table) return;
+  const groups = table.querySelectorAll('tbody.category-group');
+  groups.forEach(group => {
+    const headingCell = group.querySelector('.category-row td');
+    if (!headingCell) return;
+    const label = headingCell.textContent ? headingCell.textContent.trim() : '';
+    if (!label) return;
+    if (group.getAttribute('data-gear-table-category') === label) return;
+    group.setAttribute('data-gear-table-category', label);
+  });
+}
+
 function ensureGearTableCategoryGrouping(table) {
   if (!table) return;
   const doc = table.ownerDocument || (typeof document !== 'undefined' ? document : null);
@@ -8023,6 +8036,7 @@ function ensureGearTableCategoryGrouping(table) {
         group.classList.add('category-group');
       }
     });
+    annotateGearTableCategoryGroups(table);
     return;
   }
   const rows = Array.from(table.rows || []);
@@ -8052,6 +8066,7 @@ function ensureGearTableCategoryGrouping(table) {
   newGroups.forEach(group => {
     if (group.rows.length) table.appendChild(group);
   });
+  annotateGearTableCategoryGroups(table);
 }
 
 let overviewTitleCandidatesCache = null;

--- a/src/styles/overview-print.css
+++ b/src/styles/overview-print.css
@@ -573,6 +573,18 @@ body:not(.light-mode) .gear-table .category-row td {
   font-weight: var(--font-weight-medium);
 }
 
+#overviewDialogContent .gear-table .category-group[data-gear-table-category="Monitoring"] tr:not(.category-row) td,
+#overviewDialogContent .gear-table .category-group[data-gear-table-category="Monitoring Batteries"] tr:not(.category-row) td,
+#overviewDialogContent .gear-table .category-group[data-gear-table-category="Monitoring support"] tr:not(.category-row) td,
+#overviewDialogContent.dark-mode .gear-table .category-group[data-gear-table-category="Monitoring"] tr:not(.category-row) td,
+#overviewDialogContent.dark-mode .gear-table .category-group[data-gear-table-category="Monitoring Batteries"] tr:not(.category-row) td,
+#overviewDialogContent.dark-mode .gear-table .category-group[data-gear-table-category="Monitoring support"] tr:not(.category-row) td,
+body:not(.light-mode) .gear-table .category-group[data-gear-table-category="Monitoring"] tr:not(.category-row) td,
+body:not(.light-mode) .gear-table .category-group[data-gear-table-category="Monitoring Batteries"] tr:not(.category-row) td,
+body:not(.light-mode) .gear-table .category-group[data-gear-table-category="Monitoring support"] tr:not(.category-row) td {
+  color: var(--text-color);
+}
+
 
 .device-category {
   background: var(--panel-bg) !important;

--- a/src/styles/overview.css
+++ b/src/styles/overview.css
@@ -107,6 +107,12 @@ th { background-color: var(--control-bg); font-weight: var(--font-weight-bold); 
   page-break-after: avoid;
 }
 
+.gear-table .category-group[data-gear-table-category="Monitoring"] tr:not(.category-row) td,
+.gear-table .category-group[data-gear-table-category="Monitoring Batteries"] tr:not(.category-row) td,
+.gear-table .category-group[data-gear-table-category="Monitoring support"] tr:not(.category-row) td {
+  color: var(--text-color);
+}
+
 .dark-mode .gear-table .category-row td {
   font-weight: var(--font-weight-medium);
 }

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -6293,6 +6293,21 @@ body.dark-mode .requirement-box,
   page-break-after: avoid;
 }
 
+.gear-table .category-group[data-gear-table-category="Monitoring"] tr:not(.category-row) td,
+.gear-table .category-group[data-gear-table-category="Monitoring Batteries"] tr:not(.category-row) td,
+.gear-table .category-group[data-gear-table-category="Monitoring support"] tr:not(.category-row) td {
+  color: var(--text-color);
+}
+
+#gearListOutput.show-auto-gear-highlight .category-group[data-gear-table-category="Monitoring"] .auto-gear-item,
+#gearListOutput.show-auto-gear-highlight .category-group[data-gear-table-category="Monitoring Batteries"] .auto-gear-item,
+#gearListOutput.show-auto-gear-highlight .category-group[data-gear-table-category="Monitoring support"] .auto-gear-item,
+#gearListOutput.show-auto-gear-highlight .category-group[data-gear-table-category="Monitoring"] .auto-gear-item select,
+#gearListOutput.show-auto-gear-highlight .category-group[data-gear-table-category="Monitoring Batteries"] .auto-gear-item select,
+#gearListOutput.show-auto-gear-highlight .category-group[data-gear-table-category="Monitoring support"] .auto-gear-item select {
+  color: var(--text-color);
+}
+
 .gear-item[data-gear-name^="ND Grad HE Filter Set"],
 .gear-item[data-gear-name^="ND Grad SE Filter Set"] {
   display: inline-flex;


### PR DESCRIPTION
## Summary
- annotate gear table category groups with their display labels so they can be targeted reliably
- force monitoring-related gear entries to inherit the standard text color in the main view, overview dialog, and print layout

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d82f319e7083208551ae7290942d7b