### PR TITLE
docs: emphasize backup safeguards across readmes

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -38,6 +38,7 @@ Filmsets haben selten garantierte Konnektivität, Studios verlangen häufig luft
 - **Redundante Sicherheitsnetze.** Manuelle Saves, Hintergrund-Auto-Saves, periodische Auto-Backups, erzwungene Pre-Restore-Backups und menschenlesbare Exporte sorgen dafür, dass Benutzerdaten nicht verschwinden.
 - **Vorhersehbare Updates.** Aktualisierungen greifen nur nach deinem Trigger. Zwischengespeicherte Versionen bleiben verfügbar, bis du **Neu laden erzwingen** bestätigst.
 - **Konstante Darstellung.** Gebündelte Uicons, OpenMoji und Typografie-Dateien garantieren identische Optik – egal ob im Studio oder im Feld ohne Netz.
+- **Jede Änderung absichern.** Vor jeder Wiederherstellung legt der Planner ein erzwungenes Backup an und bewahrt frühere Revisionen, damit kein Import deine Arbeit überschreibt. Prüfprotokolle und Checksum-Notizen reisen mit jedem Archiv, um die Integrität auch offline nachzuweisen.
 
 ## Inhaltsverzeichnis
 

--- a/README.en.md
+++ b/README.en.md
@@ -89,6 +89,10 @@ production day.
 - **Consistent presentation.** Locally bundled Uicons, OpenMoji assets and
   typography files guarantee identical visuals whether you run the planner on a
   stage workstation or a field laptop with no connectivity.
+- **Guard every change.** Before any restore, the planner captures a forced
+  backup and preserves earlier revisions so no import overwrites your work.
+  Verification logs and checksum notes travel with every archive to prove
+  integrity even when you stay offline.
 
 ## Table of Contents
 

--- a/README.es.md
+++ b/README.es.md
@@ -38,6 +38,7 @@ Los rodajes raramente tienen conectividad garantizada y muchos estudios exigen h
 - **Redes redundantes.** Guardados manuales, auto-guardados en segundo plano, copias periódicas, respaldos previos a la restauración y exportaciones legibles garantizan que ningún dato desaparezca.
 - **Actualizaciones previsibles.** Sólo se aplican cuando tú las activas. Las versiones en caché siguen disponibles hasta que confirmas **Forzar recarga**.
 - **Presentación consistente.** Uicons locales, recursos OpenMoji y tipografías integradas aseguran la misma apariencia en un estudio o en un portátil desconectado.
+- **Proteger cada cambio.** Antes de cualquier restauración, el planner genera una copia de seguridad forzada y conserva las revisiones anteriores para que ninguna importación sobrescriba tu trabajo. Los registros de verificación y las notas de checksum acompañan a cada archivo para demostrar la integridad incluso sin conexión.
 
 ## Tabla de contenidos
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -38,6 +38,7 @@ Les plateaux disposent rarement d’une connectivité fiable et les studios exig
 - **Filets redondants.** Sauvegardes manuelles, autosaves en arrière-plan, backups périodiques, sauvegardes forcées avant restauration et exports lisibles empêchent toute disparition silencieuse.
 - **Mises à jour prévisibles.** Elles ne s’appliquent que sur votre action. Les versions en cache restent disponibles jusqu’à ce que vous confirmiez **Forcer le rechargement**.
 - **Présentation cohérente.** Uicons locaux, ressources OpenMoji et polices intégrées garantissent la même apparence en studio ou sur un poste déconnecté.
+- **Sécuriser chaque modification.** Avant toute restauration, le planner crée une sauvegarde forcée et conserve les versions précédentes afin qu’aucun import ne remplace ton travail. Les journaux de vérification et les notes de checksum accompagnent chaque archive pour prouver l’intégrité même hors ligne.
 
 ## Table des matières
 

--- a/README.it.md
+++ b/README.it.md
@@ -38,6 +38,7 @@ Sul set la connettività non è garantita e molti studi richiedono strumenti iso
 - **Reti ridondanti.** Salvataggi manuali, auto-save, backup periodici, backup forzati prima dei ripristini ed export leggibili lavorano insieme per evitare perdite silenziose.
 - **Aggiornamenti prevedibili.** Si applicano solo quando li attivi. Le versioni in cache restano disponibili finché non confermi **Forza ricarica**.
 - **Presentazione coerente.** Uicons locali, risorse OpenMoji e font inclusi garantiscono la stessa resa visiva in studio o su un portatile offline.
+- **Proteggi ogni modifica.** Prima di qualsiasi ripristino, il planner crea un backup forzato e conserva le revisioni precedenti così nessun import sovrascrive il tuo lavoro. I registri di verifica e le note di checksum viaggiano con ogni archivio per dimostrarne l’integrità anche offline.
 
 ## Indice
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,10 @@ production day.
 - **Consistent presentation.** Locally bundled Uicons, OpenMoji assets and
   typography files guarantee identical visuals whether you run the planner on a
   stage workstation or a field laptop with no connectivity.
+- **Guard every change.** Before any restore, the planner captures a forced
+  backup and preserves earlier revisions so no import overwrites your work.
+  Verification logs and checksum notes travel with every archive to prove
+  integrity even when you stay offline.
 
 ## Table of Contents
 


### PR DESCRIPTION
## Summary
- add a "Guard every change" principle to each README variant to highlight forced backups and verification logs

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68db794968cc832083a27adfc925b474