### PR TITLE
Fix undefined references across runtime scripts

### DIFF
--- a/src/scripts/app-core-new-2.js
+++ b/src/scripts/app-core-new-2.js
@@ -16241,7 +16241,6 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
       HIGH_CONTRAST_ACCENT_COLOR,
       applyAccentColor,
       clearAccentColorOverrides,
-      revertAccentColor,
       updateAccentColorResetButtonState,
       restoringSession,
       currentProjectInfo,


### PR DESCRIPTION
## Summary
- add helpers that defer to core runtime functions so early calls no longer reference undefined globals
- resolve language update logic by querying required DOM nodes locally before using them
- drop the duplicate `revertAccentColor` export entry from the part 2 runtime bundle

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e2a1feef548320beb1043b33307e08