### PR TITLE
Fix loader auto gear global placeholders

### DIFF
--- a/src/scripts/loader.js
+++ b/src/scripts/loader.js
@@ -26,6 +26,20 @@ if (typeof autoGearScenarioModeSelect === 'undefined') {
   var autoGearScenarioModeSelect = null;
 }
 
+if (typeof autoGearRuleNameInput === 'undefined') {
+  var autoGearRuleNameInput = null;
+}
+
+if (typeof autoGearSummaryFocus === 'undefined' || typeof autoGearSummaryFocus !== 'string') {
+  var autoGearSummaryFocus = 'all';
+}
+
+if (typeof autoGearMonitorDefaultControls === 'undefined') {
+  var autoGearMonitorDefaultControls = [];
+} else if (!Array.isArray(autoGearMonitorDefaultControls)) {
+  autoGearMonitorDefaultControls = [];
+}
+
 function loaderFallbackSafeGenerateConnectorSummary(device) {
   if (!device || typeof device !== 'object') {
     return '';


### PR DESCRIPTION
## Summary
- add missing global fallbacks for auto gear UI bindings in the loader to prevent ReferenceError crashes on startup

## Testing
- npm test -- --runTestsByPath tests/unit/storage.test.js

------
https://chatgpt.com/codex/tasks/task_e_68dce3b652ec8320b94b5df9fe0b3d7b