### PR TITLE
Fix setup initialization regressions

### DIFF
--- a/src/scripts/app-events.js
+++ b/src/scripts/app-events.js
@@ -729,7 +729,14 @@ setupSelect.addEventListener("change", (event) => {
 
 
 function populateSetupSelect() {
-  const setups = getSetups();
+  const setupsProvider =
+    typeof getSetups === 'function'
+      ? getSetups
+      : null;
+  if (!setupsProvider) {
+    console.warn('populateSetupSelect: getSetups is unavailable, using empty setup list');
+  }
+  const setups = setupsProvider ? setupsProvider() || {} : {};
   setupSelect.innerHTML = `<option value="">${texts[currentLang].newSetupOption}</option>`;
   let includeAutoBackups = false;
   if (typeof showAutoBackups === 'boolean') {

--- a/src/scripts/app-session.js
+++ b/src/scripts/app-session.js
@@ -2659,7 +2659,16 @@ function applySharedSetupFromUrl() {
 // --- EVENT LISTENERS FÜR NEUBERECHNUNG ---
 
 // Sicherstellen, dass Änderungen an den Selects auch neu berechnen
-[cameraSelect, monitorSelect, videoSelect, cageSelect, distanceSelect, batterySelect, hotswapSelect, batteryPlateSelect]
+[
+  cameraSelect,
+  monitorSelect,
+  videoSelect,
+  cageSelect,
+  distanceSelect,
+  batterySelect,
+  typeof hotswapSelect === 'undefined' ? null : hotswapSelect,
+  batteryPlateSelect
+]
   .forEach(sel => { if (sel) sel.addEventListener("change", updateCalculations); });
 if (cameraSelect) {
   cameraSelect.addEventListener('change', () => {

--- a/src/scripts/app-setups.js
+++ b/src/scripts/app-setups.js
@@ -280,13 +280,15 @@ function applyStoredPowerSelection(selection, { preferExisting = true } = {}) {
 }
 
 // Generate a printable overview of the current selected setup in a new tab
-generateOverviewBtn.addEventListener('click', () => {
-    if (!setupSelect.value) { // Ensure a setup is selected
-        alert(texts[currentLang].alertSelectSetupForOverview);
-        return;
-    }
-    generatePrintableOverview({ autoPrint: true });
-});
+if (typeof generateOverviewBtn !== 'undefined' && generateOverviewBtn) {
+    generateOverviewBtn.addEventListener('click', () => {
+        if (!setupSelect.value) { // Ensure a setup is selected
+            alert(texts[currentLang].alertSelectSetupForOverview);
+            return;
+        }
+        generatePrintableOverview({ autoPrint: true });
+    });
+}
 
 function batteryPinsSufficient() {
     const batt = batterySelect && batterySelect.value;


### PR DESCRIPTION
## Summary
- resolve the mount voltage storage key from the shared storage module and keep the backup key in sync with the global scope
- expose the accent color reset button as a global binding and guard setup/UI hooks when dependent elements are absent
- harden setup population logic by tolerating a missing getSetups implementation instead of throwing

## Testing
- `npm run test:jest -- scriptIntegrity --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68da0943ebec83208ad7d2dfc0db4066