### PR TITLE
Ensure auto gear globals bind across runtime segments

### DIFF
--- a/legacy/scripts/app-core-new-1.js
+++ b/legacy/scripts/app-core-new-1.js
@@ -318,9 +318,10 @@ if (CORE_PART1_RUNTIME_SCOPE && CORE_PART1_RUNTIME_SCOPE.__cineCorePart1Initiali
         if (typeof globalFn === 'function') {
           var binder = globalFn(
             'value',
-            "if (typeof ".concat(name, " === 'undefined') { ").concat(name, " = value; } return typeof ").concat(name, " !== 'undefined' ? ").concat(name, ' : value;'),
+            "if (typeof ".concat(name, " === 'undefined') { var ").concat(name, " = value; } else { ").concat(name, " = value; } return ").concat(name, ';'),
           );
-          binder(typeof scope[name] === 'undefined' ? fallbackValue : scope[name]);
+          var appliedValue = typeof scope[name] === 'undefined' ? fallbackValue : scope[name];
+          binder(appliedValue);
         }
       } catch (bindingError) {
         void bindingError;

--- a/src/scripts/app-core-new-1.js
+++ b/src/scripts/app-core-new-1.js
@@ -452,10 +452,11 @@ function enqueueCoreBootTask(task) {
       if (typeof globalFn === 'function') {
         const binder = globalFn(
           'value',
-          `if (typeof ${name} === 'undefined') { ${name} = value; }
-           return typeof ${name} !== 'undefined' ? ${name} : value;`,
+          `if (typeof ${name} === 'undefined') { var ${name} = value; } else { ${name} = value; }
+           return ${name};`,
         );
-        binder(typeof scope[name] === 'undefined' ? fallbackValue : scope[name]);
+        const appliedValue = typeof scope[name] === 'undefined' ? fallbackValue : scope[name];
+        binder(appliedValue);
       }
     } catch (bindingError) {
       void bindingError;


### PR DESCRIPTION
## Summary
- update the modern runtime fallback repair to create concrete global bindings for auto gear globals
- mirror the binding repair change in the legacy runtime bundle to keep behaviour consistent

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e22164fc008320b828527f004f8e80