### PR TITLE
Guard auto gear preset alignment against missing globals

### DIFF
--- a/legacy/scripts/app-core-new-2.js
+++ b/legacy/scripts/app-core-new-2.js
@@ -1305,14 +1305,27 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
         renderAutoGearPresetsControls();
       }
     }
+    function resolveBaseAutoGearRulesSnapshot() {
+      if (Array.isArray(baseAutoGearRulesState)) {
+        return baseAutoGearRulesState;
+      }
+
+      var resolved = readCoreScopeValue('baseAutoGearRules');
+      if (Array.isArray(resolved)) {
+        return resolved;
+      }
+
+      if (typeof baseAutoGearRules !== 'undefined' && Array.isArray(baseAutoGearRules)) {
+        return baseAutoGearRules;
+      }
+
+      return [];
+    }
+
     function alignActiveAutoGearPreset() {
       var options = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
       var skipRender = options.skipRender === true;
-      var rulesSource = Array.isArray(baseAutoGearRulesState)
-        ? baseAutoGearRulesState
-        : typeof baseAutoGearRules !== 'undefined' && Array.isArray(baseAutoGearRules)
-          ? baseAutoGearRules
-          : [];
+      var rulesSource = resolveBaseAutoGearRulesSnapshot();
       var fingerprint = createAutoGearRulesFingerprint(rulesSource);
       var matching = autoGearPresets.find(function (preset) {
         return preset.fingerprint === fingerprint;

--- a/src/scripts/app-core-new-2.js
+++ b/src/scripts/app-core-new-2.js
@@ -1491,13 +1491,26 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
       }
     }
     
+    function resolveBaseAutoGearRulesSnapshot() {
+      if (Array.isArray(baseAutoGearRulesState)) {
+        return baseAutoGearRulesState;
+      }
+
+      const resolved = readCoreScopeValue('baseAutoGearRules');
+      if (Array.isArray(resolved)) {
+        return resolved;
+      }
+
+      if (typeof baseAutoGearRules !== 'undefined' && Array.isArray(baseAutoGearRules)) {
+        return baseAutoGearRules;
+      }
+
+      return [];
+    }
+
     function alignActiveAutoGearPreset(options = {}) {
       const skipRender = options.skipRender === true;
-      const rulesSource = Array.isArray(baseAutoGearRulesState)
-        ? baseAutoGearRulesState
-        : typeof baseAutoGearRules !== 'undefined' && Array.isArray(baseAutoGearRules)
-          ? baseAutoGearRules
-          : [];
+      const rulesSource = resolveBaseAutoGearRulesSnapshot();
       const fingerprint = createAutoGearRulesFingerprint(rulesSource);
       const matching = autoGearPresets.find(preset => preset.fingerprint === fingerprint) || null;
       if (matching) {


### PR DESCRIPTION
## Summary
- ensure the modern runtime resolves automatic gear rules through the core scope before aligning presets
- mirror the same defensive lookup in the legacy runtime bundle to avoid ReferenceErrors during startup

## Testing
- npm test *(fails: ReferenceError: updateFavoriteButton is not defined – existing issue in full user journey regression suite)*

------
https://chatgpt.com/codex/tasks/task_e_68dcec79cd508320a2e48a206eb504da