### PR TITLE
Guard auto gear rules fallback lookup

### DIFF
--- a/src/scripts/app-core-new-2.js
+++ b/src/scripts/app-core-new-2.js
@@ -1576,8 +1576,19 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
         return resolved;
       }
 
-      if (typeof baseAutoGearRules !== 'undefined' && Array.isArray(baseAutoGearRules)) {
-        return baseAutoGearRules;
+      for (let index = 0; index < CORE_RUNTIME_SCOPE_CANDIDATES.length; index += 1) {
+        const scope = CORE_RUNTIME_SCOPE_CANDIDATES[index];
+        if (!scope || typeof scope !== 'object') {
+          continue;
+        }
+        try {
+          const value = scope.baseAutoGearRules;
+          if (Array.isArray(value)) {
+            return value;
+          }
+        } catch (fallbackError) {
+          void fallbackError;
+        }
       }
 
       return [];


### PR DESCRIPTION
## Summary
- guard the base auto gear rules snapshot against missing global definitions
- ensure alignActiveAutoGearPreset can resolve rules without throwing when presets render

## Testing
- npm test -- --watch=false *(fails: ReferenceError: updateFavoriteButton is not defined in existing runtime setup)*

------
https://chatgpt.com/codex/tasks/task_e_68dcee8aad788320b7a2c5a32b293838