### PR TITLE
Ensure mount voltage preferences persist through backups

### DIFF
--- a/index.html
+++ b/index.html
@@ -1018,6 +1018,126 @@
             <option value="fahrenheit">Fahrenheit (°F)</option>
           </select>
         </div>
+        <section
+          id="mountVoltageSettings"
+          class="mount-voltage-settings"
+          aria-labelledby="mountVoltageHeading"
+        >
+          <div class="mount-voltage-header">
+            <h4 id="mountVoltageHeading">Battery mount voltages</h4>
+            <button type="button" id="mountVoltageReset">Restore defaults</button>
+          </div>
+          <p id="mountVoltageDescription" class="settings-hint">
+            Customize the high and low voltages used for current draw calculations.
+          </p>
+          <div class="mount-voltage-grid">
+            <section
+              class="mount-voltage-card"
+              aria-labelledby="mountVoltageVTitle"
+            >
+              <h5 id="mountVoltageVTitle">V-Mount</h5>
+              <div class="mount-voltage-field">
+                <label for="mountVoltageVHigh" id="mountVoltageVHighLabel">
+                  High-voltage output
+                </label>
+                <input
+                  type="number"
+                  id="mountVoltageVHigh"
+                  class="mount-voltage-input"
+                  step="0.1"
+                  min="0"
+                  inputmode="decimal"
+                  autocomplete="off"
+                />
+              </div>
+              <div class="mount-voltage-field">
+                <label for="mountVoltageVLow" id="mountVoltageVLowLabel">
+                  Low-voltage output
+                </label>
+                <input
+                  type="number"
+                  id="mountVoltageVLow"
+                  class="mount-voltage-input"
+                  step="0.1"
+                  min="0"
+                  inputmode="decimal"
+                  autocomplete="off"
+                />
+              </div>
+            </section>
+            <section
+              class="mount-voltage-card"
+              aria-labelledby="mountVoltageGoldTitle"
+            >
+              <h5 id="mountVoltageGoldTitle">Gold Mount</h5>
+              <div class="mount-voltage-field">
+                <label for="mountVoltageGoldHigh" id="mountVoltageGoldHighLabel">
+                  High-voltage output
+                </label>
+                <input
+                  type="number"
+                  id="mountVoltageGoldHigh"
+                  class="mount-voltage-input"
+                  step="0.1"
+                  min="0"
+                  inputmode="decimal"
+                  autocomplete="off"
+                />
+              </div>
+              <div class="mount-voltage-field">
+                <label for="mountVoltageGoldLow" id="mountVoltageGoldLowLabel">
+                  Low-voltage output
+                </label>
+                <input
+                  type="number"
+                  id="mountVoltageGoldLow"
+                  class="mount-voltage-input"
+                  step="0.1"
+                  min="0"
+                  inputmode="decimal"
+                  autocomplete="off"
+                />
+              </div>
+            </section>
+            <section
+              class="mount-voltage-card"
+              aria-labelledby="mountVoltageBTitle"
+            >
+              <h5 id="mountVoltageBTitle">B-Mount</h5>
+              <div class="mount-voltage-field">
+                <label for="mountVoltageBHigh" id="mountVoltageBHighLabel">
+                  High-voltage output
+                </label>
+                <input
+                  type="number"
+                  id="mountVoltageBHigh"
+                  class="mount-voltage-input"
+                  step="0.1"
+                  min="0"
+                  inputmode="decimal"
+                  autocomplete="off"
+                />
+              </div>
+              <div class="mount-voltage-field">
+                <label for="mountVoltageBLow" id="mountVoltageBLowLabel">
+                  Low-voltage output
+                </label>
+                <input
+                  type="number"
+                  id="mountVoltageBLow"
+                  class="mount-voltage-input"
+                  step="0.1"
+                  min="0"
+                  inputmode="decimal"
+                  autocomplete="off"
+                />
+              </div>
+            </section>
+          </div>
+          <p id="mountVoltageNote" class="settings-hint">
+            These voltages update the totals in the power summary and pin warnings.
+          </p>
+        </section>
         <div class="form-row">
           <label for="settingsFontSize" id="settingsFontSizeLabel">Font size</label>
           <select id="settingsFontSize">

--- a/legacy/scripts/app-core-new-1.js
+++ b/legacy/scripts/app-core-new-1.js
@@ -542,6 +542,304 @@ try {
 } catch (error) {
   console.warn('Could not load temperature unit preference', error);
 }
