### PR TITLE
Fix missing auto gear runtime exports

### DIFF
--- a/legacy/scripts/app-core-new-2.js
+++ b/legacy/scripts/app-core-new-2.js
@@ -14895,7 +14895,21 @@ var CORE_PART2_GLOBAL_EXPORTS = {
   refreshAutoGearControllersOptions: refreshAutoGearControllersOptions,
   refreshAutoGearDistanceOptions: refreshAutoGearDistanceOptions,
   updateAutoGearCameraWeightDraft: updateAutoGearCameraWeightDraft,
-  updateAutoGearShootingDaysDraft: updateAutoGearShootingDaysDraft
+  updateAutoGearShootingDaysDraft: updateAutoGearShootingDaysDraft,
+  alignActiveAutoGearPreset: alignActiveAutoGearPreset,
+  closeAutoGearEditor: closeAutoGearEditor,
+  reconcileAutoGearAutoPresetState: reconcileAutoGearAutoPresetState,
+  renderAutoGearBackupControls: renderAutoGearBackupControls,
+  renderAutoGearBackupRetentionControls: renderAutoGearBackupRetentionControls,
+  renderAutoGearDraftImpact: renderAutoGearDraftImpact,
+  renderAutoGearDraftLists: renderAutoGearDraftLists,
+  renderAutoGearMonitorDefaultsControls: renderAutoGearMonitorDefaultsControls,
+  renderAutoGearPresetsControls: renderAutoGearPresetsControls,
+  renderAutoGearRulesList: renderAutoGearRulesList,
+  setAutoGearAutoPresetId: setAutoGearAutoPresetId,
+  syncAutoGearAutoPreset: syncAutoGearAutoPreset,
+  updateAutoGearCatalogOptions: updateAutoGearCatalogOptions,
+  updateAutoGearMonitorDefaultOptions: updateAutoGearMonitorDefaultOptions
 };
 var CORE_PART2_GLOBAL_SCOPE = CORE_SHARED_SCOPE_PART2 || (typeof globalThis !== 'undefined' ? globalThis : null) || (typeof window !== 'undefined' ? window : null) || (typeof self !== 'undefined' ? self : null) || (typeof global !== 'undefined' ? global : null);
 var CORE_PART2_RUNTIME = function resolvePart2Runtime(scope) {

--- a/src/scripts/app-core-new-2.js
+++ b/src/scripts/app-core-new-2.js
@@ -15506,6 +15506,20 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
       checkSetupChanged,
       updateCalculations,
       feedbackCancelBtn,
+      alignActiveAutoGearPreset,
+      closeAutoGearEditor,
+      reconcileAutoGearAutoPresetState,
+      renderAutoGearBackupControls,
+      renderAutoGearBackupRetentionControls,
+      renderAutoGearDraftImpact,
+      renderAutoGearDraftLists,
+      renderAutoGearMonitorDefaultsControls,
+      renderAutoGearPresetsControls,
+      renderAutoGearRulesList,
+      setAutoGearAutoPresetId,
+      syncAutoGearAutoPreset,
+      updateAutoGearCatalogOptions,
+      updateAutoGearMonitorDefaultOptions,
     };
     
     const CORE_PART2_GLOBAL_SCOPE =


### PR DESCRIPTION
## Summary
- expose the automatic gear runtime helper functions to the global scope so deferred boot tasks can resolve without reference errors
- mirror the same export list in the legacy bundle to keep classic builds in sync

## Testing
- npm run test:unit *(fails: storage fallback suite raises quota errors in current environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc5830253c8320b5b8b20e2547aa15