### PR TITLE
Restore mount voltage runtime bindings and add DOM guard

### DIFF
--- a/legacy/scripts/app-core-new-1.js
+++ b/legacy/scripts/app-core-new-1.js
@@ -14391,7 +14391,26 @@ if (CORE_PART1_RUNTIME_SCOPE && CORE_PART1_RUNTIME_SCOPE.__cineCorePart1Initiali
     TEMPERATURE_UNITS: TEMPERATURE_UNITS,
     TEMPERATURE_SCENARIOS: TEMPERATURE_SCENARIOS,
     FEEDBACK_TEMPERATURE_MIN: FEEDBACK_TEMPERATURE_MIN,
-    FEEDBACK_TEMPERATURE_MAX: FEEDBACK_TEMPERATURE_MAX
+    FEEDBACK_TEMPERATURE_MAX: FEEDBACK_TEMPERATURE_MAX,
+    // Mount voltage helpers must stay globally accessible for autosave/share flows.
+    SUPPORTED_MOUNT_VOLTAGE_TYPES: SUPPORTED_MOUNT_VOLTAGE_TYPES,
+    DEFAULT_MOUNT_VOLTAGES: DEFAULT_MOUNT_VOLTAGES,
+    mountVoltageInputs: mountVoltageInputs,
+    parseVoltageValue: parseVoltageValue,
+    getMountVoltagePreferencesClone: getMountVoltagePreferencesClone,
+    applyMountVoltagePreferences: applyMountVoltagePreferences,
+    parseStoredMountVoltages: parseStoredMountVoltages,
+    resetMountVoltagePreferences: resetMountVoltagePreferences,
+    updateMountVoltageInputsFromState: updateMountVoltageInputsFromState,
+    // Pink mode animated icon controls are required for theme toggles during imports.
+    startPinkModeAnimatedIcons: startPinkModeAnimatedIcons,
+    stopPinkModeAnimatedIcons: stopPinkModeAnimatedIcons,
+    pinkModeIcons: pinkModeIcons,
+    ensureSvgHasAriaHidden: ensureSvgHasAriaHidden,
+    triggerPinkModeIconRain: triggerPinkModeIconRain,
+    PINK_MODE_ICON_INTERVAL_MS: PINK_MODE_ICON_INTERVAL_MS,
+    PINK_MODE_ICON_ANIMATION_CLASS: PINK_MODE_ICON_ANIMATION_CLASS,
+    PINK_MODE_ICON_ANIMATION_RESET_DELAY: PINK_MODE_ICON_ANIMATION_RESET_DELAY
   });
   exposeCoreRuntimeBindings({
     safeGenerateConnectorSummary: {
@@ -14432,6 +14451,26 @@ if (CORE_PART1_RUNTIME_SCOPE && CORE_PART1_RUNTIME_SCOPE.__cineCorePart1Initiali
       },
       set: function set(value) {
         autoGearScenarioModeSelectElement = value || null;
+      }
+    },
+    pinkModeIconRotationTimer: {
+      get: function get() {
+        return pinkModeIconRotationTimer;
+      },
+      set: function set(value) {
+        if (typeof value === 'number' || value === null || typeof value === 'object') {
+          pinkModeIconRotationTimer = value;
+        }
+      }
+    },
+    pinkModeIconIndex: {
+      get: function get() {
+        return pinkModeIconIndex;
+      },
+      set: function set(value) {
+        if (typeof value === 'number') {
+          pinkModeIconIndex = value;
+        }
       }
     }
   });

--- a/src/scripts/app-core-new-1.js
+++ b/src/scripts/app-core-new-1.js
@@ -15817,6 +15817,25 @@ exposeCoreRuntimeConstants({
   TEMPERATURE_SCENARIOS,
   FEEDBACK_TEMPERATURE_MIN,
   FEEDBACK_TEMPERATURE_MAX,
+  // Mount voltage helpers must stay globally accessible for autosave/share flows.
+  SUPPORTED_MOUNT_VOLTAGE_TYPES,
+  DEFAULT_MOUNT_VOLTAGES,
+  mountVoltageInputs,
+  parseVoltageValue,
+  getMountVoltagePreferencesClone,
+  applyMountVoltagePreferences,
+  parseStoredMountVoltages,
+  resetMountVoltagePreferences,
+  updateMountVoltageInputsFromState,
+  // Pink mode animated icon controls are required for theme toggles during imports.
+  startPinkModeAnimatedIcons,
+  stopPinkModeAnimatedIcons,
+  pinkModeIcons,
+  ensureSvgHasAriaHidden,
+  triggerPinkModeIconRain,
+  PINK_MODE_ICON_INTERVAL_MS,
+  PINK_MODE_ICON_ANIMATION_CLASS,
+  PINK_MODE_ICON_ANIMATION_RESET_DELAY,
 });
 
 exposeCoreRuntimeBindings({
@@ -15850,6 +15869,22 @@ exposeCoreRuntimeBindings({
     get: () => autoGearScenarioModeSelectElement,
     set: value => {
       autoGearScenarioModeSelectElement = value || null;
+    },
+  },
+  pinkModeIconRotationTimer: {
+    get: () => pinkModeIconRotationTimer,
+    set: value => {
+      if (typeof value === 'number' || value === null || typeof value === 'object') {
+        pinkModeIconRotationTimer = value;
+      }
+    },
+  },
+  pinkModeIconIndex: {
+    get: () => pinkModeIconIndex,
+    set: value => {
+      if (typeof value === 'number') {
+        pinkModeIconIndex = value;
+      }
     },
   },
 });


### PR DESCRIPTION
## Summary
- restore mount voltage and pink mode helpers in the split runtime so session and share flows regain access to them
- expose pink mode timer state through runtime bindings to keep interval management intact after the split
- add a DOM regression test that ensures the helpers stay reachable while stubbing long-lived pink mode effects

## Testing
- npm run test:dom *(hangs after ~1 minute because pink mode asset fetches never resolve under Node; aborted manually)*

------
https://chatgpt.com/codex/tasks/task_e_68decf94c92c83208d044b7ca636906b