### PR TITLE
Add power essentials to always auto gear rule

### DIFF
--- a/src/scripts/app-core-new-1.js
+++ b/src/scripts/app-core-new-1.js
@@ -3061,6 +3061,12 @@ function buildAlwaysAutoGearRule() {
     ['Securing Straps (25mm wide)', 'Carts and Transportation', 10],
     ['Loading Ramp (pair, 420kg)', 'Carts and Transportation', 1],
     ['Ring Fitting for Airline Rails', 'Carts and Transportation', 20],
+    ['Power Cable Drum 25-50 m', 'Power', 1],
+    ['Power Cable 10 m', 'Power', 2],
+    ['Power Cable 5 m', 'Power', 2],
+    ['Power Strip', 'Power', 3],
+    ['Power Three Way Splitter', 'Power', 3],
+    ['PRCD-S (Portable Residual Current Device-Safety)', 'Power', 3],
   ].forEach(([name, category, quantity]) => pushItem(name, category, quantity));
 
   if (!additions.length) return null;


### PR DESCRIPTION
## Summary
- ensure the default always-on automatic gear rule includes core power distribution equipment
- add power cables, strips, splitters, and safety PRCD-S devices to the always rule additions list

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d8433f0df8832088099df03fb3e90e