### PR TITLE
Fix B-Mount project power selection restoration

### DIFF
--- a/src/scripts/app-events.js
+++ b/src/scripts/app-events.js
@@ -573,15 +573,15 @@ setupSelect.addEventListener("change", (event) => {
       setEasyrigValue(setup.easyrig || '');
       let storedPowerApplied = false;
       if (setup.powerSelection && typeof applyStoredPowerSelection === 'function') {
-        storedPowerApplied = applyStoredPowerSelection(setup.powerSelection);
+        storedPowerApplied = applyStoredPowerSelection(setup.powerSelection, { preferExisting: false });
       }
       const storedProject = typeof loadProject === 'function' ? loadProject(setupName) : null;
       if (!storedPowerApplied && storedProject && typeof applyStoredPowerSelection === 'function' && storedProject.powerSelection) {
-        storedPowerApplied = applyStoredPowerSelection(storedProject.powerSelection);
+        storedPowerApplied = applyStoredPowerSelection(storedProject.powerSelection, { preferExisting: false });
       }
       updateBatteryOptions();
       if (!storedPowerApplied && storedProject && typeof applyStoredPowerSelection === 'function' && storedProject.powerSelection) {
-        storedPowerApplied = applyStoredPowerSelection(storedProject.powerSelection);
+        storedPowerApplied = applyStoredPowerSelection(storedProject.powerSelection, { preferExisting: false });
         if (storedPowerApplied) {
           updateBatteryOptions();
         }

--- a/src/scripts/app-setups.js
+++ b/src/scripts/app-setups.js
@@ -68,20 +68,46 @@ function applyStoredPowerSelection(selection, { preferExisting = true } = {}) {
         || !hasMeaningfulPowerSelection(batteryPlateSelect && batteryPlateSelect.value);
     const shouldOverwriteHotswap = !preferExisting
         || !hasMeaningfulPowerSelection(hotswapSelect && hotswapSelect.value);
-    let applied = false;
+
+    const matchesTarget = (select, desired) => {
+        if (!select) return false;
+        if (desired === '') {
+            return !select.value || select.value === 'None' || select.selectedIndex === -1;
+        }
+        return select.value === desired;
+    };
+
+    let anyMatch = false;
+    let anyPending = false;
     if (batterySelect && target.battery && shouldOverwriteBattery) {
         assignSelectValue(batterySelect, target.battery);
-        applied = true;
+        if (matchesTarget(batterySelect, target.battery)) {
+            anyMatch = true;
+        } else {
+            anyPending = true;
+        }
     } else if (batterySelect && !target.battery && !preferExisting) {
         assignSelectValue(batterySelect, '');
-        applied = true;
+        if (matchesTarget(batterySelect, '')) {
+            anyMatch = true;
+        } else {
+            anyPending = true;
+        }
     }
     if (batteryPlateSelect && target.batteryPlate && shouldOverwritePlate) {
         assignSelectValue(batteryPlateSelect, target.batteryPlate);
-        applied = true;
+        if (matchesTarget(batteryPlateSelect, target.batteryPlate)) {
+            anyMatch = true;
+        } else {
+            anyPending = true;
+        }
     } else if (batteryPlateSelect && !target.batteryPlate && !preferExisting) {
         assignSelectValue(batteryPlateSelect, '');
-        applied = true;
+        if (matchesTarget(batteryPlateSelect, '')) {
+            anyMatch = true;
+        } else {
+            anyPending = true;
+        }
     }
     if (typeof applyBatteryPlateSelectionFromBattery === 'function') {
         applyBatteryPlateSelectionFromBattery(
@@ -91,12 +117,20 @@ function applyStoredPowerSelection(selection, { preferExisting = true } = {}) {
     }
     if (hotswapSelect && target.batteryHotswap && shouldOverwriteHotswap) {
         assignSelectValue(hotswapSelect, target.batteryHotswap);
-        applied = true;
+        if (matchesTarget(hotswapSelect, target.batteryHotswap)) {
+            anyMatch = true;
+        } else {
+            anyPending = true;
+        }
     } else if (hotswapSelect && !target.batteryHotswap && !preferExisting) {
         assignSelectValue(hotswapSelect, '');
-        applied = true;
+        if (matchesTarget(hotswapSelect, '')) {
+            anyMatch = true;
+        } else {
+            anyPending = true;
+        }
     }
-    return applied;
+    return anyPending ? false : anyMatch;
 }
 
 // Generate a printable overview of the current selected setup in a new tab

--- a/tests/dom/batteryPersistence.test.js
+++ b/tests/dom/batteryPersistence.test.js
@@ -29,6 +29,43 @@ function createDeviceData() {
   };
 }
 
+function createHybridDeviceData() {
+  return {
+    cameras: {
+      'Hybrid Cam': {
+        power: {
+          batteryPlateSupport: [
+            { type: 'V-Mount', mount: 'native' },
+            { type: 'B-Mount', mount: 'native' }
+          ]
+        }
+      }
+    },
+    batteries: {
+      'V Battery': {
+        mount_type: 'V-Mount',
+        capacity: 98,
+        pinA: 12
+      },
+      'B Battery': {
+        mount_type: 'B-Mount',
+        capacity: 150,
+        pinA: 20
+      }
+    },
+    batteryHotswaps: {
+      'V Swap': {
+        mount_type: 'V-Mount',
+        pinA: 12
+      },
+      'B Swap': {
+        mount_type: 'B-Mount',
+        pinA: 20
+      }
+    }
+  };
+}
+
 describe('battery persistence', () => {
   beforeEach(() => {
     localStorage.clear();
@@ -98,6 +135,68 @@ describe('battery persistence', () => {
 
     expect(batterySelect.value).toBe('Test Battery');
     expect(hotswapSelect.value).toBe('Test Swap');
+
+    env.cleanup();
+  });
+
+  test('restores B-Mount selection from stored project data after switching from V-Mount', () => {
+    const storedSetups = {
+      'Project V': {
+        camera: 'Hybrid Cam',
+        batteryPlate: 'V-Mount',
+        battery: 'V Battery',
+        batteryHotswap: 'V Swap'
+      },
+      'Project B': {
+        camera: 'Hybrid Cam'
+      }
+    };
+
+    const storedProjects = {
+      'Project V': {
+        powerSelection: {
+          batteryPlate: 'V-Mount',
+          battery: 'V Battery',
+          batteryHotswap: 'V Swap'
+        }
+      },
+      'Project B': {
+        powerSelection: {
+          batteryPlate: 'B-Mount',
+          battery: 'B Battery',
+          batteryHotswap: 'B Swap'
+        }
+      }
+    };
+
+    const env = setupScriptEnvironment({
+      devices: createHybridDeviceData(),
+      globals: {
+        saveSetups: jest.fn(),
+        loadSetups: jest.fn(() => ({ ...storedSetups })),
+        loadProject: jest.fn(name => storedProjects[name] || null),
+        saveProject: jest.fn()
+      }
+    });
+
+    require('../../src/scripts/storage.js');
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+
+    const setupSelect = document.getElementById('setupSelect');
+    setupSelect.value = 'Project V';
+    setupSelect.dispatchEvent(new Event('change'));
+
+    const batteryPlateSelect = document.getElementById('batteryPlateSelect');
+    const batterySelect = document.getElementById('batterySelect');
+
+    expect(batteryPlateSelect.value).toBe('V-Mount');
+    expect(batterySelect.value).toBe('V Battery');
+
+    setupSelect.value = 'Project B';
+    setupSelect.dispatchEvent(new Event('change'));
+
+    expect(batteryPlateSelect.value).toBe('B-Mount');
+    expect(batterySelect.value).toBe('B Battery');
 
     env.cleanup();
   });


### PR DESCRIPTION
## Summary
- ensure stored setup and project power selections overwrite existing values when loading a setup
- update power selection restoration logic to retry when target options are not yet available
- add a DOM regression test that covers switching from a V-Mount project to a B-Mount project

## Testing
- npm run test:dom -- batteryPersistence

------
https://chatgpt.com/codex/tasks/task_e_68d83a276cd4832084a2de086b64b246