### PR TITLE
Fix missing global exports for session runtime

### DIFF
--- a/src/scripts/app-core-new-2.js
+++ b/src/scripts/app-core-new-2.js
@@ -15625,6 +15625,7 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
       renderAutoGearPresetsControls,
       renderAutoGearRulesList,
       handleAutoGearImportSelection,
+      handleAutoGearPresetSelection,
       setAutoGearAutoPresetId,
       syncAutoGearAutoPreset,
       updateAutoGearCatalogOptions,
@@ -15641,6 +15642,7 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
       updateAccentColorResetButtonState,
       restoringSession,
       currentProjectInfo,
+      deriveProjectInfo,
       projectForm,
       filterSelectElem,
       filterDetailsStorage,
@@ -15653,6 +15655,8 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
       getSliderBowlValue,
       getEasyrigValue,
       setEasyrigValue,
+      fontSize,
+      fontFamily,
     };
     
     const CORE_PART2_GLOBAL_SCOPE =


### PR DESCRIPTION
## Summary
- expose handleAutoGearPresetSelection from the core runtime so auto gear preset selection works again
- export deriveProjectInfo to restore project autosave support
- include the current font size and family values in the shared runtime state for settings panels

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dce23b409c8320a0dbb5ba3466d0bd