### PR TITLE
Fix auto gear preset alignment when base rules seed is unavailable

### DIFF
--- a/legacy/scripts/app-core-new-2.js
+++ b/legacy/scripts/app-core-new-2.js
@@ -1274,7 +1274,12 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
     function alignActiveAutoGearPreset() {
       var options = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
       var skipRender = options.skipRender === true;
-      var fingerprint = createAutoGearRulesFingerprint(baseAutoGearRulesState);
+      var rulesSource = Array.isArray(baseAutoGearRulesState)
+        ? baseAutoGearRulesState
+        : typeof baseAutoGearRules !== 'undefined' && Array.isArray(baseAutoGearRules)
+          ? baseAutoGearRules
+          : [];
+      var fingerprint = createAutoGearRulesFingerprint(rulesSource);
       var matching = autoGearPresets.find(function (preset) {
         return preset.fingerprint === fingerprint;
       }) || null;

--- a/src/scripts/app-core-new-2.js
+++ b/src/scripts/app-core-new-2.js
@@ -1452,7 +1452,12 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
     
     function alignActiveAutoGearPreset(options = {}) {
       const skipRender = options.skipRender === true;
-        const fingerprint = createAutoGearRulesFingerprint(baseAutoGearRulesState);
+      const rulesSource = Array.isArray(baseAutoGearRulesState)
+        ? baseAutoGearRulesState
+        : typeof baseAutoGearRules !== 'undefined' && Array.isArray(baseAutoGearRules)
+          ? baseAutoGearRules
+          : [];
+      const fingerprint = createAutoGearRulesFingerprint(rulesSource);
       const matching = autoGearPresets.find(preset => preset.fingerprint === fingerprint) || null;
       if (matching) {
         setActiveAutoGearPresetId(matching.id, { persist: true, skipRender: true });


### PR DESCRIPTION
## Summary
- guard the auto gear preset alignment routine against missing rule seeds so it no longer throws when the global placeholder is absent
- mirror the defensive logic in the legacy bundle to keep the runtime behaviours aligned

## Testing
- npm test -- --runInBand *(fails: ReferenceError: updateFavoriteButton is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68dceace21148320ae28bf41deffc645