### PR TITLE
Fix legacy mount voltage storage key collisions

### DIFF
--- a/legacy/scripts/app-core-new-1.js
+++ b/legacy/scripts/app-core-new-1.js
@@ -543,15 +543,29 @@ try {
   console.warn('Could not load temperature unit preference', error);
 }
 var SUPPORTED_MOUNT_VOLTAGE_TYPES = ['V-Mount', 'Gold-Mount', 'B-Mount'];
-var MOUNT_VOLTAGE_STORAGE_KEY = 'cameraPowerPlanner_mountVoltages';
-var MOUNT_VOLTAGE_STORAGE_BACKUP_KEY = "".concat(MOUNT_VOLTAGE_STORAGE_KEY, '__backup');
+function resolveLegacyMountVoltageStorageKey() {
+  var fallback = 'cameraPowerPlanner_mountVoltages';
+  if (typeof resolveMountVoltageStorageKeyName === 'function') {
+    try {
+      return resolveMountVoltageStorageKeyName();
+    } catch (resolverError) {
+      void resolverError;
+    }
+  }
+  if (CORE_GLOBAL_SCOPE && _typeof(CORE_GLOBAL_SCOPE) === 'object' && typeof CORE_GLOBAL_SCOPE.MOUNT_VOLTAGE_STORAGE_KEY === 'string') {
+    return CORE_GLOBAL_SCOPE.MOUNT_VOLTAGE_STORAGE_KEY;
+  }
+  return fallback;
+}
+var LEGACY_MOUNT_VOLTAGE_STORAGE_KEY = resolveLegacyMountVoltageStorageKey();
+var LEGACY_MOUNT_VOLTAGE_STORAGE_BACKUP_KEY = "".concat(LEGACY_MOUNT_VOLTAGE_STORAGE_KEY, '__backup');
 try {
   if (CORE_GLOBAL_SCOPE && _typeof(CORE_GLOBAL_SCOPE) === 'object') {
     if (typeof CORE_GLOBAL_SCOPE.MOUNT_VOLTAGE_STORAGE_KEY !== 'string') {
-      CORE_GLOBAL_SCOPE.MOUNT_VOLTAGE_STORAGE_KEY = MOUNT_VOLTAGE_STORAGE_KEY;
+      CORE_GLOBAL_SCOPE.MOUNT_VOLTAGE_STORAGE_KEY = LEGACY_MOUNT_VOLTAGE_STORAGE_KEY;
     }
     if (typeof CORE_GLOBAL_SCOPE.MOUNT_VOLTAGE_STORAGE_BACKUP_KEY !== 'string') {
-      CORE_GLOBAL_SCOPE.MOUNT_VOLTAGE_STORAGE_BACKUP_KEY = MOUNT_VOLTAGE_STORAGE_BACKUP_KEY;
+      CORE_GLOBAL_SCOPE.MOUNT_VOLTAGE_STORAGE_BACKUP_KEY = LEGACY_MOUNT_VOLTAGE_STORAGE_BACKUP_KEY;
     }
   }
 } catch (exposeMountVoltageError) {
@@ -671,12 +685,12 @@ function persistMountVoltagePreferences(preferences) {
     return;
   }
   try {
-    localStorage.setItem(MOUNT_VOLTAGE_STORAGE_KEY, serialized);
+    localStorage.setItem(LEGACY_MOUNT_VOLTAGE_STORAGE_KEY, serialized);
   } catch (storageError) {
     console.warn('Could not save mount voltage preferences', storageError);
   }
   try {
-    localStorage.setItem(MOUNT_VOLTAGE_STORAGE_BACKUP_KEY, serialized);
+    localStorage.setItem(LEGACY_MOUNT_VOLTAGE_STORAGE_BACKUP_KEY, serialized);
   } catch (backupError) {
     console.warn('Could not save mount voltage backup copy', backupError);
   }
@@ -824,12 +838,12 @@ function updateMountVoltageSettingLabels(lang) {
 }
 try {
   if (typeof localStorage !== 'undefined') {
-    var storedVoltages = localStorage.getItem(MOUNT_VOLTAGE_STORAGE_KEY);
+    var storedVoltages = localStorage.getItem(LEGACY_MOUNT_VOLTAGE_STORAGE_KEY);
     var parsedVoltages = parseStoredMountVoltages(storedVoltages);
     if (parsedVoltages) {
       mountVoltagePreferences = parsedVoltages;
     } else {
-      var backupVoltages = localStorage.getItem(MOUNT_VOLTAGE_STORAGE_BACKUP_KEY);
+      var backupVoltages = localStorage.getItem(LEGACY_MOUNT_VOLTAGE_STORAGE_BACKUP_KEY);
       var parsedBackupVoltages = parseStoredMountVoltages(backupVoltages);
       if (parsedBackupVoltages) {
         mountVoltagePreferences = parsedBackupVoltages;

--- a/legacy/scripts/app-session.js
+++ b/legacy/scripts/app-session.js
@@ -28,6 +28,25 @@ function _arrayWithHoles(r) { if (Array.isArray(r)) return r; }
 function _typeof(o) { "@babel/helpers - typeof"; return _typeof = "function" == typeof Symbol && "symbol" == typeof Symbol.iterator ? function (o) { return typeof o; } : function (o) { return o && "function" == typeof Symbol && o.constructor === Symbol && o !== Symbol.prototype ? "symbol" : typeof o; }, _typeof(o); }
 var sessionCineUi = typeof globalThis !== 'undefined' && globalThis.cineUi || typeof window !== 'undefined' && window.cineUi || typeof self !== 'undefined' && self.cineUi || null;
 var temperaturePreferenceStorageKey = typeof TEMPERATURE_STORAGE_KEY === 'string' ? TEMPERATURE_STORAGE_KEY : typeof resolveTemperatureStorageKey === 'function' ? resolveTemperatureStorageKey() : 'cameraPowerPlanner_temperatureUnit';
+function resolveSessionMountVoltageStorageKey() {
+  var fallback = 'cameraPowerPlanner_mountVoltages';
+  if (typeof resolveMountVoltageStorageKeyName === 'function') {
+    try {
+      return resolveMountVoltageStorageKeyName();
+    } catch (resolverError) {
+      void resolverError;
+    }
+  }
+  if (typeof CORE_GLOBAL_SCOPE !== 'undefined' && CORE_GLOBAL_SCOPE && typeof CORE_GLOBAL_SCOPE.MOUNT_VOLTAGE_STORAGE_KEY === 'string') {
+    return CORE_GLOBAL_SCOPE.MOUNT_VOLTAGE_STORAGE_KEY;
+  }
+  if (typeof globalThis !== 'undefined' && globalThis && typeof globalThis.MOUNT_VOLTAGE_STORAGE_KEY === 'string') {
+    return globalThis.MOUNT_VOLTAGE_STORAGE_KEY;
+  }
+  return fallback;
+}
+var sessionMountVoltageStorageKey = resolveSessionMountVoltageStorageKey();
+var sessionMountVoltageBackupKey = "".concat(sessionMountVoltageStorageKey, '__backup');
 var recordFullBackupHistoryEntryFn = function recordFullBackupHistoryEntryFn() {};
 try {
   var _require = require('./storage.js');
@@ -5587,11 +5606,11 @@ function applyPreferencesFromStorage(safeGetItem) {
     }
   }
   try {
-    var storedVoltages = safeGetItem(MOUNT_VOLTAGE_STORAGE_KEY);
+    var storedVoltages = safeGetItem(sessionMountVoltageStorageKey);
     var parsedVoltages = parseStoredMountVoltages(storedVoltages);
     var shouldPersistVoltages = false;
     if (!parsedVoltages) {
-      var backupKey = typeof MOUNT_VOLTAGE_STORAGE_BACKUP_KEY === 'string' ? MOUNT_VOLTAGE_STORAGE_BACKUP_KEY : "".concat(MOUNT_VOLTAGE_STORAGE_KEY, '__backup');
+      var backupKey = typeof MOUNT_VOLTAGE_STORAGE_BACKUP_KEY === 'string' ? MOUNT_VOLTAGE_STORAGE_BACKUP_KEY : sessionMountVoltageBackupKey;
       var backupVoltages = safeGetItem(backupKey);
       if (backupVoltages !== undefined && backupVoltages !== null) {
         var parsedBackupVoltages = parseStoredMountVoltages(backupVoltages);

--- a/legacy/scripts/storage.js
+++ b/legacy/scripts/storage.js
@@ -28,7 +28,30 @@ var FAVORITES_STORAGE_KEY = 'cameraPowerPlanner_favorites';
 var DEVICE_SCHEMA_CACHE_KEY = 'cameraPowerPlanner_schemaCache';
 var LEGACY_SCHEMA_CACHE_KEY = 'cinePowerPlanner_schemaCache';
 var CUSTOM_FONT_STORAGE_KEY_DEFAULT = 'cameraPowerPlanner_customFonts';
-var MOUNT_VOLTAGE_STORAGE_KEY = 'cameraPowerPlanner_mountVoltages';
+function resolveMountVoltageStorageKeyName() {
+  var fallback = 'cameraPowerPlanner_mountVoltages';
+  if (!GLOBAL_SCOPE || _typeof(GLOBAL_SCOPE) !== 'object') {
+    return fallback;
+  }
+  var existing = typeof GLOBAL_SCOPE.MOUNT_VOLTAGE_STORAGE_KEY === 'string' ? GLOBAL_SCOPE.MOUNT_VOLTAGE_STORAGE_KEY : fallback;
+  if (existing !== GLOBAL_SCOPE.MOUNT_VOLTAGE_STORAGE_KEY) {
+    try {
+      GLOBAL_SCOPE.MOUNT_VOLTAGE_STORAGE_KEY = existing;
+    } catch (assignError) {
+      try {
+        Object.defineProperty(GLOBAL_SCOPE, 'MOUNT_VOLTAGE_STORAGE_KEY', {
+          configurable: true,
+          writable: true,
+          value: existing
+        });
+      } catch (defineError) {
+        void defineError;
+      }
+    }
+  }
+  return existing;
+}
+var MOUNT_VOLTAGE_STORAGE_KEY_NAME = resolveMountVoltageStorageKeyName();
 function ensureCustomFontStorageKeyName() {
   if (!GLOBAL_SCOPE) {
     return CUSTOM_FONT_STORAGE_KEY_DEFAULT;
@@ -147,7 +170,7 @@ var STORAGE_BACKUP_SUFFIX = '__backup';
 var MAX_SAVE_ATTEMPTS = 3;
 var MAX_QUOTA_RECOVERY_STEPS = 100;
 var STORAGE_MIGRATION_BACKUP_SUFFIX = '__legacyMigrationBackup';
-var RAW_STORAGE_BACKUP_KEYS = new Set([getCustomFontStorageKeyName(), CUSTOM_LOGO_STORAGE_KEY, DEVICE_SCHEMA_CACHE_KEY, MOUNT_VOLTAGE_STORAGE_KEY]);
+var RAW_STORAGE_BACKUP_KEYS = new Set([getCustomFontStorageKeyName(), CUSTOM_LOGO_STORAGE_KEY, DEVICE_SCHEMA_CACHE_KEY, MOUNT_VOLTAGE_STORAGE_KEY_NAME]);
 var MAX_MIGRATION_BACKUP_CLEANUP_STEPS = 10;
 var MIGRATION_BACKUP_COMPRESSION_ALGORITHM = 'lz-string';
 var MIGRATION_BACKUP_COMPRESSION_ENCODING = 'json-string';


### PR DESCRIPTION
## Summary
- resolve the legacy mount voltage storage key via a shared helper to avoid redeclaring the global
- update legacy core and session scripts to use the resolved key and keep global assignments consistent

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68db796f1ca08320bda452e445409c0a