### PR TITLE
Fix pink mode timers and translation fallback

### DIFF
--- a/src/scripts/app-core-new-1.js
+++ b/src/scripts/app-core-new-1.js
@@ -11968,6 +11968,12 @@ function scheduleNextPinkModeAnimatedIcon(templates) {
       scheduleNextPinkModeAnimatedIcon(templates);
     }
   }, delay);
+  if (
+    pinkModeAnimatedIconTimeoutId &&
+    typeof pinkModeAnimatedIconTimeoutId.unref === 'function'
+  ) {
+    pinkModeAnimatedIconTimeoutId.unref();
+  }
 }
 
 function startPinkModeAnimatedIcons() {
@@ -13151,7 +13157,13 @@ function fallbackAddInputClearButton(inputElem, callback) {
   if (!inputElem || typeof inputElem !== "object" || typeof inputElem.insertAdjacentElement !== "function") {
     return;
   }
-  const clearLabel = (texts[currentLang] && texts[currentLang].clearFilter) || "Clear filter";
+  const translationSource =
+    (typeof texts === "object" && texts)
+      || (typeof window !== "undefined" && typeof window.texts === "object" && window.texts)
+      || null;
+  const clearLabel =
+    (translationSource && translationSource[currentLang] && translationSource[currentLang].clearFilter)
+      || "Clear filter";
   const clearBtn = document.createElement("button");
   clearBtn.type = "button";
   clearBtn.className = "clear-input-btn";

--- a/src/scripts/app-session.js
+++ b/src/scripts/app-session.js
@@ -3401,6 +3401,12 @@ function startPinkModeIconRotation() {
     pinkModeIconIndex = (pinkModeIconIndex + 1) % sequence.length;
     applyPinkModeIcon(sequence[pinkModeIconIndex], { animate: true });
   }, PINK_MODE_ICON_INTERVAL_MS);
+  if (
+    pinkModeIconRotationTimer &&
+    typeof pinkModeIconRotationTimer.unref === 'function'
+  ) {
+    pinkModeIconRotationTimer.unref();
+  }
 }
 
 function applyPinkMode(enabled) {


### PR DESCRIPTION
## Summary
- prevent pink mode animation timers from keeping the Node.js event loop alive during tests by unref-ing their handles
- safely fall back to window-based translations when adding the filter clear button so the runtime works when `texts` isn't yet defined

## Testing
- npm run lint
- npx jest tests/unit/storageFallback.test.js --runInBand --verbose

------
https://chatgpt.com/codex/tasks/task_e_68e27a88446083209156aa868afe6fa5