### PR TITLE
Ensure auto gear globals exist before core bootstrap

### DIFF
--- a/index.html
+++ b/index.html
@@ -6351,6 +6351,7 @@
     </datalist>
   </dialog>
   <dialog id="overviewDialog"></dialog>
+  <script src="src/scripts/globals-bootstrap.js"></script>
   <script src="src/scripts/loader.js"></script>
 </body>
 </html>

--- a/legacy/scripts/globals-bootstrap.js
+++ b/legacy/scripts/globals-bootstrap.js
@@ -1,0 +1,211 @@
+function __cineIsArray(value) {
+  if (typeof Array !== 'undefined' && typeof Array.isArray === 'function') {
+    return Array.isArray(value);
+  }
+
+  return Object.prototype.toString.call(value) === '[object Array]';
+}
+
+(function bootstrapCoreRuntimeGlobals() {
+  var scope =
+    (typeof globalThis !== 'undefined' && globalThis) ||
+    (typeof window !== 'undefined' && window) ||
+    (typeof self !== 'undefined' && self) ||
+    (typeof global !== 'undefined' && global) ||
+    null;
+
+  if (!scope || (typeof scope !== 'object' && typeof scope !== 'function')) {
+    return;
+  }
+
+  function ensureString(name, fallback) {
+    var value;
+    try {
+      value = scope[name];
+    } catch (readError) {
+      value = undefined;
+      void readError;
+    }
+
+    if (typeof value !== 'string') {
+      value = fallback;
+    }
+
+    try {
+      scope[name] = value;
+    } catch (assignError) {
+      void assignError;
+    }
+
+    return value;
+  }
+
+  function ensureArray(name) {
+    var value;
+    try {
+      value = scope[name];
+    } catch (readError) {
+      value = undefined;
+      void readError;
+    }
+
+    if (!__cineIsArray(value)) {
+      value = [];
+    }
+
+    try {
+      scope[name] = value;
+    } catch (assignError) {
+      void assignError;
+    }
+
+    return value;
+  }
+
+  function ensureFunction(name, fallback) {
+    var value;
+    try {
+      value = scope[name];
+    } catch (readError) {
+      value = undefined;
+      void readError;
+    }
+
+    if (typeof value !== 'function') {
+      value = fallback;
+    }
+
+    try {
+      scope[name] = value;
+    } catch (assignError) {
+      void assignError;
+    }
+
+    return value;
+  }
+
+  function ensureNullableObject(name) {
+    var value;
+    try {
+      value = scope[name];
+    } catch (readError) {
+      value = undefined;
+      void readError;
+    }
+
+    if (typeof value === 'undefined') {
+      value = null;
+    }
+
+    try {
+      scope[name] = value;
+    } catch (assignError) {
+      void assignError;
+    }
+
+    return value;
+  }
+
+  function fallbackSafeGenerateConnectorSummary(device) {
+    if (!device || typeof device !== 'object') {
+      return '';
+    }
+
+    var keys;
+    try {
+      keys = Object.keys(device);
+    } catch (keyError) {
+      void keyError;
+      return '';
+    }
+
+    if (!keys || !keys.length) {
+      return '';
+    }
+
+    var primaryKey = keys[0];
+    var value = device[primaryKey];
+    var label = typeof primaryKey === 'string' ? primaryKey.replace(/_/g, ' ') : 'connector';
+    return value ? label + ': ' + value : label;
+  }
+
+  ensureString('autoGearAutoPresetId', '');
+  ensureArray('baseAutoGearRules');
+  ensureNullableObject('autoGearScenarioModeSelect');
+  ensureFunction('safeGenerateConnectorSummary', fallbackSafeGenerateConnectorSummary);
+})();
+
+function __cineResolveGlobalValue(name, fallback) {
+  var scope =
+    (typeof globalThis !== 'undefined' && globalThis) ||
+    (typeof window !== 'undefined' && window) ||
+    (typeof self !== 'undefined' && self) ||
+    (typeof global !== 'undefined' && global) ||
+    null;
+
+  if (!scope || (typeof scope !== 'object' && typeof scope !== 'function')) {
+    return fallback;
+  }
+
+  var value;
+  try {
+    value = scope[name];
+  } catch (readError) {
+    value = undefined;
+    void readError;
+  }
+
+  return typeof value === 'undefined' ? fallback : value;
+}
+
+var autoGearAutoPresetId =
+  typeof autoGearAutoPresetId !== 'undefined'
+    ? autoGearAutoPresetId
+    : (function resolveAutoGearAutoPresetId() {
+        var value = __cineResolveGlobalValue('autoGearAutoPresetId', '');
+        return typeof value === 'string' ? value : '';
+      })();
+
+var baseAutoGearRules =
+  typeof baseAutoGearRules !== 'undefined'
+    ? baseAutoGearRules
+    : (function resolveBaseAutoGearRules() {
+        var value = __cineResolveGlobalValue('baseAutoGearRules', []);
+        return __cineIsArray(value) ? value : [];
+      })();
+
+var autoGearScenarioModeSelect =
+  typeof autoGearScenarioModeSelect !== 'undefined'
+    ? autoGearScenarioModeSelect
+    : __cineResolveGlobalValue('autoGearScenarioModeSelect', null);
+
+var safeGenerateConnectorSummary =
+  typeof safeGenerateConnectorSummary !== 'undefined'
+    ? safeGenerateConnectorSummary
+    : (function resolveSafeGenerateConnectorSummary() {
+        var value = __cineResolveGlobalValue('safeGenerateConnectorSummary', null);
+        return typeof value === 'function'
+          ? value
+          : function fallbackSafeGenerateConnectorSummary(device) {
+            if (!device || typeof device !== 'object') {
+              return '';
+            }
+
+            var keys;
+            try {
+              keys = Object.keys(device);
+            } catch (keyError) {
+              void keyError;
+              return '';
+            }
+
+              if (!keys || !keys.length) {
+                return '';
+              }
+
+              var primaryKey = keys[0];
+              var result = device[primaryKey];
+              var label = typeof primaryKey === 'string' ? primaryKey.replace(/_/g, ' ') : 'connector';
+              return result ? label + ': ' + result : label;
+            };
+      })();

