### PR TITLE
Guard diagram download button lookups

### DIFF
--- a/src/scripts/app-core-new-1.js
+++ b/src/scripts/app-core-new-1.js
@@ -9524,11 +9524,21 @@ function setLanguage(lang) {
     exportRevert.setAttribute('data-help', texts[lang].exportAndRevertBtnHelp);
   }
 
-  if (downloadDiagramBtn) {
-    downloadDiagramBtn.textContent = texts[lang].downloadDiagramBtn;
-    downloadDiagramBtn.setAttribute("title", texts[lang].downloadDiagramBtn);
-    downloadDiagramBtn.setAttribute("aria-label", texts[lang].downloadDiagramBtn);
-    downloadDiagramBtn.setAttribute("data-help", texts[lang].downloadDiagramHelp);
+  const downloadDiagramButton =
+    (typeof downloadDiagramBtn !== 'undefined' && downloadDiagramBtn)
+    || (
+      typeof document !== 'undefined'
+        && document
+        && typeof document.getElementById === 'function'
+          ? document.getElementById('downloadDiagram')
+          : null
+    );
+
+  if (downloadDiagramButton) {
+    downloadDiagramButton.textContent = texts[lang].downloadDiagramBtn;
+    downloadDiagramButton.setAttribute("title", texts[lang].downloadDiagramBtn);
+    downloadDiagramButton.setAttribute("aria-label", texts[lang].downloadDiagramBtn);
+    downloadDiagramButton.setAttribute("data-help", texts[lang].downloadDiagramHelp);
   }
   if (gridSnapToggleBtn) {
     setButtonLabelWithIcon(gridSnapToggleBtn, texts[lang].gridSnapToggle, ICON_GLYPHS.magnet);

--- a/src/scripts/app-session.js
+++ b/src/scripts/app-session.js
@@ -73,6 +73,26 @@ function ensureSessionRuntimePlaceholder(name, fallbackValue) {
 
 ensureSessionRuntimePlaceholder('autoGearScenarioModeSelect', null);
 
+const downloadDiagramButton = ensureSessionRuntimePlaceholder(
+  'downloadDiagramBtn',
+  () => {
+    if (
+      typeof document === 'undefined'
+      || !document
+      || typeof document.getElementById !== 'function'
+    ) {
+      return null;
+    }
+
+    try {
+      return document.getElementById('downloadDiagram');
+    } catch (resolveError) {
+      void resolveError;
+      return null;
+    }
+  },
+);
+
 function getGlobalCineUi() {
   const scope =
     (typeof globalThis !== 'undefined' && globalThis)
@@ -8274,8 +8294,8 @@ function copyTextToClipboardBestEffort(text) {
   }
 }
 
-if (downloadDiagramBtn) {
-  downloadDiagramBtn.addEventListener('click', (e) => {
+if (downloadDiagramButton) {
+  downloadDiagramButton.addEventListener('click', (e) => {
     const source = exportDiagramSvg();
     if (!source) return;
 


### PR DESCRIPTION
## Summary
- guard the download diagram button lookup during session initialization so the export handler binds safely
- fall back to DOM queries when applying translations to keep the download control labelled even without a preset global

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dce9e647248320a349e3368f3b0d59