### PR TITLE
Ensure auto gear helpers are exposed globally

### DIFF
--- a/legacy/scripts/app-core-new-2.js
+++ b/legacy/scripts/app-core-new-2.js
@@ -15049,6 +15049,7 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
       renderAutoGearMonitorDefaultsControls: renderAutoGearMonitorDefaultsControls,
       renderAutoGearPresetsControls: renderAutoGearPresetsControls,
       renderAutoGearRulesList: renderAutoGearRulesList,
+      handleAutoGearImportSelection: handleAutoGearImportSelection,
       setAutoGearAutoPresetId: setAutoGearAutoPresetId,
       syncAutoGearAutoPreset: syncAutoGearAutoPreset,
       updateAutoGearCatalogOptions: updateAutoGearCatalogOptions,
@@ -15073,7 +15074,10 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
       skipNextGearListRefresh: skipNextGearListRefresh,
       refreshDarkModeAccentBoost: refreshDarkModeAccentBoost,
       isHighContrastActive: isHighContrastActive,
-      feedbackUseLocationBtn: feedbackUseLocationBtn
+      feedbackUseLocationBtn: feedbackUseLocationBtn,
+      getSliderBowlValue: getSliderBowlValue,
+      getEasyrigValue: getEasyrigValue,
+      setEasyrigValue: setEasyrigValue
     };
     var CORE_PART2_GLOBAL_SCOPE = CORE_SHARED_SCOPE_PART2 || (typeof globalThis !== 'undefined' ? globalThis : null) || (typeof window !== 'undefined' ? window : null) || (typeof self !== 'undefined' ? self : null) || (typeof global !== 'undefined' ? global : null);
     var CORE_PART2_RUNTIME = function resolvePart2Runtime(scope) {

--- a/src/scripts/app-core-new-2.js
+++ b/src/scripts/app-core-new-2.js
@@ -15579,6 +15579,7 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
       renderAutoGearMonitorDefaultsControls,
       renderAutoGearPresetsControls,
       renderAutoGearRulesList,
+      handleAutoGearImportSelection,
       setAutoGearAutoPresetId,
       syncAutoGearAutoPreset,
       updateAutoGearCatalogOptions,
@@ -15605,6 +15606,8 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
       isHighContrastActive,
       feedbackUseLocationBtn,
       getSliderBowlValue,
+      getEasyrigValue,
+      setEasyrigValue,
     };
     
     const CORE_PART2_GLOBAL_SCOPE =


### PR DESCRIPTION
## Summary
- export the auto gear import handler to the global runtime so the UI can wire the file input listener without ReferenceErrors
- expose the Easyrig accessors in both modern and legacy bundles to keep autosave and setup persistence intact when collecting project data

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dce03cbed08320a672ea684a94ba59