--- a/src/scripts/app-core-new-2.js
+++ b/src/scripts/app-core-new-2.js
@@ -153,24 +153,20 @@ normaliseGlobalValue(
 if (typeof autoGearAutoPresetId === 'undefined') {
   // Ensure a concrete global binding exists for browsers that throw when a
   // property-only binding is accessed without `window.`.
-  // eslint-disable-next-line no-var
   var autoGearAutoPresetId = '';
 }
 
 if (typeof baseAutoGearRules === 'undefined') {
-  // eslint-disable-next-line no-var
   var baseAutoGearRules = [];
 } else if (!Array.isArray(baseAutoGearRules)) {
   baseAutoGearRules = [];
 }
 
 if (typeof autoGearScenarioModeSelect === 'undefined') {
-  // eslint-disable-next-line no-var
   var autoGearScenarioModeSelect = null;
 }
 
 if (typeof safeGenerateConnectorSummary === 'undefined') {
-  // eslint-disable-next-line no-var
   var safeGenerateConnectorSummary = createFallbackSafeGenerateConnectorSummary();
 } else if (typeof safeGenerateConnectorSummary !== 'function') {
   safeGenerateConnectorSummary = createFallbackSafeGenerateConnectorSummary();

--- a/src/scripts/app-session.js
+++ b/src/scripts/app-session.js
@@ -15,6 +15,7 @@
           autoGearConditionAddButton, addAutoGearConditionFromPicker,
           autoGearConditionList, removeAutoGearCondition,
           handleAutoGearConditionShortcut, loadAutoGearRules,
+          cloneMountVoltageMap,
           duplicateAutoGearRule, autoGearScenarioModeSelect,
           normalizeAutoGearScenarioLogic, applyAutoGearScenarioSettings,
           getAutoGearScenarioSelectedValues, autoGearScenarioBaseSelect,

--- a/src/scripts/globals-bootstrap.js
+++ b/src/scripts/globals-bootstrap.js
@@ -1,0 +1,211 @@
+function __cineIsArray(value) {
+  if (typeof Array !== 'undefined' && typeof Array.isArray === 'function') {
+    return Array.isArray(value);
+  }
+
+  return Object.prototype.toString.call(value) === '[object Array]';
+}
+
+(function bootstrapCoreRuntimeGlobals() {
+  var scope =
+    (typeof globalThis !== 'undefined' && globalThis) ||
+    (typeof window !== 'undefined' && window) ||
+    (typeof self !== 'undefined' && self) ||
+    (typeof global !== 'undefined' && global) ||
+    null;
+
+  if (!scope || (typeof scope !== 'object' && typeof scope !== 'function')) {
+    return;
+  }
+
+  function ensureString(name, fallback) {
+    var value;
+    try {
+      value = scope[name];
+    } catch (readError) {
+      value = undefined;
+      void readError;
+    }
+
+    if (typeof value !== 'string') {
+      value = fallback;
+    }
+
+    try {
+      scope[name] = value;
+    } catch (assignError) {
+      void assignError;
+    }
+
+    return value;
+  }
+
+  function ensureArray(name) {
+    var value;
+    try {
+      value = scope[name];
+    } catch (readError) {
+      value = undefined;
+      void readError;
+    }
+
+    if (!__cineIsArray(value)) {
+      value = [];
+    }
+
+    try {
+      scope[name] = value;
+    } catch (assignError) {
+      void assignError;
+    }
+
+    return value;
+  }
+
+  function ensureFunction(name, fallback) {
+    var value;
+    try {
+      value = scope[name];
+    } catch (readError) {
+      value = undefined;
+      void readError;
+    }
+
+    if (typeof value !== 'function') {
+      value = fallback;
+    }
+
+    try {
+      scope[name] = value;
+    } catch (assignError) {
+      void assignError;
+    }
+
+    return value;
+  }
+
+  function ensureNullableObject(name) {
+    var value;
+    try {
+      value = scope[name];
+    } catch (readError) {
+      value = undefined;
+      void readError;
+    }
+
+    if (typeof value === 'undefined') {
+      value = null;
+    }
+
+    try {
+      scope[name] = value;
+    } catch (assignError) {
+      void assignError;
+    }
+
+    return value;
+  }
+
+  function fallbackSafeGenerateConnectorSummary(device) {
+    if (!device || typeof device !== 'object') {
+      return '';
+    }
+
+    var keys;
+    try {
+      keys = Object.keys(device);
+    } catch (keyError) {
+      void keyError;
+      return '';
+    }
+
+    if (!keys || !keys.length) {
+      return '';
+    }
+
+    var primaryKey = keys[0];
+    var value = device[primaryKey];
+    var label = typeof primaryKey === 'string' ? primaryKey.replace(/_/g, ' ') : 'connector';
+    return value ? label + ': ' + value : label;
+  }
+
+  ensureString('autoGearAutoPresetId', '');
+  ensureArray('baseAutoGearRules');
+  ensureNullableObject('autoGearScenarioModeSelect');
+  ensureFunction('safeGenerateConnectorSummary', fallbackSafeGenerateConnectorSummary);
+})();
+
+function __cineResolveGlobalValue(name, fallback) {
+  var scope =
+    (typeof globalThis !== 'undefined' && globalThis) ||
+    (typeof window !== 'undefined' && window) ||
+    (typeof self !== 'undefined' && self) ||
+    (typeof global !== 'undefined' && global) ||
+    null;
+
+  if (!scope || (typeof scope !== 'object' && typeof scope !== 'function')) {
+    return fallback;
+  }
+
+  var value;
+  try {
+    value = scope[name];
+  } catch (readError) {
+    value = undefined;
+    void readError;
+  }
+
+  return typeof value === 'undefined' ? fallback : value;
+}
+
+var autoGearAutoPresetId =
+  typeof autoGearAutoPresetId !== 'undefined'
+    ? autoGearAutoPresetId
+    : (function resolveAutoGearAutoPresetId() {
+        var value = __cineResolveGlobalValue('autoGearAutoPresetId', '');
+        return typeof value === 'string' ? value : '';
+      })();
+
+var baseAutoGearRules =
+  typeof baseAutoGearRules !== 'undefined'
+    ? baseAutoGearRules
+    : (function resolveBaseAutoGearRules() {
+        var value = __cineResolveGlobalValue('baseAutoGearRules', []);
+        return __cineIsArray(value) ? value : [];
+      })();
+
+var autoGearScenarioModeSelect =
+  typeof autoGearScenarioModeSelect !== 'undefined'
+    ? autoGearScenarioModeSelect
+    : __cineResolveGlobalValue('autoGearScenarioModeSelect', null);
+
+var safeGenerateConnectorSummary =
+  typeof safeGenerateConnectorSummary !== 'undefined'
+    ? safeGenerateConnectorSummary
+    : (function resolveSafeGenerateConnectorSummary() {
+        var value = __cineResolveGlobalValue('safeGenerateConnectorSummary', null);
+        return typeof value === 'function'
+          ? value
+          : function fallbackSafeGenerateConnectorSummary(device) {
+            if (!device || typeof device !== 'object') {
+              return '';
+            }
+
+            var keys;
+            try {
+              keys = Object.keys(device);
+            } catch (keyError) {
+              void keyError;
+              return '';
+            }
+
+              if (!keys || !keys.length) {
+                return '';
+              }
+
+              var primaryKey = keys[0];
+              var result = device[primaryKey];
+              var label = typeof primaryKey === 'string' ? primaryKey.replace(/_/g, ' ') : 'connector';
+              return result ? label + ': ' + result : label;
+            };
+      })();


### PR DESCRIPTION
## Summary
- add a bootstrap script that predefines the auto gear globals before the loader executes
- wire the bootstrap script for both modern and legacy bundles and clean up duplicate fallback declarations
- declare the cloneMountVoltageMap global so linting recognises the shared helper

## Testing
- npm test -- --runTestsByPath tests/unit/coreShared.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e0abb836088320af77c576114a9e8f