### PR TITLE
Fix grid snap toggle reference

### DIFF
--- a/src/scripts/app-session.js
+++ b/src/scripts/app-session.js
@@ -93,6 +93,26 @@ const downloadDiagramButton = ensureSessionRuntimePlaceholder(
   },
 );
 
+const gridSnapToggleButton = ensureSessionRuntimePlaceholder(
+  'gridSnapToggleBtn',
+  () => {
+    if (
+      typeof document === 'undefined'
+      || !document
+      || typeof document.getElementById !== 'function'
+    ) {
+      return null;
+    }
+
+    try {
+      return document.getElementById('gridSnapToggle');
+    } catch (resolveError) {
+      void resolveError;
+      return null;
+    }
+  },
+);
+
 function getGlobalCineUi() {
   const scope =
     (typeof globalThis !== 'undefined' && globalThis)
@@ -8356,11 +8376,11 @@ if (downloadDiagramButton) {
   });
 }
 
-if (gridSnapToggleBtn) {
-  gridSnapToggleBtn.addEventListener('click', () => {
+if (gridSnapToggleButton) {
+  gridSnapToggleButton.addEventListener('click', () => {
     gridSnap = !gridSnap;
-    gridSnapToggleBtn.classList.toggle('active', gridSnap);
-    gridSnapToggleBtn.setAttribute('aria-pressed', gridSnap ? 'true' : 'false');
+    gridSnapToggleButton.classList.toggle('active', gridSnap);
+    gridSnapToggleButton.setAttribute('aria-pressed', gridSnap ? 'true' : 'false');
     if (setupDiagramContainer) {
       setupDiagramContainer.classList.toggle('grid-snap', gridSnap);
     }


### PR DESCRIPTION
## Summary
- ensure the grid snap toggle button reference is resolved safely before use
- update the grid snap handler to use the resolved button reference to avoid runtime errors

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dceb7d51e883209c167c6ee4d46f5f