### PR TITLE
Expose mount voltage helpers for session flows

### DIFF
--- a/src/scripts/app-core-new-1.js
+++ b/src/scripts/app-core-new-1.js
@@ -1413,6 +1413,11 @@ const MOUNT_VOLTAGE_RUNTIME_EXPORTS = Object.freeze({
   persistMountVoltagePreferences,
 });
 
+// Immediately expose mount voltage helpers so downstream layers can recover even if
+// subsequent refactors adjust the consolidated runtime export list. This keeps
+// autosave/share/backup flows functional when the runtime is split across files.
+exposeCoreRuntimeConstants(MOUNT_VOLTAGE_RUNTIME_EXPORTS);
+
 function applyMountVoltagePreferences(preferences, options = {}) {
   const { persist = true, triggerUpdate = true } = options || {};
   mountVoltagePreferences = normalizeMountVoltageSource(preferences);

--- a/tests/dom/sharedProjectGearList.test.js
+++ b/tests/dom/sharedProjectGearList.test.js
@@ -50,6 +50,24 @@ describe('shared project gear list handling', () => {
   });
 
   test('mount voltage helpers remain globally accessible for share/import flows', () => {
+    const expectedHelpers = [
+      'SUPPORTED_MOUNT_VOLTAGE_TYPES',
+      'DEFAULT_MOUNT_VOLTAGES',
+      'mountVoltageInputs',
+      'parseVoltageValue',
+      'cloneMountVoltageMap',
+      'getMountVoltagePreferencesClone',
+      'applyMountVoltagePreferences',
+      'parseStoredMountVoltages',
+      'resetMountVoltagePreferences',
+      'updateMountVoltageInputsFromState',
+      'persistMountVoltagePreferences',
+    ];
+
+    expectedHelpers.forEach(helperName => {
+      expect(window[helperName]).toBeDefined();
+    });
+
     expect(typeof window.getMountVoltagePreferencesClone).toBe('function');
     expect(typeof window.applyMountVoltagePreferences).toBe('function');
 


### PR DESCRIPTION
## Summary
- immediately expose the mount voltage runtime helpers so session/share flows can access them even when the core runtime is split
- extend the shared project DOM regression test to assert every mount voltage helper stays globally reachable

## Testing
- npm run test:dom -- sharedProjectGearList *(fails: hangs in container environment, manually aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68e03fa366b883209185bcb344dbf7da