### PR TITLE
Allow storage module to reinitialise in Jest environments

### DIFF
--- a/legacy/scripts/storage.js
+++ b/legacy/scripts/storage.js
@@ -20,11 +20,28 @@ function _arrayLikeToArray(r, a) { (null == a || a > r.length) && (a = r.length)
 function _typeof(o) { "@babel/helpers - typeof"; return _typeof = "function" == typeof Symbol && "symbol" == typeof Symbol.iterator ? function (o) { return typeof o; } : function (o) { return o && "function" == typeof Symbol && o.constructor === Symbol && o !== Symbol.prototype ? "symbol" : typeof o; }, _typeof(o); }
 (function initializeStorageModule() {
   var GLOBAL_SCOPE = typeof globalThis !== 'undefined' ? globalThis : typeof window !== 'undefined' ? window : typeof global !== 'undefined' ? global : typeof self !== 'undefined' ? self : null;
+  var FORCE_STORAGE_REINITIALIZE = typeof process !== 'undefined' && process && process.env && (process.env.JEST_WORKER_ID || process.env.CINE_FORCE_STORAGE_REINIT);
   if (GLOBAL_SCOPE && GLOBAL_SCOPE.__cineStorageInitialized) {
-    if (typeof module !== 'undefined' && module.exports && GLOBAL_SCOPE.__cineStorageApi && _typeof(GLOBAL_SCOPE.__cineStorageApi) === 'object') {
-      module.exports = GLOBAL_SCOPE.__cineStorageApi;
+    if (FORCE_STORAGE_REINITIALIZE) {
+      try {
+        delete GLOBAL_SCOPE.__cineStorageInitialized;
+      } catch (resetInitFlagError) {
+        GLOBAL_SCOPE.__cineStorageInitialized = false;
+        void resetInitFlagError;
+      }
+
+      try {
+        delete GLOBAL_SCOPE.__cineStorageApi;
+      } catch (resetApiError) {
+        GLOBAL_SCOPE.__cineStorageApi = null;
+        void resetApiError;
+      }
+    } else {
+      if (typeof module !== 'undefined' && module.exports && GLOBAL_SCOPE.__cineStorageApi && _typeof(GLOBAL_SCOPE.__cineStorageApi) === 'object') {
+        module.exports = GLOBAL_SCOPE.__cineStorageApi;
+      }
+      return;
     }
-    return;
   }
   if (GLOBAL_SCOPE) {
     try {

--- a/src/scripts/storage.js
+++ b/src/scripts/storage.js
@@ -16,16 +16,38 @@
             ? self
             : null;
 
+  const FORCE_STORAGE_REINITIALIZE =
+    typeof process !== 'undefined' &&
+    process &&
+    process.env &&
+    (process.env.JEST_WORKER_ID || process.env.CINE_FORCE_STORAGE_REINIT);
+
   if (GLOBAL_SCOPE && GLOBAL_SCOPE.__cineStorageInitialized) {
-    if (
-      typeof module !== 'undefined' &&
-      module.exports &&
-      GLOBAL_SCOPE.__cineStorageApi &&
-      typeof GLOBAL_SCOPE.__cineStorageApi === 'object'
-    ) {
-      module.exports = GLOBAL_SCOPE.__cineStorageApi;
+    if (FORCE_STORAGE_REINITIALIZE) {
+      try {
+        delete GLOBAL_SCOPE.__cineStorageInitialized;
+      } catch (resetInitFlagError) {
+        GLOBAL_SCOPE.__cineStorageInitialized = false;
+        void resetInitFlagError;
+      }
+
+      try {
+        delete GLOBAL_SCOPE.__cineStorageApi;
+      } catch (resetApiError) {
+        GLOBAL_SCOPE.__cineStorageApi = null;
+        void resetApiError;
+      }
+    } else {
+      if (
+        typeof module !== 'undefined' &&
+        module.exports &&
+        GLOBAL_SCOPE.__cineStorageApi &&
+        typeof GLOBAL_SCOPE.__cineStorageApi === 'object'
+      ) {
+        module.exports = GLOBAL_SCOPE.__cineStorageApi;
+      }
+      return;
     }
-    return;
   }
 
   if (GLOBAL_SCOPE) {


### PR DESCRIPTION
## Summary
- allow the storage bootstrapper to re-run when Jest resets modules by checking for testing env variables
- clear any cached storage API before rebuilding so tests see a fresh instance in both modern and legacy bundles

## Testing
- npx jest tests/unit/storageFallback.test.js --runInBand
- npm test *(fails: ReferenceError: updateFavoriteButton is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68dcdc83ac0c8320bf3f2bb357c95ef5