### PR TITLE
Fix auto preset global binding initialization

### DIFF
--- a/src/scripts/app-core-new-1.js
+++ b/src/scripts/app-core-new-1.js
@@ -411,6 +411,18 @@ function repairAutoGearAutoPresetGlobal(scope) {
       }
     }
   }
+
+  try {
+    const globalFn = (scope && scope.Function) || Function;
+    if (typeof globalFn === 'function') {
+      globalFn(
+        'value',
+        "if (typeof autoGearAutoPresetId === 'undefined') { autoGearAutoPresetId = value; } return autoGearAutoPresetId;",
+      )(typeof scope.autoGearAutoPresetId === 'string' ? scope.autoGearAutoPresetId : '');
+    }
+  } catch (bindingError) {
+    void bindingError;
+  }
 }
 
 function callCoreFunctionIfAvailable(functionName, args = [], options = {}) {


### PR DESCRIPTION
## Summary
- ensure loader establishes resilient global bindings for critical auto gear runtime values
- harden the auto preset global repair helper to recreate missing bindings before retrying

## Testing
- npm test -- --runTestsByPath tests/unit/storage.test.js

------
https://chatgpt.com/codex/tasks/task_e_68dcee81997c83209f484d7f5d6959b6