### PR TITLE
Fix cine UI context timing and feedback label helper

### DIFF
--- a/legacy/scripts/app-core-new-1.js
+++ b/legacy/scripts/app-core-new-1.js
@@ -1056,6 +1056,42 @@ if (CORE_PART1_RUNTIME_SCOPE && CORE_PART1_RUNTIME_SCOPE.__cineCorePart1Initiali
       labelElem.textContent = label;
     }
   }
+
+  function refreshFeedbackTemperatureLabel(lang, unit) {
+    var targetLang = typeof lang === 'undefined' ? currentLang : lang;
+    var targetUnit = typeof unit === 'undefined' ? temperatureUnit : unit;
+    var handled = false;
+    try {
+      if (typeof updateFeedbackTemperatureLabel === 'function') {
+        updateFeedbackTemperatureLabel(targetLang, targetUnit);
+        handled = true;
+      }
+    } catch (error) {
+      if (typeof console !== 'undefined' && typeof console.warn === 'function') {
+        console.warn('Fallback applied while updating feedback temperature label', error);
+      }
+    }
+
+    if (handled) {
+      return;
+    }
+
+    if (typeof document === 'undefined') {
+      return;
+    }
+
+    var labelTextElem = document.getElementById('fbTemperatureLabelText');
+    var labelElem = document.getElementById('fbTemperatureLabel');
+    if (!labelTextElem && !labelElem) {
+      return;
+    }
+    var label = getTemperatureColumnLabelForLang(targetLang, targetUnit) + ':';
+    if (labelTextElem) {
+      labelTextElem.textContent = label;
+    } else if (labelElem) {
+      labelElem.textContent = label;
+    }
+  }
   function applyTemperatureUnitPreference(unit, options) {
     var opts = options && _typeof(options) === 'object' ? options : {};
     var normalized = normalizeTemperatureUnit(unit);
@@ -1079,11 +1115,11 @@ if (CORE_PART1_RUNTIME_SCOPE && CORE_PART1_RUNTIME_SCOPE.__cineCorePart1Initiali
       settingsTemperatureUnit.value = temperatureUnit;
     }
     if (reRender) {
-      updateFeedbackTemperatureLabel();
+      refreshFeedbackTemperatureLabel();
       updateFeedbackTemperatureOptions();
       renderTemperatureNote(lastRuntimeHours);
     }
-  }
+    }
   var collator = new Intl.Collator(undefined, {
     numeric: true,
     sensitivity: 'base'
@@ -7343,7 +7379,7 @@ if (CORE_PART1_RUNTIME_SCOPE && CORE_PART1_RUNTIME_SCOPE.__cineCorePart1Initiali
       runtimeAverageNoteElem.textContent = fb && fb.count > 4 ? texts[lang].runtimeAverageNote : '';
     }
     dispatchTemperatureNoteRender(lastRuntimeHours);
-    updateFeedbackTemperatureLabel(lang, temperatureUnit);
+    refreshFeedbackTemperatureLabel(lang, temperatureUnit);
     updateFeedbackTemperatureOptions(lang, temperatureUnit);
     var tempNoteElem = document.getElementById("temperatureNote");
     if (tempNoteElem) tempNoteElem.setAttribute("data-help", texts[lang].temperatureNoteHelp);

--- a/legacy/scripts/app-core-new-2.js
+++ b/legacy/scripts/app-core-new-2.js
@@ -13040,18 +13040,48 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
         });
       });
     }
-    function updateFeedbackTemperatureLabel() {
-      var lang = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : currentLang;
-      var unit = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : temperatureUnit;
-      var labelTextElem = document.getElementById('fbTemperatureLabelText');
-      var labelElem = document.getElementById('fbTemperatureLabel');
-      var label = "".concat(getTemperatureColumnLabelForLang(lang, unit), ":");
-      if (labelTextElem) {
-        labelTextElem.textContent = label;
-      } else if (labelElem) {
-        labelElem.textContent = label;
+      function updateFeedbackTemperatureLabel() {
+        var lang = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : currentLang;
+        var unit = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : temperatureUnit;
+        var labelTextElem = document.getElementById('fbTemperatureLabelText');
+        var labelElem = document.getElementById('fbTemperatureLabel');
+        var label = "".concat(getTemperatureColumnLabelForLang(lang, unit), ":");
+        if (labelTextElem) {
+          labelTextElem.textContent = label;
+        } else if (labelElem) {
+          labelElem.textContent = label;
+        }
       }
-    }
+
+      function refreshFeedbackTemperatureLabel() {
+        var lang = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : currentLang;
+        var unit = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : temperatureUnit;
+        var handled = false;
+        try {
+          if (typeof updateFeedbackTemperatureLabel === 'function') {
+            updateFeedbackTemperatureLabel(lang, unit);
+            handled = true;
+          }
+        } catch (error) {
+          console.warn('Fallback applied while updating feedback temperature label', error);
+        }
+
+        if (handled) {
+          return;
+        }
+
+        var labelTextElem = document.getElementById('fbTemperatureLabelText');
+        var labelElem = document.getElementById('fbTemperatureLabel');
+        if (!labelTextElem && !labelElem) {
+          return;
+        }
+        var label = "".concat(getTemperatureColumnLabelForLang(lang, unit), ":");
+        if (labelTextElem) {
+          labelTextElem.textContent = label;
+        } else if (labelElem) {
+          labelElem.textContent = label;
+        }
+      }
     function applyTemperatureUnitPreference(unit) {
       var options = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
       var normalized = normalizeTemperatureUnit(unit);
@@ -13077,7 +13107,7 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
         settingsTemperatureUnit.value = temperatureUnit;
       }
       if (reRender) {
-        updateFeedbackTemperatureLabel();
+        refreshFeedbackTemperatureLabel();
         updateFeedbackTemperatureOptions();
         renderTemperatureNote(lastRuntimeHours);
       }

--- a/src/scripts/app-core-new-1.js
+++ b/src/scripts/app-core-new-1.js
@@ -1324,6 +1324,40 @@ function updateFeedbackTemperatureLabel(lang = currentLang, unit = temperatureUn
   }
 }
 
