### PR TITLE
Improve Spanish backup label translation

### DIFF
--- a/src/scripts/translations.js
+++ b/src/scripts/translations.js
@@ -4052,7 +4052,7 @@ const texts = {
     restoreVersionTip: "Guardamos una copia de seguridad de tus datos antes de importar.",
     restoreVersionFooter: "Puedes continuar y recrear manualmente los elementos faltantes después.",
     restoreVersionUnknownVersion: "versión desconocida",
-    restoreVersionBackupLabel: "Copia de seguridad segura guardada antes de restaurar: {fileName}",
+    restoreVersionBackupLabel: "Copia de seguridad preventiva guardada antes de restaurar: {fileName}",
     restoreSectionDevices: "Biblioteca de dispositivos",
     restoreSectionSetups: "Configuraciones guardadas",
     restoreSectionProjects: "Proyectos",


### PR DESCRIPTION
## Summary
- refine the Spanish backup label to use a more natural and reassuring phrasing while keeping the placeholder intact

## Testing
- npm test -- --runTestsByPath tests/data/gearItemsTranslations.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d85ac260748320bd910e9cc77b0b9b