### PR TITLE
Fix install banner dismissal flag scoping

### DIFF
--- a/legacy/scripts/app-core-new-1.js
+++ b/legacy/scripts/app-core-new-1.js
@@ -629,8 +629,24 @@ if (CORE_PART1_RUNTIME_SCOPE && CORE_PART1_RUNTIME_SCOPE.__cineCorePart1Initiali
   }
   var IOS_PWA_HELP_STORAGE_KEY = 'iosPwaHelpShown';
   var INSTALL_BANNER_DISMISSED_KEY = 'installPromptDismissed';
-  if (typeof globalThis !== 'undefined' && typeof globalThis.installBannerDismissedInSession !== 'boolean') {
-    globalThis.installBannerDismissedInSession = false;
+  function resolveInstallBannerGlobalScope() {
+    if (typeof globalThis !== 'undefined' && globalThis) {
+      return globalThis;
+    }
+    if (typeof window !== 'undefined' && window) {
+      return window;
+    }
+    if (typeof self !== 'undefined' && self) {
+      return self;
+    }
+    if (typeof global !== 'undefined' && global) {
+      return global;
+    }
+    return null;
+  }
+  var installBannerGlobalScope = resolveInstallBannerGlobalScope();
+  if (installBannerGlobalScope && typeof installBannerGlobalScope.installBannerDismissedInSession !== 'boolean') {
+    installBannerGlobalScope.installBannerDismissedInSession = false;
   }
   var DEVICE_SCHEMA_PATH = 'src/data/schema.json';
   var DEVICE_SCHEMA_STORAGE_KEY = 'cameraPowerPlanner_schemaCache';

--- a/legacy/scripts/app-core-new-2.js
+++ b/legacy/scripts/app-core-new-2.js
@@ -4798,16 +4798,61 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
         console.warn('Could not store iOS PWA help dismissal', error);
       }
     }
