### PR TITLE
Handle mount voltage storage key without global var collisions

### DIFF
--- a/src/scripts/app-core-new-1.js
+++ b/src/scripts/app-core-new-1.js
@@ -738,10 +738,22 @@ const {
   resolvedMountVoltageKey: MOUNT_VOLTAGE_STORAGE_KEY_RESOLVED,
   resolvedMountVoltageBackupKey: MOUNT_VOLTAGE_STORAGE_BACKUP_KEY
 } = (() => {
-  const fallbackKey =
-    typeof MOUNT_VOLTAGE_STORAGE_KEY === 'string'
-      ? MOUNT_VOLTAGE_STORAGE_KEY
-      : 'cameraPowerPlanner_mountVoltages';
+  let fallbackKey = 'cameraPowerPlanner_mountVoltages';
+  if (typeof getMountVoltageStorageKeyName === 'function') {
+    try {
+      const resolvedKey = getMountVoltageStorageKeyName();
+      if (typeof resolvedKey === 'string' && resolvedKey) {
+        fallbackKey = resolvedKey;
+      }
+    } catch (mountVoltageKeyError) {
+      console.warn('Unable to resolve mount voltage storage key name', mountVoltageKeyError);
+    }
+  } else if (
+    typeof MOUNT_VOLTAGE_STORAGE_KEY_NAME === 'string' &&
+    MOUNT_VOLTAGE_STORAGE_KEY_NAME
+  ) {
+    fallbackKey = MOUNT_VOLTAGE_STORAGE_KEY_NAME;
+  }
   const backupKey = `${fallbackKey}__backup`;
   try {
     if (CORE_GLOBAL_SCOPE && typeof CORE_GLOBAL_SCOPE === 'object') {

--- a/src/scripts/app-session.js
+++ b/src/scripts/app-session.js
@@ -34,8 +34,8 @@
           normalizeDiagramPositionsInput, ensureAutoBackupsFromProjects */
 /* global getMountVoltagePreferencesClone, mountVoltageResetButton,
           resetMountVoltagePreferences, updateMountVoltageInputsFromState,
-          applyMountVoltagePreferences, MOUNT_VOLTAGE_STORAGE_KEY,
-          MOUNT_VOLTAGE_STORAGE_BACKUP_KEY,
+          applyMountVoltagePreferences, getMountVoltageStorageKeyName,
+          getMountVoltageStorageBackupKeyName, MOUNT_VOLTAGE_STORAGE_BACKUP_KEY,
           parseStoredMountVoltages, SUPPORTED_MOUNT_VOLTAGE_TYPES,
           DEFAULT_MOUNT_VOLTAGES, mountVoltageInputs, parseVoltageValue */
 
@@ -6282,7 +6282,11 @@ function applyPreferencesFromStorage(safeGetItem) {
   const language = safeGetItem('language');
 
   try {
-    const storedVoltages = safeGetItem(MOUNT_VOLTAGE_STORAGE_KEY);
+    const mountVoltageKeyName =
+      typeof getMountVoltageStorageKeyName === 'function'
+        ? getMountVoltageStorageKeyName()
+        : 'cameraPowerPlanner_mountVoltages';
+    const storedVoltages = safeGetItem(mountVoltageKeyName);
     let parsedVoltages = parseStoredMountVoltages(storedVoltages);
     let shouldPersistVoltages = false;
 
@@ -6290,7 +6294,9 @@ function applyPreferencesFromStorage(safeGetItem) {
       const backupKey =
         typeof MOUNT_VOLTAGE_STORAGE_BACKUP_KEY === 'string'
           ? MOUNT_VOLTAGE_STORAGE_BACKUP_KEY
-          : `${MOUNT_VOLTAGE_STORAGE_KEY}__backup`;
+          : typeof getMountVoltageStorageBackupKeyName === 'function'
+            ? getMountVoltageStorageBackupKeyName()
+            : `${mountVoltageKeyName}__backup`;
       const backupVoltages = safeGetItem(backupKey);
       if (backupVoltages !== undefined && backupVoltages !== null) {
         const parsedBackupVoltages = parseStoredMountVoltages(backupVoltages);


### PR DESCRIPTION
## Summary
- avoid redeclaring the mount voltage storage key by resolving any existing global property before defining a fallback and exposing helpers
- update the core and session scripts to use the shared helpers so backups and restores continue working across browsers

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68db7fc207448320acba75d4aacb42af