### PR TITLE
Handle temperature note renderer initialization gaps

### DIFF
--- a/legacy/scripts/app-core-new-1.js
+++ b/legacy/scripts/app-core-new-1.js
@@ -69,15 +69,42 @@ if (CORE_PART1_RUNTIME_SCOPE && CORE_PART1_RUNTIME_SCOPE.__cineCorePart1Initiali
 
   function dispatchTemperatureNoteRender(hours) {
     var scope = getCoreGlobalObject();
-    var renderer =
-      typeof renderTemperatureNote === "function"
-        ? renderTemperatureNote
-        : scope && typeof scope[CORE_TEMPERATURE_RENDER_NAME] === "function"
-          ? scope[CORE_TEMPERATURE_RENDER_NAME]
-          : null;
+    var renderer = null;
 
-    if (typeof renderer === "function") {
-      renderer(hours);
+    try {
+      if (typeof renderTemperatureNote === 'function') {
+        renderer = renderTemperatureNote;
+      }
+    } catch (referenceError) {
+      var message = String(referenceError && referenceError.message);
+      var isReferenceError =
+        referenceError &&
+        (referenceError.name === 'ReferenceError' || /is not defined|Cannot access uninitialized/i.test(message));
+
+      if (!isReferenceError) {
+        throw referenceError;
+      }
+    }
+
+    if (!renderer && scope && _typeof(scope) === 'object') {
+      try {
+        var scopedRenderer = scope[CORE_TEMPERATURE_RENDER_NAME];
+        if (typeof scopedRenderer === 'function') {
+          renderer = scopedRenderer;
+        }
+      } catch (readError) {
+        void readError;
+      }
+    }
+
+    if (typeof renderer === 'function') {
+      try {
+        renderer(hours);
+      } catch (renderError) {
+        if (typeof console !== 'undefined' && typeof console.error === 'function') {
+          console.error('Temperature note renderer failed', renderError);
+        }
+      }
       return;
     }
 


### PR DESCRIPTION
## Summary
- guard the temperature note renderer lookup so early calls no longer throw reference errors
- mirror the defensive lookup in the legacy bundle to keep both runtimes aligned
- log renderer failures so localisation updates preserve diagnostics without breaking execution

## Testing
- npm test -- --runTestsByPath tests/smoke.test.js *(fails: no matching tests)*

------
https://chatgpt.com/codex/tasks/task_e_68e229863f6c8320a04e6b130324f425