-    function getInstallBannerDismissedInSession() {
-      if (typeof globalThis !== 'undefined' && typeof globalThis.installBannerDismissedInSession === 'boolean') {
-        return globalThis.installBannerDismissedInSession;
+    function getInstallBannerGlobalScope() {
+      var candidates = [];
+      if (typeof resolveInstallBannerGlobalScope === 'function') {
+        try {
+          var resolved = resolveInstallBannerGlobalScope();
+          if (resolved) {
+            candidates.push(resolved);
+          }
+        } catch (error) {
+          console.warn('Failed to resolve shared install banner scope', error);
+        }
       }
-      return false;
+      for (var index = 0; index < CORE_PART2_GLOBAL_SCOPES.length; index += 1) {
+        var scope = CORE_PART2_GLOBAL_SCOPES[index];
+        if (scope && _typeof(scope) === 'object') {
+          candidates.push(scope);
+        }
+      }
+      if (typeof globalThis !== 'undefined' && globalThis && candidates.indexOf(globalThis) === -1) {
+        candidates.push(globalThis);
+      }
+      if (typeof window !== 'undefined' && window && candidates.indexOf(window) === -1) {
+        candidates.push(window);
+      }
+      if (typeof self !== 'undefined' && self && candidates.indexOf(self) === -1) {
+        candidates.push(self);
+      }
+      if (typeof global !== 'undefined' && global && candidates.indexOf(global) === -1) {
+        candidates.push(global);
+      }
+      for (var _index = 0; _index < candidates.length; _index += 1) {
+        var candidate = candidates[_index];
+        if (candidate && _typeof(candidate) === 'object') {
+          return candidate;
+        }
+      }
+      return null;
+    }
+    function getInstallBannerDismissedInSession() {
+      var scope = getInstallBannerGlobalScope();
+      if (!scope) {
+        return false;
+      }
+      if (typeof scope.installBannerDismissedInSession !== 'boolean') {
+        scope.installBannerDismissedInSession = false;
+        return false;
+      }
+      return scope.installBannerDismissedInSession;
     }
     function setInstallBannerDismissedInSession(value) {
-      if (typeof globalThis !== 'undefined') {
-        globalThis.installBannerDismissedInSession = Boolean(value);
+      var scope = getInstallBannerGlobalScope();
+      if (!scope) {
+        return;
       }
+      scope.installBannerDismissedInSession = Boolean(value);
     }
     function hasDismissedInstallBanner() {
       if (getInstallBannerDismissedInSession()) return true;

--- a/src/scripts/app-core-new-1.js
+++ b/src/scripts/app-core-new-1.js
@@ -844,8 +844,28 @@ if (typeof window !== 'undefined') {
 var IOS_PWA_HELP_STORAGE_KEY = 'iosPwaHelpShown';
 const INSTALL_BANNER_DISMISSED_KEY = 'installPromptDismissed';
 
-if (typeof globalThis !== 'undefined' && typeof globalThis.installBannerDismissedInSession !== 'boolean') {
-  globalThis.installBannerDismissedInSession = false;
+function resolveInstallBannerGlobalScope() {
+  if (typeof globalThis !== 'undefined' && globalThis) {
+    return globalThis;
+  }
+  if (typeof window !== 'undefined' && window) {
+    return window;
+  }
+  if (typeof self !== 'undefined' && self) {
+    return self;
+  }
+  if (typeof global !== 'undefined' && global) {
+    return global;
+  }
+  return null;
+}
+
+const installBannerGlobalScope = resolveInstallBannerGlobalScope();
+if (
+  installBannerGlobalScope
+  && typeof installBannerGlobalScope.installBannerDismissedInSession !== 'boolean'
+) {
+  installBannerGlobalScope.installBannerDismissedInSession = false;
 }
 
 const DEVICE_SCHEMA_PATH = 'src/data/schema.json';

--- a/src/scripts/app-core-new-2.js
+++ b/src/scripts/app-core-new-2.js
@@ -5459,17 +5459,63 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
       }
     }
     
-    function getInstallBannerDismissedInSession() {
-      if (typeof globalThis !== 'undefined' && typeof globalThis.installBannerDismissedInSession === 'boolean') {
-        return globalThis.installBannerDismissedInSession;
+    function getInstallBannerGlobalScope() {
+      const candidates = [];
+      if (typeof resolveInstallBannerGlobalScope === 'function') {
+        try {
+          const resolved = resolveInstallBannerGlobalScope();
+          if (resolved) {
+            candidates.push(resolved);
+          }
+        } catch (error) {
+          console.warn('Failed to resolve shared install banner scope', error);
+        }
       }
-      return false;
+      for (let index = 0; index < CORE_PART2_GLOBAL_SCOPES.length; index += 1) {
+        const scope = CORE_PART2_GLOBAL_SCOPES[index];
+        if (scope && typeof scope === 'object') {
+          candidates.push(scope);
+        }
+      }
+      if (typeof globalThis !== 'undefined' && globalThis && !candidates.includes(globalThis)) {
+        candidates.push(globalThis);
+      }
+      if (typeof window !== 'undefined' && window && !candidates.includes(window)) {
+        candidates.push(window);
+      }
+      if (typeof self !== 'undefined' && self && !candidates.includes(self)) {
+        candidates.push(self);
+      }
+      if (typeof global !== 'undefined' && global && !candidates.includes(global)) {
+        candidates.push(global);
+      }
+      for (let index = 0; index < candidates.length; index += 1) {
+        const candidate = candidates[index];
+        if (candidate && typeof candidate === 'object') {
+          return candidate;
+        }
+      }
+      return null;
+    }
+
+    function getInstallBannerDismissedInSession() {
+      const scope = getInstallBannerGlobalScope();
+      if (!scope) {
+        return false;
+      }
+      if (typeof scope.installBannerDismissedInSession !== 'boolean') {
+        scope.installBannerDismissedInSession = false;
+        return false;
+      }
+      return scope.installBannerDismissedInSession;
     }
 
     function setInstallBannerDismissedInSession(value) {
-      if (typeof globalThis !== 'undefined') {
-        globalThis.installBannerDismissedInSession = Boolean(value);
+      const scope = getInstallBannerGlobalScope();
+      if (!scope) {
+        return;
       }
+      scope.installBannerDismissedInSession = Boolean(value);
     }
 
     function hasDismissedInstallBanner() {


### PR DESCRIPTION
## Summary
- add a shared helper to reliably resolve the global scope used for the install banner dismissal flag
- ensure both runtime bundles always initialize the flag on the resolved scope before reading it
- harden the session helper so legacy builds no longer throw when the banner flag is missing

## Testing
- npm run lint *(fails: existing duplicate cloneMountVoltageMap definition in app-session.js)*

------
https://chatgpt.com/codex/tasks/task_e_68e21ddcd94c8320a6e242d0b6f9d246