### PR TITLE
Restore mount voltage helpers and add share regression guard

### DIFF
--- a/src/scripts/app-core-new-1.js
+++ b/src/scripts/app-core-new-1.js
@@ -1398,6 +1398,21 @@ function persistMountVoltagePreferences(preferences) {
     }
 }
 
+const MOUNT_VOLTAGE_RUNTIME_EXPORTS = Object.freeze({
+  // Mount voltage helpers must stay globally accessible for autosave/share flows.
+  SUPPORTED_MOUNT_VOLTAGE_TYPES,
+  DEFAULT_MOUNT_VOLTAGES,
+  mountVoltageInputs,
+  parseVoltageValue,
+  cloneMountVoltageMap,
+  getMountVoltagePreferencesClone,
+  applyMountVoltagePreferences,
+  parseStoredMountVoltages,
+  resetMountVoltagePreferences,
+  updateMountVoltageInputsFromState,
+  persistMountVoltagePreferences,
+});
+
 function applyMountVoltagePreferences(preferences, options = {}) {
   const { persist = true, triggerUpdate = true } = options || {};
   mountVoltagePreferences = normalizeMountVoltageSource(preferences);
@@ -15800,7 +15815,7 @@ function getCrewRoleEntries() {
 }
 
 exposeCoreRuntimeConstant('updateSelectIconBoxes', updateSelectIconBoxes);
-exposeCoreRuntimeConstants({
+const CORE_RUNTIME_CONSTANTS = {
   CORE_GLOBAL_SCOPE,
   CORE_BOOT_QUEUE_KEY,
   CORE_BOOT_QUEUE,
@@ -15817,16 +15832,12 @@ exposeCoreRuntimeConstants({
   TEMPERATURE_SCENARIOS,
   FEEDBACK_TEMPERATURE_MIN,
   FEEDBACK_TEMPERATURE_MAX,
-  // Mount voltage helpers must stay globally accessible for autosave/share flows.
-  SUPPORTED_MOUNT_VOLTAGE_TYPES,
-  DEFAULT_MOUNT_VOLTAGES,
-  mountVoltageInputs,
-  parseVoltageValue,
-  getMountVoltagePreferencesClone,
-  applyMountVoltagePreferences,
-  parseStoredMountVoltages,
-  resetMountVoltagePreferences,
-  updateMountVoltageInputsFromState,
+};
+
+// Ensure mount voltage helpers remain reachable from the session layer.
+Object.assign(CORE_RUNTIME_CONSTANTS, MOUNT_VOLTAGE_RUNTIME_EXPORTS);
+
+Object.assign(CORE_RUNTIME_CONSTANTS, {
   // Pink mode animated icon controls are required for theme toggles during imports.
   startPinkModeAnimatedIcons,
   stopPinkModeAnimatedIcons,
@@ -15837,6 +15848,8 @@ exposeCoreRuntimeConstants({
   PINK_MODE_ICON_ANIMATION_CLASS,
   PINK_MODE_ICON_ANIMATION_RESET_DELAY,
 });
+
+exposeCoreRuntimeConstants(CORE_RUNTIME_CONSTANTS);
 
 exposeCoreRuntimeBindings({
   safeGenerateConnectorSummary: {


### PR DESCRIPTION
## Summary
- re-expose the mount voltage helper suite through the runtime constant map so session/share flows can access it again
- add a session-side safety wrapper that falls back to default voltages when helpers are unavailable and export it for tests
- extend the shared project DOM suite with a regression test covering the fallback behaviour

## Testing
- npm run test:dom -- sharedProjectGearList *(hangs in this environment before completing)*

------
https://chatgpt.com/codex/tasks/task_e_68deef3e02a88320a3336ba68f94ade4