### PR TITLE
Fallback to legacy bundle when modern support check fails

### DIFF
--- a/legacy/scripts/loader.js
+++ b/legacy/scripts/loader.js
@@ -382,23 +382,23 @@ function _typeof(o) { "@babel/helpers - typeof"; return _typeof = "function" == 
       finalize(supported);
     };
     optionalCheckScript.onerror = function (event) {
-      var supported = !isSyntaxErrorEvent(event);
-      if (!supported) {
-        if (typeof console !== 'undefined' && typeof console.warn === 'function') {
+      var syntaxError = isSyntaxErrorEvent(event);
+      if (typeof console !== 'undefined' && typeof console.warn === 'function') {
+        if (syntaxError) {
           console.warn('Modern support check failed due to syntax error. Falling back to legacy bundle.', event);
+        } else {
+          console.warn('Modern support check could not be loaded safely. Falling back to legacy bundle.', event);
         }
-      } else if (typeof console !== 'undefined' && typeof console.warn === 'function') {
-        console.warn('Modern support check could not be loaded. Assuming modern feature support.', event);
       }
-      finalize(supported);
+      finalize(false);
     };
     try {
       head.appendChild(optionalCheckScript);
     } catch (appendError) {
       if (typeof console !== 'undefined' && typeof console.warn === 'function') {
-        console.warn('Unable to append modern support check script.', appendError);
+        console.warn('Unable to append modern support check script. Falling back to legacy bundle.', appendError);
       }
-      finalize(true);
+      finalize(false);
     }
   }
   function loadScriptsSequentially(urls) {

--- a/src/scripts/loader.js
+++ b/src/scripts/loader.js
@@ -414,24 +414,24 @@
       finalize(supported);
     };
     optionalCheckScript.onerror = function (event) {
-      var supported = !isSyntaxErrorEvent(event);
-      if (!supported) {
-        if (typeof console !== 'undefined' && typeof console.warn === 'function') {
+      var syntaxError = isSyntaxErrorEvent(event);
+      if (typeof console !== 'undefined' && typeof console.warn === 'function') {
+        if (syntaxError) {
           console.warn('Modern support check failed due to syntax error. Falling back to legacy bundle.', event);
+        } else {
+          console.warn('Modern support check could not be loaded safely. Falling back to legacy bundle.', event);
         }
-      } else if (typeof console !== 'undefined' && typeof console.warn === 'function') {
-        console.warn('Modern support check could not be loaded. Assuming modern feature support.', event);
       }
-      finalize(supported);
+      finalize(false);
     };
 
     try {
       head.appendChild(optionalCheckScript);
     } catch (appendError) {
       if (typeof console !== 'undefined' && typeof console.warn === 'function') {
-        console.warn('Unable to append modern support check script.', appendError);
+        console.warn('Unable to append modern support check script. Falling back to legacy bundle.', appendError);
       }
-      finalize(true);
+      finalize(false);
     }
   }
 


### PR DESCRIPTION
## Summary
- ensure the loader treats any failure to fetch the modern support probe as a signal to use the legacy bundle
- update both modern and legacy loaders to log safer warnings when the support probe cannot be evaluated

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d960f9c0f48320943c7305a834fcf8