### PR TITLE
Fix modern auto gear globals ReferenceError in Safari

### DIFF
--- a/src/scripts/app-core-new-2.js
+++ b/src/scripts/app-core-new-2.js
@@ -150,6 +150,32 @@ normaliseGlobalValue(
   },
 );
 
+if (typeof autoGearAutoPresetId === 'undefined') {
+  // Ensure a concrete global binding exists for browsers that throw when a
+  // property-only binding is accessed without `window.`.
+  // eslint-disable-next-line no-var
+  var autoGearAutoPresetId = '';
+}
+
+if (typeof baseAutoGearRules === 'undefined') {
+  // eslint-disable-next-line no-var
+  var baseAutoGearRules = [];
+} else if (!Array.isArray(baseAutoGearRules)) {
+  baseAutoGearRules = [];
+}
+
+if (typeof autoGearScenarioModeSelect === 'undefined') {
+  // eslint-disable-next-line no-var
+  var autoGearScenarioModeSelect = null;
+}
+
+if (typeof safeGenerateConnectorSummary === 'undefined') {
+  // eslint-disable-next-line no-var
+  var safeGenerateConnectorSummary = createFallbackSafeGenerateConnectorSummary();
+} else if (typeof safeGenerateConnectorSummary !== 'function') {
+  safeGenerateConnectorSummary = createFallbackSafeGenerateConnectorSummary();
+}
+
 function ensureCorePart2Placeholder(name, fallbackValue) {
   var providers = [
     CORE_PART2_RUNTIME_SCOPE && typeof CORE_PART2_RUNTIME_SCOPE === 'object'


### PR DESCRIPTION
## Summary
- explicitly declare browser-safe global bindings for automatic gear state in the modern runtime bundle
- fall back to safe defaults when bindings were absent or invalid to prevent ReferenceError crashes during boot

## Testing
- npm run test:unit *(fails: getMountVoltagePreferencesClone is not a function in tests/unit/featureSearchSynonyms.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68dec83b5844832098032d798883e701