### PR TITLE
Add configurable logic for auto gear conditions

### DIFF
--- a/index.html
+++ b/index.html
@@ -1346,20 +1346,28 @@
                 >
                   <div class="auto-gear-condition-header">
                     <label for="autoGearMattebox" id="autoGearMatteboxLabel">Mattebox options</label>
-                    <div class="auto-gear-condition-actions">
-                      <button type="button" class="auto-gear-condition-add" data-action="add">Add</button>
-                      <button
-                        type="button"
-                        class="auto-gear-condition-remove"
-                        data-action="remove"
-                        data-condition="mattebox"
-                      >Remove</button>
-                    </div>
+                  <div class="auto-gear-condition-actions">
+                    <button type="button" class="auto-gear-condition-add" data-action="add">Add</button>
+                    <button
+                      type="button"
+                      class="auto-gear-condition-remove"
+                      data-action="remove"
+                      data-condition="mattebox"
+                    >Remove</button>
                   </div>
-                  <select
-                    id="autoGearMattebox"
-                    class="auto-gear-mattebox auto-gear-multiselect"
-                    multiple
+                </div>
+                <div class="auto-gear-condition-mode">
+                  <label for="autoGearMatteboxMode" id="autoGearMatteboxModeLabel">Match behavior</label>
+                  <select id="autoGearMatteboxMode">
+                    <option value="all" selected>Require every selected value</option>
+                    <option value="any">Match any selected value</option>
+                    <option value="multiplier">Multiply by matched values</option>
+                  </select>
+                </div>
+                <select
+                  id="autoGearMattebox"
+                  class="auto-gear-mattebox auto-gear-multiselect"
+                  multiple
                     size="10"
                   ></select>
                 </section>
@@ -1372,20 +1380,28 @@
                 >
                   <div class="auto-gear-condition-header">
                     <label for="autoGearCameraHandle" id="autoGearCameraHandleLabel">Camera handles</label>
-                    <div class="auto-gear-condition-actions">
-                      <button type="button" class="auto-gear-condition-add" data-action="add">Add</button>
-                      <button
-                        type="button"
-                        class="auto-gear-condition-remove"
-                        data-action="remove"
-                        data-condition="cameraHandle"
-                      >Remove</button>
-                    </div>
+                  <div class="auto-gear-condition-actions">
+                    <button type="button" class="auto-gear-condition-add" data-action="add">Add</button>
+                    <button
+                      type="button"
+                      class="auto-gear-condition-remove"
+                      data-action="remove"
+                      data-condition="cameraHandle"
+                    >Remove</button>
                   </div>
-                  <select
-                    id="autoGearCameraHandle"
-                    class="auto-gear-camera-handle auto-gear-multiselect"
-                    multiple
+                </div>
+                <div class="auto-gear-condition-mode">
+                  <label for="autoGearCameraHandleMode" id="autoGearCameraHandleModeLabel">Match behavior</label>
+                  <select id="autoGearCameraHandleMode">
+                    <option value="all" selected>Require every selected value</option>
+                    <option value="any">Match any selected value</option>
+                    <option value="multiplier">Multiply by matched values</option>
+                  </select>
+                </div>
+                <select
+                  id="autoGearCameraHandle"
+                  class="auto-gear-camera-handle auto-gear-multiselect"
+                  multiple
                     size="10"
                   ></select>
                 </section>
@@ -1400,20 +1416,30 @@
                     <label for="autoGearViewfinderExtension" id="autoGearViewfinderExtensionLabel">
                       Viewfinder extension
                     </label>
-                    <div class="auto-gear-condition-actions">
-                      <button type="button" class="auto-gear-condition-add" data-action="add">Add</button>
-                      <button
-                        type="button"
-                        class="auto-gear-condition-remove"
-                        data-action="remove"
-                        data-condition="viewfinderExtension"
-                      >Remove</button>
-                    </div>
+                  <div class="auto-gear-condition-actions">
+                    <button type="button" class="auto-gear-condition-add" data-action="add">Add</button>
+                    <button
+                      type="button"
+                      class="auto-gear-condition-remove"
+                      data-action="remove"
+                      data-condition="viewfinderExtension"
+                    >Remove</button>
                   </div>