+function refreshFeedbackTemperatureLabel(lang = currentLang, unit = temperatureUnit) {
+  let handled = false;
+  try {
+    if (typeof updateFeedbackTemperatureLabel === 'function') {
+      updateFeedbackTemperatureLabel(lang, unit);
+      handled = true;
+    }
+  } catch (error) {
+    if (typeof console !== 'undefined' && typeof console.warn === 'function') {
+      console.warn('Fallback applied while updating feedback temperature label', error);
+    }
+  }
+
+  if (handled) {
+    return;
+  }
+
+  const labelTextElem = typeof document !== 'undefined'
+    ? document.getElementById('fbTemperatureLabelText')
+    : null;
+  const labelElem = typeof document !== 'undefined'
+    ? document.getElementById('fbTemperatureLabel')
+    : null;
+  if (!labelTextElem && !labelElem) {
+    return;
+  }
+  const label = `${getTemperatureColumnLabelForLang(lang, unit)}:`;
+  if (labelTextElem) {
+    labelTextElem.textContent = label;
+  } else if (labelElem) {
+    labelElem.textContent = label;
+  }
+}
+
 function applyTemperatureUnitPreference(unit, options = {}) {
   const normalized = normalizeTemperatureUnit(unit);
   const { persist = true, reRender = true, forceUpdate = false } = options || {};
@@ -1344,7 +1378,7 @@ function applyTemperatureUnitPreference(unit, options = {}) {
     settingsTemperatureUnit.value = temperatureUnit;
   }
   if (reRender) {
-    updateFeedbackTemperatureLabel();
+    refreshFeedbackTemperatureLabel();
     updateFeedbackTemperatureOptions();
     renderTemperatureNote(lastRuntimeHours);
   }
@@ -8050,7 +8084,7 @@ function setLanguage(lang) {
       fb && fb.count > 4 ? texts[lang].runtimeAverageNote : '';
   }
   dispatchTemperatureNoteRender(lastRuntimeHours);
-  updateFeedbackTemperatureLabel(lang, temperatureUnit);
+  refreshFeedbackTemperatureLabel(lang, temperatureUnit);
   updateFeedbackTemperatureOptions(lang, temperatureUnit);
   const tempNoteElem = document.getElementById("temperatureNote");
   if (tempNoteElem)

--- a/src/scripts/app-core-new-2.js
+++ b/src/scripts/app-core-new-2.js
@@ -13928,7 +13928,35 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
         labelElem.textContent = label;
       }
     }
-    
+
+    function refreshFeedbackTemperatureLabel(lang = currentLang, unit = temperatureUnit) {
+      let handled = false;
+      try {
+        if (typeof updateFeedbackTemperatureLabel === 'function') {
+          updateFeedbackTemperatureLabel(lang, unit);
+          handled = true;
+        }
+      } catch (error) {
+        console.warn('Fallback applied while updating feedback temperature label', error);
+      }
+
+      if (handled) {
+        return;
+      }
+
+      const labelTextElem = document.getElementById('fbTemperatureLabelText');
+      const labelElem = document.getElementById('fbTemperatureLabel');
+      if (!labelTextElem && !labelElem) {
+        return;
+      }
+      const label = `${getTemperatureColumnLabelForLang(lang, unit)}:`;
+      if (labelTextElem) {
+        labelTextElem.textContent = label;
+      } else if (labelElem) {
+        labelElem.textContent = label;
+      }
+    }
+
     function applyTemperatureUnitPreference(unit, options = {}) {
       const normalized = normalizeTemperatureUnit(unit);
       const { persist = true, reRender = true, forceUpdate = false } = options || {};
@@ -13947,7 +13975,7 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
         settingsTemperatureUnit.value = temperatureUnit;
       }
       if (reRender) {
-        updateFeedbackTemperatureLabel();
+        refreshFeedbackTemperatureLabel();
         updateFeedbackTemperatureOptions();
         renderTemperatureNote(lastRuntimeHours);
       }

