### PR TITLE
Expose missing globals for split runtime functions

### DIFF
--- a/legacy/scripts/app-core-new-2.js
+++ b/legacy/scripts/app-core-new-2.js
@@ -15392,6 +15392,8 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
       renderAutoGearRulesList: renderAutoGearRulesList,
       saveAutoGearRuleFromEditor: saveAutoGearRuleFromEditor,
       handleAutoGearImportSelection: handleAutoGearImportSelection,
+      handleAutoGearPresetSelection: handleAutoGearPresetSelection,
+      applyAutoGearBackupVisibility: applyAutoGearBackupVisibility,
       setAutoGearAutoPresetId: setAutoGearAutoPresetId,
       syncAutoGearAutoPreset: syncAutoGearAutoPreset,
       updateAutoGearCatalogOptions: updateAutoGearCatalogOptions,
@@ -15521,7 +15523,10 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
       ['confirmAutoGearSelection', function () { return confirmAutoGearSelection; }],
       ['configureSharedImportOptions', function () { return configureSharedImportOptions; }],
       ['resolveSharedImportMode', function () { return resolveSharedImportMode; }],
-      ['resetPlannerStateAfterFactoryReset', function () { return resetPlannerStateAfterFactoryReset; }]
+      ['resetPlannerStateAfterFactoryReset', function () { return resetPlannerStateAfterFactoryReset; }],
+      ['updateStorageSummary', function () { return updateStorageSummary; }],
+      ['normaliseMarkVariants', function () { return normaliseMarkVariants; }],
+      ['storeLoadedSetupState', function () { return storeLoadedSetupState; }]
     ];
 
     var resolvedAdditionalExports = ADDITIONAL_GLOBAL_EXPORT_ENTRIES.reduce(function (acc, entry) {

--- a/src/scripts/app-core-new-2.js
+++ b/src/scripts/app-core-new-2.js
@@ -16179,6 +16179,7 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
       saveAutoGearRuleFromEditor,
       handleAutoGearImportSelection,
       handleAutoGearPresetSelection,
+      applyAutoGearBackupVisibility,
       setAutoGearAutoPresetId,
       syncAutoGearAutoPreset,
       updateAutoGearCatalogOptions,
@@ -16313,6 +16314,9 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
       ['configureSharedImportOptions', () => configureSharedImportOptions],
       ['resolveSharedImportMode', () => resolveSharedImportMode],
       ['resetPlannerStateAfterFactoryReset', () => resetPlannerStateAfterFactoryReset],
+      ['updateStorageSummary', () => updateStorageSummary],
+      ['normaliseMarkVariants', () => normaliseMarkVariants],
+      ['storeLoadedSetupState', () => storeLoadedSetupState],
     ];
 
     const resolvedAdditionalExports = ADDITIONAL_GLOBAL_EXPORT_ENTRIES.reduce(


### PR DESCRIPTION
## Summary
- export the auto-gear backup visibility helper from the split runtime so UI toggles load
- expose storage summary, mark normalisation, and setup state persistence utilities and mirror the changes into the legacy bundle

## Testing
- npx jest --runInBand --runTestsByPath tests/unit/storage.test.js tests/unit/autoGearBackupRetention.test.js tests/unit/persistentStorage.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e230b7b66c83208ab7f30d81f0eb4c