### PR TITLE
Ensure help inline links keep regular font weight

### DIFF
--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -3402,6 +3402,10 @@ body.pink-mode:not(.dark-mode) #settingsPanel-autoGear .auto-gear-rule-items-lab
   text-decoration-thickness: 0.12em;
 }
 
+.help-link {
+  font-weight: var(--font-weight-regular);
+}
+
 .help-link:not(.button-link):visited {
   color: var(--accent-color);
 }
@@ -3409,6 +3413,11 @@ body.pink-mode:not(.dark-mode) #settingsPanel-autoGear .auto-gear-rule-items-lab
 .help-link:not(.button-link):hover,
 .help-link:not(.button-link):focus-visible {
   text-decoration: underline;
+}
+
+.help-link strong,
+.help-link b {
+  font-weight: inherit;
 }
 
 .help-link.button-link,


### PR DESCRIPTION
## Summary
- enforce regular font weight for help links in the inline help view
- prevent nested bold tags from overriding the regular weight to keep typography consistent

## Testing
- npm test -- --watch=false *(fails: tests/data/languageCoverage.test.js already failing on main)*

------
https://chatgpt.com/codex/tasks/task_e_68d838e323848320bcd729cf7fb3b96c