### PR TITLE
Improve share export resilience when power selectors missing

### DIFF
--- a/legacy/scripts/app-core-new-1.js
+++ b/legacy/scripts/app-core-new-1.js
@@ -4242,10 +4242,21 @@ function applyBatteryPlateSelectionFromBattery(batteryName, currentPlateValue) {
   return desiredPlate;
 }
 function getSelectedPlate() {
-  var camName = cameraSelect.value;
-  var plates = getAvailableBatteryPlates(camName);
-  if (!plates.length) return null;
-  return batteryPlateSelect.value || (plates.includes('V-Mount') ? 'V-Mount' : plates[0]);
+  var camName = typeof (cameraSelect && cameraSelect.value) === 'string' ? cameraSelect.value : '';
+  var plates = typeof getAvailableBatteryPlates === 'function'
+    ? getAvailableBatteryPlates(camName)
+    : [];
+  if (!Array.isArray(plates) || !plates.length) return null;
+  var plateValue = typeof (batteryPlateSelect && batteryPlateSelect.value) === 'string'
+    ? batteryPlateSelect.value
+    : '';
+  if (plateValue) {
+    return plateValue;
+  }
+  if (plates.includes('V-Mount')) {
+    return 'V-Mount';
+  }
+  return plates[0];
 }
 function isSelectedPlateNative(camName) {
   var plate = getSelectedPlate();

--- a/legacy/scripts/app-core-new-2.js
+++ b/legacy/scripts/app-core-new-2.js
@@ -11619,24 +11619,29 @@ function updateCalculations() {
   refreshGearListIfVisible();
 }
 function getCurrentSetupKey() {
-  var camera = cameraSelect.value || '';
-  var monitor = monitorSelect.value || '';
-  var video = videoSelect.value || '';
-  var cage = cageSelect ? cageSelect.value : '';
-  var motors = motorSelects.map(function (sel) {
-    return sel.value;
-  }).filter(function (v) {
-    return v && v !== 'None';
-  }).sort().join(',');
-  var controllers = controllerSelects.map(function (sel) {
-    return sel.value;
-  }).filter(function (v) {
-    return v && v !== 'None';
-  }).sort().join(',');
-  var distance = distanceSelect.value || '';
-  var battery = batterySelect.value || '';
-  var hotswap = hotswapSelect.value || '';
-  var plate = getSelectedPlate() || '';
+  var safeSelectValue = function (select) {
+    return select && typeof select.value === 'string' ? select.value : '';
+  };
+
+  var safeListValues = function (list) {
+    if (!Array.isArray(list)) return '';
+    return list.map(function (sel) {
+      return safeSelectValue(sel);
+    }).filter(function (value) {
+      return value && value !== 'None';
+    }).sort().join(',');
+  };
+
+  var camera = safeSelectValue(cameraSelect);
+  var monitor = safeSelectValue(monitorSelect);
+  var video = safeSelectValue(videoSelect);
+  var cage = safeSelectValue(cageSelect);
+  var motors = safeListValues(motorSelects);
+  var controllers = safeListValues(controllerSelects);
+  var distance = safeSelectValue(distanceSelect);
+  var battery = safeSelectValue(batterySelect);
+  var hotswap = safeSelectValue(hotswapSelect);
+  var plate = typeof getSelectedPlate === 'function' ? (getSelectedPlate() || '') : '';
   return [camera, monitor, video, cage, motors, controllers, distance, battery, hotswap, plate].join('|');
 }
 function deleteFeedbackEntry(key, index) {

--- a/src/scripts/app-core-new-1.js
+++ b/src/scripts/app-core-new-1.js
@@ -4683,10 +4683,19 @@ function applyBatteryPlateSelectionFromBattery(batteryName, currentPlateValue) {
 }
 
 function getSelectedPlate() {
-  const camName = cameraSelect.value;
-  const plates = getAvailableBatteryPlates(camName);
-  if (!plates.length) return null;
-  return batteryPlateSelect.value || (plates.includes('V-Mount') ? 'V-Mount' : plates[0]);
+  const camName = typeof cameraSelect?.value === 'string' ? cameraSelect.value : '';
+  const plates = typeof getAvailableBatteryPlates === 'function'
+    ? getAvailableBatteryPlates(camName)
+    : [];
+  if (!Array.isArray(plates) || !plates.length) return null;
+  const plateValue = typeof batteryPlateSelect?.value === 'string' ? batteryPlateSelect.value : '';
+  if (plateValue) {
+    return plateValue;
+  }
+  if (plates.includes('V-Mount')) {
+    return 'V-Mount';
+  }
+  return plates[0];
 }
 
 function isSelectedPlateNative(camName) {

--- a/src/scripts/app-core-new-2.js
+++ b/src/scripts/app-core-new-2.js
@@ -12485,16 +12485,33 @@ if (!battery || battery === "None" || !devices.batteries[battery]) {
 }
 
 function getCurrentSetupKey() {
-  const camera = cameraSelect.value || '';
-  const monitor = monitorSelect.value || '';
-  const video = videoSelect.value || '';
-  const cage = cageSelect ? cageSelect.value : '';
-  const motors = motorSelects.map(sel => sel.value).filter(v => v && v !== 'None').sort().join(',');
-  const controllers = controllerSelects.map(sel => sel.value).filter(v => v && v !== 'None').sort().join(',');
-  const distance = distanceSelect.value || '';
-  const battery = batterySelect.value || '';
-  const hotswap = hotswapSelect.value || '';
-  const plate = getSelectedPlate() || '';
+  const safeSelectValue = (select) => (
+    select && typeof select.value === 'string'
+      ? select.value
+      : ''
+  );
+
+  const safeListValues = (list) => (
+    Array.isArray(list)
+      ? list
+          .map(sel => safeSelectValue(sel))
+          .filter(value => value && value !== 'None')
+          .sort()
+          .join(',')
+      : ''
+  );
+
+  const camera = safeSelectValue(cameraSelect);
+  const monitor = safeSelectValue(monitorSelect);
+  const video = safeSelectValue(videoSelect);
+  const cage = safeSelectValue(cageSelect);
+  const motors = safeListValues(motorSelects);
+  const controllers = safeListValues(controllerSelects);
+  const distance = safeSelectValue(distanceSelect);
+  const battery = safeSelectValue(batterySelect);
+  const hotswap = safeSelectValue(hotswapSelect);
+  const plate = typeof getSelectedPlate === 'function' ? (getSelectedPlate() || '') : '';
+
   return [camera, monitor, video, cage, motors, controllers, distance, battery, hotswap, plate].join('|');
 }
 

--- a/src/scripts/app-setups.js
+++ b/src/scripts/app-setups.js
@@ -199,6 +199,16 @@ if (projectForm) {
 function downloadSharedProject(shareFileName, includeAutoGear) {
   if (!shareFileName) return;
   const setupName = getCurrentProjectName();
+  const readPowerSelectValue = (select) => (
+    select && typeof select.value === 'string'
+      ? normalizePowerSelectionString(select.value)
+      : ''
+  );
+
+  const normalizedBattery = readPowerSelectValue(batterySelect);
+  const normalizedPlate = readPowerSelectValue(batteryPlateSelect);
+  const normalizedHotswap = readPowerSelectValue(hotswapSelect);
+
   const currentSetup = {
     setupName,
     camera: cameraSelect.value,
@@ -208,13 +218,17 @@ function downloadSharedProject(shareFileName, includeAutoGear) {
     motors: motorSelects.map(sel => sel.value),
     controllers: controllerSelects.map(sel => sel.value),
     distance: distanceSelect.value,
-    batteryPlate: normalizeBatteryPlateValue(batteryPlateSelect.value, batterySelect.value),
-    battery: batterySelect.value,
-    batteryHotswap: hotswapSelect.value
+    batteryPlate: normalizeBatteryPlateValue(normalizedPlate, normalizedBattery),
+    battery: normalizedBattery,
+    batteryHotswap: normalizedHotswap
   };
+
   const sharedPowerSelection = getPowerSelectionSnapshot();
   if (sharedPowerSelection) {
     currentSetup.powerSelection = sharedPowerSelection;
+    currentSetup.battery = sharedPowerSelection.battery || '';
+    currentSetup.batteryPlate = sharedPowerSelection.batteryPlate || '';
+    currentSetup.batteryHotswap = sharedPowerSelection.batteryHotswap || '';
   }
   if (typeof getDiagramManualPositions === 'function') {
     const diagramPositions = getDiagramManualPositions();


### PR DESCRIPTION
## Summary
- normalize power selector values when building shared project payloads so downloads do not depend on DOM elements that may be absent
- harden current setup key and plate helpers to tolerate missing selects in both modern and legacy bundles
- add script-level regression test covering project export when battery selectors are unavailable

## Testing
- RUN_HEAVY_TESTS=true npx jest tests/script/shareExport.test.js --runInBand
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d8374932dc8320900784f33b7bb1c6