### PR TITLE
Improve global search coverage for data workflows

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -216,6 +216,7 @@ Dieser kurze Ablauf sollte bei neuen Teammitgliedern, frisch eingerichteten Work
 - Auf kleinen Bildschirmen spiegelt ein einklappbares Seitenmenü alle Hauptsektionen.
 - Dropdowns und Editorlisten unterstützen Inline-Suche und Tippen zum Filtern. `/` oder `Strg+F` (`⌘F`) fokussiert das nächste Suchfeld.
 - Suchvorschläge heben passende Schlüsselwörter hervor, damit du Treffer bestätigst, bevor du weiter navigierst oder Aktionen ausführst.
+- Die globale Suche verknüpft Begriffe wie Sichern, Teilen, Backup, Importieren und Wiederherstellen, damit Anfragen nach „Archiv“, „Download“ oder „Wiederherstellen“ sofort die passenden Datensicherungswerkzeuge zeigen.
 - Sterne pinnen Favoriten in Selektoren und sichern sie in Backups.
 
 ## Anpassung & Barrierefreiheit

--- a/README.en.md
+++ b/README.en.md
@@ -470,6 +470,9 @@ Use Cine Power Planner end-to-end with the following routine:
   search field.
 - Search suggestions highlight matching keywords so you can confirm results
   before committing to a navigation or action.
+- Global search links save, share, backup, import and restore wording so
+  synonyms like “archive”, “download” or “recover” surface the right data
+  safety tools first.
 - Star icons pin favorite devices so they stay at the top of selectors and
   persist across sessions and backups.
 

--- a/README.es.md
+++ b/README.es.md
@@ -216,6 +216,7 @@ Repite esta rutina cuando se incorpore personal, se prepare una estación nueva 
 - En pantallas pequeñas, un menú lateral plegable replica las secciones principales.
 - Cada lista y desplegable permite buscar escribiendo y filtrar al vuelo. `/` o `Ctrl+F` (`⌘F`) enfocan el campo más cercano.
 - Las sugerencias de búsqueda resaltan las palabras clave coincidentes para que puedas confirmar el resultado antes de navegar o ejecutar una acción.
+- La búsqueda global vincula verbos como guardar, compartir, copia de seguridad, importar y restaurar, de modo que consultas como “archivar”, “descargar” o “recuperar” muestren primero las herramientas de protección de datos.
 - Los iconos de estrella fijan dispositivos favoritos en la parte superior y los preservan en las copias de seguridad.
 
 ## Personalización y accesibilidad

--- a/README.fr.md
+++ b/README.fr.md
@@ -218,6 +218,7 @@ Cette routine prouve que sauvegarde, partage, import, backup et restauration fon
 - Sur petits écrans, un menu latéral pliable réplique les sections principales.
 - Chaque liste et éditeur propose une recherche inline et un filtrage instantané. `/` ou `Ctrl+F` (`⌘F`) ciblent le champ le plus proche.
 - Les suggestions de recherche mettent en évidence les mots clés correspondants pour confirmer le bon résultat avant de poursuivre.
+- La recherche globale relie désormais les verbes enregistrer, partager, sauvegarder, importer et restaurer : des requêtes comme « archiver », « télécharger » ou « récupérer » font immédiatement remonter les outils de protection des données.
 - Les icônes étoile épinglent les favoris en tête de liste et les conservent dans les sauvegardes.
 
 ## Personnalisation et accessibilité

--- a/README.it.md
+++ b/README.it.md
@@ -218,6 +218,7 @@ Ripeti questa routine quando arriva un nuovo membro, allestisci una postazione o
 - Su schermi piccoli un menu laterale collassabile replica le sezioni principali.
 - Liste e editor supportano la ricerca inline e il filtraggio digitando. `/` o `Ctrl+F` (`⌘F`) mettono a fuoco il campo più vicino.
 - I suggerimenti di ricerca evidenziano le parole chiave corrispondenti così puoi confermare il risultato prima di procedere o avviare un'azione.
+- La ricerca globale collega ora i verbi salvare, condividere, backup, importare e ripristinare, così ricerche come “archivia”, “scarica” o “ripristina” mostrano subito gli strumenti di protezione dei dati.
 - Le icone a stella fissano i dispositivi preferiti in cima e li mantengono nei backup.
 
 ## Personalizzazione e accessibilità

--- a/README.md
+++ b/README.md
@@ -475,6 +475,9 @@ Use Cine Power Planner end-to-end with the following routine:
   search field.
 - Search suggestions highlight matching keywords so you can confirm results
   before committing to a navigation or action.
+- Global search links save, share, backup, import and restore wording so
+  synonyms like “archive”, “download” or “recover” surface the right data
+  safety tools first.
 - Star icons pin favorite devices so they stay at the top of selectors and
   persist across sessions and backups.
 

--- a/docs/save-share-restore-reference.md
+++ b/docs/save-share-restore-reference.md
@@ -43,4 +43,12 @@ Record the outputs (or screenshots) in your verification log, and store them alo
 - **Post-update verification.** When documentation or translations change, run the matrix to confirm instructions still match the UI. Update help entries and localized READMEs if labels or button names shifted.
 - **Incident investigations.** If autosaves pause or imports warn about mismatches, perform each workflow in an isolated profile, export fresh backups, and attach the recorded outputs to your incident log before applying a restore.
 
