### PR TITLE
Fix install banner dismissal flag reference error

### DIFF
--- a/legacy/scripts/app-core-new-1.js
+++ b/legacy/scripts/app-core-new-1.js
@@ -629,7 +629,9 @@ if (CORE_PART1_RUNTIME_SCOPE && CORE_PART1_RUNTIME_SCOPE.__cineCorePart1Initiali
   }
   var IOS_PWA_HELP_STORAGE_KEY = 'iosPwaHelpShown';
   var INSTALL_BANNER_DISMISSED_KEY = 'installPromptDismissed';
-  var installBannerDismissedInSession = false;
+  if (typeof globalThis !== 'undefined' && typeof globalThis.installBannerDismissedInSession !== 'boolean') {
+    globalThis.installBannerDismissedInSession = false;
+  }
   var DEVICE_SCHEMA_PATH = 'src/data/schema.json';
   var DEVICE_SCHEMA_STORAGE_KEY = 'cameraPowerPlanner_schemaCache';
   var AUTO_GEAR_RULES_KEY = typeof AUTO_GEAR_RULES_STORAGE_KEY !== 'undefined' ? AUTO_GEAR_RULES_STORAGE_KEY : 'cameraPowerPlanner_autoGearRules';

--- a/legacy/scripts/app-core-new-2.js
+++ b/legacy/scripts/app-core-new-2.js
@@ -4798,23 +4798,34 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
         console.warn('Could not store iOS PWA help dismissal', error);
       }
     }
+    function getInstallBannerDismissedInSession() {
+      if (typeof globalThis !== 'undefined' && typeof globalThis.installBannerDismissedInSession === 'boolean') {
+        return globalThis.installBannerDismissedInSession;
+      }
+      return false;
+    }
+    function setInstallBannerDismissedInSession(value) {
+      if (typeof globalThis !== 'undefined') {
+        globalThis.installBannerDismissedInSession = Boolean(value);
+      }
+    }
     function hasDismissedInstallBanner() {
-      if (installBannerDismissedInSession) return true;
+      if (getInstallBannerDismissedInSession()) return true;
       if (typeof localStorage === 'undefined') return false;
       try {
         var storedValue = localStorage.getItem(INSTALL_BANNER_DISMISSED_KEY);
         var dismissed = storedValue === '1';
         if (dismissed) {
-          installBannerDismissedInSession = true;
+          setInstallBannerDismissedInSession(true);
         }
         return dismissed;
       } catch (error) {
         console.warn('Could not read install banner dismissal flag', error);
-        return installBannerDismissedInSession;
+        return getInstallBannerDismissedInSession();
       }
     }
     function markInstallBannerDismissed() {
-      installBannerDismissedInSession = true;
+      setInstallBannerDismissedInSession(true);
       if (typeof localStorage === 'undefined') return;
       try {
         localStorage.setItem(INSTALL_BANNER_DISMISSED_KEY, '1');

--- a/src/scripts/app-core-new-1.js
+++ b/src/scripts/app-core-new-1.js
@@ -843,7 +843,10 @@ if (typeof window !== 'undefined') {
 }
 var IOS_PWA_HELP_STORAGE_KEY = 'iosPwaHelpShown';
 const INSTALL_BANNER_DISMISSED_KEY = 'installPromptDismissed';
-let installBannerDismissedInSession = false;
+
+if (typeof globalThis !== 'undefined' && typeof globalThis.installBannerDismissedInSession !== 'boolean') {
+  globalThis.installBannerDismissedInSession = false;
+}
 
 const DEVICE_SCHEMA_PATH = 'src/data/schema.json';
 const DEVICE_SCHEMA_STORAGE_KEY = 'cameraPowerPlanner_schemaCache';

--- a/src/scripts/app-core-new-2.js
+++ b/src/scripts/app-core-new-2.js
@@ -5459,24 +5459,37 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
       }
     }
     
+    function getInstallBannerDismissedInSession() {
+      if (typeof globalThis !== 'undefined' && typeof globalThis.installBannerDismissedInSession === 'boolean') {
+        return globalThis.installBannerDismissedInSession;
+      }
+      return false;
+    }
+
+    function setInstallBannerDismissedInSession(value) {
+      if (typeof globalThis !== 'undefined') {
+        globalThis.installBannerDismissedInSession = Boolean(value);
+      }
+    }
+
     function hasDismissedInstallBanner() {
-      if (installBannerDismissedInSession) return true;
+      if (getInstallBannerDismissedInSession()) return true;
       if (typeof localStorage === 'undefined') return false;
       try {
         const storedValue = localStorage.getItem(INSTALL_BANNER_DISMISSED_KEY);
         const dismissed = storedValue === '1';
         if (dismissed) {
-          installBannerDismissedInSession = true;
+          setInstallBannerDismissedInSession(true);
         }
         return dismissed;
       } catch (error) {
         console.warn('Could not read install banner dismissal flag', error);
-        return installBannerDismissedInSession;
+        return getInstallBannerDismissedInSession();
       }
     }
-    
+
     function markInstallBannerDismissed() {
-      installBannerDismissedInSession = true;
+      setInstallBannerDismissedInSession(true);
       if (typeof localStorage === 'undefined') return;
       try {
         localStorage.setItem(INSTALL_BANNER_DISMISSED_KEY, '1');


### PR DESCRIPTION
## Summary
- ensure the install banner dismissal flag is initialized on `globalThis` in both modern and legacy bundles
- guard the install banner helpers so they read and write the session flag through `globalThis`, preventing missing reference errors

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68e21cc97c94832090ac196f062327e6