### PR TITLE
Fix restore dialog bindings and guard accent revert helper

### DIFF
--- a/legacy/scripts/app-core-new-1.js
+++ b/legacy/scripts/app-core-new-1.js
@@ -7179,6 +7179,27 @@ function updateAutoGearItemButtonState(type) {
     var backupDiffNotesEl = resolveElement("backupDiffNotes", "backupDiffNotes");
     var backupDiffExportButtonEl = resolveElement("backupDiffExportButton", "backupDiffExport");
     var backupDiffCloseButtonEl = resolveElement("backupDiffCloseButton", "backupDiffClose");
+    var restoreRehearsalButton = resolveElement("restoreRehearsalButton", "restoreRehearsalButton");
+    var restoreRehearsalHeading = resolveElement("restoreRehearsalHeading", "restoreRehearsalHeading");
+    var restoreRehearsalIntro = resolveElement("restoreRehearsalIntro", "restoreRehearsalIntro");
+    var restoreRehearsalModeLabel = resolveElement("restoreRehearsalModeLabel", "restoreRehearsalModeLabel");
+    var restoreRehearsalModeBackupText = resolveElement("restoreRehearsalModeBackupText", "restoreRehearsalModeBackupText");
+    var restoreRehearsalModeProjectText = resolveElement("restoreRehearsalModeProjectText", "restoreRehearsalModeProjectText");
+    var restoreRehearsalFileLabel = resolveElement("restoreRehearsalFileLabel", "restoreRehearsalFileLabel");
+    var restoreRehearsalBrowse = resolveElement("restoreRehearsalBrowse", "restoreRehearsalBrowse");
+    var restoreRehearsalFileName = resolveElement("restoreRehearsalFileName", "restoreRehearsalFileName");
+    var restoreRehearsalStatus = resolveElement("restoreRehearsalStatus", "restoreRehearsalStatus");
+    var restoreRehearsalRuleHeading = resolveElement("restoreRehearsalRuleHeading", "restoreRehearsalRuleHeading");
+    var restoreRehearsalRuleIntro = resolveElement("restoreRehearsalRuleIntro", "restoreRehearsalRuleIntro");
+    var restoreRehearsalRuleEmpty = resolveElement("restoreRehearsalRuleEmpty", "restoreRehearsalRuleEmpty");
+    var restoreRehearsalTableCaption = resolveElement("restoreRehearsalTableCaption", "restoreRehearsalTableCaption");
+    var restoreRehearsalMetricHeader = resolveElement("restoreRehearsalMetricHeader", "restoreRehearsalMetricHeader");
+    var restoreRehearsalLiveHeader = resolveElement("restoreRehearsalLiveHeader", "restoreRehearsalLiveHeader");
+    var restoreRehearsalSandboxHeader = resolveElement("restoreRehearsalSandboxHeader", "restoreRehearsalSandboxHeader");
+    var restoreRehearsalDifferenceHeader = resolveElement("restoreRehearsalDifferenceHeader", "restoreRehearsalDifferenceHeader");
+    var restoreRehearsalCloseButton = resolveElement("restoreRehearsalCloseButton", "restoreRehearsalClose");
+    var restoreRehearsalProceedButton = resolveElement("restoreRehearsalProceedButton", "restoreRehearsalProceed");
+    var restoreRehearsalAbortButton = resolveElement("restoreRehearsalAbortButton", "restoreRehearsalAbort");
     if (skipLink) skipLink.textContent = texts[lang].skipToContent;
     var offlineElem = document.getElementById("offlineIndicator");
     if (offlineElem) {

--- a/legacy/scripts/app-session.js
+++ b/legacy/scripts/app-session.js
@@ -48,6 +48,70 @@ function ensureSessionRuntimePlaceholder(name, fallbackValue) {
   }
 }
 
+function getSessionRuntimeScopes() {
+  var scopes = [];
+  var addScope = function addScope(candidate) {
+    if (!candidate || _typeof(candidate) !== 'object') {
+      return;
+    }
+    if (scopes.indexOf(candidate) === -1) {
+      scopes.push(candidate);
+    }
+  };
+
+  try {
+    if (typeof CORE_GLOBAL_SCOPE !== 'undefined' && CORE_GLOBAL_SCOPE) {
+      addScope(CORE_GLOBAL_SCOPE);
+    }
+  } catch (coreScopeError) {
+    void coreScopeError;
+  }
+
+  addScope(typeof globalThis !== 'undefined' ? globalThis : null);
+  addScope(typeof window !== 'undefined' ? window : null);
+  addScope(typeof self !== 'undefined' ? self : null);
+  addScope(typeof global !== 'undefined' ? global : null);
+
+  return scopes;
+}
+
+function getSessionRuntimeFunction(name) {
+  if (typeof name !== 'string' || !name) {
+    return null;
+  }
+
+  var scopes = getSessionRuntimeScopes();
+  for (var index = 0; index < scopes.length; index += 1) {
+    var scope = scopes[index];
+    var candidate = null;
+    try {
+      candidate = scope[name];
+    } catch (resolveError) {
+      candidate = null;
+      void resolveError;
+    }
+
+    if (typeof candidate === 'function') {
+      return candidate;
+    }
+  }
+
+  return null;
+}
+
+function invokeSessionRevertAccentColor() {
+  var revertFn = getSessionRuntimeFunction('revertAccentColor');
+  if (typeof revertFn !== 'function') {
+    return;
+  }
+
+  try {
+    revertFn();
+  } catch (revertError) {
+    console.warn('Failed to revert accent color', revertError);
+  }
+}
+
 ensureSessionRuntimePlaceholder('autoGearScenarioModeSelect', null);
 var gridSnapToggleBtn = ensureSessionRuntimePlaceholder('gridSnapToggleBtn', function () {
   if (typeof document === 'undefined' || !document || typeof document.getElementById !== 'function') {
@@ -3204,7 +3268,7 @@ if (settingsButton && settingsDialog) {
       rememberSettingsShowAutoBackupsBaseline();
       revertSettingsMountVoltagesIfNeeded();
       rememberSettingsMountVoltagesBaseline();
-      revertAccentColor();
+      invokeSessionRevertAccentColor();
       if (settingsLogo) settingsLogo.value = '';
       if (settingsLogoPreview) loadStoredLogoPreview();
       closeAutoGearEditor();
@@ -3348,7 +3412,7 @@ if (settingsButton && settingsDialog) {
       rememberSettingsShowAutoBackupsBaseline();
       revertSettingsMountVoltagesIfNeeded();
       rememberSettingsMountVoltagesBaseline();
-      revertAccentColor();
+      invokeSessionRevertAccentColor();
       if (settingsLogo) settingsLogo.value = '';
       if (settingsLogoPreview) loadStoredLogoPreview();
       closeAutoGearEditor();
@@ -3367,7 +3431,7 @@ if (settingsButton && settingsDialog) {
     rememberSettingsShowAutoBackupsBaseline();
     revertSettingsMountVoltagesIfNeeded();
     rememberSettingsMountVoltagesBaseline();
-    revertAccentColor();
+    invokeSessionRevertAccentColor();
     if (settingsLogo) settingsLogo.value = '';
     if (settingsLogoPreview) loadStoredLogoPreview();
     closeAutoGearEditor();
@@ -9499,7 +9563,7 @@ if (helpButton && helpDialog) {
       rememberSettingsPinkModeBaseline();
       revertSettingsTemperatureUnitIfNeeded();
       rememberSettingsTemperatureUnitBaseline();
-      revertAccentColor();
+      invokeSessionRevertAccentColor();
       closeDialog(settingsDialog);
       settingsDialog.setAttribute('hidden', '');
     } else if (e.key === 'F1' || (e.key === '/' || e.key === '?') && (e.ctrlKey || e.metaKey)) {

--- a/src/scripts/app-core-new-1.js
+++ b/src/scripts/app-core-new-1.js
@@ -7839,6 +7839,90 @@ function setLanguage(lang) {
     "backupDiffCloseButton",
     "backupDiffClose"
   );
+  const restoreRehearsalButton = resolveElement(
+    "restoreRehearsalButton",
+    "restoreRehearsalButton"
+  );
+  const restoreRehearsalHeading = resolveElement(
+    "restoreRehearsalHeading",
+    "restoreRehearsalHeading"
+  );
+  const restoreRehearsalIntro = resolveElement(
+    "restoreRehearsalIntro",
+    "restoreRehearsalIntro"
+  );
+  const restoreRehearsalModeLabel = resolveElement(
+    "restoreRehearsalModeLabel",
+    "restoreRehearsalModeLabel"
+  );
+  const restoreRehearsalModeBackupText = resolveElement(
+    "restoreRehearsalModeBackupText",
+    "restoreRehearsalModeBackupText"
+  );
+  const restoreRehearsalModeProjectText = resolveElement(
+    "restoreRehearsalModeProjectText",
+    "restoreRehearsalModeProjectText"
+  );
+  const restoreRehearsalFileLabel = resolveElement(
+    "restoreRehearsalFileLabel",
+    "restoreRehearsalFileLabel"
+  );
+  const restoreRehearsalBrowse = resolveElement(
+    "restoreRehearsalBrowse",
+    "restoreRehearsalBrowse"
+  );
+  const restoreRehearsalFileName = resolveElement(
+    "restoreRehearsalFileName",
+    "restoreRehearsalFileName"
+  );
+  const restoreRehearsalStatus = resolveElement(
+    "restoreRehearsalStatus",
+    "restoreRehearsalStatus"
+  );
+  const restoreRehearsalRuleHeading = resolveElement(
+    "restoreRehearsalRuleHeading",
+    "restoreRehearsalRuleHeading"
+  );
+  const restoreRehearsalRuleIntro = resolveElement(
+    "restoreRehearsalRuleIntro",
+    "restoreRehearsalRuleIntro"
+  );
+  const restoreRehearsalRuleEmpty = resolveElement(
+    "restoreRehearsalRuleEmpty",
+    "restoreRehearsalRuleEmpty"
+  );
+  const restoreRehearsalTableCaption = resolveElement(
+    "restoreRehearsalTableCaption",
+    "restoreRehearsalTableCaption"
+  );
+  const restoreRehearsalMetricHeader = resolveElement(
+    "restoreRehearsalMetricHeader",
+    "restoreRehearsalMetricHeader"
+  );
+  const restoreRehearsalLiveHeader = resolveElement(
+    "restoreRehearsalLiveHeader",
+    "restoreRehearsalLiveHeader"
+  );
+  const restoreRehearsalSandboxHeader = resolveElement(
+    "restoreRehearsalSandboxHeader",
+    "restoreRehearsalSandboxHeader"
+  );
+  const restoreRehearsalDifferenceHeader = resolveElement(
+    "restoreRehearsalDifferenceHeader",
+    "restoreRehearsalDifferenceHeader"
+  );
+  const restoreRehearsalCloseButton = resolveElement(
+    "restoreRehearsalCloseButton",
+    "restoreRehearsalClose"
+  );
+  const restoreRehearsalProceedButton = resolveElement(
+    "restoreRehearsalProceedButton",
+    "restoreRehearsalProceed"
+  );
+  const restoreRehearsalAbortButton = resolveElement(
+    "restoreRehearsalAbortButton",
+    "restoreRehearsalAbort"
+  );
   if (skipLink) skipLink.textContent = texts[lang].skipToContent;
   const offlineElem = document.getElementById("offlineIndicator");
   if (offlineElem) {

--- a/src/scripts/app-session.js
+++ b/src/scripts/app-session.js
@@ -126,6 +126,19 @@ function getSessionRuntimeFunction(name) {
   return null;
 }
 
+function invokeSessionRevertAccentColor() {
+  const revertFn = getSessionRuntimeFunction('revertAccentColor');
+  if (typeof revertFn !== 'function') {
+    return;
+  }
+
+  try {
+    revertFn();
+  } catch (revertError) {
+    console.warn('Failed to revert accent color', revertError);
+  }
+}
+
 ensureSessionRuntimePlaceholder('autoGearScenarioModeSelect', null);
 
 const downloadDiagramButton = ensureSessionRuntimePlaceholder(
@@ -3776,7 +3789,7 @@ const mountVoltageResetButtonRef = (() => {
       rememberSettingsShowAutoBackupsBaseline();
       revertSettingsMountVoltagesIfNeeded();
       rememberSettingsMountVoltagesBaseline();
-      revertAccentColor();
+      invokeSessionRevertAccentColor();
       if (settingsLogo) settingsLogo.value = '';
       if (settingsLogoPreview) safeLoadStoredLogoPreview();
       closeAutoGearEditor();
@@ -3922,7 +3935,7 @@ const mountVoltageResetButtonRef = (() => {
       rememberSettingsShowAutoBackupsBaseline();
       revertSettingsMountVoltagesIfNeeded();
       rememberSettingsMountVoltagesBaseline();
-      revertAccentColor();
+      invokeSessionRevertAccentColor();
       if (settingsLogo) settingsLogo.value = '';
       if (settingsLogoPreview) safeLoadStoredLogoPreview();
       closeAutoGearEditor();
@@ -3942,7 +3955,7 @@ const mountVoltageResetButtonRef = (() => {
     rememberSettingsShowAutoBackupsBaseline();
     revertSettingsMountVoltagesIfNeeded();
     rememberSettingsMountVoltagesBaseline();
-    revertAccentColor();
+    invokeSessionRevertAccentColor();
     if (settingsLogo) settingsLogo.value = '';
     if (settingsLogoPreview) safeLoadStoredLogoPreview();
     closeAutoGearEditor();
@@ -10615,7 +10628,7 @@ if (helpButton && helpDialog) {
       rememberSettingsPinkModeBaseline();
       revertSettingsTemperatureUnitIfNeeded();
       rememberSettingsTemperatureUnitBaseline();
-      revertAccentColor();
+      invokeSessionRevertAccentColor();
       closeDialog(settingsDialog);
       settingsDialog.setAttribute('hidden', '');
     } else if (


### PR DESCRIPTION
## Summary
- resolve all restore rehearsal controls through `resolveElement` so language updates no longer reference undefined globals
- add a runtime-checked `invokeSessionRevertAccentColor` helper and reuse it across settings flows to avoid ReferenceErrors in both modern and legacy scripts

## Testing
- npm test -- --watch=false *(aborted after extended hang during Jest DOM suite)*

------
https://chatgpt.com/codex/tasks/task_e_68e29d6bb47083209398d8dccdaee6bf