### PR TITLE
Fix auto gear fallback globals initialization

### DIFF
--- a/legacy/scripts/app-core-new-2.js
+++ b/legacy/scripts/app-core-new-2.js
@@ -21,6 +21,11 @@ function _toPrimitive(t, r) { if ("object" != _typeof(t) || !t) return t; var e 
 function _typeof(o) { "@babel/helpers - typeof"; return _typeof = "function" == typeof Symbol && "symbol" == typeof Symbol.iterator ? function (o) { return typeof o; } : function (o) { return o && "function" == typeof Symbol && o.constructor === Symbol && o !== Symbol.prototype ? "symbol" : typeof o; }, _typeof(o); }
 function _asyncIterator(r) { var n, t, o, e = 2; for ("undefined" != typeof Symbol && (t = Symbol.asyncIterator, o = Symbol.iterator); e--;) { if (t && null != (n = r[t])) return n.call(r); if (o && null != (n = r[o])) return new AsyncFromSyncIterator(n.call(r)); t = "@@asyncIterator", o = "@@iterator"; } throw new TypeError("Object is not async iterable"); }
 function AsyncFromSyncIterator(r) { function AsyncFromSyncIteratorContinuation(r) { if (Object(r) !== r) return Promise.reject(new TypeError(r + " is not an object.")); var n = r.done; return Promise.resolve(r.value).then(function (r) { return { value: r, done: n }; }); } return AsyncFromSyncIterator = function AsyncFromSyncIterator(r) { this.s = r, this.n = r.next; }, AsyncFromSyncIterator.prototype = { s: null, n: null, next: function next() { return AsyncFromSyncIteratorContinuation(this.n.apply(this.s, arguments)); }, return: function _return(r) { var n = this.s.return; return void 0 === n ? Promise.resolve({ value: r, done: !0 }) : AsyncFromSyncIteratorContinuation(n.apply(this.s, arguments)); }, throw: function _throw(r) { var n = this.s.return; return void 0 === n ? Promise.reject(r) : AsyncFromSyncIteratorContinuation(n.apply(this.s, arguments)); } }, new AsyncFromSyncIterator(r); }
+var autoGearAutoPresetId;
+var baseAutoGearRules;
+var autoGearScenarioModeSelect;
+var safeGenerateConnectorSummary;
+
 var CORE_PART2_RUNTIME_SCOPE = typeof CORE_GLOBAL_SCOPE !== 'undefined' && CORE_GLOBAL_SCOPE ? CORE_GLOBAL_SCOPE : typeof globalThis !== 'undefined' ? globalThis : typeof window !== 'undefined' ? window : typeof self !== 'undefined' ? self : typeof global !== 'undefined' ? global : null;
 
 if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initialized) {
@@ -114,7 +119,7 @@ function declareCoreFallbackBinding(name, factory) {
   return fallbackValue;
 }
 
-var autoGearAutoPresetId = declareCoreFallbackBinding('autoGearAutoPresetId', function () {
+autoGearAutoPresetId = declareCoreFallbackBinding('autoGearAutoPresetId', function () {
   if (typeof loadAutoGearAutoPresetId === 'function') {
     try {
       var storedId = loadAutoGearAutoPresetId();
@@ -128,7 +133,7 @@ var autoGearAutoPresetId = declareCoreFallbackBinding('autoGearAutoPresetId', fu
   return '';
 });
 
-var baseAutoGearRules = declareCoreFallbackBinding('baseAutoGearRules', function () {
+baseAutoGearRules = declareCoreFallbackBinding('baseAutoGearRules', function () {
   if (typeof loadAutoGearRules === 'function') {
     try {
       var storedRules = loadAutoGearRules();
@@ -142,11 +147,11 @@ var baseAutoGearRules = declareCoreFallbackBinding('baseAutoGearRules', function
   return [];
 });
 
-var autoGearScenarioModeSelect = declareCoreFallbackBinding('autoGearScenarioModeSelect', function () {
+autoGearScenarioModeSelect = declareCoreFallbackBinding('autoGearScenarioModeSelect', function () {
   return null;
 });
 
-var safeGenerateConnectorSummary = declareCoreFallbackBinding('safeGenerateConnectorSummary', function () {
+safeGenerateConnectorSummary = declareCoreFallbackBinding('safeGenerateConnectorSummary', function () {
   return function safeGenerateConnectorSummary(device) {
     if (!device || _typeof(device) !== 'object') {
       return '';

--- a/src/scripts/app-core-new-2.js
+++ b/src/scripts/app-core-new-2.js
@@ -1,3 +1,8 @@
+var autoGearAutoPresetId;
+var baseAutoGearRules;
+var autoGearScenarioModeSelect;
+var safeGenerateConnectorSummary;
+
 var CORE_PART2_RUNTIME_SCOPE =
   typeof CORE_GLOBAL_SCOPE !== 'undefined' && CORE_GLOBAL_SCOPE
     ? CORE_GLOBAL_SCOPE
@@ -123,7 +128,7 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
       return fallbackValue;
     }
 
-    var autoGearAutoPresetId = declareCoreFallbackBinding('autoGearAutoPresetId', () => {
+    autoGearAutoPresetId = declareCoreFallbackBinding('autoGearAutoPresetId', () => {
       if (typeof loadAutoGearAutoPresetId === 'function') {
         try {
           const storedId = loadAutoGearAutoPresetId();
@@ -137,7 +142,7 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
       return '';
     });
 
-    var baseAutoGearRules = declareCoreFallbackBinding('baseAutoGearRules', () => {
+    baseAutoGearRules = declareCoreFallbackBinding('baseAutoGearRules', () => {
       if (typeof loadAutoGearRules === 'function') {
         try {
           const storedRules = loadAutoGearRules();
@@ -151,9 +156,9 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
       return [];
     });
 
-    var autoGearScenarioModeSelect = declareCoreFallbackBinding('autoGearScenarioModeSelect', () => null);
+    autoGearScenarioModeSelect = declareCoreFallbackBinding('autoGearScenarioModeSelect', () => null);
 
-    var safeGenerateConnectorSummary = declareCoreFallbackBinding(
+    safeGenerateConnectorSummary = declareCoreFallbackBinding(
       'safeGenerateConnectorSummary',
       () =>
         function safeGenerateConnectorSummary(device) {


### PR DESCRIPTION
## Summary
- ensure core fallback bindings for auto gear globals attach to shared scope before runtime executes
- mirror the fix in the legacy runtime bundle to keep classic builds aligned

## Testing
- npm test -- --runTestsByPath tests/unit/storage.test.js

------
https://chatgpt.com/codex/tasks/task_e_68dc56f587e08320b02f4210771e17a2