### PR TITLE
Prevent duplicate storage initialization

### DIFF
--- a/legacy/scripts/storage.js
+++ b/legacy/scripts/storage.js
@@ -19,6 +19,19 @@ function _arrayWithoutHoles(r) { if (Array.isArray(r)) return _arrayLikeToArray(
 function _arrayLikeToArray(r, a) { (null == a || a > r.length) && (a = r.length); for (var e = 0, n = Array(a); e < a; e++) n[e] = r[e]; return n; }
 function _typeof(o) { "@babel/helpers - typeof"; return _typeof = "function" == typeof Symbol && "symbol" == typeof Symbol.iterator ? function (o) { return typeof o; } : function (o) { return o && "function" == typeof Symbol && o.constructor === Symbol && o !== Symbol.prototype ? "symbol" : typeof o; }, _typeof(o); }
 var GLOBAL_SCOPE = typeof globalThis !== 'undefined' ? globalThis : typeof window !== 'undefined' ? window : typeof global !== 'undefined' ? global : typeof self !== 'undefined' ? self : null;
+if (GLOBAL_SCOPE && GLOBAL_SCOPE.__cineStorageInitialized) {
+  if (typeof module !== 'undefined' && module && module.exports && GLOBAL_SCOPE.__cineStorageApi && typeof GLOBAL_SCOPE.__cineStorageApi === 'object') {
+    module.exports = GLOBAL_SCOPE.__cineStorageApi;
+  }
+} else {
+  try {
+    Object.defineProperty(GLOBAL_SCOPE, '__cineStorageInitialized', { configurable: true, writable: true, value: true });
+  } catch (storageInitFlagError) {
+    if (GLOBAL_SCOPE) {
+      GLOBAL_SCOPE.__cineStorageInitialized = true;
+    }
+    void storageInitFlagError;
+  }
 var DEVICE_STORAGE_KEY = 'cameraPowerPlanner_devices';
 var SETUP_STORAGE_KEY = 'cameraPowerPlanner_setups';
 var SESSION_STATE_KEY = 'cameraPowerPlanner_session';
@@ -5092,4 +5105,13 @@ if (GLOBAL_SCOPE && _typeof(GLOBAL_SCOPE) === 'object') {
   } catch (ex) {
     void ex;
   }
+}
+if (GLOBAL_SCOPE) {
+  try {
+    Object.defineProperty(GLOBAL_SCOPE, '__cineStorageApi', { configurable: true, writable: true, value: STORAGE_API });
+  } catch (storageApiExposeError) {
+    GLOBAL_SCOPE.__cineStorageApi = STORAGE_API;
+    void storageApiExposeError;
+  }
+}
 }

--- a/src/scripts/storage.js
+++ b/src/scripts/storage.js
@@ -4,16 +4,42 @@
           resetMountVoltagePreferences */
 /* exported getMountVoltageStorageKeyName, getMountVoltageStorageBackupKeyName */
 
-var GLOBAL_SCOPE =
-  typeof globalThis !== 'undefined'
-    ? globalThis
-    : typeof window !== 'undefined'
-      ? window
-      : typeof global !== 'undefined'
-        ? global
-        : typeof self !== 'undefined'
-          ? self
-          : null;
+(function initializeStorageModule() {
+  const GLOBAL_SCOPE =
+    typeof globalThis !== 'undefined'
+      ? globalThis
+      : typeof window !== 'undefined'
+        ? window
+        : typeof global !== 'undefined'
+          ? global
+          : typeof self !== 'undefined'
+            ? self
+            : null;
+
+  if (GLOBAL_SCOPE && GLOBAL_SCOPE.__cineStorageInitialized) {
+    if (
+      typeof module !== 'undefined' &&
+      module.exports &&
+      GLOBAL_SCOPE.__cineStorageApi &&
+      typeof GLOBAL_SCOPE.__cineStorageApi === 'object'
+    ) {
+      module.exports = GLOBAL_SCOPE.__cineStorageApi;
+    }
+    return;
+  }
+
+  if (GLOBAL_SCOPE) {
+    try {
+      Object.defineProperty(GLOBAL_SCOPE, '__cineStorageInitialized', {
+        configurable: true,
+        writable: true,
+        value: true,
+      });
+    } catch (storageInitFlagError) {
+      GLOBAL_SCOPE.__cineStorageInitialized = true;
+      void storageInitFlagError;
+    }
+  }
 
 var DEVICE_STORAGE_KEY = 'cameraPowerPlanner_devices';
 var SETUP_STORAGE_KEY = 'cameraPowerPlanner_setups';
@@ -6446,3 +6472,18 @@ if (GLOBAL_SCOPE && typeof GLOBAL_SCOPE === 'object') {
     void ex;
   }
 }
+
+if (GLOBAL_SCOPE) {
+  try {
+    Object.defineProperty(GLOBAL_SCOPE, '__cineStorageApi', {
+      configurable: true,
+      writable: true,
+      value: STORAGE_API,
+    });
+  } catch (storageApiExposeError) {
+    GLOBAL_SCOPE.__cineStorageApi = STORAGE_API;
+    void storageApiExposeError;
+  }
+}
+
+})();


### PR DESCRIPTION
## Summary
- prevent the modern storage bundle from re-declaring globals by wrapping initialization and caching its API
- mirror the duplicate-initialization guard in the legacy storage bundle for feature parity

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dc36ab6628832086eff22f09d03ba2