### PR TITLE
Ensure applyFilters helper is registered globally

### DIFF
--- a/legacy/scripts/app-core-new-2.js
+++ b/legacy/scripts/app-core-new-2.js
@@ -12891,6 +12891,9 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
         filterDeviceList(list, value);
       });
     }
+    if (filterHelperScope && typeof filterHelperScope.applyFilters !== 'function') {
+      filterHelperScope.applyFilters = applyFilters;
+    }
     populateSelect(cameraSelect, devices.cameras, true);
     populateMonitorSelect();
     populateSelect(videoSelect, devices.video, true);

--- a/src/scripts/app-core-new-2.js
+++ b/src/scripts/app-core-new-2.js
@@ -13771,6 +13771,10 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
         filterDeviceList(list, value);
       });
     }
+
+    if (filterHelperScope && typeof filterHelperScope.applyFilters !== 'function') {
+      filterHelperScope.applyFilters = applyFilters;
+    }
     
     // Initialize device selection dropdowns
     populateSelect(cameraSelect, devices.cameras, true);


### PR DESCRIPTION
## Summary
- expose the applyFilters helper on the shared filterHelperScope so language switching and other flows can use it
- mirror the same fix in the legacy bundle to prevent regressions in the legacy build

## Testing
- npm run lint
- npm run check-consistency
- npm run test:jest -- --runTestsByPath tests/unit/storageFallback.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e22b7b1efc83208dd7988559b81cfa