### PR TITLE
Fix grid snap initialization to prevent ReferenceError

### DIFF
--- a/legacy/scripts/app-core-new-1.js
+++ b/legacy/scripts/app-core-new-1.js
@@ -67,6 +67,65 @@ if (CORE_PART1_RUNTIME_SCOPE && CORE_PART1_RUNTIME_SCOPE.__cineCorePart1Initiali
     return null;
   }
 
+  function ensureCoreGlobalValue(name, fallbackValue) {
+    var fallbackProvider =
+      typeof fallbackValue === 'function' ? fallbackValue : function () {
+        return fallbackValue;
+      };
+
+    if (typeof name !== 'string' || !name) {
+      return fallbackProvider();
+    }
+
+    var scope = getCoreGlobalObject();
+    if (!scope || _typeof(scope) !== 'object') {
+      return fallbackProvider();
+    }
+
+    var existing;
+    try {
+      existing = scope[name];
+    } catch (readError) {
+      existing = undefined;
+      void readError;
+    }
+
+    if (typeof existing !== 'undefined') {
+      return existing;
+    }
+
+    var value = fallbackProvider();
+
+    try {
+      scope[name] = value;
+      return scope[name];
+    } catch (assignError) {
+      void assignError;
+    }
+
+    try {
+      Object.defineProperty(scope, name, {
+        configurable: true,
+        writable: true,
+        value: value
+      });
+    } catch (defineError) {
+      void defineError;
+    }
+
+    try {
+      return scope[name];
+    } catch (finalReadError) {
+      void finalReadError;
+    }
+
+    return value;
+  }
+
+  ensureCoreGlobalValue('gridSnap', function () {
+    return false;
+  });
+
   function dispatchTemperatureNoteRender(hours) {
     var scope = getCoreGlobalObject();
     var renderer = null;


### PR DESCRIPTION
## Summary
- ensure the grid snap runtime flag is initialised safely in the modern core bundle
- mirror the initialisation helper in the legacy bundle to keep builds in sync

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e2a9c3a504832088ee0a2d84f1323f