### PR TITLE
Add console verification guidance to help center

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -190,7 +190,10 @@ Dieser kurze Ablauf sollte bei neuen Teammitgliedern, frisch eingerichteten Work
   landen.
 - **Help-Center** (`?`, `H`, `F1`, `Strg+/`) liefert Guides, Shortcuts, FAQs und Hover-Hilfe. Die Start-hier-Checkliste beschreibt
   jetzt, wie du den Offline-Indikator vorbereitest, doppelte Exporte sicherst und eine Wiederherstellungsprobe durchläufst,
-  damit Teams Backups vor dem Einsatz prüfen.
+  damit Teams Backups vor dem Einsatz prüfen. Ein Konsolen-Schnellcheck listet
+  `window.__cineRuntimeIntegrity`, `window.cineRuntime.verifyCriticalFlows()`
+  und die `cinePersistence`-Hilfsfunktionen, damit du Offline-Proben direkt im
+  Dialog protokollierst.
 - **Projektdiagramm** visualisiert Strom- und Signalpfade; mit gedrückter Umschalttaste als JPG exportieren.
 - **Akkuvergleich** zeigt Leistung kompatibler Packs und warnt vor Überlast.
 - **Gerätelistengenerator** erstellt kategorisierte Tabellen mit Metadaten, Crew-E-Mails und Szenario-Zubehör.

--- a/README.en.md
+++ b/README.en.md
@@ -417,7 +417,10 @@ Use Cine Power Planner end-to-end with the following routine:
   shortcuts, FAQs and an optional hover-help mode so every control explains
   itself. The Start Here checklist now covers priming the offline indicator,
   capturing redundant exports and walking through a restore rehearsal drill so
-  crews verify backups before field use.
+  crews verify backups before field use. A console verification callout lists
+  `window.__cineRuntimeIntegrity`, `window.cineRuntime.verifyCriticalFlows()`
+  and the `cinePersistence` helpers so you can log offline rehearsals without
+  leaving the dialog.
 - **Project diagram** visualizes power and signal paths. Hold Shift while
   exporting to save a JPG snapshot instead of SVG.
 - **Battery comparison panel** reveals how each compatible pack performs and

--- a/README.es.md
+++ b/README.es.md
@@ -190,7 +190,9 @@ Repite esta rutina cuando se incorpore personal, se prepare una estación nueva 
   con teclado lleguen a los controles principales.
 - **Centro de ayuda** (`?`, `H`, `F1`, `Ctrl+/`) ofrece guías, atajos, preguntas frecuentes y modo de ayuda flotante. La lista
   «Comienza aquí» ahora cubre cómo preparar el indicador sin conexión, guardar exportaciones redundantes y repasar un simulacro
-  de restauración para que el equipo verifique las copias de seguridad antes de salir a rodaje.
+  de restauración para que el equipo verifique las copias de seguridad antes de salir a rodaje. Un recuadro de verificación en
+  consola enumera `window.__cineRuntimeIntegrity`, `window.cineRuntime.verifyCriticalFlows()` y las utilidades de
+  `cinePersistence` para registrar ensayos sin conexión sin salir del diálogo.
 - **Diagrama de proyecto** visualiza rutas de energía y señal; mantén Shift al exportar para guardar JPG.
 - **Panel de comparación de baterías** muestra rendimiento de packs compatibles y alerta sobre sobrecargas.
 - **Generador de listas** crea tablas categorizadas con metadatos, correos de equipo y accesorios según escenarios.

--- a/README.fr.md
+++ b/README.fr.md
@@ -190,7 +190,11 @@ Cette routine prouve que sauvegarde, partage, import, backup et restauration fon
   d’aide pour que les parcours clavier atteignent d’abord les commandes essentielles.
 - **Centre d’aide** (`?`, `H`, `F1`, `Ctrl+/`) proposant guides, raccourcis, FAQ et mode aide au survol. La liste «Commencer ici»
   explique désormais comment préparer l’indicateur hors ligne, sécuriser des exports redondants et suivre un exercice de
-  restauration afin que l’équipe valide les sauvegardes avant le tournage.
+  restauration afin que l’équipe valide les sauvegardes avant le tournage. Un
+  encadré « Vérification console » liste
+  `window.__cineRuntimeIntegrity`, `window.cineRuntime.verifyCriticalFlows()`
+  et les aides `cinePersistence` pour consigner vos répétitions hors ligne sans
+  quitter le dialogue.
 - **Diagramme de projet** pour visualiser alimentation et signal ; maintenez Maj lors de l’export pour enregistrer un JPG.
 - **Comparateur de batteries** affichant les performances et alertant sur les surcharges.
 - **Générateur de listes** qui produit des tableaux catégorisés avec métadonnées, emails et accessoires liés aux scénarios.

--- a/README.it.md
+++ b/README.it.md
@@ -190,7 +190,11 @@ Ripeti questa routine quando arriva un nuovo membro, allestisci una postazione o
   tastiera raggiungono subito i controlli principali.
 - **Centro assistenza** (`?`, `H`, `F1`, `Ctrl+/`) con guide, scorciatoie, FAQ e modalità aiuto al passaggio. La checklist «Inizia
   qui» ora spiega come preparare l’indicatore offline, salvare esportazioni ridondanti e provare un’esercitazione di ripristino
