### PR TITLE
Guard connector summary global lookup

### DIFF
--- a/legacy/scripts/app-core-new-2.js
+++ b/legacy/scripts/app-core-new-2.js
@@ -125,8 +125,12 @@ function generateSafeConnectorSummary(device) {
   if (typeof safeGenerateConnectorSummaryFn === 'function') {
     candidates.push(safeGenerateConnectorSummaryFn);
   }
-  if (typeof safeGenerateConnectorSummary === 'function') {
-    candidates.push(safeGenerateConnectorSummary);
+  try {
+    if (typeof safeGenerateConnectorSummary === 'function') {
+      candidates.push(safeGenerateConnectorSummary);
+    }
+  } catch (referenceError) {
+    void referenceError;
   }
   if (typeof CORE_SHARED !== 'undefined' && CORE_SHARED && typeof CORE_SHARED.safeGenerateConnectorSummary === 'function') {
     candidates.push(CORE_SHARED.safeGenerateConnectorSummary);

--- a/src/scripts/app-core-new-2.js
+++ b/src/scripts/app-core-new-2.js
@@ -165,8 +165,12 @@ function generateSafeConnectorSummary(device) {
   if (typeof safeGenerateConnectorSummaryFn === 'function') {
     candidates.push(safeGenerateConnectorSummaryFn);
   }
-  if (typeof safeGenerateConnectorSummary === 'function') {
-    candidates.push(safeGenerateConnectorSummary);
+  try {
+    if (typeof safeGenerateConnectorSummary === 'function') {
+      candidates.push(safeGenerateConnectorSummary);
+    }
+  } catch (referenceError) {
+    void referenceError;
   }
   if (
     typeof CORE_SHARED !== 'undefined' &&


### PR DESCRIPTION
## Summary
- wrap the global `safeGenerateConnectorSummary` probe in a try/catch so fallback logic survives when the global binding is absent
- mirror the fix in the legacy bundle to keep the distributed build aligned

## Testing
- npm test -- --runTestsByPath tests/unit/coreShared.test.js

------
https://chatgpt.com/codex/tasks/task_e_68dcec7251e4832095d9699cebef5dae