### PR TITLE
Improve hover help tooltip placement near viewport edges

### DIFF
--- a/src/scripts/app-session.js
+++ b/src/scripts/app-session.js
@@ -8633,13 +8633,27 @@ if (helpButton && helpDialog) {
 
     const pointerAnchored = usingPointerAnchor();
 
-    const preferLeftSide = (() => {
-      if (!tooltipWidth) return false;
+    const pointerClientX = (() => {
       if (pointerAnchored && typeof hoverHelpPointerClientX === 'number') {
-        return hoverHelpPointerClientX >= viewportWidth / 2;
+        return hoverHelpPointerClientX;
       }
-      const elementMidpoint = safeLeft + (rect.width || 0) / 2;
-      return elementMidpoint >= viewportWidth / 2;
+      if (Number.isFinite(rect.left)) {
+        return safeLeft + (rect.width || 0) / 2;
+      }
+      return viewportWidth / 2;
+    })();
+
+    const preferLeftSide = (() => {
+      if (tooltipWidth) {
+        const requiredSpace = tooltipWidth + horizontalOffset + viewportPadding;
+        const availableRight = viewportWidth - pointerClientX;
+        const availableLeft = pointerClientX;
+        if (availableRight < requiredSpace && availableLeft >= requiredSpace) {
+          return true;
+        }
+      }
+      const rightSideThreshold = viewportWidth * 0.6;
+      return pointerClientX >= rightSideThreshold;
     })();
 
     let top = pointerAnchored


### PR DESCRIPTION
## Summary
- calculate a resilient pointer fallback position for hover help tooltips
- prefer positioning tooltips to the left of the pointer when hovering near the right side of the viewport or when space is limited

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d8402a64448320bd66149594dc07a5