### PR TITLE
Handle binary backup payloads when sanitizing

### DIFF
--- a/tests/script/backupCompatibility.test.js
+++ b/tests/script/backupCompatibility.test.js
@@ -35,6 +35,23 @@ describe('backup compatibility utilities', () => {
     expect(sanitized).toBe('{"version":"1.0.0"}');
   });
 
+  test('sanitizeBackupPayload decodes binary payload sources', () => {
+    const { sanitizeBackupPayload } = loadApp();
+
+    const sample = '\ufeff{"version":"1.0.0"}';
+    const expected = '{"version":"1.0.0"}';
+    const nodeBuffer = Buffer.from(sample, 'utf8');
+    const arrayBuffer = nodeBuffer.buffer.slice(
+      nodeBuffer.byteOffset,
+      nodeBuffer.byteOffset + nodeBuffer.byteLength,
+    );
+    const typedArray = new Uint8Array(arrayBuffer);
+
+    expect(sanitizeBackupPayload(arrayBuffer)).toBe(expected);
+    expect(sanitizeBackupPayload(typedArray)).toBe(expected);
+    expect(sanitizeBackupPayload(nodeBuffer)).toBe(expected);
+  });
+
   test('extractBackupSections parses stringified storage snapshots', () => {
     const { extractBackupSections } = loadApp();
 


### PR DESCRIPTION
## Summary
- ensure `sanitizeBackupPayload` converts ArrayBuffer, typed array, and Node Buffer inputs into UTF-8 strings before stripping BOMs
- extend backup compatibility tests to cover binary payload sources so the new decoding paths stay verified

## Testing
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68d83e1c831083209c74fca4856c5093