-                  <select
-                    id="autoGearViewfinderExtension"
-                    class="auto-gear-viewfinder-extension auto-gear-multiselect"
-                    multiple
+                </div>
+                <div class="auto-gear-condition-mode">
+                  <label for="autoGearViewfinderExtensionMode" id="autoGearViewfinderExtensionModeLabel">
+                    Match behavior
+                  </label>
+                  <select id="autoGearViewfinderExtensionMode">
+                    <option value="all" selected>Require every selected value</option>
+                    <option value="any">Match any selected value</option>
+                    <option value="multiplier">Multiply by matched values</option>
+                  </select>
+                </div>
+                <select
+                  id="autoGearViewfinderExtension"
+                  class="auto-gear-viewfinder-extension auto-gear-multiselect"
+                  multiple
                     size="10"
                   ></select>
                 </section>
@@ -1428,20 +1454,30 @@
                     <label for="autoGearDeliveryResolution" id="autoGearDeliveryResolutionLabel"
                       >Delivery resolution</label
                     >
-                    <div class="auto-gear-condition-actions">
-                      <button type="button" class="auto-gear-condition-add" data-action="add">Add</button>
-                      <button
-                        type="button"
-                        class="auto-gear-condition-remove"
-                        data-action="remove"
-                        data-condition="deliveryResolution"
-                      >Remove</button>
-                    </div>
+                  <div class="auto-gear-condition-actions">
+                    <button type="button" class="auto-gear-condition-add" data-action="add">Add</button>
+                    <button
+                      type="button"
+                      class="auto-gear-condition-remove"
+                      data-action="remove"
+                      data-condition="deliveryResolution"
+                    >Remove</button>
                   </div>
-                  <select
-                    id="autoGearDeliveryResolution"
-                    class="auto-gear-delivery-resolution auto-gear-multiselect"
-                    multiple
+                </div>
+                <div class="auto-gear-condition-mode">
+                  <label for="autoGearDeliveryResolutionMode" id="autoGearDeliveryResolutionModeLabel">
+                    Match behavior
+                  </label>
+                  <select id="autoGearDeliveryResolutionMode">
+                    <option value="all" selected>Require every selected value</option>
+                    <option value="any">Match any selected value</option>
+                    <option value="multiplier">Multiply by matched values</option>
+                  </select>
+                </div>
+                <select
+                  id="autoGearDeliveryResolution"
+                  class="auto-gear-delivery-resolution auto-gear-multiselect"
+                  multiple
                     size="10"
                   ></select>
                 </section>
@@ -1454,19 +1490,27 @@
                 >
                   <div class="auto-gear-condition-header">
                     <label for="autoGearVideoDistribution" id="autoGearVideoDistributionLabel">Video distribution</label>
-                    <div class="auto-gear-condition-actions">
-                      <button type="button" class="auto-gear-condition-add" data-action="add">Add</button>
-                      <button
-                        type="button"
-                        class="auto-gear-condition-remove"
-                        data-action="remove"
-                        data-condition="videoDistribution"
-                      >Remove</button>
-                    </div>
+                  <div class="auto-gear-condition-actions">
+                    <button type="button" class="auto-gear-condition-add" data-action="add">Add</button>
+                    <button
+                      type="button"
+                      class="auto-gear-condition-remove"
+                      data-action="remove"
+                      data-condition="videoDistribution"
+                    >Remove</button>
                   </div>
-                  <select
-                    id="autoGearVideoDistribution"
-                    class="auto-gear-video-distribution auto-gear-multiselect"
+                </div>
+                <div class="auto-gear-condition-mode">
+                  <label for="autoGearVideoDistributionMode" id="autoGearVideoDistributionModeLabel">Match behavior</label>
+                  <select id="autoGearVideoDistributionMode">
+                    <option value="all" selected>Require every selected value</option>
+                    <option value="any">Match any selected value</option>
+                    <option value="multiplier">Multiply by matched values</option>
+                  </select>
+                </div>
+                <select
+                  id="autoGearVideoDistribution"
+                  class="auto-gear-video-distribution auto-gear-multiselect"
                     multiple
                     size="10"
                   ></select>
