### PR TITLE
Fix missing guards for install banner and setup state storage

### DIFF
--- a/legacy/scripts/app-events.js
+++ b/legacy/scripts/app-events.js
@@ -81,6 +81,11 @@ function getEventsCoreValue(functionName) {
     return defaultValue;
   }
 }
+function storeLoadedSetupStateSafe(state) {
+  callEventsCoreFunction('storeLoadedSetupState', [state], {
+    defaultValue: undefined
+  });
+}
 function resolveCineUi() {
   var scopes = [];
   if (typeof globalThis !== 'undefined') scopes.push(globalThis);
@@ -222,7 +227,7 @@ function handleSaveSetupClick() {
   }
   lastSetupName = finalName;
   saveCurrentSession();
-  storeLoadedSetupState(getCurrentSetupState());
+  storeLoadedSetupStateSafe(getCurrentSetupState());
   checkSetupChanged();
   saveCurrentGearList();
   if (renamingExisting && selectedName && selectedName !== finalName) {
@@ -287,7 +292,7 @@ function handleDeleteSetupClick() {
       }
       currentProjectInfo = null;
       if (projectForm) populateProjectForm({});
-      storeLoadedSetupState(null);
+      storeLoadedSetupStateSafe(null);
       updateBatteryPlateVisibility();
       updateBatteryOptions();
       clearProjectAutoGearRules();
@@ -411,12 +416,10 @@ function resetSetupStateToDefaults() {
       console.warn('Failed to reset manual diagram positions while preparing setup switch', error);
     }
   }
-  if (typeof storeLoadedSetupState === 'function') {
-    try {
-      storeLoadedSetupState(null);
-    } catch (error) {
-      console.warn('Failed to reset stored setup state while preparing setup switch', error);
-    }
+  try {
+    storeLoadedSetupStateSafe(null);
+  } catch (error) {
+    console.warn('Failed to reset stored setup state while preparing setup switch', error);
   }
   if (typeof globalThis !== 'undefined') {
     globalThis.__cineLastGearListHtml = '';
@@ -700,7 +703,7 @@ addSafeEventListener(setupSelectTarget, "change", function (event) {
         });
       }
     }
-    storeLoadedSetupState(getCurrentSetupState());
+    storeLoadedSetupStateSafe(getCurrentSetupState());
   }
   finalizeSetupSelection(setupName);
   });

--- a/legacy/scripts/app-session.js
+++ b/legacy/scripts/app-session.js
@@ -9678,7 +9678,15 @@ function initApp() {
     attachSelectSearch(sel);
     initFavoritableSelect(sel);
   });
-  setupInstallBanner();
+  if (
+    typeof globalThis !== 'undefined' &&
+    globalThis &&
+    typeof globalThis.setupInstallBanner === 'function'
+  ) {
+    globalThis.setupInstallBanner();
+  } else if (typeof setupInstallBanner === 'function') {
+    setupInstallBanner();
+  }
   setLanguage(currentLang);
   maybeShowIosPwaHelp();
   resetDeviceForm();

--- a/src/scripts/app-events.js
+++ b/src/scripts/app-events.js
@@ -92,6 +92,10 @@ function getEventsCoreValue(functionName, options = {}) {
   }
 }
 
+function storeLoadedSetupStateSafe(state) {
+  callEventsCoreFunction('storeLoadedSetupState', [state], { defaultValue: undefined });
+}
+
 function resolveCineUi() {
   const scopes = [];
 
@@ -278,7 +282,7 @@ function handleSaveSetupClick() {
   }
   lastSetupName = finalName;
   saveCurrentSession(); // Persist selection so refreshes restore this setup
-  storeLoadedSetupState(getCurrentSetupState());
+  storeLoadedSetupStateSafe(getCurrentSetupState());
   checkSetupChanged();
   // Ensure the current gear list stays persisted with the project so setups
   // remain in sync with the automatically saved table.
@@ -354,7 +358,7 @@ function handleDeleteSetupClick() {
       }
       currentProjectInfo = null;
       if (projectForm) populateProjectForm({});
-      storeLoadedSetupState(null);
+      storeLoadedSetupStateSafe(null);
       updateBatteryPlateVisibility();
       updateBatteryOptions();
       clearProjectAutoGearRules();
@@ -493,12 +497,10 @@ function resetSetupStateToDefaults(options = {}) {
     }
   }
 
-  if (typeof storeLoadedSetupState === 'function') {
-    try {
-      storeLoadedSetupState(null);
-    } catch (error) {
-      console.warn('Failed to reset stored setup state while preparing setup switch', error);
-    }
+  try {
+    storeLoadedSetupStateSafe(null);
+  } catch (error) {
+    console.warn('Failed to reset stored setup state while preparing setup switch', error);
   }
 
   if (typeof globalThis !== 'undefined') {
@@ -809,7 +811,7 @@ addSafeEventListener(setupSelectTarget, "change", (event) => {
         setManualDiagramPositions(normalizedDiagram || {}, { render: false });
       }
     }
-    storeLoadedSetupState(getCurrentSetupState());
+    storeLoadedSetupStateSafe(getCurrentSetupState());
   }
 
   finalizeSetupSelection(setupName);


### PR DESCRIPTION
## Summary
- guard the legacy session bootstrap against missing `setupInstallBanner`
- centralize safe calls to `storeLoadedSetupState` so events do not crash when the core export is unavailable

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0ac6beb308320aedd10f81cb34d6a