### PR TITLE
Handle mount voltage key initialization without redefining globals

### DIFF
--- a/legacy/scripts/storage.js
+++ b/legacy/scripts/storage.js
@@ -37,15 +37,14 @@ function resolveMountVoltageStorageKeyName() {
   if (existing !== GLOBAL_SCOPE.MOUNT_VOLTAGE_STORAGE_KEY) {
     try {
       GLOBAL_SCOPE.MOUNT_VOLTAGE_STORAGE_KEY = existing;
+      var assigned = GLOBAL_SCOPE.MOUNT_VOLTAGE_STORAGE_KEY;
+      if (typeof assigned === 'string' && assigned) {
+        return assigned;
+      }
     } catch (assignError) {
-      try {
-        Object.defineProperty(GLOBAL_SCOPE, 'MOUNT_VOLTAGE_STORAGE_KEY', {
-          configurable: true,
-          writable: true,
-          value: existing
-        });
-      } catch (defineError) {
-        void defineError;
+      void assignError;
+      if (typeof console !== 'undefined' && typeof console.warn === 'function') {
+        console.warn('Unable to expose mount voltage storage key globally. Using fallback only.', assignError);
       }
     }
   }

--- a/src/scripts/storage.js
+++ b/src/scripts/storage.js
@@ -58,17 +58,21 @@ function resolveMountVoltageStorageKeyName() {
   }
 
   try {
-    Object.defineProperty(GLOBAL_SCOPE, 'MOUNT_VOLTAGE_STORAGE_KEY', {
-      configurable: true,
-      writable: true,
-      value: MOUNT_VOLTAGE_STORAGE_KEY_FALLBACK
-    });
-  } catch (defineError) {
-    void defineError;
-    try {
-      GLOBAL_SCOPE.MOUNT_VOLTAGE_STORAGE_KEY = MOUNT_VOLTAGE_STORAGE_KEY_FALLBACK;
-    } catch (assignError) {
-      void assignError;
+    GLOBAL_SCOPE.MOUNT_VOLTAGE_STORAGE_KEY = MOUNT_VOLTAGE_STORAGE_KEY_FALLBACK;
+    var assigned = GLOBAL_SCOPE.MOUNT_VOLTAGE_STORAGE_KEY;
+    if (typeof assigned === 'string' && assigned) {
+      return assigned;
+    }
+  } catch (assignError) {
+    void assignError;
+    if (
+      typeof console !== 'undefined' &&
+      typeof console.warn === 'function'
+    ) {
+      console.warn(
+        'Unable to expose mount voltage storage key globally. Using fallback only.',
+        assignError
+      );
     }
   }
 


### PR DESCRIPTION
## Summary
- prevent modern storage initialisation from redefining the global mount voltage key when an environment already owns the binding
- mirror the safer initialisation pathway inside the legacy bundle to keep runtime parity

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dbfa921538832099630da3ce8c05cf