### PR TITLE
Improve printed diagram scale

### DIFF
--- a/src/styles/overview-print.css
+++ b/src/styles/overview-print.css
@@ -377,7 +377,7 @@ table, th, td {
 
   #overviewDialogContent #setupDiagram svg {
     width: 100% !important;
-    max-width: var(--print-diagram-max-width, 20cm) !important;
+    max-width: var(--print-diagram-max-width, 24cm) !important;
   }
 }
 
@@ -386,10 +386,10 @@ table, th, td {
   body.dark-mode {
     --font-size-base: 10pt;
     --line-height-base: 1.65;
-    --print-diagram-max-width: 24cm;
-    --print-diagram-icon-scale: 1.05;
-    --print-diagram-text-scale: 1.07;
-    --print-diagram-label-scale: 1.06;
+    --print-diagram-max-width: 28cm;
+    --print-diagram-icon-scale: 1.08;
+    --print-diagram-text-scale: 1.1;
+    --print-diagram-label-scale: 1.08;
   }
 
   #overviewDialogContent {
@@ -402,10 +402,10 @@ table, th, td {
   body.dark-mode {
     --font-size-base: 10pt;
     --line-height-base: 1.7;
-    --print-diagram-max-width: 28cm;
-    --print-diagram-icon-scale: 1.1;
-    --print-diagram-text-scale: 1.12;
-    --print-diagram-label-scale: 1.1;
+    --print-diagram-max-width: 32cm;
+    --print-diagram-icon-scale: 1.14;
+    --print-diagram-text-scale: 1.16;
+    --print-diagram-label-scale: 1.14;
   }
 
   #overviewDialogContent {


### PR DESCRIPTION
## Summary
- increase the printed diagram's default maximum width to better fill the page
- raise large-format print breakpoints to expand diagram area and scale accompanying icon/text sizes for clarity

## Testing
- not run (CSS change)

------
https://chatgpt.com/codex/tasks/task_e_68d83e624a488320a19f9b4690140a44