### PR TITLE
Fix shared setup decoding for mixed payload keys

### DIFF
--- a/legacy/scripts/app-core-new-1.js
+++ b/legacy/scripts/app-core-new-1.js
@@ -9330,19 +9330,55 @@ function encodeSharedSetup(setup) {
 function decodeSharedSetup(setup) {
   if (!setup || _typeof(setup) !== "object") return {};
 
+  var hasLongKeys = false;
+  var hasShortKeys = false;
+  var needsMerge = false;
+
   for (var index = 0; index < sharedKeyMapKeys.length; index += 1) {
     var key = sharedKeyMapKeys[index];
-    if (Object.prototype.hasOwnProperty.call(setup, key)) {
-      return setup;
+    var hasLongKey = Object.prototype.hasOwnProperty.call(setup, key);
+    var short = sharedKeyMap[key];
+    var hasShortKey = Object.prototype.hasOwnProperty.call(setup, short);
+
+    if (hasLongKey) {
+      hasLongKeys = true;
+    }
+    if (hasShortKey) {
+      hasShortKeys = true;
+      if (!hasLongKey && setup[short] != null) {
+        needsMerge = true;
+      }
     }
   }
 
-  var out = {};
+  if (!hasLongKeys && !hasShortKeys) {
+    return {};
+  }
+
+  if (!hasLongKeys) {
+    var out = {};
+    sharedKeyMapKeys.forEach(function (key) {
+      var short = sharedKeyMap[key];
+      if (setup[short] != null) out[key] = setup[short];
+    });
+    return out;
+  }
+
+  if (!needsMerge) {
+    return setup;
+  }
+
+  var merged = _objectSpread({}, setup);
   sharedKeyMapKeys.forEach(function (key) {
+    if (Object.prototype.hasOwnProperty.call(merged, key)) {
+      return;
+    }
     var short = sharedKeyMap[key];
-    if (setup[short] != null) out[key] = setup[short];
+    if (setup[short] != null) {
+      merged[key] = setup[short];
+    }
   });
-  return out;
+  return merged;
 }
 var deviceManagerSection = document.getElementById("device-manager");
 var toggleDeviceBtn = document.getElementById("toggleDeviceManager");

--- a/src/scripts/app-core-new-1.js
+++ b/src/scripts/app-core-new-1.js
@@ -10727,19 +10727,55 @@ function encodeSharedSetup(setup) {
 function decodeSharedSetup(setup) {
   if (!setup || typeof setup !== "object") return {};
 
+  let hasLongKeys = false;
+  let hasShortKeys = false;
+  let needsMerge = false;
+
   for (let index = 0; index < sharedKeyMapKeys.length; index += 1) {
     const key = sharedKeyMapKeys[index];
-    if (Object.prototype.hasOwnProperty.call(setup, key)) {
-      return setup;
+    const hasLongKey = Object.prototype.hasOwnProperty.call(setup, key);
+    const short = sharedKeyMap[key];
+    const hasShortKey = Object.prototype.hasOwnProperty.call(setup, short);
+
+    if (hasLongKey) {
+      hasLongKeys = true;
+    }
+    if (hasShortKey) {
+      hasShortKeys = true;
+      if (!hasLongKey && setup[short] != null) {
+        needsMerge = true;
+      }
     }
   }
 
-  const out = {};
+  if (!hasLongKeys && !hasShortKeys) {
+    return {};
+  }
+
+  if (!hasLongKeys) {
+    const out = {};
+    sharedKeyMapKeys.forEach(key => {
+      const short = sharedKeyMap[key];
+      if (setup[short] != null) out[key] = setup[short];
+    });
+    return out;
+  }
+
+  if (!needsMerge) {
+    return setup;
+  }
+
+  const merged = { ...setup };
   sharedKeyMapKeys.forEach(key => {
+    if (Object.prototype.hasOwnProperty.call(merged, key)) {
+      return;
+    }
     const short = sharedKeyMap[key];
-    if (setup[short] != null) out[key] = setup[short];
+    if (setup[short] != null) {
+      merged[key] = setup[short];
+    }
   });
-  return out;
+  return merged;
 }
 var deviceManagerSection = document.getElementById("device-manager");
 var toggleDeviceBtn = document.getElementById("toggleDeviceManager");

--- a/tests/dom/sharedProjectGearList.test.js
+++ b/tests/dom/sharedProjectGearList.test.js
@@ -52,6 +52,24 @@ describe('shared project gear list handling', () => {
     expect(decoded.gearList).toBe(payload.gearList);
   });
 
+  test('decodeSharedSetup fills missing modern fields from encoded keys', () => {
+    const { utils } = env;
+    const payload = {
+      setupName: 'Mixed Payload',
+      l: '<div>Encoded Gear</div>',
+      a: [{ id: 'rule-1' }]
+    };
+
+    const decoded = utils.decodeSharedSetup(payload);
+    expect(decoded).not.toBe(payload);
+    expect(decoded.setupName).toBe('Mixed Payload');
+    expect(decoded.gearList).toBe('<div>Encoded Gear</div>');
+    expect(Array.isArray(decoded.autoGearRules)).toBe(true);
+    expect(decoded.autoGearRules).toEqual([{ id: 'rule-1' }]);
+    expect(payload.gearList).toBeUndefined();
+    expect(payload.autoGearRules).toBeUndefined();
+  });
+
   test('encodeSharedSetup preserves auto gear coverage snapshots', () => {
     const { utils } = env;
     const payload = {


### PR DESCRIPTION
## Summary
- ensure shared setup decoding maps encoded keys even when some modern keys are already present, preventing data loss for mixed payloads
- mirror the decoding fix in the legacy bundle to keep offline compatibility consistent
- add regression coverage verifying mixed-key payloads retain gear lists and auto gear rules after decoding

## Testing
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68d82e9461f883209fea0804d8953fd2