### PR TITLE
Refine general settings layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -995,201 +995,238 @@
             role="tabpanel"
             aria-labelledby="settingsTab-general generalSettingsHeading"
           >
-        <h3 id="generalSettingsHeading">General</h3>
-        <div class="form-row">
-          <label for="settingsLanguage" id="settingsLanguageLabel">Language</label>
-          <select id="settingsLanguage">
-            <option value="en">English</option>
-            <option value="de">Deutsch</option>
-            <option value="es">Español</option>
-            <option value="fr">Français</option>
-            <option value="it">Italiano</option>
-          </select>
-        </div>
-        <div class="form-row">
-          <label for="settingsDarkMode" id="settingsDarkModeLabel">Dark mode</label>
-          <input type="checkbox" id="settingsDarkMode" />
-        </div>
-        <div class="form-row">
-          <label for="settingsPinkMode" id="settingsPinkModeLabel">Pink mode</label>
-          <input type="checkbox" id="settingsPinkMode" />
-        </div>
-        <div class="form-row">
-          <label for="accentColorInput" id="accentColorLabel">Accent color</label>
-          <input type="color" id="accentColorInput" value="#001589" />
-          <button type="button" id="accentColorReset" class="inline-form-button">
-            Reset to default
-          </button>
-        </div>
-        <div class="form-row">
-          <label for="settingsTemperatureUnit" id="settingsTemperatureUnitLabel">Temperature unit</label>
-          <select id="settingsTemperatureUnit">
-            <option value="celsius">Celsius (°C)</option>
-            <option value="fahrenheit">Fahrenheit (°F)</option>
-          </select>
-        </div>
-        <section
-          id="mountVoltageSettings"
-          class="mount-voltage-settings"
-          aria-labelledby="mountVoltageHeading"
-        >
-          <div class="mount-voltage-header">
-            <h4 id="mountVoltageHeading">Battery mount voltages</h4>
-            <button type="button" id="mountVoltageReset">Restore defaults</button>
-          </div>
-          <p id="mountVoltageDescription" class="settings-hint">
-            Customize the high and low voltages used for current draw calculations.
-          </p>
-          <div class="mount-voltage-grid">
-            <section
-              class="mount-voltage-card"
-              aria-labelledby="mountVoltageVTitle"
-            >
-              <h5 id="mountVoltageVTitle">V-Mount</h5>
-              <div class="mount-voltage-field">
-                <label for="mountVoltageVHigh" id="mountVoltageVHighLabel">
-                  High-voltage output
-                </label>
-                <input
-                  type="number"
-                  id="mountVoltageVHigh"
-                  class="mount-voltage-input"
-                  step="0.1"
-                  min="0"
-                  inputmode="decimal"
-                  autocomplete="off"
-                />
-              </div>
-              <div class="mount-voltage-field">
-                <label for="mountVoltageVLow" id="mountVoltageVLowLabel">
-                  Low-voltage output
-                </label>
-                <input
-                  type="number"
-                  id="mountVoltageVLow"
-                  class="mount-voltage-input"
-                  step="0.1"
-                  min="0"
-                  inputmode="decimal"
-                  autocomplete="off"
-                />
-              </div>
-            </section>
-            <section
-              class="mount-voltage-card"
-              aria-labelledby="mountVoltageGoldTitle"
-            >
-              <h5 id="mountVoltageGoldTitle">Gold Mount</h5>
-              <div class="mount-voltage-field">
-                <label for="mountVoltageGoldHigh" id="mountVoltageGoldHighLabel">
-                  High-voltage output
-                </label>
-                <input
-                  type="number"
-                  id="mountVoltageGoldHigh"
-                  class="mount-voltage-input"
-                  step="0.1"
-                  min="0"
-                  inputmode="decimal"
-                  autocomplete="off"
-                />
-              </div>
-              <div class="mount-voltage-field">
-                <label for="mountVoltageGoldLow" id="mountVoltageGoldLowLabel">
-                  Low-voltage output
-                </label>
-                <input
-                  type="number"
-                  id="mountVoltageGoldLow"
-                  class="mount-voltage-input"
-                  step="0.1"
-                  min="0"
-                  inputmode="decimal"
-                  autocomplete="off"
-                />
-              </div>
-            </section>
-            <section
-              class="mount-voltage-card"
-              aria-labelledby="mountVoltageBTitle"
-            >
-              <h5 id="mountVoltageBTitle">B-Mount</h5>
-              <div class="mount-voltage-field">
-                <label for="mountVoltageBHigh" id="mountVoltageBHighLabel">
-                  High-voltage output
-                </label>
-                <input
-                  type="number"
-                  id="mountVoltageBHigh"
-                  class="mount-voltage-input"
-                  step="0.1"
-                  min="0"
-                  inputmode="decimal"
-                  autocomplete="off"
-                />
-              </div>
-              <div class="mount-voltage-field">
-                <label for="mountVoltageBLow" id="mountVoltageBLowLabel">
-                  Low-voltage output
-                </label>
-                <input
-                  type="number"
-                  id="mountVoltageBLow"
-                  class="mount-voltage-input"
-                  step="0.1"
-                  min="0"
-                  inputmode="decimal"
-                  autocomplete="off"
-                />
-              </div>
-            </section>
-          </div>
-          <p id="mountVoltageNote" class="settings-hint">
-            These voltages update the totals in the power summary and pin warnings.
-          </p>
-        </section>
-        <div class="form-row">
-          <label for="settingsFontSize" id="settingsFontSizeLabel">Font size</label>
-          <select id="settingsFontSize">
-            <option value="12">12px (Smaller)</option>
-            <option value="14">14px</option>
-            <option value="16">16px</option>
-            <option value="18">18px</option>
-            <option value="20">20px (Bigger)</option>
-          </select>
-        </div>
-        <div class="form-row">
-          <label for="settingsFontFamily" id="settingsFontFamilyLabel">Font</label>
-          <select id="settingsFontFamily">
-            <optgroup label="Bundled fonts" id="bundledFontOptions">
-              <option value="'Ubuntu', sans-serif">Ubuntu</option>
-              <option value="'Arial', sans-serif">Arial</option>
-              <option value="'Times New Roman', serif">Times New Roman</option>
-              <option value="'Courier New', monospace">Courier New</option>
-            </optgroup>
-            <optgroup label="Local fonts" id="localFontsGroup"></optgroup>
-          </select>
-          <button type="button" id="localFontsButton" class="inline-form-button" hidden>
-            Add local font…
-          </button>
-          <input
-            type="file"
-            id="localFontsInput"
-            class="visually-hidden"
-            accept=".woff2,.woff,.ttf,.otf,.ttc,application/font-woff,application/font-woff2,application/x-font-ttf,application/x-font-opentype,font/ttf,font/otf,font/woff,font/woff2"
-            multiple
-            hidden
-          />
-          <p id="localFontsStatus" class="settings-hint" role="status" aria-live="polite" hidden></p>
-        </div>
-        <div class="form-row">
-          <label for="settingsLogo" id="settingsLogoLabel">Logo (SVG)</label>
-          <div class="file-input-wrapper">
-            <input type="file" id="settingsLogo" accept="image/svg+xml" />
-            <div id="settingsLogoPreview" class="logo-preview" hidden aria-live="polite"></div>
-          </div>
-        </div>
-      </section>
+            <h3 id="generalSettingsHeading">General</h3>
+            <div class="settings-section-grid">
+              <section
+                class="settings-card"
+                aria-labelledby="generalLanguageHeading"
+              >
+                <h4 id="generalLanguageHeading">Language &amp; units</h4>
+                <div class="settings-card-body">
+                  <div class="settings-field">
+                    <label for="settingsLanguage" id="settingsLanguageLabel">Language</label>
+                    <select id="settingsLanguage">
+                      <option value="en">English</option>
+                      <option value="de">Deutsch</option>
+                      <option value="es">Español</option>
+                      <option value="fr">Français</option>
+                      <option value="it">Italiano</option>
+                    </select>
+                  </div>
+                  <div class="settings-field">
+                    <label for="settingsTemperatureUnit" id="settingsTemperatureUnitLabel">Temperature unit</label>
+                    <select id="settingsTemperatureUnit">
+                      <option value="celsius">Celsius (°C)</option>
+                      <option value="fahrenheit">Fahrenheit (°F)</option>
+                    </select>
+                  </div>
+                </div>
+              </section>
+              <section
+                class="settings-card"
+                aria-labelledby="generalAppearanceHeading"
+              >
+                <h4 id="generalAppearanceHeading">Appearance</h4>
+                <div class="settings-card-body">
+                  <div class="settings-field settings-field-toggle">
+                    <label for="settingsDarkMode" id="settingsDarkModeLabel">Dark mode</label>
+                    <input type="checkbox" id="settingsDarkMode" />
+                  </div>
+                  <div class="settings-field settings-field-toggle">
+                    <label for="settingsPinkMode" id="settingsPinkModeLabel">Pink mode</label>
+                    <input type="checkbox" id="settingsPinkMode" />
+                  </div>
+                  <div class="settings-field">
+                    <label for="accentColorInput" id="accentColorLabel">Accent color</label>
+                    <div class="settings-inline-controls">
+                      <input type="color" id="accentColorInput" value="#001589" />
+                      <button type="button" id="accentColorReset" class="inline-form-button">
+                        Reset to default
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              </section>
+              <section
+                class="settings-card"
+                aria-labelledby="generalTypographyHeading"
+              >
+                <h4 id="generalTypographyHeading">Typography</h4>
+                <div class="settings-card-body">
+                  <div class="settings-field">
+                    <label for="settingsFontSize" id="settingsFontSizeLabel">Font size</label>
+                    <select id="settingsFontSize">
+                      <option value="12">12px (Smaller)</option>
+                      <option value="14">14px</option>
+                      <option value="16">16px</option>
+                      <option value="18">18px</option>
+                      <option value="20">20px (Bigger)</option>
+                    </select>
+                  </div>
+                  <div class="settings-field">
+                    <label for="settingsFontFamily" id="settingsFontFamilyLabel">Font</label>
+                    <select id="settingsFontFamily">
+                      <optgroup label="Bundled fonts" id="bundledFontOptions">
+                        <option value="'Ubuntu', sans-serif">Ubuntu</option>
+                        <option value="'Arial', sans-serif">Arial</option>
+                        <option value="'Times New Roman', serif">Times New Roman</option>
+                        <option value="'Courier New', monospace">Courier New</option>
+                      </optgroup>
+                      <optgroup label="Local fonts" id="localFontsGroup"></optgroup>
+                    </select>
+                    <div class="settings-inline-actions">
+                      <button type="button" id="localFontsButton" class="inline-form-button" hidden>
+                        Add local font…
+                      </button>
+                      <input
+                        type="file"
+                        id="localFontsInput"
+                        class="visually-hidden"
+                        accept=".woff2,.woff,.ttf,.otf,.ttc,application/font-woff,application/font-woff2,application/x-font-ttf,application/x-font-opentype,font/ttf,font/otf,font/woff,font/woff2"
+                        multiple
+                        hidden
+                      />
+                      <p id="localFontsStatus" class="settings-hint" role="status" aria-live="polite" hidden></p>
+                    </div>
+                  </div>
+                </div>
+              </section>
+              <section
+                class="settings-card"
+                aria-labelledby="generalBrandingHeading"
+              >
+                <h4 id="generalBrandingHeading">Branding</h4>
+                <div class="settings-card-body">
+                  <div class="settings-field">
+                    <label for="settingsLogo" id="settingsLogoLabel">Logo (SVG)</label>
+                    <div class="file-input-wrapper">
+                      <input type="file" id="settingsLogo" accept="image/svg+xml" />
+                      <div id="settingsLogoPreview" class="logo-preview" hidden aria-live="polite"></div>
+                    </div>
+                  </div>
+                </div>
+              </section>
+              <section
+                id="mountVoltageSettings"
+                class="settings-card settings-card-wide mount-voltage-settings"
+                aria-labelledby="mountVoltageHeading"
+              >
+                <div class="mount-voltage-header">
+                  <h4 id="mountVoltageHeading">Battery mount voltages</h4>
+                  <button type="button" id="mountVoltageReset">Restore defaults</button>
+                </div>
+                <p id="mountVoltageDescription" class="settings-hint">
+                  Customize the high and low voltages used for current draw calculations.
+                </p>
+                <div class="mount-voltage-grid">
+                  <section
+                    class="mount-voltage-card"
+                    aria-labelledby="mountVoltageVTitle"
+                  >
+                    <h5 id="mountVoltageVTitle">V-Mount</h5>
+                    <div class="mount-voltage-field">
+                      <label for="mountVoltageVHigh" id="mountVoltageVHighLabel">
+                        High-voltage output
+                      </label>
+                      <input
+                        type="number"
+                        id="mountVoltageVHigh"
+                        class="mount-voltage-input"
+                        step="0.1"
+                        min="0"
+                        inputmode="decimal"
+                        autocomplete="off"
+                      />
+                    </div>
+                    <div class="mount-voltage-field">
+                      <label for="mountVoltageVLow" id="mountVoltageVLowLabel">
+                        Low-voltage output
+                      </label>
+                      <input
+                        type="number"
+                        id="mountVoltageVLow"
+                        class="mount-voltage-input"
+                        step="0.1"
+                        min="0"
+                        inputmode="decimal"
+                        autocomplete="off"
+                      />
+                    </div>
+                  </section>
+                  <section
+                    class="mount-voltage-card"
+                    aria-labelledby="mountVoltageGoldTitle"
+                  >
+                    <h5 id="mountVoltageGoldTitle">Gold Mount</h5>
+                    <div class="mount-voltage-field">
+                      <label for="mountVoltageGoldHigh" id="mountVoltageGoldHighLabel">
+                        High-voltage output
+                      </label>
+                      <input
+                        type="number"
+                        id="mountVoltageGoldHigh"
+                        class="mount-voltage-input"
+                        step="0.1"
+                        min="0"
+                        inputmode="decimal"
+                        autocomplete="off"
+                      />
+                    </div>
+                    <div class="mount-voltage-field">
+                      <label for="mountVoltageGoldLow" id="mountVoltageGoldLowLabel">
+                        Low-voltage output
+                      </label>
+                      <input
+                        type="number"
+                        id="mountVoltageGoldLow"
+                        class="mount-voltage-input"
+                        step="0.1"
+                        min="0"
+                        inputmode="decimal"
+                        autocomplete="off"
+                      />
+                    </div>
+                  </section>
+                  <section
+                    class="mount-voltage-card"
+                    aria-labelledby="mountVoltageBTitle"
+                  >
+                    <h5 id="mountVoltageBTitle">B-Mount</h5>
+                    <div class="mount-voltage-field">
+                      <label for="mountVoltageBHigh" id="mountVoltageBHighLabel">
+                        High-voltage output
+                      </label>
+                      <input
+                        type="number"
+                        id="mountVoltageBHigh"
+                        class="mount-voltage-input"
+                        step="0.1"
+                        min="0"
+                        inputmode="decimal"
+                        autocomplete="off"
+                      />
+                    </div>
+                    <div class="mount-voltage-field">
+                      <label for="mountVoltageBLow" id="mountVoltageBLowLabel">
+                        Low-voltage output
+                      </label>
+                      <input
+                        type="number"
+                        id="mountVoltageBLow"
+                        class="mount-voltage-input"
+                        step="0.1"
+                        min="0"
+                        inputmode="decimal"
+                        autocomplete="off"
+                      />
+                    </div>
+                  </section>
+                </div>
+                <p id="mountVoltageNote" class="settings-hint">
+                  These voltages update the totals in the power summary and pin warnings.
+                </p>
+              </section>
+            </div>
           </section>
           <section
             id="settingsPanel-autoGear"

