### PR TITLE
Fix shooting days auto gear condition editing

### DIFF
--- a/legacy/scripts/app-core-new-1.js
+++ b/legacy/scripts/app-core-new-1.js
@@ -11443,6 +11443,23 @@ function initializeAutoGearConditionsFromDraft() {
 refreshAutoGearConditionPicker();
 updateAutoGearConditionAddButtonState();
 configureAutoGearConditionButtons();
+if (autoGearShootingDaysMode) {
+  var handleShootingDaysModeChange = function handleShootingDaysModeChange() {
+    updateAutoGearShootingDaysDraft();
+    renderAutoGearDraftImpact();
+  };
+  autoGearShootingDaysMode.addEventListener('input', handleShootingDaysModeChange);
+  autoGearShootingDaysMode.addEventListener('change', handleShootingDaysModeChange);
+}
+if (autoGearShootingDaysInput) {
+  var handleShootingDaysValueInput = function handleShootingDaysValueInput() {
+    updateAutoGearShootingDaysDraft();
+    renderAutoGearDraftImpact();
+  };
+  autoGearShootingDaysInput.addEventListener('input', handleShootingDaysValueInput);
+  autoGearShootingDaysInput.addEventListener('change', handleShootingDaysValueInput);
+  autoGearShootingDaysInput.addEventListener('blur', handleShootingDaysValueInput);
+}
 if (autoGearCameraWeightOperator) {
   var handleCameraWeightOperatorChange = function handleCameraWeightOperatorChange() {
     updateAutoGearCameraWeightDraft();

--- a/legacy/scripts/app-core-new-2.js
+++ b/legacy/scripts/app-core-new-2.js
@@ -273,6 +273,36 @@ function updateAutoGearCameraWeightDraft() {
     autoGearEditorDraft.cameraWeight = null;
   }
 }
+function updateAutoGearShootingDaysDraft() {
+  if (!autoGearEditorDraft) return;
+  if (!isAutoGearConditionActive('shootingDays')) {
+    autoGearEditorDraft.shootingDays = null;
+    return;
+  }
+  var modeValue = autoGearShootingDaysMode ? autoGearShootingDaysMode.value : 'minimum';
+  var valueSource = autoGearShootingDaysInput ? autoGearShootingDaysInput.value : '';
+  var normalized = normalizeAutoGearShootingDaysCondition({
+    mode: modeValue,
+    value: valueSource
+  });
+  if (normalized) {
+    autoGearEditorDraft.shootingDays = _objectSpread({}, normalized);
+    return;
+  }
+  var fallbackMode = typeof normalizeAutoGearShootingDayMode === 'function'
+    ? normalizeAutoGearShootingDayMode(modeValue)
+    : typeof modeValue === 'string' && modeValue
+      ? modeValue.trim().toLowerCase()
+      : 'minimum';
+  if (fallbackMode) {
+    autoGearEditorDraft.shootingDays = {
+      mode: fallbackMode,
+      value: null
+    };
+  } else {
+    autoGearEditorDraft.shootingDays = null;
+  }
+}
 function refreshAutoGearMonitorOptions(selected) {
   if (!autoGearMonitorSelect) return;
   var selectedValues = collectAutoGearSelectedValues(selected, 'monitor');

--- a/src/scripts/app-core-new-1.js
+++ b/src/scripts/app-core-new-1.js
@@ -12583,6 +12583,23 @@ function initializeAutoGearConditionsFromDraft() {
 refreshAutoGearConditionPicker();
 updateAutoGearConditionAddButtonState();
 configureAutoGearConditionButtons();
+if (autoGearShootingDaysMode) {
+  const handleShootingDaysModeChange = () => {
+    updateAutoGearShootingDaysDraft();
+    callCoreFunctionIfAvailable('renderAutoGearDraftImpact', [], { defer: true });
+  };
+  autoGearShootingDaysMode.addEventListener('input', handleShootingDaysModeChange);
+  autoGearShootingDaysMode.addEventListener('change', handleShootingDaysModeChange);
+}
+if (autoGearShootingDaysInput) {
+  const handleShootingDaysValueInput = () => {
+    updateAutoGearShootingDaysDraft();
+    callCoreFunctionIfAvailable('renderAutoGearDraftImpact', [], { defer: true });
+  };
+  autoGearShootingDaysInput.addEventListener('input', handleShootingDaysValueInput);
+  autoGearShootingDaysInput.addEventListener('change', handleShootingDaysValueInput);
+  autoGearShootingDaysInput.addEventListener('blur', handleShootingDaysValueInput);
+}
 if (autoGearCameraWeightOperator) {
   const handleCameraWeightOperatorChange = () => {
     updateAutoGearCameraWeightDraft();

--- a/src/scripts/app-core-new-2.js
+++ b/src/scripts/app-core-new-2.js
@@ -332,6 +332,29 @@ function updateAutoGearCameraWeightDraft() {
   }
 }
 
+function updateAutoGearShootingDaysDraft() {
+  if (!autoGearEditorDraft) return;
+  if (!isAutoGearConditionActive('shootingDays')) {
+    autoGearEditorDraft.shootingDays = null;
+    return;
+  }
+  const modeValue = autoGearShootingDaysMode ? autoGearShootingDaysMode.value : 'minimum';
+  const valueSource = autoGearShootingDaysInput ? autoGearShootingDaysInput.value : '';
+  const normalized = normalizeAutoGearShootingDaysCondition({ mode: modeValue, value: valueSource });
+  if (normalized) {
+    autoGearEditorDraft.shootingDays = { ...normalized };
+    return;
+  }
+  const fallbackMode = typeof normalizeAutoGearShootingDayMode === 'function'
+    ? normalizeAutoGearShootingDayMode(modeValue)
+    : (typeof modeValue === 'string' && modeValue ? modeValue.trim().toLowerCase() : 'minimum');
+  if (fallbackMode) {
+    autoGearEditorDraft.shootingDays = { mode: fallbackMode, value: null };
+  } else {
+    autoGearEditorDraft.shootingDays = null;
+  }
+}
+
 function refreshAutoGearMonitorOptions(selected) {
   if (!autoGearMonitorSelect) return;
 
@@ -13662,6 +13685,7 @@ const CORE_PART2_GLOBAL_EXPORTS = {
   refreshAutoGearControllersOptions,
   refreshAutoGearDistanceOptions,
   updateAutoGearCameraWeightDraft,
+  updateAutoGearShootingDaysDraft,
 };
 
 const CORE_PART2_GLOBAL_SCOPE =

--- a/tools/appScriptGlobals.json
+++ b/tools/appScriptGlobals.json
@@ -753,6 +753,7 @@
     "updateAutoGearBackupRestoreButtonState",
     "updateAutoGearCatalogOptions",
     "updateAutoGearCameraWeightDraft",
+    "updateAutoGearShootingDaysDraft",
     "updateAutoGearMonitorCatalogOptions",
     "updateBatteryOptions",
     "updateBatteryPlateVisibility",


### PR DESCRIPTION
## Summary
- wire the shooting days auto gear condition inputs so changes update the draft and refresh the impact preview
- add an update helper for shooting days in the modern and legacy bundles and expose it alongside the other auto gear utilities
- register the new helper in the script globals list to keep bundling metadata accurate

## Testing
- npm test -- --runTestsByPath tests/unit/loaderScripts.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d8337401b08320ad6721c89a65eebe