### PR TITLE
chore: bump version to 1.0.10

### DIFF
--- a/index.html
+++ b/index.html
@@ -2583,7 +2583,7 @@
             hidden
           >
         <h3 id="aboutHeading">About &amp; Support</h3>
-        <p id="aboutVersion">Version 1.0.9</p>
+        <p id="aboutVersion">Version 1.0.10</p>
         <p><a href="https://github.com" id="supportLink" target="_blank">Support</a></p>
       </section>
           <div class="button-row action-buttons">

--- a/legacy/scripts/app-core-new-1.js
+++ b/legacy/scripts/app-core-new-1.js
@@ -320,7 +320,7 @@ try {
   var _require = require('./overview.js');
   generatePrintableOverview = _require.generatePrintableOverview;
 } catch (_unused) {}
-var APP_VERSION = typeof CORE_SHARED.APP_VERSION === 'string' ? CORE_SHARED.APP_VERSION : '1.0.9';
+var APP_VERSION = typeof CORE_SHARED.APP_VERSION === 'string' ? CORE_SHARED.APP_VERSION : '1.0.10';
 if (typeof window !== 'undefined') {
   var lottie = window.lottie;
   if (lottie && typeof lottie.useWebWorker === 'function') {

--- a/legacy/scripts/modules/core-shared.js
+++ b/legacy/scripts/modules/core-shared.js
@@ -339,7 +339,7 @@ function _typeof(o) { "@babel/helpers - typeof"; return _typeof = "function" == 
     return resolved;
   }
   var LZString = resolveLzString();
-  var APP_VERSION = '1.0.9';
+  var APP_VERSION = '1.0.10';
   var shared = freezeDeep({
     APP_VERSION: APP_VERSION,
     stableStringify: stableStringify,

--- a/legacy/scripts/script.js
+++ b/legacy/scripts/script.js
@@ -34,7 +34,7 @@ if (typeof require === 'function' && typeof module !== 'undefined' && module && 
   attemptRegistryBackfill(globalScope);
   var aggregatedExports = module.exports;
   var combinedAppVersion = aggregatedExports && aggregatedExports.APP_VERSION;
-  var APP_VERSION = "1.0.9";
+  var APP_VERSION = "1.0.10";
   if (combinedAppVersion && combinedAppVersion !== APP_VERSION) {
     throw new Error("Combined app version (".concat(combinedAppVersion, ") does not match script marker (").concat(APP_VERSION, ")."));
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cine-power-planner",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cine-power-planner",
-      "version": "1.0.9",
+      "version": "1.0.10",
       "license": "ISC",
       "dependencies": {
         "lottie-web": "^5.13.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cine-power-planner",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "Browser-based tool for planning professional camera setups powered by V-Mount or B-Mount batteries. It calculates total power consumption, current draw at 14.4 V and 12 V, and estimated battery runtime while checking that the battery can safely deliver the required power.",
   "main": "src/data/index.js",
   "scripts": {

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,5 +1,5 @@
 /* eslint-env serviceworker */
-const CACHE_NAME = 'cine-power-planner-v1.0.9';
+const CACHE_NAME = 'cine-power-planner-v1.0.10';
 const ASSETS = [
   './',
   './index.html',

--- a/src/scripts/app-core-new-1.js
+++ b/src/scripts/app-core-new-1.js
@@ -465,7 +465,7 @@ try {
   // overview generation not needed in test environments without module support
 }
 
-var APP_VERSION = typeof CORE_SHARED.APP_VERSION === 'string' ? CORE_SHARED.APP_VERSION : '1.0.9';
+var APP_VERSION = typeof CORE_SHARED.APP_VERSION === 'string' ? CORE_SHARED.APP_VERSION : '1.0.10';
 
 if (typeof window !== 'undefined') {
   const lottie = window.lottie;

--- a/src/scripts/modules/core-shared.js
+++ b/src/scripts/modules/core-shared.js
@@ -428,7 +428,7 @@
 
   const LZString = resolveLzString();
 
-  const APP_VERSION = '1.0.9';
+  const APP_VERSION = '1.0.10';
 
   const shared = freezeDeep({
     APP_VERSION,

--- a/src/scripts/script.js
+++ b/src/scripts/script.js
@@ -81,7 +81,7 @@ if (typeof require === 'function' && typeof module !== 'undefined' && module && 
 
   const aggregatedExports = module.exports;
   const combinedAppVersion = aggregatedExports && aggregatedExports.APP_VERSION;
-  const APP_VERSION = "1.0.9"; // Version marker for consistency checks
+  const APP_VERSION = "1.0.10"; // Version marker for consistency checks
 
   if (combinedAppVersion && combinedAppVersion !== APP_VERSION) {
     throw new Error(


### PR DESCRIPTION
## Summary
- bump the application version metadata to 1.0.10 across package files
- align displayed version strings and service worker cache name with the new release
- keep core scripts in sync with the updated APP_VERSION constant

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc3ef326648320bea86fe5442b21ae