### PR TITLE
Surface factory auto gear rule templates in settings

### DIFF
--- a/docs/auto-gear-rule-options.md
+++ b/docs/auto-gear-rule-options.md
@@ -1,0 +1,94 @@
+# Automatic Gear Rule Options Overview
+
+This document summarises how the existing automatic gear additions are currently generated and
+presents equivalent automatic gear rule options that can replace the implicit logic. Use these
+rule ideas when migrating projects away from the legacy "automatic additions" behaviour so the
+planner remains predictable, offline-ready and data-safe. The Automatic Gear Rules settings panel
+now ships with a **Factory rule templates** section that surfaces the same guidance in-app for
+offline reference.
+
+## How the current automatic additions work
+
+1. **Scenario diffs per requirement** – The planner renders a baseline gear table without extra
+   scenarios and compares it with tables generated for each selected scenario. The delta becomes
+   a rule scoped to that scenario (including removal entries), so every scenario-specific auto
+   addition can be recreated as an explicit rule.【F:src/scripts/app-core-new-1.js†L3371-L3402】
+2. **Scenario combinations and overlaps** – Known pairs such as `Handheld + Easyrig` and
+   `Slider + Undersling mode` receive additional rules after subtracting the individual scenario
+   contributions. An extra overlap rule removes duplicate rain gear when both "Extreme rain" and
+   "Rain Machine" are active.【F:src/scripts/app-core-new-1.js†L3404-L3451】
+3. **Equipment option triggers** – Camera handles, viewfinder extensions and video distribution
+   choices each produce rules by toggling a single option on/off against the baseline table. The
+   generated rule stores the calculated additions and removals for that option.【F:src/scripts/app-core-new-1.js†L2701-L2837】
+4. **Default coverage rules** – Additional helper rules are appended for default video
+   distribution options, onboard monitor rigging, any-motor support kits, always-needed gear,
+   five-day consumables top-ups and matte box templates.【F:src/scripts/app-core-new-1.js†L2840-L3502】
+5. **Gear table parsing** – All comparisons rely on parsing the rendered gear table into category
+   maps and diffing them. This ensures quantities remain accurate when converting legacy
+   behaviour into explicit rules.【F:src/scripts/app-core-new-1.js†L2508-L2559】
+
+## Replacement automatic rule options
+
+The following rules replicate the behaviour of the automatic additions and can be stored as
+explicit automatic gear rules.
+
+### Scenario-specific catalogue
+
+* Create one rule per scenario using the diffed additions/removals for that scenario.
+* Provide extra combo rules for `Handheld + Easyrig` and `Slider + Undersling mode` that subtract
+  overlap from their individual scenario rules.
+* Add a removal-only rule titled "Extreme rain + Rain Machine overlap" to prevent duplicate
+  matte box rain accessories when both scenarios apply.【F:src/scripts/app-core-new-1.js†L3404-L3451】
+
+### Camera handle variations
+
+* Generate a rule for each camera-handle option, triggered by the handle name and containing the
+  diffed additions/removals compared with the baseline configuration.【F:src/scripts/app-core-new-1.js†L2701-L2770】
+
+### Viewfinder extension coverage
+
+* For every selected viewfinder extension, add a rule whose trigger is the extension name and
+  whose payload equals the diff versus removing that extension.【F:src/scripts/app-core-new-1.js†L2772-L2814】
+
+### Video distribution presets
+
+* Build rules per distribution option so toggling an option recreates its additions/removals. This
+  includes a fallback rule that seeds iOS monitoring gear (iPad, chargers, Wi-Fi router and any
+  configured iOS devices) when the `iOS Video` option exists but produced no diff during parsing.
+  【F:src/scripts/app-core-new-1.js†L2816-L3019】
+
+### Onboard monitor rigging
+
+* Add a rule for each onboard monitor option that injects one "ULCS Arm mit 3/8\" und 1/4\"
+  double" rigging arm with contextual notes referencing the monitor.【F:src/scripts/app-core-new-1.js†L2840-L2888】
+
+### FIZ motor support kit
+
+* Provide a rule named "FIZ motor support kit" that triggers whenever any motor is present and
+  adds the support stands, adapters, cabling and batteries listed in the current implementation.
+  【F:src/scripts/app-core-new-1.js†L3080-L3138】
+
+### Always-on essentials
+
+* Introduce an "Always" rule flagged with `always: true` that contributes the standard cable
+  lengths, rigging hardware, transport aids and power distribution set used today.【F:src/scripts/app-core-new-1.js†L3141-L3207】
+
+### Five-day consumables rotation
+
+* Add a recurring rule named "Every 5 shooting days" with a cadence of five days to top up wipes,
+  tapes, clapper sticks and other expendables as per the existing logic.【F:src/scripts/app-core-new-1.js†L3210-L3261】
+
+### Matte box templates
+
+* Ship three matte box rules (`Swing Away`, `Rod based`, `Clamp On`) that preload the relevant
+  ARRI LMB kits and accessories so planners can pick the correct template instead of relying on
+  silent additions.【F:src/scripts/app-core-new-1.js†L3022-L3077】
+
+## Migration checklist
+
+* Ensure rule generation continues to parse the gear table HTML before diffing so quantity math
+  stays correct.【F:src/scripts/app-core-new-1.js†L2508-L2559】
+* Preserve the logic that deduplicates appended helper rules to avoid duplicated presets when
+  saving or sharing projects.【F:src/scripts/app-core-new-1.js†L3456-L3502】
+* When exporting or backing up, store these rules using the existing automatic gear backup and
+  preset infrastructure so user data remains safe and offline-capable.

