### PR TITLE
Reorder printable project requirements

### DIFF
--- a/src/scripts/overview.js
+++ b/src/scripts/overview.js
@@ -315,12 +315,11 @@ function generatePrintableOverview() {
             gearSectionHtml = `<section id="gearListOutput" class="gear-list-section">${parts.gearHtml}</section>`;
         }
     }
-    const gearListHtmlCombined = projectSectionHtml || gearSectionHtml
-        ? `${projectSectionHtml || ''}${gearSectionHtml || ''}`
-        : '';
+    const projectRequirementsHtml = projectSectionHtml || '';
+    const gearListHtml = gearSectionHtml || '';
     const deleteGearListLabel = t.deleteGearListBtn || 'Delete Gear List';
     const deleteGearListHelp = t.deleteGearListBtnHelp || deleteGearListLabel;
-    const gearListActionsHtml = gearListHtmlCombined
+    const gearListActionsHtml = gearListHtml
         ? `<div class="overview-gear-actions"><button id="overviewDeleteGearListBtn" class="overview-delete-gear-btn" title="${escapeHtmlSafe(deleteGearListHelp)}" data-help="${escapeHtmlSafe(deleteGearListHelp)}"><span class="btn-icon icon-glyph" aria-hidden="true" data-icon-font="essential">&#xF254;</span>${escapeHtmlSafe(deleteGearListLabel)}</button></div>`
         : '';
 
@@ -350,6 +349,8 @@ function generatePrintableOverview() {
             <p><strong>${t.setupNameLabel}</strong> ${safeSetupName}</p>
             <p><em>${generatedOnDisplay}</em></p>
 
+            ${projectRequirementsHtml}
+
             <h2>${t.overviewDeviceSelectionHeading || t.deviceSelectionHeading}</h2>
             ${deviceListHtml}
 
@@ -357,7 +358,7 @@ function generatePrintableOverview() {
 
             ${diagramSectionHtml}
 
-            ${gearListHtmlCombined}
+            ${gearListHtml}
             ${gearListActionsHtml}
             ${batteryComparisonHtml}
         </div>

--- a/src/styles/overview-print.css
+++ b/src/styles/overview-print.css
@@ -459,6 +459,14 @@ table, th, td {
   break-inside: avoid;
 }
 
+#overviewDialogContent .requirements-grid .requirement-box,
+#overviewDialogContent.dark-mode .requirements-grid .requirement-box,
+body.dark-mode #overviewDialogContent .requirements-grid .requirement-box {
+  background: var(--overview-requirements-print-bg, #f0f1f4) !important;
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.4);
+}
+
 #overviewDialogContent .requirement-box,
 #overviewDialogContent.dark-mode .requirement-box,
 body.dark-mode #overviewDialogContent .requirement-box {


### PR DESCRIPTION
## Summary
- Move the printable project requirements section ahead of the device selection list so it appears at the top of the overview
- Restore a neutral gray background treatment for project requirement cards in the printable view for clarity

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d83bad33ec83208ae2b7e0485e2855