### PR TITLE
Fix missing runtime globals for favorites and accessibility

### DIFF
--- a/src/scripts/app-core-new-1.js
+++ b/src/scripts/app-core-new-1.js
@@ -6314,11 +6314,27 @@ function updateBatteryOptions() {
   if (Array.from(batterySelect.options).some(o => o.value === current)) {
     batterySelect.value = current;
   }
-  updateFavoriteButton(batterySelect);
+  if (typeof updateFavoriteButton === 'function') {
+    updateFavoriteButton(batterySelect);
+  } else if (typeof enqueueCoreBootTask === 'function') {
+    enqueueCoreBootTask(() => {
+      if (typeof updateFavoriteButton === 'function') {
+        updateFavoriteButton(batterySelect);
+      }
+    });
+  }
   if (Array.from(hotswapSelect.options).some(o => o.value === currentSwap)) {
     hotswapSelect.value = currentSwap;
   }
-  updateFavoriteButton(hotswapSelect);
+  if (typeof updateFavoriteButton === 'function') {
+    updateFavoriteButton(hotswapSelect);
+  } else if (typeof enqueueCoreBootTask === 'function') {
+    enqueueCoreBootTask(() => {
+      if (typeof updateFavoriteButton === 'function') {
+        updateFavoriteButton(hotswapSelect);
+      }
+    });
+  }
   updateBatteryLabel();
 }
 

--- a/src/scripts/app-core-new-2.js
+++ b/src/scripts/app-core-new-2.js
@@ -15525,6 +15525,12 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
       syncAutoGearAutoPreset,
       updateAutoGearCatalogOptions,
       updateAutoGearMonitorDefaultOptions,
+      applyFavoritesToSelect,
+      updateFavoriteButton,
+      toggleFavorite,
+      refreshDarkModeAccentBoost,
+      isHighContrastActive,
+      feedbackUseLocationBtn,
     };
     
     const CORE_PART2_GLOBAL_SCOPE =

--- a/src/scripts/app-session.js
+++ b/src/scripts/app-session.js
@@ -2830,9 +2830,11 @@ function applyDarkMode(enabled) {
       darkModeToggle.setAttribute("aria-pressed", "false");
     }
   }
-  const highContrast = isHighContrastActive();
+  const highContrast = typeof isHighContrastActive === 'function' ? isHighContrastActive() : false;
   const accentSource = highContrast ? HIGH_CONTRAST_ACCENT_COLOR : accentColor;
-  refreshDarkModeAccentBoost({ color: accentSource, highContrast });
+  if (typeof refreshDarkModeAccentBoost === 'function') {
+    refreshDarkModeAccentBoost({ color: accentSource, highContrast });
+  }
   updateThemeColor(enabled);
   if (settingsDarkMode) {
     settingsDarkMode.checked = enabled;

--- a/src/scripts/app-setups.js
+++ b/src/scripts/app-setups.js
@@ -904,6 +904,11 @@ if (runtimeFeedbackBtn && feedbackDialog && feedbackForm) {
     });
   }
 
+  const feedbackUseLocationBtn =
+    (typeof globalThis !== 'undefined' && globalThis.feedbackUseLocationBtn)
+    || (typeof window !== 'undefined' && window.feedbackUseLocationBtn)
+    || document.getElementById('fbUseLocationBtn');
+
   if (feedbackUseLocationBtn) {
     feedbackUseLocationBtn.addEventListener('click', () => {
       const locationInput = document.getElementById('fbLocation');


### PR DESCRIPTION
## Summary
- guard updateBatteryOptions so favorite buttons wait for the runtime helpers
- export favorite controls and accessibility helpers from the core runtime segment
- make setups and session scripts resolve shared DOM nodes and helpers safely

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dc644cab54832082c1416e7cf31253