@@ -1480,20 +1524,28 @@
                 >
                   <div class="auto-gear-condition-header">
                     <label for="autoGearCamera" id="autoGearCameraLabel">Camera</label>
-                    <div class="auto-gear-condition-actions">
-                      <button type="button" class="auto-gear-condition-add" data-action="add">Add</button>
-                      <button
-                        type="button"
-                        class="auto-gear-condition-remove"
-                        data-action="remove"
-                        data-condition="camera"
-                      >Remove</button>
-                    </div>
+                  <div class="auto-gear-condition-actions">
+                    <button type="button" class="auto-gear-condition-add" data-action="add">Add</button>
+                    <button
+                      type="button"
+                      class="auto-gear-condition-remove"
+                      data-action="remove"
+                      data-condition="camera"
+                    >Remove</button>
                   </div>
-                  <select
-                    id="autoGearCamera"
-                    class="auto-gear-camera auto-gear-multiselect auto-gear-device-multiselect"
-                    multiple
+                </div>
+                <div class="auto-gear-condition-mode">
+                  <label for="autoGearCameraMode" id="autoGearCameraModeLabel">Match behavior</label>
+                  <select id="autoGearCameraMode">
+                    <option value="all" selected>Require every selected value</option>
+                    <option value="any">Match any selected value</option>
+                    <option value="multiplier">Multiply by matched values</option>
+                  </select>
+                </div>
+                <select
+                  id="autoGearCamera"
+                  class="auto-gear-camera auto-gear-multiselect auto-gear-device-multiselect"
+                  multiple
                     size="10"
                   ></select>
                 </section>
@@ -1543,19 +1595,27 @@
                 >
                   <div class="auto-gear-condition-header">
                     <label for="autoGearMonitor" id="autoGearMonitorLabel">Onboard monitor</label>
-                    <div class="auto-gear-condition-actions">
-                      <button type="button" class="auto-gear-condition-add" data-action="add">Add</button>
-                      <button
-                        type="button"
-                        class="auto-gear-condition-remove"
-                        data-action="remove"
-                        data-condition="monitor"
-                      >Remove</button>
-                    </div>
+                  <div class="auto-gear-condition-actions">
+                    <button type="button" class="auto-gear-condition-add" data-action="add">Add</button>
+                    <button
+                      type="button"
+                      class="auto-gear-condition-remove"
+                      data-action="remove"
+                      data-condition="monitor"
+                    >Remove</button>
                   </div>
-                  <select
-                    id="autoGearMonitor"
-                    class="auto-gear-monitor auto-gear-multiselect auto-gear-device-multiselect"
+                </div>
+                <div class="auto-gear-condition-mode">
+                  <label for="autoGearMonitorMode" id="autoGearMonitorModeLabel">Match behavior</label>
+                  <select id="autoGearMonitorMode">
+                    <option value="all" selected>Require every selected value</option>
+                    <option value="any">Match any selected value</option>
+                    <option value="multiplier">Multiply by matched values</option>
+                  </select>
+                </div>
+                <select
+                  id="autoGearMonitor"
+                  class="auto-gear-monitor auto-gear-multiselect auto-gear-device-multiselect"
                     multiple
                     size="10"
                   ></select>
@@ -1569,20 +1629,28 @@
                 >
                   <div class="auto-gear-condition-header">
                     <label for="autoGearCrewPresent" id="autoGearCrewPresentLabel">Crew present</label>
