### PR TITLE
Add five-day consumables automatic gear rule

### DIFF
--- a/docs/operations-checklist.md
+++ b/docs/operations-checklist.md
@@ -46,7 +46,10 @@ update the repository or hand off a project at the end of the day.
    **Quick safeguards** to capture a fresh full backup if anything looks stale.
 7. **Check draft impact preview.** Open the automatic gear rule editor, review
    the draft impact preview for quantity deltas and warnings, then cancel to
-   confirm the live generator stays unchanged.
+   confirm the live generator stays unchanged. Adjust the shooting-day counter
+   long enough to verify the factory “every five shooting days” consumables rule
+   multiplies Bluestar eye leathers, Pro Gaff rolls, clapper sticks, Kimtech
+   wipes and Sprigs to cover longer schedules automatically.
 8. **Log the drill.** Append a verification note (timestamp, machine, operator
    and files inspected) to your archival log or create one beside the exports
    if it does not exist yet. Pair the note with checksum manifests so every

--- a/index.html
+++ b/index.html
@@ -4825,6 +4825,12 @@
               <strong>Reset to factory additions</strong> to restore the built-in helpers, or download and reload JSON sets with
               <strong>Export rules</strong> and <strong>Import rules</strong> when collaborating offline.
             </p>
+            <p>
+              Factory additions include an <strong>every five shooting days</strong> consumables kit that adds four Bluestar eye
+              leathers, two rolls of Pro Gaff tape per color slot, four clapper sticks, two Kimtech wipe sleeves and a Sprigs
+              Red 1/4&quot; pack for each interval. Longer shoots automatically scale those quantities so you can reset to the
+              defaults and keep continuity gear stocked without editing rules by hand.
+            </p>
           </details>
           <details
             class="faq-item"

--- a/legacy/scripts/app-core-new-1.js
+++ b/legacy/scripts/app-core-new-1.js
@@ -2765,6 +2765,58 @@ function buildAlwaysAutoGearRule() {
     remove: []
   };
 }
