### PR TITLE
Fix auto gear scenario selector initialization

### DIFF
--- a/src/scripts/app-session.js
+++ b/src/scripts/app-session.js
@@ -3763,11 +3763,26 @@ if (autoGearConditionAddButton) {
     addAutoGearConditionFromPicker();
   });
 }
-if (autoGearScenarioModeSelect) {
-  autoGearScenarioModeSelect.addEventListener('change', () => {
+const autoGearScenarioModeSelectHandle =
+  typeof autoGearScenarioModeSelect !== 'undefined'
+    ? autoGearScenarioModeSelect
+    : typeof globalThis !== 'undefined'
+        && globalThis
+        && typeof globalThis.autoGearScenarioModeSelect !== 'undefined'
+      ? globalThis.autoGearScenarioModeSelect
+      : null;
+
+if (autoGearScenarioModeSelectHandle && typeof autoGearScenarioModeSelectHandle.addEventListener === 'function') {
+  autoGearScenarioModeSelectHandle.addEventListener('change', () => {
     if (autoGearEditorDraft) {
-      autoGearEditorDraft.scenarioLogic = normalizeAutoGearScenarioLogic(autoGearScenarioModeSelect.value);
+      const selectValue =
+        typeof autoGearScenarioModeSelectHandle.value === 'string'
+          ? autoGearScenarioModeSelectHandle.value
+          : '';
+
+      autoGearEditorDraft.scenarioLogic = normalizeAutoGearScenarioLogic(selectValue);
     }
+
     applyAutoGearScenarioSettings(getAutoGearScenarioSelectedValues());
   });
 }


### PR DESCRIPTION
## Summary
- guard access to the auto gear scenario mode select element when wiring listeners
- ensure scenario logic updates continue to run after resolving the element reference safely

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dceae2c0f48320983f480e1a99dce5