+var SUPPORTED_MOUNT_VOLTAGE_TYPES = ['V-Mount', 'Gold-Mount', 'B-Mount'];
+var MOUNT_VOLTAGE_STORAGE_KEY = 'cameraPowerPlanner_mountVoltages';
+var MOUNT_VOLTAGE_STORAGE_BACKUP_KEY = "".concat(MOUNT_VOLTAGE_STORAGE_KEY, '__backup');
+try {
+  if (CORE_GLOBAL_SCOPE && _typeof(CORE_GLOBAL_SCOPE) === 'object') {
+    if (typeof CORE_GLOBAL_SCOPE.MOUNT_VOLTAGE_STORAGE_KEY !== 'string') {
+      CORE_GLOBAL_SCOPE.MOUNT_VOLTAGE_STORAGE_KEY = MOUNT_VOLTAGE_STORAGE_KEY;
+    }
+    if (typeof CORE_GLOBAL_SCOPE.MOUNT_VOLTAGE_STORAGE_BACKUP_KEY !== 'string') {
+      CORE_GLOBAL_SCOPE.MOUNT_VOLTAGE_STORAGE_BACKUP_KEY = MOUNT_VOLTAGE_STORAGE_BACKUP_KEY;
+    }
+  }
+} catch (exposeMountVoltageError) {
+  console.warn('Unable to expose mount voltage storage keys globally', exposeMountVoltageError);
+}
+var DEFAULT_MOUNT_VOLTAGES = Object.freeze({
+  'V-Mount': Object.freeze({ high: 14.4, low: 12 }),
+  'Gold-Mount': Object.freeze({ high: 14.4, low: 12 }),
+  'B-Mount': Object.freeze({ high: 33.6, low: 21.6 })
+});
+var TOTAL_CURRENT_LABEL_FALLBACK = 'Total Current (at {voltage}V):';
+var TOTAL_CURRENT_HELP_HIGH_FALLBACK = 'Current draw at the battery\'s main output ({voltage}V).';
+var TOTAL_CURRENT_HELP_LOW_FALLBACK = 'Current draw at auxiliary outputs ({voltage}V).';
+var mountVoltagePreferences = cloneMountVoltageMap(DEFAULT_MOUNT_VOLTAGES);
+var mountVoltageInputs = null;
+var mountVoltageSectionElem = null;
+var mountVoltageHeadingElem = null;
+var mountVoltageDescriptionElem = null;
+var mountVoltageNoteElem = null;
+var mountVoltageResetButton = null;
+var mountVoltageTitleElems = null;
+function parseVoltageValue(value, fallback) {
+  var numeric = Number.NaN;
+  if (typeof value === 'number') {
+    numeric = value;
+  } else if (typeof value === 'string') {
+    numeric = Number.parseFloat(value.replace(',', '.'));
+  }
+  if (!Number.isFinite(numeric) || numeric <= 0) {
+    return fallback;
+  }
+  var clamped = Math.min(1000, Math.max(0.1, numeric));
+  return Math.round(clamped * 100) / 100;
+}
+function cloneMountVoltageMap(source) {
+  var result = {};
+  SUPPORTED_MOUNT_VOLTAGE_TYPES.forEach(function (type) {
+    var entry = source && source[type] ? source[type] : DEFAULT_MOUNT_VOLTAGES[type];
+    var high = parseVoltageValue(entry && entry.high, DEFAULT_MOUNT_VOLTAGES[type].high);
+    var low = parseVoltageValue(entry && entry.low, DEFAULT_MOUNT_VOLTAGES[type].low);
+    result[type] = { high: high, low: low };
+  });
+  return result;
+}
+function normalizeMountVoltageSource(source) {
+  if (!source || typeof source !== 'object') {
+    return cloneMountVoltageMap(DEFAULT_MOUNT_VOLTAGES);
+  }
+  return cloneMountVoltageMap(source);
+}
+function parseStoredMountVoltages(raw) {
+  if (!raw) {
+    return null;
+  }
+  try {
+    if (typeof raw === 'string') {
+      var parsed = JSON.parse(raw);
+      return normalizeMountVoltageSource(parsed);
+    }
+    return normalizeMountVoltageSource(raw);
+  } catch (error) {
+    console.warn('Could not parse stored mount voltages', error);
+    return null;
+  }
+}
+function getDefaultMountKey(mount) {
+  return SUPPORTED_MOUNT_VOLTAGE_TYPES.indexOf(mount) !== -1 ? mount : 'V-Mount';
+}
+function getMountVoltageConfig(mount) {
+  var key = getDefaultMountKey(mount);
+  var entry = mountVoltagePreferences[key] || DEFAULT_MOUNT_VOLTAGES[key];
+  return {
+    high: parseVoltageValue(entry && entry.high, DEFAULT_MOUNT_VOLTAGES[key].high),
+    low: parseVoltageValue(entry && entry.low, DEFAULT_MOUNT_VOLTAGES[key].low)
+  };
+}
+function getActiveMountVoltageConfig() {
+  var plate = getSelectedPlate();
+  return getMountVoltageConfig(plate);
+}
+function formatVoltageForDisplay(voltage, lang) {
+  var numeric = Number(voltage);
+  if (!Number.isFinite(numeric)) {
+    return '';
+  }
+  var locale = lang || currentLang;
+  var options = {
+    maximumFractionDigits: 2,
+    minimumFractionDigits: numeric % 1 === 0 ? 0 : 1
+  };
+  if (typeof formatNumberForLang === 'function') {
+    try {
+      return formatNumberForLang(locale, numeric, options);
+    } catch (error) {
+      console.warn('formatNumberForLang failed for voltage display', error);
+    }
+  }
+  try {
+    return new Intl.NumberFormat(locale, options).format(numeric);
+  } catch (intlError) {
+    void intlError;
+  }
+  return numeric.toFixed(options.minimumFractionDigits);
+}
+function getMountVoltagePreferencesClone() {
+  return cloneMountVoltageMap(mountVoltagePreferences);
+}
+function persistMountVoltagePreferences(preferences) {
+  if (typeof localStorage === 'undefined') {
+    return;
+  }
+  var serialized;
+  try {
+    serialized = JSON.stringify(preferences);
+  } catch (serializationError) {
+    console.warn('Could not serialize mount voltage preferences', serializationError);
+    return;
+  }
+  try {
+    localStorage.setItem(MOUNT_VOLTAGE_STORAGE_KEY, serialized);
+  } catch (storageError) {
+    console.warn('Could not save mount voltage preferences', storageError);
+  }
+  try {
+    localStorage.setItem(MOUNT_VOLTAGE_STORAGE_BACKUP_KEY, serialized);
+  } catch (backupError) {
+    console.warn('Could not save mount voltage backup copy', backupError);
+  }
+}
+function applyMountVoltagePreferences(preferences, options) {
+  var opts = options || {};
+  var persist = typeof opts.persist === 'boolean' ? opts.persist : true;
+  var triggerUpdate = typeof opts.triggerUpdate === 'boolean' ? opts.triggerUpdate : true;
+  mountVoltagePreferences = normalizeMountVoltageSource(preferences);
+  if (persist) {
+    persistMountVoltagePreferences(mountVoltagePreferences);
+  }
+  if (triggerUpdate) {
+    updateMountVoltageInputsFromState();
+    refreshTotalCurrentLabels(currentLang);
+    if (typeof updateCalculations === 'function') {
+      try {
+        updateCalculations();
+      } catch (calcError) {
+        console.warn('Failed to refresh calculations after voltage change', calcError);
+      }
+    }
+  }
+}
+function resetMountVoltagePreferences(options) {
+  applyMountVoltagePreferences(DEFAULT_MOUNT_VOLTAGES, options);
+}
+function formatVoltageInputValue(value) {
+  return Number.isFinite(value) ? String(Math.round(Number(value) * 100) / 100) : '';
+}
+function updateMountVoltageInputsFromState() {
+  if (!mountVoltageInputs) {
+    return;
+  }
+  var preferences = mountVoltagePreferences || DEFAULT_MOUNT_VOLTAGES;
+  SUPPORTED_MOUNT_VOLTAGE_TYPES.forEach(function (type) {
+    var fields = mountVoltageInputs[type];
+    if (!fields) return;
+    var entry = preferences[type] || DEFAULT_MOUNT_VOLTAGES[type];
+    if (fields.high) {
+      fields.high.value = formatVoltageInputValue(entry && entry.high);
+    }
+    if (fields.low) {
+      fields.low.value = formatVoltageInputValue(entry && entry.low);
+    }
+  });
+}
+function getTemplateString(lang, key, fallback) {
+  var localeTexts = texts && texts[lang] ? texts[lang] : null;
+  var defaultTexts = texts && texts.en ? texts.en : null;
+  if (localeTexts && typeof localeTexts[key] === 'string') {
+    return localeTexts[key];
+  }
+  if (defaultTexts && typeof defaultTexts[key] === 'string') {
+    return defaultTexts[key];
+  }
+  return fallback;
+}
+function renderVoltageTemplate(template, voltage, lang, fallback) {
+  var formatted = formatVoltageForDisplay(voltage, lang);
+  var source = typeof template === 'string' && template.indexOf('{voltage}') !== -1 ? template : fallback;
+  if (typeof source !== 'string') {
+    return formatted ? "".concat(formatted, " V") : '';
+  }
+  return source.replace('{voltage}', formatted);
+}
+function refreshTotalCurrentLabels(lang, mount, voltages) {
+  if (typeof document === 'undefined') {
+    return;
+  }
+  var highLabelElem = document.getElementById('totalCurrent144Label');
+  var lowLabelElem = document.getElementById('totalCurrent12Label');
+  if (!highLabelElem || !lowLabelElem) {
+    return;
+  }
+  var effectiveLang = lang || currentLang;
+  var effectiveMount = mount || getSelectedPlate();
+  var config = voltages || getMountVoltageConfig(effectiveMount);
+  var highTemplate = getTemplateString(effectiveLang, 'totalCurrentHighLabelTemplate', TOTAL_CURRENT_LABEL_FALLBACK);
+  var lowTemplate = getTemplateString(effectiveLang, 'totalCurrentLowLabelTemplate', TOTAL_CURRENT_LABEL_FALLBACK);
+  var highHelpTemplate = getTemplateString(effectiveLang, 'totalCurrentHighHelpTemplate', TOTAL_CURRENT_HELP_HIGH_FALLBACK);
+  var lowHelpTemplate = getTemplateString(effectiveLang, 'totalCurrentLowHelpTemplate', TOTAL_CURRENT_HELP_LOW_FALLBACK);
+  highLabelElem.textContent = renderVoltageTemplate(highTemplate, config.high, effectiveLang, TOTAL_CURRENT_LABEL_FALLBACK);
+  lowLabelElem.textContent = renderVoltageTemplate(lowTemplate, config.low, effectiveLang, TOTAL_CURRENT_LABEL_FALLBACK);
+  highLabelElem.setAttribute('data-help', renderVoltageTemplate(highHelpTemplate, config.high, effectiveLang, TOTAL_CURRENT_HELP_HIGH_FALLBACK));
+  lowLabelElem.setAttribute('data-help', renderVoltageTemplate(lowHelpTemplate, config.low, effectiveLang, TOTAL_CURRENT_HELP_LOW_FALLBACK));
+}
+function updateMountVoltageSettingLabels(lang) {
+  var effectiveLang = lang || currentLang;
+  var localeTexts = texts && texts[effectiveLang] ? texts[effectiveLang] : texts.en;
+  if (!localeTexts) return;
+  if (mountVoltageHeadingElem) {
+    mountVoltageHeadingElem.textContent = localeTexts.mountVoltageSettingsHeading || (texts.en ? texts.en.mountVoltageSettingsHeading : 'Battery mount voltages');
+    var helpText = localeTexts.mountVoltageSettingsHelp || (texts.en ? texts.en.mountVoltageSettingsHelp : '');
+    if (helpText) {
+      mountVoltageHeadingElem.setAttribute('data-help', helpText);
+    }
+  }
+  if (mountVoltageDescriptionElem) {
+    mountVoltageDescriptionElem.textContent = localeTexts.mountVoltageDescription || (texts.en ? texts.en.mountVoltageDescription : '');
+  }
+  if (mountVoltageNoteElem) {
+    mountVoltageNoteElem.textContent = localeTexts.mountVoltageNote || (texts.en ? texts.en.mountVoltageNote : '');
+  }
+  if (mountVoltageResetButton) {
+    mountVoltageResetButton.textContent = localeTexts.mountVoltageReset || (texts.en ? texts.en.mountVoltageReset : 'Restore defaults');
+    var resetHelp = localeTexts.mountVoltageResetHelp || (texts.en ? texts.en.mountVoltageResetHelp : '');
+    if (resetHelp) {
+      mountVoltageResetButton.setAttribute('data-help', resetHelp);
+    }
+  }
+  if (mountVoltageTitleElems) {
+    if (mountVoltageTitleElems.V) {
+      mountVoltageTitleElems.V.textContent = localeTexts.mountVoltageCardLabelV || (texts.en ? texts.en.mountVoltageCardLabelV : 'V-Mount');
+    }
+    if (mountVoltageTitleElems.Gold) {
+      mountVoltageTitleElems.Gold.textContent = localeTexts.mountVoltageCardLabelGold || (texts.en ? texts.en.mountVoltageCardLabelGold : 'Gold Mount');
+    }
+    if (mountVoltageTitleElems.B) {
+      mountVoltageTitleElems.B.textContent = localeTexts.mountVoltageCardLabelB || (texts.en ? texts.en.mountVoltageCardLabelB : 'B-Mount');
+    }
+  }
+  if (mountVoltageInputs) {
+    SUPPORTED_MOUNT_VOLTAGE_TYPES.forEach(function (type) {
+      var fields = mountVoltageInputs[type];
+      if (!fields) return;
+      if (fields.highLabel) {
+        fields.highLabel.textContent = localeTexts.mountVoltageHighLabel || (texts.en ? texts.en.mountVoltageHighLabel : 'High-voltage output');
+        var highHelp = localeTexts.mountVoltageHighHelp || (texts.en ? texts.en.mountVoltageHighHelp : '');
+        if (highHelp) {
+          fields.highLabel.setAttribute('data-help', highHelp);
+          if (fields.high) fields.high.setAttribute('data-help', highHelp);
+        }
+      }
+      if (fields.lowLabel) {
+        fields.lowLabel.textContent = localeTexts.mountVoltageLowLabel || (texts.en ? texts.en.mountVoltageLowLabel : 'Low-voltage output');
+        var lowHelp = localeTexts.mountVoltageLowHelp || (texts.en ? texts.en.mountVoltageLowHelp : '');
+        if (lowHelp) {
+          fields.lowLabel.setAttribute('data-help', lowHelp);
+          if (fields.low) fields.low.setAttribute('data-help', lowHelp);
+        }
+      }
+    });
+  }
+}
+try {
+  if (typeof localStorage !== 'undefined') {
+    var storedVoltages = localStorage.getItem(MOUNT_VOLTAGE_STORAGE_KEY);
+    var parsedVoltages = parseStoredMountVoltages(storedVoltages);
+    if (parsedVoltages) {
+      mountVoltagePreferences = parsedVoltages;
+    } else {
+      var backupVoltages = localStorage.getItem(MOUNT_VOLTAGE_STORAGE_BACKUP_KEY);
+      var parsedBackupVoltages = parseStoredMountVoltages(backupVoltages);
+      if (parsedBackupVoltages) {
+        mountVoltagePreferences = parsedBackupVoltages;
+        persistMountVoltagePreferences(parsedBackupVoltages);
+      }
+    }
+  }
+} catch (error) {
+  console.warn('Could not load mount voltage preferences', error);
+}
 var schemaStorage = function () {
   if (typeof window === 'undefined') return null;
   try {
@@ -5271,12 +5569,8 @@ function setLanguage(lang) {
   var totalPowerLabelElem = document.getElementById("totalPowerLabel");
   totalPowerLabelElem.textContent = texts[lang].totalPowerLabel;
   totalPowerLabelElem.setAttribute("data-help", texts[lang].totalPowerHelp);
-  var totalCurrent144LabelElem = document.getElementById("totalCurrent144Label");
-  totalCurrent144LabelElem.textContent = texts[lang].totalCurrent144Label;
-  totalCurrent144LabelElem.setAttribute("data-help", texts[lang].totalCurrent144Help);
-  var totalCurrent12LabelElem = document.getElementById("totalCurrent12Label");
-  totalCurrent12LabelElem.textContent = texts[lang].totalCurrent12Label;
-  totalCurrent12LabelElem.setAttribute("data-help", texts[lang].totalCurrent12Help);
+  refreshTotalCurrentLabels(lang);
+  updateMountVoltageSettingLabels(lang);
   var batteryCountLabelElem = document.getElementById("batteryCountLabel");
   batteryCountLabelElem.textContent = texts[lang].batteryCountLabel;
   batteryCountLabelElem.setAttribute("data-help", texts[lang].batteryCountHelp);
@@ -10469,6 +10763,38 @@ var iosPwaHelpDialog = document.getElementById("iosPwaHelpDialog");
 var iosPwaHelpTitle = document.getElementById("iosPwaHelpTitle");
 var iosPwaHelpIntro = document.getElementById("iosPwaHelpIntro");
 var iosPwaHelpStep1 = document.getElementById("iosPwaHelpStep1");
+mountVoltageSectionElem = document.getElementById('mountVoltageSettings');
+mountVoltageHeadingElem = document.getElementById('mountVoltageHeading');
+mountVoltageDescriptionElem = document.getElementById('mountVoltageDescription');
+mountVoltageNoteElem = document.getElementById('mountVoltageNote');
+mountVoltageResetButton = document.getElementById('mountVoltageReset');
+mountVoltageTitleElems = {
+  V: document.getElementById('mountVoltageVTitle'),
+  Gold: document.getElementById('mountVoltageGoldTitle'),
+  B: document.getElementById('mountVoltageBTitle')
+};
+mountVoltageInputs = {
+  'V-Mount': {
+    high: document.getElementById('mountVoltageVHigh'),
+    low: document.getElementById('mountVoltageVLow'),
+    highLabel: document.getElementById('mountVoltageVHighLabel'),
+    lowLabel: document.getElementById('mountVoltageVLowLabel')
+  },
+  'Gold-Mount': {
+    high: document.getElementById('mountVoltageGoldHigh'),
+    low: document.getElementById('mountVoltageGoldLow'),
+    highLabel: document.getElementById('mountVoltageGoldHighLabel'),
+    lowLabel: document.getElementById('mountVoltageGoldLowLabel')
+  },
+  'B-Mount': {
+    high: document.getElementById('mountVoltageBHigh'),
+    low: document.getElementById('mountVoltageBLow'),
+    highLabel: document.getElementById('mountVoltageBHighLabel'),
+    lowLabel: document.getElementById('mountVoltageBLowLabel')
+  }
+};
+updateMountVoltageInputsFromState();
+updateMountVoltageSettingLabels(currentLang);
 var iosPwaHelpStep2 = document.getElementById("iosPwaHelpStep2");
 var iosPwaHelpStep3 = document.getElementById("iosPwaHelpStep3");
 setPinkModeIconSequence(PINK_MODE_ICON_FALLBACK_MARKUP);

--- a/legacy/scripts/app-core-new-2.js
+++ b/legacy/scripts/app-core-new-2.js
@@ -11329,21 +11329,18 @@ function updateCalculations() {
     _li5.innerHTML = "<strong>".concat(texts[currentLang].distanceLabel, "</strong> ").concat(distanceW.toFixed(1), " W");
     breakdownListElem.appendChild(_li5);
   }
-  var bMountCam = getSelectedPlate() === 'B-Mount';
-  var highV = bMountCam ? 33.6 : 14.4;
-  var lowV = bMountCam ? 21.6 : 12.0;
+  var selectedPlate = getSelectedPlate();
+  var mountVoltages = getMountVoltageConfig(selectedPlate);
+  var bMountCam = selectedPlate === 'B-Mount';
+  var highV = Number.isFinite(mountVoltages.high) ? mountVoltages.high : bMountCam ? 33.6 : 14.4;
+  var lowV = Number.isFinite(mountVoltages.low) ? mountVoltages.low : bMountCam ? 21.6 : 12.0;
   var totalCurrentHigh = 0;
   var totalCurrentLow = 0;
   if (totalWatt > 0) {
     totalCurrentHigh = totalWatt / highV;
     totalCurrentLow = totalWatt / lowV;
   }
-  var currentHighLabel = document.getElementById("totalCurrent144Label");
-  currentHighLabel.textContent = bMountCam ? texts[currentLang].totalCurrent336Label : texts[currentLang].totalCurrent144Label;
-  currentHighLabel.setAttribute("data-help", bMountCam ? texts[currentLang].totalCurrent336Help : texts[currentLang].totalCurrent144Help);
-  var currentLowLabel = document.getElementById("totalCurrent12Label");
-  currentLowLabel.textContent = bMountCam ? texts[currentLang].totalCurrent216Label : texts[currentLang].totalCurrent12Label;
-  currentLowLabel.setAttribute("data-help", bMountCam ? texts[currentLang].totalCurrent216Help : texts[currentLang].totalCurrent12Help);
+  refreshTotalCurrentLabels(currentLang, selectedPlate, mountVoltages);
   totalCurrent144Elem.textContent = totalCurrentHigh.toFixed(2);
   totalCurrent12Elem.textContent = totalCurrentLow.toFixed(2);
   updateBatteryOptions();

--- a/legacy/scripts/storage.js
+++ b/legacy/scripts/storage.js
@@ -28,6 +28,7 @@ var FAVORITES_STORAGE_KEY = 'cameraPowerPlanner_favorites';
 var DEVICE_SCHEMA_CACHE_KEY = 'cameraPowerPlanner_schemaCache';
 var LEGACY_SCHEMA_CACHE_KEY = 'cinePowerPlanner_schemaCache';
 var CUSTOM_FONT_STORAGE_KEY_DEFAULT = 'cameraPowerPlanner_customFonts';
+var MOUNT_VOLTAGE_STORAGE_KEY = 'cameraPowerPlanner_mountVoltages';
 function ensureCustomFontStorageKeyName() {
   if (!GLOBAL_SCOPE) {
     return CUSTOM_FONT_STORAGE_KEY_DEFAULT;
@@ -146,7 +147,7 @@ var STORAGE_BACKUP_SUFFIX = '__backup';
 var MAX_SAVE_ATTEMPTS = 3;
 var MAX_QUOTA_RECOVERY_STEPS = 100;
 var STORAGE_MIGRATION_BACKUP_SUFFIX = '__legacyMigrationBackup';
-var RAW_STORAGE_BACKUP_KEYS = new Set([getCustomFontStorageKeyName(), CUSTOM_LOGO_STORAGE_KEY, DEVICE_SCHEMA_CACHE_KEY]);
+var RAW_STORAGE_BACKUP_KEYS = new Set([getCustomFontStorageKeyName(), CUSTOM_LOGO_STORAGE_KEY, DEVICE_SCHEMA_CACHE_KEY, MOUNT_VOLTAGE_STORAGE_KEY]);
 var MAX_MIGRATION_BACKUP_CLEANUP_STEPS = 10;
 var MIGRATION_BACKUP_COMPRESSION_ALGORITHM = 'lz-string';
 var MIGRATION_BACKUP_COMPRESSION_ENCODING = 'json-string';

--- a/legacy/scripts/translations.js
+++ b/legacy/scripts/translations.js
@@ -96,6 +96,28 @@ var texts = {
     accentColorResetHelp: "Revert the accent color to the original theme color while keeping other preferences intact.",
     temperatureUnitSetting: "Temperature unit",
     temperatureUnitSettingHelp: "Choose whether temperatures are shown in Celsius or Fahrenheit throughout the app.",
+    mountVoltageSettingsHeading: "Battery mount voltages",
+    mountVoltageSettingsHelp:
+      "Adjust the voltages used for current draw calculations across B-Mount, V-Mount and Gold Mount setups.",
+    mountVoltageDescription:
+      "Set the default high and low voltages for each battery mount so the planner matches your hardware.",
+    mountVoltageReset: "Restore defaults",
+    mountVoltageResetHelp: "Reset all mount voltages to their factory defaults.",
+    mountVoltageHighLabel: "High-voltage output",
+    mountVoltageLowLabel: "Low-voltage output",
+    mountVoltageHighHelp:
+      "Used to calculate total current at the battery's main output such as the high-voltage pins.",
+    mountVoltageLowHelp:
+      "Used to calculate total current at auxiliary outputs such as D-Tap ports or B-Mount low-voltage pins.",
+    mountVoltageNote:
+      "These voltages update the totals in the power summary, runtime estimates and pin warnings.",
+    mountVoltageCardLabelV: "V-Mount",
+    mountVoltageCardLabelGold: "Gold Mount",
+    mountVoltageCardLabelB: "B-Mount",
+    totalCurrentHighLabelTemplate: "Total Current (at {voltage}V):",
+    totalCurrentLowLabelTemplate: "Total Current (at {voltage}V):",
+    totalCurrentHighHelpTemplate: "Current draw at the battery's main output ({voltage}V).",
+    totalCurrentLowHelpTemplate: "Current draw at auxiliary outputs ({voltage}V).",
     temperatureUnitCelsius: "Celsius (°C)",
     temperatureUnitFahrenheit: "Fahrenheit (°F)",
     temperatureUnitSymbolCelsius: "°C",
@@ -1577,6 +1599,28 @@ var texts = {
     accentColorResetHelp: "Ripristina il colore d'accento originale del tema senza modificare le altre preferenze.",
     temperatureUnitSetting: "Unità di temperatura",
     temperatureUnitSettingHelp: "Scegli se mostrare le temperature in Celsius o Fahrenheit in tutta l'app.",
+    mountVoltageSettingsHeading: "Tensioni dei battery mount",
+    mountVoltageSettingsHelp:
+      "Regola le tensioni usate nei calcoli della corrente per configurazioni B-Mount, V-Mount e Gold Mount.",
+    mountVoltageDescription:
+      "Imposta le tensioni alta e bassa predefinite per ogni attacco batteria così che il planner rispecchi il tuo hardware.",
+    mountVoltageReset: "Ripristina predefiniti",
+    mountVoltageResetHelp: "Ripristina le tensioni dei mount ai valori di fabbrica.",
+    mountVoltageHighLabel: "Uscita ad alta tensione",
+    mountVoltageLowLabel: "Uscita a bassa tensione",
+    mountVoltageHighHelp:
+      "Usata per calcolare la corrente totale sull'uscita principale della batteria, ad esempio i pin ad alta tensione.",
+    mountVoltageLowHelp:
+      "Usata per calcolare la corrente totale sulle uscite ausiliarie come porte D-Tap o pin B-Mount a bassa tensione.",
+    mountVoltageNote:
+      "Queste tensioni aggiornano i totali nel riepilogo potenza, le stime di autonomia e gli avvisi sui pin.",
+    mountVoltageCardLabelV: "V-Mount",
+    mountVoltageCardLabelGold: "Gold Mount",
+    mountVoltageCardLabelB: "B-Mount",
+    totalCurrentHighLabelTemplate: "Corrente totale (a {voltage}V):",
+    totalCurrentLowLabelTemplate: "Corrente totale (a {voltage}V):",
+    totalCurrentHighHelpTemplate: "Corrente assorbita dall'uscita principale della batteria ({voltage}V).",
+    totalCurrentLowHelpTemplate: "Corrente assorbita dalle uscite ausiliarie ({voltage}V).",
     temperatureUnitCelsius: "Celsius (°C)",
     temperatureUnitFahrenheit: "Fahrenheit (°F)",
     temperatureUnitSymbolCelsius: "°C",
@@ -2654,6 +2698,28 @@ var texts = {
     accentColorResetHelp: "Restaura el color de acento original del tema sin cambiar otras preferencias.",
     temperatureUnitSetting: "Unidad de temperatura",
     temperatureUnitSettingHelp: "Elige si mostrar las temperaturas en grados Celsius o Fahrenheit en toda la aplicación.",
+    mountVoltageSettingsHeading: "Tensiones de los soportes de batería",
+    mountVoltageSettingsHelp:
+      "Ajusta las tensiones utilizadas en los cálculos de corriente para configuraciones B-Mount, V-Mount y Gold Mount.",
+    mountVoltageDescription:
+      "Define las tensiones alta y baja predeterminadas de cada soporte para que el planificador coincida con tu hardware.",
+    mountVoltageReset: "Restaurar valores predeterminados",
+    mountVoltageResetHelp: "Restablece las tensiones de los soportes a los valores de fábrica.",
+    mountVoltageHighLabel: "Salida de alta tensión",
+    mountVoltageLowLabel: "Salida de baja tensión",
+    mountVoltageHighHelp:
+      "Se utiliza para calcular la corriente total en la salida principal de la batería, como los pines de alta tensión.",
+    mountVoltageLowHelp:
+      "Se utiliza para calcular la corriente total en salidas auxiliares como conectores D-Tap o pines B-Mount de baja tensión.",
+    mountVoltageNote:
+      "Estas tensiones actualizan los totales del resumen de potencia, las estimaciones de autonomía y las alertas de pines.",
+    mountVoltageCardLabelV: "V-Mount",
+    mountVoltageCardLabelGold: "Gold Mount",
+    mountVoltageCardLabelB: "B-Mount",
+    totalCurrentHighLabelTemplate: "Corriente total (a {voltage}V):",
+    totalCurrentLowLabelTemplate: "Corriente total (a {voltage}V):",
+    totalCurrentHighHelpTemplate: "Corriente en la salida principal de la batería ({voltage}V).",
+    totalCurrentLowHelpTemplate: "Corriente en las salidas auxiliares ({voltage}V).",
     temperatureUnitCelsius: "Celsius (°C)",
     temperatureUnitFahrenheit: "Fahrenheit (°F)",
     temperatureUnitSymbolCelsius: "°C",
@@ -3731,6 +3797,28 @@ var texts = {
     accentColorResetHelp: "Rétablit la couleur d’accent d’origine du thème sans modifier les autres préférences.",
     temperatureUnitSetting: "Unité de température",
     temperatureUnitSettingHelp: "Choisissez d'afficher les températures en Celsius ou en Fahrenheit dans toute l'application.",
+    mountVoltageSettingsHeading: "Tensions des supports de batterie",
+    mountVoltageSettingsHelp:
+      "Ajustez les tensions utilisées dans les calculs d'intensité pour les configurations B-Mount, V-Mount et Gold Mount.",
+    mountVoltageDescription:
+      "Définissez les tensions haute et basse par défaut de chaque support pour aligner le planificateur sur votre matériel.",
+    mountVoltageReset: "Restaurer les valeurs par défaut",
+    mountVoltageResetHelp: "Rétablit les tensions des supports à leurs valeurs d'usine.",
+    mountVoltageHighLabel: "Sortie haute tension",
+    mountVoltageLowLabel: "Sortie basse tension",
+    mountVoltageHighHelp:
+      "Utilisée pour calculer l'intensité totale sur la sortie principale de la batterie comme les broches haute tension.",
+    mountVoltageLowHelp:
+      "Utilisée pour calculer l'intensité totale sur les sorties auxiliaires comme les D-Tap ou les broches basse tension B-Mount.",
+    mountVoltageNote:
+      "Ces tensions mettent à jour le résumé de puissance, les estimations d'autonomie et les alertes sur les broches.",
+    mountVoltageCardLabelV: "V-Mount",
+    mountVoltageCardLabelGold: "Gold Mount",
+    mountVoltageCardLabelB: "B-Mount",
+    totalCurrentHighLabelTemplate: "Courant total (à {voltage} V) :",
+    totalCurrentLowLabelTemplate: "Courant total (à {voltage} V) :",
+    totalCurrentHighHelpTemplate: "Courant sur la sortie principale de la batterie ({voltage} V).",
+    totalCurrentLowHelpTemplate: "Courant sur les sorties auxiliaires ({voltage} V).",
     temperatureUnitCelsius: "Celsius (°C)",
     temperatureUnitFahrenheit: "Fahrenheit (°F)",
     temperatureUnitSymbolCelsius: "°C",
@@ -4808,6 +4896,28 @@ var texts = {
     accentColorResetHelp: "Stellt die ursprüngliche Akzentfarbe des Designs wieder her, ohne andere Einstellungen zu ändern.",
     temperatureUnitSetting: "Temperatureinheit",
     temperatureUnitSettingHelp: "Wählen Sie, ob Temperaturen in Celsius oder Fahrenheit in der gesamten App angezeigt werden.",
+    mountVoltageSettingsHeading: "Batterie-Mount-Spannungen",
+    mountVoltageSettingsHelp:
+      "Passe die Spannungen für Stromberechnungen bei B-Mount-, V-Mount- und Gold-Mount-Setups an.",
+    mountVoltageDescription:
+      "Lege die Standard-Hoch- und Niederspannung für jeden Mount fest, damit der Planer zu deiner Hardware passt.",
+    mountVoltageReset: "Auf Standard zurücksetzen",
+    mountVoltageResetHelp: "Setzt alle Mount-Spannungen auf die Werkseinstellungen zurück.",
+    mountVoltageHighLabel: "Hochspannungs-Ausgang",
+    mountVoltageLowLabel: "Niederspannungs-Ausgang",
+    mountVoltageHighHelp:
+      "Wird zur Berechnung des Gesamtstroms am Hauptausgang der Batterie wie den Hochspannungs-Pins verwendet.",
+    mountVoltageLowHelp:
+      "Wird zur Berechnung des Gesamtstroms an Zusatzanschlüssen wie D-Tap-Ports oder B-Mount-Niederspannungspins verwendet.",
+    mountVoltageNote:
+      "Diese Spannungen aktualisieren die Leistungsübersicht, Laufzeitabschätzungen und Pin-Warnungen.",
+    mountVoltageCardLabelV: "V-Mount",
+    mountVoltageCardLabelGold: "Gold Mount",
+    mountVoltageCardLabelB: "B-Mount",
+    totalCurrentHighLabelTemplate: "Gesamtstrom (bei {voltage} V):",
+    totalCurrentLowLabelTemplate: "Gesamtstrom (bei {voltage} V):",
+    totalCurrentHighHelpTemplate: "Strom am Hauptausgang der Batterie ({voltage} V).",
+    totalCurrentLowHelpTemplate: "Strom an Zusatzanschlüssen ({voltage} V).",
     temperatureUnitCelsius: "Celsius (°C)",
     temperatureUnitFahrenheit: "Fahrenheit (°F)",
     temperatureUnitSymbolCelsius: "°C",

--- a/src/scripts/app-core-new-1.js
+++ b/src/scripts/app-core-new-1.js
@@ -729,6 +729,365 @@ try {
   console.warn('Could not load temperature unit preference', error);
 }
 
+const SUPPORTED_MOUNT_VOLTAGE_TYPES = ['V-Mount', 'Gold-Mount', 'B-Mount'];
+const MOUNT_VOLTAGE_STORAGE_KEY = 'cameraPowerPlanner_mountVoltages';
+const MOUNT_VOLTAGE_STORAGE_BACKUP_KEY = `${MOUNT_VOLTAGE_STORAGE_KEY}__backup`;
+try {
+  if (CORE_GLOBAL_SCOPE && typeof CORE_GLOBAL_SCOPE === 'object') {
+    if (typeof CORE_GLOBAL_SCOPE.MOUNT_VOLTAGE_STORAGE_KEY !== 'string') {
+      CORE_GLOBAL_SCOPE.MOUNT_VOLTAGE_STORAGE_KEY = MOUNT_VOLTAGE_STORAGE_KEY;
+    }
+    if (typeof CORE_GLOBAL_SCOPE.MOUNT_VOLTAGE_STORAGE_BACKUP_KEY !== 'string') {
+      CORE_GLOBAL_SCOPE.MOUNT_VOLTAGE_STORAGE_BACKUP_KEY = MOUNT_VOLTAGE_STORAGE_BACKUP_KEY;
+    }
+  }
+} catch (exposeMountVoltageError) {
+  console.warn('Unable to expose mount voltage storage keys globally', exposeMountVoltageError);
+}
+const DEFAULT_MOUNT_VOLTAGES = Object.freeze({
+  'V-Mount': Object.freeze({ high: 14.4, low: 12 }),
+  'Gold-Mount': Object.freeze({ high: 14.4, low: 12 }),
+  'B-Mount': Object.freeze({ high: 33.6, low: 21.6 }),
+});
+const TOTAL_CURRENT_LABEL_FALLBACK = 'Total Current (at {voltage}V):';
+const TOTAL_CURRENT_HELP_HIGH_FALLBACK = 'Current draw at the battery\'s main output ({voltage}V).';
+const TOTAL_CURRENT_HELP_LOW_FALLBACK = 'Current draw at auxiliary outputs ({voltage}V).';
+
+let mountVoltagePreferences = cloneMountVoltageMap(DEFAULT_MOUNT_VOLTAGES);
+let mountVoltageInputs = null;
+let mountVoltageSectionElem = null;
+let mountVoltageHeadingElem = null;
+let mountVoltageDescriptionElem = null;
+let mountVoltageNoteElem = null;
+let mountVoltageResetButton = null;
+let mountVoltageTitleElems = null;
+
+function parseVoltageValue(value, fallback) {
+  let numeric = Number.NaN;
+  if (typeof value === 'number') {
+    numeric = value;
+  } else if (typeof value === 'string') {
+    const normalized = value.replace(',', '.');
+    numeric = Number.parseFloat(normalized);
+  }
+  if (!Number.isFinite(numeric)) {
+    return fallback;
+  }
+  if (numeric <= 0) {
+    return fallback;
+  }
+  const clamped = Math.min(1000, Math.max(0.1, numeric));
+  return Math.round(clamped * 100) / 100;
+}
+
+function cloneMountVoltageMap(source = DEFAULT_MOUNT_VOLTAGES) {
+  const result = {};
+  SUPPORTED_MOUNT_VOLTAGE_TYPES.forEach(type => {
+    const entry = source && source[type] ? source[type] : DEFAULT_MOUNT_VOLTAGES[type];
+    const high = parseVoltageValue(entry && entry.high, DEFAULT_MOUNT_VOLTAGES[type].high);
+    const low = parseVoltageValue(entry && entry.low, DEFAULT_MOUNT_VOLTAGES[type].low);
+    result[type] = { high, low };
+  });
+  return result;
+}
+
+function normalizeMountVoltageSource(source) {
+  if (!source || typeof source !== 'object') {
+    return cloneMountVoltageMap(DEFAULT_MOUNT_VOLTAGES);
+  }
+  return cloneMountVoltageMap(source);
+}
+
+function parseStoredMountVoltages(raw) {
+  if (!raw) {
+    return null;
+  }
+  try {
+    if (typeof raw === 'string') {
+      const parsed = JSON.parse(raw);
+      return normalizeMountVoltageSource(parsed);
+    }
+    return normalizeMountVoltageSource(raw);
+  } catch (error) {
+    console.warn('Could not parse stored mount voltages', error);
+    return null;
+  }
+}
+
+function getDefaultMountKey(mount) {
+  if (SUPPORTED_MOUNT_VOLTAGE_TYPES.includes(mount)) {
+    return mount;
+  }
+  return 'V-Mount';
+}
+
+function getMountVoltageConfig(mount) {
+  const key = getDefaultMountKey(mount);
+  const entry = mountVoltagePreferences[key] || DEFAULT_MOUNT_VOLTAGES[key];
+  return {
+    high: parseVoltageValue(entry && entry.high, DEFAULT_MOUNT_VOLTAGES[key].high),
+    low: parseVoltageValue(entry && entry.low, DEFAULT_MOUNT_VOLTAGES[key].low),
+  };
+}
+
+function getActiveMountVoltageConfig() {
+  const plate = getSelectedPlate();
+  return getMountVoltageConfig(plate);
+}
+
+function formatVoltageForDisplay(voltage, lang = currentLang) {
+  const numeric = Number(voltage);
+  if (!Number.isFinite(numeric)) {
+    return '';
+  }
+  const options = {
+    maximumFractionDigits: 2,
+    minimumFractionDigits: numeric % 1 === 0 ? 0 : 1,
+  };
+  if (typeof formatNumberForLang === 'function') {
+    try {
+      return formatNumberForLang(lang, numeric, options);
+    } catch (error) {
+      console.warn('formatNumberForLang failed for voltage display', error);
+    }
+  }
+  try {
+    const formatter = new Intl.NumberFormat(lang, options);
+    return formatter.format(numeric);
+  } catch (intlError) {
+    void intlError;
+  }
+  return numeric.toFixed(options.minimumFractionDigits);
+}
+
+function getMountVoltagePreferencesClone() {
+  return cloneMountVoltageMap(mountVoltagePreferences);
+}
+
+function persistMountVoltagePreferences(preferences) {
+  if (typeof localStorage === 'undefined') {
+    return;
+  }
+
+  let serialized;
+  try {
+    serialized = JSON.stringify(preferences);
+  } catch (serializationError) {
+    console.warn('Could not serialize mount voltage preferences', serializationError);
+    return;
+  }
+
+  try {
+    localStorage.setItem(MOUNT_VOLTAGE_STORAGE_KEY, serialized);
+  } catch (storageError) {
+    console.warn('Could not save mount voltage preferences', storageError);
+  }
+
+  try {
+    localStorage.setItem(MOUNT_VOLTAGE_STORAGE_BACKUP_KEY, serialized);
+  } catch (backupError) {
+    console.warn('Could not save mount voltage backup copy', backupError);
+  }
+}
+
+function applyMountVoltagePreferences(preferences, options = {}) {
+  const { persist = true, triggerUpdate = true } = options || {};
+  mountVoltagePreferences = normalizeMountVoltageSource(preferences);
+  if (persist) {
+    persistMountVoltagePreferences(mountVoltagePreferences);
+  }
+  if (triggerUpdate) {
+    updateMountVoltageInputsFromState();
+    refreshTotalCurrentLabels(currentLang);
+    if (typeof updateCalculations === 'function') {
+      try {
+        updateCalculations();
+      } catch (calcError) {
+        console.warn('Failed to refresh calculations after voltage change', calcError);
+      }
+    }
+  }
+}
+
+function resetMountVoltagePreferences(options = {}) {
+  applyMountVoltagePreferences(DEFAULT_MOUNT_VOLTAGES, options);
+}
+
+function formatVoltageInputValue(value) {
+  return Number.isFinite(value) ? String(Math.round(Number(value) * 100) / 100) : '';
+}
+
+function updateMountVoltageInputsFromState() {
+  if (!mountVoltageInputs) {
+    return;
+  }
+  const preferences = mountVoltagePreferences || DEFAULT_MOUNT_VOLTAGES;
+  SUPPORTED_MOUNT_VOLTAGE_TYPES.forEach(type => {
+    const fields = mountVoltageInputs[type];
+    if (!fields) return;
+    const entry = preferences[type] || DEFAULT_MOUNT_VOLTAGES[type];
+    if (fields.high) {
+      fields.high.value = formatVoltageInputValue(entry && entry.high);
+    }
+    if (fields.low) {
+      fields.low.value = formatVoltageInputValue(entry && entry.low);
+    }
+  });
+}
+
+function getTemplateString(lang, key, fallback) {
+  const localeTexts = texts && texts[lang] ? texts[lang] : null;
+  const defaultTexts = texts && texts.en ? texts.en : null;
+  if (localeTexts && typeof localeTexts[key] === 'string') {
+    return localeTexts[key];
+  }
+  if (defaultTexts && typeof defaultTexts[key] === 'string') {
+    return defaultTexts[key];
+  }
+  return fallback;
+}
+
+function renderVoltageTemplate(template, voltage, lang, fallback) {
+  const formatted = formatVoltageForDisplay(voltage, lang);
+  const source = typeof template === 'string' && template.includes('{voltage}')
+    ? template
+    : fallback;
+  if (typeof source !== 'string') {
+    return formatted ? `${formatted} V` : '';
+  }
+  return source.replace('{voltage}', formatted);
+}
+
+function refreshTotalCurrentLabels(lang = currentLang, mount = null, voltages = null) {
+  if (typeof document === 'undefined') {
+    return;
+  }
+  const highLabelElem = document.getElementById('totalCurrent144Label');
+  const lowLabelElem = document.getElementById('totalCurrent12Label');
+  if (!highLabelElem || !lowLabelElem) {
+    return;
+  }
+  const effectiveMount = mount || getSelectedPlate();
+  const config = voltages || getMountVoltageConfig(effectiveMount);
+  const highTemplate = getTemplateString(lang, 'totalCurrentHighLabelTemplate', TOTAL_CURRENT_LABEL_FALLBACK);
+  const lowTemplate = getTemplateString(lang, 'totalCurrentLowLabelTemplate', TOTAL_CURRENT_LABEL_FALLBACK);
+  const highHelpTemplate = getTemplateString(lang, 'totalCurrentHighHelpTemplate', TOTAL_CURRENT_HELP_HIGH_FALLBACK);
+  const lowHelpTemplate = getTemplateString(lang, 'totalCurrentLowHelpTemplate', TOTAL_CURRENT_HELP_LOW_FALLBACK);
+  highLabelElem.textContent = renderVoltageTemplate(highTemplate, config.high, lang, TOTAL_CURRENT_LABEL_FALLBACK);
+  lowLabelElem.textContent = renderVoltageTemplate(lowTemplate, config.low, lang, TOTAL_CURRENT_LABEL_FALLBACK);
+  highLabelElem.setAttribute(
+    'data-help',
+    renderVoltageTemplate(highHelpTemplate, config.high, lang, TOTAL_CURRENT_HELP_HIGH_FALLBACK)
+  );
+  lowLabelElem.setAttribute(
+    'data-help',
+    renderVoltageTemplate(lowHelpTemplate, config.low, lang, TOTAL_CURRENT_HELP_LOW_FALLBACK)
+  );
+}
+
+function updateMountVoltageSettingLabels(lang = currentLang) {
+  const localeTexts = texts && texts[lang] ? texts[lang] : texts.en;
+  if (!localeTexts) return;
+  if (mountVoltageHeadingElem) {
+    mountVoltageHeadingElem.textContent = localeTexts.mountVoltageSettingsHeading
+      || texts.en?.mountVoltageSettingsHeading
+      || 'Battery mount voltages';
+    const helpText = localeTexts.mountVoltageSettingsHelp
+      || texts.en?.mountVoltageSettingsHelp
+      || '';
+    if (helpText) {
+      mountVoltageHeadingElem.setAttribute('data-help', helpText);
+    }
+  }
+  if (mountVoltageDescriptionElem) {
+    mountVoltageDescriptionElem.textContent = localeTexts.mountVoltageDescription
+      || texts.en?.mountVoltageDescription
+      || '';
+  }
+  if (mountVoltageNoteElem) {
+    mountVoltageNoteElem.textContent = localeTexts.mountVoltageNote
+      || texts.en?.mountVoltageNote
+      || '';
+  }
+  if (mountVoltageResetButton) {
+    mountVoltageResetButton.textContent = localeTexts.mountVoltageReset
+      || texts.en?.mountVoltageReset
+      || 'Restore defaults';
+    const resetHelp = localeTexts.mountVoltageResetHelp
+      || texts.en?.mountVoltageResetHelp
+      || '';
+    if (resetHelp) {
+      mountVoltageResetButton.setAttribute('data-help', resetHelp);
+    }
+  }
+  if (mountVoltageTitleElems) {
+    if (mountVoltageTitleElems.V) {
+      mountVoltageTitleElems.V.textContent = localeTexts.mountVoltageCardLabelV
+        || texts.en?.mountVoltageCardLabelV
+        || 'V-Mount';
+    }
+    if (mountVoltageTitleElems.Gold) {
+      mountVoltageTitleElems.Gold.textContent = localeTexts.mountVoltageCardLabelGold
+        || texts.en?.mountVoltageCardLabelGold
+        || 'Gold Mount';
+    }
+    if (mountVoltageTitleElems.B) {
+      mountVoltageTitleElems.B.textContent = localeTexts.mountVoltageCardLabelB
+        || texts.en?.mountVoltageCardLabelB
+        || 'B-Mount';
+    }
+  }
+  if (mountVoltageInputs) {
+    SUPPORTED_MOUNT_VOLTAGE_TYPES.forEach(type => {
+      const fields = mountVoltageInputs[type];
+      if (!fields) return;
+      if (fields.highLabel) {
+        fields.highLabel.textContent = localeTexts.mountVoltageHighLabel
+          || texts.en?.mountVoltageHighLabel
+          || 'High-voltage output';
+        const highHelp = localeTexts.mountVoltageHighHelp
+          || texts.en?.mountVoltageHighHelp
+          || '';
+        if (highHelp) {
+          fields.highLabel.setAttribute('data-help', highHelp);
+          fields.high?.setAttribute('data-help', highHelp);
+        }
+      }
+      if (fields.lowLabel) {
+        fields.lowLabel.textContent = localeTexts.mountVoltageLowLabel
+          || texts.en?.mountVoltageLowLabel
+          || 'Low-voltage output';
+        const lowHelp = localeTexts.mountVoltageLowHelp
+          || texts.en?.mountVoltageLowHelp
+          || '';
+        if (lowHelp) {
+          fields.lowLabel.setAttribute('data-help', lowHelp);
+          fields.low?.setAttribute('data-help', lowHelp);
+        }
+      }
+    });
+  }
+}
+
+try {
+  if (typeof localStorage !== 'undefined') {
+    const storedVoltages = localStorage.getItem(MOUNT_VOLTAGE_STORAGE_KEY);
+    const parsedVoltages = parseStoredMountVoltages(storedVoltages);
+    if (parsedVoltages) {
+      mountVoltagePreferences = parsedVoltages;
+    } else {
+      const backupVoltages = localStorage.getItem(MOUNT_VOLTAGE_STORAGE_BACKUP_KEY);
+      const parsedBackupVoltages = parseStoredMountVoltages(backupVoltages);
+      if (parsedBackupVoltages) {
+        mountVoltagePreferences = parsedBackupVoltages;
+        persistMountVoltagePreferences(parsedBackupVoltages);
+      }
+    }
+  }
+} catch (error) {
+  console.warn('Could not load mount voltage preferences', error);
+}
+
 const schemaStorage = (() => {
   if (typeof window === 'undefined') return null;
   try {
@@ -6041,21 +6400,8 @@ function setLanguage(lang) {
   totalPowerLabelElem.textContent = texts[lang].totalPowerLabel;
   totalPowerLabelElem.setAttribute("data-help", texts[lang].totalPowerHelp);
 
-  const totalCurrent144LabelElem = document.getElementById(
-    "totalCurrent144Label"
-  );
-  totalCurrent144LabelElem.textContent = texts[lang].totalCurrent144Label;
-  totalCurrent144LabelElem.setAttribute(
-    "data-help",
-    texts[lang].totalCurrent144Help
-  );
-
-  const totalCurrent12LabelElem = document.getElementById("totalCurrent12Label");
-  totalCurrent12LabelElem.textContent = texts[lang].totalCurrent12Label;
-  totalCurrent12LabelElem.setAttribute(
-    "data-help",
-    texts[lang].totalCurrent12Help
-  );
+  refreshTotalCurrentLabels(lang);
+  updateMountVoltageSettingLabels(lang);
 
   const batteryCountLabelElem = document.getElementById("batteryCountLabel");
   batteryCountLabelElem.textContent = texts[lang].batteryCountLabel;
@@ -11898,6 +12244,38 @@ const iosPwaHelpDialog = document.getElementById("iosPwaHelpDialog");
 const iosPwaHelpTitle = document.getElementById("iosPwaHelpTitle");
 const iosPwaHelpIntro = document.getElementById("iosPwaHelpIntro");
 const iosPwaHelpStep1 = document.getElementById("iosPwaHelpStep1");
+mountVoltageSectionElem = document.getElementById('mountVoltageSettings');
+mountVoltageHeadingElem = document.getElementById('mountVoltageHeading');
+mountVoltageDescriptionElem = document.getElementById('mountVoltageDescription');
+mountVoltageNoteElem = document.getElementById('mountVoltageNote');
+mountVoltageResetButton = document.getElementById('mountVoltageReset');
+mountVoltageTitleElems = {
+  V: document.getElementById('mountVoltageVTitle'),
+  Gold: document.getElementById('mountVoltageGoldTitle'),
+  B: document.getElementById('mountVoltageBTitle'),
+};
+mountVoltageInputs = {
+  'V-Mount': {
+    high: document.getElementById('mountVoltageVHigh'),
+    low: document.getElementById('mountVoltageVLow'),
+    highLabel: document.getElementById('mountVoltageVHighLabel'),
+    lowLabel: document.getElementById('mountVoltageVLowLabel'),
+  },
+  'Gold-Mount': {
+    high: document.getElementById('mountVoltageGoldHigh'),
+    low: document.getElementById('mountVoltageGoldLow'),
+    highLabel: document.getElementById('mountVoltageGoldHighLabel'),
+    lowLabel: document.getElementById('mountVoltageGoldLowLabel'),
+  },
+  'B-Mount': {
+    high: document.getElementById('mountVoltageBHigh'),
+    low: document.getElementById('mountVoltageBLow'),
+    highLabel: document.getElementById('mountVoltageBHighLabel'),
+    lowLabel: document.getElementById('mountVoltageBLowLabel'),
+  },
+};
+updateMountVoltageInputsFromState();
+updateMountVoltageSettingLabels(currentLang);
 const iosPwaHelpStep2 = document.getElementById("iosPwaHelpStep2");
 const iosPwaHelpStep3 = document.getElementById("iosPwaHelpStep3");
 

--- a/src/scripts/app-core-new-2.js
+++ b/src/scripts/app-core-new-2.js
@@ -12125,35 +12125,18 @@ function updateCalculations() {
   }
 
   // Calculate currents depending on battery type
-  const bMountCam = getSelectedPlate() === 'B-Mount';
-  let highV = bMountCam ? 33.6 : 14.4;
-  let lowV = bMountCam ? 21.6 : 12.0;
+  const selectedPlate = getSelectedPlate();
+  const mountVoltages = getMountVoltageConfig(selectedPlate);
+  const bMountCam = selectedPlate === 'B-Mount';
+  const highV = Number.isFinite(mountVoltages.high) ? mountVoltages.high : (bMountCam ? 33.6 : 14.4);
+  const lowV = Number.isFinite(mountVoltages.low) ? mountVoltages.low : (bMountCam ? 21.6 : 12.0);
   let totalCurrentHigh = 0;
   let totalCurrentLow = 0;
   if (totalWatt > 0) {
     totalCurrentHigh = totalWatt / highV;
     totalCurrentLow = totalWatt / lowV;
   }
-  const currentHighLabel = document.getElementById("totalCurrent144Label");
-  currentHighLabel.textContent = bMountCam
-    ? texts[currentLang].totalCurrent336Label
-    : texts[currentLang].totalCurrent144Label;
-  currentHighLabel.setAttribute(
-    "data-help",
-    bMountCam
-      ? texts[currentLang].totalCurrent336Help
-      : texts[currentLang].totalCurrent144Help
-  );
-  const currentLowLabel = document.getElementById("totalCurrent12Label");
-  currentLowLabel.textContent = bMountCam
-    ? texts[currentLang].totalCurrent216Label
-    : texts[currentLang].totalCurrent12Label;
-  currentLowLabel.setAttribute(
-    "data-help",
-    bMountCam
-      ? texts[currentLang].totalCurrent216Help
-      : texts[currentLang].totalCurrent12Help
-  );
+  refreshTotalCurrentLabels(currentLang, selectedPlate, mountVoltages);
   totalCurrent144Elem.textContent = totalCurrentHigh.toFixed(2);
   totalCurrent12Elem.textContent = totalCurrentLow.toFixed(2);
 

--- a/src/scripts/translations.js
+++ b/src/scripts/translations.js
@@ -137,6 +137,28 @@ const texts = {
     temperatureUnitSetting: "Temperature unit",
     temperatureUnitSettingHelp:
       "Choose whether temperatures are shown in Celsius or Fahrenheit throughout the app.",
+    mountVoltageSettingsHeading: "Battery mount voltages",
+    mountVoltageSettingsHelp:
+      "Adjust the voltages used for current draw calculations across B-Mount, V-Mount and Gold Mount setups.",
+    mountVoltageDescription:
+      "Set the default high and low voltages for each battery mount so the planner matches your hardware.",
+    mountVoltageReset: "Restore defaults",
+    mountVoltageResetHelp: "Reset all mount voltages to their factory defaults.",
+    mountVoltageHighLabel: "High-voltage output",
+    mountVoltageLowLabel: "Low-voltage output",
+    mountVoltageHighHelp:
+      "Used to calculate total current at the battery's main output such as the high-voltage pins.",
+    mountVoltageLowHelp:
+      "Used to calculate total current at auxiliary outputs such as D-Tap ports or B-Mount low-voltage pins.",
+    mountVoltageNote:
+      "These voltages update the totals in the power summary, runtime estimates and pin warnings.",
+    mountVoltageCardLabelV: "V-Mount",
+    mountVoltageCardLabelGold: "Gold Mount",
+    mountVoltageCardLabelB: "B-Mount",
+    totalCurrentHighLabelTemplate: "Total Current (at {voltage}V):",
+    totalCurrentLowLabelTemplate: "Total Current (at {voltage}V):",
+    totalCurrentHighHelpTemplate: "Current draw at the battery's main output ({voltage}V).",
+    totalCurrentLowHelpTemplate: "Current draw at auxiliary outputs ({voltage}V).",
     temperatureUnitCelsius: "Celsius (°C)",
     temperatureUnitFahrenheit: "Fahrenheit (°F)",
     temperatureUnitSymbolCelsius: "°C",
@@ -1838,6 +1860,28 @@ const texts = {
     temperatureUnitSetting: "Unità di temperatura",
     temperatureUnitSettingHelp:
       "Scegli se mostrare le temperature in Celsius o Fahrenheit in tutta l'app.",
+    mountVoltageSettingsHeading: "Tensioni dei battery mount",
+    mountVoltageSettingsHelp:
+      "Regola le tensioni usate nei calcoli della corrente per configurazioni B-Mount, V-Mount e Gold Mount.",
+    mountVoltageDescription:
+      "Imposta le tensioni alta e bassa predefinite per ogni attacco batteria così che il planner rispecchi il tuo hardware.",
+    mountVoltageReset: "Ripristina predefiniti",
+    mountVoltageResetHelp: "Ripristina le tensioni dei mount ai valori di fabbrica.",
+    mountVoltageHighLabel: "Uscita ad alta tensione",
+    mountVoltageLowLabel: "Uscita a bassa tensione",
+    mountVoltageHighHelp:
+      "Usata per calcolare la corrente totale sull'uscita principale della batteria, ad esempio i pin ad alta tensione.",
+    mountVoltageLowHelp:
+      "Usata per calcolare la corrente totale sulle uscite ausiliarie come porte D-Tap o pin B-Mount a bassa tensione.",
+    mountVoltageNote:
+      "Queste tensioni aggiornano i totali nel riepilogo potenza, le stime di autonomia e gli avvisi sui pin.",
+    mountVoltageCardLabelV: "V-Mount",
+    mountVoltageCardLabelGold: "Gold Mount",
+    mountVoltageCardLabelB: "B-Mount",
+    totalCurrentHighLabelTemplate: "Corrente totale (a {voltage}V):",
+    totalCurrentLowLabelTemplate: "Corrente totale (a {voltage}V):",
+    totalCurrentHighHelpTemplate: "Corrente assorbita dall'uscita principale della batteria ({voltage}V).",
+    totalCurrentLowHelpTemplate: "Corrente assorbita dalle uscite ausiliarie ({voltage}V).",
     temperatureUnitCelsius: "Celsius (°C)",
     temperatureUnitFahrenheit: "Fahrenheit (°F)",
     temperatureUnitSymbolCelsius: "°C",
@@ -3123,6 +3167,28 @@ const texts = {
     temperatureUnitSetting: "Unidad de temperatura",
     temperatureUnitSettingHelp:
       "Elige si mostrar las temperaturas en grados Celsius o Fahrenheit en toda la aplicación.",
+    mountVoltageSettingsHeading: "Tensiones de los soportes de batería",
+    mountVoltageSettingsHelp:
+      "Ajusta las tensiones utilizadas en los cálculos de corriente para configuraciones B-Mount, V-Mount y Gold Mount.",
+    mountVoltageDescription:
+      "Define las tensiones alta y baja predeterminadas de cada soporte para que el planificador coincida con tu hardware.",
+    mountVoltageReset: "Restaurar valores predeterminados",
+    mountVoltageResetHelp: "Restablece las tensiones de los soportes a los valores de fábrica.",
+    mountVoltageHighLabel: "Salida de alta tensión",
+    mountVoltageLowLabel: "Salida de baja tensión",
+    mountVoltageHighHelp:
+      "Se utiliza para calcular la corriente total en la salida principal de la batería, como los pines de alta tensión.",
+    mountVoltageLowHelp:
+      "Se utiliza para calcular la corriente total en salidas auxiliares como conectores D-Tap o pines B-Mount de baja tensión.",
+    mountVoltageNote:
+      "Estas tensiones actualizan los totales del resumen de potencia, las estimaciones de autonomía y las alertas de pines.",
+    mountVoltageCardLabelV: "V-Mount",
+    mountVoltageCardLabelGold: "Gold Mount",
+    mountVoltageCardLabelB: "B-Mount",
+    totalCurrentHighLabelTemplate: "Corriente total (a {voltage}V):",
+    totalCurrentLowLabelTemplate: "Corriente total (a {voltage}V):",
+    totalCurrentHighHelpTemplate: "Corriente en la salida principal de la batería ({voltage}V).",
+    totalCurrentLowHelpTemplate: "Corriente en las salidas auxiliares ({voltage}V).",
     temperatureUnitCelsius: "Celsius (°C)",
     temperatureUnitFahrenheit: "Fahrenheit (°F)",
     temperatureUnitSymbolCelsius: "°C",
@@ -4409,6 +4475,28 @@ const texts = {
     temperatureUnitSetting: "Unité de température",
     temperatureUnitSettingHelp:
       "Choisissez d'afficher les températures en Celsius ou en Fahrenheit dans toute l'application.",
+    mountVoltageSettingsHeading: "Tensions des supports de batterie",
+    mountVoltageSettingsHelp:
+      "Ajustez les tensions utilisées pour les calculs de courant avec les configurations B-Mount, V-Mount et Gold Mount.",
+    mountVoltageDescription:
+      "Définissez les tensions haute et basse par défaut pour chaque support afin d'aligner le planificateur sur votre matériel.",
+    mountVoltageReset: "Restaurer les valeurs par défaut",
+    mountVoltageResetHelp: "Rétablit les tensions des supports à leurs valeurs d'usine.",
+    mountVoltageHighLabel: "Sortie haute tension",
+    mountVoltageLowLabel: "Sortie basse tension",
+    mountVoltageHighHelp:
+      "Utilisée pour calculer le courant total sur la sortie principale de la batterie, par exemple les broches haute tension.",
+    mountVoltageLowHelp:
+      "Utilisée pour calculer le courant total sur les sorties auxiliaires comme les ports D-Tap ou les broches B-Mount basse tension.",
+    mountVoltageNote:
+      "Ces tensions mettent à jour les totaux du résumé de puissance, les estimations d'autonomie et les alertes de broches.",
+    mountVoltageCardLabelV: "V-Mount",
+    mountVoltageCardLabelGold: "Gold Mount",
+    mountVoltageCardLabelB: "B-Mount",
+    totalCurrentHighLabelTemplate: "Courant total (à {voltage}V) :",
+    totalCurrentLowLabelTemplate: "Courant total (à {voltage}V) :",
+    totalCurrentHighHelpTemplate: "Courant sur la sortie principale de la batterie ({voltage}V).",
+    totalCurrentLowHelpTemplate: "Courant sur les sorties auxiliaires ({voltage}V).",
     temperatureUnitCelsius: "Celsius (°C)",
     temperatureUnitFahrenheit: "Fahrenheit (°F)",
     temperatureUnitSymbolCelsius: "°C",
@@ -5707,6 +5795,28 @@ const texts = {
     temperatureUnitSetting: "Temperatureinheit",
     temperatureUnitSettingHelp:
       "Wählen Sie, ob Temperaturen in Celsius oder Fahrenheit in der gesamten App angezeigt werden.",
+    mountVoltageSettingsHeading: "Batterie-Mount-Spannungen",
+    mountVoltageSettingsHelp:
+      "Passen Sie die Spannungen an, die für die Stromberechnung bei B-Mount-, V-Mount- und Gold-Mount-Konfigurationen verwendet werden.",
+    mountVoltageDescription:
+      "Legen Sie die Standardwerte für Hoch- und Niederspannung jedes Mounts fest, damit der Planer zu Ihrer Hardware passt.",
+    mountVoltageReset: "Auf Standard zurücksetzen",
+    mountVoltageResetHelp: "Setzt alle Mount-Spannungen auf die Werkseinstellungen zurück.",
+    mountVoltageHighLabel: "Hochspannungs-Ausgang",
+    mountVoltageLowLabel: "Niederspannungs-Ausgang",
+    mountVoltageHighHelp:
+      "Wird für die Berechnung des Gesamtstroms am Hauptausgang der Batterie verwendet, z. B. an den Hochspannungspins.",
+    mountVoltageLowHelp:
+      "Wird für die Berechnung des Gesamtstroms an Nebenanschlüssen wie D-Tap-Buchsen oder B-Mount-Niedervolt-Pins verwendet.",
+    mountVoltageNote:
+      "Diese Spannungen aktualisieren die Summen in der Leistungsübersicht, die Laufzeitabschätzungen und die Pin-Warnungen.",
+    mountVoltageCardLabelV: "V-Mount",
+    mountVoltageCardLabelGold: "Gold Mount",
+    mountVoltageCardLabelB: "B-Mount",
+    totalCurrentHighLabelTemplate: "Gesamtstrom (bei {voltage}V):",
+    totalCurrentLowLabelTemplate: "Gesamtstrom (bei {voltage}V):",
+    totalCurrentHighHelpTemplate: "Stromaufnahme am Hauptausgang der Batterie ({voltage}V).",
+    totalCurrentLowHelpTemplate: "Stromaufnahme an Nebenanschlüssen ({voltage}V).",
     temperatureUnitCelsius: "Celsius (°C)",
     temperatureUnitFahrenheit: "Fahrenheit (°F)",
     temperatureUnitSymbolCelsius: "°C",

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -2211,6 +2211,62 @@ body.high-contrast .settings-tab[aria-selected="true"] {
   font-weight: var(--font-weight-light);
 }
 
+.mount-voltage-settings {
+  margin-top: 8px;
+  padding: 16px;
+  border: 1px solid var(--panel-border);
+  border-radius: var(--border-radius);
+  background: var(--panel-bg);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.mount-voltage-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.mount-voltage-header h4 {
+  margin: 0;
+  font-weight: var(--font-weight-semibold);
+}
+
+.mount-voltage-grid {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.mount-voltage-card {
+  border: 1px solid var(--panel-border);
+  border-radius: var(--border-radius);
+  padding: 12px;
+  background: var(--panel-bg);
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.mount-voltage-card h5 {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: var(--font-weight-semibold);
+}
+
+.mount-voltage-field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.mount-voltage-input {
+  width: 100%;
+}
+
 .settings-panel .button-row {
   justify-content: flex-start;
   flex-wrap: wrap;


### PR DESCRIPTION
## Summary
- expose the mount voltage storage key and backup key globally and persist the user-defined voltages to both copies in the modern and legacy cores
- load mount voltage preferences from the backup copy when the primary entry is unavailable, rehydrating storage so reloads and restores keep the configured values
- include the mount voltage preference key in the raw backup set so exports, imports, and restores protect the configuration

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d84769ac208320876d5f01218d9ce7