### PR TITLE
Add Safari global initialization shim

### DIFF
--- a/index.html
+++ b/index.html
@@ -6351,6 +6351,7 @@
     </datalist>
   </dialog>
   <dialog id="overviewDialog"></dialog>
+  <script src="src/scripts/globals-legacy-shim.js"></script>
   <script src="src/scripts/globals-bootstrap.js"></script>
   <script src="src/scripts/loader.js"></script>
 </body>

--- a/src/scripts/globals-legacy-shim.js
+++ b/src/scripts/globals-legacy-shim.js
@@ -1,0 +1,119 @@
+(function ensureLegacyCoreGlobals() {
+  var scope =
+    (typeof globalThis !== 'undefined' && globalThis) ||
+    (typeof window !== 'undefined' && window) ||
+    (typeof self !== 'undefined' && self) ||
+    (typeof global !== 'undefined' && global) ||
+    null;
+
+  if (!scope || (typeof scope !== 'object' && typeof scope !== 'function')) {
+    return;
+  }
+
+  function fallbackSafeGenerateConnectorSummary(device) {
+    if (!device || typeof device !== 'object') {
+      return '';
+    }
+
+    try {
+      var keys = Object.keys(device);
+      if (!keys.length) {
+        return '';
+      }
+
+      var primaryKey = keys[0];
+      var value = device[primaryKey];
+      var label = typeof primaryKey === 'string' ? primaryKey.replace(/_/g, ' ') : 'connector';
+      return value ? label + ': ' + value : label;
+    } catch (error) {
+      void error;
+      return '';
+    }
+  }
+
+  function ensureBinding(name, validator, fallbackProvider) {
+    var value;
+
+    try {
+      value = scope[name];
+    } catch (readError) {
+      void readError;
+      value = undefined;
+    }
+
+    if (!validator(value)) {
+      try {
+        value = fallbackProvider();
+      } catch (fallbackError) {
+        void fallbackError;
+        value = undefined;
+      }
+    }
+
+    if (!validator(value)) {
+      return;
+    }
+
+    try {
+      scope[name] = value;
+    } catch (assignError) {
+      void assignError;
+    }
+
+    try {
+      var bind = scope.Function || Function;
+      bind(
+        'value',
+        "try { if (typeof " +
+          name +
+          " === 'undefined') { " +
+          name +
+          " = value; } } catch (bindingError) { try { " +
+          name +
+          " = value; } catch (assignError) { void assignError; } } return value;"
+      )(value);
+    } catch (bindingError) {
+      void bindingError;
+    }
+  }
+
+  ensureBinding(
+    'autoGearAutoPresetId',
+    function validateAutoPresetId(candidate) {
+      return typeof candidate === 'string';
+    },
+    function provideAutoPresetIdFallback() {
+      return '';
+    }
+  );
+
+  ensureBinding(
+    'baseAutoGearRules',
+    function validateBaseRules(candidate) {
+      return Array.isArray(candidate);
+    },
+    function provideBaseRulesFallback() {
+      return [];
+    }
+  );
+
+  ensureBinding(
+    'autoGearScenarioModeSelect',
+    function validateScenarioSelect(candidate) {
+      return candidate === null || typeof candidate === 'object';
+    },
+    function provideScenarioSelectFallback() {
+      return null;
+    }
+  );
+
+  ensureBinding(
+    'safeGenerateConnectorSummary',
+    function validateConnectorSummary(candidate) {
+      return typeof candidate === 'function';
+    },
+    function provideConnectorSummaryFallback() {
+      return fallbackSafeGenerateConnectorSummary;
+    }
+  );
+})();

--- a/src/scripts/loader.js
+++ b/src/scripts/loader.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-redeclare */
 /*
  * Ensure critical core runtime globals always exist before the loader
  * initialises the rest of the application. Some browsers, notably older


### PR DESCRIPTION
## Summary
- add a legacy compatibility shim that eagerly binds critical auto gear globals for browsers that throw on missing global variables
- load the shim before the existing bootstrap script to keep Safari from raising ReferenceError on startup
- silence redundant redeclaration lint warnings in the loader where intentional global fallbacks are declared

## Testing
- npm test -- --runTestsByPath tests/unit/coreShared.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e220f4fe348320b7347c4bd39b959d