### PR TITLE
Prevent connector summary generator reference errors

### DIFF
--- a/legacy/scripts/app-core-new-2.js
+++ b/legacy/scripts/app-core-new-2.js
@@ -22,6 +22,33 @@ function _typeof(o) { "@babel/helpers - typeof"; return _typeof = "function" == 
 function _asyncIterator(r) { var n, t, o, e = 2; for ("undefined" != typeof Symbol && (t = Symbol.asyncIterator, o = Symbol.iterator); e--;) { if (t && null != (n = r[t])) return n.call(r); if (o && null != (n = r[o])) return new AsyncFromSyncIterator(n.call(r)); t = "@@asyncIterator", o = "@@iterator"; } throw new TypeError("Object is not async iterable"); }
 function AsyncFromSyncIterator(r) { function AsyncFromSyncIteratorContinuation(r) { if (Object(r) !== r) return Promise.reject(new TypeError(r + " is not an object.")); var n = r.done; return Promise.resolve(r.value).then(function (r) { return { value: r, done: n }; }); } return AsyncFromSyncIterator = function AsyncFromSyncIterator(r) { this.s = r, this.n = r.next; }, AsyncFromSyncIterator.prototype = { s: null, n: null, next: function next() { return AsyncFromSyncIteratorContinuation(this.n.apply(this.s, arguments)); }, return: function _return(r) { var n = this.s.return; return void 0 === n ? Promise.resolve({ value: r, done: !0 }) : AsyncFromSyncIteratorContinuation(n.apply(this.s, arguments)); }, throw: function _throw(r) { var n = this.s.return; return void 0 === n ? Promise.reject(r) : AsyncFromSyncIteratorContinuation(n.apply(this.s, arguments)); } }, new AsyncFromSyncIterator(r); }
 var CORE_PART2_RUNTIME_SCOPE = typeof CORE_GLOBAL_SCOPE !== 'undefined' && CORE_GLOBAL_SCOPE ? CORE_GLOBAL_SCOPE : typeof globalThis !== 'undefined' ? globalThis : typeof window !== 'undefined' ? window : typeof self !== 'undefined' ? self : typeof global !== 'undefined' ? global : null;
+var CORE_PART2_GLOBAL_SCOPES = [
+  CORE_PART2_RUNTIME_SCOPE && _typeof(CORE_PART2_RUNTIME_SCOPE) === 'object' ? CORE_PART2_RUNTIME_SCOPE : null,
+  typeof CORE_GLOBAL_SCOPE !== 'undefined' && CORE_GLOBAL_SCOPE && _typeof(CORE_GLOBAL_SCOPE) === 'object' ? CORE_GLOBAL_SCOPE : null,
+  typeof globalThis !== 'undefined' && _typeof(globalThis) === 'object' ? globalThis : null,
+  typeof window !== 'undefined' && _typeof(window) === 'object' ? window : null,
+  typeof self !== 'undefined' && _typeof(self) === 'object' ? self : null,
+  typeof global !== 'undefined' && _typeof(global) === 'object' ? global : null
+].filter(Boolean);
+
+function readGlobalScopeValue(name) {
+  for (var index = 0; index < CORE_PART2_GLOBAL_SCOPES.length; index += 1) {
+    var scope = CORE_PART2_GLOBAL_SCOPES[index];
+    if (!scope || _typeof(scope) !== 'object') {
+      continue;
+    }
+
+    try {
+      if (name in scope) {
+        return scope[name];
+      }
+    } catch (readError) {
+      void readError;
+    }
+  }
+
+  return undefined;
+}
 if (typeof autoGearAutoPresetId === 'undefined') {
   var autoGearAutoPresetId = '';
 }
@@ -125,12 +152,9 @@ function generateSafeConnectorSummary(device) {
   if (typeof safeGenerateConnectorSummaryFn === 'function') {
     candidates.push(safeGenerateConnectorSummaryFn);
   }
-  try {
-    if (typeof safeGenerateConnectorSummary === 'function') {
-      candidates.push(safeGenerateConnectorSummary);
-    }
-  } catch (referenceError) {
-    void referenceError;
+  var globalSafeSummary = readGlobalScopeValue('safeGenerateConnectorSummary');
+  if (typeof globalSafeSummary === 'function') {
+    candidates.push(globalSafeSummary);
   }
   if (typeof CORE_SHARED !== 'undefined' && CORE_SHARED && typeof CORE_SHARED.safeGenerateConnectorSummary === 'function') {
     candidates.push(CORE_SHARED.safeGenerateConnectorSummary);

--- a/src/scripts/app-core-new-2.js
+++ b/src/scripts/app-core-new-2.js
@@ -24,6 +24,25 @@ var CORE_PART2_GLOBAL_SCOPES = [
   typeof global !== 'undefined' && typeof global === 'object' ? global : null,
 ].filter(Boolean);
 
+function readGlobalScopeValue(name) {
+  for (let index = 0; index < CORE_PART2_GLOBAL_SCOPES.length; index += 1) {
+    const scope = CORE_PART2_GLOBAL_SCOPES[index];
+    if (!scope || typeof scope !== 'object') {
+      continue;
+    }
+
+    try {
+      if (name in scope) {
+        return scope[name];
+      }
+    } catch (readError) {
+      void readError;
+    }
+  }
+
+  return undefined;
+}
+
 function ensureGlobalFallback(name, fallbackValue) {
   var fallbackProvider =
     typeof fallbackValue === 'function'
@@ -236,12 +255,9 @@ function generateSafeConnectorSummary(device) {
   if (typeof safeGenerateConnectorSummaryFn === 'function') {
     candidates.push(safeGenerateConnectorSummaryFn);
   }
-  try {
-    if (typeof safeGenerateConnectorSummary === 'function') {
-      candidates.push(safeGenerateConnectorSummary);
-    }
-  } catch (referenceError) {
-    void referenceError;
+  const globalSafeSummary = readGlobalScopeValue('safeGenerateConnectorSummary');
+  if (typeof globalSafeSummary === 'function') {
+    candidates.push(globalSafeSummary);
   }
   if (
     typeof CORE_SHARED !== 'undefined' &&


### PR DESCRIPTION
## Summary
- add a shared helper to safely read core runtime globals
- use the helper when resolving connector summary generators to avoid ReferenceErrors

## Testing
- npm test -- --runTestsByPath tests/unit/runtimeModule.test.js

------
https://chatgpt.com/codex/tasks/task_e_68dcee951f0c8320bc292ffce924c30b