### PR TITLE
Fix mount voltage key resolution guard

### DIFF
--- a/legacy/scripts/app-core-new-1.js
+++ b/legacy/scripts/app-core-new-1.js
@@ -548,67 +548,102 @@ var SUPPORTED_MOUNT_VOLTAGE_TYPES = function resolveSupportedMounts() {
   }
   return created;
 }();
-var MOUNT_VOLTAGE_STORAGE_KEY_RESOLVED = function resolveMountVoltageStorageKey() {
-  var existing = null;
-  if (CORE_GLOBAL_SCOPE && typeof CORE_GLOBAL_SCOPE.MOUNT_VOLTAGE_STORAGE_KEY === 'string' && CORE_GLOBAL_SCOPE.MOUNT_VOLTAGE_STORAGE_KEY) {
-    existing = CORE_GLOBAL_SCOPE.MOUNT_VOLTAGE_STORAGE_KEY;
-  }
-  if (!existing && CORE_GLOBAL_SCOPE) {
-    var scopedResolved = CORE_GLOBAL_SCOPE.MOUNT_VOLTAGE_STORAGE_KEY_RESOLVED;
-    if (typeof scopedResolved === 'string' && scopedResolved) {
-      existing = scopedResolved;
+  var MOUNT_VOLTAGE_STORAGE_KEY_FALLBACK = 'cameraPowerPlanner_mountVoltages';
+  var cachedMountVoltagePrimaryKey = '';
+  var cachedMountVoltageBackupKey = '';
+  var mountVoltageKeysResolved = false;
+
+  function readGlobalMountVoltageKey(property) {
+    if (!CORE_GLOBAL_SCOPE || _typeof(CORE_GLOBAL_SCOPE) !== 'object') {
+      return '';
     }
+    var value = CORE_GLOBAL_SCOPE[property];
+    return typeof value === 'string' && value ? value : '';
   }
-  if (!existing && typeof getMountVoltageStorageKeyName === 'function') {
+
+  function assignGlobalMountVoltageKey(property, value) {
+    if (!CORE_GLOBAL_SCOPE || _typeof(CORE_GLOBAL_SCOPE) !== 'object') {
+      return;
+    }
+    if (typeof value !== 'string' || !value) {
+      return;
+    }
+    var descriptor = null;
     try {
-      var resolvedKey = getMountVoltageStorageKeyName();
-      if (typeof resolvedKey === 'string' && resolvedKey) {
-        existing = resolvedKey;
+      descriptor = Object.getOwnPropertyDescriptor(CORE_GLOBAL_SCOPE, property);
+    } catch (descriptorError) {
+      descriptor = null;
+      void descriptorError;
+    }
+    if (descriptor && descriptor.configurable === false && descriptor.writable === false) {
+      return;
+    }
+    try {
+      CORE_GLOBAL_SCOPE[property] = value;
+    } catch (assignError) {
+      if (typeof console !== 'undefined' && typeof console.warn === 'function') {
+        console.warn('Unable to expose ' + property + ' globally', assignError);
       }
-    } catch (mountVoltageKeyError) {
-      console.warn('Unable to resolve mount voltage storage key name', mountVoltageKeyError);
     }
   }
-  if (!existing && typeof MOUNT_VOLTAGE_STORAGE_KEY_NAME === 'string' && MOUNT_VOLTAGE_STORAGE_KEY_NAME) {
-    existing = MOUNT_VOLTAGE_STORAGE_KEY_NAME;
-  }
-  var resolved = existing || 'cameraPowerPlanner_mountVoltages';
-  if (CORE_GLOBAL_SCOPE && _typeof(CORE_GLOBAL_SCOPE) === 'object') {
-    try {
-      CORE_GLOBAL_SCOPE.MOUNT_VOLTAGE_STORAGE_KEY = resolved;
-    } catch (assignError) {
-      console.warn('Unable to expose mount voltage storage key globally', assignError);
+
+  function resolveMountVoltageStorageKeys() {
+    if (mountVoltageKeysResolved) {
+      return;
     }
-    try {
-      CORE_GLOBAL_SCOPE.MOUNT_VOLTAGE_STORAGE_KEY_RESOLVED = resolved;
-    } catch (exposeResolvedError) {
-      void exposeResolvedError;
+    var resolvedPrimary = readGlobalMountVoltageKey('MOUNT_VOLTAGE_STORAGE_KEY') || readGlobalMountVoltageKey('MOUNT_VOLTAGE_STORAGE_KEY_RESOLVED');
+    if (!resolvedPrimary && typeof getMountVoltageStorageKeyName === 'function') {
+      try {
+        var resolvedKey = getMountVoltageStorageKeyName();
+        if (typeof resolvedKey === 'string' && resolvedKey) {
+          resolvedPrimary = resolvedKey;
+        }
+      } catch (mountVoltageKeyError) {
+        console.warn('Unable to resolve mount voltage storage key name', mountVoltageKeyError);
+      }
     }
-  }
-  return resolved;
-}();
-var MOUNT_VOLTAGE_STORAGE_BACKUP_KEY = function resolveMountVoltageBackupKey() {
-  if (CORE_GLOBAL_SCOPE && typeof CORE_GLOBAL_SCOPE.MOUNT_VOLTAGE_STORAGE_BACKUP_KEY === 'string' && CORE_GLOBAL_SCOPE.MOUNT_VOLTAGE_STORAGE_BACKUP_KEY) {
-    return CORE_GLOBAL_SCOPE.MOUNT_VOLTAGE_STORAGE_BACKUP_KEY;
-  }
-  if (CORE_GLOBAL_SCOPE && typeof CORE_GLOBAL_SCOPE.MOUNT_VOLTAGE_STORAGE_BACKUP_KEY_RESOLVED === 'string' && CORE_GLOBAL_SCOPE.MOUNT_VOLTAGE_STORAGE_BACKUP_KEY_RESOLVED) {
-    return CORE_GLOBAL_SCOPE.MOUNT_VOLTAGE_STORAGE_BACKUP_KEY_RESOLVED;
-  }
-  var backupKey = "".concat(MOUNT_VOLTAGE_STORAGE_KEY_RESOLVED, "__backup");
-  if (CORE_GLOBAL_SCOPE && _typeof(CORE_GLOBAL_SCOPE) === 'object') {
-    try {
-      CORE_GLOBAL_SCOPE.MOUNT_VOLTAGE_STORAGE_BACKUP_KEY = backupKey;
-    } catch (assignError) {
-      console.warn('Unable to expose mount voltage storage backup key globally', assignError);
+    if (!resolvedPrimary && typeof MOUNT_VOLTAGE_STORAGE_KEY_NAME === 'string' && MOUNT_VOLTAGE_STORAGE_KEY_NAME) {
+      resolvedPrimary = MOUNT_VOLTAGE_STORAGE_KEY_NAME;
     }
-    try {
-      CORE_GLOBAL_SCOPE.MOUNT_VOLTAGE_STORAGE_BACKUP_KEY_RESOLVED = backupKey;
-    } catch (exposeResolvedError) {
-      void exposeResolvedError;
+    if (!resolvedPrimary) {
+      resolvedPrimary = MOUNT_VOLTAGE_STORAGE_KEY_FALLBACK;
     }
+    var resolvedBackup = readGlobalMountVoltageKey('MOUNT_VOLTAGE_STORAGE_BACKUP_KEY') || readGlobalMountVoltageKey('MOUNT_VOLTAGE_STORAGE_BACKUP_KEY_RESOLVED');
+    if (!resolvedBackup && typeof getMountVoltageStorageBackupKeyName === 'function') {
+      try {
+        var backupKeyName = getMountVoltageStorageBackupKeyName();
+        if (typeof backupKeyName === 'string' && backupKeyName) {
+          resolvedBackup = backupKeyName;
+        }
+      } catch (backupKeyError) {
+        console.warn('Unable to resolve mount voltage storage backup key name', backupKeyError);
+      }
+    }
+    if (!resolvedBackup && resolvedPrimary) {
+      resolvedBackup = "".concat(resolvedPrimary, "__backup");
+    }
+    cachedMountVoltagePrimaryKey = resolvedPrimary || MOUNT_VOLTAGE_STORAGE_KEY_FALLBACK;
+    cachedMountVoltageBackupKey = resolvedBackup || "".concat(cachedMountVoltagePrimaryKey, "__backup");
+    mountVoltageKeysResolved = true;
+    assignGlobalMountVoltageKey('MOUNT_VOLTAGE_STORAGE_KEY', cachedMountVoltagePrimaryKey);
+    assignGlobalMountVoltageKey('MOUNT_VOLTAGE_STORAGE_KEY_RESOLVED', cachedMountVoltagePrimaryKey);
+    assignGlobalMountVoltageKey('MOUNT_VOLTAGE_STORAGE_BACKUP_KEY', cachedMountVoltageBackupKey);
+    assignGlobalMountVoltageKey('MOUNT_VOLTAGE_STORAGE_BACKUP_KEY_RESOLVED', cachedMountVoltageBackupKey);
   }
-  return backupKey;
-}();
+
+  function getMountVoltagePrimaryStorageKey() {
+    if (!mountVoltageKeysResolved) {
+      resolveMountVoltageStorageKeys();
+    }
+    return cachedMountVoltagePrimaryKey || MOUNT_VOLTAGE_STORAGE_KEY_FALLBACK;
+  }
+
+  function getMountVoltageBackupStorageKey() {
+    if (!mountVoltageKeysResolved) {
+      resolveMountVoltageStorageKeys();
+    }
+    return cachedMountVoltageBackupKey || "".concat(getMountVoltagePrimaryStorageKey(), "__backup");
+  }
 var DEFAULT_MOUNT_VOLTAGES = function resolveDefaultMountVoltages() {
   if (CORE_GLOBAL_SCOPE && CORE_GLOBAL_SCOPE.DEFAULT_MOUNT_VOLTAGES && _typeof(CORE_GLOBAL_SCOPE.DEFAULT_MOUNT_VOLTAGES) === 'object') {
     return CORE_GLOBAL_SCOPE.DEFAULT_MOUNT_VOLTAGES;
@@ -756,16 +791,18 @@ function persistMountVoltagePreferences(preferences) {
     console.warn('Could not serialize mount voltage preferences', serializationError);
     return;
   }
-  try {
-    localStorage.setItem(MOUNT_VOLTAGE_STORAGE_KEY_RESOLVED, serialized);
-  } catch (storageError) {
-    console.warn('Could not save mount voltage preferences', storageError);
-  }
-  try {
-    localStorage.setItem(MOUNT_VOLTAGE_STORAGE_BACKUP_KEY, serialized);
-  } catch (backupError) {
-    console.warn('Could not save mount voltage backup copy', backupError);
-  }
+    var primaryMountVoltageKey = getMountVoltagePrimaryStorageKey();
+    try {
+      localStorage.setItem(primaryMountVoltageKey, serialized);
+    } catch (storageError) {
+      console.warn('Could not save mount voltage preferences', storageError);
+    }
+    var backupMountVoltageKey = getMountVoltageBackupStorageKey();
+    try {
+      localStorage.setItem(backupMountVoltageKey, serialized);
+    } catch (backupError) {
+      console.warn('Could not save mount voltage backup copy', backupError);
+    }
 }
 function applyMountVoltagePreferences(preferences) {
   var options = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
@@ -927,12 +964,12 @@ function updateMountVoltageSettingLabels() {
 }
 try {
   if (typeof localStorage !== 'undefined') {
-    var storedVoltages = localStorage.getItem(MOUNT_VOLTAGE_STORAGE_KEY_RESOLVED);
+    var storedVoltages = localStorage.getItem(getMountVoltagePrimaryStorageKey());
     var parsedVoltages = parseStoredMountVoltages(storedVoltages);
     if (parsedVoltages) {
       mountVoltagePreferences = parsedVoltages;
     } else {
-      var backupVoltages = localStorage.getItem(MOUNT_VOLTAGE_STORAGE_BACKUP_KEY);
+      var backupVoltages = localStorage.getItem(getMountVoltageBackupStorageKey());
       var parsedBackupVoltages = parseStoredMountVoltages(backupVoltages);
       if (parsedBackupVoltages) {
         mountVoltagePreferences = parsedBackupVoltages;

--- a/legacy/scripts/app-session.js
+++ b/legacy/scripts/app-session.js
@@ -5776,7 +5776,7 @@ function applyPreferencesFromStorage(safeGetItem) {
     var parsedVoltages = parseStoredMountVoltages(storedVoltages);
     var shouldPersistVoltages = false;
     if (!parsedVoltages) {
-      var backupKey = typeof MOUNT_VOLTAGE_STORAGE_BACKUP_KEY === 'string' ? MOUNT_VOLTAGE_STORAGE_BACKUP_KEY : typeof getMountVoltageStorageBackupKeyName === 'function' ? getMountVoltageStorageBackupKeyName() : "".concat(mountVoltageKeyName, "__backup");
+      var backupKey = typeof getMountVoltageStorageBackupKeyName === 'function' ? getMountVoltageStorageBackupKeyName() : "".concat(mountVoltageKeyName, "__backup");
       var backupVoltages = safeGetItem(backupKey);
       if (backupVoltages !== undefined && backupVoltages !== null) {
         var parsedBackupVoltages = parseStoredMountVoltages(backupVoltages);

--- a/src/scripts/app-core-new-1.js
+++ b/src/scripts/app-core-new-1.js
@@ -753,90 +753,118 @@ var SUPPORTED_MOUNT_VOLTAGE_TYPES = (function resolveSupportedMounts() {
   return created;
 })();
 
-var MOUNT_VOLTAGE_STORAGE_KEY_RESOLVED = (function resolveMountVoltageStorageKey() {
-  let existing = null;
-  if (
-    CORE_GLOBAL_SCOPE &&
-    typeof CORE_GLOBAL_SCOPE.MOUNT_VOLTAGE_STORAGE_KEY === 'string' &&
-    CORE_GLOBAL_SCOPE.MOUNT_VOLTAGE_STORAGE_KEY
-  ) {
-    existing = CORE_GLOBAL_SCOPE.MOUNT_VOLTAGE_STORAGE_KEY;
-  }
+  const MOUNT_VOLTAGE_STORAGE_KEY_FALLBACK = 'cameraPowerPlanner_mountVoltages';
+  let cachedMountVoltagePrimaryKey = '';
+  let cachedMountVoltageBackupKey = '';
+  let mountVoltageKeysResolved = false;
 
-  if (!existing && CORE_GLOBAL_SCOPE) {
-    const scopedResolved = CORE_GLOBAL_SCOPE.MOUNT_VOLTAGE_STORAGE_KEY_RESOLVED;
-    if (typeof scopedResolved === 'string' && scopedResolved) {
-      existing = scopedResolved;
+  const readGlobalMountVoltageKey = (property) => {
+    if (!CORE_GLOBAL_SCOPE || typeof CORE_GLOBAL_SCOPE !== 'object') {
+      return '';
     }
-  }
+    const value = CORE_GLOBAL_SCOPE[property];
+    return typeof value === 'string' && value ? value : '';
+  };
 
-  if (!existing && typeof getMountVoltageStorageKeyName === 'function') {
+  const assignGlobalMountVoltageKey = (property, value) => {
+    if (!CORE_GLOBAL_SCOPE || typeof CORE_GLOBAL_SCOPE !== 'object') {
+      return;
+    }
+    if (typeof value !== 'string' || !value) {
+      return;
+    }
+
+    let descriptor = null;
     try {
-      const resolvedKey = getMountVoltageStorageKeyName();
-      if (typeof resolvedKey === 'string' && resolvedKey) {
-        existing = resolvedKey;
+      descriptor = Object.getOwnPropertyDescriptor(CORE_GLOBAL_SCOPE, property);
+    } catch (descriptorError) {
+      descriptor = null;
+      void descriptorError;
+    }
+
+    if (descriptor && descriptor.configurable === false && descriptor.writable === false) {
+      return;
+    }
+
+    try {
+      CORE_GLOBAL_SCOPE[property] = value;
+    } catch (assignError) {
+      if (typeof console !== 'undefined' && typeof console.warn === 'function') {
+        console.warn(`Unable to expose ${property} globally`, assignError);
       }
-    } catch (mountVoltageKeyError) {
-      console.warn('Unable to resolve mount voltage storage key name', mountVoltageKeyError);
     }
-  }
+  };
 
-  if (!existing && typeof MOUNT_VOLTAGE_STORAGE_KEY_NAME === 'string' && MOUNT_VOLTAGE_STORAGE_KEY_NAME) {
-    existing = MOUNT_VOLTAGE_STORAGE_KEY_NAME;
-  }
-
-  const resolved = existing || 'cameraPowerPlanner_mountVoltages';
-
-  if (CORE_GLOBAL_SCOPE && typeof CORE_GLOBAL_SCOPE === 'object') {
-    try {
-      CORE_GLOBAL_SCOPE.MOUNT_VOLTAGE_STORAGE_KEY = resolved;
-    } catch (assignError) {
-      console.warn('Unable to expose mount voltage storage key globally', assignError);
+  const resolveMountVoltageStorageKeys = () => {
+    if (mountVoltageKeysResolved) {
+      return;
     }
-    try {
-      CORE_GLOBAL_SCOPE.MOUNT_VOLTAGE_STORAGE_KEY_RESOLVED = resolved;
-    } catch (exposeResolvedError) {
-      void exposeResolvedError;
+
+    let resolvedPrimary =
+      readGlobalMountVoltageKey('MOUNT_VOLTAGE_STORAGE_KEY') ||
+      readGlobalMountVoltageKey('MOUNT_VOLTAGE_STORAGE_KEY_RESOLVED');
+
+    if (!resolvedPrimary && typeof getMountVoltageStorageKeyName === 'function') {
+      try {
+        const resolvedKey = getMountVoltageStorageKeyName();
+        if (typeof resolvedKey === 'string' && resolvedKey) {
+          resolvedPrimary = resolvedKey;
+        }
+      } catch (mountVoltageKeyError) {
+        console.warn('Unable to resolve mount voltage storage key name', mountVoltageKeyError);
+      }
     }
-  }
 
-  return resolved;
-})();
-
-var MOUNT_VOLTAGE_STORAGE_BACKUP_KEY = (function resolveMountVoltageBackupKey() {
-  if (
-    CORE_GLOBAL_SCOPE &&
-    typeof CORE_GLOBAL_SCOPE.MOUNT_VOLTAGE_STORAGE_BACKUP_KEY === 'string' &&
-    CORE_GLOBAL_SCOPE.MOUNT_VOLTAGE_STORAGE_BACKUP_KEY
-  ) {
-    return CORE_GLOBAL_SCOPE.MOUNT_VOLTAGE_STORAGE_BACKUP_KEY;
-  }
-
-  if (
-    CORE_GLOBAL_SCOPE &&
-    typeof CORE_GLOBAL_SCOPE.MOUNT_VOLTAGE_STORAGE_BACKUP_KEY_RESOLVED === 'string' &&
-    CORE_GLOBAL_SCOPE.MOUNT_VOLTAGE_STORAGE_BACKUP_KEY_RESOLVED
-  ) {
-    return CORE_GLOBAL_SCOPE.MOUNT_VOLTAGE_STORAGE_BACKUP_KEY_RESOLVED;
-  }
-
-  const backupKey = `${MOUNT_VOLTAGE_STORAGE_KEY_RESOLVED}__backup`;
-
-  if (CORE_GLOBAL_SCOPE && typeof CORE_GLOBAL_SCOPE === 'object') {
-    try {
-      CORE_GLOBAL_SCOPE.MOUNT_VOLTAGE_STORAGE_BACKUP_KEY = backupKey;
-    } catch (assignError) {
-      console.warn('Unable to expose mount voltage storage backup key globally', assignError);
+    if (!resolvedPrimary && typeof MOUNT_VOLTAGE_STORAGE_KEY_NAME === 'string' && MOUNT_VOLTAGE_STORAGE_KEY_NAME) {
+      resolvedPrimary = MOUNT_VOLTAGE_STORAGE_KEY_NAME;
     }
-    try {
-      CORE_GLOBAL_SCOPE.MOUNT_VOLTAGE_STORAGE_BACKUP_KEY_RESOLVED = backupKey;
-    } catch (exposeResolvedError) {
-      void exposeResolvedError;
-    }
-  }
 
-  return backupKey;
-})();
+    if (!resolvedPrimary) {
+      resolvedPrimary = MOUNT_VOLTAGE_STORAGE_KEY_FALLBACK;
+    }
+
+    let resolvedBackup =
+      readGlobalMountVoltageKey('MOUNT_VOLTAGE_STORAGE_BACKUP_KEY') ||
+      readGlobalMountVoltageKey('MOUNT_VOLTAGE_STORAGE_BACKUP_KEY_RESOLVED');
+
+    if (!resolvedBackup && typeof getMountVoltageStorageBackupKeyName === 'function') {
+      try {
+        const backupKeyName = getMountVoltageStorageBackupKeyName();
+        if (typeof backupKeyName === 'string' && backupKeyName) {
+          resolvedBackup = backupKeyName;
+        }
+      } catch (backupKeyError) {
+        console.warn('Unable to resolve mount voltage storage backup key name', backupKeyError);
+      }
+    }
+
+    if (!resolvedBackup && resolvedPrimary) {
+      resolvedBackup = `${resolvedPrimary}__backup`;
+    }
+
+    cachedMountVoltagePrimaryKey = resolvedPrimary || MOUNT_VOLTAGE_STORAGE_KEY_FALLBACK;
+    cachedMountVoltageBackupKey = resolvedBackup || `${cachedMountVoltagePrimaryKey}__backup`;
+    mountVoltageKeysResolved = true;
+
+    assignGlobalMountVoltageKey('MOUNT_VOLTAGE_STORAGE_KEY', cachedMountVoltagePrimaryKey);
+    assignGlobalMountVoltageKey('MOUNT_VOLTAGE_STORAGE_KEY_RESOLVED', cachedMountVoltagePrimaryKey);
+    assignGlobalMountVoltageKey('MOUNT_VOLTAGE_STORAGE_BACKUP_KEY', cachedMountVoltageBackupKey);
+    assignGlobalMountVoltageKey('MOUNT_VOLTAGE_STORAGE_BACKUP_KEY_RESOLVED', cachedMountVoltageBackupKey);
+  };
+
+  const getMountVoltagePrimaryStorageKey = () => {
+    if (!mountVoltageKeysResolved) {
+      resolveMountVoltageStorageKeys();
+    }
+    return cachedMountVoltagePrimaryKey || MOUNT_VOLTAGE_STORAGE_KEY_FALLBACK;
+  };
+
+  const getMountVoltageBackupStorageKey = () => {
+    if (!mountVoltageKeysResolved) {
+      resolveMountVoltageStorageKeys();
+    }
+    return cachedMountVoltageBackupKey || `${getMountVoltagePrimaryStorageKey()}__backup`;
+  };
 
 var DEFAULT_MOUNT_VOLTAGES = (function resolveDefaultMountVoltages() {
   if (
@@ -991,17 +1019,19 @@ function persistMountVoltagePreferences(preferences) {
     return;
   }
 
-  try {
-    localStorage.setItem(MOUNT_VOLTAGE_STORAGE_KEY_RESOLVED, serialized);
-  } catch (storageError) {
-    console.warn('Could not save mount voltage preferences', storageError);
-  }
+    const primaryMountVoltageKey = getMountVoltagePrimaryStorageKey();
+    try {
+      localStorage.setItem(primaryMountVoltageKey, serialized);
+    } catch (storageError) {
+      console.warn('Could not save mount voltage preferences', storageError);
+    }
 
-  try {
-    localStorage.setItem(MOUNT_VOLTAGE_STORAGE_BACKUP_KEY, serialized);
-  } catch (backupError) {
-    console.warn('Could not save mount voltage backup copy', backupError);
-  }
+    const backupMountVoltageKey = getMountVoltageBackupStorageKey();
+    try {
+      localStorage.setItem(backupMountVoltageKey, serialized);
+    } catch (backupError) {
+      console.warn('Could not save mount voltage backup copy', backupError);
+    }
 }
 
 function applyMountVoltagePreferences(preferences, options = {}) {
@@ -1185,12 +1215,12 @@ function updateMountVoltageSettingLabels(lang = currentLang) {
 
 try {
   if (typeof localStorage !== 'undefined') {
-    const storedVoltages = localStorage.getItem(MOUNT_VOLTAGE_STORAGE_KEY_RESOLVED);
+    const storedVoltages = localStorage.getItem(getMountVoltagePrimaryStorageKey());
     const parsedVoltages = parseStoredMountVoltages(storedVoltages);
     if (parsedVoltages) {
       mountVoltagePreferences = parsedVoltages;
     } else {
-      const backupVoltages = localStorage.getItem(MOUNT_VOLTAGE_STORAGE_BACKUP_KEY);
+      const backupVoltages = localStorage.getItem(getMountVoltageBackupStorageKey());
       const parsedBackupVoltages = parseStoredMountVoltages(backupVoltages);
       if (parsedBackupVoltages) {
         mountVoltagePreferences = parsedBackupVoltages;

--- a/src/scripts/app-session.js
+++ b/src/scripts/app-session.js
@@ -36,7 +36,7 @@
 /* global getMountVoltagePreferencesClone, mountVoltageResetButton,
           resetMountVoltagePreferences, updateMountVoltageInputsFromState,
           applyMountVoltagePreferences, getMountVoltageStorageKeyName,
-          getMountVoltageStorageBackupKeyName, MOUNT_VOLTAGE_STORAGE_BACKUP_KEY,
+          getMountVoltageStorageBackupKeyName,
           parseStoredMountVoltages, SUPPORTED_MOUNT_VOLTAGE_TYPES,
           DEFAULT_MOUNT_VOLTAGES, mountVoltageInputs, parseVoltageValue */
 
@@ -6324,11 +6324,9 @@ function applyPreferencesFromStorage(safeGetItem) {
 
     if (!parsedVoltages) {
       const backupKey =
-        typeof MOUNT_VOLTAGE_STORAGE_BACKUP_KEY === 'string'
-          ? MOUNT_VOLTAGE_STORAGE_BACKUP_KEY
-          : typeof getMountVoltageStorageBackupKeyName === 'function'
-            ? getMountVoltageStorageBackupKeyName()
-            : `${mountVoltageKeyName}__backup`;
+        typeof getMountVoltageStorageBackupKeyName === 'function'
+          ? getMountVoltageStorageBackupKeyName()
+          : `${mountVoltageKeyName}__backup`;
       const backupVoltages = safeGetItem(backupKey);
       if (backupVoltages !== undefined && backupVoltages !== null) {
         const parsedBackupVoltages = parseStoredMountVoltages(backupVoltages);


### PR DESCRIPTION
## Summary
- refactor mount voltage storage key resolution into cached helpers that reuse existing globals when safe
- update mount voltage persistence and recovery to consume the new helpers across modern and legacy bundles
- adjust session restore logic to derive backup keys from the storage helper instead of globals

## Testing
- npm run test:script

------
https://chatgpt.com/codex/tasks/task_e_68dc3cd60fe08320b5aaaa1576c6a93d