--- a/src/scripts/app-setups.js
+++ b/src/scripts/app-setups.js
@@ -806,17 +806,17 @@ function handleShareDialogCancel(event) {
   closeDialog(shareDialog);
 }
 
-const shareUiContext = getShareUiContext();
-if (shareUiContext.form) {
-  shareUiContext.form.addEventListener('submit', handleShareFormSubmit);
+const initialShareUiContext = getShareUiContext();
+if (initialShareUiContext.form) {
+  initialShareUiContext.form.addEventListener('submit', handleShareFormSubmit);
 }
 
-if (shareUiContext.cancelButton) {
-  shareUiContext.cancelButton.addEventListener('click', handleShareCancelClick);
+if (initialShareUiContext.cancelButton) {
+  initialShareUiContext.cancelButton.addEventListener('click', handleShareCancelClick);
 }
 
-if (shareUiContext.dialog) {
-  shareUiContext.dialog.addEventListener('cancel', handleShareDialogCancel);
+if (initialShareUiContext.dialog) {
+  initialShareUiContext.dialog.addEventListener('cancel', handleShareDialogCancel);
 }
 
 function handleSharedLinkInputChange() {
@@ -856,12 +856,12 @@ function handleApplySharedLinkClick() {
   }
 }
 
-if (shareUiContext.sharedLinkInput) {
-  shareUiContext.sharedLinkInput.addEventListener('change', handleSharedLinkInputChange);
+if (initialShareUiContext.sharedLinkInput) {
+  initialShareUiContext.sharedLinkInput.addEventListener('change', handleSharedLinkInputChange);
 }
 
-if (shareUiContext.applySharedLinkButton && shareUiContext.sharedLinkInput) {
-  shareUiContext.applySharedLinkButton.addEventListener('click', handleApplySharedLinkClick);
+if (initialShareUiContext.applySharedLinkButton && initialShareUiContext.sharedLinkInput) {
+  initialShareUiContext.applySharedLinkButton.addEventListener('click', handleApplySharedLinkClick);
 }
 
 enqueueCineUiRegistration(registerSetupsCineUiInternal);
@@ -889,21 +889,21 @@ function handleSharedImportDialogCancel(event) {
   clearStoredSharedImportData();
 }
 
-const sharedImportUiContext = getSharedImportUiContext();
-if (sharedImportUiContext.modeSelect) {
-  sharedImportUiContext.modeSelect.addEventListener('change', handleSharedImportModeChange);
+const initialSharedImportUiContext = getSharedImportUiContext();
+if (initialSharedImportUiContext.modeSelect) {
+  initialSharedImportUiContext.modeSelect.addEventListener('change', handleSharedImportModeChange);
 }
 
-if (sharedImportUiContext.form) {
-  sharedImportUiContext.form.addEventListener('submit', handleSharedImportSubmit);
+if (initialSharedImportUiContext.form) {
+  initialSharedImportUiContext.form.addEventListener('submit', handleSharedImportSubmit);
 }
 
-if (sharedImportUiContext.cancelButton) {
-  sharedImportUiContext.cancelButton.addEventListener('click', handleSharedImportCancel);
+if (initialSharedImportUiContext.cancelButton) {
+  initialSharedImportUiContext.cancelButton.addEventListener('click', handleSharedImportCancel);
 }
 
-if (sharedImportUiContext.dialog) {
-  sharedImportUiContext.dialog.addEventListener('cancel', handleSharedImportDialogCancel);
+if (initialSharedImportUiContext.dialog) {
+  initialSharedImportUiContext.dialog.addEventListener('cancel', handleSharedImportDialogCancel);
 }
 
 function getSafeLanguageTexts() {
@@ -941,13 +941,16 @@ function registerSetupsCineUiInternal(cineUi) {
     return;
   }
 
+  const shareContext = getShareUiContext();
+  const sharedImportContext = getSharedImportUiContext();
+
   registerCineUiEntries(
     cineUi.controllers,
     [
       {
         name: 'shareDialog',
         value: {
-          context: shareUiContext,
+          context: shareContext,
           open: handleShareSetupClick,
           submit: handleShareFormSubmit,
           cancel: handleShareCancelClick,
@@ -957,7 +960,7 @@ function registerSetupsCineUiInternal(cineUi) {
       {
         name: 'sharedImportDialog',
         value: {
-          context: sharedImportUiContext,
+          context: sharedImportContext,
           submit: handleSharedImportSubmit,
           cancel: handleSharedImportCancel,
           dismiss: handleSharedImportDialogCancel,


### PR DESCRIPTION
## Summary
- ensure the share and import UI contexts are resolved before cine UI registration so callbacks see initialized references
- add a safe feedback temperature label helper (and re-use it) in both modern and legacy bundles to avoid missing-function errors

## Testing
- npm test *(aborted after hanging during jest run)*
- npm run test:unit *(aborted after hanging during jest run, individual suites reported as passing before termination)*

------
https://chatgpt.com/codex/tasks/task_e_68e2271f86c8832089711a626a641695