### PR TITLE
Improve help dialog navigation guidance

### DIFF
--- a/docs/documentation-maintenance.md
+++ b/docs/documentation-maintenance.md
@@ -31,7 +31,9 @@ copy offline.【F:src/scripts/script.js†L92-L183】
    shortcuts and workflow descriptions so crews see accurate instructions while offline.
    Keep the console verification callout in `index.html` aligned with the commands documented
    in the save/share reference so operators can rehearse data audits directly inside the help
-   dialog.【F:index.html†L3899-L3920】【F:docs/save-share-restore-reference.md†L28-L35】
+   dialog.【F:index.html†L3899-L3920】【F:docs/save-share-restore-reference.md†L28-L35】 Document
+   any new navigation tips—like the quick-link keyboard guidance surfaced through
+   `helpResultsAssist`—so translations and hover help mirror the latest behaviour.【F:index.html†L2641-L2663】【F:src/scripts/app-session.js†L8427-L8486】【F:src/scripts/translations.js†L1327-L1340】
 2. **README family.** Revise the primary `README.md` plus each localized README under the
    project root. Ensure new workflows appear in the *Save, Share & Import Drill*, *Backup &
    Recovery* and *Emergency Recovery Playbook* sections so every language documents the same

--- a/index.html
+++ b/index.html
@@ -2653,6 +2653,15 @@
         aria-live="polite"
         hidden
       ></p>
+      <p
+        id="helpResultsAssist"
+        class="help-results-assist"
+        aria-live="polite"
+        hidden
+      >
+        Tip: Press Tab to move into the quick links, or press Enter to open the top visible
+        topic.
+      </p>
       <p id="helpNoResults" aria-live="polite" hidden>No results found.</p>
       <div id="helpSections">
         <section
@@ -2675,8 +2684,9 @@
               <a class="help-link button-link" href="#helpSearch" data-help-target="#helpSearch">search box</a>
               filters topics as you type and highlights matching words. Use the
               <a class="help-link button-link" href="#helpSearchClear" data-help-target="#helpSearchClear">clear</a>
-              button to reset the query, or press <strong>/</strong> or <strong>Ctrl+F</strong> (<strong>⌘F</strong>) while
-              the dialog is open to jump straight to search.
+              button to reset the query, press <strong>/</strong> or <strong>Ctrl+F</strong> (<strong>⌘F</strong>) while the
+              dialog is open to jump straight to search, then press <strong>Tab</strong> to land on refreshed quick links or
+              <strong>Enter</strong> to open the first visible topic.
             </li>
             <li>
               Use the

--- a/src/scripts/app-core-new-1.js
+++ b/src/scripts/app-core-new-1.js
@@ -12990,6 +12990,7 @@ var closeHelpBtn    = document.getElementById("closeHelp");
 var helpSearch      = document.getElementById("helpSearch");
 var helpNoResults   = document.getElementById("helpNoResults");
 var helpResultsSummary = document.getElementById("helpResultsSummary");
+var helpResultsAssist = document.getElementById("helpResultsAssist");
 var helpSearchClear = document.getElementById("helpSearchClear");
 var helpSectionsContainer = document.getElementById("helpSections");
 var helpQuickLinksNav = document.getElementById("helpQuickLinks");

--- a/src/scripts/app-session.js
+++ b/src/scripts/app-session.js
@@ -22,14 +22,14 @@
           clearUiCacheStorageEntries, __cineGlobal, humanizeKey,
           normalizeBatteryPlateValue, applyBatteryPlateSelectionFromBattery,
           getPowerSelectionSnapshot, applyStoredPowerSelection,
-          settingsReduceMotion, settingsRelaxedSpacing, callCoreFunctionIfAvailable */
+          settingsReduceMotion, settingsRelaxedSpacing, callCoreFunctionIfAvailable,
+          recordFeatureSearchUsage, helpResultsSummary, helpResultsAssist */
 /* eslint-enable no-redeclare */
 /* global triggerPinkModeIconRain, loadDeviceData, loadSetups, loadSessionState,
           loadFeedback, loadFavorites, loadAutoGearBackups,
           loadAutoGearPresets, loadAutoGearSeedFlag, loadAutoGearActivePresetId,
           loadAutoGearAutoPresetId, loadAutoGearBackupVisibility,
           loadAutoGearBackupRetention, loadFullBackupHistory */