+
+function buildFiveDayConsumablesAutoGearRule() {
+  var createItem = function createItem(name, category) {
+    var quantity = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : 1;
+    var options = arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : {};
+    if (!name || !category || quantity <= 0) return null;
+    return {
+      id: generateAutoGearId('item'),
+      name: name,
+      category: category,
+      quantity: quantity,
+      screenSize: typeof options.screenSize === 'string' ? options.screenSize : '',
+      selectorType: typeof options.selectorType === 'string' ? options.selectorType : 'none',
+      selectorDefault: typeof options.selectorDefault === 'string' ? options.selectorDefault : '',
+      selectorEnabled: options.selectorEnabled === true,
+      notes: typeof options.notes === 'string' ? options.notes : ''
+    };
+  };
+  var additions = [];
+  var pushItem = function pushItem(name, category, quantity, options) {
+    var item = createItem(name, category, quantity, options);
+    if (item) additions.push(item);
+  };
+  pushItem('Bluestar eye leather made of microfiber oval, large', 'Consumables', 4);
+  pushItem('Pro Gaff Tape', 'Consumables', 2, { notes: 'Primary color roll' });
+  pushItem('Pro Gaff Tape', 'Consumables', 2, { notes: 'Secondary color roll' });
+  pushItem('Clapper Stick', 'Rigging', 4);
+  pushItem('Kimtech Wipes', 'Consumables', 2);
+  pushItem('Sprigs Red 1/4"', 'Consumables', 1);
+  if (!additions.length) return null;
+  return {
+    id: generateAutoGearId('rule'),
+    label: 'Every 5 shooting days',
+    scenarios: [],
+    mattebox: [],
+    cameraHandle: [],
+    viewfinderExtension: [],
+    deliveryResolution: [],
+    videoDistribution: [],
+    camera: [],
+    monitor: [],
+    crewPresent: [],
+    crewAbsent: [],
+    wireless: [],
+    motors: [],
+    controllers: [],
+    distance: [],
+    shootingDays: { mode: 'every', value: 5 },
+    add: additions,
+    remove: []
+  };
+}
 function ensureDefaultMatteboxAutoGearRules() {
   var defaults = buildDefaultMatteboxAutoGearRules();
   if (!defaults.length) return false;
@@ -2985,6 +3037,10 @@ function buildAutoGearRulesFromBaseInfo(baseInfo, scenarioValues) {
   var alwaysRule = buildAlwaysAutoGearRule();
   if (alwaysRule) {
     rules.push(alwaysRule);
+  }
+  var fiveDayRule = buildFiveDayConsumablesAutoGearRule();
+  if (fiveDayRule) {
+    rules.push(fiveDayRule);
   }
   buildDefaultMatteboxAutoGearRules().forEach(function (rule) {
     return rules.push(rule);

--- a/src/scripts/app-core-new-1.js
+++ b/src/scripts/app-core-new-1.js
@@ -3085,6 +3085,60 @@ function buildAlwaysAutoGearRule() {
   };
 }
 
+function buildFiveDayConsumablesAutoGearRule() {
+  const createItem = (name, category, quantity = 1, options = {}) => {
+    if (!name || !category || quantity <= 0) return null;
+    return {
+      id: generateAutoGearId('item'),
+      name,
+      category,
+      quantity,
+      screenSize: typeof options.screenSize === 'string' ? options.screenSize : '',
+      selectorType: typeof options.selectorType === 'string' ? options.selectorType : 'none',
+      selectorDefault: typeof options.selectorDefault === 'string' ? options.selectorDefault : '',
+      selectorEnabled: options.selectorEnabled === true,
+      notes: typeof options.notes === 'string' ? options.notes : '',
+    };
+  };
+
+  const additions = [];
+  const pushItem = (name, category, quantity, options) => {
+    const item = createItem(name, category, quantity, options);
+    if (item) additions.push(item);
+  };
+
+  pushItem('Bluestar eye leather made of microfiber oval, large', 'Consumables', 4);
+  pushItem('Pro Gaff Tape', 'Consumables', 2, { notes: 'Primary color roll' });
+  pushItem('Pro Gaff Tape', 'Consumables', 2, { notes: 'Secondary color roll' });
+  pushItem('Clapper Stick', 'Rigging', 4);
+  pushItem('Kimtech Wipes', 'Consumables', 2);
+  pushItem('Sprigs Red 1/4"', 'Consumables', 1);
+
+  if (!additions.length) return null;
+
+  return {
+    id: generateAutoGearId('rule'),
+    label: 'Every 5 shooting days',
+    scenarios: [],
+    mattebox: [],
+    cameraHandle: [],
+    viewfinderExtension: [],
+    deliveryResolution: [],
+    videoDistribution: [],
+    camera: [],
+    monitor: [],
+    crewPresent: [],
+    crewAbsent: [],
+    wireless: [],
+    motors: [],
+    controllers: [],
+    distance: [],
+    shootingDays: { mode: 'every', value: 5 },
+    add: additions,
+    remove: [],
+  };
+}
+
 function ensureDefaultMatteboxAutoGearRules() {
   const defaults = buildDefaultMatteboxAutoGearRules();
   if (!defaults.length) return false;
@@ -3301,6 +3355,11 @@ function buildAutoGearRulesFromBaseInfo(baseInfo, scenarioValues) {
   const alwaysRule = buildAlwaysAutoGearRule();
   if (alwaysRule) {
     rules.push(alwaysRule);
+  }
+
+  const fiveDayRule = buildFiveDayConsumablesAutoGearRule();
+  if (fiveDayRule) {
+    rules.push(fiveDayRule);
   }
 
   buildDefaultMatteboxAutoGearRules().forEach(rule => rules.push(rule));


### PR DESCRIPTION
## Summary
- add a factory automatic gear rule that provisions consumables every five shooting days and scales with the schedule
- mirror the new rule in the legacy core so resets and backups include the same defaults and document the behaviour in help content
- extend the operations checklist with a verification step for the five-day consumables automation

## Testing
- npm test -- --runTestsByPath tests/unit/storage.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d84383c2b88320a36f046cbff5ff23