### PR TITLE
Fix grid snap toggle button reference

### DIFF
--- a/legacy/scripts/app-session.js
+++ b/legacy/scripts/app-session.js
@@ -48,6 +48,18 @@ function ensureSessionRuntimePlaceholder(name, fallbackValue) {
 }
 
 ensureSessionRuntimePlaceholder('autoGearScenarioModeSelect', null);
+var gridSnapToggleBtn = ensureSessionRuntimePlaceholder('gridSnapToggleBtn', function () {
+  if (typeof document === 'undefined' || !document || typeof document.getElementById !== 'function') {
+    return null;
+  }
+
+  try {
+    return document.getElementById('gridSnapToggle');
+  } catch (resolveError) {
+    void resolveError;
+    return null;
+  }
+});
 function getGlobalCineUi() {
   var scope = typeof globalThis !== 'undefined' && globalThis || typeof window !== 'undefined' && window || typeof self !== 'undefined' && self || typeof global !== 'undefined' && global || null;
   if (!scope || _typeof(scope) !== 'object') {


### PR DESCRIPTION
## Summary
- register the grid snap toggle button placeholder before it is referenced so the session script can safely attach listeners

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dcedae3c5083208f44924b8a7f0140