-/* global recordFeatureSearchUsage */
 /* global getDiagramManualPositions, setManualDiagramPositions,
           normalizeDiagramPositionsInput, ensureAutoBackupsFromProjects */
 /* global getMountVoltagePreferencesClone, mountVoltageResetButton,
@@ -8436,7 +8436,15 @@ if (helpButton && helpDialog) {
     hasQuery,
     queryText
   } = {}) => {
-    if (!helpResultsSummary) return;
+    const hideAssist = () => {
+      if (!helpResultsAssist) return;
+      helpResultsAssist.textContent = '';
+      helpResultsAssist.setAttribute('hidden', '');
+    };
+    if (!helpResultsSummary) {
+      hideAssist();
+      return;
+    }
     if (typeof totalCount === 'number' && Number.isFinite(totalCount)) {
       helpResultsSummary.dataset.totalCount = String(totalCount);
     }
@@ -8453,6 +8461,7 @@ if (helpButton && helpDialog) {
     if (!storedTotal) {
       helpResultsSummary.textContent = '';
       helpResultsSummary.setAttribute('hidden', '');
+      hideAssist();
       return;
     }
     const storedVisible = Number(
@@ -8489,6 +8498,19 @@ if (helpButton && helpDialog) {
     }
     helpResultsSummary.textContent = summaryText;
     helpResultsSummary.removeAttribute('hidden');
+    if (helpResultsAssist) {
+      if (storedVisible > 0) {
+        const assistTemplate =
+          langTexts.helpResultsAssist || fallbackTexts.helpResultsAssist;
+        const assistText =
+          assistTemplate ||
+          'Tip: Press Tab to move into the quick links, or press Enter to open the top visible topic.';
+        helpResultsAssist.textContent = assistText;
+        helpResultsAssist.removeAttribute('hidden');
+      } else {
+        hideAssist();
+      }
+    }
   };
 
   const filterHelp = () => {

--- a/src/scripts/translations.js
+++ b/src/scripts/translations.js
@@ -1326,6 +1326,8 @@ const texts = {
     helpSearchLabel: "Search help topics",
     helpResultsSummaryAll: "All %s help topics are shown.",
     helpResultsSummaryFiltered: "Showing %1$s of %2$s help topics for “%3$s”.",
+    helpResultsAssist:
+      "Tip: Press Tab to move into the quick links, or press Enter to open the top visible topic.",
     helpNoResults: "No results found. Try shorter keywords or clear the search to browse all topics.",
     helpSearchClear: "Clear search",
     helpSearchHelp:
@@ -2730,6 +2732,8 @@ const texts = {
     helpSearchLabel: "Cerca negli argomenti dell'aiuto",
     helpResultsSummaryAll: "Sono visualizzati tutti i %s argomenti dell'aiuto.",
     helpResultsSummaryFiltered: "Visualizzati %1$s argomenti dell'aiuto su %2$s per “%3$s”.",
+    helpResultsAssist:
+      "Suggerimento: premi Tab per passare ai collegamenti rapidi oppure premi Invio per aprire il primo argomento visibile.",
     helpNoResults: "Nessun risultato trovato. Prova con parole chiave più brevi oppure cancella la ricerca per vedere tutti gli argomenti.",
     helpSearchClear: "Cancella ricerca",
     helpSearchHelp:
@@ -4142,6 +4146,8 @@ const texts = {
     helpSearchLabel: "Buscar temas de ayuda",
     helpResultsSummaryAll: "Se muestran los %s temas de ayuda.",
     helpResultsSummaryFiltered: "Mostrando %1$s de %2$s temas de ayuda para “%3$s”.",
+    helpResultsAssist:
+      "Consejo: pulsa Tab para moverte a los accesos directos o pulsa Intro para abrir el primer tema visible.",
     helpNoResults: "No se encontraron resultados. Prueba con palabras clave más cortas o borra la búsqueda para ver todos los temas.",
     helpSearchClear: "Borrar búsqueda",
     helpSearchHelp:
@@ -5564,6 +5570,8 @@ const texts = {
     helpSearchLabel: "Rechercher des sujets d'aide",
     helpResultsSummaryAll: "Tous les %s sujets d’aide sont affichés.",
     helpResultsSummaryFiltered: "Affichage de %1$s sujet(s) d’aide sur %2$s pour « %3$s ».",
+    helpResultsAssist:
+      "Astuce : appuyez sur Tab pour rejoindre les raccourcis ou sur Entrée pour ouvrir le premier sujet visible.",
     helpNoResults: "Aucun résultat trouvé. Essayez avec des mots-clés plus courts ou effacez la recherche pour afficher tous les sujets.",
     helpSearchClear: "Effacer la recherche",
     helpSearchHelp:
@@ -6991,6 +6999,8 @@ const texts = {
     helpSearchLabel: "Hilfe-Themen durchsuchen",
     helpResultsSummaryAll: "Alle %s Hilfethemen werden angezeigt.",
     helpResultsSummaryFiltered: "Es werden %1$s von %2$s Hilfethemen für „%3$s“ angezeigt.",
+    helpResultsAssist:
+      "Tipp: Drücke Tab, um zu den Schnelllinks zu wechseln, oder drücke Eingabe, um das erste sichtbare Thema zu öffnen.",
     helpNoResults: "Keine Ergebnisse gefunden. Verwende kürzere Suchbegriffe oder lösche die Suche, um alle Themen anzuzeigen.",
     helpSearchClear: "Suche löschen",
     helpSearchHelp:


### PR DESCRIPTION
## Summary
- surface a quick-link navigation assist message in the help dialog and update the start-here instructions
- teach the help results summary logic to manage the new assist text and translate it for all supported locales
- capture the new guidance in the documentation-maintenance checklist so docs and translations stay aligned

## Testing
- npm test -- --runTestsByPath tests/dom/globalFeatureSearch.test.js

------
https://chatgpt.com/codex/tasks/task_e_68db794212dc8320960660b50ffa565a