### PR TITLE
Allow module registry re-registration

### DIFF
--- a/src/scripts/modules/core-shared.js
+++ b/src/scripts/modules/core-shared.js
@@ -388,6 +388,7 @@
       MODULE_REGISTRY.register('cineCoreShared', shared, {
         category: 'shared',
         description: 'Shared helpers for deterministic stringification, weights, and version markers.',
+        replace: true,
       });
     } catch (error) {
       void error;

--- a/src/scripts/modules/offline.js
+++ b/src/scripts/modules/offline.js
@@ -614,6 +614,7 @@
       MODULE_REGISTRY.register('cineOffline', offlineAPI, {
         category: 'offline',
         description: 'Offline helpers for service worker registration and cache recovery.',
+        replace: true,
       });
     } catch (error) {
       safeWarn('Unable to register cineOffline in module registry.', error);

--- a/src/scripts/modules/persistence.js
+++ b/src/scripts/modules/persistence.js
@@ -189,6 +189,7 @@
       MODULE_REGISTRY.register('cinePersistence', persistenceAPI, {
         category: 'persistence',
         description: 'Data integrity facade for storage, autosave, backups, restore, and share flows.',
+        replace: true,
       });
     } catch (error) {
       void error;

--- a/src/scripts/modules/runtime.js
+++ b/src/scripts/modules/runtime.js
@@ -543,6 +543,7 @@
       MODULE_REGISTRY.register('cineRuntime', runtimeAPI, {
         category: 'runtime',
         description: 'Runtime orchestrator ensuring persistence, offline, and UI safeguards stay intact.',
+        replace: true,
       });
     } catch (error) {
       safeWarn('Unable to register cineRuntime module.', error);

--- a/src/scripts/modules/ui.js
+++ b/src/scripts/modules/ui.js
@@ -321,6 +321,7 @@
       MODULE_REGISTRY.register('cineUi', uiAPI, {
         category: 'ui',
         description: 'UI controller registry for dialogs, interactions, orchestration, and help copy.',
+        replace: true,
       });
     } catch (error) {
       safeWarn('Unable to register cineUi module.', error);


### PR DESCRIPTION
## Summary
- allow the runtime, offline, persistence, UI, and core shared modules to replace existing registry entries when re-registering
- prevent duplicate-registration warnings when the runtime is reloaded in tests or during offline recoveries

## Testing
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68d9b59002948320b5654bee8a4f0b1d