### PR TITLE
Guard autosave from missing core functions

### DIFF
--- a/legacy/scripts/app-session.js
+++ b/legacy/scripts/app-session.js
@@ -243,6 +243,26 @@ function callSessionCoreFunction(functionName) {
   }
   return options && Object.prototype.hasOwnProperty.call(options, 'defaultValue') ? options.defaultValue : undefined;
 }
+
+function getSessionCoreValue(functionName) {
+  var options = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+  var defaultValue = Object.prototype.hasOwnProperty.call(options, 'defaultValue') ? options.defaultValue : '';
+  var value = callSessionCoreFunction(functionName, [], {
+    defaultValue: defaultValue
+  });
+  if (typeof value === 'string') {
+    return value;
+  }
+  if (value === null || value === undefined) {
+    return defaultValue;
+  }
+  try {
+    return String(value);
+  } catch (coerceError) {
+    void coerceError;
+    return defaultValue;
+  }
+}
 var temperaturePreferenceStorageKey = typeof TEMPERATURE_STORAGE_KEY === 'string' ? TEMPERATURE_STORAGE_KEY : typeof resolveTemperatureStorageKey === 'function' ? resolveTemperatureStorageKey() : 'cameraPowerPlanner_temperatureUnit';
 var recordFullBackupHistoryEntryFn = function recordFullBackupHistoryEntryFn() {};
 var ensureCriticalStorageBackupsFn = function ensureCriticalStorageBackupsFn() {
@@ -1642,8 +1662,8 @@ function saveCurrentSession() {
   var options = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
   if (restoringSession || factoryResetInProgress) return;
   var info = projectForm ? collectProjectFormData() : {};
-  info.sliderBowl = getSliderBowlValue();
-  info.easyrig = getEasyrigValue();
+  info.sliderBowl = getSessionCoreValue('getSliderBowlValue');
+  info.easyrig = getSessionCoreValue('getEasyrigValue');
   currentProjectInfo = deriveProjectInfo(info);
   var batteryValue = batterySelect ? batterySelect.value : '';
   var batteryPlateValue = batteryPlateSelect ? batteryPlateSelect.value : '';
@@ -3328,7 +3348,11 @@ if (settingsButton && settingsDialog) {
     autoGearResetFactoryButton.addEventListener('click', resetAutoGearRulesToFactoryAdditions);
   }
   if (autoGearExportButton) {
-    autoGearExportButton.addEventListener('click', exportAutoGearRules);
+    autoGearExportButton.addEventListener('click', function () {
+      callSessionCoreFunction('exportAutoGearRules', [], {
+        defer: true
+      });
+    });
   }
   if (autoGearImportButton && autoGearImportInput) {
     autoGearImportButton.addEventListener('click', function () {

--- a/src/scripts/app-session.js
+++ b/src/scripts/app-session.js
@@ -359,6 +359,25 @@ function callSessionCoreFunction(functionName, args = [], options = {}) {
     : undefined;
 }
 
+function getSessionCoreValue(functionName, options = {}) {
+  const defaultValue = Object.prototype.hasOwnProperty.call(options, 'defaultValue')
+    ? options.defaultValue
+    : '';
+  const value = callSessionCoreFunction(functionName, [], { defaultValue });
+  if (typeof value === 'string') {
+    return value;
+  }
+  if (value === null || value === undefined) {
+    return defaultValue;
+  }
+  try {
+    return String(value);
+  } catch (coerceError) {
+    void coerceError;
+    return defaultValue;
+  }
+}
+
 const temperaturePreferenceStorageKey =
   typeof TEMPERATURE_STORAGE_KEY === 'string'
     ? TEMPERATURE_STORAGE_KEY
@@ -1939,8 +1958,8 @@ function handleRestoreRehearsalAbort() {
 function saveCurrentSession(options = {}) {
   if (restoringSession || factoryResetInProgress) return;
   const info = projectForm ? collectProjectFormData() : {};
-  info.sliderBowl = getSliderBowlValue();
-  info.easyrig = getEasyrigValue();
+  info.sliderBowl = getSessionCoreValue('getSliderBowlValue');
+  info.easyrig = getSessionCoreValue('getEasyrigValue');
   currentProjectInfo = deriveProjectInfo(info);
   const batteryValue = batterySelect ? batterySelect.value : '';
   const batteryPlateValue = batteryPlateSelect ? batteryPlateSelect.value : '';
@@ -3739,7 +3758,9 @@ if (autoGearResetFactoryButton) {
   autoGearResetFactoryButton.addEventListener('click', resetAutoGearRulesToFactoryAdditions);
 }
 if (autoGearExportButton) {
-  autoGearExportButton.addEventListener('click', exportAutoGearRules);
+  autoGearExportButton.addEventListener('click', () => {
+    callSessionCoreFunction('exportAutoGearRules', [], { defer: true });
+  });
 }
 if (autoGearImportButton && autoGearImportInput) {
   autoGearImportButton.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- add helpers that safely resolve core runtime functions before collecting slider bowl and Easyrig values
- wire the auto gear export button through the deferred core invocation path to avoid ReferenceErrors when boot order changes
- mirror the same safeguards in the legacy scripts to keep both builds stable

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dcde4ee1c083209bc2edd45022fdcb