-  così la troupe verifica i backup prima della produzione.
+  così la troupe verifica i backup prima della produzione. Un riquadro di
+  verifica console elenca `window.__cineRuntimeIntegrity`,
+  `window.cineRuntime.verifyCriticalFlows()` e gli helper
+  `cinePersistence` per registrare le prove offline senza lasciare il
+  dialogo.
 - **Diagramma di progetto** per visualizzare alimentazione e segnali; tieni premuto Shift durante l’export per salvare un JPG.
 - **Confronto batterie** che mostra le prestazioni dei pack compatibili e avvisa in caso di sovraccarichi.
 - **Generatore di liste** che produce tabelle categorizzate con metadati, email e accessori basati sugli scenari.

--- a/README.md
+++ b/README.md
@@ -422,7 +422,10 @@ Use Cine Power Planner end-to-end with the following routine:
   shortcuts, FAQs and an optional hover-help mode so every control explains
   itself. The Start Here checklist now covers priming the offline indicator,
   capturing redundant exports and walking through a restore rehearsal drill so
-  crews verify backups before field use.
+  crews verify backups before field use. A console verification callout lists
+  `window.__cineRuntimeIntegrity`, `window.cineRuntime.verifyCriticalFlows()`
+  and the `cinePersistence` helpers so you can log offline rehearsals without
+  leaving the dialog.
 - **Project diagram** visualizes power and signal paths. Hold Shift while
   exporting to save a JPG snapshot instead of SVG.
 - **Battery comparison panel** reveals how each compatible pack performs and

--- a/docs/documentation-maintenance.md
+++ b/docs/documentation-maintenance.md
@@ -29,6 +29,9 @@ copy offline.【F:src/scripts/script.js†L92-L183】
 1. **Help dialog topics.** Review contextual help entries, FAQ answers and hover-help copy in
    `src/scripts/help/` before landing a feature change. Update screenshots, keyboard
    shortcuts and workflow descriptions so crews see accurate instructions while offline.
+   Keep the console verification callout in `index.html` aligned with the commands documented
+   in the save/share reference so operators can rehearse data audits directly inside the help
+   dialog.【F:index.html†L3899-L3920】【F:docs/save-share-restore-reference.md†L28-L35】
 2. **README family.** Revise the primary `README.md` plus each localized README under the
    project root. Ensure new workflows appear in the *Save, Share & Import Drill*, *Backup &
    Recovery* and *Emergency Recovery Playbook* sections so every language documents the same

--- a/docs/save-share-restore-reference.md
+++ b/docs/save-share-restore-reference.md
@@ -27,6 +27,8 @@ Run these quick inspections while documenting or rehearsing the workflows above:
 3. `window.cinePersistence.storage.exportAllData()` – returns the same payload used for planner backups so you can sanity-check file size, project counts and timestamps without triggering a download.【F:src/scripts/modules/persistence.js†L90-L145】
 4. `window.cinePersistence.share.decodeSharedSetup(payload)` – validates bundle text before you import it into production data. Pair it with `window.cinePersistence.share.applySharedSetup()` inside a disposable profile to confirm recovery paths stay healthy.【F:src/scripts/modules/persistence.js†L152-L157】
 
+The Help Center’s console verification callout mirrors these commands so crews have the checklist available directly inside the offline dialog alongside export and rehearsal guidance.【F:index.html†L3899-L3920】
+
 Record the outputs (or screenshots) in your verification log, and store them alongside the exported files so any teammate can confirm the same safeguards were present.
 
 ## When to run this checklist

--- a/index.html
+++ b/index.html
@@ -3876,6 +3876,39 @@
               offline.
             </p>
           </div>
+          <div
+            id="helpConsoleVerification"
+            class="help-callout"
+            role="note"
+            aria-label="Console verification commands"
+          >
+            <h4>Console verification commands</h4>
+            <ul>
+              <li>
+                Open the developer console and inspect <code>window.__cineRuntimeIntegrity</code>. The guard should report
+                <code>{ ok: true }</code> with an empty <code>missing</code> list before you rely on local saves, shares or
+                restores.
+              </li>
+              <li>
+                Run <code>window.cineRuntime.verifyCriticalFlows({ warnOnFailure: true })</code> whenever you finish a rehearsal
+                or incident review. The refreshed report confirms every persistence, offline and UI safeguard stayed available
+                without connectivity.
+              </li>
+              <li>
+                Use <code>window.cinePersistence.storage.exportAllData()</code> to preview the exact JSON captured by planner
+                backups. Compare project counts, timestamps and file size before archiving exports to redundant media.
+              </li>
+              <li>
+                Validate incoming bundles with <code>window.cinePersistence.share.decodeSharedSetup(payload)</code> before you
+                import them on production data. Pair it with <code>window.cinePersistence.share.applySharedSetup()</code> inside a
+                rehearsal profile to rehearse restores without touching live saves.
+              </li>
+            </ul>
+            <p class="help-callout-note">
+              Tip: Capture the console output alongside your backup filenames so audits prove which commands you checked before
+              travelling or rotating media.
+            </p>
+          </div>
         </section>
         <section
           data-help-section


### PR DESCRIPTION
## Summary
- add a console verification callout to the in-app help center so crews can check runtime and cinePersistence safeguards without leaving the dialog
- document the new callout across the English and localized READMEs and reference it from the save/share/restore guide
- expand the documentation maintenance checklist to keep the console commands in sync with the reference material

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68da18bb1e348320a7420bde17cbb0a2