### PR TITLE
Fix runtime guard scoping for Safari compatibility

### DIFF
--- a/legacy/scripts/app-core-new-1.js
+++ b/legacy/scripts/app-core-new-1.js
@@ -28,23 +28,24 @@ function _toPrimitive(t, r) { if ("object" != _typeof(t) || !t) return t; var e 
 function _typeof(o) { "@babel/helpers - typeof"; return _typeof = "function" == typeof Symbol && "symbol" == typeof Symbol.iterator ? function (o) { return typeof o; } : function (o) { return o && "function" == typeof Symbol && o.constructor === Symbol && o !== Symbol.prototype ? "symbol" : typeof o; }, _typeof(o); }
 var CORE_PART1_RUNTIME_SCOPE = typeof globalThis !== 'undefined' ? globalThis : typeof window !== 'undefined' ? window : typeof self !== 'undefined' ? self : typeof global !== 'undefined' ? global : null;
 
-if (CORE_PART1_RUNTIME_SCOPE && CORE_PART1_RUNTIME_SCOPE.__cineCorePart1Initialized) {
+var CORE_PART1_RUNTIME_ALREADY_INITIALIZED = !!(CORE_PART1_RUNTIME_SCOPE && CORE_PART1_RUNTIME_SCOPE.__cineCorePart1Initialized);
+
+if (CORE_PART1_RUNTIME_ALREADY_INITIALIZED) {
   if (typeof console !== 'undefined' && typeof console.warn === 'function') {
     console.warn('Cine Power Planner core runtime (part 1) already initialized. Skipping duplicate load.');
   }
-} else {
-  if (CORE_PART1_RUNTIME_SCOPE) {
-    try {
-      Object.defineProperty(CORE_PART1_RUNTIME_SCOPE, '__cineCorePart1Initialized', {
-        configurable: true,
-        writable: true,
-        value: true
-      });
-    } catch (corePart1InitError) {
-      CORE_PART1_RUNTIME_SCOPE.__cineCorePart1Initialized = true;
-      void corePart1InitError;
-    }
+} else if (CORE_PART1_RUNTIME_SCOPE) {
+  try {
+    Object.defineProperty(CORE_PART1_RUNTIME_SCOPE, '__cineCorePart1Initialized', {
+      configurable: true,
+      writable: true,
+      value: true
+    });
+  } catch (corePart1InitError) {
+    CORE_PART1_RUNTIME_SCOPE.__cineCorePart1Initialized = true;
+    void corePart1InitError;
   }
+}
 
 var CORE_GLOBAL_SCOPE = CORE_PART1_RUNTIME_SCOPE;
 function resolveCoreShared() {

--- a/legacy/scripts/app-core-new-2.js
+++ b/legacy/scripts/app-core-new-2.js
@@ -23,23 +23,24 @@ function _asyncIterator(r) { var n, t, o, e = 2; for ("undefined" != typeof Symb
 function AsyncFromSyncIterator(r) { function AsyncFromSyncIteratorContinuation(r) { if (Object(r) !== r) return Promise.reject(new TypeError(r + " is not an object.")); var n = r.done; return Promise.resolve(r.value).then(function (r) { return { value: r, done: n }; }); } return AsyncFromSyncIterator = function AsyncFromSyncIterator(r) { this.s = r, this.n = r.next; }, AsyncFromSyncIterator.prototype = { s: null, n: null, next: function next() { return AsyncFromSyncIteratorContinuation(this.n.apply(this.s, arguments)); }, return: function _return(r) { var n = this.s.return; return void 0 === n ? Promise.resolve({ value: r, done: !0 }) : AsyncFromSyncIteratorContinuation(n.apply(this.s, arguments)); }, throw: function _throw(r) { var n = this.s.return; return void 0 === n ? Promise.reject(r) : AsyncFromSyncIteratorContinuation(n.apply(this.s, arguments)); } }, new AsyncFromSyncIterator(r); }
 var CORE_PART2_RUNTIME_SCOPE = typeof CORE_GLOBAL_SCOPE !== 'undefined' && CORE_GLOBAL_SCOPE ? CORE_GLOBAL_SCOPE : typeof globalThis !== 'undefined' ? globalThis : typeof window !== 'undefined' ? window : typeof self !== 'undefined' ? self : typeof global !== 'undefined' ? global : null;
 
-if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initialized) {
+var CORE_PART2_RUNTIME_ALREADY_INITIALIZED = !!(CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initialized);
+
+if (CORE_PART2_RUNTIME_ALREADY_INITIALIZED) {
   if (typeof console !== 'undefined' && typeof console.warn === 'function') {
     console.warn('Cine Power Planner core runtime (part 2) already initialized. Skipping duplicate load.');
   }
-} else {
-  if (CORE_PART2_RUNTIME_SCOPE) {
-    try {
-      Object.defineProperty(CORE_PART2_RUNTIME_SCOPE, '__cineCorePart2Initialized', {
-        configurable: true,
-        writable: true,
-        value: true
-      });
-    } catch (corePart2InitError) {
-      CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initialized = true;
-      void corePart2InitError;
-    }
+} else if (CORE_PART2_RUNTIME_SCOPE) {
+  try {
+    Object.defineProperty(CORE_PART2_RUNTIME_SCOPE, '__cineCorePart2Initialized', {
+      configurable: true,
+      writable: true,
+      value: true
+    });
+  } catch (corePart2InitError) {
+    CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initialized = true;
+    void corePart2InitError;
   }
+}
 
 var CORE_SHARED_SCOPE_PART2 = CORE_PART2_RUNTIME_SCOPE;
 function resolveCoreSharedPart2() {

--- a/src/scripts/app-core-new-1.js
+++ b/src/scripts/app-core-new-1.js
@@ -91,23 +91,25 @@ var CORE_PART1_RUNTIME_SCOPE =
           ? global
           : null;
 
-if (CORE_PART1_RUNTIME_SCOPE && CORE_PART1_RUNTIME_SCOPE.__cineCorePart1Initialized) {
+var CORE_PART1_RUNTIME_ALREADY_INITIALIZED =
+  !!(CORE_PART1_RUNTIME_SCOPE && CORE_PART1_RUNTIME_SCOPE.__cineCorePart1Initialized);
+
+if (CORE_PART1_RUNTIME_ALREADY_INITIALIZED) {
   if (typeof console !== 'undefined' && typeof console.warn === 'function') {
     console.warn('Cine Power Planner core runtime (part 1) already initialized. Skipping duplicate load.');
   }
-} else {
-  if (CORE_PART1_RUNTIME_SCOPE) {
-    try {
-      Object.defineProperty(CORE_PART1_RUNTIME_SCOPE, '__cineCorePart1Initialized', {
-        configurable: true,
-        writable: true,
-        value: true,
-      });
-    } catch (corePart1InitError) {
-      CORE_PART1_RUNTIME_SCOPE.__cineCorePart1Initialized = true;
-      void corePart1InitError;
-    }
+} else if (CORE_PART1_RUNTIME_SCOPE) {
+  try {
+    Object.defineProperty(CORE_PART1_RUNTIME_SCOPE, '__cineCorePart1Initialized', {
+      configurable: true,
+      writable: true,
+      value: true,
+    });
+  } catch (corePart1InitError) {
+    CORE_PART1_RUNTIME_SCOPE.__cineCorePart1Initialized = true;
+    void corePart1InitError;
   }
+}
 
 const CORE_GLOBAL_SCOPE = CORE_PART1_RUNTIME_SCOPE;
 
@@ -15451,7 +15453,5 @@ function getCrewRoleEntries() {
     entries.push({ value: trimmedValue, label: displayLabel });
   });
   return entries.sort((a, b) => a.label.localeCompare(b.label, undefined, { sensitivity: 'base' }));
-}
-
 }
 

--- a/src/scripts/app-core-new-2.js
+++ b/src/scripts/app-core-new-2.js
@@ -11,23 +11,25 @@ var CORE_PART2_RUNTIME_SCOPE =
             ? global
             : null;
 
-if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initialized) {
+var CORE_PART2_RUNTIME_ALREADY_INITIALIZED =
+  !!(CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initialized);
+
+if (CORE_PART2_RUNTIME_ALREADY_INITIALIZED) {
   if (typeof console !== 'undefined' && typeof console.warn === 'function') {
     console.warn('Cine Power Planner core runtime (part 2) already initialized. Skipping duplicate load.');
   }
-} else {
-  if (CORE_PART2_RUNTIME_SCOPE) {
-    try {
-      Object.defineProperty(CORE_PART2_RUNTIME_SCOPE, '__cineCorePart2Initialized', {
-        configurable: true,
-        writable: true,
-        value: true,
-      });
-    } catch (corePart2InitError) {
-      CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initialized = true;
-      void corePart2InitError;
-    }
+} else if (CORE_PART2_RUNTIME_SCOPE) {
+  try {
+    Object.defineProperty(CORE_PART2_RUNTIME_SCOPE, '__cineCorePart2Initialized', {
+      configurable: true,
+      writable: true,
+      value: true,
+    });
+  } catch (corePart2InitError) {
+    CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initialized = true;
+    void corePart2InitError;
   }
+}
 
 const CORE_SHARED_SCOPE_PART2 = CORE_PART2_RUNTIME_SCOPE;
 
@@ -15387,6 +15389,4 @@ if (typeof module !== 'undefined' && module.exports) {
     formatAutoGearCameraWeight,
     getAutoGearCameraWeightOperatorLabel,
   };
-}
-
 }


### PR DESCRIPTION
## Summary
- restructure the core runtime guard to avoid block-scoped globals that Safari could not resolve
- mirror the initialization guard update in the legacy bundles to keep the fallback build aligned

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc4845d2308320a3d9c8148936c0bf