### PR TITLE
Fix missing global auto gear helpers

### DIFF
--- a/src/scripts/app-core-new-2.js
+++ b/src/scripts/app-core-new-2.js
@@ -15563,6 +15563,7 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
       refreshAutoGearMotorsOptions,
       refreshAutoGearControllersOptions,
       refreshAutoGearDistanceOptions,
+      exportAutoGearRules,
       updateAutoGearCameraWeightDraft,
       updateAutoGearShootingDaysDraft,
       checkSetupChanged,
@@ -15603,6 +15604,7 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
       refreshDarkModeAccentBoost,
       isHighContrastActive,
       feedbackUseLocationBtn,
+      getSliderBowlValue,
     };
     
     const CORE_PART2_GLOBAL_SCOPE =


### PR DESCRIPTION
## Summary
- expose `exportAutoGearRules` and `getSliderBowlValue` through the core runtime exports so session scripts can access them

## Testing
- npm test -- --runTestsByPath tests/unit/app-session.test.js *(fails: no tests found for the specified path)*

------
https://chatgpt.com/codex/tasks/task_e_68dcdd048e0c8320a7e8ab2bb23e5517