--- a/index.html
+++ b/index.html
@@ -1071,6 +1071,16 @@
         <h3 id="autoGearHeading">Automatic Gear Rules</h3>
         <p id="autoGearDescription" class="settings-hint"></p>
         <section
+          id="autoGearRuleOptions"
+          class="auto-gear-rule-options"
+          aria-labelledby="autoGearRuleOptionsHeading"
+          hidden
+        >
+          <h4 id="autoGearRuleOptionsHeading">Factory rule templates</h4>
+          <p id="autoGearRuleOptionsIntro" class="settings-hint"></p>
+          <ul id="autoGearRuleOptionsList" class="auto-gear-rule-options-list"></ul>
+        </section>
+        <section
           id="autoGearMonitorDefaultsSection"
           class="auto-gear-defaults"
           aria-labelledby="autoGearMonitorDefaultsHeading"

--- a/src/scripts/app-core-new-1.js
+++ b/src/scripts/app-core-new-1.js
@@ -5539,6 +5539,10 @@ function resolveLanguagePreference(candidate) {
 
 const autoGearHeadingElem = document.getElementById('autoGearHeading');
 const autoGearDescriptionElem = document.getElementById('autoGearDescription');
+const autoGearRuleOptionsSection = document.getElementById('autoGearRuleOptions');
+const autoGearRuleOptionsHeading = document.getElementById('autoGearRuleOptionsHeading');
+const autoGearRuleOptionsIntro = document.getElementById('autoGearRuleOptionsIntro');
+const autoGearRuleOptionsList = document.getElementById('autoGearRuleOptionsList');
 const autoGearMonitorDefaultsSection = document.getElementById('autoGearMonitorDefaultsSection');
 const autoGearMonitorDefaultsHeading = document.getElementById('autoGearMonitorDefaultsHeading');
 const autoGearMonitorDefaultsDescription = document.getElementById('autoGearMonitorDefaultsDescription');
@@ -5578,6 +5582,90 @@ autoGearMonitorDefaultControls.forEach(control => {
     setAutoGearMonitorDefault(control.key, event.target.value);
   });
 });
