### PR TITLE
Ensure auto gear preset ID globals exist under CSP

### DIFF
--- a/legacy/scripts/loader.js
+++ b/legacy/scripts/loader.js
@@ -1,4 +1,7 @@
 function _typeof(o) { "@babel/helpers - typeof"; return _typeof = "function" == typeof Symbol && "symbol" == typeof Symbol.iterator ? function (o) { return typeof o; } : function (o) { return o && "function" == typeof Symbol && o.constructor === Symbol && o !== Symbol.prototype ? "symbol" : typeof o; }, _typeof(o); }
+if (typeof autoGearAutoPresetId === 'undefined') {
+  var autoGearAutoPresetId = '';
+}
 (function () {
   var OPTIONAL_CHAINING_FLAG = '__cinePowerOptionalChainingCheck__';
   function getGlobalScope() {

--- a/src/scripts/loader.js
+++ b/src/scripts/loader.js
@@ -74,6 +74,9 @@ function ensureCriticalGlobalVariable(name, fallback) {
 }
 
 ensureCriticalGlobalVariable('autoGearAutoPresetId', '');
+if (typeof autoGearAutoPresetId === 'undefined') {
+  var autoGearAutoPresetId = '';
+}
 ensureCriticalGlobalVariable('baseAutoGearRules', []);
 ensureCriticalGlobalVariable('autoGearScenarioModeSelect', null);
 ensureCriticalGlobalVariable('autoGearRuleNameInput', null);


### PR DESCRIPTION
## Summary
- add an explicit fallback declaration for `autoGearAutoPresetId` in the modern loader so the global exists even when `Function` is blocked by CSP
- mirror the same manual safeguard in the legacy loader bundle to keep runtime parity

## Testing
- npm run build:legacy

------
https://chatgpt.com/codex/tasks/task_e_68e21f4e16348320be629b305b1d9405