### PR TITLE
Ensure cineUi help resolvers tolerate missing translations

### DIFF
--- a/src/scripts/app-events.js
+++ b/src/scripts/app-events.js
@@ -1048,6 +1048,36 @@ if (toggleDeviceBtn) {
   toggleDeviceBtn.addEventListener('click', toggleDeviceManagerSection);
 }
 
+function getEventsLanguageTexts() {
+  const scope =
+    (typeof globalThis !== 'undefined' && globalThis)
+    || (typeof window !== 'undefined' && window)
+    || (typeof self !== 'undefined' && self)
+    || (typeof global !== 'undefined' && global)
+    || null;
+
+  const allTexts =
+    (typeof texts !== 'undefined' && texts)
+    || (scope && typeof scope.texts === 'object' ? scope.texts : null);
+
+  const resolvedLang =
+    typeof currentLang === 'string'
+    && allTexts
+    && typeof allTexts[currentLang] === 'object'
+      ? currentLang
+      : 'en';
+
+  const langTexts =
+    (allTexts && typeof allTexts[resolvedLang] === 'object' && allTexts[resolvedLang])
+    || {};
+
+  const fallbackTexts =
+    (allTexts && typeof allTexts.en === 'object' && allTexts.en)
+    || {};
+
+  return { langTexts, fallbackTexts };
+}
+
 function registerEventsCineUiInternal(cineUi) {
   if (!cineUi || eventsCineUiRegistered) {
     return;
@@ -1079,8 +1109,7 @@ function registerEventsCineUiInternal(cineUi) {
   try {
     if (cineUi.help && typeof cineUi.help.register === 'function') {
       cineUi.help.register('saveSetup', () => {
-        const langTexts = texts[currentLang] || {};
-        const fallbackTexts = texts.en || {};
+        const { langTexts, fallbackTexts } = getEventsLanguageTexts();
         return (
           langTexts.saveSetupHelp
           || fallbackTexts.saveSetupHelp
@@ -1089,8 +1118,7 @@ function registerEventsCineUiInternal(cineUi) {
       });
 
       cineUi.help.register('autoBackupBeforeDeletion', () => {
-        const langTexts = texts[currentLang] || {};
-        const fallbackTexts = texts.en || {};
+        const { langTexts, fallbackTexts } = getEventsLanguageTexts();
         return (
           langTexts.preDeleteBackupSuccess
           || fallbackTexts.preDeleteBackupSuccess

--- a/src/scripts/app-session.js
+++ b/src/scripts/app-session.js
@@ -6817,6 +6817,36 @@ if (restoreSettings && restoreSettingsInput) {
   restoreSettingsInput.addEventListener('change', handleRestoreSettingsInputChange);
 }
 
+function getSessionLanguageTexts() {
+  const scope =
+    (typeof globalThis !== 'undefined' && globalThis)
+    || (typeof window !== 'undefined' && window)
+    || (typeof self !== 'undefined' && self)
+    || (typeof global !== 'undefined' && global)
+    || null;
+
+  const allTexts =
+    (typeof texts !== 'undefined' && texts)
+    || (scope && typeof scope.texts === 'object' ? scope.texts : null);
+
+  const resolvedLang =
+    typeof currentLang === 'string'
+    && allTexts
+    && typeof allTexts[currentLang] === 'object'
+      ? currentLang
+      : 'en';
+
+  const langTexts =
+    (allTexts && typeof allTexts[resolvedLang] === 'object' && allTexts[resolvedLang])
+    || {};
+
+  const fallbackTexts =
+    (allTexts && typeof allTexts.en === 'object' && allTexts.en)
+    || {};
+
+  return { langTexts, fallbackTexts };
+}
+
 function registerSessionCineUiInternal(cineUi) {
   if (!cineUi || sessionCineUiRegistered) {
     return;
@@ -6852,8 +6882,7 @@ function registerSessionCineUiInternal(cineUi) {
   try {
     if (cineUi.help && typeof cineUi.help.register === 'function') {
       cineUi.help.register('backupSettings', () => {
-        const langTexts = texts[currentLang] || {};
-        const fallbackTexts = texts.en || {};
+        const { langTexts, fallbackTexts } = getSessionLanguageTexts();
         return (
           langTexts.backupSettingsHelp
           || fallbackTexts.backupSettingsHelp
@@ -6862,8 +6891,7 @@ function registerSessionCineUiInternal(cineUi) {
       });
 
       cineUi.help.register('restoreSettings', () => {
-        const langTexts = texts[currentLang] || {};
-        const fallbackTexts = texts.en || {};
+        const { langTexts, fallbackTexts } = getSessionLanguageTexts();
         return (
           langTexts.restoreSettingsHelp
           || fallbackTexts.restoreSettingsHelp

--- a/src/scripts/app-setups.js
+++ b/src/scripts/app-setups.js
@@ -632,6 +632,36 @@ if (sharedImportDialog) {
   sharedImportDialog.addEventListener('cancel', handleSharedImportDialogCancel);
 }
 
+function getSafeLanguageTexts() {
+  const scope =
+    (typeof globalThis !== 'undefined' && globalThis)
+    || (typeof window !== 'undefined' && window)
+    || (typeof self !== 'undefined' && self)
+    || (typeof global !== 'undefined' && global)
+    || null;
+
+  const allTexts =
+    (typeof texts !== 'undefined' && texts)
+    || (scope && typeof scope.texts === 'object' ? scope.texts : null);
+
+  const resolvedLang =
+    typeof currentLang === 'string'
+    && allTexts
+    && typeof allTexts[currentLang] === 'object'
+      ? currentLang
+      : 'en';
+
+  const langTexts =
+    (allTexts && typeof allTexts[resolvedLang] === 'object' && allTexts[resolvedLang])
+    || {};
+
+  const fallbackTexts =
+    (allTexts && typeof allTexts.en === 'object' && allTexts.en)
+    || {};
+
+  return { langTexts, fallbackTexts };
+}
+
 function registerSetupsCineUiInternal(cineUi) {
   if (!cineUi || setupsCineUiRegistered) {
     return;
@@ -676,8 +706,7 @@ function registerSetupsCineUiInternal(cineUi) {
   try {
     if (cineUi.help && typeof cineUi.help.register === 'function') {
       cineUi.help.register('shareProject', () => {
-        const langTexts = texts[currentLang] || {};
-        const fallbackTexts = texts.en || {};
+        const { langTexts, fallbackTexts } = getSafeLanguageTexts();
         return (
           langTexts.shareSetupHelp
           || fallbackTexts.shareSetupHelp
@@ -686,8 +715,7 @@ function registerSetupsCineUiInternal(cineUi) {
       });
 
       cineUi.help.register('sharedImport', () => {
-        const langTexts = texts[currentLang] || {};
-        const fallbackTexts = texts.en || {};
+        const { langTexts, fallbackTexts } = getSafeLanguageTexts();
         return (
           langTexts.applySharedLinkHelp
           || fallbackTexts.applySharedLinkHelp


### PR DESCRIPTION
## Summary
- add safe helper utilities in the setups, session, and events modules to read language bundles without throwing when translations are unavailable
- update cineUi help registrations to rely on the safe helpers so required help entries always resolve strings even in minimal test environments

## Testing
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68d995068af483209fc10ae203e69a41