+
+function renderAutoGearRuleOptionsContent(lang) {
+  if (!autoGearRuleOptionsSection || !autoGearRuleOptionsList) {
+    return;
+  }
+
+  const fallbackBundle = texts.en && texts.en.autoGearRuleOptions
+    ? texts.en.autoGearRuleOptions
+    : null;
+  const langBundle = texts[lang] && texts[lang].autoGearRuleOptions
+    ? texts[lang].autoGearRuleOptions
+    : null;
+
+  const bundle = langBundle || fallbackBundle;
+  const groups = Array.isArray(bundle?.groups) && bundle.groups.length
+    ? bundle.groups
+    : Array.isArray(fallbackBundle?.groups) && fallbackBundle.groups.length
+      ? fallbackBundle.groups
+      : [];
+
+  const headingText = bundle?.heading || fallbackBundle?.heading || '';
+  if (autoGearRuleOptionsHeading) {
+    autoGearRuleOptionsHeading.textContent = headingText;
+    if (headingText) {
+      autoGearRuleOptionsHeading.setAttribute('data-help', headingText);
+    } else {
+      autoGearRuleOptionsHeading.removeAttribute('data-help');
+    }
+  }
+
+  const introText = bundle?.intro || fallbackBundle?.intro || '';
+  if (autoGearRuleOptionsIntro) {
+    autoGearRuleOptionsIntro.textContent = introText;
+    autoGearRuleOptionsIntro.hidden = !introText;
+  }
+
+  autoGearRuleOptionsList.innerHTML = '';
+
+  groups.forEach(group => {
+    if (!group || typeof group !== 'object') return;
+    const title = typeof group.title === 'string' ? group.title.trim() : '';
+    const summary = typeof group.summary === 'string' ? group.summary.trim() : '';
+    const details = Array.isArray(group.details)
+      ? group.details
+          .map(detail => (typeof detail === 'string' ? detail.trim() : ''))
+          .filter(Boolean)
+      : [];
+
+    if (!title && !summary && !details.length) return;
+
+    const item = document.createElement('li');
+    item.className = 'auto-gear-rule-options-item';
+
+    if (title) {
+      const titleElem = document.createElement('strong');
+      titleElem.className = 'auto-gear-rule-option-title';
+      titleElem.textContent = title;
+      item.appendChild(titleElem);
+    }
+
+    if (summary) {
+      const summaryElem = document.createElement('p');
+      summaryElem.className = 'auto-gear-rule-option-summary settings-hint';
+      summaryElem.textContent = summary;
+      item.appendChild(summaryElem);
+    }
+
+    if (details.length) {
+      const detailsList = document.createElement('ul');
+      detailsList.className = 'auto-gear-rule-option-details';
+      details.forEach(detailText => {
+        const detailItem = document.createElement('li');
+        detailItem.textContent = detailText;
+        detailsList.appendChild(detailItem);
+      });
+      item.appendChild(detailsList);
+    }
+
+    autoGearRuleOptionsList.appendChild(item);
+  });
+
+  const hasItems = autoGearRuleOptionsList.children.length > 0;
+  autoGearRuleOptionsSection.hidden = !hasItems;
+}
 const autoGearSearchInput = document.getElementById('autoGearSearch');
 const autoGearSearchLabel = document.getElementById('autoGearSearchLabel');
 const autoGearFilterScenarioLabel = document.getElementById('autoGearFilterScenarioLabel');
