### PR TITLE
Guard pink mode rotation helpers before session bootstrap

### DIFF
--- a/legacy/scripts/app-core-new-1.js
+++ b/legacy/scripts/app-core-new-1.js
@@ -9754,12 +9754,18 @@ function updateAutoGearItemButtonState(type) {
     }
     pinkModeIcons.onSequence = Object.freeze(configs);
     if (typeof document !== 'undefined' && document.body && document.body.classList.contains('pink-mode')) {
-      stopPinkModeIconRotation();
+      if (typeof stopPinkModeIconRotation === 'function') {
+        stopPinkModeIconRotation();
+      }
       pinkModeIconIndex = 0;
-      applyPinkModeIcon(pinkModeIcons.onSequence[pinkModeIconIndex], {
-        animate: false
-      });
-      startPinkModeIconRotation();
+      if (typeof applyPinkModeIcon === 'function') {
+        applyPinkModeIcon(pinkModeIcons.onSequence[pinkModeIconIndex], {
+          animate: false
+        });
+      }
+      if (typeof startPinkModeIconRotation === 'function') {
+        startPinkModeIconRotation();
+      }
     }
     return true;
   }

--- a/src/scripts/app-core-new-1.js
+++ b/src/scripts/app-core-new-1.js
@@ -11031,10 +11031,16 @@ function setPinkModeIconSequence(markupList) {
     document.body &&
     document.body.classList.contains('pink-mode')
   ) {
-    stopPinkModeIconRotation();
+    if (typeof stopPinkModeIconRotation === 'function') {
+      stopPinkModeIconRotation();
+    }
     pinkModeIconIndex = 0;
-    applyPinkModeIcon(pinkModeIcons.onSequence[pinkModeIconIndex], { animate: false });
-    startPinkModeIconRotation();
+    if (typeof applyPinkModeIcon === 'function') {
+      applyPinkModeIcon(pinkModeIcons.onSequence[pinkModeIconIndex], { animate: false });
+    }
+    if (typeof startPinkModeIconRotation === 'function') {
+      startPinkModeIconRotation();
+    }
   }
   return true;
 }


### PR DESCRIPTION
## Summary
- guard the pink mode icon rotation helpers in the modern runtime so they only run once the session script has registered them
- mirror the same safeguards in the legacy runtime to preserve bundle parity

## Testing
- npm test -- sharedProjectGearList *(fails: Duplicate key 'revertAccentColor' reported by eslint in src/scripts/app-core-new-2.js)*

------
https://chatgpt.com/codex/tasks/task_e_68e2a3821c308320ba06d815738ebc85