### PR TITLE
Add auto gear support kit for any FIZ motor

### DIFF
--- a/src/scripts/app-core-new-1.js
+++ b/src/scripts/app-core-new-1.js
@@ -467,6 +467,10 @@ const AUTO_GEAR_RULES_KEY =
   typeof AUTO_GEAR_RULES_STORAGE_KEY !== 'undefined'
     ? AUTO_GEAR_RULES_STORAGE_KEY
     : 'cameraPowerPlanner_autoGearRules';
+const AUTO_GEAR_ANY_MOTOR_TOKEN = '__any__';
+if (typeof globalThis !== 'undefined') {
+  globalThis.AUTO_GEAR_ANY_MOTOR_TOKEN = AUTO_GEAR_ANY_MOTOR_TOKEN;
+}
 const AUTO_GEAR_SEEDED_KEY =
   typeof AUTO_GEAR_SEEDED_STORAGE_KEY !== 'undefined'
     ? AUTO_GEAR_SEEDED_STORAGE_KEY
@@ -3022,6 +3026,67 @@ function buildDefaultMatteboxAutoGearRules() {
   ];
 }
 
+function buildAutoGearAnyMotorRule() {
+  if (typeof captureSetupSelectValues !== 'function') return null;
+  const setupValues = captureSetupSelectValues();
+  const selectedMotors = Array.isArray(setupValues?.motors)
+    ? setupValues.motors.filter(value => typeof value === 'string' && value && value !== 'None')
+    : [];
+  if (!selectedMotors.length) return null;
+
+  const createItem = (name, category, quantity = 1) => {
+    if (!name || !category || quantity <= 0) return null;
+    return {
+      id: generateAutoGearId('item'),
+      name,
+      category,
+      quantity,
+      screenSize: '',
+      selectorType: 'none',
+      selectorDefault: '',
+      selectorEnabled: false,
+      notes: '',
+    };
+  };
+
+  const additions = [];
+  const pushItem = (name, category, quantity = 1) => {
+    const item = createItem(name, category, quantity);
+    if (item) additions.push(item);
+  };
+
+  pushItem('Avenger C-Stand Sliding Leg 20" (Focus)', 'Grip');
+  pushItem('Steelfingers Wheel C-Stand 3er Set (Focus)', 'Grip');
+  pushItem('Lite-Tite Swivel Aluminium Umbrella Adapter (Focus)', 'Grip');
+  pushItem('Tennis ball', 'Grip', 3);
+  pushItem('D-Tap to Mini XLR 3-pin Cable 0,3m (Focus)', 'Monitoring support', 2);
+  pushItem('Ultraslim BNC Cable 0.3 m (Focus)', 'Monitoring support', 2);
+  pushItem('Bebob V150micro (V-Mount) (Focus)', 'Monitoring Batteries', 3);
+
+  if (!additions.length) return null;
+
+  return {
+    id: generateAutoGearId('rule'),
+    label: 'FIZ motor support kit',
+    scenarios: [],
+    mattebox: [],
+    cameraHandle: [],
+    viewfinderExtension: [],
+    deliveryResolution: [],
+    videoDistribution: [],
+    camera: [],
+    monitor: [],
+    crewPresent: [],
+    crewAbsent: [],
+    wireless: [],
+    motors: [AUTO_GEAR_ANY_MOTOR_TOKEN],
+    controllers: [],
+    distance: [],
+    add: additions,
+    remove: [],
+  };
+}
+
 function buildAlwaysAutoGearRule() {
   const createItem = (name, category, quantity = 1, options = {}) => {
     if (!name || !category || quantity <= 0) return null;
@@ -3355,6 +3420,15 @@ function buildAutoGearRulesFromBaseInfo(baseInfo, scenarioValues) {
         rules.push(rule);
         existingSignatures.add(signature);
       });
+    }
+  }
+
+  const anyMotorRule = buildAutoGearAnyMotorRule();
+  if (anyMotorRule) {
+    const targetSignature = autoGearRuleSignature(anyMotorRule);
+    const exists = rules.some(rule => autoGearRuleSignature(rule) === targetSignature);
+    if (!exists) {
+      rules.push(anyMotorRule);
     }
   }
 

--- a/src/scripts/app-setups.js
+++ b/src/scripts/app-setups.js
@@ -4,6 +4,11 @@
           createProjectInfoSnapshotForStorage, getProjectAutoSaveOverrides, getAutoGearRuleCoverageSummary,
           normalizeBatteryPlateValue, setSelectValue, applyBatteryPlateSelectionFromBattery */
 
+const AUTO_GEAR_ANY_MOTOR_TOKEN_FALLBACK =
+    (typeof globalThis !== 'undefined' && globalThis.AUTO_GEAR_ANY_MOTOR_TOKEN)
+        ? globalThis.AUTO_GEAR_ANY_MOTOR_TOKEN
+        : '__any__';
+
 // --- NEW SETUP MANAGEMENT FUNCTIONS ---
 
 const setupsCineUi =
@@ -2646,7 +2651,10 @@ function applyAutoGearRulesToTableHtml(tableHtml, info) {
             .map(normalizeAutoGearTriggerValue)
             .filter(Boolean);
           if (!normalizedTargets.length) return false;
-          if (!normalizedTargets.every(target => normalizedMotorSet.has(target))) return false;
+          const requiresAnyMotor = normalizedTargets.includes(AUTO_GEAR_ANY_MOTOR_TOKEN_FALLBACK);
+          const specificTargets = normalizedTargets.filter(target => target !== AUTO_GEAR_ANY_MOTOR_TOKEN_FALLBACK);
+          if (requiresAnyMotor && normalizedMotorSet.size === 0) return false;
+          if (specificTargets.length && !specificTargets.every(target => normalizedMotorSet.has(target))) return false;
         }
         const controllersList = Array.isArray(rule.controllers) ? rule.controllers.filter(Boolean) : [];
         if (controllersList.length) {
@@ -2985,14 +2993,6 @@ function generateGearListHtml(info = {}) {
         );
     };
     largeMonitorPrefs.forEach(p => addLargeMonitorCables(`${p.role} 15-21"`));