-                    <div class="auto-gear-condition-actions">
-                      <button type="button" class="auto-gear-condition-add" data-action="add">Add</button>
-                      <button
-                        type="button"
-                        class="auto-gear-condition-remove"
-                        data-action="remove"
-                        data-condition="crewPresent"
-                      >Remove</button>
-                    </div>
+                  <div class="auto-gear-condition-actions">
+                    <button type="button" class="auto-gear-condition-add" data-action="add">Add</button>
+                    <button
+                      type="button"
+                      class="auto-gear-condition-remove"
+                      data-action="remove"
+                      data-condition="crewPresent"
+                    >Remove</button>
                   </div>
-                  <select
-                    id="autoGearCrewPresent"
-                    class="auto-gear-crew auto-gear-multiselect"
-                    multiple
+                </div>
+                <div class="auto-gear-condition-mode">
+                  <label for="autoGearCrewPresentMode" id="autoGearCrewPresentModeLabel">Match behavior</label>
+                  <select id="autoGearCrewPresentMode">
+                    <option value="all" selected>Require every selected value</option>
+                    <option value="any">Match any selected value</option>
+                    <option value="multiplier">Multiply by matched values</option>
+                  </select>
+                </div>
+                <select
+                  id="autoGearCrewPresent"
+                  class="auto-gear-crew auto-gear-multiselect"
+                  multiple
                     size="10"
                   ></select>
                 </section>
@@ -1595,20 +1663,28 @@
                 >
                   <div class="auto-gear-condition-header">
                     <label for="autoGearCrewAbsent" id="autoGearCrewAbsentLabel">Crew absent</label>
-                    <div class="auto-gear-condition-actions">
-                      <button type="button" class="auto-gear-condition-add" data-action="add">Add</button>
-                      <button
-                        type="button"
-                        class="auto-gear-condition-remove"
-                        data-action="remove"
-                        data-condition="crewAbsent"
-                      >Remove</button>
-                    </div>
+                  <div class="auto-gear-condition-actions">
+                    <button type="button" class="auto-gear-condition-add" data-action="add">Add</button>
+                    <button
+                      type="button"
+                      class="auto-gear-condition-remove"
+                      data-action="remove"
+                      data-condition="crewAbsent"
+                    >Remove</button>
                   </div>
-                  <select
-                    id="autoGearCrewAbsent"
-                    class="auto-gear-crew auto-gear-multiselect"
-                    multiple
+                </div>
+                <div class="auto-gear-condition-mode">
+                  <label for="autoGearCrewAbsentMode" id="autoGearCrewAbsentModeLabel">Match behavior</label>
+                  <select id="autoGearCrewAbsentMode">
+                    <option value="all" selected>Require every selected value</option>
+                    <option value="any">Match any selected value</option>
+                    <option value="multiplier">Multiply by matched values</option>
+                  </select>
+                </div>
+                <select
+                  id="autoGearCrewAbsent"
+                  class="auto-gear-crew auto-gear-multiselect"
+                  multiple
                     size="10"
                   ></select>
                 </section>
@@ -1621,19 +1697,27 @@
                 >
                   <div class="auto-gear-condition-header">
                     <label for="autoGearWireless" id="autoGearWirelessLabel">Wireless transmitter</label>
-                    <div class="auto-gear-condition-actions">
-                      <button type="button" class="auto-gear-condition-add" data-action="add">Add</button>
-                      <button
-                        type="button"
-                        class="auto-gear-condition-remove"
-                        data-action="remove"
-                        data-condition="wireless"
-                      >Remove</button>
-                    </div>
+                  <div class="auto-gear-condition-actions">
+                    <button type="button" class="auto-gear-condition-add" data-action="add">Add</button>
+                    <button
+                      type="button"
+                      class="auto-gear-condition-remove"
+                      data-action="remove"
+                      data-condition="wireless"
+                    >Remove</button>
                   </div>
-                  <select
-                    id="autoGearWireless"
-                    class="auto-gear-wireless auto-gear-multiselect auto-gear-device-multiselect"
+                </div>
+                <div class="auto-gear-condition-mode">
+                  <label for="autoGearWirelessMode" id="autoGearWirelessModeLabel">Match behavior</label>
+                  <select id="autoGearWirelessMode">
+                    <option value="all" selected>Require every selected value</option>
+                    <option value="any">Match any selected value</option>
+                    <option value="multiplier">Multiply by matched values</option>
+                  </select>
+                </div>
+                <select
+                  id="autoGearWireless"
+                  class="auto-gear-wireless auto-gear-multiselect auto-gear-device-multiselect"
                     multiple
                     size="10"
                   ></select>
