### PR TITLE
Add fallbacks for feedback temperature dropdown initialization

### DIFF
--- a/legacy/scripts/app-session.js
+++ b/legacy/scripts/app-session.js
@@ -9614,11 +9614,61 @@ function initApp() {
   updateCalculations();
   applyFilters();
 }
+function ensureFeedbackTemperatureOptionsSafe(select) {
+  if (!select) return;
+  if (typeof ensureFeedbackTemperatureOptions === 'function') {
+    ensureFeedbackTemperatureOptions(select);
+    return;
+  }
+  var minTemp = typeof FEEDBACK_TEMPERATURE_MIN === 'number' ? FEEDBACK_TEMPERATURE_MIN : -20;
+  var maxTemp = typeof FEEDBACK_TEMPERATURE_MAX === 'number' ? FEEDBACK_TEMPERATURE_MAX : 50;
+  var expectedOptions = maxTemp - minTemp + 2;
+  if (select.options.length === expectedOptions) {
+    return;
+  }
+  var previousValue = select.value;
+  select.innerHTML = '';
+  var emptyOpt = document.createElement('option');
+  emptyOpt.value = '';
+  emptyOpt.textContent = '';
+  select.appendChild(emptyOpt);
+  for (var temp = minTemp; temp <= maxTemp; temp += 1) {
+    var opt = document.createElement('option');
+    opt.value = String(temp);
+    opt.textContent = String(temp);
+    select.appendChild(opt);
+  }
+  if (previousValue) {
+    var previousOption = Array.from(select.options).find(function (option) {
+      return option.value === previousValue;
+    });
+    if (previousOption) {
+      select.value = previousValue;
+    }
+  }
+}
+function updateFeedbackTemperatureOptionsSafe() {
+  if (typeof updateFeedbackTemperatureOptions === 'function') {
+    updateFeedbackTemperatureOptions();
+    return;
+  }
+  var tempSelect = document.getElementById('fbTemperature');
+  if (!tempSelect) return;
+  ensureFeedbackTemperatureOptionsSafe(tempSelect);
+  Array.from(tempSelect.options).forEach(function (option) {
+    if (!option) return;
+    if (option.value === '') {
+      option.textContent = '';
+      return;
+    }
+    option.textContent = "".concat(option.value, "°C");
+  });
+}
 function populateEnvironmentDropdowns() {
   var tempSelect = document.getElementById('fbTemperature');
   if (tempSelect) {
-    ensureFeedbackTemperatureOptions(tempSelect);
-    updateFeedbackTemperatureOptions();
+    ensureFeedbackTemperatureOptionsSafe(tempSelect);
+    updateFeedbackTemperatureOptionsSafe();
   }
 }
 function populateLensDropdown() {

--- a/src/scripts/app-session.js
+++ b/src/scripts/app-session.js
@@ -34,6 +34,7 @@
           loadAutoGearPresets, loadAutoGearSeedFlag, loadAutoGearActivePresetId,
           loadAutoGearAutoPresetId, loadAutoGearBackupVisibility,
           loadAutoGearBackupRetention, loadFullBackupHistory */
+/* global FEEDBACK_TEMPERATURE_MIN: true, FEEDBACK_TEMPERATURE_MAX: true */
 /* global getDiagramManualPositions, setManualDiagramPositions,
           normalizeDiagramPositionsInput, ensureAutoBackupsFromProjects */
 /* global getMountVoltagePreferencesClone, mountVoltageResetButton, CORE_GLOBAL_SCOPE,
@@ -10654,11 +10655,67 @@ function initApp() {
   applyFilters();
 }
 
+function ensureFeedbackTemperatureOptionsSafe(select) {
+  if (!select) return;
+  if (typeof ensureFeedbackTemperatureOptions === 'function') {
+    ensureFeedbackTemperatureOptions(select);
+    return;
+  }
+
+  const minTemp = typeof FEEDBACK_TEMPERATURE_MIN === 'number' ? FEEDBACK_TEMPERATURE_MIN : -20;
+  const maxTemp = typeof FEEDBACK_TEMPERATURE_MAX === 'number' ? FEEDBACK_TEMPERATURE_MAX : 50;
+  const expectedOptions = maxTemp - minTemp + 2;
+  if (select.options.length === expectedOptions) {
+    return;
+  }
+
+  const previousValue = select.value;
+  select.innerHTML = '';
+  const emptyOpt = document.createElement('option');
+  emptyOpt.value = '';
+  emptyOpt.textContent = '';
+  select.appendChild(emptyOpt);
+
+  for (let temp = minTemp; temp <= maxTemp; temp += 1) {
+    const opt = document.createElement('option');
+    opt.value = String(temp);
+    opt.textContent = String(temp);
+    select.appendChild(opt);
+  }
+
+  if (previousValue) {
+    const previousOption = Array.from(select.options).find(option => option.value === previousValue);
+    if (previousOption) {
+      select.value = previousValue;
+    }
+  }
+}
+
+function updateFeedbackTemperatureOptionsSafe() {
+  if (typeof updateFeedbackTemperatureOptions === 'function') {
+    updateFeedbackTemperatureOptions();
+    return;
+  }
+
+  const tempSelect = document.getElementById('fbTemperature');
+  if (!tempSelect) return;
+
+  ensureFeedbackTemperatureOptionsSafe(tempSelect);
+  Array.from(tempSelect.options).forEach(option => {
+    if (!option) return;
+    if (option.value === '') {
+      option.textContent = '';
+      return;
+    }
+    option.textContent = `${option.value}°C`;
+  });
+}
+
 function populateEnvironmentDropdowns() {
   const tempSelect = document.getElementById('fbTemperature');
   if (tempSelect) {
-    ensureFeedbackTemperatureOptions(tempSelect);
-    updateFeedbackTemperatureOptions();
+    ensureFeedbackTemperatureOptionsSafe(tempSelect);
+    updateFeedbackTemperatureOptionsSafe();
   }
 
 }


### PR DESCRIPTION
## Summary
- ensure the feedback temperature dropdown initializes even when core helpers are unavailable
- add equivalent guard logic in the legacy session runtime and declare global constants for linting

## Testing
- npm test -- --watch=false *(fails: ReferenceError: updateFavoriteButton is not defined during full user journey test)*

------
https://chatgpt.com/codex/tasks/task_e_68dcee6af88c83209cf47f4d1151b34a