-    if (hasMotor) {
-        monitoringSupportAcc.push(
-            'D-Tap to Mini XLR 3-pin Cable 0,3m (Focus)',
-            'D-Tap to Mini XLR 3-pin Cable 0,3m (Focus)',
-            'Ultraslim BNC Cable 0.3 m (Focus)',
-            'Ultraslim BNC Cable 0.3 m (Focus)'
-        );
-    }
     const handleName = 'SHAPE Telescopic Handle ARRI Rosette Kit 12"';
     const addHandle = () => {
         if (!supportAccNoCages.includes(handleName)) {
@@ -3647,10 +3647,6 @@ function generateGearListHtml(info = {}) {
     handheldPrefs.forEach(p => {
         for (let i = 0; i < 3; i++) monitoringBatteryItems.push(`${bebob98} (${p.role} handheld)`);
     });
-    if (hasMotor) {
-        const bebob150 = Object.keys(devices.batteries || {}).find(n => /V150micro/i.test(n)) || 'Bebob V150micro';
-        for (let i = 0; i < 3; i++) monitoringBatteryItems.push(`${bebob150} (Focus)`);
-    }
     const bebob290 = Object.keys(devices.batteries || {}).find(n => /V290RM-Cine/i.test(n)) || 'Bebob V290RM-Cine';
     largeMonitorPrefs.forEach(p => {
         monitoringBatteryItems.push(`${bebob290} (${p.role} 15-21")`, `${bebob290} (${p.role} 15-21")`);
@@ -3686,11 +3682,6 @@ function generateGearListHtml(info = {}) {
         riggingAcc.push(`D-Tap Splitter (${p.role} 15-21")`);
         riggingAcc.push(`D-Tap Splitter (${p.role} 15-21")`);
     });
-    if (hasMotor) {
-        gripItems.push('Avenger C-Stand Sliding Leg 20" (Focus)');
-        gripItems.push('Steelfingers Wheel C-Stand 3er Set (Focus)');
-        gripItems.push('Lite-Tite Swivel Aluminium Umbrella Adapter (Focus)');
-    }
     if (isScenarioActive('Easyrig')) {
         const stabiliser = devices && devices.accessories && devices.accessories.cameraStabiliser && devices.accessories.cameraStabiliser['Easyrig 5 Vario'];
         const opts = stabiliser && Array.isArray(stabiliser.options) ? stabiliser.options : [];

--- a/src/scripts/translations.js
+++ b/src/scripts/translations.js
@@ -330,6 +330,7 @@ const texts = {
     autoGearWirelessHelp:
       "Apply this rule when these wireless transmitters are selected.",
     autoGearMotorsLabel: "FIZ motors",
+    autoGearMotorsAny: "Any motor selected",
     autoGearMotorsHelp:
       "Apply this rule when these FIZ motors are selected.",
     autoGearControllersLabel: "FIZ controllers",
@@ -2035,6 +2036,7 @@ const texts = {
     autoGearWirelessHelp:
       "Applica la regola quando sono selezionati questi trasmettitori wireless.",
     autoGearMotorsLabel: "Motori FIZ",
+    autoGearMotorsAny: "Qualsiasi motore selezionato",
     autoGearMotorsHelp:
       "Applica la regola quando sono selezionati questi motori FIZ.",
     autoGearControllersLabel: "Controller FIZ",
@@ -3320,6 +3322,7 @@ const texts = {
     autoGearWirelessHelp:
       "Aplica la regla cuando se seleccionan estos transmisores inalámbricos.",
     autoGearMotorsLabel: "Motores FIZ",
+    autoGearMotorsAny: "Cualquier motor seleccionado",
     autoGearMotorsHelp:
       "Aplica la regla cuando se seleccionan estos motores FIZ.",
     autoGearControllersLabel: "Controladores FIZ",
@@ -4607,6 +4610,7 @@ const texts = {
     autoGearWirelessHelp:
       "Appliquez la règle lorsque ces émetteurs sans fil sont sélectionnés.",
     autoGearMotorsLabel: "Moteurs FIZ",
+    autoGearMotorsAny: "N'importe quel moteur sélectionné",
     autoGearMotorsHelp:
       "Appliquez la règle lorsque ces moteurs FIZ sont sélectionnés.",
     autoGearControllersLabel: "Contrôleurs FIZ",
@@ -5906,6 +5910,7 @@ const texts = {
     autoGearWirelessHelp:
       "Wende die Regel an, wenn diese Funk-Sender ausgewählt sind.",
     autoGearMotorsLabel: "FIZ Motoren",
+    autoGearMotorsAny: "Beliebiger Motor ausgewählt",
     autoGearMotorsHelp:
       "Wende die Regel an, wenn diese FIZ Motoren ausgewählt sind.",
     autoGearControllersLabel: "FIZ Controller",


### PR DESCRIPTION
## Summary
- add a factory auto gear rule that detects any FIZ motor selection and adds the required support kit
- update auto gear evaluation, editor UI, and translations to understand the new "any motor" trigger token
- rely on the new rule by removing the previous motor-specific additions from the static gear generation

## Testing
- npm test -- --passWithNoTests

------
https://chatgpt.com/codex/tasks/task_e_68d84923aa688320851c5144de8e73bb