@@ -1647,19 +1731,27 @@
                 >
                   <div class="auto-gear-condition-header">
                     <label for="autoGearMotors" id="autoGearMotorsLabel">FIZ motors</label>
-                    <div class="auto-gear-condition-actions">
-                      <button type="button" class="auto-gear-condition-add" data-action="add">Add</button>
-                      <button
-                        type="button"
-                        class="auto-gear-condition-remove"
-                        data-action="remove"
-                        data-condition="motors"
-                      >Remove</button>
-                    </div>
+                  <div class="auto-gear-condition-actions">
+                    <button type="button" class="auto-gear-condition-add" data-action="add">Add</button>
+                    <button
+                      type="button"
+                      class="auto-gear-condition-remove"
+                      data-action="remove"
+                      data-condition="motors"
+                    >Remove</button>
                   </div>
-                  <select
-                    id="autoGearMotors"
-                    class="auto-gear-motors auto-gear-multiselect auto-gear-device-multiselect"
+                </div>
+                <div class="auto-gear-condition-mode">
+                  <label for="autoGearMotorsMode" id="autoGearMotorsModeLabel">Match behavior</label>
+                  <select id="autoGearMotorsMode">
+                    <option value="all" selected>Require every selected value</option>
+                    <option value="any">Match any selected value</option>
+                    <option value="multiplier">Multiply by matched values</option>
+                  </select>
+                </div>
+                <select
+                  id="autoGearMotors"
+                  class="auto-gear-motors auto-gear-multiselect auto-gear-device-multiselect"
                     multiple
                     size="10"
                   ></select>
@@ -1673,19 +1765,27 @@
                 >
                   <div class="auto-gear-condition-header">
                     <label for="autoGearControllers" id="autoGearControllersLabel">FIZ controllers</label>
-                    <div class="auto-gear-condition-actions">
-                      <button type="button" class="auto-gear-condition-add" data-action="add">Add</button>
-                      <button
-                        type="button"
-                        class="auto-gear-condition-remove"
-                        data-action="remove"
-                        data-condition="controllers"
-                      >Remove</button>
-                    </div>
+                  <div class="auto-gear-condition-actions">
+                    <button type="button" class="auto-gear-condition-add" data-action="add">Add</button>
+                    <button
+                      type="button"
+                      class="auto-gear-condition-remove"
+                      data-action="remove"
+                      data-condition="controllers"
+                    >Remove</button>
                   </div>
-                  <select
-                    id="autoGearControllers"
-                    class="auto-gear-controllers auto-gear-multiselect auto-gear-device-multiselect"
+                </div>
+                <div class="auto-gear-condition-mode">
+                  <label for="autoGearControllersMode" id="autoGearControllersModeLabel">Match behavior</label>
+                  <select id="autoGearControllersMode">
+                    <option value="all" selected>Require every selected value</option>
+                    <option value="any">Match any selected value</option>
+                    <option value="multiplier">Multiply by matched values</option>
+                  </select>
+                </div>
+                <select
+                  id="autoGearControllers"
+                  class="auto-gear-controllers auto-gear-multiselect auto-gear-device-multiselect"
                     multiple
                     size="10"
                   ></select>
@@ -1699,20 +1799,28 @@
                 >
                   <div class="auto-gear-condition-header">
                     <label for="autoGearDistance" id="autoGearDistanceLabel">FIZ distance devices</label>
-                    <div class="auto-gear-condition-actions">
-                      <button type="button" class="auto-gear-condition-add" data-action="add">Add</button>
-                      <button
-                        type="button"
-                        class="auto-gear-condition-remove"
-                        data-action="remove"
-                        data-condition="distance"
-                      >Remove</button>
-                    </div>
+                  <div class="auto-gear-condition-actions">
+                    <button type="button" class="auto-gear-condition-add" data-action="add">Add</button>
+                    <button
+                      type="button"
+                      class="auto-gear-condition-remove"
+                      data-action="remove"
+                      data-condition="distance"
+                    >Remove</button>
                   </div>
