### PR TITLE
Fix renderTemperatureNote availability during language initialization

### DIFF
--- a/legacy/scripts/app-core-new-1.js
+++ b/legacy/scripts/app-core-new-1.js
@@ -45,6 +45,59 @@ if (CORE_PART1_RUNTIME_SCOPE && CORE_PART1_RUNTIME_SCOPE.__cineCorePart1Initiali
     }
   }
   var CORE_GLOBAL_SCOPE = CORE_PART1_RUNTIME_SCOPE;
+  var CORE_TEMPERATURE_QUEUE_KEY = "__cinePendingTemperatureNote";
+  var CORE_TEMPERATURE_RENDER_NAME = "renderTemperatureNote";
+
+  function getCoreGlobalObject() {
+    if (CORE_GLOBAL_SCOPE && _typeof(CORE_GLOBAL_SCOPE) === "object") {
+      return CORE_GLOBAL_SCOPE;
+    }
+    if (typeof globalThis !== "undefined" && _typeof(globalThis) === "object") {
+      return globalThis;
+    }
+    if (typeof window !== "undefined" && _typeof(window) === "object") {
+      return window;
+    }
+    if (typeof self !== "undefined" && _typeof(self) === "object") {
+      return self;
+    }
+    if (typeof global !== "undefined" && _typeof(global) === "object") {
+      return global;
+    }
+    return null;
+  }
+
+  function dispatchTemperatureNoteRender(hours) {
+    var scope = getCoreGlobalObject();
+    var renderer =
+      typeof renderTemperatureNote === "function"
+        ? renderTemperatureNote
+        : scope && typeof scope[CORE_TEMPERATURE_RENDER_NAME] === "function"
+          ? scope[CORE_TEMPERATURE_RENDER_NAME]
+          : null;
+
+    if (typeof renderer === "function") {
+      renderer(hours);
+      return;
+    }
+
+    if (!scope || _typeof(scope) !== "object") {
+      return;
+    }
+
+    var pending = scope[CORE_TEMPERATURE_QUEUE_KEY];
+    if (!pending || _typeof(pending) !== "object") {
+      pending = {};
+    }
+    pending.latestHours = hours;
+    try {
+      pending.updatedAt = Date.now ? Date.now() : new Date().getTime();
+    } catch (timestampError) {
+      void timestampError;
+      pending.updatedAt = 0;
+    }
+    scope[CORE_TEMPERATURE_QUEUE_KEY] = pending;
+  }
   function exposeCoreRuntimeConstant(name, value) {
     if (typeof name !== 'string' || !name) {
       return;
@@ -7042,7 +7095,7 @@ if (CORE_PART1_RUNTIME_SCOPE && CORE_PART1_RUNTIME_SCOPE.__cineCorePart1Initiali
     if (runtimeAverageNoteElem) {
       runtimeAverageNoteElem.textContent = fb && fb.count > 4 ? texts[lang].runtimeAverageNote : '';
     }
-    renderTemperatureNote(lastRuntimeHours);
+    dispatchTemperatureNoteRender(lastRuntimeHours);
     updateFeedbackTemperatureLabel(lang, temperatureUnit);
     updateFeedbackTemperatureOptions(lang, temperatureUnit);
     var tempNoteElem = document.getElementById("temperatureNote");

--- a/legacy/scripts/app-core-new-2.js
+++ b/legacy/scripts/app-core-new-2.js
@@ -31,6 +31,49 @@ var CORE_PART2_GLOBAL_SCOPES = [
   typeof global !== 'undefined' && _typeof(global) === 'object' ? global : null
 ].filter(Boolean);
 
+var CORE_TEMPERATURE_QUEUE_KEY = '__cinePendingTemperatureNote';
+var CORE_TEMPERATURE_RENDER_NAME = 'renderTemperatureNote';
+
+function assignCoreTemperatureNoteRenderer(renderer) {
+  if (typeof renderer !== 'function') {
+    return;
+  }
+
+  for (var index = 0; index < CORE_PART2_GLOBAL_SCOPES.length; index += 1) {
+    var scope = CORE_PART2_GLOBAL_SCOPES[index];
+    if (!scope || _typeof(scope) !== 'object') {
+      continue;
+    }
+
+    try {
+      scope[CORE_TEMPERATURE_RENDER_NAME] = renderer;
+      var pending = scope[CORE_TEMPERATURE_QUEUE_KEY];
+      if (pending && _typeof(pending) === 'object') {
+        if (Object.prototype.hasOwnProperty.call(pending, 'latestHours')) {
+          var hours = pending.latestHours;
+          if (typeof hours !== 'undefined') {
+            try {
+              renderer(hours);
+            } catch (temperatureRenderError) {
+              if (typeof console !== 'undefined' && typeof console.error === 'function') {
+                console.error('Failed to apply pending temperature note render', temperatureRenderError);
+              }
+            }
+          }
+        }
+        try {
+          delete pending.latestHours;
+        } catch (clearLatestError) {
+          void clearLatestError;
+          pending.latestHours = undefined;
+        }
+      }
+    } catch (assignError) {
+      void assignError;
+    }
+  }
+}
+
 function readGlobalScopeValue(name) {
   for (var index = 0; index < CORE_PART2_GLOBAL_SCOPES.length; index += 1) {
     var scope = CORE_PART2_GLOBAL_SCOPES[index];
@@ -12953,6 +12996,8 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
       html += "</table>";
       container.innerHTML = html;
     }
+
+    assignCoreTemperatureNoteRenderer(renderTemperatureNote);
     function ensureFeedbackTemperatureOptions(select) {
       if (!select) return;
       var expectedOptions = FEEDBACK_TEMPERATURE_MAX - FEEDBACK_TEMPERATURE_MIN + 2;


### PR DESCRIPTION
## Summary
- add a shared dispatcher to queue temperature note renders while the second runtime bundle is still loading
- register the definitive temperature note renderer once part two finishes loading and flush any pending updates
- mirror the safety changes in the legacy bundles to preserve offline parity

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e225222818832085ff32527d3250ff