### PR TITLE
Adjust gear list strong text color

### DIFF
--- a/src/styles/overview-print.css
+++ b/src/styles/overview-print.css
@@ -226,6 +226,11 @@ body.pink-mode,
   font-weight: var(--font-weight-bold, 500);
 }
 
+#overviewDialogContent .gear-table strong,
+#overviewDialogContent .gear-table b {
+  color: inherit !important;
+}
+
 #overviewDialogContent .device-category h3 {
   display: flex;
   align-items: center;

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -6439,7 +6439,7 @@ body.dark-mode .requirement-box,
 body.light-mode .gear-table strong,
 #gearListOutput:not(.dark-mode) .gear-table strong,
 #overviewDialogContent:not(.dark-mode) .gear-table strong {
-  color: var(--accent-color);
+  color: inherit;
 }
 
 .dark-mode .gear-table td {


### PR DESCRIPTION
## Summary
- ensure bold text in the gear list inherits the normal text color so monitor names no longer appear blue
- keep printed gear list entries consistent by inheriting the surrounding text color for bold content

## Testing
- not run (CSS-only change)

------
https://chatgpt.com/codex/tasks/task_e_68d8431ad0dc8320b97fca23abc7e596