### PR TITLE
Improve hover help coverage and documentation

### DIFF
--- a/docs/documentation-maintenance.md
+++ b/docs/documentation-maintenance.md
@@ -34,6 +34,9 @@ copy offline.【F:src/scripts/script.js†L92-L183】
    dialog.【F:index.html†L3899-L3920】【F:docs/save-share-restore-reference.md†L28-L35】 Document
    any new navigation tips—like the quick-link keyboard guidance surfaced through
    `helpResultsAssist`—so translations and hover help mirror the latest behaviour.【F:index.html†L2641-L2663】【F:src/scripts/app-session.js†L8427-L8486】【F:src/scripts/translations.js†L1327-L1340】
+   Hover help now reads from linked selectors (`data-help-target`, `data-hover-help-target` and
+   ARIA reference IDs), so double-check that contextual copy stays accurate for every
+   referenced control when you update docs or UI labels.【F:src/scripts/app-session.js†L8896-L8996】
 2. **README family.** Revise the primary `README.md` plus each localized README under the
    project root. Ensure new workflows appear in the *Save, Share & Import Drill*, *Backup &
    Recovery* and *Emergency Recovery Playbook* sections so every language documents the same


### PR DESCRIPTION
## Summary
- expand hover help to gather descriptions from linked selectors and additional ARIA references while covering more roles and content-editable controls
- mirror the hover help enhancements in the legacy session bundle to keep behaviour consistent offline
- document the selector-driven hover help coverage requirement in the maintenance guide

## Testing
- `npm test` *(fails: storage fallback suite expects browser localStorage access in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc45edfe708320b5ffe2bb85caf7f8