### PR TITLE
Fix missing globals for device manager and mount reset

### DIFF
--- a/legacy/scripts/app-core-new-2.js
+++ b/legacy/scripts/app-core-new-2.js
@@ -163,6 +163,31 @@ function fallbackHumanizeKey(key) {
 }
 var coreStableStringify = typeof CORE_SHARED_LOCAL.stableStringify === 'function' ? CORE_SHARED_LOCAL.stableStringify : fallbackStableStringify;
 var coreHumanizeKey = typeof CORE_SHARED_LOCAL.humanizeKey === 'function' ? CORE_SHARED_LOCAL.humanizeKey : fallbackHumanizeKey;
+var sharedDeviceManagerLists = function () {
+  var candidates = [CORE_PART2_RUNTIME_SCOPE && _typeof(CORE_PART2_RUNTIME_SCOPE) === 'object' ? CORE_PART2_RUNTIME_SCOPE : null, typeof CORE_GLOBAL_SCOPE !== 'undefined' && CORE_GLOBAL_SCOPE && _typeof(CORE_GLOBAL_SCOPE) === 'object' ? CORE_GLOBAL_SCOPE : null, typeof globalThis !== 'undefined' && _typeof(globalThis) === 'object' ? globalThis : null, typeof window !== 'undefined' && _typeof(window) === 'object' ? window : null, typeof self !== 'undefined' && _typeof(self) === 'object' ? self : null, typeof global !== 'undefined' && _typeof(global) === 'object' ? global : null].filter(Boolean);
+
+  for (var index = 0; index < candidates.length; index += 1) {
+    var scope = candidates[index];
+    if (scope && scope.deviceManagerLists instanceof Map) {
+      return scope.deviceManagerLists;
+    }
+  }
+
+  var fallback = new Map();
+  var assignTarget = candidates.find(function (scope) {
+    return scope && Object.isExtensible(scope);
+  });
+  if (assignTarget) {
+    try {
+      assignTarget.deviceManagerLists = fallback;
+    } catch (assignError) {
+      void assignError;
+      assignTarget.deviceManagerLists = fallback;
+    }
+  }
+  return fallback;
+}();
+var deviceManagerLists = sharedDeviceManagerLists;
 function callCoreFunctionFromPart2(functionName) {
   var args = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : [];
   var options = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {};

--- a/legacy/scripts/app-session.js
+++ b/legacy/scripts/app-session.js
@@ -2892,8 +2892,18 @@ mountVoltageInputNodes.forEach(function (input) {
   input.addEventListener('change', handleMountVoltageInputChange);
   input.addEventListener('blur', handleMountVoltageInputChange);
 });
-if (mountVoltageResetButton) {
-  mountVoltageResetButton.addEventListener('click', function () {
+var mountVoltageResetButtonRef = function () {
+  if (typeof mountVoltageResetButton !== 'undefined' && mountVoltageResetButton) {
+    return mountVoltageResetButton;
+  }
+  var scope = typeof CORE_GLOBAL_SCOPE !== 'undefined' && CORE_GLOBAL_SCOPE ? CORE_GLOBAL_SCOPE : typeof globalThis !== 'undefined' && globalThis ? globalThis : typeof window !== 'undefined' && window ? window : typeof self !== 'undefined' && self ? self : typeof global !== 'undefined' && global ? global : null;
+  if (scope && scope.mountVoltageResetButton) {
+    return scope.mountVoltageResetButton;
+  }
+  return null;
+}();
+if (mountVoltageResetButtonRef) {
+  mountVoltageResetButtonRef.addEventListener('click', function () {
     resetMountVoltagePreferences({
       persist: false,
       triggerUpdate: true

--- a/src/scripts/app-core-new-2.js
+++ b/src/scripts/app-core-new-2.js
@@ -215,6 +215,8 @@ const sharedDeviceManagerLists = (() => {
   return fallback;
 })();
 
+const deviceManagerLists = sharedDeviceManagerLists;
+
 function callCoreFunctionFromPart2(functionName, args = [], options = {}) {
   if (typeof callCoreFunctionIfAvailable === 'function') {
     return callCoreFunctionIfAvailable(functionName, args, options);


### PR DESCRIPTION
## Summary
- ensure the part 2 core runtime reuses the shared device manager list map
- guard the legacy session script against missing mount voltage reset button globals

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dc423ee6d8832087e3927ede55a8cb