### PR TITLE
Fix shared import initialization and expose device refresh

### DIFF
--- a/src/scripts/app-core-new-2.js
+++ b/src/scripts/app-core-new-2.js
@@ -16115,6 +16115,7 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
     
     const CORE_PART2_GLOBAL_EXPORTS = {
       populateSelect,
+      refreshDeviceLists,
       refreshAutoGearCameraOptions,
       refreshAutoGearCameraWeightCondition,
       refreshAutoGearMonitorOptions,

--- a/src/scripts/app-setups.js
+++ b/src/scripts/app-setups.js
@@ -864,8 +864,6 @@ if (shareUiContext.applySharedLinkButton && shareUiContext.sharedLinkInput) {
   shareUiContext.applySharedLinkButton.addEventListener('click', handleApplySharedLinkClick);
 }
 
-enqueueCineUiRegistration(registerSetupsCineUiInternal);
-
 function handleSharedImportModeChange() {
   if (sharedImportPromptActive) return;
   if (lastSharedSetupData === null) return;
@@ -905,6 +903,8 @@ if (sharedImportUiContext.cancelButton) {
 if (sharedImportUiContext.dialog) {
   sharedImportUiContext.dialog.addEventListener('cancel', handleSharedImportDialogCancel);
 }
+
+enqueueCineUiRegistration(registerSetupsCineUiInternal);
 
 function getSafeLanguageTexts() {
   const scope =


### PR DESCRIPTION
## Summary
- ensure the shared import UI context is initialized before Cine UI registration to avoid runtime errors
- expose the device list refresh helper from core part 2 so language changes can update device controls

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e229593a708320a13a6fab7bc1a354