### PR TITLE
Adjust spacing for scenario controls

### DIFF
--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -3059,6 +3059,12 @@ body.pink-mode:not(.dark-mode) #settingsPanel-autoGear .auto-gear-rule-items-lab
 
 .auto-gear-scenario-settings .auto-gear-field {
   flex: 1 1 220px;
+  gap: 2px;
+}
+
+.auto-gear-scenario-settings .auto-gear-field select,
+.auto-gear-scenario-settings .auto-gear-field input {
+  flex: 0 0 auto;
 }
 
 .auto-gear-scenario-multiplier {


### PR DESCRIPTION
## Summary
- tighten the label gap within the auto gear scenario controls so the UI feels less sparse
- prevent scenario selects and inputs from stretching vertically by resetting their flex sizing

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d837f05f688320bb1894df8165dc80