### PR TITLE
Fix rule coverage summary dark mode styles

### DIFF
--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -2713,6 +2713,31 @@ body.high-contrast .settings-tab[aria-selected="true"] {
   outline: none;
 }
 
+.auto-gear-summary-details button[data-auto-gear-rule],
+.auto-gear-summary-details button[data-auto-gear-scenario] {
+  background: none;
+  border: none;
+  padding: 0;
+  color: var(--link-color);
+  cursor: pointer;
+  font: inherit;
+  text-align: left;
+  border-radius: 4px;
+}
+
+.auto-gear-summary-details button[data-auto-gear-rule]:hover,
+.auto-gear-summary-details button[data-auto-gear-scenario]:hover,
+.auto-gear-summary-details button[data-auto-gear-rule]:focus-visible,
+.auto-gear-summary-details button[data-auto-gear-scenario]:focus-visible {
+  text-decoration: underline;
+}
+
+.auto-gear-summary-details button[data-auto-gear-rule]:focus-visible,
+.auto-gear-summary-details button[data-auto-gear-scenario]:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--accent-color) 45%, transparent);
+  outline-offset: 2px;
+}
+
 .auto-gear-summary-reset {
   align-self: flex-start;
   background: none;


### PR DESCRIPTION
## Summary
- ensure rule coverage detail buttons inherit link styling so dark mode colors remain consistent
- provide a themed focus outline for scenario and rule shortcuts within the summary panel

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dc32572f448320834439e2588279cd