### PR TITLE
Fix auto gear button state helper availability

### DIFF
--- a/legacy/scripts/app-core-new-1.js
+++ b/legacy/scripts/app-core-new-1.js
@@ -3317,11 +3317,31 @@ if (CORE_PART1_RUNTIME_SCOPE && CORE_PART1_RUNTIME_SCOPE.__cineCorePart1Initiali
   var autoGearBackupRetentionWarningText = '';
   var autoGearEditorDraft = null;
   var autoGearEditorActiveItem = null;
-  var autoGearDraftPendingWarnings = null;
-  var autoGearSearchQuery = '';
-  var autoGearSummaryFocus = 'all';
-  var autoGearSummaryLast = null;
-  var autoGearScenarioFilter = 'all';
+var autoGearDraftPendingWarnings = null;
+var autoGearSearchQuery = '';
+var autoGearSummaryFocus = 'all';
+var autoGearSummaryLast = null;
+var autoGearScenarioFilter = 'all';
+
+function updateAutoGearItemButtonState(type) {
+  var normalizedType = type === 'remove' ? 'remove' : 'add';
+  var button = normalizedType === 'remove' ? autoGearRemoveItemButton : autoGearAddItemButton;
+  if (!button) return;
+  var langTexts = texts[currentLang] || texts.en || {};
+  var isEditing = !!(autoGearEditorActiveItem && autoGearEditorActiveItem.listType === normalizedType);
+  var defaultKey = normalizedType === 'remove' ? 'autoGearRemoveItemButton' : 'autoGearAddItemButton';
+  var defaultLabel = langTexts[defaultKey]
+    || (texts.en && texts.en[defaultKey])
+    || button.textContent
+    || '';
+  var updateLabel = langTexts.autoGearUpdateItemButton
+    || (texts.en && texts.en.autoGearUpdateItemButton)
+    || defaultLabel;
+  var label = isEditing ? updateLabel : defaultLabel;
+  var glyph = isEditing ? ICON_GLYPHS.save : normalizedType === 'remove' ? ICON_GLYPHS.minus : ICON_GLYPHS.add;
+  setButtonLabelWithIcon(button, label, glyph);
+  button.setAttribute('data-help', label);
+}
   function getAutoGearBackupEntrySignature(entry) {
     if (!entry || _typeof(entry) !== 'object') return '';
     return stableStringify({

--- a/src/scripts/app-core-new-1.js
+++ b/src/scripts/app-core-new-1.js
@@ -3731,6 +3731,28 @@ var autoGearSearchQuery = '';
 var autoGearSummaryFocus = 'all';
 var autoGearSummaryLast = null;
 var autoGearScenarioFilter = 'all';
+
+function updateAutoGearItemButtonState(type) {
+  const normalizedType = type === 'remove' ? 'remove' : 'add';
+  const button = normalizedType === 'remove' ? autoGearRemoveItemButton : autoGearAddItemButton;
+  if (!button) return;
+  const langTexts = texts[currentLang] || texts.en || {};
+  const isEditing = autoGearEditorActiveItem?.listType === normalizedType;
+  const defaultKey = normalizedType === 'remove' ? 'autoGearRemoveItemButton' : 'autoGearAddItemButton';
+  const defaultLabel = langTexts[defaultKey]
+    || texts.en?.[defaultKey]
+    || button.textContent
+    || '';
+  const updateLabel = langTexts.autoGearUpdateItemButton
+    || texts.en?.autoGearUpdateItemButton
+    || defaultLabel;
+  const label = isEditing ? updateLabel : defaultLabel;
+  const glyph = isEditing
+    ? ICON_GLYPHS.save
+    : (normalizedType === 'remove' ? ICON_GLYPHS.minus : ICON_GLYPHS.add);
+  setButtonLabelWithIcon(button, label, glyph);
+  button.setAttribute('data-help', label);
+}
 function getAutoGearBackupEntrySignature(entry) {
   if (!entry || typeof entry !== 'object') return '';
   return stableStringify({


### PR DESCRIPTION
## Summary
- define the auto gear button state helper in both modern and legacy app-core bundles so translation updates no longer throw
- ensure the helper updates labels and help text based on the current edit state

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e22d96f7b483209ac4d34bfecab86e