### PR TITLE
Prevent mount voltage key duplication error

### DIFF
--- a/legacy/scripts/storage.js
+++ b/legacy/scripts/storage.js
@@ -28,9 +28,20 @@ var FAVORITES_STORAGE_KEY = 'cameraPowerPlanner_favorites';
 var DEVICE_SCHEMA_CACHE_KEY = 'cameraPowerPlanner_schemaCache';
 var LEGACY_SCHEMA_CACHE_KEY = 'cinePowerPlanner_schemaCache';
 var CUSTOM_FONT_STORAGE_KEY_DEFAULT = 'cameraPowerPlanner_customFonts';
+var MOUNT_VOLTAGE_STORAGE_KEY_SYMBOL = typeof Symbol === 'function' ? Symbol.for('cinePowerPlanner.mountVoltageKey') : null;
 function readGlobalStringValue(scope, key) {
   if (!scope || _typeof(scope) !== 'object') {
     return '';
+  }
+  if (key === 'MOUNT_VOLTAGE_STORAGE_KEY' && MOUNT_VOLTAGE_STORAGE_KEY_SYMBOL) {
+    try {
+      var symbolValue = scope[MOUNT_VOLTAGE_STORAGE_KEY_SYMBOL];
+      if (typeof symbolValue === 'string' && symbolValue) {
+        return symbolValue;
+      }
+    } catch (symbolReadError) {
+      void symbolReadError;
+    }
   }
   var descriptor = null;
   try {
@@ -53,6 +64,17 @@ function exposeGlobalStringValue(scope, key, value) {
   if (!scope || _typeof(scope) !== 'object') {
     return '';
   }
+  if (key === 'MOUNT_VOLTAGE_STORAGE_KEY' && MOUNT_VOLTAGE_STORAGE_KEY_SYMBOL) {
+    try {
+      scope[MOUNT_VOLTAGE_STORAGE_KEY_SYMBOL] = value;
+      var symbolAssigned = scope[MOUNT_VOLTAGE_STORAGE_KEY_SYMBOL];
+      if (typeof symbolAssigned === 'string' && symbolAssigned) {
+        return symbolAssigned;
+      }
+    } catch (symbolExposeError) {
+      void symbolExposeError;
+    }
+  }
   var descriptor = null;
   try {
     descriptor = Object.getOwnPropertyDescriptor(scope, key);
@@ -74,23 +96,13 @@ function exposeGlobalStringValue(scope, key, value) {
     assigned = '';
     void assignError;
   }
-  if (typeof assigned !== 'string' || !assigned) {
-    try {
-      Object.defineProperty(scope, key, {
-        configurable: true,
-        writable: true,
-        value: value
-      });
-      assigned = scope[key];
-    } catch (defineError) {
-      void defineError;
-      if (typeof console !== 'undefined' && typeof console.warn === 'function') {
-        console.warn('Unable to expose mount voltage storage key globally. Using fallback only.', defineError);
-      }
-      return '';
-    }
+  if (typeof assigned === 'string' && assigned) {
+    return assigned;
   }
-  return typeof assigned === 'string' && assigned ? assigned : '';
+  if (key === 'MOUNT_VOLTAGE_STORAGE_KEY' && typeof console !== 'undefined' && typeof console.warn === 'function') {
+    console.warn('Unable to expose mount voltage storage key globally. Using fallback only.');
+  }
+  return '';
 }
 function resolveMountVoltageStorageKeyName() {
   var fallback = 'cameraPowerPlanner_mountVoltages';

--- a/src/scripts/storage.js
+++ b/src/scripts/storage.js
@@ -25,10 +25,25 @@ var DEVICE_SCHEMA_CACHE_KEY = 'cameraPowerPlanner_schemaCache';
 var LEGACY_SCHEMA_CACHE_KEY = 'cinePowerPlanner_schemaCache';
 var CUSTOM_FONT_STORAGE_KEY_DEFAULT = 'cameraPowerPlanner_customFonts';
 var MOUNT_VOLTAGE_STORAGE_KEY_FALLBACK = 'cameraPowerPlanner_mountVoltages';
+var MOUNT_VOLTAGE_STORAGE_KEY_SYMBOL =
+  typeof Symbol === 'function'
+    ? Symbol.for('cinePowerPlanner.mountVoltageKey')
+    : null;
 
 function readGlobalStringValue(scope, key) {
   if (!scope || typeof scope !== 'object') {
     return '';
+  }
+
+  if (key === 'MOUNT_VOLTAGE_STORAGE_KEY' && MOUNT_VOLTAGE_STORAGE_KEY_SYMBOL) {
+    try {
+      const symbolValue = scope[MOUNT_VOLTAGE_STORAGE_KEY_SYMBOL];
+      if (typeof symbolValue === 'string' && symbolValue) {
+        return symbolValue;
+      }
+    } catch (symbolReadError) {
+      void symbolReadError;
+    }
   }
 
   var descriptor;
@@ -64,6 +79,18 @@ function exposeGlobalStringValue(scope, key, value) {
     return '';
   }
 
+  if (key === 'MOUNT_VOLTAGE_STORAGE_KEY' && MOUNT_VOLTAGE_STORAGE_KEY_SYMBOL) {
+    try {
+      scope[MOUNT_VOLTAGE_STORAGE_KEY_SYMBOL] = value;
+      const symbolAssigned = scope[MOUNT_VOLTAGE_STORAGE_KEY_SYMBOL];
+      if (typeof symbolAssigned === 'string' && symbolAssigned) {
+        return symbolAssigned;
+      }
+    } catch (symbolExposeError) {
+      void symbolExposeError;
+    }
+  }
+
   var descriptor;
   try {
     descriptor = Object.getOwnPropertyDescriptor(scope, key);
@@ -95,30 +122,21 @@ function exposeGlobalStringValue(scope, key, value) {
     void assignError;
   }
 
-  if (typeof assigned !== 'string' || !assigned) {
-    try {
-      Object.defineProperty(scope, key, {
-        configurable: true,
-        writable: true,
-        value: value
-      });
-      assigned = scope[key];
-    } catch (defineError) {
-      void defineError;
-      if (
-        typeof console !== 'undefined' &&
-        typeof console.warn === 'function'
-      ) {
-        console.warn(
-          'Unable to expose mount voltage storage key globally. Using fallback only.',
-          defineError
-        );
-      }
-      return '';
-    }
+  if (typeof assigned === 'string' && assigned) {
+    return assigned;
   }
 
-  return typeof assigned === 'string' && assigned ? assigned : '';
+  if (
+    key === 'MOUNT_VOLTAGE_STORAGE_KEY' &&
+    typeof console !== 'undefined' &&
+    typeof console.warn === 'function'
+  ) {
+    console.warn(
+      'Unable to expose mount voltage storage key globally. Using fallback only.'
+    );
+  }
+
+  return '';
 }
 
 function resolveMountVoltageStorageKeyName() {


### PR DESCRIPTION
## Summary
- add a shared Symbol fallback for the mount voltage storage key to avoid duplicate global bindings
- stop using Object.defineProperty when exposing the key so Safari no longer raises duplicate variable errors
- mirror the safer exposure logic in the legacy storage bundle

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dc33e0e92c83208a38658048ab8f0c