-                  <select
-                    id="autoGearDistance"
-                    class="auto-gear-distance auto-gear-multiselect"
-                    multiple
+                </div>
+                <div class="auto-gear-condition-mode">
+                  <label for="autoGearDistanceMode" id="autoGearDistanceModeLabel">Match behavior</label>
+                  <select id="autoGearDistanceMode">
+                    <option value="all" selected>Require every selected value</option>
+                    <option value="any">Match any selected value</option>
+                    <option value="multiplier">Multiply by matched values</option>
+                  </select>
+                </div>
+                <select
+                  id="autoGearDistance"
+                  class="auto-gear-distance auto-gear-multiselect"
+                  multiple
                     size="10"
                   ></select>
                 </section>

--- a/src/scripts/app-core-new-2.js
+++ b/src/scripts/app-core-new-2.js
@@ -3597,6 +3597,62 @@ function saveAutoGearRuleFromEditor() {
         .map(option => option.value)
         .filter(value => typeof value === 'string' && value.trim())
     : [];
+  const draftConditionLogic = {};
+  if (scenarioMode !== 'all') {
+    draftConditionLogic.scenarios = scenarioMode;
+  }
+  const matteboxLogic = autoGearMatteboxModeSelect
+    ? normalizeAutoGearConditionLogic(autoGearMatteboxModeSelect.value)
+    : 'all';
+  const cameraHandleLogic = autoGearCameraHandleModeSelect
+    ? normalizeAutoGearConditionLogic(autoGearCameraHandleModeSelect.value)
+    : 'all';
+  const viewfinderLogic = autoGearViewfinderExtensionModeSelect
+    ? normalizeAutoGearConditionLogic(autoGearViewfinderExtensionModeSelect.value)
+    : 'all';
+  const deliveryLogic = autoGearDeliveryResolutionModeSelect
+    ? normalizeAutoGearConditionLogic(autoGearDeliveryResolutionModeSelect.value)
+    : 'all';
+  const videoDistributionLogic = autoGearVideoDistributionModeSelect
+    ? normalizeAutoGearConditionLogic(autoGearVideoDistributionModeSelect.value)
+    : 'all';
+  const cameraLogic = autoGearCameraModeSelect
+    ? normalizeAutoGearConditionLogic(autoGearCameraModeSelect.value)
+    : 'all';
+  const monitorLogic = autoGearMonitorModeSelect
+    ? normalizeAutoGearConditionLogic(autoGearMonitorModeSelect.value)
+    : 'all';
+  const crewPresentLogic = autoGearCrewPresentModeSelect
+    ? normalizeAutoGearConditionLogic(autoGearCrewPresentModeSelect.value)
+    : 'all';
+  const crewAbsentLogic = autoGearCrewAbsentModeSelect
+    ? normalizeAutoGearConditionLogic(autoGearCrewAbsentModeSelect.value)
+    : 'all';
+  const wirelessLogic = autoGearWirelessModeSelect
+    ? normalizeAutoGearConditionLogic(autoGearWirelessModeSelect.value)
+    : 'all';
+  const motorsLogic = autoGearMotorsModeSelect
+    ? normalizeAutoGearConditionLogic(autoGearMotorsModeSelect.value)
+    : 'all';
+  const controllersLogic = autoGearControllersModeSelect
+    ? normalizeAutoGearConditionLogic(autoGearControllersModeSelect.value)
+    : 'all';
+  const distanceLogic = autoGearDistanceModeSelect
+    ? normalizeAutoGearConditionLogic(autoGearDistanceModeSelect.value)
+    : 'all';
+  if (matteboxLogic !== 'all') draftConditionLogic.mattebox = matteboxLogic;
+  if (cameraHandleLogic !== 'all') draftConditionLogic.cameraHandle = cameraHandleLogic;
+  if (viewfinderLogic !== 'all') draftConditionLogic.viewfinderExtension = viewfinderLogic;
+  if (deliveryLogic !== 'all') draftConditionLogic.deliveryResolution = deliveryLogic;
+  if (videoDistributionLogic !== 'all') draftConditionLogic.videoDistribution = videoDistributionLogic;
+  if (cameraLogic !== 'all') draftConditionLogic.camera = cameraLogic;
+  if (monitorLogic !== 'all') draftConditionLogic.monitor = monitorLogic;
+  if (crewPresentLogic !== 'all') draftConditionLogic.crewPresent = crewPresentLogic;
+  if (crewAbsentLogic !== 'all') draftConditionLogic.crewAbsent = crewAbsentLogic;
+  if (wirelessLogic !== 'all') draftConditionLogic.wireless = wirelessLogic;
+  if (motorsLogic !== 'all') draftConditionLogic.motors = motorsLogic;
+  if (controllersLogic !== 'all') draftConditionLogic.controllers = controllersLogic;
+  if (distanceLogic !== 'all') draftConditionLogic.distance = distanceLogic;
   const shootingDaysRequirement = (() => {
     if (!isAutoGearConditionActive('shootingDays')) return null;
     if (!autoGearShootingDaysInput) return null;
@@ -3671,6 +3727,20 @@ function saveAutoGearRuleFromEditor() {
   autoGearEditorDraft.motors = motorSelections;
   autoGearEditorDraft.controllers = controllerSelections;
   autoGearEditorDraft.distance = distanceSelections;
+  autoGearEditorDraft.matteboxLogic = matteboxLogic;
+  autoGearEditorDraft.cameraHandleLogic = cameraHandleLogic;
+  autoGearEditorDraft.viewfinderExtensionLogic = viewfinderLogic;
+  autoGearEditorDraft.deliveryResolutionLogic = deliveryLogic;
+  autoGearEditorDraft.videoDistributionLogic = videoDistributionLogic;
+  autoGearEditorDraft.cameraLogic = cameraLogic;
+  autoGearEditorDraft.monitorLogic = monitorLogic;
+  autoGearEditorDraft.crewPresentLogic = crewPresentLogic;
+  autoGearEditorDraft.crewAbsentLogic = crewAbsentLogic;
+  autoGearEditorDraft.wirelessLogic = wirelessLogic;
+  autoGearEditorDraft.motorsLogic = motorsLogic;
+  autoGearEditorDraft.controllersLogic = controllersLogic;
+  autoGearEditorDraft.distanceLogic = distanceLogic;
+  autoGearEditorDraft.conditionLogic = draftConditionLogic;
   autoGearEditorDraft.shootingDays = shootingDaysRequirement;
   if (!autoGearEditorDraft.add.length && !autoGearEditorDraft.remove.length) {
     const message = texts[currentLang]?.autoGearRuleNeedsItems

--- a/src/scripts/translations.js
+++ b/src/scripts/translations.js
@@ -250,6 +250,11 @@ const texts = {
     autoGearConditionPlaceholder: "Choose a condition",
     autoGearConditionAddShortcut: "Add another condition",
     autoGearConditionRemove: "Remove this condition",
+    autoGearConditionLogicLabel: "Match behavior",
+    autoGearConditionLogicHelp: "Choose how the selected values interact before the rule activates.",
+    autoGearConditionLogicAll: "Require every selected value",
+    autoGearConditionLogicAny: "Match any selected value",
+    autoGearConditionLogicMultiplier: "Multiply by matched values",
     autoGearConditionRepeatHint:
       "Condition already added. Existing inputs for {condition} are highlighted so you can add more selections.",
     autoGearAlwaysLabel: "Always include",
@@ -1952,6 +1957,12 @@ const texts = {
     autoGearConditionPlaceholder: "Scegli una condizione",
     autoGearConditionAddShortcut: "Aggiungi un'altra condizione",
     autoGearConditionRemove: "Rimuovi questa condizione",
+    autoGearConditionLogicLabel: "Comportamento di corrispondenza",
+    autoGearConditionLogicHelp:
+      "Scegli come interagiscono i valori selezionati prima di attivare la regola.",
+    autoGearConditionLogicAll: "Richiedi tutti i valori selezionati",
+    autoGearConditionLogicAny: "Abbina qualsiasi valore selezionato",
+    autoGearConditionLogicMultiplier: "Moltiplica in base ai valori corrispondenti",
     autoGearConditionRepeatHint:
       "Condizione già aggiunta. I campi esistenti per {condition} vengono evidenziati per permetterti di aggiungere altre selezioni.",
     autoGearAlwaysLabel: "Includi sempre",
@@ -3237,6 +3248,12 @@ const texts = {
     autoGearConditionPlaceholder: "Elige una condición",
     autoGearConditionAddShortcut: "Añadir otra condición",
     autoGearConditionRemove: "Eliminar esta condición",
+    autoGearConditionLogicLabel: "Comportamiento de coincidencia",
+    autoGearConditionLogicHelp:
+      "Elige cómo interactúan los valores seleccionados antes de que se active la regla.",
+    autoGearConditionLogicAll: "Requerir todos los valores seleccionados",
+    autoGearConditionLogicAny: "Coincidir con cualquier valor seleccionado",
+    autoGearConditionLogicMultiplier: "Multiplicar por los valores coincidentes",
     autoGearConditionRepeatHint:
       "Condición ya añadida. Resaltamos los campos existentes de {condition} para que puedas añadir más selecciones.",
     autoGearAlwaysLabel: "Incluir siempre",
@@ -4524,6 +4541,12 @@ const texts = {
     autoGearConditionPlaceholder: "Choisissez une condition",
     autoGearConditionAddShortcut: "Ajouter une autre condition",
     autoGearConditionRemove: "Supprimer cette condition",
+    autoGearConditionLogicLabel: "Comportement de correspondance",
+    autoGearConditionLogicHelp:
+      "Choisissez comment les valeurs sélectionnées interagissent avant l’activation de la règle.",
+    autoGearConditionLogicAll: "Exiger toutes les valeurs sélectionnées",
+    autoGearConditionLogicAny: "Correspondre à n’importe quelle valeur sélectionnée",
+    autoGearConditionLogicMultiplier: "Multiplier selon les valeurs correspondantes",
     autoGearConditionRepeatHint:
       "Condition déjà ajoutée. Les champs existants pour {condition} sont mis en évidence pour vous permettre d'ajouter d'autres sélections.",
     autoGearAlwaysLabel: "Toujours inclure",
@@ -5822,6 +5845,12 @@ const texts = {
     autoGearConditionPlaceholder: "Wähle eine Bedingung",
     autoGearConditionAddShortcut: "Weitere Bedingung hinzufügen",
     autoGearConditionRemove: "Diese Bedingung entfernen",
+    autoGearConditionLogicLabel: "Abgleichsverhalten",
+    autoGearConditionLogicHelp:
+      "Legt fest, wie die ausgewählten Werte zusammenwirken, bevor die Regel aktiv wird.",
+    autoGearConditionLogicAll: "Alle ausgewählten Werte erforderlich",
+    autoGearConditionLogicAny: "Beliebiger ausgewählter Wert genügt",
+    autoGearConditionLogicMultiplier: "Mit passenden Werten multiplizieren",
     autoGearConditionRepeatHint:
       "Bedingung bereits hinzugefügt. Die vorhandenen Eingaben für {condition} sind markiert, damit du weitere Auswahlmöglichkeiten setzen kannst.",
     autoGearAlwaysLabel: "Immer einschließen",


### PR DESCRIPTION
## Summary
- add match behavior selectors to each list-driven auto gear condition in the editor UI
- persist the selected logic through normalization, saving, and evaluation while fixing initialization order issues
- finish German translations for the new condition-logic copy

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d84ee7d46083208191ab65ddc2bca7