### PR TITLE
Prevent auto gear scenario mode select reference errors

### DIFF
--- a/legacy/scripts/app-session.js
+++ b/legacy/scripts/app-session.js
@@ -3336,11 +3336,43 @@ if (settingsButton && settingsDialog) {
       addAutoGearConditionFromPicker();
     });
   }
-  if (autoGearScenarioModeSelect) {
-    autoGearScenarioModeSelect.addEventListener('change', function () {
-      if (autoGearEditorDraft) {
-        autoGearEditorDraft.scenarioLogic = normalizeAutoGearScenarioLogic(autoGearScenarioModeSelect.value);
+  var autoGearScenarioModeSelectHandle = function resolveAutoGearScenarioModeSelectHandle() {
+    var resolvedHandle = null;
+
+    try {
+      if (typeof autoGearScenarioModeSelect !== 'undefined') {
+        resolvedHandle = autoGearScenarioModeSelect;
       }
+    } catch (resolveAutoGearScenarioModeSelectError) {
+      void resolveAutoGearScenarioModeSelectError;
+    }
+
+    if (!resolvedHandle) {
+      var scope = typeof globalThis !== 'undefined' && globalThis || typeof window !== 'undefined' && window || typeof self !== 'undefined' && self || typeof global !== 'undefined' && global || null;
+
+      if (scope && _typeof(scope) === 'object' && 'autoGearScenarioModeSelect' in scope) {
+        resolvedHandle = scope.autoGearScenarioModeSelect || null;
+      }
+    }
+
+    if (!resolvedHandle && typeof document !== 'undefined' && document && typeof document.getElementById === 'function') {
+      try {
+        resolvedHandle = document.getElementById('autoGearScenarioMode') || null;
+      } catch (resolveAutoGearScenarioModeSelectElementError) {
+        void resolveAutoGearScenarioModeSelectElementError;
+      }
+    }
+
+    return resolvedHandle;
+  }();
+
+  if (autoGearScenarioModeSelectHandle && typeof autoGearScenarioModeSelectHandle.addEventListener === 'function') {
+    autoGearScenarioModeSelectHandle.addEventListener('change', function () {
+      if (autoGearEditorDraft) {
+        var selectValue = typeof autoGearScenarioModeSelectHandle.value === 'string' ? autoGearScenarioModeSelectHandle.value : '';
+        autoGearEditorDraft.scenarioLogic = normalizeAutoGearScenarioLogic(selectValue);
+      }
+
       applyAutoGearScenarioSettings(getAutoGearScenarioSelectedValues());
     });
   }


### PR DESCRIPTION
## Summary
- resolve the auto gear scenario mode select element safely when wiring session listeners
- avoid referencing an undefined global by falling back to global scope and DOM lookup
- ensure scenario mode changes continue to update the draft logic before applying settings

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68dcee9ea4048320917a87be9c6a3fe4