### PR TITLE
Fix restore rehearsal translation lookups and export accent reset

### DIFF
--- a/src/scripts/app-core-new-1.js
+++ b/src/scripts/app-core-new-1.js
@@ -7839,6 +7839,90 @@ function setLanguage(lang) {
     "backupDiffCloseButton",
     "backupDiffClose"
   );
+  const restoreRehearsalButton = resolveElement(
+    "restoreRehearsalButton",
+    "restoreRehearsalButton"
+  );
+  const restoreRehearsalHeading = resolveElement(
+    "restoreRehearsalHeading",
+    "restoreRehearsalHeading"
+  );
+  const restoreRehearsalIntro = resolveElement(
+    "restoreRehearsalIntro",
+    "restoreRehearsalIntro"
+  );
+  const restoreRehearsalModeLabel = resolveElement(
+    "restoreRehearsalModeLabel",
+    "restoreRehearsalModeLabel"
+  );
+  const restoreRehearsalModeBackupText = resolveElement(
+    "restoreRehearsalModeBackupText",
+    "restoreRehearsalModeBackupText"
+  );
+  const restoreRehearsalModeProjectText = resolveElement(
+    "restoreRehearsalModeProjectText",
+    "restoreRehearsalModeProjectText"
+  );
+  const restoreRehearsalFileLabel = resolveElement(
+    "restoreRehearsalFileLabel",
+    "restoreRehearsalFileLabel"
+  );
+  const restoreRehearsalBrowse = resolveElement(
+    "restoreRehearsalBrowse",
+    "restoreRehearsalBrowse"
+  );
+  const restoreRehearsalFileName = resolveElement(
+    "restoreRehearsalFileName",
+    "restoreRehearsalFileName"
+  );
+  const restoreRehearsalStatus = resolveElement(
+    "restoreRehearsalStatus",
+    "restoreRehearsalStatus"
+  );
+  const restoreRehearsalRuleHeading = resolveElement(
+    "restoreRehearsalRuleHeading",
+    "restoreRehearsalRuleHeading"
+  );
+  const restoreRehearsalRuleIntro = resolveElement(
+    "restoreRehearsalRuleIntro",
+    "restoreRehearsalRuleIntro"
+  );
+  const restoreRehearsalRuleEmpty = resolveElement(
+    "restoreRehearsalRuleEmpty",
+    "restoreRehearsalRuleEmpty"
+  );
+  const restoreRehearsalTableCaption = resolveElement(
+    "restoreRehearsalTableCaption",
+    "restoreRehearsalTableCaption"
+  );
+  const restoreRehearsalMetricHeader = resolveElement(
+    "restoreRehearsalMetricHeader",
+    "restoreRehearsalMetricHeader"
+  );
+  const restoreRehearsalLiveHeader = resolveElement(
+    "restoreRehearsalLiveHeader",
+    "restoreRehearsalLiveHeader"
+  );
+  const restoreRehearsalSandboxHeader = resolveElement(
+    "restoreRehearsalSandboxHeader",
+    "restoreRehearsalSandboxHeader"
+  );
+  const restoreRehearsalDifferenceHeader = resolveElement(
+    "restoreRehearsalDifferenceHeader",
+    "restoreRehearsalDifferenceHeader"
+  );
+  const restoreRehearsalCloseButton = resolveElement(
+    "restoreRehearsalCloseButton",
+    "restoreRehearsalClose"
+  );
+  const restoreRehearsalProceedButton = resolveElement(
+    "restoreRehearsalProceedButton",
+    "restoreRehearsalProceed"
+  );
+  const restoreRehearsalAbortButton = resolveElement(
+    "restoreRehearsalAbortButton",
+    "restoreRehearsalAbort"
+  );
   if (skipLink) skipLink.textContent = texts[lang].skipToContent;
   const offlineElem = document.getElementById("offlineIndicator");
   if (offlineElem) {

--- a/src/scripts/app-core-new-2.js
+++ b/src/scripts/app-core-new-2.js
@@ -16236,6 +16236,7 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
       renderSettingsLogoPreview,
       normalizeSpellingVariants,
       prevAccentColor,
+      revertAccentColor,
       DEFAULT_ACCENT_COLOR,
       HIGH_CONTRAST_ACCENT_COLOR,
       applyAccentColor,


### PR DESCRIPTION
## Summary
- resolve restore rehearsal controls inside the language updater so translation bindings no longer throw reference errors
- expose the revertAccentColor helper from the core runtime so session flows can safely reset accent colors

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e29c8c4350832095739b9d7ca6c89c