--- a/src/scripts/app-core-new-1.js
+++ b/src/scripts/app-core-new-1.js
@@ -7474,6 +7474,34 @@ function setLanguage(lang) {
       generalSettingsHeading.textContent = generalLabel;
       generalSettingsHeading.setAttribute('data-help', generalHelp);
     }
+    if (generalLanguageHeading) {
+      const sectionHeading =
+        texts[lang].generalSectionLanguageHeading ||
+        texts.en?.generalSectionLanguageHeading ||
+        generalLanguageHeading.textContent;
+      generalLanguageHeading.textContent = sectionHeading;
+    }
+    if (generalAppearanceHeading) {
+      const sectionHeading =
+        texts[lang].generalSectionAppearanceHeading ||
+        texts.en?.generalSectionAppearanceHeading ||
+        generalAppearanceHeading.textContent;
+      generalAppearanceHeading.textContent = sectionHeading;
+    }
+    if (generalTypographyHeading) {
+      const sectionHeading =
+        texts[lang].generalSectionTypographyHeading ||
+        texts.en?.generalSectionTypographyHeading ||
+        generalTypographyHeading.textContent;
+      generalTypographyHeading.textContent = sectionHeading;
+    }
+    if (generalBrandingHeading) {
+      const sectionHeading =
+        texts[lang].generalSectionBrandingHeading ||
+        texts.en?.generalSectionBrandingHeading ||
+        generalBrandingHeading.textContent;
+      generalBrandingHeading.textContent = sectionHeading;
+    }
   }
   applySettingsTabLabel(
     settingsTabAutoGear,
@@ -13364,6 +13392,10 @@ settingsTabIconAssignments.forEach(([button, glyph]) => {
   iconElement.setAttribute('aria-hidden', 'true');
 });
 const generalSettingsHeading = document.getElementById('generalSettingsHeading');
+const generalLanguageHeading = document.getElementById('generalLanguageHeading');
+const generalAppearanceHeading = document.getElementById('generalAppearanceHeading');
+const generalTypographyHeading = document.getElementById('generalTypographyHeading');
+const generalBrandingHeading = document.getElementById('generalBrandingHeading');
 var settingsLanguage = document.getElementById("settingsLanguage");
 var settingsDarkMode = document.getElementById("settingsDarkMode");
 var settingsPinkMode = document.getElementById("settingsPinkMode");

--- a/src/scripts/translations.js
+++ b/src/scripts/translations.js
@@ -119,6 +119,10 @@ const texts = {
     settingsTabGeneral: "General",
     settingsTabGeneralHelp:
       "Adjust language, theme, typography and branding preferences.",
+    generalSectionLanguageHeading: "Language & units",
+    generalSectionAppearanceHeading: "Appearance",
+    generalSectionTypographyHeading: "Typography",
+    generalSectionBrandingHeading: "Branding",
     languageSetting: "Language",
     settingsLanguageHelp:
       "Choose the interface language. Changes apply immediately and are remembered for next time.",
@@ -1947,6 +1951,10 @@ const texts = {
     settingsTabGeneral: "Generali",
     settingsTabGeneralHelp:
       "Regola lingua, tema, tipografia e branding.",
+    generalSectionLanguageHeading: "Lingua e unità",
+    generalSectionAppearanceHeading: "Aspetto",
+    generalSectionTypographyHeading: "Tipografia",
+    generalSectionBrandingHeading: "Branding e logo",
     languageSetting: "Lingua",
     settingsLanguageHelp:
       "Scegli la lingua dell'interfaccia. Le modifiche sono immediate e vengono ricordate alla visita successiva.",
@@ -3361,6 +3369,10 @@ const texts = {
     settingsTabGeneral: "General",
     settingsTabGeneralHelp:
       "Ajusta idioma, tema, tipografía y opciones de marca.",
+    generalSectionLanguageHeading: "Idioma y unidades",
+    generalSectionAppearanceHeading: "Apariencia",
+    generalSectionTypographyHeading: "Tipografía",
+    generalSectionBrandingHeading: "Marca y logotipo",
     languageSetting: "Idioma",
     settingsLanguageHelp:
       "Elige el idioma de la interfaz. Los cambios se aplican al instante y se recuerdan para la próxima visita.",
@@ -4776,6 +4788,10 @@ const texts = {
     settingsTabGeneral: "Général",
     settingsTabGeneralHelp:
       "Ajustez la langue, le thème, la typographie et l'identité visuelle.",
+    generalSectionLanguageHeading: "Langue et unités",
+    generalSectionAppearanceHeading: "Apparence",
+    generalSectionTypographyHeading: "Typographie",
+    generalSectionBrandingHeading: "Image de marque",
     languageSetting: "Langue",
     settingsLanguageHelp:
       "Choisissez la langue de l’interface. Les modifications sont instantanées et mémorisées pour la prochaine visite.",
@@ -6203,6 +6219,10 @@ const texts = {
     settingsTabGeneral: "Allgemein",
     settingsTabGeneralHelp:
       "Sprache, Erscheinungsbild, Typografie und Branding anpassen.",
+    generalSectionLanguageHeading: "Sprache & Einheiten",
+    generalSectionAppearanceHeading: "Darstellung & Farben",
+    generalSectionTypographyHeading: "Typografie",
+    generalSectionBrandingHeading: "Branding & Logo",
     languageSetting: "Sprache",
     settingsLanguageHelp:
       "Wähle die Oberflächensprache. Änderungen wirken sofort und werden gespeichert.",

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -2136,6 +2136,10 @@ body.high-contrast .settings-tab[aria-selected="true"] {
   .settings-tab {
     flex-basis: 100%;
   }
+
+  .settings-section-grid {
+    grid-template-columns: 1fr;
+  }
 }
 
 @media (max-width: 720px) {
@@ -2203,6 +2207,113 @@ body.high-contrast .settings-tab[aria-selected="true"] {
   font-weight: var(--font-weight-semibold);
 }
 
+.settings-section-grid {
+  display: grid;
+  gap: 20px;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.settings-card {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 18px;
+  border: 1px solid var(--panel-border);
+  border-radius: var(--border-radius);
+  background: var(--panel-bg);
+  min-width: 0;
+}
+
+.settings-card h4 {
+  margin: 0;
+  font-weight: var(--font-weight-semibold);
+  font-size: 1.05rem;
+}
+
+.settings-card-body {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  min-width: 0;
+}
+
+.settings-card-wide {
+  grid-column: 1 / -1;
+}
+
+.settings-field {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-width: 0;
+}
+
+.settings-field select,
+.settings-field input:not([type='checkbox']):not([type='color']),
+.settings-field textarea {
+  width: 100%;
+  max-width: 100%;
+}
+
+.settings-field-toggle {
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.settings-field-toggle label {
+  flex: 1 1 auto;
+}
+
+.settings-field-toggle input[type='checkbox'] {
+  flex: 0 0 auto;
+}
+
+.settings-inline-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: center;
+}
+
+.settings-inline-controls input[type='color'] {
+  padding: 0;
+  width: 52px;
+  height: 32px;
+  border: 1px solid var(--panel-border);
+  border-radius: var(--border-radius);
+  background: var(--surface-color);
+}
+
+.settings-inline-controls .inline-form-button {
+  flex: 0 0 auto;
+}
+
+.settings-inline-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.settings-inline-actions p {
+  margin: 0;
+}
+
+.settings-inline-actions[hidden] {
+  display: none;
+}
+
+.settings-card .settings-hint {
+  margin: 0;
+}
+
+.settings-card .file-input-wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
 .settings-panel p {
   margin: 0;
 }
@@ -2212,14 +2323,13 @@ body.high-contrast .settings-tab[aria-selected="true"] {
 }
 
 .mount-voltage-settings {
-  margin-top: 8px;
-  padding: 16px;
-  border: 1px solid var(--panel-border);
-  border-radius: var(--border-radius);
-  background: var(--panel-bg);
   display: flex;
   flex-direction: column;
   gap: 12px;
+}
+
+.mount-voltage-settings .settings-hint {
+  margin: 0;
 }
 
 .mount-voltage-header {


### PR DESCRIPTION
## Summary
- reorganize the General settings tab into grouped cards for language, appearance, typography, branding, and mount voltages
- add supporting layout styles and ensure translation strings cover the new section headings in all supported languages
- update settings translation logic to populate the new headings at runtime

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dc32cb5dc08320a6a4d109b6503a25