### PR TITLE
Guard setupInstallBanner invocation in session init

### DIFF
--- a/src/scripts/app-session.js
+++ b/src/scripts/app-session.js
@@ -10697,7 +10697,12 @@ function initApp() {
       attachSelectSearch(sel);
       callSessionCoreFunction('initFavoritableSelect', [sel], { defer: true });
     });
-  setupInstallBanner();
+  if (
+    typeof globalThis !== 'undefined'
+    && typeof globalThis.setupInstallBanner === 'function'
+  ) {
+    globalThis.setupInstallBanner();
+  }
   setLanguage(currentLang);
   maybeShowIosPwaHelp();
   resetDeviceForm();


### PR DESCRIPTION
## Summary
- prevent `initApp` from throwing when `setupInstallBanner` is not registered by checking the global before invoking it

## Testing
- npm run lint *(fails: existing `cloneMountVoltageMap` no-undef warning in src/scripts/app-session.js)*

------
https://chatgpt.com/codex/tasks/task_e_68e0a9e9f33c8320b16388f9ab74ba8f