### PR TITLE
Fix clearing saved gear list when gear output is empty

### DIFF
--- a/src/scripts/app-setups.js
+++ b/src/scripts/app-setups.js
@@ -4546,6 +4546,9 @@ function saveCurrentGearList() {
             setup.gearList = html;
             changed = true;
         }
+    } else if (Object.prototype.hasOwnProperty.call(setup, 'gearList')) {
+        delete setup.gearList;
+        changed = true;
     }
 
     if (projectInfoSignature) {


### PR DESCRIPTION
## Summary
- delete saved gear list HTML when the generated gear list becomes empty so stale HTML is not kept in setups

## Testing
- npm run lint
- npx jest tests/dom/saveCurrentGearList.test.js --runInBand
- npx jest tests/dom/projectRequirementsSave.test.js --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68da18b1dc30832090c012cffc887377