### PR TITLE
Remove print circles behind requirement icons

### DIFF
--- a/src/styles/overview-print.css
+++ b/src/styles/overview-print.css
@@ -485,9 +485,6 @@ body.dark-mode #overviewDialogContent .requirement-box {
 
 #overviewDialogContent .requirements-grid .requirement-box .req-icon {
   --req-icon-size: 1.15rem;
-  padding: 0.2em;
-  border-radius: 0.5em;
-  background: var(--panel-bg);
   margin-bottom: 0.15em;
 }
 


### PR DESCRIPTION
## Summary
- remove the print-specific background styling that added circles behind requirement icons

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d850e77e348320a57571dbb46a80da