### PR TITLE
Handle missing favorite select initializer during session boot

### DIFF
--- a/src/scripts/app-session.js
+++ b/src/scripts/app-session.js
@@ -10693,7 +10693,7 @@ function initApp() {
   document.querySelectorAll('#projectForm select')
     .forEach(sel => {
       attachSelectSearch(sel);
-      initFavoritableSelect(sel);
+      callSessionCoreFunction('initFavoritableSelect', [sel], { defer: true });
     });
   setupInstallBanner();
   setLanguage(currentLang);


### PR DESCRIPTION
## Summary
- guard the project form select initialisation to defer to initFavoritableSelect through the core function dispatcher
- prevent runtime failures when the core initializer is not yet available during session startup

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dec84e9684832097c90563323025e5