@@ -6761,6 +6849,7 @@ function setLanguage(lang) {
   if (autoGearDescriptionElem) {
     autoGearDescriptionElem.textContent = texts[lang].autoGearDescription || texts.en?.autoGearDescription || '';
   }
+  renderAutoGearRuleOptionsContent(lang);
   if (autoGearMonitorDefaultsHeading) {
     const heading = texts[lang].autoGearMonitorDefaultsHeading
       || texts.en?.autoGearMonitorDefaultsHeading

--- a/src/scripts/translations.js
+++ b/src/scripts/translations.js
@@ -173,6 +173,87 @@ const texts = {
       "Adjust which Project Requirements scenarios automatically add or remove gear items.",
     autoGearDescription:
       "Create scenario-based rules that tweak the generated gear list. Rules apply after the default planner suggestions.",
+    autoGearRuleOptions: {
+      heading: "Factory rule templates",
+      intro:
+        "Use these ready-made rule ideas to replace the legacy automatic additions without losing coverage.",
+      groups: [
+        {
+          title: "Scenario-specific catalogue",
+          summary:
+            "Diff each required scenario against the baseline gear list to turn its additions and removals into a dedicated rule.",
+          details: [
+            "Add combo rules for Handheld + Easyrig and Slider + Undersling mode so their shared gear is only counted once.",
+            "Include a removal-only overlap for Extreme rain + Rain Machine to keep matte box rain accessories unique.",
+          ],
+        },
+        {
+          title: "Camera handle variations",
+          summary:
+            "Trigger rules by camera-handle selection so switching handles adds or removes the correct support brackets.",
+          details: [
+            "Compare each handle option against the baseline to capture the accessories it adds.",
+            "Reuse the same diff when a handle is deselected so its dedicated parts are removed.",
+          ],
+        },
+        {
+          title: "Viewfinder extension coverage",
+          summary:
+            "Create rules for every viewfinder extension so each selection brings its cabling and mounting hardware.",
+          details: [
+            "Diff the gear list with and without each extension to capture the matching additions and removals.",
+          ],
+        },
+        {
+          title: "Video distribution presets",
+          summary:
+            "Mirror the video distribution selector with per-option rules that reproduce the diffed add and remove lists.",
+          details: [
+            "Record payloads for Teradek, QTAKE or similar options directly from the rendered gear list diff.",
+            "Provide a fallback that seeds iOS monitoring gear when an option exists but rendered no diff.",
+          ],
+        },
+        {
+          title: "Onboard monitor rigging",
+          summary:
+            "Guarantee each onboard monitor adds its ULCS arm and rigging notes whenever the monitor is selected.",
+          details: [
+            "Generate a rule per monitor option so the correct arm and notes appear automatically.",
+          ],
+        },
+        {
+          title: "FIZ motor support kit",
+          summary:
+            "When any motor is present, pull in the stands, adapters, cabling and power needed to support it.",
+          details: [
+            "Key the rule to the special \"Any motor selected\" trigger so it fires for every motor combination.",
+          ],
+        },
+        {
+          title: "Always-on essentials",
+          summary:
+            "Keep standard cables, rigging aids and transport helpers active in every project.",
+          details: [
+            "Mark the rule as always active so the essentials stay in place even with no scenarios selected.",
+          ],
+        },
+        {
+          title: "Five-day consumables rotation",
+          summary: "Top up expendables on a five-day cadence to keep wipes, tape and sticks stocked.",
+          details: [
+            "Schedule the rule for every five shooting days so consumables automatically refresh during long shoots.",
+          ],
+        },
+        {
+          title: "Matte box templates",
+          summary:
+            "Offer ready-made templates for Swing Away, Rod based and Clamp On matte boxes.",
+          details: [
+            "Preload each template with the matching ARRI LMB kits and accessories so planners can pick the right build quickly.",
+          ],
+        },
+      ],
+    },
     autoGearPresetDescription:
       "Save and reuse complete sets of automatic gear rules.",
     autoGearPresetLabel: "Preset",
@@ -1875,6 +1956,88 @@ const texts = {
       "Decidi quali scenari del modulo aggiungono o rimuovono automaticamente elementi dalla lista.",
     autoGearDescription:
       "Crea regole basate sugli scenari per rifinire la lista generata dopo i suggerimenti predefiniti.",
+    autoGearRuleOptions: {
+      heading: "Modelli di regole predefinite",
+      intro:
+        "Usa queste idee già pronte per sostituire le vecchie aggiunte automatiche senza perdere copertura.",
+      groups: [
+        {
+          title: "Catalogo specifico per scenario",
+          summary:
+            "Confronta ogni scenario richiesto con la lista di base per trasformare aggiunte e rimozioni in una regola dedicata.",
+          details: [
+            "Aggiungi regole combinate per Handheld + Easyrig e Slider + Modalità underslung così l'attrezzatura condivisa viene conteggiata una sola volta.",
+            "Includi una regola solo rimozioni per Extreme rain + Rain Machine per mantenere unici gli accessori antipioggia del matte box.",
+          ],
+        },
+        {
+          title: "Varianti di maniglia camera",
+          summary:
+            "Attiva le regole in base alla maniglia scelta così il cambio di maniglia aggiunge o rimuove i supporti corretti.",
+          details: [
+            "Confronta ogni opzione di maniglia con la configurazione base per catturare gli accessori che aggiunge.",
+            "Riutilizza lo stesso diff quando una maniglia viene rimossa così i suoi componenti dedicati vengono eliminati.",
+          ],
+        },
+        {
+          title: "Copertura delle estensioni viewfinder",
+          summary:
+            "Crea regole per ogni estensione del mirino così ogni scelta porta con sé cablaggi e staffe.",
+          details: [
+            "Confronta la lista con e senza ciascuna estensione per raccogliere le rispettive aggiunte e rimozioni.",
+          ],
+        },
+        {
+          title: "Preset di distribuzione video",
+          summary:
+            "Rispecchia il selettore di distribuzione video con regole per opzione che riproducono gli elenchi di aggiunte e rimozioni.",
+          details: [
+            "Registra i payload per opzioni come Teradek o QTAKE direttamente dal diff della lista generata.",
+            "Prevedi un fallback che carica il kit di monitoraggio iOS quando un'opzione esiste ma non genera differenze.",
+          ],
+        },
+        {
+          title: "Rigging monitor onboard",
+          summary:
+            "Garantisci che ogni monitor onboard aggiunga il braccio ULCS e le note di rigging quando è selezionato.",
+          details: [
+            "Genera una regola per ogni monitor in modo che il braccio corretto e le note compaiano automaticamente.",
+          ],
+        },
+        {
+          title: "Kit supporto motori FIZ",
+          summary:
+            "Quando è presente un motore, aggiungi cavalletti, adattatori, cablaggi e alimentazione necessari.",
+          details: [
+            "Collega la regola al trigger speciale \"Qualsiasi motore\" così si attiva con ogni combinazione di motori.",
+          ],
+        },
+        {
+          title: "Essenziali sempre attivi",
+          summary:
+            "Mantieni cavi standard, accessori di rigging e supporti al trasporto in ogni progetto.",
+          details: [
+            "Segna la regola come sempre attiva così gli elementi essenziali restano anche senza scenari selezionati.",
+          ],
+        },
+        {
+          title: "Rotazione consumabili ogni cinque giorni",
+          summary:
+            "Rifornisci i consumabili con una cadenza di cinque giorni per avere salviette, nastro e ciak sempre pronti.",
+          details: [
+            "Programma la regola ogni cinque giorni di riprese così i consumabili si aggiornano automaticamente durante i set lunghi.",
+          ],
+        },
+        {
+          title: "Template per matte box",
+          summary:
+            "Offri template pronti per matte box Swing Away, su barre e clamp-on.",
+          details: [
+            "Precarica ogni template con i kit ARRI LMB e gli accessori corrispondenti per scegliere rapidamente l'allestimento giusto.",
+          ],
+        },
+      ],
+    },
     autoGearPresetDescription:
       "Salva e riutilizza insiemi completi di regole automatiche.",
     autoGearPresetLabel: "Preimpostazione",
@@ -3161,6 +3324,88 @@ const texts = {
       "Configura qué escenarios de requisitos agregan o quitan equipo automáticamente.",
     autoGearDescription:
       "Crea reglas basadas en escenarios para ajustar la lista generada después de las sugerencias predeterminadas.",
+    autoGearRuleOptions: {
+      heading: "Plantillas de reglas predefinidas",
+      intro:
+        "Utiliza estas ideas listas para sustituir las antiguas adiciones automáticas sin perder cobertura.",
+      groups: [
+        {
+          title: "Catálogo específico por escenario",
+          summary:
+            "Compara cada escenario requerido con la lista base para convertir sus altas y bajas en una regla dedicada.",
+          details: [
+            "Añade reglas combinadas para Handheld + Easyrig y Slider + modo underslung para contar el equipo compartido solo una vez.",
+            "Incluye una regla solo de retiradas para Extreme rain + Rain Machine y así mantener únicos los accesorios de lluvia del matte box.",
+          ],
+        },
+        {
+          title: "Variaciones de empuñadura de cámara",
+          summary:
+            "Activa las reglas según la empuñadura elegida para que cambiarla añada o quite los soportes correctos.",
+          details: [
+            "Compara cada opción de empuñadura con la configuración base para capturar los accesorios que incorpora.",
+            "Reutiliza el mismo diff cuando se retira una empuñadura para eliminar sus piezas dedicadas.",
+          ],
+        },
+        {
+          title: "Cobertura de extensiones de visor",
+          summary:
+            "Crea reglas para cada extensión del visor y así cada elección lleve su cableado y herrajes.",
+          details: [
+            "Compara la lista con y sin cada extensión para recoger las altas y bajas correspondientes.",
+          ],
+        },
+        {
+          title: "Preajustes de distribución de vídeo",
+          summary:
+            "Refleja el selector de distribución de vídeo con reglas por opción que reproduzcan las listas de altas y bajas.",
+          details: [
+            "Registra las cargas de opciones como Teradek o QTAKE directamente del diff de la lista generada.",
+            "Añade un respaldo que cargue el kit de monitorización iOS cuando existe la opción pero no genera diferencias.",
+          ],
+        },
+        {
+          title: "Rigging de monitor onboard",
+          summary:
+            "Garantiza que cada monitor onboard añada su brazo ULCS y notas de rigging cuando se seleccione.",
+          details: [
+            "Genera una regla por monitor para insertar automáticamente el brazo correcto y las notas.",
+          ],
+        },
+        {
+          title: "Kit de soporte para motores FIZ",
+          summary:
+            "Cuando haya un motor, suma los trípodes, adaptadores, cables y energía necesarios.",
+          details: [
+            "Vincula la regla al disparador especial \"Cualquier motor\" para que se active con cualquier combinación.",
+          ],
+        },
+        {
+          title: "Elementos esenciales siempre activos",
+          summary:
+            "Mantén cables estándar, ayudas de rigging y soportes de transporte en cada proyecto.",
+          details: [
+            "Marca la regla como siempre activa para conservar los esenciales incluso sin escenarios seleccionados.",
+          ],
+        },
+        {
+          title: "Rotación de consumibles cada cinco días",
+          summary:
+            "Reabastece los consumibles cada cinco días de rodaje para tener toallitas, cinta y claquetas listas.",
+          details: [
+            "Programa la regla cada cinco días de rodaje para que los consumibles se renueven automáticamente en rodajes largos.",
+          ],
+        },
+        {
+          title: "Plantillas de matte box",
+          summary:
+            "Ofrece plantillas listas para Swing Away, de barras y clamp-on.",
+          details: [
+            "Precarga cada plantilla con los kits ARRI LMB y accesorios correspondientes para elegir rápidamente el montaje adecuado.",
+          ],
+        },
+      ],
+    },
     autoGearPresetDescription:
       "Guarda y reutiliza conjuntos completos de reglas automáticas de equipo.",
     autoGearPresetLabel: "Preajuste",
@@ -4448,6 +4693,88 @@ const texts = {
       "Définissez quels scénarios du formulaire ajoutent ou retirent automatiquement du matériel.",
     autoGearDescription:
       "Créez des règles basées sur des scénarios pour ajuster la liste générée après les suggestions par défaut.",
+    autoGearRuleOptions: {
+      heading: "Modèles de règles intégrés",
+      intro:
+        "Utilisez ces idées prêtes à l'emploi pour remplacer les anciens ajouts automatiques sans perdre de couverture.",
+      groups: [
+        {
+          title: "Catalogue spécifique aux scénarios",
+          summary:
+            "Comparez chaque scénario requis à la liste de base pour transformer ses ajouts et retraits en règle dédiée.",
+          details: [
+            "Ajoutez des règles combinées pour Handheld + Easyrig et Slider + mode underslung afin de compter l’équipement partagé une seule fois.",
+            "Incluez une règle uniquement en retrait pour Extreme rain + Rain Machine afin de garder uniques les accessoires pluie du matte box.",
+          ],
+        },
+        {
+          title: "Variations de poignée caméra",
+          summary:
+            "Déclenchez les règles selon la poignée choisie pour qu’un changement ajoute ou retire les bons supports.",
+          details: [
+            "Comparez chaque poignée à la configuration de base pour capter les accessoires ajoutés.",
+            "Réutilisez le même diff lorsque la poignée est retirée afin de supprimer ses pièces dédiées.",
+          ],
+        },
+        {
+          title: "Couverture des rallonges de viseur",
+          summary:
+            "Créez des règles pour chaque rallonge de viseur afin que chaque choix apporte son câblage et sa fixation.",
+          details: [
+            "Comparez la liste avec et sans chaque rallonge pour récupérer ajouts et retraits correspondants.",
+          ],
+        },
+        {
+          title: "Préréglages de distribution vidéo",
+          summary:
+            "Reflétez le sélecteur de distribution vidéo avec des règles par option qui reproduisent les listes d’ajouts et de retraits.",
+          details: [
+            "Enregistrez les charges pour des options comme Teradek ou QTAKE directement depuis le diff de la liste générée.",
+            "Prévoyez un secours qui ajoute le kit de monitoring iOS lorsqu’une option existe mais ne génère pas de diff.",
+          ],
+        },
+        {
+          title: "Rigging du moniteur embarqué",
+          summary:
+            "Assurez-vous que chaque moniteur embarqué ajoute son bras ULCS et ses notes de montage lorsqu’il est sélectionné.",
+          details: [
+            "Générez une règle par moniteur afin que le bras approprié et les notes apparaissent automatiquement.",
+          ],
+        },
+        {
+          title: "Kit de support moteurs FIZ",
+          summary:
+            "Dès qu’un moteur est présent, ajoutez pieds, adaptateurs, câbles et alimentation nécessaires.",
+          details: [
+            "Associez la règle au déclencheur spécial \"N'importe quel moteur\" pour qu’elle s’exécute avec chaque combinaison.",
+          ],
+        },
+        {
+          title: "Essentiels toujours actifs",
+          summary:
+            "Maintenez câbles standard, aides de rigging et accessoires de transport dans chaque projet.",
+          details: [
+            "Marquez la règle comme toujours active pour conserver ces essentiels même sans scénario sélectionné.",
+          ],
+        },
+        {
+          title: "Rotation des consommables tous les cinq jours",
+          summary:
+            "Réapprovisionnez les consommables tous les cinq jours de tournage pour garder lingettes, gaffer et clap prêts.",
+          details: [
+            "Planifiez la règle tous les cinq jours de tournage afin que les consommables se renouvellent automatiquement sur les longs tournages.",
+          ],
+        },
+        {
+          title: "Modèles de matte box",
+          summary:
+            "Proposez des modèles prêts pour Swing Away, sur tiges et clamp-on.",
+          details: [
+            "Préchargez chaque modèle avec les kits ARRI LMB et accessoires correspondants pour choisir rapidement le montage adapté.",
+          ],
+        },
+      ],
+    },
     autoGearPresetDescription:
       "Enregistrez et réutilisez des ensembles complets de règles automatiques d’équipement.",
     autoGearPresetLabel: "Préréglage",
@@ -5747,6 +6074,88 @@ const texts = {
       "Lege fest, welche Projektanforderungen automatisch Geräte hinzufügen oder entfernen.",
     autoGearDescription:
       "Erstelle szenariobasierte Regeln, um die erzeugte Packliste nach den Standardvorschlägen anzupassen.",
+    autoGearRuleOptions: {
+      heading: "Vorlagen für automatische Regeln",
+      intro:
+        "Nutze diese vorbereiteten Ideen, um die alten automatischen Ergänzungen zu ersetzen, ohne Abdeckung zu verlieren.",
+      groups: [
+        {
+          title: "Szenario-spezifischer Katalog",
+          summary:
+            "Vergleiche jedes benötigte Szenario mit der Basistabelle, um seine Ergänzungen und Entnahmen in eine eigene Regel zu verwandeln.",
+          details: [
+            "Füge Kombi-Regeln für Handheld + Easyrig sowie Slider + Undersling-Modus hinzu, damit geteiltes Equipment nur einmal gezählt wird.",
+            "Ergänze eine reine Entnahme-Regel für Extreme rain + Rain Machine, damit die Matte-Box-Regenaccessoires eindeutig bleiben.",
+          ],
+        },
+        {
+          title: "Varianten der Kameragriffe",
+          summary:
+            "Löse Regeln über die gewählte Kameragriff-Option aus, damit ein Wechsel die passenden Halterungen ergänzt oder entfernt.",
+          details: [
+            "Vergleiche jede Griffoption mit der Basis, um die zusätzlichen Zubehörteile zu erfassen.",
+            "Nutze den gleichen Diff, wenn ein Griff abgewählt wird, damit seine speziellen Teile entfernt werden.",
+          ],
+        },
+        {
+          title: "Sucher-Erweiterungen abdecken",
+          summary:
+            "Erzeuge Regeln für jede Sucher-Erweiterung, damit jede Auswahl die zugehörigen Kabel und Halter mitbringt.",
+          details: [
+            "Vergleiche die Liste mit und ohne die Erweiterung, um passende Ergänzungen und Entnahmen zu erfassen.",
+          ],
+        },
+        {
+          title: "Videoverteilungs-Presets",
+          summary:
+            "Spiegele den Videoverteilungs-Selector mit Regeln pro Option, die die Listen aus Ergänzungen und Entnahmen nachbilden.",
+          details: [
+            "Übernimm Payloads für Optionen wie Teradek oder QTAKE direkt aus dem Differenzvergleich der erzeugten Liste.",
+            "Hinterlege ein Fallback, das iOS-Monitoring-Equipment hinzufügt, wenn eine Option existiert, aber keine Differenz liefert.",
+          ],
+        },
+        {
+          title: "Onboard-Monitor-Rigging",
+          summary:
+            "Stelle sicher, dass jeder Onboard-Monitor seinen ULCS-Arm und Rigging-Hinweise ergänzt, sobald er gewählt ist.",
+          details: [
+            "Erzeuge pro Monitor eine Regel, damit Arm und Hinweise automatisch eingefügt werden.",
+          ],
+        },
+        {
+          title: "FIZ-Motorsupport-Kit",
+          summary:
+            "Sobald ein Motor vorhanden ist, ergänze Stative, Adapter, Kabel und Stromversorgung.",
+          details: [
+            "Verknüpfe die Regel mit dem speziellen Trigger \"Beliebiger Motor\", damit sie für jede Motor-Kombination greift.",
+          ],
+        },
+        {
+          title: "Immer aktive Essentials",
+          summary:
+            "Halte Standardkabel, Rigging-Hilfen und Transportzubehör in jedem Projekt aktiv.",
+          details: [
+            "Markiere die Regel als immer aktiv, damit die Essentials auch ohne Szenarien erhalten bleiben.",
+          ],
+        },
+        {
+          title: "Verbrauchsmaterial im Fünf-Tage-Rhythmus",
+          summary:
+            "Fülle Verbrauchsmaterial alle fünf Drehtage nach, damit Tücher, Tape und Klappen bereitstehen.",
+          details: [
+            "Plane die Regel alle fünf Drehtage ein, damit Verbrauchsgüter auf langen Drehs automatisch erneuert werden.",
+          ],
+        },
+        {
+          title: "Matte-Box-Templates",
+          summary:
+            "Biete fertige Vorlagen für Swing-Away-, Rod-basierte und Clamp-On-Matte-Boxen.",
+          details: [
+            "Lade jede Vorlage mit den passenden ARRI-LMB-Kits und Zubehör vor, um schnell die richtige Variante zu wählen.",
+          ],
+        },
+      ],
+    },
     autoGearPresetDescription:
       "Speichere komplette Sets automatischer Gear-Regeln zur Wiederverwendung.",
     autoGearPresetLabel: "Voreinstellung",


### PR DESCRIPTION
## Summary
- add a Factory rule templates section to the Automatic Gear Rules settings and render localized guidance dynamically
- document that the template guidance now ships inside the app and translate the copy for English, Italian, Spanish, French, and German

## Testing
- npm run test:unit

------
https://chatgpt.com/codex/tasks/task_e_68d84fd5b3c883209ae6b4d0ddbf1962