+## Search cues for data workflows
+
+Global search connects every save, share, import, backup, restore, sync and duplicate control so data guardians can find the
+right safeguard even when they start with different verbs. Queries such as “archive”, “download”, “recover”, “upload”, “clone”
+or “sync” expand to the same token family, ensuring the planner highlights the matching UI controls, help topics and saved
+projects before anything unrelated. Encourage crews to rely on `/` or `Ctrl+K` (`⌘K`) when rehearsing this checklist so search
+results reinforce the same data-protection story documented here and nothing slips past when working offline.
+
 Keeping this reference near the workstation ensures crews rehearse the exact same offline workflows the application enforces in code, preserving user data at every step.

--- a/index.html
+++ b/index.html
@@ -3696,6 +3696,11 @@
               library or be ignored altogether.
             </li>
             <li>
+              Tap the global search (`/` or `Ctrl+K`) to surface every save, share, backup, import, restore or sync control —
+              even when you search for words like “archive”, “download”, “recover”, “upload” or “clone”. Related verbs resolve
+              to the same safeguards so nothing gets missed while working offline.
+            </li>
+            <li>
               Open
               <a class="help-link button-link" href="#settingsButton" data-help-target="#settingsButton">Settings</a>
               → <em>Backup &amp; Restore</em> whenever you need a full-application snapshot.

--- a/src/scripts/app-core-new-2.js
+++ b/src/scripts/app-core-new-2.js
@@ -7822,6 +7822,128 @@ const applySearchTokenSynonyms = (tokens, addToken) => {
     addAll(['mp', 'megapixel', 'megapixels']);
   }
 
+  const addSynonymGroup = values => {
+    if (hasAny(values)) {
+      addAll(values);
+    }
+  };
+
+  addSynonymGroup([
+    'save',
+    'saved',
+    'saving',
+    'autosave',
+    'autosaved',
+    'autosaving',
+    'store',
+    'stored',
+    'storing',
+    'backup',
+    'backups',
+    'backingup',
+    'backedup',
+    'archive',
+    'archives',
+    'archived',
+    'archiving',
+    'restore',
+    'restores',
+    'restoring',
+    'restored',
+    'recover',
+    'recovers',
+    'recovered',
+    'recovering',
+    'import',
+    'imports',
+    'imported',
+    'importing',
+    'ingest',
+    'ingests',
+    'ingested',
+    'ingesting',
+    'load',
+    'loads',
+    'loaded',
+    'loading',
+    'reload',
+    'reloads',
+    'reloaded',
+    'reloading',
+    'upload',
+    'uploads',
+    'uploaded',
+    'uploading'
+  ]);
+
+  addSynonymGroup([
+    'share',
+    'shares',
+    'sharing',
+    'shared',
+    'export',
+    'exports',
+    'exported',
+    'exporting',
+    'download',
+    'downloads',
+    'downloaded',
+    'downloading',
+    'send',
+    'sends',
+    'sent',
+    'sending',
+    'deliver',
+    'delivers',
+    'delivered',
+    'delivering',
+    'distribution',
+    'distribute',
+    'distributes',
+    'distributed',
+    'publishing',
+    'publish',
+    'published'
+  ]);
+
+  addSynonymGroup([
+    'sync',
+    'syncs',
+    'synced',
+    'syncing',
+    'resync',
+    'resyncs',
+    'resynced',
+    'resyncing',
+    'synchronize',
+    'synchronizes',
+    'synchronized',
+    'synchronizing',
+    'synchronise',
+    'synchronises',
+    'synchronised',
+    'synchronising'
+  ]);
+
+  addSynonymGroup([
+    'duplicate',
+    'duplicates',
+    'duplicated',
+    'duplicating',
+    'copy',
+    'copies',
+    'copied',
+    'copying',
+    'clone',
+    'clones',
+    'cloned',
+    'cloning',
+    'replicate',
+    'replicates',
+    'replicated',
+    'replicating'
+  ]);
+
   if (hasAny(['mm', 'millimeter', 'millimeters'])) {
     addAll(['mm', 'millimeter', 'millimeters']);
   }

--- a/tests/unit/featureSearchSynonyms.test.js
+++ b/tests/unit/featureSearchSynonyms.test.js
@@ -62,5 +62,21 @@ describe('feature search token synonyms', () => {
     expectTokensToContain('exposure value', ['ev']);
     expectTokensToContain('ev', ['exposure']);
   });
+
+  test('data safety verbs surface save, backup, import and restore tools together', () => {
+    expectTokensToContain('backup footage', ['save', 'restore', 'import']);
+    expectTokensToContain('restore project', ['backup', 'save', 'import']);
+    expectTokensToContain('import bundle', ['save', 'restore']);
+  });
+
+  test('sharing language links export and download workflows', () => {
+    expectTokensToContain('share link', ['export', 'download']);
+    expectTokensToContain('download archive', ['share', 'export']);
+  });
+
+  test('sync and duplication keywords expand related matches', () => {
+    expectTokensToContain('sync presets', ['synchronize']);
+    expectTokensToContain('copy device', ['duplicate', 'clone']);
+  });
 });
 


### PR DESCRIPTION
## Summary
- expand feature-search token synonyms so queries about saving, sharing, backups, imports, restores, syncs and duplicates surface the same data-safety tools
- add unit coverage for the new synonym families and update help documentation plus localized READMEs to describe the behaviour
- refresh the save/share/restore reference with guidance that reinforces the new global search cues

## Testing
- npm run test:unit *(fails: storageFallback tests complain about mocked storage quota handling in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc47b2cf9c83209f892915eb9099a6