### PR TITLE
Fix breakdown list localization guard

### DIFF
--- a/legacy/scripts/app-core-new-1.js
+++ b/legacy/scripts/app-core-new-1.js
@@ -7001,7 +7001,13 @@ if (CORE_PART1_RUNTIME_SCOPE && CORE_PART1_RUNTIME_SCOPE.__cineCorePart1Initiali
     document.querySelectorAll('#motorNotesLabel,#controllerNotesLabel,#distanceNotesLabel').forEach(function (el) {
       el.textContent = texts[lang].notesLabel;
     });
-    if (breakdownListElem) breakdownListElem.setAttribute("data-help", texts[lang].breakdownListHelp);
+    const breakdownListTarget =
+      typeof breakdownListElem !== 'undefined' && breakdownListElem
+        ? breakdownListElem
+        : document.getElementById('breakdownList');
+    if (breakdownListTarget) {
+      breakdownListTarget.setAttribute("data-help", texts[lang].breakdownListHelp);
+    }
     var totalPowerLabelElem = document.getElementById("totalPowerLabel");
     totalPowerLabelElem.textContent = texts[lang].totalPowerLabel;
     totalPowerLabelElem.setAttribute("data-help", texts[lang].totalPowerHelp);

--- a/src/scripts/app-core-new-1.js
+++ b/src/scripts/app-core-new-1.js
@@ -7678,8 +7678,13 @@ function setLanguage(lang) {
       el.textContent = texts[lang].notesLabel;
     });
   // Results labels
-  if (breakdownListElem)
-    breakdownListElem.setAttribute("data-help", texts[lang].breakdownListHelp);
+  const breakdownListTarget =
+    typeof breakdownListElem !== "undefined" && breakdownListElem
+      ? breakdownListElem
+      : document.getElementById('breakdownList');
+  if (breakdownListTarget) {
+    breakdownListTarget.setAttribute("data-help", texts[lang].breakdownListHelp);
+  }
 
   const totalPowerLabelElem = document.getElementById("totalPowerLabel");
   totalPowerLabelElem.textContent = texts[lang].totalPowerLabel;


### PR DESCRIPTION
## Summary
- ensure the breakdown list help text lookup tolerates missing globals by resolving the element on demand
- mirror the runtime safeguard in the legacy bundle to keep both builds aligned

## Testing
- npm test -- --runTestsByPath tests/data/languageCoverage.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e2225b11ec83209d30366715636c6e