### PR TITLE
Allow reusing automatic gear conditions

### DIFF
--- a/src/scripts/app-core-new-1.js
+++ b/src/scripts/app-core-new-1.js
@@ -5576,6 +5576,22 @@ const AUTO_GEAR_CONDITION_KEYS = [
   'controllers',
   'distance',
 ];
+const AUTO_GEAR_REPEATABLE_CONDITIONS = new Set([
+  'scenarios',
+  'mattebox',
+  'cameraHandle',
+  'viewfinderExtension',
+  'deliveryResolution',
+  'videoDistribution',
+  'camera',
+  'monitor',
+  'crewPresent',
+  'crewAbsent',
+  'wireless',
+  'motors',
+  'controllers',
+  'distance',
+]);
 const AUTO_GEAR_CONDITION_FALLBACK_LABELS = {
   always: 'Always include',
   scenarios: 'Required scenarios',
@@ -12307,7 +12323,12 @@ function refreshAutoGearConditionPicker() {
   placeholder.value = '';
   placeholder.textContent = placeholderLabel;
   autoGearConditionSelect.appendChild(placeholder);
-  const available = AUTO_GEAR_CONDITION_KEYS.filter(key => !autoGearActiveConditions.has(key));
+  const available = AUTO_GEAR_CONDITION_KEYS.filter(key => {
+    if (!autoGearActiveConditions.has(key)) {
+      return true;
+    }
+    return AUTO_GEAR_REPEATABLE_CONDITIONS.has(key);
+  });
   available.forEach(key => {
     const option = document.createElement('option');
     option.value = key;
@@ -12328,7 +12349,12 @@ function updateAutoGearConditionAddButtonState() {
   if (autoGearConditionAddButton) {
     autoGearConditionAddButton.disabled = !hasSelection || disabledPicker;
   }
-  const hasAvailable = AUTO_GEAR_CONDITION_KEYS.some(key => !autoGearActiveConditions.has(key));
+  const hasAvailable = AUTO_GEAR_CONDITION_KEYS.some(key => {
+    if (!autoGearActiveConditions.has(key)) {
+      return true;
+    }
+    return AUTO_GEAR_REPEATABLE_CONDITIONS.has(key);
+  });
   AUTO_GEAR_CONDITION_KEYS.forEach(key => {
     const shortcut = autoGearConditionAddShortcuts[key];
     if (shortcut) {
@@ -12344,6 +12370,57 @@ function focusAutoGearConditionPicker() {
     } catch {
       autoGearConditionSelect.focus();
     }
+  }
+}
+
+function focusAutoGearConditionSection(key, options = {}) {
+  const config = getAutoGearConditionConfig(key);
+  if (!config || !config.section) {
+    return;
+  }
+  const { section, select } = config;
+  const { flash = false } = options || {};
+  if (section.hidden) {
+    section.hidden = false;
+    section.setAttribute('aria-hidden', 'false');
+  }
+  if (flash && section.classList) {
+    section.classList.add('auto-gear-condition-flash');
+    const schedule = typeof window !== 'undefined' && typeof window.setTimeout === 'function'
+      ? window.setTimeout
+      : setTimeout;
+    schedule(() => {
+      section.classList.remove('auto-gear-condition-flash');
+    }, 1200);
+  }
+  const target = select || section.querySelector('select, input, button');
+  if (!target) return;
+  try {
+    target.focus({ preventScroll: true });
+  } catch {
+    target.focus();
+  }
+}
+
+function notifyAutoGearConditionRepeat(key) {
+  if (typeof showNotification !== 'function') {
+    return;
+  }
+  const template = texts[currentLang]?.autoGearConditionRepeatHint
+    || texts.en?.autoGearConditionRepeatHint
+    || '';
+  if (!template) return;
+  const label = getAutoGearConditionLabel(key);
+  let message;
+  if (label) {
+    message = template.replace('{condition}', label);
+  } else if (template.includes(' {condition}')) {
+    message = template.replace(' {condition}', '');
+  } else {
+    message = template.replace('{condition}', '');
+  }
+  if (message) {
+    showNotification('info', message);
   }
 }
 
@@ -12395,6 +12472,11 @@ function addAutoGearCondition(key, options = {}) {
   const config = getAutoGearConditionConfig(key);
   if (!config) return false;
   if (autoGearActiveConditions.has(key)) {
+    if (AUTO_GEAR_REPEATABLE_CONDITIONS.has(key)) {
+      focusAutoGearConditionSection(key, { flash: true });
+      notifyAutoGearConditionRepeat(key);
+      return true;
+    }
     if (options.focus !== false && config.select) {
       try {
         config.select.focus({ preventScroll: true });

--- a/src/scripts/translations.js
+++ b/src/scripts/translations.js
@@ -250,6 +250,8 @@ const texts = {
     autoGearConditionPlaceholder: "Choose a condition",
     autoGearConditionAddShortcut: "Add another condition",
     autoGearConditionRemove: "Remove this condition",
+    autoGearConditionRepeatHint:
+      "Condition already added. Existing inputs for {condition} are highlighted so you can add more selections.",
     autoGearAlwaysLabel: "Always include",
     autoGearAlwaysHelp: "Apply this rule to every gear list.",
     autoGearAlwaysMeta: "Always active",
@@ -1944,6 +1946,8 @@ const texts = {
     autoGearConditionPlaceholder: "Scegli una condizione",
     autoGearConditionAddShortcut: "Aggiungi un'altra condizione",
     autoGearConditionRemove: "Rimuovi questa condizione",
+    autoGearConditionRepeatHint:
+      "Condizione già aggiunta. I campi esistenti per {condition} vengono evidenziati per permetterti di aggiungere altre selezioni.",
     autoGearAlwaysLabel: "Includi sempre",
     autoGearAlwaysHelp: "Applica questa regola a ogni lista attrezzatura.",
     autoGearAlwaysMeta: "Sempre attiva",
@@ -3221,6 +3225,8 @@ const texts = {
     autoGearConditionPlaceholder: "Elige una condición",
     autoGearConditionAddShortcut: "Añadir otra condición",
     autoGearConditionRemove: "Eliminar esta condición",
+    autoGearConditionRepeatHint:
+      "Condición ya añadida. Resaltamos los campos existentes de {condition} para que puedas añadir más selecciones.",
     autoGearAlwaysLabel: "Incluir siempre",
     autoGearAlwaysHelp: "Aplica esta regla a todas las listas de equipo.",
     autoGearAlwaysMeta: "Siempre activa",
@@ -4500,6 +4506,8 @@ const texts = {
     autoGearConditionPlaceholder: "Choisissez une condition",
     autoGearConditionAddShortcut: "Ajouter une autre condition",
     autoGearConditionRemove: "Supprimer cette condition",
+    autoGearConditionRepeatHint:
+      "Condition déjà ajoutée. Les champs existants pour {condition} sont mis en évidence pour vous permettre d'ajouter d'autres sélections.",
     autoGearAlwaysLabel: "Toujours inclure",
     autoGearAlwaysHelp: "Applique cette règle à chaque liste de matériel.",
     autoGearAlwaysMeta: "Toujours active",
@@ -5790,6 +5798,8 @@ const texts = {
     autoGearConditionPlaceholder: "Wähle eine Bedingung",
     autoGearConditionAddShortcut: "Weitere Bedingung hinzufügen",
     autoGearConditionRemove: "Diese Bedingung entfernen",
+    autoGearConditionRepeatHint:
+      "Bedingung bereits hinzugefügt. Die vorhandenen Eingaben für {condition} sind markiert, damit du weitere Auswahlmöglichkeiten setzen kannst.",
     autoGearAlwaysLabel: "Immer einschließen",
     autoGearAlwaysHelp: "Wendet diese Regel auf jede Geräteliste an.",
     autoGearAlwaysMeta: "Immer aktiv",

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -2836,6 +2836,32 @@ body.pink-mode:not(.dark-mode) #settingsPanel-autoGear .auto-gear-rule-items-lab
   background: var(--surface-color);
 }
 
+.auto-gear-condition-flash {
+  box-shadow: 0 0 0 2px var(--accent-color, #007aff);
+  animation: auto-gear-condition-flash 1.2s ease-out;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .auto-gear-condition-flash {
+    animation: none;
+  }
+}
+
+@keyframes auto-gear-condition-flash {
+  0% {
+    box-shadow: 0 0 0 0 rgba(0, 122, 255, 0.55);
+    background-color: rgba(0, 122, 255, 0.08);
+  }
+  50% {
+    box-shadow: 0 0 0 3px rgba(0, 122, 255, 0.4);
+    background-color: rgba(0, 122, 255, 0.12);
+  }
+  100% {
+    box-shadow: 0 0 0 0 rgba(0, 122, 255, 0);
+    background-color: var(--surface-color);
+  }
+}
+
 .auto-gear-condition[hidden] {
   display: none !important;
 }


### PR DESCRIPTION
## Summary
- keep repeatable automatic gear conditions available in the picker instead of hiding them
- highlight the existing condition inputs and show a notification when a repeatable condition is added again
- add translations and styling for the new highlight hint

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d83783018c8320b86b6a309ccfcbfb