### PR TITLE
Fix runtime resolution errors for session UI

### DIFF
--- a/legacy/scripts/app-core-new-1.js
+++ b/legacy/scripts/app-core-new-1.js
@@ -7167,14 +7167,34 @@ function updateAutoGearItemButtonState(type) {
       return element;
     };
     var resolveElement = function resolveElement(globalName, elementId) {
-      var existing = resolveRuntimeValue(globalName);
+      var existing = null;
+      try {
+        existing = resolveRuntimeValue(globalName);
+      } catch (resolveError) {
+        console.warn(
+          "Failed to resolve runtime value for \"".concat(globalName, "\""),
+          resolveError,
+        );
+        existing = null;
+      }
+
       if (existing && typeof existing === "object") {
         return existing;
       }
+
       if (doc && typeof doc.getElementById === "function" && elementId) {
-        var element = doc.getElementById(elementId);
-        return registerResolvedElement(globalName, element);
+        try {
+          var element = doc.getElementById(elementId);
+          return registerResolvedElement(globalName, element);
+        } catch (resolveDomError) {
+          console.warn(
+            "Failed to resolve document element \"".concat(elementId, "\""),
+            resolveDomError,
+          );
+          return null;
+        }
       }
+
       return null;
     };
     var settingsShowAutoBackupsEl = resolveElement("settingsShowAutoBackups", "settingsShowAutoBackups");

--- a/legacy/scripts/app-session.js
+++ b/legacy/scripts/app-session.js
@@ -112,6 +112,20 @@ function invokeSessionRevertAccentColor() {
   }
 }
 
+function invokeSessionOpenAutoGearEditor() {
+  var openFn = getSessionRuntimeFunction('openAutoGearEditor');
+  if (typeof openFn !== 'function') {
+    console.warn('Auto Gear editor runtime is not available yet.');
+    return;
+  }
+
+  try {
+    openFn.apply(void 0, arguments);
+  } catch (openError) {
+    console.warn('Failed to open Auto Gear editor', openError);
+  }
+}
+
 ensureSessionRuntimePlaceholder('autoGearScenarioModeSelect', null);
 var gridSnapToggleBtn = ensureSessionRuntimePlaceholder('gridSnapToggleBtn', function () {
   if (typeof document === 'undefined' || !document || typeof document.getElementById !== 'function') {
@@ -3441,7 +3455,7 @@ if (settingsButton && settingsDialog) {
   });
   if (autoGearAddRuleBtn) {
     autoGearAddRuleBtn.addEventListener('click', function () {
-      openAutoGearEditor();
+      invokeSessionOpenAutoGearEditor();
     });
   }
   if (autoGearConditionSelect) {
@@ -3627,7 +3641,7 @@ if (settingsButton && settingsDialog) {
       var button = targetElement && typeof targetElement.closest === 'function' ? targetElement.closest('button') : null;
       if (!button) return;
       if (button.classList.contains('auto-gear-edit')) {
-        openAutoGearEditor(button.dataset.ruleId || '');
+        invokeSessionOpenAutoGearEditor(button.dataset.ruleId || '');
       } else if (button.classList.contains('auto-gear-duplicate')) {
         duplicateAutoGearRule(button.dataset.ruleId || '');
       } else if (button.classList.contains('auto-gear-delete')) {

--- a/src/scripts/app-core-new-1.js
+++ b/src/scripts/app-core-new-1.js
@@ -7857,14 +7857,34 @@ function setLanguage(lang) {
     return element;
   };
   const resolveElement = (globalName, elementId) => {
-    const existing = resolveRuntimeValue(globalName);
+    let existing = null;
+    try {
+      existing = resolveRuntimeValue(globalName);
+    } catch (resolveError) {
+      console.warn(
+        `Failed to resolve runtime value for "${globalName}"`,
+        resolveError,
+      );
+      existing = null;
+    }
+
     if (existing && typeof existing === "object") {
       return existing;
     }
+
     if (doc && typeof doc.getElementById === "function" && elementId) {
-      const element = doc.getElementById(elementId);
-      return registerResolvedElement(globalName, element);
+      try {
+        const element = doc.getElementById(elementId);
+        return registerResolvedElement(globalName, element);
+      } catch (resolveDomError) {
+        console.warn(
+          `Failed to resolve document element "${elementId}"`,
+          resolveDomError,
+        );
+        return null;
+      }
     }
+
     return null;
   };
   const settingsShowAutoBackupsEl = resolveElement(

--- a/src/scripts/app-session.js
+++ b/src/scripts/app-session.js
@@ -139,6 +139,20 @@ function invokeSessionRevertAccentColor() {
   }
 }
 
+function invokeSessionOpenAutoGearEditor(...args) {
+  const openFn = getSessionRuntimeFunction('openAutoGearEditor');
+  if (typeof openFn !== 'function') {
+    console.warn('Auto Gear editor runtime is not available yet.');
+    return;
+  }
+
+  try {
+    openFn(...args);
+  } catch (openError) {
+    console.warn('Failed to open Auto Gear editor', openError);
+  }
+}
+
 ensureSessionRuntimePlaceholder('autoGearScenarioModeSelect', null);
 
 const downloadDiagramButton = ensureSessionRuntimePlaceholder(
@@ -3966,7 +3980,7 @@ const mountVoltageResetButtonRef = (() => {
 
 if (autoGearAddRuleBtn) {
   autoGearAddRuleBtn.addEventListener('click', () => {
-    openAutoGearEditor();
+    invokeSessionOpenAutoGearEditor();
   });
 }
 if (autoGearConditionSelect) {
@@ -4162,7 +4176,7 @@ if (autoGearAddItemButton) {
         : null;
       if (!button) return;
       if (button.classList.contains('auto-gear-edit')) {
-        openAutoGearEditor(button.dataset.ruleId || '');
+        invokeSessionOpenAutoGearEditor(button.dataset.ruleId || '');
       } else if (button.classList.contains('auto-gear-duplicate')) {
         duplicateAutoGearRule(button.dataset.ruleId || '');
       } else if (button.classList.contains('auto-gear-delete')) {


### PR DESCRIPTION
## Summary
- harden the language setup element resolver to gracefully handle lookup failures
- add a guarded helper for opening the Auto Gear editor so session code waits for the runtime export (applied to both modern and legacy bundles)

## Testing
- npm test -- --runTestsByPath tests/smoke.test.js *(fails: no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68e2a7e57a7c8320b54c4c73de132018