### PR TITLE
Ensure auto gear globals exist before runtime initialisation

### DIFF
--- a/legacy/scripts/app-core-new-2.js
+++ b/legacy/scripts/app-core-new-2.js
@@ -49,16 +49,21 @@ function readGlobalScopeValue(name) {
 
   return undefined;
 }
+var autoGearAutoPresetId;
 if (typeof autoGearAutoPresetId === 'undefined') {
-  var autoGearAutoPresetId = '';
+  autoGearAutoPresetId = '';
+} else if (typeof autoGearAutoPresetId !== 'string') {
+  autoGearAutoPresetId = '';
 }
+var baseAutoGearRules;
 if (typeof baseAutoGearRules === 'undefined') {
-  var baseAutoGearRules = [];
+  baseAutoGearRules = [];
 } else if (!Array.isArray(baseAutoGearRules)) {
   baseAutoGearRules = [];
 }
+var autoGearScenarioModeSelect;
 if (typeof autoGearScenarioModeSelect === 'undefined') {
-  var autoGearScenarioModeSelect = null;
+  autoGearScenarioModeSelect = null;
 }
 function createFallbackSafeGenerateConnectorSummary() {
   return function safeGenerateConnectorSummary(device) {
@@ -83,8 +88,9 @@ function createFallbackSafeGenerateConnectorSummary() {
     }
   };
 }
+var safeGenerateConnectorSummary;
 if (typeof safeGenerateConnectorSummary === 'undefined') {
-  var safeGenerateConnectorSummary = createFallbackSafeGenerateConnectorSummary();
+  safeGenerateConnectorSummary = createFallbackSafeGenerateConnectorSummary();
 } else if (typeof safeGenerateConnectorSummary !== 'function') {
   safeGenerateConnectorSummary = createFallbackSafeGenerateConnectorSummary();
 }

--- a/src/scripts/app-core-new-2.js
+++ b/src/scripts/app-core-new-2.js
@@ -150,24 +150,30 @@ normaliseGlobalValue(
   },
 );
 
+var autoGearAutoPresetId;
 if (typeof autoGearAutoPresetId === 'undefined') {
   // Ensure a concrete global binding exists for browsers that throw when a
   // property-only binding is accessed without `window.`.
-  var autoGearAutoPresetId = '';
+  autoGearAutoPresetId = '';
+} else if (typeof autoGearAutoPresetId !== 'string') {
+  autoGearAutoPresetId = '';
 }
 
+var baseAutoGearRules;
 if (typeof baseAutoGearRules === 'undefined') {
-  var baseAutoGearRules = [];
+  baseAutoGearRules = [];
 } else if (!Array.isArray(baseAutoGearRules)) {
   baseAutoGearRules = [];
 }
 
+var autoGearScenarioModeSelect;
 if (typeof autoGearScenarioModeSelect === 'undefined') {
-  var autoGearScenarioModeSelect = null;
+  autoGearScenarioModeSelect = null;
 }
 
+var safeGenerateConnectorSummary;
 if (typeof safeGenerateConnectorSummary === 'undefined') {
-  var safeGenerateConnectorSummary = createFallbackSafeGenerateConnectorSummary();
+  safeGenerateConnectorSummary = createFallbackSafeGenerateConnectorSummary();
 } else if (typeof safeGenerateConnectorSummary !== 'function') {
   safeGenerateConnectorSummary = createFallbackSafeGenerateConnectorSummary();
 }

--- a/src/scripts/loader.js
+++ b/src/scripts/loader.js
@@ -80,26 +80,36 @@ ensureCriticalGlobalVariable('autoGearRuleNameInput', null);
 ensureCriticalGlobalVariable('autoGearSummaryFocus', 'all');
 ensureCriticalGlobalVariable('autoGearMonitorDefaultControls', []);
 
+var autoGearAutoPresetId;
+if (typeof autoGearAutoPresetId === 'undefined' || typeof autoGearAutoPresetId !== 'string') {
+  autoGearAutoPresetId = '';
+}
+
+var baseAutoGearRules;
 if (typeof baseAutoGearRules === 'undefined') {
-  var baseAutoGearRules = [];
+  baseAutoGearRules = [];
 } else if (!Array.isArray(baseAutoGearRules)) {
   baseAutoGearRules = [];
 }
 
+var autoGearScenarioModeSelect;
 if (typeof autoGearScenarioModeSelect === 'undefined') {
-  var autoGearScenarioModeSelect = null;
+  autoGearScenarioModeSelect = null;
 }
 
+var autoGearRuleNameInput;
 if (typeof autoGearRuleNameInput === 'undefined') {
-  var autoGearRuleNameInput = null;
+  autoGearRuleNameInput = null;
 }
 
+var autoGearSummaryFocus;
 if (typeof autoGearSummaryFocus === 'undefined' || typeof autoGearSummaryFocus !== 'string') {
-  var autoGearSummaryFocus = 'all';
+  autoGearSummaryFocus = 'all';
 }
 
+var autoGearMonitorDefaultControls;
 if (typeof autoGearMonitorDefaultControls === 'undefined') {
-  var autoGearMonitorDefaultControls = [];
+  autoGearMonitorDefaultControls = [];
 } else if (!Array.isArray(autoGearMonitorDefaultControls)) {
   autoGearMonitorDefaultControls = [];
 }


### PR DESCRIPTION
## Summary
- declare critical auto gear globals with safe defaults in the loader so lexical bindings always exist before other scripts execute
- mirror the explicit global declarations in both modern and legacy core runtime bundles to avoid Safari reference errors when bindings are missing

## Testing
- `npm test -- --runInBand` *(fails: eslint reports "cloneMountVoltageMap is already defined")*

------
https://chatgpt.com/codex/tasks/task_e_68e21c5e6b448320a7cdd526a9108aa1