### PR TITLE
Adjust diagram popup height for tall content

### DIFF
--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -5033,7 +5033,7 @@ body.light-mode #topBar select:focus-visible {
   box-shadow: var(--panel-shadow);
   z-index: 10;
   max-width: 320px;
-  max-height: min(70vh, 480px);
+  max-height: min(85vh, calc(100vh - 32px));
   overflow: auto;
 }
 


### PR DESCRIPTION
## Summary
- allow the diagram hover popup to grow taller by basing its max height on the viewport

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d83e95a050832095c09618f0e9b5bc