### PR TITLE
Fix install banner initialization regression

### DIFF
--- a/legacy/scripts/app-core-new-2.js
+++ b/legacy/scripts/app-core-new-2.js
@@ -15290,6 +15290,7 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
       ['applyDarkMode', function () { return applyDarkMode; }],
       ['applyPinkMode', function () { return applyPinkMode; }],
       ['applyHighContrast', function () { return applyHighContrast; }],
+      ['setupInstallBanner', function () { return setupInstallBanner; }],
       ['generatePrintableOverview', function () { return generatePrintableOverview; }],
       ['generateGearListHtml', function () { return generateGearListHtml; }],
       ['displayGearAndRequirements', function () { return displayGearAndRequirements; }],

--- a/src/scripts/app-core-new-2.js
+++ b/src/scripts/app-core-new-2.js
@@ -16082,6 +16082,7 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
       ['applyDarkMode', () => applyDarkMode],
       ['applyPinkMode', () => applyPinkMode],
       ['applyHighContrast', () => applyHighContrast],
+      ['setupInstallBanner', () => setupInstallBanner],
       ['generatePrintableOverview', () => generatePrintableOverview],
       ['generateGearListHtml', () => generateGearListHtml],
       ['displayGearAndRequirements', () => displayGearAndRequirements],


### PR DESCRIPTION
## Summary
- expose setupInstallBanner on the global runtime exports so app-session can invoke it without errors

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e0ab80fd748320807214aec0a063dc