### PR TITLE
Support additional units in automatic gear weight rules

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -749,7 +749,8 @@ list without editing JSON exports manually:
 - Build rules that only trigger when selected **Required Scenarios** are active.
   Each rule can have an optional label for quick scanning in the settings list.
 - Gate rules by **Camera weight**, comparing the selected body to a heavier-than,
-  lighter-than or exact gram threshold before the automation fires.
+  lighter-than or exact gram threshold before the automation fires. Weight
+  thresholds accept grams, kilograms, pounds or ounces for fast data entry.
 - Add equipment with explicit category and quantity values or pick **Custom
   Additions** for reminders, specialty kits or callouts. Matching remove rules
   hide specific rows the generator would normally include.

--- a/README.md
+++ b/README.md
@@ -766,7 +766,8 @@ list without editing JSON exports manually:
 - Build rules that only trigger when selected **Required Scenarios** are active.
   Each rule can have an optional label for quick scanning in the settings list.
 - Gate rules by **Camera weight**, comparing the selected body to a heavier-than,
-  lighter-than or exact gram threshold before the automation fires.
+  lighter-than or exact gram threshold before the automation fires. Weight
+  thresholds accept grams, kilograms, pounds or ounces for fast data entry.
 - Add equipment with explicit category and quantity values or pick **Custom
   Additions** for reminders, specialty kits or callouts. Matching remove rules
   hide specific rows the generator would normally include.

--- a/legacy/scripts/auto-gear-weight.js
+++ b/legacy/scripts/auto-gear-weight.js
@@ -31,11 +31,33 @@ function _typeof(o) { "@babel/helpers - typeof"; return _typeof = "function" == 
     if (typeof value === 'string') {
       var trimmed = value.trim();
       if (!trimmed) return null;
-      var sanitized = trimmed.replace(/[^0-9.,-]/g, '').replace(/,/g, '.');
+      var lowerCased = trimmed.toLowerCase();
+      var multiplier = 1;
+      var unitFragment = lowerCased.replace(/[-0-9.,]/g, ' ');
+      var unitTokens = unitFragment.split(/\s+/).map(function (token) {
+        return token.replace(/[^a-z]/g, '');
+      }).filter(Boolean);
+      for (var i = 0; i < unitTokens.length; i += 1) {
+        var token = unitTokens[i];
+        if (token === 'kg' || token === 'kilogram' || token === 'kilograms' || token === 'kilo' || token === 'kilos') {
+          multiplier = 1000;
+          break;
+        }
+        if (token === 'lb' || token === 'lbs' || token === 'pound' || token === 'pounds') {
+          multiplier = 453.59237;
+          break;
+        }
+        if (token === 'oz' || token === 'ounce' || token === 'ounces') {
+          multiplier = 28.349523125;
+          break;
+        }
+      }
+      var sanitized = lowerCased.replace(/[^0-9.,-]/g, '').replace(/,/g, '.');
       if (!sanitized) return null;
       var parsed = Number.parseFloat(sanitized);
       if (!Number.isFinite(parsed)) return null;
-      var roundedParsed = Math.round(parsed);
+      var converted = parsed * multiplier;
+      var roundedParsed = Math.round(converted);
       return roundedParsed >= 0 ? roundedParsed : null;
     }
     return null;

--- a/src/scripts/auto-gear-weight.js
+++ b/src/scripts/auto-gear-weight.js
@@ -41,11 +41,34 @@
     if (typeof value === 'string') {
       var trimmed = value.trim();
       if (!trimmed) return null;
-      var sanitized = trimmed.replace(/[^0-9.,-]/g, '').replace(/,/g, '.');
+      var lowerCased = trimmed.toLowerCase();
+      var multiplier = 1;
+      var unitFragment = lowerCased.replace(/[-0-9.,]/g, ' ');
+      var unitTokens = unitFragment
+        .split(/\s+/)
+        .map(function (token) { return token.replace(/[^a-z]/g, ''); })
+        .filter(Boolean);
+      for (var i = 0; i < unitTokens.length; i += 1) {
+        var token = unitTokens[i];
+        if (token === 'kg' || token === 'kilogram' || token === 'kilograms' || token === 'kilo' || token === 'kilos') {
+          multiplier = 1000;
+          break;
+        }
+        if (token === 'lb' || token === 'lbs' || token === 'pound' || token === 'pounds') {
+          multiplier = 453.59237;
+          break;
+        }
+        if (token === 'oz' || token === 'ounce' || token === 'ounces') {
+          multiplier = 28.349523125;
+          break;
+        }
+      }
+      var sanitized = lowerCased.replace(/[^0-9.,-]/g, '').replace(/,/g, '.');
       if (!sanitized) return null;
       var parsed = Number.parseFloat(sanitized);
       if (!Number.isFinite(parsed)) return null;
-      var roundedParsed = Math.round(parsed);
+      var converted = parsed * multiplier;
+      var roundedParsed = Math.round(converted);
       return roundedParsed >= 0 ? roundedParsed : null;
     }
     return null;

--- a/tests/unit/autoGearCameraWeight.test.js
+++ b/tests/unit/autoGearCameraWeight.test.js
@@ -29,6 +29,13 @@ describe('auto gear camera weight helpers', () => {
     expect(normalizeAutoGearWeightValue('')).toBeNull();
   });
 
+  test('normalizes string values that include kilograms, pounds or ounces', () => {
+    expect(normalizeAutoGearWeightValue('2.5 kg')).toBe(2500);
+    expect(normalizeAutoGearWeightValue('2kg')).toBe(2000);
+    expect(normalizeAutoGearWeightValue('10 lb')).toBe(4536);
+    expect(normalizeAutoGearWeightValue('8 ounces')).toBe(227);
+  });
+
   test('evaluateAutoGearCameraWeightCondition compares correctly', () => {
     expect(
       evaluateAutoGearCameraWeightCondition({ operator: 'greater', value: 1500 }, 1600)


### PR DESCRIPTION
## Summary
- allow the automatic gear weight normalizer to convert kilogram, pound, and ounce inputs across modern and legacy bundles
- document the expanded camera weight thresholds in the English readme variants
- extend unit coverage for the new parsing behaviour

## Testing
- npm test -- --runTestsByPath tests/unit/autoGearCameraWeight.test.js

------
https://chatgpt.com/codex/tasks/task_e_68dc3abe58a88320bc012d10c342d373