### PR TITLE
Fix device manager globals and mount voltage reset access

### DIFF
--- a/src/scripts/app-core-new-1.js
+++ b/src/scripts/app-core-new-1.js
@@ -921,8 +921,39 @@ let mountVoltageSectionElem = null;
 let mountVoltageHeadingElem = null;
 let mountVoltageDescriptionElem = null;
 let mountVoltageNoteElem = null;
-let mountVoltageResetButton = null;
+let mountVoltageResetButton =
+  (typeof CORE_GLOBAL_SCOPE !== 'undefined' && CORE_GLOBAL_SCOPE && CORE_GLOBAL_SCOPE.mountVoltageResetButton)
+    ? CORE_GLOBAL_SCOPE.mountVoltageResetButton
+    : (typeof globalThis !== 'undefined' && globalThis && globalThis.mountVoltageResetButton)
+      ? globalThis.mountVoltageResetButton
+      : null;
 let mountVoltageTitleElems = null;
+
+function syncMountVoltageResetButtonGlobal(value) {
+  const targetScope =
+    (typeof CORE_GLOBAL_SCOPE !== 'undefined' && CORE_GLOBAL_SCOPE)
+      ? CORE_GLOBAL_SCOPE
+      : (typeof globalThis !== 'undefined' && globalThis)
+        ? globalThis
+        : (typeof window !== 'undefined' && window)
+          ? window
+          : (typeof self !== 'undefined' && self)
+            ? self
+            : (typeof global !== 'undefined' && global)
+              ? global
+              : null;
+  if (!targetScope || typeof targetScope !== 'object') {
+    return;
+  }
+  try {
+    targetScope.mountVoltageResetButton = value;
+  } catch (assignError) {
+    void assignError;
+    targetScope.mountVoltageResetButton = value;
+  }
+}
+
+syncMountVoltageResetButtonGlobal(mountVoltageResetButton);
 
 function parseVoltageValue(value, fallback) {
   let numeric = Number.NaN;
@@ -12172,7 +12203,39 @@ function decodeSharedSetup(setup) {
 var deviceManagerSection = document.getElementById("device-manager");
 var toggleDeviceBtn = document.getElementById("toggleDeviceManager");
 const deviceListContainer = document.getElementById("deviceListContainer");
-const deviceManagerLists = new Map();
+const deviceManagerLists = (() => {
+  const globalScope =
+    (typeof CORE_GLOBAL_SCOPE !== 'undefined' && CORE_GLOBAL_SCOPE)
+      ? CORE_GLOBAL_SCOPE
+      : (typeof globalThis !== 'undefined' && globalThis)
+        ? globalThis
+        : (typeof window !== 'undefined' && window)
+          ? window
+          : (typeof self !== 'undefined' && self)
+            ? self
+            : (typeof global !== 'undefined' && global)
+              ? global
+              : null;
+
+  if (
+    globalScope &&
+    globalScope.deviceManagerLists &&
+    globalScope.deviceManagerLists instanceof Map
+  ) {
+    return globalScope.deviceManagerLists;
+  }
+
+  const created = new Map();
+  if (globalScope && typeof globalScope === 'object') {
+    try {
+      globalScope.deviceManagerLists = created;
+    } catch (assignError) {
+      void assignError;
+      globalScope.deviceManagerLists = created;
+    }
+  }
+  return created;
+})();
 const deviceManagerPreferredOrder = [
   "cameras",
   "viewfinders",
@@ -13197,6 +13260,7 @@ mountVoltageHeadingElem = document.getElementById('mountVoltageHeading');
 mountVoltageDescriptionElem = document.getElementById('mountVoltageDescription');
 mountVoltageNoteElem = document.getElementById('mountVoltageNote');
 mountVoltageResetButton = document.getElementById('mountVoltageReset');
+syncMountVoltageResetButtonGlobal(mountVoltageResetButton);
 mountVoltageTitleElems = {
   V: document.getElementById('mountVoltageVTitle'),
   Gold: document.getElementById('mountVoltageGoldTitle'),

--- a/src/scripts/app-session.js
+++ b/src/scripts/app-session.js
@@ -33,7 +33,7 @@
           loadAutoGearBackupRetention, loadFullBackupHistory */
 /* global getDiagramManualPositions, setManualDiagramPositions,
           normalizeDiagramPositionsInput, ensureAutoBackupsFromProjects */
-/* global getMountVoltagePreferencesClone, mountVoltageResetButton,
+/* global getMountVoltagePreferencesClone, mountVoltageResetButton, CORE_GLOBAL_SCOPE,
           resetMountVoltagePreferences, updateMountVoltageInputsFromState,
           applyMountVoltagePreferences, getMountVoltageStorageKeyName,
           getMountVoltageStorageBackupKeyName,
@@ -3240,8 +3240,30 @@ mountVoltageInputNodes.forEach(input => {
   input.addEventListener('blur', handleMountVoltageInputChange);
 });
 
-if (mountVoltageResetButton) {
-  mountVoltageResetButton.addEventListener('click', () => {
+const mountVoltageResetButtonRef = (() => {
+  if (typeof mountVoltageResetButton !== 'undefined' && mountVoltageResetButton) {
+    return mountVoltageResetButton;
+  }
+  const scope =
+    (typeof CORE_GLOBAL_SCOPE !== 'undefined' && CORE_GLOBAL_SCOPE)
+      ? CORE_GLOBAL_SCOPE
+      : (typeof globalThis !== 'undefined' && globalThis)
+        ? globalThis
+        : (typeof window !== 'undefined' && window)
+          ? window
+          : (typeof self !== 'undefined' && self)
+            ? self
+            : (typeof global !== 'undefined' && global)
+              ? global
+              : null;
+  if (scope && scope.mountVoltageResetButton) {
+    return scope.mountVoltageResetButton;
+  }
+  return null;
+})();
+
+if (mountVoltageResetButtonRef) {
+  mountVoltageResetButtonRef.addEventListener('click', () => {
     resetMountVoltagePreferences({ persist: false, triggerUpdate: true });
     updateMountVoltageInputsFromState();
   });


### PR DESCRIPTION
## Summary
- share the device manager list map across both core bundles to avoid reference errors
- keep the mount voltage reset button reference synced to the global scope and resolve it safely in the session script

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dc40e2bad083209f18a7efb15ab63f