### PR TITLE
chore: update legacy bundle

### DIFF
--- a/legacy/scripts/app-core-new-1.js
+++ b/legacy/scripts/app-core-new-1.js
@@ -47,71 +47,60 @@ if (CORE_PART1_RUNTIME_SCOPE && CORE_PART1_RUNTIME_SCOPE.__cineCorePart1Initiali
   var CORE_GLOBAL_SCOPE = CORE_PART1_RUNTIME_SCOPE;
   var CORE_TEMPERATURE_QUEUE_KEY = "__cinePendingTemperatureNote";
   var CORE_TEMPERATURE_RENDER_NAME = "renderTemperatureNote";
-
   function getCoreGlobalObject() {
     if (CORE_GLOBAL_SCOPE && _typeof(CORE_GLOBAL_SCOPE) === "object") {
       return CORE_GLOBAL_SCOPE;
     }
-    if (typeof globalThis !== "undefined" && _typeof(globalThis) === "object") {
+    if (typeof globalThis !== "undefined" && (typeof globalThis === "undefined" ? "undefined" : _typeof(globalThis)) === "object") {
       return globalThis;
     }
-    if (typeof window !== "undefined" && _typeof(window) === "object") {
+    if (typeof window !== "undefined" && (typeof window === "undefined" ? "undefined" : _typeof(window)) === "object") {
       return window;
     }
-    if (typeof self !== "undefined" && _typeof(self) === "object") {
+    if (typeof self !== "undefined" && (typeof self === "undefined" ? "undefined" : _typeof(self)) === "object") {
       return self;
     }
-    if (typeof global !== "undefined" && _typeof(global) === "object") {
+    if (typeof global !== "undefined" && (typeof global === "undefined" ? "undefined" : _typeof(global)) === "object") {
       return global;
     }
     return null;
   }
-
   function dispatchTemperatureNoteRender(hours) {
     var scope = getCoreGlobalObject();
     var renderer = null;
-
     try {
-      if (typeof renderTemperatureNote === 'function') {
+      if (typeof renderTemperatureNote === "function") {
         renderer = renderTemperatureNote;
       }
     } catch (referenceError) {
-      var message = String(referenceError && referenceError.message);
-      var isReferenceError =
-        referenceError &&
-        (referenceError.name === 'ReferenceError' || /is not defined|Cannot access uninitialized/i.test(message));
-
+      var isReferenceError = referenceError && (referenceError.name === "ReferenceError" || /is not defined|Cannot access uninitialized/i.test(String(referenceError && referenceError.message)));
       if (!isReferenceError) {
         throw referenceError;
       }
     }
-
-    if (!renderer && scope && _typeof(scope) === 'object') {
+    if (!renderer && scope && _typeof(scope) === "object") {
       try {
         var scopedRenderer = scope[CORE_TEMPERATURE_RENDER_NAME];
-        if (typeof scopedRenderer === 'function') {
+        if (typeof scopedRenderer === "function") {
           renderer = scopedRenderer;
         }
       } catch (readError) {
         void readError;
       }
     }
-
-    if (typeof renderer === 'function') {
+    if (typeof renderer === "function") {
       try {
         renderer(hours);
       } catch (renderError) {
-        if (typeof console !== 'undefined' && typeof console.error === 'function') {
-          console.error('Temperature note renderer failed', renderError);
+        if (typeof console !== "undefined" && typeof console.error === "function") {
+          console.error("Temperature note renderer failed", renderError);
         }
       }
       return;
     }
-
     if (!scope || _typeof(scope) !== "object") {
       return;
     }
-
     var pending = scope[CORE_TEMPERATURE_QUEUE_KEY];
     if (!pending || _typeof(pending) !== "object") {
       pending = {};
@@ -326,102 +315,94 @@ if (CORE_PART1_RUNTIME_SCOPE && CORE_PART1_RUNTIME_SCOPE.__cineCorePart1Initiali
       CORE_BOOT_QUEUE.push(task);
     }
   }
-    var AUTO_GEAR_GLOBAL_FALLBACKS = {
-      autoGearAutoPresetId: function autoGearAutoPresetId() {
-        return '';
-      },
-      baseAutoGearRules: function baseAutoGearRules() {
-        return [];
-      },
-      autoGearScenarioModeSelect: function autoGearScenarioModeSelect() {
-        return null;
-      },
-      safeGenerateConnectorSummary: function safeGenerateConnectorSummary() {
-        return function safeGenerateConnectorSummary(device) {
-          if (!device || _typeof(device) !== 'object') {
-            return '';
-          }
-          try {
-            var entries = Object.entries(device);
-            if (!entries.length) {
-              return '';
-            }
-            var _entries$ = _slicedToArray(entries[0], 2),
-              primaryKey = _entries$[0],
-              value = _entries$[1];
-            var label = typeof primaryKey === 'string' ? primaryKey.replace(/_/g, ' ') : 'connector';
-            return value ? "".concat(label, ": ").concat(value) : label;
-          } catch (fallbackError) {
-            void fallbackError;
-            return '';
-          }
-        };
-      },
-    };
-
-    var AUTO_GEAR_REFERENCE_NAMES = Object.keys(AUTO_GEAR_GLOBAL_FALLBACKS);
-
-    function isAutoGearGlobalReferenceError(error) {
-      if (!error || _typeof(error) !== 'object') {
-        return false;
-      }
-      var message = typeof error.message === 'string' ? error.message : '';
-      return error.name === 'ReferenceError' && AUTO_GEAR_REFERENCE_NAMES.some(function (name) {
-        return message.indexOf(name) !== -1;
-      });
-    }
-
-    function ensureAutoGearGlobal(scope, name) {
-      var createFallback = AUTO_GEAR_GLOBAL_FALLBACKS[name];
-      if (typeof createFallback !== 'function') {
-        return;
-      }
-      var fallbackValue = createFallback();
-      if (typeof scope[name] === 'undefined') {
-        try {
-          scope[name] = fallbackValue;
-        } catch (assignmentError) {
-          try {
-            Object.defineProperty(scope, name, {
-              configurable: true,
-              writable: true,
-              enumerable: false,
-              value: fallbackValue,
-            });
-          } catch (defineError) {
-            void defineError;
-          }
+  var AUTO_GEAR_GLOBAL_FALLBACKS = {
+    autoGearAutoPresetId: function autoGearAutoPresetId() {
+      return '';
+    },
+    baseAutoGearRules: function baseAutoGearRules() {
+      return [];
+    },
+    autoGearScenarioModeSelect: function autoGearScenarioModeSelect() {
+      return null;
+    },
+    safeGenerateConnectorSummary: function safeGenerateConnectorSummary() {
+      return function safeGenerateConnectorSummary(device) {
+        if (!device || _typeof(device) !== 'object') {
+          return '';
         }
-      }
+        try {
+          var entries = Object.entries(device);
+          if (!entries.length) {
+            return '';
+          }
+          var _entries$ = _slicedToArray(entries[0], 2),
+            primaryKey = _entries$[0],
+            value = _entries$[1];
+          var label = typeof primaryKey === 'string' ? primaryKey.replace(/_/g, ' ') : 'connector';
+          return value ? "".concat(label, ": ").concat(value) : label;
+        } catch (fallbackError) {
+          void fallbackError;
+          return '';
+        }
+      };
+    }
+  };
+  var AUTO_GEAR_REFERENCE_NAMES = Object.keys(AUTO_GEAR_GLOBAL_FALLBACKS);
+  function isAutoGearGlobalReferenceError(error) {
+    if (!error || _typeof(error) !== 'object') {
+      return false;
+    }
+    var message = typeof error.message === 'string' ? error.message : '';
+    return error.name === 'ReferenceError' && AUTO_GEAR_REFERENCE_NAMES.some(function (name) {
+      return message.includes(name);
+    });
+  }
+  function ensureAutoGearGlobal(scope, name) {
+    var createFallback = AUTO_GEAR_GLOBAL_FALLBACKS[name];
+    if (typeof createFallback !== 'function') {
+      return;
+    }
+    var fallbackValue = createFallback();
+    if (typeof scope[name] === 'undefined') {
       try {
-        var globalFn = scope && scope.Function || Function;
-        if (typeof globalFn === 'function') {
-          var binder = globalFn(
-            'value',
-            "if (typeof ".concat(name, " === 'undefined') { var ").concat(name, " = value; } else { ").concat(name, " = value; } return ").concat(name, ';'),
-          );
-          var appliedValue = typeof scope[name] === 'undefined' ? fallbackValue : scope[name];
-          binder(appliedValue);
-        }
-      } catch (bindingError) {
-        void bindingError;
-      }
-    }
-
-    function repairAutoGearGlobals(scope) {
-      if (!scope || _typeof(scope) !== 'object' && typeof scope !== 'function') {
-        return;
-      }
-      AUTO_GEAR_REFERENCE_NAMES.forEach(function (name) {
+        scope[name] = fallbackValue;
+      } catch (assignmentError) {
         try {
-          ensureAutoGearGlobal(scope, name);
-        } catch (ensureError) {
-          void ensureError;
+          Object.defineProperty(scope, name, {
+            configurable: true,
+            writable: true,
+            enumerable: false,
+            value: fallbackValue
+          });
+        } catch (defineError) {
+          void defineError;
         }
-      });
+      }
     }
-
-    function callCoreFunctionIfAvailable(functionName) {
+    try {
+      var globalFn = scope && scope.Function || Function;
+      if (typeof globalFn === 'function') {
+        var binder = globalFn('value', "if (typeof ".concat(name, " === 'undefined') { var ").concat(name, " = value; } else { ").concat(name, " = value; }\n           return ").concat(name, ";"));
+        var appliedValue = typeof scope[name] === 'undefined' ? fallbackValue : scope[name];
+        binder(appliedValue);
+      }
+    } catch (bindingError) {
+      void bindingError;
+    }
+  }
+  function repairAutoGearGlobals(scope) {
+    if (!scope || _typeof(scope) !== 'object' && typeof scope !== 'function') {
+      return;
+    }
+    AUTO_GEAR_REFERENCE_NAMES.forEach(function (name) {
+      try {
+        ensureAutoGearGlobal(scope, name);
+      } catch (ensureError) {
+        void ensureError;
+      }
+    });
+  }
+  function callCoreFunctionIfAvailable(functionName) {
     var args = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : [];
     var options = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {};
     var scope = CORE_GLOBAL_SCOPE || (typeof globalThis !== 'undefined' ? globalThis : null) || (typeof window !== 'undefined' ? window : null) || (typeof self !== 'undefined' ? self : null) || (typeof global !== 'undefined' ? global : null);
@@ -429,14 +410,14 @@ if (CORE_PART1_RUNTIME_SCOPE && CORE_PART1_RUNTIME_SCOPE.__cineCorePart1Initiali
     if (typeof target === 'function') {
       var attempt = 0;
       while (attempt < 2) {
-          try {
-            return target.apply(scope, args);
-          } catch (invokeError) {
-            if (attempt === 0 && isAutoGearGlobalReferenceError(invokeError)) {
-              repairAutoGearGlobals(scope);
-              attempt += 1;
-              continue;
-            }
+        try {
+          return target.apply(scope, args);
+        } catch (invokeError) {
+          if (attempt === 0 && isAutoGearGlobalReferenceError(invokeError)) {
+            repairAutoGearGlobals(scope);
+            attempt += 1;
+            continue;
+          }
           if (typeof console !== 'undefined' && typeof console.error === 'function') {
             console.error("Failed to invoke ".concat(functionName), invokeError);
           }
@@ -453,6 +434,59 @@ if (CORE_PART1_RUNTIME_SCOPE && CORE_PART1_RUNTIME_SCOPE.__cineCorePart1Initiali
       });
     }
     return typeof options !== 'undefined' && Object.prototype.hasOwnProperty.call(options, 'defaultValue') ? options.defaultValue : undefined;
+  }
+  function safeFormatAutoGearItemSummary(item) {
+    var options = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+    if (typeof formatAutoGearItemSummary === 'function') {
+      try {
+        return formatAutoGearItemSummary(item, options);
+      } catch (formatError) {
+        if (typeof console !== 'undefined' && typeof console.warn === 'function') {
+          console.warn('Failed to format automatic gear item summary via direct formatter.', formatError);
+        }
+      }
+    }
+    var fallback = callCoreFunctionIfAvailable('formatAutoGearItemSummary', [item, options], {
+      defaultValue: ''
+    });
+    if (typeof fallback === 'string') {
+      return fallback;
+    }
+    if (fallback === null || typeof fallback === 'undefined') {
+      return '';
+    }
+    try {
+      return String(fallback);
+    } catch (coerceError) {
+      void coerceError;
+      return '';
+    }
+  }
+  function formatWithPlaceholdersSafe(template) {
+    for (var _len = arguments.length, values = new Array(_len > 1 ? _len - 1 : 0), _key = 1; _key < _len; _key++) {
+      values[_key - 1] = arguments[_key];
+    }
+    if (typeof formatWithPlaceholders === 'function') {
+      try {
+        return formatWithPlaceholders.apply(void 0, [template].concat(values));
+      } catch (formatError) {
+        if (typeof console !== 'undefined' && typeof console.warn === 'function') {
+          console.warn('Failed to format placeholder template via direct formatter.', formatError);
+        }
+      }
+    }
+    var fallback = callCoreFunctionIfAvailable('formatWithPlaceholders', [template].concat(values), {
+      defaultValue: null
+    });
+    if (typeof fallback === 'string' && fallback) {
+      return fallback;
+    }
+    var formatted = typeof template === 'string' ? template : String(template || '');
+    for (var index = 0; index < values.length; index += 1) {
+      var value = values[index];
+      formatted = formatted.replace('%s', value);
+    }
+    return formatted;
   }
   (function ensureCoreRuntimePlaceholders() {
     var scope = CORE_GLOBAL_SCOPE || (typeof globalThis !== 'undefined' ? globalThis : null) || (typeof window !== 'undefined' ? window : null) || (typeof self !== 'undefined' ? self : null) || (typeof global !== 'undefined' ? global : null);
@@ -515,8 +549,8 @@ if (CORE_PART1_RUNTIME_SCOPE && CORE_PART1_RUNTIME_SCOPE.__cineCorePart1Initiali
         return;
       }
       var placeholder = function coreDeferredFunctionPlaceholder() {
-        for (var _len = arguments.length, args = new Array(_len), _key = 0; _key < _len; _key++) {
-          args[_key] = arguments[_key];
+        for (var _len2 = arguments.length, args = new Array(_len2), _key2 = 0; _key2 < _len2; _key2++) {
+          args[_key2] = arguments[_key2];
         }
         return callCoreFunctionIfAvailable(name, args, {
           defer: true
@@ -875,7 +909,7 @@ if (CORE_PART1_RUNTIME_SCOPE && CORE_PART1_RUNTIME_SCOPE.__cineCorePart1Initiali
   }
   function getLanguageTexts(lang) {
     var resolved = resolveLanguageCode(lang);
-    var allTexts = typeof texts !== 'undefined' && texts ? texts : {};
+    var allTexts = typeof texts !== 'undefined' && texts || {};
     if (allTexts && _typeof(allTexts[resolved]) === 'object') {
       return allTexts[resolved] || {};
     }
@@ -914,50 +948,54 @@ if (CORE_PART1_RUNTIME_SCOPE && CORE_PART1_RUNTIME_SCOPE.__cineCorePart1Initiali
     }
     return TEMPERATURE_UNITS.celsius;
   }
-  function convertCelsiusToUnit(value, unit) {
-    var targetUnit = typeof unit === 'undefined' ? temperatureUnit : unit;
+  function convertCelsiusToUnit(value) {
+    var unit = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : temperatureUnit;
     var numeric = Number(value);
     if (!Number.isFinite(numeric)) {
       return Number.NaN;
     }
-    var resolvedUnit = normalizeTemperatureUnit(targetUnit);
+    var resolvedUnit = normalizeTemperatureUnit(unit);
     if (resolvedUnit === TEMPERATURE_UNITS.fahrenheit) {
       return numeric * 9 / 5 + 32;
     }
     return numeric;
   }
-  function getTemperatureUnitSymbolForLang(lang, unit) {
-    var targetLang = typeof lang === 'undefined' ? currentLang : lang;
-    var targetUnit = typeof unit === 'undefined' ? temperatureUnit : unit;
-    var resolvedUnit = normalizeTemperatureUnit(targetUnit);
-    var langTexts = getLanguageTexts(targetLang);
+  function getTemperatureUnitSymbolForLang() {
+    var lang = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : currentLang;
+    var unit = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : temperatureUnit;
+    var resolvedUnit = normalizeTemperatureUnit(unit);
+    var langTexts = getLanguageTexts(lang);
     var fallbackTexts = getLanguageTexts('en');
     var key = resolvedUnit === TEMPERATURE_UNITS.fahrenheit ? 'temperatureUnitSymbolFahrenheit' : 'temperatureUnitSymbolCelsius';
     return langTexts[key] || fallbackTexts[key] || (resolvedUnit === TEMPERATURE_UNITS.fahrenheit ? '°F' : '°C');
   }
-  function getTemperatureUnitLabelForLang(lang, unit) {
-    var targetLang = typeof lang === 'undefined' ? currentLang : lang;
-    var targetUnit = typeof unit === 'undefined' ? temperatureUnit : unit;
-    var resolvedUnit = normalizeTemperatureUnit(targetUnit);
-    var langTexts = getLanguageTexts(targetLang);
+  function getTemperatureUnitLabelForLang() {
+    var lang = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : currentLang;
+    var unit = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : temperatureUnit;
+    var resolvedUnit = normalizeTemperatureUnit(unit);
+    var langTexts = getLanguageTexts(lang);
     var fallbackTexts = getLanguageTexts('en');
     var key = resolvedUnit === TEMPERATURE_UNITS.fahrenheit ? 'temperatureUnitFahrenheit' : 'temperatureUnitCelsius';
     return langTexts[key] || fallbackTexts[key] || (resolvedUnit === TEMPERATURE_UNITS.fahrenheit ? 'Fahrenheit (°F)' : 'Celsius (°C)');
   }
-  function getTemperatureColumnLabelForLang(lang, unit) {
-    var targetLang = typeof lang === 'undefined' ? currentLang : lang;
-    var targetUnit = typeof unit === 'undefined' ? temperatureUnit : unit;
-    var langTexts = getLanguageTexts(targetLang);
+  function getTemperatureColumnLabelForLang() {
+    var lang = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : currentLang;
+    var unit = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : temperatureUnit;
+    var langTexts = getLanguageTexts(lang);
     var fallbackTexts = getLanguageTexts('en');
     var baseLabel = langTexts.temperatureLabel || fallbackTexts.temperatureLabel || 'Temperature';
-    var symbol = getTemperatureUnitSymbolForLang(targetLang, targetUnit);
-    return baseLabel + ' (' + symbol + ')';
+    var symbol = getTemperatureUnitSymbolForLang(lang, unit);
+    return "".concat(baseLabel, " (").concat(symbol, ")");
   }
-  function formatTemperatureForDisplay(celsius, options) {
-    var opts = options && _typeof(options) === 'object' ? options : {};
-    var unit = typeof opts.unit === 'undefined' ? temperatureUnit : opts.unit;
-    var lang = typeof opts.lang === 'undefined' ? currentLang : opts.lang;
-    var includeSign = typeof opts.includeSign === 'undefined' ? true : opts.includeSign;
+  function formatTemperatureForDisplay(celsius) {
+    var options = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+    var _ref3 = options || {},
+      _ref3$unit = _ref3.unit,
+      unit = _ref3$unit === void 0 ? temperatureUnit : _ref3$unit,
+      _ref3$lang = _ref3.lang,
+      lang = _ref3$lang === void 0 ? currentLang : _ref3$lang,
+      _ref3$includeSign = _ref3.includeSign,
+      includeSign = _ref3$includeSign === void 0 ? true : _ref3$includeSign;
     var resolvedUnit = normalizeTemperatureUnit(unit);
     var converted = convertCelsiusToUnit(celsius, resolvedUnit);
     if (!Number.isFinite(converted)) {
@@ -980,15 +1018,15 @@ if (CORE_PART1_RUNTIME_SCOPE && CORE_PART1_RUNTIME_SCOPE.__cineCorePart1Initiali
       prefix = '';
     } else if (includeSign === false || includeSign === 'negative') {
       if (isNegative) {
-        prefix = '\u2013';
+        prefix = "\u2013";
       }
     } else if (isPositive) {
       prefix = '+';
     } else if (isNegative) {
-      prefix = '\u2013';
+      prefix = "\u2013";
     }
     var symbol = getTemperatureUnitSymbolForLang(lang, resolvedUnit);
-    return '' + prefix + formatted + ' ' + symbol;
+    return "".concat(prefix).concat(formatted, " ").concat(symbol);
   }
   function renderTemperatureNote(baseHours) {
     if (typeof document === 'undefined') {
@@ -1001,7 +1039,7 @@ if (CORE_PART1_RUNTIME_SCOPE && CORE_PART1_RUNTIME_SCOPE.__cineCorePart1Initiali
     var langTexts = getLanguageTexts(currentLang);
     var fallbackTexts = getLanguageTexts('en');
     var heading = langTexts.temperatureNoteHeading || fallbackTexts.temperatureNoteHeading || '';
-    var html = heading ? '<p>' + heading + '</p>' : '';
+    var html = heading ? "<p>".concat(heading, "</p>") : '';
     if (!baseHours || !Number.isFinite(baseHours)) {
       container.innerHTML = html;
       return;
@@ -1009,7 +1047,7 @@ if (CORE_PART1_RUNTIME_SCOPE && CORE_PART1_RUNTIME_SCOPE.__cineCorePart1Initiali
     var temperatureHeader = getTemperatureColumnLabelForLang(currentLang, temperatureUnit);
     var runtimeHeader = langTexts.runtimeLabel || fallbackTexts.runtimeLabel || 'Runtime';
     var batteryHeader = langTexts.batteryCountTempLabel || fallbackTexts.batteryCountTempLabel || 'Batteries';
-    html += '<table><tr><th>' + temperatureHeader + '</th><th>' + runtimeHeader + '</th><th>' + batteryHeader + '</th></tr>';
+    html += "<table><tr><th>".concat(temperatureHeader, "</th><th>").concat(runtimeHeader, "</th><th>").concat(batteryHeader, "</th></tr>");
     TEMPERATURE_SCENARIOS.forEach(function (scenario) {
       var runtime = baseHours * scenario.factor;
       var runtimeCell = Number.isFinite(runtime) ? runtime.toFixed(2) : '0.00';
@@ -1018,7 +1056,7 @@ if (CORE_PART1_RUNTIME_SCOPE && CORE_PART1_RUNTIME_SCOPE.__cineCorePart1Initiali
         batteries = String(Math.ceil(10 / runtime));
       }
       var temperatureCell = formatTemperatureForDisplay(scenario.celsius);
-      html += '<tr><td style="color:' + scenario.color + '">' + temperatureCell + '</td><td>' + runtimeCell + '</td><td>' + batteries + '</td></tr>';
+      html += "<tr><td style=\"color:".concat(scenario.color, "\">").concat(temperatureCell, "</td><td>").concat(runtimeCell, "</td><td>").concat(batteries, "</td></tr>");
     });
     html += '</table>';
     container.innerHTML = html;
@@ -1044,12 +1082,12 @@ if (CORE_PART1_RUNTIME_SCOPE && CORE_PART1_RUNTIME_SCOPE.__cineCorePart1Initiali
       select.value = previousValue;
     }
   }
-  function updateFeedbackTemperatureOptions(lang, unit) {
+  function updateFeedbackTemperatureOptions() {
+    var lang = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : currentLang;
+    var unit = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : temperatureUnit;
     if (typeof document === 'undefined') {
       return;
     }
-    var targetLang = typeof lang === 'undefined' ? currentLang : lang;
-    var targetUnit = typeof unit === 'undefined' ? temperatureUnit : unit;
     var tempSelect = document.getElementById('fbTemperature');
     if (!tempSelect) return;
     ensureFeedbackTemperatureOptions(tempSelect);
@@ -1062,35 +1100,34 @@ if (CORE_PART1_RUNTIME_SCOPE && CORE_PART1_RUNTIME_SCOPE.__cineCorePart1Initiali
       var celsiusValue = Number(option.value);
       if (!Number.isFinite(celsiusValue)) return;
       option.textContent = formatTemperatureForDisplay(celsiusValue, {
-        lang: targetLang,
-        unit: targetUnit,
+        lang: lang,
+        unit: unit,
         includeSign: 'negative'
       });
     });
   }
-  function updateFeedbackTemperatureLabel(lang, unit) {
+  function updateFeedbackTemperatureLabel() {
+    var lang = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : currentLang;
+    var unit = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : temperatureUnit;
     if (typeof document === 'undefined') {
       return;
     }
-    var targetLang = typeof lang === 'undefined' ? currentLang : lang;
-    var targetUnit = typeof unit === 'undefined' ? temperatureUnit : unit;
     var labelTextElem = document.getElementById('fbTemperatureLabelText');
     var labelElem = document.getElementById('fbTemperatureLabel');
-    var label = getTemperatureColumnLabelForLang(targetLang, targetUnit) + ':';
+    var label = "".concat(getTemperatureColumnLabelForLang(lang, unit), ":");
     if (labelTextElem) {
       labelTextElem.textContent = label;
     } else if (labelElem) {
       labelElem.textContent = label;
     }
   }
-
-  function refreshFeedbackTemperatureLabel(lang, unit) {
-    var targetLang = typeof lang === 'undefined' ? currentLang : lang;
-    var targetUnit = typeof unit === 'undefined' ? temperatureUnit : unit;
+  function refreshFeedbackTemperatureLabel() {
+    var lang = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : currentLang;
+    var unit = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : temperatureUnit;
     var handled = false;
     try {
       if (typeof updateFeedbackTemperatureLabel === 'function') {
-        updateFeedbackTemperatureLabel(targetLang, targetUnit);
+        updateFeedbackTemperatureLabel(lang, unit);
         handled = true;
       }
     } catch (error) {
@@ -1098,33 +1135,31 @@ if (CORE_PART1_RUNTIME_SCOPE && CORE_PART1_RUNTIME_SCOPE.__cineCorePart1Initiali
         console.warn('Fallback applied while updating feedback temperature label', error);
       }
     }
-
     if (handled) {
       return;
     }
-
-    if (typeof document === 'undefined') {
-      return;
-    }
-
-    var labelTextElem = document.getElementById('fbTemperatureLabelText');
-    var labelElem = document.getElementById('fbTemperatureLabel');
+    var labelTextElem = typeof document !== 'undefined' ? document.getElementById('fbTemperatureLabelText') : null;
+    var labelElem = typeof document !== 'undefined' ? document.getElementById('fbTemperatureLabel') : null;
     if (!labelTextElem && !labelElem) {
       return;
     }
-    var label = getTemperatureColumnLabelForLang(targetLang, targetUnit) + ':';
+    var label = "".concat(getTemperatureColumnLabelForLang(lang, unit), ":");
     if (labelTextElem) {
       labelTextElem.textContent = label;
     } else if (labelElem) {
       labelElem.textContent = label;
     }
   }
-  function applyTemperatureUnitPreference(unit, options) {
-    var opts = options && _typeof(options) === 'object' ? options : {};
+  function applyTemperatureUnitPreference(unit) {
+    var options = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
     var normalized = normalizeTemperatureUnit(unit);
-    var persist = typeof opts.persist === 'undefined' ? true : opts.persist;
-    var reRender = typeof opts.reRender === 'undefined' ? true : opts.reRender;
-    var forceUpdate = typeof opts.forceUpdate === 'undefined' ? false : opts.forceUpdate;
+    var _ref4 = options || {},
+      _ref4$persist = _ref4.persist,
+      persist = _ref4$persist === void 0 ? true : _ref4$persist,
+      _ref4$reRender = _ref4.reRender,
+      reRender = _ref4$reRender === void 0 ? true : _ref4$reRender,
+      _ref4$forceUpdate = _ref4.forceUpdate,
+      forceUpdate = _ref4$forceUpdate === void 0 ? false : _ref4$forceUpdate;
     if (!forceUpdate && temperatureUnit === normalized) {
       return;
     }
@@ -1146,7 +1181,7 @@ if (CORE_PART1_RUNTIME_SCOPE && CORE_PART1_RUNTIME_SCOPE.__cineCorePart1Initiali
       updateFeedbackTemperatureOptions();
       renderTemperatureNote(lastRuntimeHours);
     }
-    }
+  }
   var collator = new Intl.Collator(undefined, {
     numeric: true,
     sensitivity: 'base'
@@ -1510,13 +1545,27 @@ if (CORE_PART1_RUNTIME_SCOPE && CORE_PART1_RUNTIME_SCOPE.__cineCorePart1Initiali
       console.warn('Could not save mount voltage backup copy', backupError);
     }
   }
+  var MOUNT_VOLTAGE_RUNTIME_EXPORTS = Object.freeze({
+    SUPPORTED_MOUNT_VOLTAGE_TYPES: SUPPORTED_MOUNT_VOLTAGE_TYPES,
+    DEFAULT_MOUNT_VOLTAGES: DEFAULT_MOUNT_VOLTAGES,
+    mountVoltageInputs: mountVoltageInputs,
+    parseVoltageValue: parseVoltageValue,
+    cloneMountVoltageMap: cloneMountVoltageMap,
+    getMountVoltagePreferencesClone: getMountVoltagePreferencesClone,
+    applyMountVoltagePreferences: applyMountVoltagePreferences,
+    parseStoredMountVoltages: parseStoredMountVoltages,
+    resetMountVoltagePreferences: resetMountVoltagePreferences,
+    updateMountVoltageInputsFromState: updateMountVoltageInputsFromState,
+    persistMountVoltagePreferences: persistMountVoltagePreferences
+  });
+  exposeCoreRuntimeConstants(MOUNT_VOLTAGE_RUNTIME_EXPORTS);
   function applyMountVoltagePreferences(preferences) {
     var options = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
-    var _ref3 = options || {},
-      _ref3$persist = _ref3.persist,
-      persist = _ref3$persist === void 0 ? true : _ref3$persist,
-      _ref3$triggerUpdate = _ref3.triggerUpdate,
-      triggerUpdate = _ref3$triggerUpdate === void 0 ? true : _ref3$triggerUpdate;
+    var _ref5 = options || {},
+      _ref5$persist = _ref5.persist,
+      persist = _ref5$persist === void 0 ? true : _ref5$persist,
+      _ref5$triggerUpdate = _ref5.triggerUpdate,
+      triggerUpdate = _ref5$triggerUpdate === void 0 ? true : _ref5$triggerUpdate;
     mountVoltagePreferences = normalizeMountVoltageSource(preferences);
     if (persist) {
       persistMountVoltagePreferences(mountVoltagePreferences);
@@ -1924,9 +1973,9 @@ if (CORE_PART1_RUNTIME_SCOPE && CORE_PART1_RUNTIME_SCOPE.__cineCorePart1Initiali
     }).filter(Boolean);
   }
   function normalizeAutoGearText(value) {
-    var _ref4 = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {},
-      _ref4$collapseWhitesp = _ref4.collapseWhitespace,
-      collapseWhitespace = _ref4$collapseWhitesp === void 0 ? true : _ref4$collapseWhitesp;
+    var _ref6 = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {},
+      _ref6$collapseWhitesp = _ref6.collapseWhitespace,
+      collapseWhitespace = _ref6$collapseWhitesp === void 0 ? true : _ref6$collapseWhitesp;
     if (typeof value === 'number' && Number.isFinite(value)) {
       return String(value);
     }
@@ -2081,6 +2130,29 @@ if (CORE_PART1_RUNTIME_SCOPE && CORE_PART1_RUNTIME_SCOPE.__cineCorePart1Initiali
       return addArriKNumber(normalizedValue);
     }
     return normalizedValue;
+  }
+  function populateAutoGearCategorySelect(select, currentValue) {
+    var _texts, _texts2;
+    if (!select) return;
+    var current = typeof currentValue === 'string' ? currentValue : '';
+    var lang = typeof currentLang === 'string' ? currentLang : 'en';
+    select.innerHTML = '';
+    GEAR_LIST_CATEGORIES.forEach(function (category) {
+      var option = document.createElement('option');
+      option.value = category;
+      option.textContent = category;
+      if (current === category) {
+        option.selected = true;
+      }
+      select.appendChild(option);
+    });
+    var customOption = document.createElement('option');
+    customOption.value = AUTO_GEAR_CUSTOM_CATEGORY;
+    customOption.textContent = ((_texts = texts) === null || _texts === void 0 || (_texts = _texts[lang]) === null || _texts === void 0 ? void 0 : _texts.autoGearCustomCategory) || ((_texts2 = texts) === null || _texts2 === void 0 || (_texts2 = _texts2.en) === null || _texts2 === void 0 ? void 0 : _texts2.autoGearCustomCategory) || 'Custom Additions';
+    if (!current || current === AUTO_GEAR_CUSTOM_CATEGORY) {
+      customOption.selected = true;
+    }
+    select.appendChild(customOption);
   }
   function isAutoGearMonitoringCategory(value) {
     if (typeof value !== 'string') return false;
@@ -2395,10 +2467,10 @@ if (CORE_PART1_RUNTIME_SCOPE && CORE_PART1_RUNTIME_SCOPE.__cineCorePart1Initiali
       } : null;
     }
     if (_typeof(setting) === 'object') {
-      var _ref5, _ref6, _ref7, _setting$mode, _ref8, _ref9, _ref0, _ref1, _setting$value;
-      var modeSource = (_ref5 = (_ref6 = (_ref7 = (_setting$mode = setting.mode) !== null && _setting$mode !== void 0 ? _setting$mode : setting.type) !== null && _ref7 !== void 0 ? _ref7 : setting.comparison) !== null && _ref6 !== void 0 ? _ref6 : setting.condition) !== null && _ref5 !== void 0 ? _ref5 : setting.kind;
+      var _ref7, _ref8, _ref9, _setting$mode, _ref0, _ref1, _ref10, _ref11, _setting$value;
+      var modeSource = (_ref7 = (_ref8 = (_ref9 = (_setting$mode = setting.mode) !== null && _setting$mode !== void 0 ? _setting$mode : setting.type) !== null && _ref9 !== void 0 ? _ref9 : setting.comparison) !== null && _ref8 !== void 0 ? _ref8 : setting.condition) !== null && _ref7 !== void 0 ? _ref7 : setting.kind;
       var mode = normalizeAutoGearShootingDayMode(modeSource);
-      var valueSource = (_ref8 = (_ref9 = (_ref0 = (_ref1 = (_setting$value = setting.value) !== null && _setting$value !== void 0 ? _setting$value : setting.count) !== null && _ref1 !== void 0 ? _ref1 : setting.days) !== null && _ref0 !== void 0 ? _ref0 : setting.minimum) !== null && _ref9 !== void 0 ? _ref9 : setting.maximum) !== null && _ref8 !== void 0 ? _ref8 : setting.frequency;
+      var valueSource = (_ref0 = (_ref1 = (_ref10 = (_ref11 = (_setting$value = setting.value) !== null && _setting$value !== void 0 ? _setting$value : setting.count) !== null && _ref11 !== void 0 ? _ref11 : setting.days) !== null && _ref10 !== void 0 ? _ref10 : setting.minimum) !== null && _ref1 !== void 0 ? _ref1 : setting.maximum) !== null && _ref0 !== void 0 ? _ref0 : setting.frequency;
       var value = normalizeAutoGearShootingDayValue(valueSource);
       if (Number.isFinite(value) && value > 0) {
         return {
@@ -3317,31 +3389,26 @@ if (CORE_PART1_RUNTIME_SCOPE && CORE_PART1_RUNTIME_SCOPE.__cineCorePart1Initiali
   var autoGearBackupRetentionWarningText = '';
   var autoGearEditorDraft = null;
   var autoGearEditorActiveItem = null;
-var autoGearDraftPendingWarnings = null;
-var autoGearSearchQuery = '';
-var autoGearSummaryFocus = 'all';
-var autoGearSummaryLast = null;
-var autoGearScenarioFilter = 'all';
-
-function updateAutoGearItemButtonState(type) {
-  var normalizedType = type === 'remove' ? 'remove' : 'add';
-  var button = normalizedType === 'remove' ? autoGearRemoveItemButton : autoGearAddItemButton;
-  if (!button) return;
-  var langTexts = texts[currentLang] || texts.en || {};
-  var isEditing = !!(autoGearEditorActiveItem && autoGearEditorActiveItem.listType === normalizedType);
-  var defaultKey = normalizedType === 'remove' ? 'autoGearRemoveItemButton' : 'autoGearAddItemButton';
-  var defaultLabel = langTexts[defaultKey]
-    || (texts.en && texts.en[defaultKey])
-    || button.textContent
-    || '';
-  var updateLabel = langTexts.autoGearUpdateItemButton
-    || (texts.en && texts.en.autoGearUpdateItemButton)
-    || defaultLabel;
-  var label = isEditing ? updateLabel : defaultLabel;
-  var glyph = isEditing ? ICON_GLYPHS.save : normalizedType === 'remove' ? ICON_GLYPHS.minus : ICON_GLYPHS.add;
-  setButtonLabelWithIcon(button, label, glyph);
-  button.setAttribute('data-help', label);
-}
+  var autoGearDraftPendingWarnings = null;
+  var autoGearSearchQuery = '';
+  var autoGearSummaryFocus = 'all';
+  var autoGearSummaryLast = null;
+  var autoGearScenarioFilter = 'all';
+  function updateAutoGearItemButtonState(type) {
+    var _texts$en22, _texts$en23;
+    var normalizedType = type === 'remove' ? 'remove' : 'add';
+    var button = normalizedType === 'remove' ? autoGearRemoveItemButton : autoGearAddItemButton;
+    if (!button) return;
+    var langTexts = texts[currentLang] || texts.en || {};
+    var isEditing = (autoGearEditorActiveItem === null || autoGearEditorActiveItem === void 0 ? void 0 : autoGearEditorActiveItem.listType) === normalizedType;
+    var defaultKey = normalizedType === 'remove' ? 'autoGearRemoveItemButton' : 'autoGearAddItemButton';
+    var defaultLabel = langTexts[defaultKey] || ((_texts$en22 = texts.en) === null || _texts$en22 === void 0 ? void 0 : _texts$en22[defaultKey]) || button.textContent || '';
+    var updateLabel = langTexts.autoGearUpdateItemButton || ((_texts$en23 = texts.en) === null || _texts$en23 === void 0 ? void 0 : _texts$en23.autoGearUpdateItemButton) || defaultLabel;
+    var label = isEditing ? updateLabel : defaultLabel;
+    var glyph = isEditing ? ICON_GLYPHS.save : normalizedType === 'remove' ? ICON_GLYPHS.minus : ICON_GLYPHS.add;
+    setButtonLabelWithIcon(button, label, glyph);
+    button.setAttribute('data-help', label);
+  }
   function getAutoGearBackupEntrySignature(entry) {
     if (!entry || _typeof(entry) !== 'object') return '';
     return stableStringify({
@@ -3413,11 +3480,11 @@ function updateAutoGearItemButtonState(type) {
     return _objectSpread({}, autoGearMonitorDefaults);
   }
   function setAutoGearMonitorDefaults(defaults) {
-    var _ref10 = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {},
-      _ref10$skipRender = _ref10.skipRender,
-      skipRender = _ref10$skipRender === void 0 ? false : _ref10$skipRender,
-      _ref10$skipRefresh = _ref10.skipRefresh,
-      skipRefresh = _ref10$skipRefresh === void 0 ? false : _ref10$skipRefresh;
+    var _ref12 = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {},
+      _ref12$skipRender = _ref12.skipRender,
+      skipRender = _ref12$skipRender === void 0 ? false : _ref12$skipRender,
+      _ref12$skipRefresh = _ref12.skipRefresh,
+      skipRefresh = _ref12$skipRefresh === void 0 ? false : _ref12$skipRefresh;
     var normalized = normalizeAutoGearMonitorDefaults(defaults);
     var changed = false;
     Object.keys(AUTO_GEAR_MONITOR_DEFAULT_TYPES).forEach(function (key) {
@@ -4343,11 +4410,11 @@ function updateAutoGearItemButtonState(type) {
       var item = createItem(name, category, quantity, options);
       if (item) additions.push(item);
     };
-    [['BNC Cable 0.5 m', 'Monitoring support', 1], ['BNC Cable 1 m', 'Monitoring support', 1], ['BNC Cable 5 m', 'Monitoring support', 1], ['BNC Cable 10 m', 'Monitoring support', 1], ['BNC Drum 25 m', 'Monitoring support', 1], ['ULCS Bracket with 1/4" to 1/4"', 'Rigging', 2], ['ULCS Bracket with 3/8" to 1/4"', 'Rigging', 2], ['Noga Arm', 'Rigging', 2], ['Mini Magic Arm', 'Rigging', 2], ['Cine Quick Release', 'Rigging', 4], ['SmallRig - Super lightweight 15mm RailBlock', 'Rigging', 1], ['Spigot with male 3/8" and 1/4"', 'Rigging', 3], ['Clapper Stick', 'Rigging', 2], ['D-Tap Splitter', 'Rigging', 2], ['Magliner Senior - with quick release mount + tripod holder + utility tray + O‘Connor-Aufhängung', 'Carts and Transportation', 1], ['Securing Straps (25mm wide)', 'Carts and Transportation', 10], ['Loading Ramp (pair, 420kg)', 'Carts and Transportation', 1], ['Ring Fitting for Airline Rails', 'Carts and Transportation', 20], ['Power Cable Drum 25-50 m', 'Power', 1], ['Power Cable 10 m', 'Power', 2], ['Power Cable 5 m', 'Power', 2], ['Power Strip', 'Power', 3], ['Power Three Way Splitter', 'Power', 3], ['PRCD-S (Portable Residual Current Device-Safety)', 'Power', 3]].forEach(function (_ref11) {
-      var _ref12 = _slicedToArray(_ref11, 3),
-        name = _ref12[0],
-        category = _ref12[1],
-        quantity = _ref12[2];
+    [['BNC Cable 0.5 m', 'Monitoring support', 1], ['BNC Cable 1 m', 'Monitoring support', 1], ['BNC Cable 5 m', 'Monitoring support', 1], ['BNC Cable 10 m', 'Monitoring support', 1], ['BNC Drum 25 m', 'Monitoring support', 1], ['ULCS Bracket with 1/4" to 1/4"', 'Rigging', 2], ['ULCS Bracket with 3/8" to 1/4"', 'Rigging', 2], ['Noga Arm', 'Rigging', 2], ['Mini Magic Arm', 'Rigging', 2], ['Cine Quick Release', 'Rigging', 4], ['SmallRig - Super lightweight 15mm RailBlock', 'Rigging', 1], ['Spigot with male 3/8" and 1/4"', 'Rigging', 3], ['Clapper Stick', 'Rigging', 2], ['D-Tap Splitter', 'Rigging', 2], ['Magliner Senior - with quick release mount + tripod holder + utility tray + O‘Connor-Aufhängung', 'Carts and Transportation', 1], ['Securing Straps (25mm wide)', 'Carts and Transportation', 10], ['Loading Ramp (pair, 420kg)', 'Carts and Transportation', 1], ['Ring Fitting for Airline Rails', 'Carts and Transportation', 20], ['Power Cable Drum 25-50 m', 'Power', 1], ['Power Cable 10 m', 'Power', 2], ['Power Cable 5 m', 'Power', 2], ['Power Strip', 'Power', 3], ['Power Three Way Splitter', 'Power', 3], ['PRCD-S (Portable Residual Current Device-Safety)', 'Power', 3]].forEach(function (_ref13) {
+      var _ref14 = _slicedToArray(_ref13, 3),
+        name = _ref14[0],
+        category = _ref14[1],
+        quantity = _ref14[2];
       return pushItem(name, category, quantity);
     });
     if (!additions.length) return null;
@@ -4760,9 +4827,9 @@ function updateAutoGearItemButtonState(type) {
     setFactoryAutoGearRulesSnapshot(rules);
   }
   function resetAutoGearRulesToFactoryAdditions() {
-    var _texts$en22;
+    var _texts$en24;
     var langTexts = texts[currentLang] || texts.en || {};
-    var confirmation = langTexts.autoGearResetFactoryConfirm || ((_texts$en22 = texts.en) === null || _texts$en22 === void 0 ? void 0 : _texts$en22.autoGearResetFactoryConfirm) || 'Replace your automatic gear rules with the default additions?';
+    var confirmation = langTexts.autoGearResetFactoryConfirm || ((_texts$en24 = texts.en) === null || _texts$en24 === void 0 ? void 0 : _texts$en24.autoGearResetFactoryConfirm) || 'Replace your automatic gear rules with the default additions?';
     if (typeof confirm === 'function' && !confirm(confirmation)) {
       return;
     }
@@ -4771,7 +4838,7 @@ function updateAutoGearItemButtonState(type) {
       return;
     }
     try {
-      var _texts$en23;
+      var _texts$en25;
       var factoryRules = computeFactoryAutoGearRules();
       var appliedRules = [];
       if (Array.isArray(factoryRules) && factoryRules.length) {
@@ -4799,13 +4866,13 @@ function updateAutoGearItemButtonState(type) {
       });
       var messageKey = updatedRules.length ? 'autoGearResetFactoryDone' : 'autoGearResetFactoryEmpty';
       var fallback = updatedRules.length ? 'Automatic gear rules restored to factory additions.' : 'Factory additions unavailable. Automatic gear rules cleared.';
-      var message = langTexts[messageKey] || ((_texts$en23 = texts.en) === null || _texts$en23 === void 0 ? void 0 : _texts$en23[messageKey]) || fallback;
+      var message = langTexts[messageKey] || ((_texts$en25 = texts.en) === null || _texts$en25 === void 0 ? void 0 : _texts$en25[messageKey]) || fallback;
       var type = updatedRules.length ? 'success' : 'warning';
       showNotification(type, message);
     } catch (error) {
-      var _texts$en24;
+      var _texts$en26;
       console.error('Failed to reset automatic gear rules to factory additions', error);
-      var errorMsg = langTexts.autoGearResetFactoryError || ((_texts$en24 = texts.en) === null || _texts$en24 === void 0 ? void 0 : _texts$en24.autoGearResetFactoryError) || 'Reset failed. Please try again.';
+      var errorMsg = langTexts.autoGearResetFactoryError || ((_texts$en26 = texts.en) === null || _texts$en26 === void 0 ? void 0 : _texts$en26.autoGearResetFactoryError) || 'Reset failed. Please try again.';
       showNotification('error', errorMsg);
     }
   }
@@ -4821,10 +4888,10 @@ function updateAutoGearItemButtonState(type) {
         if (seen.has(obj)) return;
         seen.add(obj);
       }
-      Object.entries(obj).forEach(function (_ref13) {
-        var _ref14 = _slicedToArray(_ref13, 2),
-          key = _ref14[0],
-          value = _ref14[1];
+      Object.entries(obj).forEach(function (_ref15) {
+        var _ref16 = _slicedToArray(_ref15, 2),
+          key = _ref16[0],
+          value = _ref16[1];
         if (!value || _typeof(value) !== 'object' || Array.isArray(value)) return;
         addName(key);
         _visit(value);
@@ -5470,8 +5537,8 @@ function updateAutoGearItemButtonState(type) {
     value: 'DisplayPort'
   }];
   var normalizeVideoType = memoizeNormalization(function (_, key) {
-    var match = VIDEO_TYPE_PATTERNS.find(function (_ref15) {
-      var needles = _ref15.needles;
+    var match = VIDEO_TYPE_PATTERNS.find(function (_ref17) {
+      var needles = _ref17.needles;
       return needles.every(function (n) {
         return key.includes(n);
       });
@@ -5666,9 +5733,9 @@ function updateAutoGearItemButtonState(type) {
         type: '',
         notes: ''
       }).flatMap(function (vo) {
-        var _ref16 = vo || {},
-          count = _ref16.count,
-          rest = _objectWithoutProperties(_ref16, _excluded2);
+        var _ref18 = vo || {},
+          count = _ref18.count,
+          rest = _objectWithoutProperties(_ref18, _excluded2);
         var norm = normalizeVideoType(rest.type);
         if (!VIDEO_OUTPUT_TYPES.has(norm)) return [];
         var parsedCount = parseInt(count, 10);
@@ -5687,9 +5754,9 @@ function updateAutoGearItemButtonState(type) {
         type: '',
         notes: ''
       }).map(function (fc) {
-        var _ref17 = fc || {},
-          type = _ref17.type,
-          rest = _objectWithoutProperties(_ref17, _excluded3);
+        var _ref19 = fc || {},
+          type = _ref19.type,
+          rest = _objectWithoutProperties(_ref19, _excluded3);
         return _objectSpread(_objectSpread({}, rest), {}, {
           type: normalizeFizConnectorType(type)
         });
@@ -5700,9 +5767,9 @@ function updateAutoGearItemButtonState(type) {
         connector: '',
         notes: ''
       }).map(function (vf) {
-        var _ref18 = vf || {},
-          type = _ref18.type,
-          rest = _objectWithoutProperties(_ref18, _excluded4);
+        var _ref20 = vf || {},
+          type = _ref20.type,
+          rest = _objectWithoutProperties(_ref20, _excluded4);
         return _objectSpread(_objectSpread({}, rest), {}, {
           type: normalizeViewfinderType(type)
         });
@@ -5711,11 +5778,11 @@ function updateAutoGearItemButtonState(type) {
         type: '',
         notes: ''
       }).map(function (m) {
-        var _ref19 = m || {},
-          _ref19$type = _ref19.type,
-          type = _ref19$type === void 0 ? '' : _ref19$type,
-          _ref19$notes = _ref19.notes,
-          notes = _ref19$notes === void 0 ? '' : _ref19$notes;
+        var _ref21 = m || {},
+          _ref21$type = _ref21.type,
+          type = _ref21$type === void 0 ? '' : _ref21$type,
+          _ref21$notes = _ref21.notes,
+          notes = _ref21$notes === void 0 ? '' : _ref21$notes;
         var match = type.match(/^(.*?)(?:\((.*)\))?$/);
         if (match) {
           type = match[1].trim();
@@ -6268,48 +6335,48 @@ function updateAutoGearItemButtonState(type) {
     } else {
       var bats = devices.batteries;
       if (!supportsB) {
-        bats = Object.fromEntries(Object.entries(bats).filter(function (_ref20) {
-          var _ref21 = _slicedToArray(_ref20, 2),
-            b = _ref21[1];
+        bats = Object.fromEntries(Object.entries(bats).filter(function (_ref22) {
+          var _ref23 = _slicedToArray(_ref22, 2),
+            b = _ref23[1];
           return b.mount_type !== 'B-Mount';
         }));
       }
       if (!supportsGold) {
-        bats = Object.fromEntries(Object.entries(bats).filter(function (_ref22) {
-          var _ref23 = _slicedToArray(_ref22, 2),
-            b = _ref23[1];
+        bats = Object.fromEntries(Object.entries(bats).filter(function (_ref24) {
+          var _ref25 = _slicedToArray(_ref24, 2),
+            b = _ref25[1];
           return b.mount_type !== 'Gold-Mount';
         }));
       }
       populateSelect(batterySelect, bats, true);
       swaps = devices.batteryHotswaps || {};
       if (!supportsB) {
-        swaps = Object.fromEntries(Object.entries(swaps).filter(function (_ref24) {
-          var _ref25 = _slicedToArray(_ref24, 2),
-            b = _ref25[1];
+        swaps = Object.fromEntries(Object.entries(swaps).filter(function (_ref26) {
+          var _ref27 = _slicedToArray(_ref26, 2),
+            b = _ref27[1];
           return b.mount_type !== 'B-Mount';
         }));
       }
       if (!supportsGold) {
-        swaps = Object.fromEntries(Object.entries(swaps).filter(function (_ref26) {
-          var _ref27 = _slicedToArray(_ref26, 2),
-            b = _ref27[1];
+        swaps = Object.fromEntries(Object.entries(swaps).filter(function (_ref28) {
+          var _ref29 = _slicedToArray(_ref28, 2),
+            b = _ref29[1];
           return b.mount_type !== 'Gold-Mount';
         }));
       }
     }
     if (!/FXLion Nano/i.test(current)) {
-      swaps = Object.fromEntries(Object.entries(swaps).filter(function (_ref28) {
-        var _ref29 = _slicedToArray(_ref28, 1),
-          name = _ref29[0];
+      swaps = Object.fromEntries(Object.entries(swaps).filter(function (_ref30) {
+        var _ref31 = _slicedToArray(_ref30, 1),
+          name = _ref31[0];
         return name !== 'FX-Lion NANO Dual V-Mount Hot-Swap Plate';
       }));
     }
     var totalCurrentLow = parseFloat(totalCurrent12Elem.textContent);
     if (isFinite(totalCurrentLow) && totalCurrentLow > 0) {
-      swaps = Object.fromEntries(Object.entries(swaps).filter(function (_ref30) {
-        var _ref31 = _slicedToArray(_ref30, 2),
-          info = _ref31[1];
+      swaps = Object.fromEntries(Object.entries(swaps).filter(function (_ref32) {
+        var _ref33 = _slicedToArray(_ref32, 2),
+          info = _ref33[1];
         return typeof info.pinA !== 'number' || info.pinA >= totalCurrentLow;
       }));
     }
@@ -6873,7 +6940,7 @@ function updateAutoGearItemButtonState(type) {
   var autoGearRuleNameLabel = document.getElementById('autoGearRuleNameLabel');
   var autoGearScenariosSelect = document.getElementById('autoGearScenarios');
   var autoGearScenariosLabel = document.getElementById('autoGearScenariosLabel');
-  let autoGearScenarioModeSelectElement = document.getElementById('autoGearScenarioMode');
+  var autoGearScenarioModeSelectElement = document.getElementById('autoGearScenarioMode');
   var autoGearScenarioModeLabel = document.getElementById('autoGearScenarioModeLabel');
   var autoGearScenarioMultiplierContainer = document.getElementById('autoGearScenarioMultiplierContainer');
   var autoGearScenarioBaseSelect = document.getElementById('autoGearScenarioBase');
@@ -7103,7 +7170,7 @@ function updateAutoGearItemButtonState(type) {
     console.warn("Could not load language from localStorage", e);
   }
   function setLanguage(lang) {
-    var _texts$en49, _texts$en50, _texts$en51, _texts$en52, _texts$en53, _texts$en54, _texts$en55, _texts$en56, _texts$en57, _texts$en58, _texts$en59, _texts$en60, _texts$en61, _texts$en62, _texts$en63, _texts$en64, _texts$en65, _texts$en66, _texts$en67, _texts$en68, _texts$en168, _texts$en169, _texts$lang, _texts$en170, _texts$lang2, _texts$en171, _texts$lang3, _texts$en172, _texts$en222;
+    var _texts$en51, _texts$en52, _texts$en53, _texts$en54, _texts$en55, _texts$en56, _texts$en57, _texts$en58, _texts$en59, _texts$en60, _texts$en61, _texts$en62, _texts$en63, _texts$en64, _texts$en65, _texts$en66, _texts$en67, _texts$en68, _texts$en69, _texts$en70, _texts$en170, _texts$en171, _texts$lang, _texts$en172, _texts$lang2, _texts$en173, _texts$lang3, _texts$en174, _texts$en224;
     var requested = typeof lang === "string" ? lang : "";
     var resolved = resolveLanguagePreference(requested);
     var normalizedLang = resolved.language;
@@ -7134,8 +7201,8 @@ function updateAutoGearItemButtonState(type) {
     var doc = typeof document !== "undefined" ? document : null;
     var runtimeScope = getCoreGlobalObject();
     var resolveRuntimeValue = function resolveRuntimeValue(name) {
-      if (!name) return void 0;
-      if (runtimeScope && typeof runtimeScope === "object") {
+      if (!name) return undefined;
+      if (runtimeScope && _typeof(runtimeScope) === "object") {
         try {
           if (name in runtimeScope) {
             return runtimeScope[name];
@@ -7153,7 +7220,7 @@ function updateAutoGearItemButtonState(type) {
           void globalError;
         }
       }
-      return void 0;
+      return undefined;
     };
     var registerResolvedElement = function registerResolvedElement(globalName, element) {
       if (!globalName || !element) {
@@ -7171,30 +7238,21 @@ function updateAutoGearItemButtonState(type) {
       try {
         existing = resolveRuntimeValue(globalName);
       } catch (resolveError) {
-        console.warn(
-          "Failed to resolve runtime value for \"".concat(globalName, "\""),
-          resolveError,
-        );
+        console.warn("Failed to resolve runtime value for \"".concat(globalName, "\""), resolveError);
         existing = null;
       }
-
-      if (existing && typeof existing === "object") {
+      if (existing && _typeof(existing) === "object") {
         return existing;
       }
-
       if (doc && typeof doc.getElementById === "function" && elementId) {
         try {
           var element = doc.getElementById(elementId);
           return registerResolvedElement(globalName, element);
         } catch (resolveDomError) {
-          console.warn(
-            "Failed to resolve document element \"".concat(elementId, "\""),
-            resolveDomError,
-          );
+          console.warn("Failed to resolve document element \"".concat(elementId, "\""), resolveDomError);
           return null;
         }
       }
-
       return null;
     };
     var settingsShowAutoBackupsEl = resolveElement("settingsShowAutoBackups", "settingsShowAutoBackups");
@@ -7333,35 +7391,35 @@ function updateAutoGearItemButtonState(type) {
     shareSetupBtn.setAttribute("title", texts[lang].shareSetupBtn);
     shareSetupBtn.setAttribute("data-help", texts[lang].shareSetupHelp);
     if (shareDialogHeadingElem) {
-      var _texts$en25;
-      var heading = texts[lang].shareDialogTitle || ((_texts$en25 = texts.en) === null || _texts$en25 === void 0 ? void 0 : _texts$en25.shareDialogTitle) || shareDialogHeadingElem.textContent;
+      var _texts$en27;
+      var heading = texts[lang].shareDialogTitle || ((_texts$en27 = texts.en) === null || _texts$en27 === void 0 ? void 0 : _texts$en27.shareDialogTitle) || shareDialogHeadingElem.textContent;
       shareDialogHeadingElem.textContent = heading;
     }
     if (shareFilenameLabelElem) {
-      var _texts$en26;
-      var filenameLabel = texts[lang].shareFilenameLabel || ((_texts$en26 = texts.en) === null || _texts$en26 === void 0 ? void 0 : _texts$en26.shareFilenameLabel) || shareFilenameLabelElem.textContent;
+      var _texts$en28;
+      var filenameLabel = texts[lang].shareFilenameLabel || ((_texts$en28 = texts.en) === null || _texts$en28 === void 0 ? void 0 : _texts$en28.shareFilenameLabel) || shareFilenameLabelElem.textContent;
       shareFilenameLabelElem.textContent = filenameLabel;
     }
     if (shareConfirmBtn) {
-      var _texts$en27;
-      var confirmLabel = texts[lang].shareDialogConfirm || ((_texts$en27 = texts.en) === null || _texts$en27 === void 0 ? void 0 : _texts$en27.shareDialogConfirm) || shareConfirmBtn.textContent;
+      var _texts$en29;
+      var confirmLabel = texts[lang].shareDialogConfirm || ((_texts$en29 = texts.en) === null || _texts$en29 === void 0 ? void 0 : _texts$en29.shareDialogConfirm) || shareConfirmBtn.textContent;
       setButtonLabelWithIcon(shareConfirmBtn, confirmLabel, ICON_GLYPHS.fileExport);
       shareConfirmBtn.setAttribute('title', confirmLabel);
       shareConfirmBtn.setAttribute('aria-label', confirmLabel);
       shareConfirmBtn.setAttribute('data-help', texts[lang].shareSetupHelp);
     }
     if (shareCancelBtn) {
-      var _texts$en28;
-      var cancelLabel = texts[lang].shareDialogCancel || ((_texts$en28 = texts.en) === null || _texts$en28 === void 0 ? void 0 : _texts$en28.shareDialogCancel) || shareCancelBtn.textContent;
+      var _texts$en30;
+      var cancelLabel = texts[lang].shareDialogCancel || ((_texts$en30 = texts.en) === null || _texts$en30 === void 0 ? void 0 : _texts$en30.shareDialogCancel) || shareCancelBtn.textContent;
       setButtonLabelWithIcon(shareCancelBtn, cancelLabel, ICON_GLYPHS.circleX);
       shareCancelBtn.setAttribute('title', cancelLabel);
       shareCancelBtn.setAttribute('aria-label', cancelLabel);
     }
     if (shareIncludeAutoGearText) {
-      var _texts$en29, _texts$en30;
-      var label = texts[lang].shareIncludeAutoGearLabel || ((_texts$en29 = texts.en) === null || _texts$en29 === void 0 ? void 0 : _texts$en29.shareIncludeAutoGearLabel) || shareIncludeAutoGearText.textContent;
+      var _texts$en31, _texts$en32;
+      var label = texts[lang].shareIncludeAutoGearLabel || ((_texts$en31 = texts.en) === null || _texts$en31 === void 0 ? void 0 : _texts$en31.shareIncludeAutoGearLabel) || shareIncludeAutoGearText.textContent;
       shareIncludeAutoGearText.textContent = label;
-      var help = texts[lang].shareIncludeAutoGearHelp || ((_texts$en30 = texts.en) === null || _texts$en30 === void 0 ? void 0 : _texts$en30.shareIncludeAutoGearHelp) || label;
+      var help = texts[lang].shareIncludeAutoGearHelp || ((_texts$en32 = texts.en) === null || _texts$en32 === void 0 ? void 0 : _texts$en32.shareIncludeAutoGearHelp) || label;
       if (shareIncludeAutoGearLabelElem) {
         shareIncludeAutoGearLabelElem.setAttribute('data-help', help);
       }
@@ -7371,31 +7429,31 @@ function updateAutoGearItemButtonState(type) {
     }
     var sharedImportLegendText = sharedImportLegend ? sharedImportLegend.textContent : '';
     if (sharedImportDialogHeading) {
-      var _texts$en31;
-      var title = texts[lang].sharedImportDialogTitle || ((_texts$en31 = texts.en) === null || _texts$en31 === void 0 ? void 0 : _texts$en31.sharedImportDialogTitle) || sharedImportDialogHeading.textContent;
+      var _texts$en33;
+      var title = texts[lang].sharedImportDialogTitle || ((_texts$en33 = texts.en) === null || _texts$en33 === void 0 ? void 0 : _texts$en33.sharedImportDialogTitle) || sharedImportDialogHeading.textContent;
       sharedImportDialogHeading.textContent = title;
     }
     if (sharedImportDialogMessage) {
-      var _texts$en32;
-      var message = texts[lang].sharedImportDialogMessage || ((_texts$en32 = texts.en) === null || _texts$en32 === void 0 ? void 0 : _texts$en32.sharedImportDialogMessage) || sharedImportDialogMessage.textContent;
+      var _texts$en34;
+      var message = texts[lang].sharedImportDialogMessage || ((_texts$en34 = texts.en) === null || _texts$en34 === void 0 ? void 0 : _texts$en34.sharedImportDialogMessage) || sharedImportDialogMessage.textContent;
       sharedImportDialogMessage.textContent = message;
       sharedImportDialogMessage.setAttribute('data-help', message);
     }
     if (sharedImportConfirmBtn) {
-      var _texts$en33;
-      var _label = texts[lang].sharedImportDialogConfirm || ((_texts$en33 = texts.en) === null || _texts$en33 === void 0 ? void 0 : _texts$en33.sharedImportDialogConfirm) || sharedImportConfirmBtn.textContent;
+      var _texts$en35;
+      var _label = texts[lang].sharedImportDialogConfirm || ((_texts$en35 = texts.en) === null || _texts$en35 === void 0 ? void 0 : _texts$en35.sharedImportDialogConfirm) || sharedImportConfirmBtn.textContent;
       setButtonLabelWithIcon(sharedImportConfirmBtn, _label, ICON_GLYPHS.check);
       sharedImportConfirmBtn.setAttribute('data-help', _label);
     }
     if (sharedImportCancelBtn) {
-      var _texts$en34;
-      var _label2 = texts[lang].sharedImportDialogCancel || ((_texts$en34 = texts.en) === null || _texts$en34 === void 0 ? void 0 : _texts$en34.sharedImportDialogCancel) || sharedImportCancelBtn.textContent;
+      var _texts$en36;
+      var _label2 = texts[lang].sharedImportDialogCancel || ((_texts$en36 = texts.en) === null || _texts$en36 === void 0 ? void 0 : _texts$en36.sharedImportDialogCancel) || sharedImportCancelBtn.textContent;
       setButtonLabelWithIcon(sharedImportCancelBtn, _label2, ICON_GLYPHS.circleX);
       sharedImportCancelBtn.setAttribute('data-help', _label2);
     }
     if (sharedImportLegend) {
-      var _texts$en35;
-      var legend = texts[lang].sharedImportAutoGearLabel || ((_texts$en35 = texts.en) === null || _texts$en35 === void 0 ? void 0 : _texts$en35.sharedImportAutoGearLabel) || sharedImportLegend.textContent;
+      var _texts$en37;
+      var legend = texts[lang].sharedImportAutoGearLabel || ((_texts$en37 = texts.en) === null || _texts$en37 === void 0 ? void 0 : _texts$en37.sharedImportAutoGearLabel) || sharedImportLegend.textContent;
       sharedImportLegend.textContent = legend;
       sharedImportLegendText = legend;
       if (sharedImportOptions) {
@@ -7407,28 +7465,28 @@ function updateAutoGearItemButtonState(type) {
       sharedImportModeSelect.setAttribute('data-help', sharedImportLegendText);
     }
     if (sharedImportModeNoneOption) {
-      var _texts$en36, _texts$en37;
-      var _label3 = texts[lang].sharedImportAutoGearNone || ((_texts$en36 = texts.en) === null || _texts$en36 === void 0 ? void 0 : _texts$en36.sharedImportAutoGearNone) || sharedImportModeNoneOption.textContent;
+      var _texts$en38, _texts$en39;
+      var _label3 = texts[lang].sharedImportAutoGearNone || ((_texts$en38 = texts.en) === null || _texts$en38 === void 0 ? void 0 : _texts$en38.sharedImportAutoGearNone) || sharedImportModeNoneOption.textContent;
       sharedImportModeNoneOption.textContent = _label3;
-      var _help = texts[lang].sharedImportAutoGearNoneHelp || ((_texts$en37 = texts.en) === null || _texts$en37 === void 0 ? void 0 : _texts$en37.sharedImportAutoGearNoneHelp) || _label3;
+      var _help = texts[lang].sharedImportAutoGearNoneHelp || ((_texts$en39 = texts.en) === null || _texts$en39 === void 0 ? void 0 : _texts$en39.sharedImportAutoGearNoneHelp) || _label3;
       sharedImportModeNoneOption.setAttribute('data-help', _help);
       sharedImportModeNoneOption.setAttribute('title', _help);
       sharedImportModeNoneOption.setAttribute('aria-label', _label3);
     }
     if (sharedImportModeProjectOption) {
-      var _texts$en38, _texts$en39;
-      var _label4 = texts[lang].sharedImportAutoGearProject || ((_texts$en38 = texts.en) === null || _texts$en38 === void 0 ? void 0 : _texts$en38.sharedImportAutoGearProject) || sharedImportModeProjectOption.textContent;
+      var _texts$en40, _texts$en41;
+      var _label4 = texts[lang].sharedImportAutoGearProject || ((_texts$en40 = texts.en) === null || _texts$en40 === void 0 ? void 0 : _texts$en40.sharedImportAutoGearProject) || sharedImportModeProjectOption.textContent;
       sharedImportModeProjectOption.textContent = _label4;
-      var _help2 = texts[lang].sharedImportAutoGearProjectHelp || ((_texts$en39 = texts.en) === null || _texts$en39 === void 0 ? void 0 : _texts$en39.sharedImportAutoGearProjectHelp) || _label4;
+      var _help2 = texts[lang].sharedImportAutoGearProjectHelp || ((_texts$en41 = texts.en) === null || _texts$en41 === void 0 ? void 0 : _texts$en41.sharedImportAutoGearProjectHelp) || _label4;
       sharedImportModeProjectOption.setAttribute('data-help', _help2);
       sharedImportModeProjectOption.setAttribute('title', _help2);
       sharedImportModeProjectOption.setAttribute('aria-label', _label4);
     }
     if (sharedImportModeGlobalOption) {
-      var _texts$en40, _texts$en41;
-      var _label5 = texts[lang].sharedImportAutoGearGlobal || ((_texts$en40 = texts.en) === null || _texts$en40 === void 0 ? void 0 : _texts$en40.sharedImportAutoGearGlobal) || sharedImportModeGlobalOption.textContent;
+      var _texts$en42, _texts$en43;
+      var _label5 = texts[lang].sharedImportAutoGearGlobal || ((_texts$en42 = texts.en) === null || _texts$en42 === void 0 ? void 0 : _texts$en42.sharedImportAutoGearGlobal) || sharedImportModeGlobalOption.textContent;
       sharedImportModeGlobalOption.textContent = _label5;
-      var _help3 = texts[lang].sharedImportAutoGearGlobalHelp || ((_texts$en41 = texts.en) === null || _texts$en41 === void 0 ? void 0 : _texts$en41.sharedImportAutoGearGlobalHelp) || _label5;
+      var _help3 = texts[lang].sharedImportAutoGearGlobalHelp || ((_texts$en43 = texts.en) === null || _texts$en43 === void 0 ? void 0 : _texts$en43.sharedImportAutoGearGlobalHelp) || _label5;
       sharedImportModeGlobalOption.setAttribute('data-help', _help3);
       sharedImportModeGlobalOption.setAttribute('title', _help3);
       sharedImportModeGlobalOption.setAttribute('aria-label', _label5);
@@ -7486,10 +7544,7 @@ function updateAutoGearItemButtonState(type) {
     document.querySelectorAll('#motorNotesLabel,#controllerNotesLabel,#distanceNotesLabel').forEach(function (el) {
       el.textContent = texts[lang].notesLabel;
     });
-    const breakdownListTarget =
-      typeof breakdownListElem !== 'undefined' && breakdownListElem
-        ? breakdownListElem
-        : document.getElementById('breakdownList');
+    var breakdownListTarget = typeof breakdownListElem !== "undefined" && breakdownListElem ? breakdownListElem : document.getElementById('breakdownList');
     if (breakdownListTarget) {
       breakdownListTarget.setAttribute("data-help", texts[lang].breakdownListHelp);
     }
@@ -7642,6 +7697,7 @@ function updateAutoGearItemButtonState(type) {
     refreshDeviceLists();
     applyFilters();
     updateCalculations();
+    var existingDevicesHeading = typeof document !== 'undefined' ? document.getElementById('existingDevicesHeading') : null;
     if (existingDevicesHeading) {
       existingDevicesHeading.textContent = texts[lang].existingDevicesHeading;
     }
@@ -7666,8 +7722,8 @@ function updateAutoGearItemButtonState(type) {
       settingsTitleElem.setAttribute("data-help", texts[lang].settingsHeadingHelp || texts[lang].settingsHeading);
     }
     if (settingsTablist) {
-      var _texts$en42;
-      var sectionsLabel = texts[lang].settingsSectionsLabel || ((_texts$en42 = texts.en) === null || _texts$en42 === void 0 ? void 0 : _texts$en42.settingsSectionsLabel) || settingsTablist.getAttribute('aria-label') || texts[lang].settingsHeading || 'Settings sections';
+      var _texts$en44;
+      var sectionsLabel = texts[lang].settingsSectionsLabel || ((_texts$en44 = texts.en) === null || _texts$en44 === void 0 ? void 0 : _texts$en44.settingsSectionsLabel) || settingsTablist.getAttribute('aria-label') || texts[lang].settingsHeading || 'Settings sections';
       settingsTablist.setAttribute('aria-label', sectionsLabel);
     }
     var getSettingsTabLabelText = function getSettingsTabLabelText(button) {
@@ -7741,40 +7797,40 @@ function updateAutoGearItemButtonState(type) {
       }
     };
     if (settingsTabGeneral) {
-      var _texts$en43, _texts$en44;
-      var generalLabel = texts[lang].settingsTabGeneral || ((_texts$en43 = texts.en) === null || _texts$en43 === void 0 ? void 0 : _texts$en43.settingsTabGeneral) || getSettingsTabLabelText(settingsTabGeneral) || 'General';
-      var generalHelp = texts[lang].settingsTabGeneralHelp || ((_texts$en44 = texts.en) === null || _texts$en44 === void 0 ? void 0 : _texts$en44.settingsTabGeneralHelp) || texts[lang].settingsHeadingHelp || generalLabel;
+      var _texts$en45, _texts$en46;
+      var generalLabel = texts[lang].settingsTabGeneral || ((_texts$en45 = texts.en) === null || _texts$en45 === void 0 ? void 0 : _texts$en45.settingsTabGeneral) || getSettingsTabLabelText(settingsTabGeneral) || 'General';
+      var generalHelp = texts[lang].settingsTabGeneralHelp || ((_texts$en46 = texts.en) === null || _texts$en46 === void 0 ? void 0 : _texts$en46.settingsTabGeneralHelp) || texts[lang].settingsHeadingHelp || generalLabel;
       applySettingsTabLabel(settingsTabGeneral, generalLabel, generalHelp);
       if (generalSettingsHeading) {
         generalSettingsHeading.textContent = generalLabel;
         generalSettingsHeading.setAttribute('data-help', generalHelp);
       }
       if (generalLanguageHeading) {
-        var _texts$en45;
-        var sectionHeading = texts[lang].generalSectionLanguageHeading || ((_texts$en45 = texts.en) === null || _texts$en45 === void 0 ? void 0 : _texts$en45.generalSectionLanguageHeading) || generalLanguageHeading.textContent;
+        var _texts$en47;
+        var sectionHeading = texts[lang].generalSectionLanguageHeading || ((_texts$en47 = texts.en) === null || _texts$en47 === void 0 ? void 0 : _texts$en47.generalSectionLanguageHeading) || generalLanguageHeading.textContent;
         generalLanguageHeading.textContent = sectionHeading;
       }
       if (generalAppearanceHeading) {
-        var _texts$en46;
-        var _sectionHeading = texts[lang].generalSectionAppearanceHeading || ((_texts$en46 = texts.en) === null || _texts$en46 === void 0 ? void 0 : _texts$en46.generalSectionAppearanceHeading) || generalAppearanceHeading.textContent;
+        var _texts$en48;
+        var _sectionHeading = texts[lang].generalSectionAppearanceHeading || ((_texts$en48 = texts.en) === null || _texts$en48 === void 0 ? void 0 : _texts$en48.generalSectionAppearanceHeading) || generalAppearanceHeading.textContent;
         generalAppearanceHeading.textContent = _sectionHeading;
       }
       if (generalTypographyHeading) {
-        var _texts$en47;
-        var _sectionHeading2 = texts[lang].generalSectionTypographyHeading || ((_texts$en47 = texts.en) === null || _texts$en47 === void 0 ? void 0 : _texts$en47.generalSectionTypographyHeading) || generalTypographyHeading.textContent;
+        var _texts$en49;
+        var _sectionHeading2 = texts[lang].generalSectionTypographyHeading || ((_texts$en49 = texts.en) === null || _texts$en49 === void 0 ? void 0 : _texts$en49.generalSectionTypographyHeading) || generalTypographyHeading.textContent;
         generalTypographyHeading.textContent = _sectionHeading2;
       }
       if (generalBrandingHeading) {
-        var _texts$en48;
-        var _sectionHeading3 = texts[lang].generalSectionBrandingHeading || ((_texts$en48 = texts.en) === null || _texts$en48 === void 0 ? void 0 : _texts$en48.generalSectionBrandingHeading) || generalBrandingHeading.textContent;
+        var _texts$en50;
+        var _sectionHeading3 = texts[lang].generalSectionBrandingHeading || ((_texts$en50 = texts.en) === null || _texts$en50 === void 0 ? void 0 : _texts$en50.generalSectionBrandingHeading) || generalBrandingHeading.textContent;
         generalBrandingHeading.textContent = _sectionHeading3;
       }
     }
-    applySettingsTabLabel(settingsTabAutoGear, texts[lang].settingsTabAutoGear || ((_texts$en49 = texts.en) === null || _texts$en49 === void 0 ? void 0 : _texts$en49.settingsTabAutoGear) || texts[lang].autoGearHeading || ((_texts$en50 = texts.en) === null || _texts$en50 === void 0 ? void 0 : _texts$en50.autoGearHeading), texts[lang].settingsTabAutoGearHelp || ((_texts$en51 = texts.en) === null || _texts$en51 === void 0 ? void 0 : _texts$en51.settingsTabAutoGearHelp) || texts[lang].autoGearHeadingHelp || ((_texts$en52 = texts.en) === null || _texts$en52 === void 0 ? void 0 : _texts$en52.autoGearHeadingHelp));
-    applySettingsTabLabel(settingsTabAccessibility, texts[lang].settingsTabAccessibility || ((_texts$en53 = texts.en) === null || _texts$en53 === void 0 ? void 0 : _texts$en53.settingsTabAccessibility) || texts[lang].accessibilityHeading || ((_texts$en54 = texts.en) === null || _texts$en54 === void 0 ? void 0 : _texts$en54.accessibilityHeading), texts[lang].settingsTabAccessibilityHelp || ((_texts$en55 = texts.en) === null || _texts$en55 === void 0 ? void 0 : _texts$en55.settingsTabAccessibilityHelp) || texts[lang].accessibilityHeadingHelp || ((_texts$en56 = texts.en) === null || _texts$en56 === void 0 ? void 0 : _texts$en56.accessibilityHeadingHelp));
-    applySettingsTabLabel(settingsTabBackup, texts[lang].settingsTabBackup || ((_texts$en57 = texts.en) === null || _texts$en57 === void 0 ? void 0 : _texts$en57.settingsTabBackup) || texts[lang].backupHeading || ((_texts$en58 = texts.en) === null || _texts$en58 === void 0 ? void 0 : _texts$en58.backupHeading), texts[lang].settingsTabBackupHelp || ((_texts$en59 = texts.en) === null || _texts$en59 === void 0 ? void 0 : _texts$en59.settingsTabBackupHelp) || texts[lang].backupHeadingHelp || ((_texts$en60 = texts.en) === null || _texts$en60 === void 0 ? void 0 : _texts$en60.backupHeadingHelp));
-    applySettingsTabLabel(settingsTabData, texts[lang].settingsTabData || ((_texts$en61 = texts.en) === null || _texts$en61 === void 0 ? void 0 : _texts$en61.settingsTabData) || texts[lang].dataHeading || ((_texts$en62 = texts.en) === null || _texts$en62 === void 0 ? void 0 : _texts$en62.dataHeading), texts[lang].settingsTabDataHelp || ((_texts$en63 = texts.en) === null || _texts$en63 === void 0 ? void 0 : _texts$en63.settingsTabDataHelp) || texts[lang].dataHeadingHelp || ((_texts$en64 = texts.en) === null || _texts$en64 === void 0 ? void 0 : _texts$en64.dataHeadingHelp));
-    applySettingsTabLabel(settingsTabAbout, texts[lang].settingsTabAbout || ((_texts$en65 = texts.en) === null || _texts$en65 === void 0 ? void 0 : _texts$en65.settingsTabAbout) || texts[lang].aboutHeading || ((_texts$en66 = texts.en) === null || _texts$en66 === void 0 ? void 0 : _texts$en66.aboutHeading), texts[lang].settingsTabAboutHelp || ((_texts$en67 = texts.en) === null || _texts$en67 === void 0 ? void 0 : _texts$en67.settingsTabAboutHelp) || texts[lang].aboutHeadingHelp || ((_texts$en68 = texts.en) === null || _texts$en68 === void 0 ? void 0 : _texts$en68.aboutHeadingHelp));
+    applySettingsTabLabel(settingsTabAutoGear, texts[lang].settingsTabAutoGear || ((_texts$en51 = texts.en) === null || _texts$en51 === void 0 ? void 0 : _texts$en51.settingsTabAutoGear) || texts[lang].autoGearHeading || ((_texts$en52 = texts.en) === null || _texts$en52 === void 0 ? void 0 : _texts$en52.autoGearHeading), texts[lang].settingsTabAutoGearHelp || ((_texts$en53 = texts.en) === null || _texts$en53 === void 0 ? void 0 : _texts$en53.settingsTabAutoGearHelp) || texts[lang].autoGearHeadingHelp || ((_texts$en54 = texts.en) === null || _texts$en54 === void 0 ? void 0 : _texts$en54.autoGearHeadingHelp));
+    applySettingsTabLabel(settingsTabAccessibility, texts[lang].settingsTabAccessibility || ((_texts$en55 = texts.en) === null || _texts$en55 === void 0 ? void 0 : _texts$en55.settingsTabAccessibility) || texts[lang].accessibilityHeading || ((_texts$en56 = texts.en) === null || _texts$en56 === void 0 ? void 0 : _texts$en56.accessibilityHeading), texts[lang].settingsTabAccessibilityHelp || ((_texts$en57 = texts.en) === null || _texts$en57 === void 0 ? void 0 : _texts$en57.settingsTabAccessibilityHelp) || texts[lang].accessibilityHeadingHelp || ((_texts$en58 = texts.en) === null || _texts$en58 === void 0 ? void 0 : _texts$en58.accessibilityHeadingHelp));
+    applySettingsTabLabel(settingsTabBackup, texts[lang].settingsTabBackup || ((_texts$en59 = texts.en) === null || _texts$en59 === void 0 ? void 0 : _texts$en59.settingsTabBackup) || texts[lang].backupHeading || ((_texts$en60 = texts.en) === null || _texts$en60 === void 0 ? void 0 : _texts$en60.backupHeading), texts[lang].settingsTabBackupHelp || ((_texts$en61 = texts.en) === null || _texts$en61 === void 0 ? void 0 : _texts$en61.settingsTabBackupHelp) || texts[lang].backupHeadingHelp || ((_texts$en62 = texts.en) === null || _texts$en62 === void 0 ? void 0 : _texts$en62.backupHeadingHelp));
+    applySettingsTabLabel(settingsTabData, texts[lang].settingsTabData || ((_texts$en63 = texts.en) === null || _texts$en63 === void 0 ? void 0 : _texts$en63.settingsTabData) || texts[lang].dataHeading || ((_texts$en64 = texts.en) === null || _texts$en64 === void 0 ? void 0 : _texts$en64.dataHeading), texts[lang].settingsTabDataHelp || ((_texts$en65 = texts.en) === null || _texts$en65 === void 0 ? void 0 : _texts$en65.settingsTabDataHelp) || texts[lang].dataHeadingHelp || ((_texts$en66 = texts.en) === null || _texts$en66 === void 0 ? void 0 : _texts$en66.dataHeadingHelp));
+    applySettingsTabLabel(settingsTabAbout, texts[lang].settingsTabAbout || ((_texts$en67 = texts.en) === null || _texts$en67 === void 0 ? void 0 : _texts$en67.settingsTabAbout) || texts[lang].aboutHeading || ((_texts$en68 = texts.en) === null || _texts$en68 === void 0 ? void 0 : _texts$en68.aboutHeading), texts[lang].settingsTabAboutHelp || ((_texts$en69 = texts.en) === null || _texts$en69 === void 0 ? void 0 : _texts$en69.settingsTabAboutHelp) || texts[lang].aboutHeadingHelp || ((_texts$en70 = texts.en) === null || _texts$en70 === void 0 ? void 0 : _texts$en70.aboutHeadingHelp));
     var settingsLanguageLabel = document.getElementById("settingsLanguageLabel");
     if (settingsLanguageLabel) {
       settingsLanguageLabel.textContent = texts[lang].languageSetting;
@@ -7903,31 +7959,31 @@ function updateAutoGearItemButtonState(type) {
       }
     }
     if (autoGearHeadingElem) {
-      var _texts$en69, _texts$en70;
-      autoGearHeadingElem.textContent = texts[lang].autoGearHeading || ((_texts$en69 = texts.en) === null || _texts$en69 === void 0 ? void 0 : _texts$en69.autoGearHeading) || 'Automatic Gear Rules';
-      var headingHelp = texts[lang].autoGearHeadingHelp || ((_texts$en70 = texts.en) === null || _texts$en70 === void 0 ? void 0 : _texts$en70.autoGearHeadingHelp);
+      var _texts$en71, _texts$en72;
+      autoGearHeadingElem.textContent = texts[lang].autoGearHeading || ((_texts$en71 = texts.en) === null || _texts$en71 === void 0 ? void 0 : _texts$en71.autoGearHeading) || 'Automatic Gear Rules';
+      var headingHelp = texts[lang].autoGearHeadingHelp || ((_texts$en72 = texts.en) === null || _texts$en72 === void 0 ? void 0 : _texts$en72.autoGearHeadingHelp);
       if (headingHelp) autoGearHeadingElem.setAttribute('data-help', headingHelp);
     }
     if (autoGearDescriptionElem) {
-      var _texts$en71;
-      autoGearDescriptionElem.textContent = texts[lang].autoGearDescription || ((_texts$en71 = texts.en) === null || _texts$en71 === void 0 ? void 0 : _texts$en71.autoGearDescription) || '';
+      var _texts$en73;
+      autoGearDescriptionElem.textContent = texts[lang].autoGearDescription || ((_texts$en73 = texts.en) === null || _texts$en73 === void 0 ? void 0 : _texts$en73.autoGearDescription) || '';
     }
     renderAutoGearRuleOptionsContent(lang);
     if (autoGearMonitorDefaultsHeading) {
-      var _texts$en72;
-      var _heading = texts[lang].autoGearMonitorDefaultsHeading || ((_texts$en72 = texts.en) === null || _texts$en72 === void 0 ? void 0 : _texts$en72.autoGearMonitorDefaultsHeading) || autoGearMonitorDefaultsHeading.textContent;
+      var _texts$en74;
+      var _heading = texts[lang].autoGearMonitorDefaultsHeading || ((_texts$en74 = texts.en) === null || _texts$en74 === void 0 ? void 0 : _texts$en74.autoGearMonitorDefaultsHeading) || autoGearMonitorDefaultsHeading.textContent;
       autoGearMonitorDefaultsHeading.textContent = _heading;
     }
     if (autoGearMonitorDefaultsDescription) {
-      var _texts$en73;
-      var description = texts[lang].autoGearMonitorDefaultsDescription || ((_texts$en73 = texts.en) === null || _texts$en73 === void 0 ? void 0 : _texts$en73.autoGearMonitorDefaultsDescription) || autoGearMonitorDefaultsDescription.textContent;
+      var _texts$en75;
+      var description = texts[lang].autoGearMonitorDefaultsDescription || ((_texts$en75 = texts.en) === null || _texts$en75 === void 0 ? void 0 : _texts$en75.autoGearMonitorDefaultsDescription) || autoGearMonitorDefaultsDescription.textContent;
       autoGearMonitorDefaultsDescription.textContent = description;
     }
     autoGearMonitorDefaultControls.forEach(function (control) {
-      var _texts$en74, _control$label, _control$label2;
+      var _texts$en76, _control$label, _control$label2;
       if (!control) return;
       var labelKey = AUTO_GEAR_MONITOR_DEFAULT_LABEL_KEYS[control.key];
-      var labelText = labelKey ? texts[lang][labelKey] || ((_texts$en74 = texts.en) === null || _texts$en74 === void 0 ? void 0 : _texts$en74[labelKey]) || ((_control$label = control.label) === null || _control$label === void 0 ? void 0 : _control$label.textContent) : (_control$label2 = control.label) === null || _control$label2 === void 0 ? void 0 : _control$label2.textContent;
+      var labelText = labelKey ? texts[lang][labelKey] || ((_texts$en76 = texts.en) === null || _texts$en76 === void 0 ? void 0 : _texts$en76[labelKey]) || ((_control$label = control.label) === null || _control$label === void 0 ? void 0 : _control$label.textContent) : (_control$label2 = control.label) === null || _control$label2 === void 0 ? void 0 : _control$label2.textContent;
       if (control.label && labelText) {
         control.label.textContent = labelText;
         control.label.setAttribute('data-help', labelText);
@@ -7944,13 +8000,13 @@ function updateAutoGearItemButtonState(type) {
       defer: true
     });
     if (autoGearPresetDescription) {
-      var _texts$en75;
-      autoGearPresetDescription.textContent = texts[lang].autoGearPresetDescription || ((_texts$en75 = texts.en) === null || _texts$en75 === void 0 ? void 0 : _texts$en75.autoGearPresetDescription) || '';
+      var _texts$en77;
+      autoGearPresetDescription.textContent = texts[lang].autoGearPresetDescription || ((_texts$en77 = texts.en) === null || _texts$en77 === void 0 ? void 0 : _texts$en77.autoGearPresetDescription) || '';
     }
     if (autoGearPresetLabel) {
-      var _texts$en76, _texts$en77;
-      var _label7 = texts[lang].autoGearPresetLabel || ((_texts$en76 = texts.en) === null || _texts$en76 === void 0 ? void 0 : _texts$en76.autoGearPresetLabel) || autoGearPresetLabel.textContent;
-      var _help4 = texts[lang].autoGearPresetDescription || ((_texts$en77 = texts.en) === null || _texts$en77 === void 0 ? void 0 : _texts$en77.autoGearPresetDescription) || _label7;
+      var _texts$en78, _texts$en79;
+      var _label7 = texts[lang].autoGearPresetLabel || ((_texts$en78 = texts.en) === null || _texts$en78 === void 0 ? void 0 : _texts$en78.autoGearPresetLabel) || autoGearPresetLabel.textContent;
+      var _help4 = texts[lang].autoGearPresetDescription || ((_texts$en79 = texts.en) === null || _texts$en79 === void 0 ? void 0 : _texts$en79.autoGearPresetDescription) || _label7;
       autoGearPresetLabel.textContent = _label7;
       autoGearPresetLabel.setAttribute('data-help', _help4);
       if (autoGearPresetSelect) {
@@ -7959,71 +8015,71 @@ function updateAutoGearItemButtonState(type) {
       }
     }
     if (autoGearSavePresetButton) {
-      var _texts$en78;
-      var _label8 = texts[lang].autoGearSavePresetButton || ((_texts$en78 = texts.en) === null || _texts$en78 === void 0 ? void 0 : _texts$en78.autoGearSavePresetButton) || autoGearSavePresetButton.textContent;
+      var _texts$en80;
+      var _label8 = texts[lang].autoGearSavePresetButton || ((_texts$en80 = texts.en) === null || _texts$en80 === void 0 ? void 0 : _texts$en80.autoGearSavePresetButton) || autoGearSavePresetButton.textContent;
       setButtonLabelWithIcon(autoGearSavePresetButton, _label8, ICON_GLYPHS.save);
       autoGearSavePresetButton.setAttribute('data-help', _label8);
       autoGearSavePresetButton.setAttribute('aria-label', _label8);
     }
     if (autoGearDeletePresetButton) {
-      var _texts$en79;
-      var _label9 = texts[lang].autoGearDeletePresetButton || ((_texts$en79 = texts.en) === null || _texts$en79 === void 0 ? void 0 : _texts$en79.autoGearDeletePresetButton) || autoGearDeletePresetButton.textContent;
+      var _texts$en81;
+      var _label9 = texts[lang].autoGearDeletePresetButton || ((_texts$en81 = texts.en) === null || _texts$en81 === void 0 ? void 0 : _texts$en81.autoGearDeletePresetButton) || autoGearDeletePresetButton.textContent;
       setButtonLabelWithIcon(autoGearDeletePresetButton, _label9, ICON_GLYPHS.trash);
       autoGearDeletePresetButton.setAttribute('data-help', _label9);
       autoGearDeletePresetButton.setAttribute('aria-label', _label9);
     }
     if (autoGearAddRuleBtn) {
-      var _texts$en80, _texts$en81;
-      var _label0 = texts[lang].autoGearAddRule || ((_texts$en80 = texts.en) === null || _texts$en80 === void 0 ? void 0 : _texts$en80.autoGearAddRule) || autoGearAddRuleBtn.textContent;
+      var _texts$en82, _texts$en83;
+      var _label0 = texts[lang].autoGearAddRule || ((_texts$en82 = texts.en) === null || _texts$en82 === void 0 ? void 0 : _texts$en82.autoGearAddRule) || autoGearAddRuleBtn.textContent;
       setButtonLabelWithIcon(autoGearAddRuleBtn, _label0, ICON_GLYPHS.add);
-      var _help5 = texts[lang].autoGearHeadingHelp || ((_texts$en81 = texts.en) === null || _texts$en81 === void 0 ? void 0 : _texts$en81.autoGearHeadingHelp) || _label0;
+      var _help5 = texts[lang].autoGearHeadingHelp || ((_texts$en83 = texts.en) === null || _texts$en83 === void 0 ? void 0 : _texts$en83.autoGearHeadingHelp) || _label0;
       autoGearAddRuleBtn.setAttribute('data-help', _help5);
     }
     if (autoGearResetFactoryButton) {
-      var _texts$en82, _texts$en83;
-      var _label1 = texts[lang].autoGearResetFactoryButton || ((_texts$en82 = texts.en) === null || _texts$en82 === void 0 ? void 0 : _texts$en82.autoGearResetFactoryButton) || autoGearResetFactoryButton.textContent;
-      var _help6 = texts[lang].autoGearResetFactoryHelp || ((_texts$en83 = texts.en) === null || _texts$en83 === void 0 ? void 0 : _texts$en83.autoGearResetFactoryHelp) || _label1;
+      var _texts$en84, _texts$en85;
+      var _label1 = texts[lang].autoGearResetFactoryButton || ((_texts$en84 = texts.en) === null || _texts$en84 === void 0 ? void 0 : _texts$en84.autoGearResetFactoryButton) || autoGearResetFactoryButton.textContent;
+      var _help6 = texts[lang].autoGearResetFactoryHelp || ((_texts$en85 = texts.en) === null || _texts$en85 === void 0 ? void 0 : _texts$en85.autoGearResetFactoryHelp) || _label1;
       setButtonLabelWithIcon(autoGearResetFactoryButton, _label1, ICON_GLYPHS.reload);
       autoGearResetFactoryButton.setAttribute('data-help', _help6);
       autoGearResetFactoryButton.setAttribute('title', _help6);
       autoGearResetFactoryButton.setAttribute('aria-label', _label1);
     }
     if (autoGearExportButton) {
-      var _texts$en84, _texts$en85;
-      var _label10 = texts[lang].autoGearExportButton || ((_texts$en84 = texts.en) === null || _texts$en84 === void 0 ? void 0 : _texts$en84.autoGearExportButton) || autoGearExportButton.textContent;
-      var _help7 = texts[lang].autoGearExportHelp || ((_texts$en85 = texts.en) === null || _texts$en85 === void 0 ? void 0 : _texts$en85.autoGearExportHelp) || _label10;
+      var _texts$en86, _texts$en87;
+      var _label10 = texts[lang].autoGearExportButton || ((_texts$en86 = texts.en) === null || _texts$en86 === void 0 ? void 0 : _texts$en86.autoGearExportButton) || autoGearExportButton.textContent;
+      var _help7 = texts[lang].autoGearExportHelp || ((_texts$en87 = texts.en) === null || _texts$en87 === void 0 ? void 0 : _texts$en87.autoGearExportHelp) || _label10;
       setButtonLabelWithIcon(autoGearExportButton, _label10, ICON_GLYPHS.fileExport);
       autoGearExportButton.setAttribute('data-help', _help7);
       autoGearExportButton.setAttribute('title', _help7);
       autoGearExportButton.setAttribute('aria-label', _label10);
     }
     if (autoGearImportButton) {
-      var _texts$en86, _texts$en87;
-      var _label11 = texts[lang].autoGearImportButton || ((_texts$en86 = texts.en) === null || _texts$en86 === void 0 ? void 0 : _texts$en86.autoGearImportButton) || autoGearImportButton.textContent;
-      var _help8 = texts[lang].autoGearImportHelp || ((_texts$en87 = texts.en) === null || _texts$en87 === void 0 ? void 0 : _texts$en87.autoGearImportHelp) || _label11;
+      var _texts$en88, _texts$en89;
+      var _label11 = texts[lang].autoGearImportButton || ((_texts$en88 = texts.en) === null || _texts$en88 === void 0 ? void 0 : _texts$en88.autoGearImportButton) || autoGearImportButton.textContent;
+      var _help8 = texts[lang].autoGearImportHelp || ((_texts$en89 = texts.en) === null || _texts$en89 === void 0 ? void 0 : _texts$en89.autoGearImportHelp) || _label11;
       setButtonLabelWithIcon(autoGearImportButton, _label11, ICON_GLYPHS.fileImport);
       autoGearImportButton.setAttribute('data-help', _help8);
       autoGearImportButton.setAttribute('title', _help8);
       autoGearImportButton.setAttribute('aria-label', _label11);
     }
     if (autoGearSearchLabel) {
-      var _texts$en88, _texts$en89;
-      var _label12 = texts[lang].autoGearSearchLabel || ((_texts$en88 = texts.en) === null || _texts$en88 === void 0 ? void 0 : _texts$en88.autoGearSearchLabel) || autoGearSearchLabel.textContent;
-      var _help9 = texts[lang].autoGearSearchHelp || ((_texts$en89 = texts.en) === null || _texts$en89 === void 0 ? void 0 : _texts$en89.autoGearSearchHelp) || _label12;
+      var _texts$en90, _texts$en91;
+      var _label12 = texts[lang].autoGearSearchLabel || ((_texts$en90 = texts.en) === null || _texts$en90 === void 0 ? void 0 : _texts$en90.autoGearSearchLabel) || autoGearSearchLabel.textContent;
+      var _help9 = texts[lang].autoGearSearchHelp || ((_texts$en91 = texts.en) === null || _texts$en91 === void 0 ? void 0 : _texts$en91.autoGearSearchHelp) || _label12;
       autoGearSearchLabel.textContent = _label12;
       autoGearSearchLabel.setAttribute('data-help', _help9);
       if (autoGearSearchInput) {
-        var _texts$en90;
-        var placeholder = texts[lang].autoGearSearchPlaceholder || ((_texts$en90 = texts.en) === null || _texts$en90 === void 0 ? void 0 : _texts$en90.autoGearSearchPlaceholder) || autoGearSearchInput.getAttribute('placeholder') || '';
+        var _texts$en92;
+        var placeholder = texts[lang].autoGearSearchPlaceholder || ((_texts$en92 = texts.en) === null || _texts$en92 === void 0 ? void 0 : _texts$en92.autoGearSearchPlaceholder) || autoGearSearchInput.getAttribute('placeholder') || '';
         autoGearSearchInput.setAttribute('placeholder', placeholder);
         autoGearSearchInput.setAttribute('aria-label', _label12);
         autoGearSearchInput.setAttribute('data-help', _help9);
       }
     }
     if (autoGearFilterScenarioLabel) {
-      var _texts$en91, _texts$en92;
-      var _label13 = texts[lang].autoGearFilterScenarioLabel || ((_texts$en91 = texts.en) === null || _texts$en91 === void 0 ? void 0 : _texts$en91.autoGearFilterScenarioLabel) || autoGearFilterScenarioLabel.textContent;
-      var _help0 = texts[lang].autoGearFilterScenarioHelp || ((_texts$en92 = texts.en) === null || _texts$en92 === void 0 ? void 0 : _texts$en92.autoGearFilterScenarioHelp) || _label13;
+      var _texts$en93, _texts$en94;
+      var _label13 = texts[lang].autoGearFilterScenarioLabel || ((_texts$en93 = texts.en) === null || _texts$en93 === void 0 ? void 0 : _texts$en93.autoGearFilterScenarioLabel) || autoGearFilterScenarioLabel.textContent;
+      var _help0 = texts[lang].autoGearFilterScenarioHelp || ((_texts$en94 = texts.en) === null || _texts$en94 === void 0 ? void 0 : _texts$en94.autoGearFilterScenarioHelp) || _label13;
       autoGearFilterScenarioLabel.textContent = _label13;
       autoGearFilterScenarioLabel.setAttribute('data-help', _help0);
       if (autoGearFilterScenarioSelect) {
@@ -8032,29 +8088,29 @@ function updateAutoGearItemButtonState(type) {
       }
     }
     if (autoGearFilterClearButton) {
-      var _texts$en93;
-      var _label14 = texts[lang].autoGearFilterClear || ((_texts$en93 = texts.en) === null || _texts$en93 === void 0 ? void 0 : _texts$en93.autoGearFilterClear) || autoGearFilterClearButton.textContent;
+      var _texts$en95;
+      var _label14 = texts[lang].autoGearFilterClear || ((_texts$en95 = texts.en) === null || _texts$en95 === void 0 ? void 0 : _texts$en95.autoGearFilterClear) || autoGearFilterClearButton.textContent;
       setButtonLabelWithIcon(autoGearFilterClearButton, _label14, ICON_GLYPHS.circleX);
       autoGearFilterClearButton.setAttribute('data-help', _label14);
       autoGearFilterClearButton.setAttribute('aria-label', _label14);
     }
     refreshAutoGearScenarioFilterOptions(getAutoGearRules());
     if (autoGearBackupsHeading) {
-      var _texts$en94;
-      autoGearBackupsHeading.textContent = texts[lang].autoGearBackupsHeading || ((_texts$en94 = texts.en) === null || _texts$en94 === void 0 ? void 0 : _texts$en94.autoGearBackupsHeading) || autoGearBackupsHeading.textContent;
+      var _texts$en96;
+      autoGearBackupsHeading.textContent = texts[lang].autoGearBackupsHeading || ((_texts$en96 = texts.en) === null || _texts$en96 === void 0 ? void 0 : _texts$en96.autoGearBackupsHeading) || autoGearBackupsHeading.textContent;
     }
     if (autoGearBackupsDescription) {
-      var _texts$en95;
-      var _description = texts[lang].autoGearBackupsDescription || ((_texts$en95 = texts.en) === null || _texts$en95 === void 0 ? void 0 : _texts$en95.autoGearBackupsDescription) || '';
+      var _texts$en97;
+      var _description = texts[lang].autoGearBackupsDescription || ((_texts$en97 = texts.en) === null || _texts$en97 === void 0 ? void 0 : _texts$en97.autoGearBackupsDescription) || '';
       autoGearBackupsDescription.textContent = _description;
       if (_description) {
         autoGearBackupsDescription.setAttribute('data-help', _description);
       }
     }
     if (autoGearShowBackupsLabel) {
-      var _texts$en96, _texts$en97;
-      var _label15 = texts[lang].autoGearShowBackupsLabel || ((_texts$en96 = texts.en) === null || _texts$en96 === void 0 ? void 0 : _texts$en96.autoGearShowBackupsLabel) || autoGearShowBackupsLabel.textContent;
-      var _help1 = texts[lang].autoGearShowBackupsHelp || ((_texts$en97 = texts.en) === null || _texts$en97 === void 0 ? void 0 : _texts$en97.autoGearShowBackupsHelp) || _label15;
+      var _texts$en98, _texts$en99;
+      var _label15 = texts[lang].autoGearShowBackupsLabel || ((_texts$en98 = texts.en) === null || _texts$en98 === void 0 ? void 0 : _texts$en98.autoGearShowBackupsLabel) || autoGearShowBackupsLabel.textContent;
+      var _help1 = texts[lang].autoGearShowBackupsHelp || ((_texts$en99 = texts.en) === null || _texts$en99 === void 0 ? void 0 : _texts$en99.autoGearShowBackupsHelp) || _label15;
       autoGearShowBackupsLabel.textContent = _label15;
       autoGearShowBackupsLabel.setAttribute('data-help', _help1);
       if (autoGearShowBackupsCheckbox) {
@@ -8063,14 +8119,14 @@ function updateAutoGearItemButtonState(type) {
       }
     }
     if (autoGearBackupsHiddenNotice) {
-      var _texts$en98;
-      var hiddenText = texts[lang].autoGearBackupsHidden || ((_texts$en98 = texts.en) === null || _texts$en98 === void 0 ? void 0 : _texts$en98.autoGearBackupsHidden) || autoGearBackupsHiddenNotice.textContent;
+      var _texts$en100;
+      var hiddenText = texts[lang].autoGearBackupsHidden || ((_texts$en100 = texts.en) === null || _texts$en100 === void 0 ? void 0 : _texts$en100.autoGearBackupsHidden) || autoGearBackupsHiddenNotice.textContent;
       autoGearBackupsHiddenNotice.textContent = hiddenText;
     }
     if (autoGearBackupRetentionLabel) {
-      var _texts$en99, _texts$en100;
-      var _label16 = texts[lang].autoGearBackupRetentionLabel || ((_texts$en99 = texts.en) === null || _texts$en99 === void 0 ? void 0 : _texts$en99.autoGearBackupRetentionLabel) || autoGearBackupRetentionLabel.textContent;
-      var _help10 = texts[lang].autoGearBackupRetentionHelp || ((_texts$en100 = texts.en) === null || _texts$en100 === void 0 ? void 0 : _texts$en100.autoGearBackupRetentionHelp) || _label16;
+      var _texts$en101, _texts$en102;
+      var _label16 = texts[lang].autoGearBackupRetentionLabel || ((_texts$en101 = texts.en) === null || _texts$en101 === void 0 ? void 0 : _texts$en101.autoGearBackupRetentionLabel) || autoGearBackupRetentionLabel.textContent;
+      var _help10 = texts[lang].autoGearBackupRetentionHelp || ((_texts$en102 = texts.en) === null || _texts$en102 === void 0 ? void 0 : _texts$en102.autoGearBackupRetentionHelp) || _label16;
       autoGearBackupRetentionLabel.textContent = _label16;
       autoGearBackupRetentionLabel.setAttribute('data-help', _help10);
       if (autoGearBackupRetentionInput) {
@@ -8084,8 +8140,8 @@ function updateAutoGearItemButtonState(type) {
       });
     }
     if (autoGearBackupSelectLabel) {
-      var _texts$en101;
-      var _label17 = texts[lang].autoGearBackupSelectLabel || ((_texts$en101 = texts.en) === null || _texts$en101 === void 0 ? void 0 : _texts$en101.autoGearBackupSelectLabel) || autoGearBackupSelectLabel.textContent;
+      var _texts$en103;
+      var _label17 = texts[lang].autoGearBackupSelectLabel || ((_texts$en103 = texts.en) === null || _texts$en103 === void 0 ? void 0 : _texts$en103.autoGearBackupSelectLabel) || autoGearBackupSelectLabel.textContent;
       autoGearBackupSelectLabel.textContent = _label17;
       if (autoGearBackupSelect) {
         autoGearBackupSelect.setAttribute('aria-label', _label17);
@@ -8093,15 +8149,15 @@ function updateAutoGearItemButtonState(type) {
       }
     }
     if (autoGearBackupRestoreButton) {
-      var _texts$en102;
-      var _label18 = texts[lang].autoGearBackupRestore || ((_texts$en102 = texts.en) === null || _texts$en102 === void 0 ? void 0 : _texts$en102.autoGearBackupRestore) || autoGearBackupRestoreButton.textContent;
+      var _texts$en104;
+      var _label18 = texts[lang].autoGearBackupRestore || ((_texts$en104 = texts.en) === null || _texts$en104 === void 0 ? void 0 : _texts$en104.autoGearBackupRestore) || autoGearBackupRestoreButton.textContent;
       setButtonLabelWithIcon(autoGearBackupRestoreButton, _label18, ICON_GLYPHS.fileImport);
       autoGearBackupRestoreButton.setAttribute('aria-label', _label18);
       autoGearBackupRestoreButton.setAttribute('title', _label18);
     }
     if (autoGearBackupEmptyMessage) {
-      var _texts$en103;
-      var emptyText = texts[lang].autoGearBackupEmpty || ((_texts$en103 = texts.en) === null || _texts$en103 === void 0 ? void 0 : _texts$en103.autoGearBackupEmpty) || autoGearBackupEmptyMessage.textContent;
+      var _texts$en105;
+      var emptyText = texts[lang].autoGearBackupEmpty || ((_texts$en105 = texts.en) === null || _texts$en105 === void 0 ? void 0 : _texts$en105.autoGearBackupEmpty) || autoGearBackupEmptyMessage.textContent;
       autoGearBackupEmptyMessage.textContent = emptyText;
     }
     if (autoGearBackupSelect) {
@@ -8110,10 +8166,10 @@ function updateAutoGearItemButtonState(type) {
       });
     }
     if (autoGearRuleNameLabel) {
-      var _texts$en104, _texts$en105;
-      var _label19 = texts[lang].autoGearRuleNameLabel || ((_texts$en104 = texts.en) === null || _texts$en104 === void 0 ? void 0 : _texts$en104.autoGearRuleNameLabel) || autoGearRuleNameLabel.textContent;
+      var _texts$en106, _texts$en107;
+      var _label19 = texts[lang].autoGearRuleNameLabel || ((_texts$en106 = texts.en) === null || _texts$en106 === void 0 ? void 0 : _texts$en106.autoGearRuleNameLabel) || autoGearRuleNameLabel.textContent;
       autoGearRuleNameLabel.textContent = _label19;
-      var _help11 = texts[lang].autoGearRuleNameHelp || ((_texts$en105 = texts.en) === null || _texts$en105 === void 0 ? void 0 : _texts$en105.autoGearRuleNameHelp) || _label19;
+      var _help11 = texts[lang].autoGearRuleNameHelp || ((_texts$en107 = texts.en) === null || _texts$en107 === void 0 ? void 0 : _texts$en107.autoGearRuleNameHelp) || _label19;
       autoGearRuleNameLabel.setAttribute('data-help', _help11);
       if (autoGearRuleNameInput) {
         autoGearRuleNameInput.setAttribute('data-help', _help11);
@@ -8121,9 +8177,9 @@ function updateAutoGearItemButtonState(type) {
       }
     }
     if (autoGearConditionSelectLabel) {
-      var _texts$en106, _texts$en107;
-      var _label20 = texts[lang].autoGearConditionSelectLabel || ((_texts$en106 = texts.en) === null || _texts$en106 === void 0 ? void 0 : _texts$en106.autoGearConditionSelectLabel) || autoGearConditionSelectLabel.textContent || 'Add a condition';
-      var _help12 = texts[lang].autoGearConditionSelectHelp || ((_texts$en107 = texts.en) === null || _texts$en107 === void 0 ? void 0 : _texts$en107.autoGearConditionSelectHelp) || _label20;
+      var _texts$en108, _texts$en109;
+      var _label20 = texts[lang].autoGearConditionSelectLabel || ((_texts$en108 = texts.en) === null || _texts$en108 === void 0 ? void 0 : _texts$en108.autoGearConditionSelectLabel) || autoGearConditionSelectLabel.textContent || 'Add a condition';
+      var _help12 = texts[lang].autoGearConditionSelectHelp || ((_texts$en109 = texts.en) === null || _texts$en109 === void 0 ? void 0 : _texts$en109.autoGearConditionSelectHelp) || _label20;
       autoGearConditionSelectLabel.textContent = _label20;
       autoGearConditionSelectLabel.setAttribute('data-help', _help12);
       if (autoGearConditionSelect) {
@@ -8132,16 +8188,16 @@ function updateAutoGearItemButtonState(type) {
       }
     }
     if (autoGearConditionAddButton) {
-      var _texts$en108;
-      var _label21 = texts[lang].autoGearAddCondition || ((_texts$en108 = texts.en) === null || _texts$en108 === void 0 ? void 0 : _texts$en108.autoGearAddCondition) || autoGearConditionAddButton.textContent || 'Add condition';
+      var _texts$en110;
+      var _label21 = texts[lang].autoGearAddCondition || ((_texts$en110 = texts.en) === null || _texts$en110 === void 0 ? void 0 : _texts$en110.autoGearAddCondition) || autoGearConditionAddButton.textContent || 'Add condition';
       setButtonLabelWithIcon(autoGearConditionAddButton, _label21, ICON_GLYPHS.add);
       autoGearConditionAddButton.setAttribute('aria-label', _label21);
       autoGearConditionAddButton.setAttribute('data-help', _label21);
     }
     if (autoGearAlwaysLabel) {
-      var _texts$en109, _texts$en110;
-      var _label22 = texts[lang].autoGearAlwaysLabel || ((_texts$en109 = texts.en) === null || _texts$en109 === void 0 ? void 0 : _texts$en109.autoGearAlwaysLabel) || autoGearAlwaysLabel.textContent || 'Always include';
-      var _help13 = texts[lang].autoGearAlwaysHelp || ((_texts$en110 = texts.en) === null || _texts$en110 === void 0 ? void 0 : _texts$en110.autoGearAlwaysHelp) || _label22;
+      var _texts$en111, _texts$en112;
+      var _label22 = texts[lang].autoGearAlwaysLabel || ((_texts$en111 = texts.en) === null || _texts$en111 === void 0 ? void 0 : _texts$en111.autoGearAlwaysLabel) || autoGearAlwaysLabel.textContent || 'Always include';
+      var _help13 = texts[lang].autoGearAlwaysHelp || ((_texts$en112 = texts.en) === null || _texts$en112 === void 0 ? void 0 : _texts$en112.autoGearAlwaysHelp) || _label22;
       autoGearAlwaysLabel.textContent = _label22;
       autoGearAlwaysLabel.setAttribute('data-help', _help13);
       if (autoGearAlwaysHelp) {
@@ -8153,19 +8209,19 @@ function updateAutoGearItemButtonState(type) {
     refreshAutoGearConditionPicker();
     updateAutoGearConditionAddButtonState();
     if (autoGearScenariosLabel) {
-      var _texts$en111, _texts$en112;
-      var _label23 = texts[lang].autoGearScenariosLabel || ((_texts$en111 = texts.en) === null || _texts$en111 === void 0 ? void 0 : _texts$en111.autoGearScenariosLabel) || autoGearScenariosLabel.textContent;
+      var _texts$en113, _texts$en114;
+      var _label23 = texts[lang].autoGearScenariosLabel || ((_texts$en113 = texts.en) === null || _texts$en113 === void 0 ? void 0 : _texts$en113.autoGearScenariosLabel) || autoGearScenariosLabel.textContent;
       autoGearScenariosLabel.textContent = _label23;
-      var _help14 = texts[lang].autoGearScenariosHelp || ((_texts$en112 = texts.en) === null || _texts$en112 === void 0 ? void 0 : _texts$en112.autoGearScenariosHelp) || _label23;
+      var _help14 = texts[lang].autoGearScenariosHelp || ((_texts$en114 = texts.en) === null || _texts$en114 === void 0 ? void 0 : _texts$en114.autoGearScenariosHelp) || _label23;
       autoGearScenariosLabel.setAttribute('data-help', _help14);
       if (autoGearScenariosSelect) {
         autoGearScenariosSelect.setAttribute('data-help', _help14);
         autoGearScenariosSelect.setAttribute('aria-label', _label23);
       }
       if (autoGearScenarioModeLabel) {
-        var _texts$en113, _texts$en114;
-        var modeLabel = texts[lang].autoGearScenarioModeLabel || ((_texts$en113 = texts.en) === null || _texts$en113 === void 0 ? void 0 : _texts$en113.autoGearScenarioModeLabel) || autoGearScenarioModeLabel.textContent || 'Scenario matching';
-        var modeHelp = texts[lang].autoGearScenarioModeHelp || ((_texts$en114 = texts.en) === null || _texts$en114 === void 0 ? void 0 : _texts$en114.autoGearScenarioModeHelp) || modeLabel;
+        var _texts$en115, _texts$en116;
+        var modeLabel = texts[lang].autoGearScenarioModeLabel || ((_texts$en115 = texts.en) === null || _texts$en115 === void 0 ? void 0 : _texts$en115.autoGearScenarioModeLabel) || autoGearScenarioModeLabel.textContent || 'Scenario matching';
+        var modeHelp = texts[lang].autoGearScenarioModeHelp || ((_texts$en116 = texts.en) === null || _texts$en116 === void 0 ? void 0 : _texts$en116.autoGearScenarioModeHelp) || modeLabel;
         autoGearScenarioModeLabel.textContent = modeLabel;
         autoGearScenarioModeLabel.setAttribute('data-help', modeHelp);
         if (autoGearScenarioModeSelectElement) {
@@ -8174,9 +8230,9 @@ function updateAutoGearItemButtonState(type) {
         }
       }
       if (autoGearScenarioBaseLabel) {
-        var _texts$en115, _texts$en116;
-        var baseLabel = texts[lang].autoGearScenarioBaseLabel || ((_texts$en115 = texts.en) === null || _texts$en115 === void 0 ? void 0 : _texts$en115.autoGearScenarioBaseLabel) || autoGearScenarioBaseLabel.textContent || 'Base scenario';
-        var baseHelp = texts[lang].autoGearScenarioBaseHelp || ((_texts$en116 = texts.en) === null || _texts$en116 === void 0 ? void 0 : _texts$en116.autoGearScenarioBaseHelp) || baseLabel;
+        var _texts$en117, _texts$en118;
+        var baseLabel = texts[lang].autoGearScenarioBaseLabel || ((_texts$en117 = texts.en) === null || _texts$en117 === void 0 ? void 0 : _texts$en117.autoGearScenarioBaseLabel) || autoGearScenarioBaseLabel.textContent || 'Base scenario';
+        var baseHelp = texts[lang].autoGearScenarioBaseHelp || ((_texts$en118 = texts.en) === null || _texts$en118 === void 0 ? void 0 : _texts$en118.autoGearScenarioBaseHelp) || baseLabel;
         autoGearScenarioBaseLabel.textContent = baseLabel;
         autoGearScenarioBaseLabel.setAttribute('data-help', baseHelp);
         if (autoGearScenarioBaseSelect) {
@@ -8185,9 +8241,9 @@ function updateAutoGearItemButtonState(type) {
         }
       }
       if (autoGearScenarioFactorLabel) {
-        var _texts$en117, _texts$en118;
-        var factorLabel = texts[lang].autoGearScenarioFactorLabel || ((_texts$en117 = texts.en) === null || _texts$en117 === void 0 ? void 0 : _texts$en117.autoGearScenarioFactorLabel) || autoGearScenarioFactorLabel.textContent || 'Multiplier factor';
-        var factorHelp = texts[lang].autoGearScenarioFactorHelp || ((_texts$en118 = texts.en) === null || _texts$en118 === void 0 ? void 0 : _texts$en118.autoGearScenarioFactorHelp) || factorLabel;
+        var _texts$en119, _texts$en120;
+        var factorLabel = texts[lang].autoGearScenarioFactorLabel || ((_texts$en119 = texts.en) === null || _texts$en119 === void 0 ? void 0 : _texts$en119.autoGearScenarioFactorLabel) || autoGearScenarioFactorLabel.textContent || 'Multiplier factor';
+        var factorHelp = texts[lang].autoGearScenarioFactorHelp || ((_texts$en120 = texts.en) === null || _texts$en120 === void 0 ? void 0 : _texts$en120.autoGearScenarioFactorHelp) || factorLabel;
         autoGearScenarioFactorLabel.textContent = factorLabel;
         autoGearScenarioFactorLabel.setAttribute('data-help', factorHelp);
         if (autoGearScenarioFactorInput) {
@@ -8197,13 +8253,13 @@ function updateAutoGearItemButtonState(type) {
       }
     }
     if (autoGearShootingDaysLabel) {
-      var _texts$en119, _texts$en120, _texts$en121, _texts$en122, _texts$en123, _texts$en124;
-      var _label24 = texts[lang].autoGearShootingDaysLabel || ((_texts$en119 = texts.en) === null || _texts$en119 === void 0 ? void 0 : _texts$en119.autoGearShootingDaysLabel) || autoGearShootingDaysLabel.textContent || 'Shooting days condition';
-      var _help15 = texts[lang].autoGearShootingDaysHelp || ((_texts$en120 = texts.en) === null || _texts$en120 === void 0 ? void 0 : _texts$en120.autoGearShootingDaysHelp) || _label24;
-      var minimumLabel = texts[lang].autoGearShootingDaysModeMinimum || ((_texts$en121 = texts.en) === null || _texts$en121 === void 0 ? void 0 : _texts$en121.autoGearShootingDaysModeMinimum) || 'Minimum';
-      var maximumLabel = texts[lang].autoGearShootingDaysModeMaximum || ((_texts$en122 = texts.en) === null || _texts$en122 === void 0 ? void 0 : _texts$en122.autoGearShootingDaysModeMaximum) || 'Maximum';
-      var everyLabel = texts[lang].autoGearShootingDaysModeEvery || ((_texts$en123 = texts.en) === null || _texts$en123 === void 0 ? void 0 : _texts$en123.autoGearShootingDaysModeEvery) || 'Every';
-      var valueLabel = texts[lang].autoGearShootingDaysValueLabel || ((_texts$en124 = texts.en) === null || _texts$en124 === void 0 ? void 0 : _texts$en124.autoGearShootingDaysValueLabel) || 'Shooting days value';
+      var _texts$en121, _texts$en122, _texts$en123, _texts$en124, _texts$en125, _texts$en126;
+      var _label24 = texts[lang].autoGearShootingDaysLabel || ((_texts$en121 = texts.en) === null || _texts$en121 === void 0 ? void 0 : _texts$en121.autoGearShootingDaysLabel) || autoGearShootingDaysLabel.textContent || 'Shooting days condition';
+      var _help15 = texts[lang].autoGearShootingDaysHelp || ((_texts$en122 = texts.en) === null || _texts$en122 === void 0 ? void 0 : _texts$en122.autoGearShootingDaysHelp) || _label24;
+      var minimumLabel = texts[lang].autoGearShootingDaysModeMinimum || ((_texts$en123 = texts.en) === null || _texts$en123 === void 0 ? void 0 : _texts$en123.autoGearShootingDaysModeMinimum) || 'Minimum';
+      var maximumLabel = texts[lang].autoGearShootingDaysModeMaximum || ((_texts$en124 = texts.en) === null || _texts$en124 === void 0 ? void 0 : _texts$en124.autoGearShootingDaysModeMaximum) || 'Maximum';
+      var everyLabel = texts[lang].autoGearShootingDaysModeEvery || ((_texts$en125 = texts.en) === null || _texts$en125 === void 0 ? void 0 : _texts$en125.autoGearShootingDaysModeEvery) || 'Every';
+      var valueLabel = texts[lang].autoGearShootingDaysValueLabel || ((_texts$en126 = texts.en) === null || _texts$en126 === void 0 ? void 0 : _texts$en126.autoGearShootingDaysValueLabel) || 'Shooting days value';
       autoGearShootingDaysLabel.textContent = _label24;
       autoGearShootingDaysLabel.setAttribute('data-help', _help15);
       if (autoGearShootingDaysMode) {
@@ -8234,10 +8290,10 @@ function updateAutoGearItemButtonState(type) {
       }
     }
     if (autoGearMatteboxLabel) {
-      var _texts$en125, _texts$en126;
-      var _label25 = texts[lang].autoGearMatteboxLabel || ((_texts$en125 = texts.en) === null || _texts$en125 === void 0 ? void 0 : _texts$en125.autoGearMatteboxLabel) || autoGearMatteboxLabel.textContent;
+      var _texts$en127, _texts$en128;
+      var _label25 = texts[lang].autoGearMatteboxLabel || ((_texts$en127 = texts.en) === null || _texts$en127 === void 0 ? void 0 : _texts$en127.autoGearMatteboxLabel) || autoGearMatteboxLabel.textContent;
       autoGearMatteboxLabel.textContent = _label25;
-      var _help16 = texts[lang].autoGearMatteboxHelp || ((_texts$en126 = texts.en) === null || _texts$en126 === void 0 ? void 0 : _texts$en126.autoGearMatteboxHelp) || _label25;
+      var _help16 = texts[lang].autoGearMatteboxHelp || ((_texts$en128 = texts.en) === null || _texts$en128 === void 0 ? void 0 : _texts$en128.autoGearMatteboxHelp) || _label25;
       autoGearMatteboxLabel.setAttribute('data-help', _help16);
       if (autoGearMatteboxSelect) {
         autoGearMatteboxSelect.setAttribute('data-help', _help16);
@@ -8245,10 +8301,10 @@ function updateAutoGearItemButtonState(type) {
       }
     }
     if (autoGearCameraHandleLabel) {
-      var _texts$en127, _texts$en128;
-      var _label26 = texts[lang].autoGearCameraHandleLabel || ((_texts$en127 = texts.en) === null || _texts$en127 === void 0 ? void 0 : _texts$en127.autoGearCameraHandleLabel) || autoGearCameraHandleLabel.textContent;
+      var _texts$en129, _texts$en130;
+      var _label26 = texts[lang].autoGearCameraHandleLabel || ((_texts$en129 = texts.en) === null || _texts$en129 === void 0 ? void 0 : _texts$en129.autoGearCameraHandleLabel) || autoGearCameraHandleLabel.textContent;
       autoGearCameraHandleLabel.textContent = _label26;
-      var _help17 = texts[lang].autoGearCameraHandleHelp || ((_texts$en128 = texts.en) === null || _texts$en128 === void 0 ? void 0 : _texts$en128.autoGearCameraHandleHelp) || _label26;
+      var _help17 = texts[lang].autoGearCameraHandleHelp || ((_texts$en130 = texts.en) === null || _texts$en130 === void 0 ? void 0 : _texts$en130.autoGearCameraHandleHelp) || _label26;
       autoGearCameraHandleLabel.setAttribute('data-help', _help17);
       if (autoGearCameraHandleSelect) {
         autoGearCameraHandleSelect.setAttribute('data-help', _help17);
@@ -8256,10 +8312,10 @@ function updateAutoGearItemButtonState(type) {
       }
     }
     if (autoGearViewfinderExtensionLabel) {
-      var _texts$en129, _texts$en130;
-      var _label27 = texts[lang].autoGearViewfinderExtensionLabel || ((_texts$en129 = texts.en) === null || _texts$en129 === void 0 ? void 0 : _texts$en129.autoGearViewfinderExtensionLabel) || autoGearViewfinderExtensionLabel.textContent;
+      var _texts$en131, _texts$en132;
+      var _label27 = texts[lang].autoGearViewfinderExtensionLabel || ((_texts$en131 = texts.en) === null || _texts$en131 === void 0 ? void 0 : _texts$en131.autoGearViewfinderExtensionLabel) || autoGearViewfinderExtensionLabel.textContent;
       autoGearViewfinderExtensionLabel.textContent = _label27;
-      var _help18 = texts[lang].autoGearViewfinderExtensionHelp || ((_texts$en130 = texts.en) === null || _texts$en130 === void 0 ? void 0 : _texts$en130.autoGearViewfinderExtensionHelp) || _label27;
+      var _help18 = texts[lang].autoGearViewfinderExtensionHelp || ((_texts$en132 = texts.en) === null || _texts$en132 === void 0 ? void 0 : _texts$en132.autoGearViewfinderExtensionHelp) || _label27;
       autoGearViewfinderExtensionLabel.setAttribute('data-help', _help18);
       if (autoGearViewfinderExtensionSelect) {
         autoGearViewfinderExtensionSelect.setAttribute('data-help', _help18);
@@ -8267,10 +8323,10 @@ function updateAutoGearItemButtonState(type) {
       }
     }
     if (autoGearDeliveryResolutionLabel) {
-      var _texts$en131, _texts$en132;
-      var _label28 = texts[lang].autoGearDeliveryResolutionLabel || ((_texts$en131 = texts.en) === null || _texts$en131 === void 0 ? void 0 : _texts$en131.autoGearDeliveryResolutionLabel) || autoGearDeliveryResolutionLabel.textContent;
+      var _texts$en133, _texts$en134;
+      var _label28 = texts[lang].autoGearDeliveryResolutionLabel || ((_texts$en133 = texts.en) === null || _texts$en133 === void 0 ? void 0 : _texts$en133.autoGearDeliveryResolutionLabel) || autoGearDeliveryResolutionLabel.textContent;
       autoGearDeliveryResolutionLabel.textContent = _label28;
-      var _help19 = texts[lang].autoGearDeliveryResolutionHelp || ((_texts$en132 = texts.en) === null || _texts$en132 === void 0 ? void 0 : _texts$en132.autoGearDeliveryResolutionHelp) || _label28;
+      var _help19 = texts[lang].autoGearDeliveryResolutionHelp || ((_texts$en134 = texts.en) === null || _texts$en134 === void 0 ? void 0 : _texts$en134.autoGearDeliveryResolutionHelp) || _label28;
       autoGearDeliveryResolutionLabel.setAttribute('data-help', _help19);
       if (autoGearDeliveryResolutionSelect) {
         autoGearDeliveryResolutionSelect.setAttribute('data-help', _help19);
@@ -8278,10 +8334,10 @@ function updateAutoGearItemButtonState(type) {
       }
     }
     if (autoGearVideoDistributionLabel) {
-      var _texts$en133, _texts$en134;
-      var _label29 = texts[lang].autoGearVideoDistributionLabel || ((_texts$en133 = texts.en) === null || _texts$en133 === void 0 ? void 0 : _texts$en133.autoGearVideoDistributionLabel) || autoGearVideoDistributionLabel.textContent;
+      var _texts$en135, _texts$en136;
+      var _label29 = texts[lang].autoGearVideoDistributionLabel || ((_texts$en135 = texts.en) === null || _texts$en135 === void 0 ? void 0 : _texts$en135.autoGearVideoDistributionLabel) || autoGearVideoDistributionLabel.textContent;
       autoGearVideoDistributionLabel.textContent = _label29;
-      var _help20 = texts[lang].autoGearVideoDistributionHelp || ((_texts$en134 = texts.en) === null || _texts$en134 === void 0 ? void 0 : _texts$en134.autoGearVideoDistributionHelp) || _label29;
+      var _help20 = texts[lang].autoGearVideoDistributionHelp || ((_texts$en136 = texts.en) === null || _texts$en136 === void 0 ? void 0 : _texts$en136.autoGearVideoDistributionHelp) || _label29;
       autoGearVideoDistributionLabel.setAttribute('data-help', _help20);
       if (autoGearVideoDistributionSelect) {
         autoGearVideoDistributionSelect.setAttribute('data-help', _help20);
@@ -8289,10 +8345,10 @@ function updateAutoGearItemButtonState(type) {
       }
     }
     if (autoGearCameraLabel) {
-      var _texts$en135, _texts$en136;
-      var _label30 = texts[lang].autoGearCameraLabel || ((_texts$en135 = texts.en) === null || _texts$en135 === void 0 ? void 0 : _texts$en135.autoGearCameraLabel) || autoGearCameraLabel.textContent;
+      var _texts$en137, _texts$en138;
+      var _label30 = texts[lang].autoGearCameraLabel || ((_texts$en137 = texts.en) === null || _texts$en137 === void 0 ? void 0 : _texts$en137.autoGearCameraLabel) || autoGearCameraLabel.textContent;
       autoGearCameraLabel.textContent = _label30;
-      var _help21 = texts[lang].autoGearCameraHelp || ((_texts$en136 = texts.en) === null || _texts$en136 === void 0 ? void 0 : _texts$en136.autoGearCameraHelp) || _label30;
+      var _help21 = texts[lang].autoGearCameraHelp || ((_texts$en138 = texts.en) === null || _texts$en138 === void 0 ? void 0 : _texts$en138.autoGearCameraHelp) || _label30;
       autoGearCameraLabel.setAttribute('data-help', _help21);
       if (autoGearCameraSelect) {
         autoGearCameraSelect.setAttribute('data-help', _help21);
@@ -8300,24 +8356,24 @@ function updateAutoGearItemButtonState(type) {
       }
     }
     if (autoGearCameraWeightLabel) {
-      var _texts$en137, _texts$en138;
-      var _label31 = texts[lang].autoGearCameraWeightLabel || ((_texts$en137 = texts.en) === null || _texts$en137 === void 0 ? void 0 : _texts$en137.autoGearCameraWeightLabel) || autoGearCameraWeightLabel.textContent || 'Camera weight';
-      var _help22 = texts[lang].autoGearCameraWeightHelp || ((_texts$en138 = texts.en) === null || _texts$en138 === void 0 ? void 0 : _texts$en138.autoGearCameraWeightHelp) || _label31;
+      var _texts$en139, _texts$en140;
+      var _label31 = texts[lang].autoGearCameraWeightLabel || ((_texts$en139 = texts.en) === null || _texts$en139 === void 0 ? void 0 : _texts$en139.autoGearCameraWeightLabel) || autoGearCameraWeightLabel.textContent || 'Camera weight';
+      var _help22 = texts[lang].autoGearCameraWeightHelp || ((_texts$en140 = texts.en) === null || _texts$en140 === void 0 ? void 0 : _texts$en140.autoGearCameraWeightHelp) || _label31;
       autoGearCameraWeightLabel.textContent = _label31;
       autoGearCameraWeightLabel.setAttribute('data-help', _help22);
     }
     if (autoGearCameraWeightOperatorLabel) {
-      var _texts$en139;
-      var _label32 = texts[lang].autoGearCameraWeightOperatorLabel || ((_texts$en139 = texts.en) === null || _texts$en139 === void 0 ? void 0 : _texts$en139.autoGearCameraWeightOperatorLabel) || autoGearCameraWeightOperatorLabel.textContent || 'Weight comparison';
+      var _texts$en141;
+      var _label32 = texts[lang].autoGearCameraWeightOperatorLabel || ((_texts$en141 = texts.en) === null || _texts$en141 === void 0 ? void 0 : _texts$en141.autoGearCameraWeightOperatorLabel) || autoGearCameraWeightOperatorLabel.textContent || 'Weight comparison';
       autoGearCameraWeightOperatorLabel.textContent = _label32;
       autoGearCameraWeightOperatorLabel.setAttribute('data-help', _label32);
       if (autoGearCameraWeightOperator) {
-        var _texts$en140, _texts$en141, _texts$en142;
+        var _texts$en142, _texts$en143, _texts$en144;
         autoGearCameraWeightOperator.setAttribute('data-help', _label32);
         autoGearCameraWeightOperator.setAttribute('aria-label', _label32);
-        var greaterLabel = texts[lang].autoGearCameraWeightOperatorGreater || ((_texts$en140 = texts.en) === null || _texts$en140 === void 0 ? void 0 : _texts$en140.autoGearCameraWeightOperatorGreater) || 'Heavier than';
-        var lessLabel = texts[lang].autoGearCameraWeightOperatorLess || ((_texts$en141 = texts.en) === null || _texts$en141 === void 0 ? void 0 : _texts$en141.autoGearCameraWeightOperatorLess) || 'Lighter than';
-        var equalLabel = texts[lang].autoGearCameraWeightOperatorEqual || ((_texts$en142 = texts.en) === null || _texts$en142 === void 0 ? void 0 : _texts$en142.autoGearCameraWeightOperatorEqual) || 'Exactly';
+        var greaterLabel = texts[lang].autoGearCameraWeightOperatorGreater || ((_texts$en142 = texts.en) === null || _texts$en142 === void 0 ? void 0 : _texts$en142.autoGearCameraWeightOperatorGreater) || 'Heavier than';
+        var lessLabel = texts[lang].autoGearCameraWeightOperatorLess || ((_texts$en143 = texts.en) === null || _texts$en143 === void 0 ? void 0 : _texts$en143.autoGearCameraWeightOperatorLess) || 'Lighter than';
+        var equalLabel = texts[lang].autoGearCameraWeightOperatorEqual || ((_texts$en144 = texts.en) === null || _texts$en144 === void 0 ? void 0 : _texts$en144.autoGearCameraWeightOperatorEqual) || 'Exactly';
         Array.from(autoGearCameraWeightOperator.options || []).forEach(function (option) {
           if (!option) return;
           if (option.value === 'greater') {
@@ -8331,9 +8387,9 @@ function updateAutoGearItemButtonState(type) {
       }
     }
     if (autoGearCameraWeightValueLabel) {
-      var _texts$en143, _texts$en144;
-      var _label33 = texts[lang].autoGearCameraWeightValueLabel || ((_texts$en143 = texts.en) === null || _texts$en143 === void 0 ? void 0 : _texts$en143.autoGearCameraWeightValueLabel) || autoGearCameraWeightValueLabel.textContent || 'Weight threshold (grams)';
-      var _help23 = texts[lang].autoGearCameraWeightHelp || ((_texts$en144 = texts.en) === null || _texts$en144 === void 0 ? void 0 : _texts$en144.autoGearCameraWeightHelp) || _label33;
+      var _texts$en145, _texts$en146;
+      var _label33 = texts[lang].autoGearCameraWeightValueLabel || ((_texts$en145 = texts.en) === null || _texts$en145 === void 0 ? void 0 : _texts$en145.autoGearCameraWeightValueLabel) || autoGearCameraWeightValueLabel.textContent || 'Weight threshold (grams)';
+      var _help23 = texts[lang].autoGearCameraWeightHelp || ((_texts$en146 = texts.en) === null || _texts$en146 === void 0 ? void 0 : _texts$en146.autoGearCameraWeightHelp) || _label33;
       autoGearCameraWeightValueLabel.textContent = _label33;
       autoGearCameraWeightValueLabel.setAttribute('data-help', _help23);
       if (autoGearCameraWeightValueInput) {
@@ -8342,18 +8398,18 @@ function updateAutoGearItemButtonState(type) {
       }
     }
     if (autoGearCameraWeightHelp) {
-      var _texts$en145;
-      var _help24 = texts[lang].autoGearCameraWeightHelp || ((_texts$en145 = texts.en) === null || _texts$en145 === void 0 ? void 0 : _texts$en145.autoGearCameraWeightHelp) || autoGearCameraWeightHelp.textContent || '';
+      var _texts$en147;
+      var _help24 = texts[lang].autoGearCameraWeightHelp || ((_texts$en147 = texts.en) === null || _texts$en147 === void 0 ? void 0 : _texts$en147.autoGearCameraWeightHelp) || autoGearCameraWeightHelp.textContent || '';
       autoGearCameraWeightHelp.textContent = _help24;
       if (_help24) {
         autoGearCameraWeightHelp.setAttribute('data-help', _help24);
       }
     }
     if (autoGearMonitorLabel) {
-      var _texts$en146, _texts$en147;
-      var _label34 = texts[lang].autoGearMonitorLabel || ((_texts$en146 = texts.en) === null || _texts$en146 === void 0 ? void 0 : _texts$en146.autoGearMonitorLabel) || autoGearMonitorLabel.textContent;
+      var _texts$en148, _texts$en149;
+      var _label34 = texts[lang].autoGearMonitorLabel || ((_texts$en148 = texts.en) === null || _texts$en148 === void 0 ? void 0 : _texts$en148.autoGearMonitorLabel) || autoGearMonitorLabel.textContent;
       autoGearMonitorLabel.textContent = _label34;
-      var _help25 = texts[lang].autoGearMonitorHelp || ((_texts$en147 = texts.en) === null || _texts$en147 === void 0 ? void 0 : _texts$en147.autoGearMonitorHelp) || _label34;
+      var _help25 = texts[lang].autoGearMonitorHelp || ((_texts$en149 = texts.en) === null || _texts$en149 === void 0 ? void 0 : _texts$en149.autoGearMonitorHelp) || _label34;
       autoGearMonitorLabel.setAttribute('data-help', _help25);
       if (autoGearMonitorSelect) {
         autoGearMonitorSelect.setAttribute('data-help', _help25);
@@ -8361,10 +8417,10 @@ function updateAutoGearItemButtonState(type) {
       }
     }
     if (autoGearTripodHeadBrandLabel) {
-      var _texts$en148, _texts$en149;
-      var _label35 = texts[lang].autoGearTripodHeadBrandLabel || ((_texts$en148 = texts.en) === null || _texts$en148 === void 0 ? void 0 : _texts$en148.autoGearTripodHeadBrandLabel) || autoGearTripodHeadBrandLabel.textContent;
+      var _texts$en150, _texts$en151;
+      var _label35 = texts[lang].autoGearTripodHeadBrandLabel || ((_texts$en150 = texts.en) === null || _texts$en150 === void 0 ? void 0 : _texts$en150.autoGearTripodHeadBrandLabel) || autoGearTripodHeadBrandLabel.textContent;
       autoGearTripodHeadBrandLabel.textContent = _label35;
-      var _help26 = texts[lang].autoGearTripodHeadBrandHelp || ((_texts$en149 = texts.en) === null || _texts$en149 === void 0 ? void 0 : _texts$en149.autoGearTripodHeadBrandHelp) || _label35;
+      var _help26 = texts[lang].autoGearTripodHeadBrandHelp || ((_texts$en151 = texts.en) === null || _texts$en151 === void 0 ? void 0 : _texts$en151.autoGearTripodHeadBrandHelp) || _label35;
       autoGearTripodHeadBrandLabel.setAttribute('data-help', _help26);
       if (autoGearTripodHeadBrandSelect) {
         autoGearTripodHeadBrandSelect.setAttribute('data-help', _help26);
@@ -8372,10 +8428,10 @@ function updateAutoGearItemButtonState(type) {
       }
     }
     if (autoGearTripodBowlLabel) {
-      var _texts$en150, _texts$en151;
-      var _label36 = texts[lang].autoGearTripodBowlLabel || ((_texts$en150 = texts.en) === null || _texts$en150 === void 0 ? void 0 : _texts$en150.autoGearTripodBowlLabel) || autoGearTripodBowlLabel.textContent;
+      var _texts$en152, _texts$en153;
+      var _label36 = texts[lang].autoGearTripodBowlLabel || ((_texts$en152 = texts.en) === null || _texts$en152 === void 0 ? void 0 : _texts$en152.autoGearTripodBowlLabel) || autoGearTripodBowlLabel.textContent;
       autoGearTripodBowlLabel.textContent = _label36;
-      var _help27 = texts[lang].autoGearTripodBowlHelp || ((_texts$en151 = texts.en) === null || _texts$en151 === void 0 ? void 0 : _texts$en151.autoGearTripodBowlHelp) || _label36;
+      var _help27 = texts[lang].autoGearTripodBowlHelp || ((_texts$en153 = texts.en) === null || _texts$en153 === void 0 ? void 0 : _texts$en153.autoGearTripodBowlHelp) || _label36;
       autoGearTripodBowlLabel.setAttribute('data-help', _help27);
       if (autoGearTripodBowlSelect) {
         autoGearTripodBowlSelect.setAttribute('data-help', _help27);
@@ -8383,10 +8439,10 @@ function updateAutoGearItemButtonState(type) {
       }
     }
     if (autoGearTripodTypesLabel) {
-      var _texts$en152, _texts$en153;
-      var _label37 = texts[lang].autoGearTripodTypesLabel || ((_texts$en152 = texts.en) === null || _texts$en152 === void 0 ? void 0 : _texts$en152.autoGearTripodTypesLabel) || autoGearTripodTypesLabel.textContent;
+      var _texts$en154, _texts$en155;
+      var _label37 = texts[lang].autoGearTripodTypesLabel || ((_texts$en154 = texts.en) === null || _texts$en154 === void 0 ? void 0 : _texts$en154.autoGearTripodTypesLabel) || autoGearTripodTypesLabel.textContent;
       autoGearTripodTypesLabel.textContent = _label37;
-      var _help28 = texts[lang].autoGearTripodTypesHelp || ((_texts$en153 = texts.en) === null || _texts$en153 === void 0 ? void 0 : _texts$en153.autoGearTripodTypesHelp) || _label37;
+      var _help28 = texts[lang].autoGearTripodTypesHelp || ((_texts$en155 = texts.en) === null || _texts$en155 === void 0 ? void 0 : _texts$en155.autoGearTripodTypesHelp) || _label37;
       autoGearTripodTypesLabel.setAttribute('data-help', _help28);
       if (autoGearTripodTypesSelect) {
         autoGearTripodTypesSelect.setAttribute('data-help', _help28);
@@ -8394,10 +8450,10 @@ function updateAutoGearItemButtonState(type) {
       }
     }
     if (autoGearTripodSpreaderLabel) {
-      var _texts$en154, _texts$en155;
-      var _label38 = texts[lang].autoGearTripodSpreaderLabel || ((_texts$en154 = texts.en) === null || _texts$en154 === void 0 ? void 0 : _texts$en154.autoGearTripodSpreaderLabel) || autoGearTripodSpreaderLabel.textContent;
+      var _texts$en156, _texts$en157;
+      var _label38 = texts[lang].autoGearTripodSpreaderLabel || ((_texts$en156 = texts.en) === null || _texts$en156 === void 0 ? void 0 : _texts$en156.autoGearTripodSpreaderLabel) || autoGearTripodSpreaderLabel.textContent;
       autoGearTripodSpreaderLabel.textContent = _label38;
-      var _help29 = texts[lang].autoGearTripodSpreaderHelp || ((_texts$en155 = texts.en) === null || _texts$en155 === void 0 ? void 0 : _texts$en155.autoGearTripodSpreaderHelp) || _label38;
+      var _help29 = texts[lang].autoGearTripodSpreaderHelp || ((_texts$en157 = texts.en) === null || _texts$en157 === void 0 ? void 0 : _texts$en157.autoGearTripodSpreaderHelp) || _label38;
       autoGearTripodSpreaderLabel.setAttribute('data-help', _help29);
       if (autoGearTripodSpreaderSelect) {
         autoGearTripodSpreaderSelect.setAttribute('data-help', _help29);
@@ -8405,10 +8461,10 @@ function updateAutoGearItemButtonState(type) {
       }
     }
     if (autoGearCrewPresentLabel) {
-      var _texts$en156, _texts$en157;
-      var _label39 = texts[lang].autoGearCrewPresentLabel || ((_texts$en156 = texts.en) === null || _texts$en156 === void 0 ? void 0 : _texts$en156.autoGearCrewPresentLabel) || autoGearCrewPresentLabel.textContent;
+      var _texts$en158, _texts$en159;
+      var _label39 = texts[lang].autoGearCrewPresentLabel || ((_texts$en158 = texts.en) === null || _texts$en158 === void 0 ? void 0 : _texts$en158.autoGearCrewPresentLabel) || autoGearCrewPresentLabel.textContent;
       autoGearCrewPresentLabel.textContent = _label39;
-      var _help30 = texts[lang].autoGearCrewPresentHelp || ((_texts$en157 = texts.en) === null || _texts$en157 === void 0 ? void 0 : _texts$en157.autoGearCrewPresentHelp) || _label39;
+      var _help30 = texts[lang].autoGearCrewPresentHelp || ((_texts$en159 = texts.en) === null || _texts$en159 === void 0 ? void 0 : _texts$en159.autoGearCrewPresentHelp) || _label39;
       autoGearCrewPresentLabel.setAttribute('data-help', _help30);
       if (autoGearCrewPresentSelect) {
         autoGearCrewPresentSelect.setAttribute('data-help', _help30);
@@ -8416,10 +8472,10 @@ function updateAutoGearItemButtonState(type) {
       }
     }
     if (autoGearCrewAbsentLabel) {
-      var _texts$en158, _texts$en159;
-      var _label40 = texts[lang].autoGearCrewAbsentLabel || ((_texts$en158 = texts.en) === null || _texts$en158 === void 0 ? void 0 : _texts$en158.autoGearCrewAbsentLabel) || autoGearCrewAbsentLabel.textContent;
+      var _texts$en160, _texts$en161;
+      var _label40 = texts[lang].autoGearCrewAbsentLabel || ((_texts$en160 = texts.en) === null || _texts$en160 === void 0 ? void 0 : _texts$en160.autoGearCrewAbsentLabel) || autoGearCrewAbsentLabel.textContent;
       autoGearCrewAbsentLabel.textContent = _label40;
-      var _help31 = texts[lang].autoGearCrewAbsentHelp || ((_texts$en159 = texts.en) === null || _texts$en159 === void 0 ? void 0 : _texts$en159.autoGearCrewAbsentHelp) || _label40;
+      var _help31 = texts[lang].autoGearCrewAbsentHelp || ((_texts$en161 = texts.en) === null || _texts$en161 === void 0 ? void 0 : _texts$en161.autoGearCrewAbsentHelp) || _label40;
       autoGearCrewAbsentLabel.setAttribute('data-help', _help31);
       if (autoGearCrewAbsentSelect) {
         autoGearCrewAbsentSelect.setAttribute('data-help', _help31);
@@ -8427,10 +8483,10 @@ function updateAutoGearItemButtonState(type) {
       }
     }
     if (autoGearWirelessLabel) {
-      var _texts$en160, _texts$en161;
-      var _label41 = texts[lang].autoGearWirelessLabel || ((_texts$en160 = texts.en) === null || _texts$en160 === void 0 ? void 0 : _texts$en160.autoGearWirelessLabel) || autoGearWirelessLabel.textContent;
+      var _texts$en162, _texts$en163;
+      var _label41 = texts[lang].autoGearWirelessLabel || ((_texts$en162 = texts.en) === null || _texts$en162 === void 0 ? void 0 : _texts$en162.autoGearWirelessLabel) || autoGearWirelessLabel.textContent;
       autoGearWirelessLabel.textContent = _label41;
-      var _help32 = texts[lang].autoGearWirelessHelp || ((_texts$en161 = texts.en) === null || _texts$en161 === void 0 ? void 0 : _texts$en161.autoGearWirelessHelp) || _label41;
+      var _help32 = texts[lang].autoGearWirelessHelp || ((_texts$en163 = texts.en) === null || _texts$en163 === void 0 ? void 0 : _texts$en163.autoGearWirelessHelp) || _label41;
       autoGearWirelessLabel.setAttribute('data-help', _help32);
       if (autoGearWirelessSelect) {
         autoGearWirelessSelect.setAttribute('data-help', _help32);
@@ -8438,10 +8494,10 @@ function updateAutoGearItemButtonState(type) {
       }
     }
     if (autoGearMotorsLabel) {
-      var _texts$en162, _texts$en163;
-      var _label42 = texts[lang].autoGearMotorsLabel || ((_texts$en162 = texts.en) === null || _texts$en162 === void 0 ? void 0 : _texts$en162.autoGearMotorsLabel) || autoGearMotorsLabel.textContent;
+      var _texts$en164, _texts$en165;
+      var _label42 = texts[lang].autoGearMotorsLabel || ((_texts$en164 = texts.en) === null || _texts$en164 === void 0 ? void 0 : _texts$en164.autoGearMotorsLabel) || autoGearMotorsLabel.textContent;
       autoGearMotorsLabel.textContent = _label42;
-      var _help33 = texts[lang].autoGearMotorsHelp || ((_texts$en163 = texts.en) === null || _texts$en163 === void 0 ? void 0 : _texts$en163.autoGearMotorsHelp) || _label42;
+      var _help33 = texts[lang].autoGearMotorsHelp || ((_texts$en165 = texts.en) === null || _texts$en165 === void 0 ? void 0 : _texts$en165.autoGearMotorsHelp) || _label42;
       autoGearMotorsLabel.setAttribute('data-help', _help33);
       if (autoGearMotorsSelect) {
         autoGearMotorsSelect.setAttribute('data-help', _help33);
@@ -8449,10 +8505,10 @@ function updateAutoGearItemButtonState(type) {
       }
     }
     if (autoGearControllersLabel) {
-      var _texts$en164, _texts$en165;
-      var _label43 = texts[lang].autoGearControllersLabel || ((_texts$en164 = texts.en) === null || _texts$en164 === void 0 ? void 0 : _texts$en164.autoGearControllersLabel) || autoGearControllersLabel.textContent;
+      var _texts$en166, _texts$en167;
+      var _label43 = texts[lang].autoGearControllersLabel || ((_texts$en166 = texts.en) === null || _texts$en166 === void 0 ? void 0 : _texts$en166.autoGearControllersLabel) || autoGearControllersLabel.textContent;
       autoGearControllersLabel.textContent = _label43;
-      var _help34 = texts[lang].autoGearControllersHelp || ((_texts$en165 = texts.en) === null || _texts$en165 === void 0 ? void 0 : _texts$en165.autoGearControllersHelp) || _label43;
+      var _help34 = texts[lang].autoGearControllersHelp || ((_texts$en167 = texts.en) === null || _texts$en167 === void 0 ? void 0 : _texts$en167.autoGearControllersHelp) || _label43;
       autoGearControllersLabel.setAttribute('data-help', _help34);
       if (autoGearControllersSelect) {
         autoGearControllersSelect.setAttribute('data-help', _help34);
@@ -8460,27 +8516,27 @@ function updateAutoGearItemButtonState(type) {
       }
     }
     if (autoGearDistanceLabel) {
-      var _texts$en166, _texts$en167;
-      var _label44 = texts[lang].autoGearDistanceLabel || ((_texts$en166 = texts.en) === null || _texts$en166 === void 0 ? void 0 : _texts$en166.autoGearDistanceLabel) || autoGearDistanceLabel.textContent;
+      var _texts$en168, _texts$en169;
+      var _label44 = texts[lang].autoGearDistanceLabel || ((_texts$en168 = texts.en) === null || _texts$en168 === void 0 ? void 0 : _texts$en168.autoGearDistanceLabel) || autoGearDistanceLabel.textContent;
       autoGearDistanceLabel.textContent = _label44;
-      var _help35 = texts[lang].autoGearDistanceHelp || ((_texts$en167 = texts.en) === null || _texts$en167 === void 0 ? void 0 : _texts$en167.autoGearDistanceHelp) || _label44;
+      var _help35 = texts[lang].autoGearDistanceHelp || ((_texts$en169 = texts.en) === null || _texts$en169 === void 0 ? void 0 : _texts$en169.autoGearDistanceHelp) || _label44;
       autoGearDistanceLabel.setAttribute('data-help', _help35);
       if (autoGearDistanceSelect) {
         autoGearDistanceSelect.setAttribute('data-help', _help35);
         autoGearDistanceSelect.setAttribute('aria-label', _label44);
       }
     }
-    var logicLabelText = texts[lang].autoGearConditionLogicLabel || ((_texts$en168 = texts.en) === null || _texts$en168 === void 0 ? void 0 : _texts$en168.autoGearConditionLogicLabel) || 'Match behavior';
-    var logicHelpText = texts[lang].autoGearConditionLogicHelp || ((_texts$en169 = texts.en) === null || _texts$en169 === void 0 ? void 0 : _texts$en169.autoGearConditionLogicHelp) || logicLabelText;
+    var logicLabelText = texts[lang].autoGearConditionLogicLabel || ((_texts$en170 = texts.en) === null || _texts$en170 === void 0 ? void 0 : _texts$en170.autoGearConditionLogicLabel) || 'Match behavior';
+    var logicHelpText = texts[lang].autoGearConditionLogicHelp || ((_texts$en171 = texts.en) === null || _texts$en171 === void 0 ? void 0 : _texts$en171.autoGearConditionLogicHelp) || logicLabelText;
     var logicOptionTexts = {
-      all: ((_texts$lang = texts[lang]) === null || _texts$lang === void 0 ? void 0 : _texts$lang.autoGearConditionLogicAll) || ((_texts$en170 = texts.en) === null || _texts$en170 === void 0 ? void 0 : _texts$en170.autoGearConditionLogicAll) || 'Require every selected value',
-      any: ((_texts$lang2 = texts[lang]) === null || _texts$lang2 === void 0 ? void 0 : _texts$lang2.autoGearConditionLogicAny) || ((_texts$en171 = texts.en) === null || _texts$en171 === void 0 ? void 0 : _texts$en171.autoGearConditionLogicAny) || 'Match any selected value',
-      multiplier: ((_texts$lang3 = texts[lang]) === null || _texts$lang3 === void 0 ? void 0 : _texts$lang3.autoGearConditionLogicMultiplier) || ((_texts$en172 = texts.en) === null || _texts$en172 === void 0 ? void 0 : _texts$en172.autoGearConditionLogicMultiplier) || 'Multiply by matched values'
+      all: ((_texts$lang = texts[lang]) === null || _texts$lang === void 0 ? void 0 : _texts$lang.autoGearConditionLogicAll) || ((_texts$en172 = texts.en) === null || _texts$en172 === void 0 ? void 0 : _texts$en172.autoGearConditionLogicAll) || 'Require every selected value',
+      any: ((_texts$lang2 = texts[lang]) === null || _texts$lang2 === void 0 ? void 0 : _texts$lang2.autoGearConditionLogicAny) || ((_texts$en173 = texts.en) === null || _texts$en173 === void 0 ? void 0 : _texts$en173.autoGearConditionLogicAny) || 'Match any selected value',
+      multiplier: ((_texts$lang3 = texts[lang]) === null || _texts$lang3 === void 0 ? void 0 : _texts$lang3.autoGearConditionLogicMultiplier) || ((_texts$en174 = texts.en) === null || _texts$en174 === void 0 ? void 0 : _texts$en174.autoGearConditionLogicMultiplier) || 'Multiply by matched values'
     };
-    Object.entries(autoGearConditionLogicSelects).forEach(function (_ref32) {
-      var _ref33 = _slicedToArray(_ref32, 2),
-        key = _ref33[0],
-        select = _ref33[1];
+    Object.entries(autoGearConditionLogicSelects).forEach(function (_ref34) {
+      var _ref35 = _slicedToArray(_ref34, 2),
+        key = _ref35[0],
+        select = _ref35[1];
       var label = autoGearConditionLogicLabels[key];
       if (label) {
         label.textContent = logicLabelText;
@@ -8498,13 +8554,13 @@ function updateAutoGearItemButtonState(type) {
       }
     });
     if (autoGearAddItemsHeading) {
-      var _texts$en173;
-      autoGearAddItemsHeading.textContent = texts[lang].autoGearAddItemsHeading || ((_texts$en173 = texts.en) === null || _texts$en173 === void 0 ? void 0 : _texts$en173.autoGearAddItemsHeading) || autoGearAddItemsHeading.textContent;
+      var _texts$en175;
+      autoGearAddItemsHeading.textContent = texts[lang].autoGearAddItemsHeading || ((_texts$en175 = texts.en) === null || _texts$en175 === void 0 ? void 0 : _texts$en175.autoGearAddItemsHeading) || autoGearAddItemsHeading.textContent;
     }
     if (autoGearAddItemLabel) {
-      var _texts$en174, _texts$en175;
-      var _label45 = texts[lang].autoGearAddItemLabel || ((_texts$en174 = texts.en) === null || _texts$en174 === void 0 ? void 0 : _texts$en174.autoGearAddItemLabel) || autoGearAddItemLabel.textContent;
-      var hint = texts[lang].autoGearAddMultipleHint || ((_texts$en175 = texts.en) === null || _texts$en175 === void 0 ? void 0 : _texts$en175.autoGearAddMultipleHint) || '';
+      var _texts$en176, _texts$en177;
+      var _label45 = texts[lang].autoGearAddItemLabel || ((_texts$en176 = texts.en) === null || _texts$en176 === void 0 ? void 0 : _texts$en176.autoGearAddItemLabel) || autoGearAddItemLabel.textContent;
+      var hint = texts[lang].autoGearAddMultipleHint || ((_texts$en177 = texts.en) === null || _texts$en177 === void 0 ? void 0 : _texts$en177.autoGearAddMultipleHint) || '';
       var helpText = hint ? "".concat(_label45, " \u2013 ").concat(hint) : _label45;
       autoGearAddItemLabel.textContent = _label45;
       autoGearAddItemLabel.setAttribute('data-help', helpText);
@@ -8519,43 +8575,43 @@ function updateAutoGearItemButtonState(type) {
       }
     }
     if (autoGearAddCategoryLabel) {
-      var _texts$en176;
-      var _label46 = texts[lang].autoGearAddCategoryLabel || ((_texts$en176 = texts.en) === null || _texts$en176 === void 0 ? void 0 : _texts$en176.autoGearAddCategoryLabel) || autoGearAddCategoryLabel.textContent;
+      var _texts$en178;
+      var _label46 = texts[lang].autoGearAddCategoryLabel || ((_texts$en178 = texts.en) === null || _texts$en178 === void 0 ? void 0 : _texts$en178.autoGearAddCategoryLabel) || autoGearAddCategoryLabel.textContent;
       autoGearAddCategoryLabel.textContent = _label46;
       if (autoGearAddCategorySelect) {
         autoGearAddCategorySelect.setAttribute('aria-label', _label46);
       }
     }
     if (autoGearAddQuantityLabel) {
-      var _texts$en177;
-      var _label47 = texts[lang].autoGearAddQuantityLabel || ((_texts$en177 = texts.en) === null || _texts$en177 === void 0 ? void 0 : _texts$en177.autoGearAddQuantityLabel) || autoGearAddQuantityLabel.textContent;
+      var _texts$en179;
+      var _label47 = texts[lang].autoGearAddQuantityLabel || ((_texts$en179 = texts.en) === null || _texts$en179 === void 0 ? void 0 : _texts$en179.autoGearAddQuantityLabel) || autoGearAddQuantityLabel.textContent;
       autoGearAddQuantityLabel.textContent = _label47;
       if (autoGearAddQuantityInput) {
         autoGearAddQuantityInput.setAttribute('aria-label', _label47);
       }
     }
     if (autoGearAddScreenSizeLabel) {
-      var _texts$en178;
-      var _label48 = texts[lang].autoGearAddScreenSizeLabel || ((_texts$en178 = texts.en) === null || _texts$en178 === void 0 ? void 0 : _texts$en178.autoGearAddScreenSizeLabel) || autoGearAddScreenSizeLabel.textContent;
+      var _texts$en180;
+      var _label48 = texts[lang].autoGearAddScreenSizeLabel || ((_texts$en180 = texts.en) === null || _texts$en180 === void 0 ? void 0 : _texts$en180.autoGearAddScreenSizeLabel) || autoGearAddScreenSizeLabel.textContent;
       autoGearAddScreenSizeLabel.textContent = _label48;
       if (autoGearAddScreenSizeInput) {
         autoGearAddScreenSizeInput.setAttribute('aria-label', _label48);
       }
     }
     if (autoGearAddSelectorTypeLabel) {
-      var _texts$en179;
-      var _label49 = texts[lang].autoGearAddSelectorTypeLabel || ((_texts$en179 = texts.en) === null || _texts$en179 === void 0 ? void 0 : _texts$en179.autoGearAddSelectorTypeLabel) || autoGearAddSelectorTypeLabel.textContent;
+      var _texts$en181;
+      var _label49 = texts[lang].autoGearAddSelectorTypeLabel || ((_texts$en181 = texts.en) === null || _texts$en181 === void 0 ? void 0 : _texts$en181.autoGearAddSelectorTypeLabel) || autoGearAddSelectorTypeLabel.textContent;
       autoGearAddSelectorTypeLabel.textContent = _label49;
       if (autoGearAddSelectorTypeSelect) {
-        var _texts$en180, _texts$en181, _texts$en182, _texts$en183, _texts$en184, _texts$en185, _texts$en186;
+        var _texts$en182, _texts$en183, _texts$en184, _texts$en185, _texts$en186, _texts$en187, _texts$en188;
         autoGearAddSelectorTypeSelect.setAttribute('aria-label', _label49);
-        var noneLabel = texts[lang].autoGearSelectorNoneOption || ((_texts$en180 = texts.en) === null || _texts$en180 === void 0 ? void 0 : _texts$en180.autoGearSelectorNoneOption) || 'No selector';
-        var monitorLabel = texts[lang].autoGearSelectorMonitorOption || ((_texts$en181 = texts.en) === null || _texts$en181 === void 0 ? void 0 : _texts$en181.autoGearSelectorMonitorOption) || 'Monitor selector';
-        var directorLabel = texts[lang].autoGearSelectorDirectorOption || ((_texts$en182 = texts.en) === null || _texts$en182 === void 0 ? void 0 : _texts$en182.autoGearSelectorDirectorOption) || 'Director monitor selector';
-        var tripodHeadLabel = texts[lang].autoGearSelectorTripodHeadOption || ((_texts$en183 = texts.en) === null || _texts$en183 === void 0 ? void 0 : _texts$en183.autoGearSelectorTripodHeadOption) || 'Tripod head selector';
-        var _tripodBowlLabel = texts[lang].autoGearSelectorTripodBowlOption || ((_texts$en184 = texts.en) === null || _texts$en184 === void 0 ? void 0 : _texts$en184.autoGearSelectorTripodBowlOption) || 'Tripod bowl selector';
-        var _tripodTypesLabel = texts[lang].autoGearSelectorTripodTypesOption || ((_texts$en185 = texts.en) === null || _texts$en185 === void 0 ? void 0 : _texts$en185.autoGearSelectorTripodTypesOption) || 'Tripod type selector';
-        var _tripodSpreaderLabel = texts[lang].autoGearSelectorTripodSpreaderOption || ((_texts$en186 = texts.en) === null || _texts$en186 === void 0 ? void 0 : _texts$en186.autoGearSelectorTripodSpreaderOption) || 'Tripod spreader selector';
+        var noneLabel = texts[lang].autoGearSelectorNoneOption || ((_texts$en182 = texts.en) === null || _texts$en182 === void 0 ? void 0 : _texts$en182.autoGearSelectorNoneOption) || 'No selector';
+        var monitorLabel = texts[lang].autoGearSelectorMonitorOption || ((_texts$en183 = texts.en) === null || _texts$en183 === void 0 ? void 0 : _texts$en183.autoGearSelectorMonitorOption) || 'Monitor selector';
+        var directorLabel = texts[lang].autoGearSelectorDirectorOption || ((_texts$en184 = texts.en) === null || _texts$en184 === void 0 ? void 0 : _texts$en184.autoGearSelectorDirectorOption) || 'Director monitor selector';
+        var tripodHeadLabel = texts[lang].autoGearSelectorTripodHeadOption || ((_texts$en185 = texts.en) === null || _texts$en185 === void 0 ? void 0 : _texts$en185.autoGearSelectorTripodHeadOption) || 'Tripod head selector';
+        var _tripodBowlLabel = texts[lang].autoGearSelectorTripodBowlOption || ((_texts$en186 = texts.en) === null || _texts$en186 === void 0 ? void 0 : _texts$en186.autoGearSelectorTripodBowlOption) || 'Tripod bowl selector';
+        var _tripodTypesLabel = texts[lang].autoGearSelectorTripodTypesOption || ((_texts$en187 = texts.en) === null || _texts$en187 === void 0 ? void 0 : _texts$en187.autoGearSelectorTripodTypesOption) || 'Tripod type selector';
+        var _tripodSpreaderLabel = texts[lang].autoGearSelectorTripodSpreaderOption || ((_texts$en188 = texts.en) === null || _texts$en188 === void 0 ? void 0 : _texts$en188.autoGearSelectorTripodSpreaderOption) || 'Tripod spreader selector';
         var selectorLabels = new Map([['none', noneLabel], ['monitor', monitorLabel], ['directorMonitor', directorLabel], ['tripodHeadBrand', tripodHeadLabel], ['tripodBowl', _tripodBowlLabel], ['tripodTypes', _tripodTypesLabel], ['tripodSpreader', _tripodSpreaderLabel]]);
         Array.from(autoGearAddSelectorTypeSelect.options || []).forEach(function (opt) {
           var text = selectorLabels.get(opt.value);
@@ -8564,32 +8620,34 @@ function updateAutoGearItemButtonState(type) {
       }
     }
     if (autoGearAddSelectorDefaultLabel) {
-      var _texts$en187;
-      var _label50 = texts[lang].autoGearAddSelectorDefaultLabel || ((_texts$en187 = texts.en) === null || _texts$en187 === void 0 ? void 0 : _texts$en187.autoGearAddSelectorDefaultLabel) || autoGearAddSelectorDefaultLabel.textContent;
+      var _texts$en189;
+      var _label50 = texts[lang].autoGearAddSelectorDefaultLabel || ((_texts$en189 = texts.en) === null || _texts$en189 === void 0 ? void 0 : _texts$en189.autoGearAddSelectorDefaultLabel) || autoGearAddSelectorDefaultLabel.textContent;
       autoGearAddSelectorDefaultLabel.textContent = _label50;
       if (autoGearAddSelectorDefaultInput) {
         autoGearAddSelectorDefaultInput.setAttribute('aria-label', _label50);
       }
     }
     if (autoGearAddNotesLabel) {
-      var _texts$en188;
-      var _label51 = texts[lang].autoGearAddNotesLabel || ((_texts$en188 = texts.en) === null || _texts$en188 === void 0 ? void 0 : _texts$en188.autoGearAddNotesLabel) || autoGearAddNotesLabel.textContent;
+      var _texts$en190;
+      var _label51 = texts[lang].autoGearAddNotesLabel || ((_texts$en190 = texts.en) === null || _texts$en190 === void 0 ? void 0 : _texts$en190.autoGearAddNotesLabel) || autoGearAddNotesLabel.textContent;
       autoGearAddNotesLabel.textContent = _label51;
       if (autoGearAddNotesInput) {
         autoGearAddNotesInput.setAttribute('aria-label', _label51);
       }
     }
     if (autoGearAddItemButton) {
-      updateAutoGearItemButtonState('add');
+      if (typeof updateAutoGearItemButtonState === 'function') {
+        updateAutoGearItemButtonState('add');
+      }
     }
     if (autoGearRemoveItemsHeading) {
-      var _texts$en189;
-      autoGearRemoveItemsHeading.textContent = texts[lang].autoGearRemoveItemsHeading || ((_texts$en189 = texts.en) === null || _texts$en189 === void 0 ? void 0 : _texts$en189.autoGearRemoveItemsHeading) || autoGearRemoveItemsHeading.textContent;
+      var _texts$en191;
+      autoGearRemoveItemsHeading.textContent = texts[lang].autoGearRemoveItemsHeading || ((_texts$en191 = texts.en) === null || _texts$en191 === void 0 ? void 0 : _texts$en191.autoGearRemoveItemsHeading) || autoGearRemoveItemsHeading.textContent;
     }
     if (autoGearRemoveItemLabel) {
-      var _texts$en190, _texts$en191;
-      var _label52 = texts[lang].autoGearRemoveItemLabel || ((_texts$en190 = texts.en) === null || _texts$en190 === void 0 ? void 0 : _texts$en190.autoGearRemoveItemLabel) || autoGearRemoveItemLabel.textContent;
-      var _hint = texts[lang].autoGearRemoveMultipleHint || ((_texts$en191 = texts.en) === null || _texts$en191 === void 0 ? void 0 : _texts$en191.autoGearRemoveMultipleHint) || '';
+      var _texts$en192, _texts$en193;
+      var _label52 = texts[lang].autoGearRemoveItemLabel || ((_texts$en192 = texts.en) === null || _texts$en192 === void 0 ? void 0 : _texts$en192.autoGearRemoveItemLabel) || autoGearRemoveItemLabel.textContent;
+      var _hint = texts[lang].autoGearRemoveMultipleHint || ((_texts$en193 = texts.en) === null || _texts$en193 === void 0 ? void 0 : _texts$en193.autoGearRemoveMultipleHint) || '';
       var _helpText = _hint ? "".concat(_label52, " \u2013 ").concat(_hint) : _label52;
       autoGearRemoveItemLabel.textContent = _label52;
       autoGearRemoveItemLabel.setAttribute('data-help', _helpText);
@@ -8604,43 +8662,43 @@ function updateAutoGearItemButtonState(type) {
       }
     }
     if (autoGearRemoveCategoryLabel) {
-      var _texts$en192;
-      var _label53 = texts[lang].autoGearRemoveCategoryLabel || ((_texts$en192 = texts.en) === null || _texts$en192 === void 0 ? void 0 : _texts$en192.autoGearRemoveCategoryLabel) || autoGearRemoveCategoryLabel.textContent;
+      var _texts$en194;
+      var _label53 = texts[lang].autoGearRemoveCategoryLabel || ((_texts$en194 = texts.en) === null || _texts$en194 === void 0 ? void 0 : _texts$en194.autoGearRemoveCategoryLabel) || autoGearRemoveCategoryLabel.textContent;
       autoGearRemoveCategoryLabel.textContent = _label53;
       if (autoGearRemoveCategorySelect) {
         autoGearRemoveCategorySelect.setAttribute('aria-label', _label53);
       }
     }
     if (autoGearRemoveQuantityLabel) {
-      var _texts$en193;
-      var _label54 = texts[lang].autoGearRemoveQuantityLabel || ((_texts$en193 = texts.en) === null || _texts$en193 === void 0 ? void 0 : _texts$en193.autoGearRemoveQuantityLabel) || autoGearRemoveQuantityLabel.textContent;
+      var _texts$en195;
+      var _label54 = texts[lang].autoGearRemoveQuantityLabel || ((_texts$en195 = texts.en) === null || _texts$en195 === void 0 ? void 0 : _texts$en195.autoGearRemoveQuantityLabel) || autoGearRemoveQuantityLabel.textContent;
       autoGearRemoveQuantityLabel.textContent = _label54;
       if (autoGearRemoveQuantityInput) {
         autoGearRemoveQuantityInput.setAttribute('aria-label', _label54);
       }
     }
     if (autoGearRemoveScreenSizeLabel) {
-      var _texts$en194;
-      var _label55 = texts[lang].autoGearRemoveScreenSizeLabel || ((_texts$en194 = texts.en) === null || _texts$en194 === void 0 ? void 0 : _texts$en194.autoGearRemoveScreenSizeLabel) || autoGearRemoveScreenSizeLabel.textContent;
+      var _texts$en196;
+      var _label55 = texts[lang].autoGearRemoveScreenSizeLabel || ((_texts$en196 = texts.en) === null || _texts$en196 === void 0 ? void 0 : _texts$en196.autoGearRemoveScreenSizeLabel) || autoGearRemoveScreenSizeLabel.textContent;
       autoGearRemoveScreenSizeLabel.textContent = _label55;
       if (autoGearRemoveScreenSizeInput) {
         autoGearRemoveScreenSizeInput.setAttribute('aria-label', _label55);
       }
     }
     if (autoGearRemoveSelectorTypeLabel) {
-      var _texts$en195;
-      var _label56 = texts[lang].autoGearRemoveSelectorTypeLabel || ((_texts$en195 = texts.en) === null || _texts$en195 === void 0 ? void 0 : _texts$en195.autoGearRemoveSelectorTypeLabel) || autoGearRemoveSelectorTypeLabel.textContent;
+      var _texts$en197;
+      var _label56 = texts[lang].autoGearRemoveSelectorTypeLabel || ((_texts$en197 = texts.en) === null || _texts$en197 === void 0 ? void 0 : _texts$en197.autoGearRemoveSelectorTypeLabel) || autoGearRemoveSelectorTypeLabel.textContent;
       autoGearRemoveSelectorTypeLabel.textContent = _label56;
       if (autoGearRemoveSelectorTypeSelect) {
-        var _texts$en196, _texts$en197, _texts$en198, _texts$en199, _texts$en200, _texts$en201, _texts$en202;
+        var _texts$en198, _texts$en199, _texts$en200, _texts$en201, _texts$en202, _texts$en203, _texts$en204;
         autoGearRemoveSelectorTypeSelect.setAttribute('aria-label', _label56);
-        var _noneLabel = texts[lang].autoGearSelectorNoneOption || ((_texts$en196 = texts.en) === null || _texts$en196 === void 0 ? void 0 : _texts$en196.autoGearSelectorNoneOption) || 'No selector';
-        var _monitorLabel = texts[lang].autoGearSelectorMonitorOption || ((_texts$en197 = texts.en) === null || _texts$en197 === void 0 ? void 0 : _texts$en197.autoGearSelectorMonitorOption) || 'Monitor selector';
-        var _directorLabel = texts[lang].autoGearSelectorDirectorOption || ((_texts$en198 = texts.en) === null || _texts$en198 === void 0 ? void 0 : _texts$en198.autoGearSelectorDirectorOption) || 'Director monitor selector';
-        var _tripodHeadLabel = texts[lang].autoGearSelectorTripodHeadOption || ((_texts$en199 = texts.en) === null || _texts$en199 === void 0 ? void 0 : _texts$en199.autoGearSelectorTripodHeadOption) || 'Tripod head selector';
-        var _tripodBowlLabel2 = texts[lang].autoGearSelectorTripodBowlOption || ((_texts$en200 = texts.en) === null || _texts$en200 === void 0 ? void 0 : _texts$en200.autoGearSelectorTripodBowlOption) || 'Tripod bowl selector';
-        var _tripodTypesLabel2 = texts[lang].autoGearSelectorTripodTypesOption || ((_texts$en201 = texts.en) === null || _texts$en201 === void 0 ? void 0 : _texts$en201.autoGearSelectorTripodTypesOption) || 'Tripod type selector';
-        var _tripodSpreaderLabel2 = texts[lang].autoGearSelectorTripodSpreaderOption || ((_texts$en202 = texts.en) === null || _texts$en202 === void 0 ? void 0 : _texts$en202.autoGearSelectorTripodSpreaderOption) || 'Tripod spreader selector';
+        var _noneLabel = texts[lang].autoGearSelectorNoneOption || ((_texts$en198 = texts.en) === null || _texts$en198 === void 0 ? void 0 : _texts$en198.autoGearSelectorNoneOption) || 'No selector';
+        var _monitorLabel = texts[lang].autoGearSelectorMonitorOption || ((_texts$en199 = texts.en) === null || _texts$en199 === void 0 ? void 0 : _texts$en199.autoGearSelectorMonitorOption) || 'Monitor selector';
+        var _directorLabel = texts[lang].autoGearSelectorDirectorOption || ((_texts$en200 = texts.en) === null || _texts$en200 === void 0 ? void 0 : _texts$en200.autoGearSelectorDirectorOption) || 'Director monitor selector';
+        var _tripodHeadLabel = texts[lang].autoGearSelectorTripodHeadOption || ((_texts$en201 = texts.en) === null || _texts$en201 === void 0 ? void 0 : _texts$en201.autoGearSelectorTripodHeadOption) || 'Tripod head selector';
+        var _tripodBowlLabel2 = texts[lang].autoGearSelectorTripodBowlOption || ((_texts$en202 = texts.en) === null || _texts$en202 === void 0 ? void 0 : _texts$en202.autoGearSelectorTripodBowlOption) || 'Tripod bowl selector';
+        var _tripodTypesLabel2 = texts[lang].autoGearSelectorTripodTypesOption || ((_texts$en203 = texts.en) === null || _texts$en203 === void 0 ? void 0 : _texts$en203.autoGearSelectorTripodTypesOption) || 'Tripod type selector';
+        var _tripodSpreaderLabel2 = texts[lang].autoGearSelectorTripodSpreaderOption || ((_texts$en204 = texts.en) === null || _texts$en204 === void 0 ? void 0 : _texts$en204.autoGearSelectorTripodSpreaderOption) || 'Tripod spreader selector';
         var _selectorLabels = new Map([['none', _noneLabel], ['monitor', _monitorLabel], ['directorMonitor', _directorLabel], ['tripodHeadBrand', _tripodHeadLabel], ['tripodBowl', _tripodBowlLabel2], ['tripodTypes', _tripodTypesLabel2], ['tripodSpreader', _tripodSpreaderLabel2]]);
         Array.from(autoGearRemoveSelectorTypeSelect.options || []).forEach(function (opt) {
           var text = _selectorLabels.get(opt.value);
@@ -8649,29 +8707,29 @@ function updateAutoGearItemButtonState(type) {
       }
     }
     if (autoGearRemoveSelectorDefaultLabel) {
-      var _texts$en203;
-      var _label57 = texts[lang].autoGearRemoveSelectorDefaultLabel || ((_texts$en203 = texts.en) === null || _texts$en203 === void 0 ? void 0 : _texts$en203.autoGearRemoveSelectorDefaultLabel) || autoGearRemoveSelectorDefaultLabel.textContent;
+      var _texts$en205;
+      var _label57 = texts[lang].autoGearRemoveSelectorDefaultLabel || ((_texts$en205 = texts.en) === null || _texts$en205 === void 0 ? void 0 : _texts$en205.autoGearRemoveSelectorDefaultLabel) || autoGearRemoveSelectorDefaultLabel.textContent;
       autoGearRemoveSelectorDefaultLabel.textContent = _label57;
       if (autoGearRemoveSelectorDefaultInput) {
         autoGearRemoveSelectorDefaultInput.setAttribute('aria-label', _label57);
       }
     }
     if (autoGearRemoveNotesLabel) {
-      var _texts$en204;
-      var _label58 = texts[lang].autoGearRemoveNotesLabel || ((_texts$en204 = texts.en) === null || _texts$en204 === void 0 ? void 0 : _texts$en204.autoGearRemoveNotesLabel) || autoGearRemoveNotesLabel.textContent;
+      var _texts$en206;
+      var _label58 = texts[lang].autoGearRemoveNotesLabel || ((_texts$en206 = texts.en) === null || _texts$en206 === void 0 ? void 0 : _texts$en206.autoGearRemoveNotesLabel) || autoGearRemoveNotesLabel.textContent;
       autoGearRemoveNotesLabel.textContent = _label58;
       if (autoGearRemoveNotesInput) {
         autoGearRemoveNotesInput.setAttribute('aria-label', _label58);
       }
     }
     if (autoGearDraftImpactHeading) {
-      var _texts$en205;
-      var _heading2 = texts[lang].autoGearDraftImpactHeading || ((_texts$en205 = texts.en) === null || _texts$en205 === void 0 ? void 0 : _texts$en205.autoGearDraftImpactHeading) || autoGearDraftImpactHeading.textContent;
+      var _texts$en207;
+      var _heading2 = texts[lang].autoGearDraftImpactHeading || ((_texts$en207 = texts.en) === null || _texts$en207 === void 0 ? void 0 : _texts$en207.autoGearDraftImpactHeading) || autoGearDraftImpactHeading.textContent;
       autoGearDraftImpactHeading.textContent = _heading2;
     }
     if (autoGearDraftImpactDescription) {
-      var _texts$en206;
-      var _description2 = texts[lang].autoGearDraftImpactDescription || ((_texts$en206 = texts.en) === null || _texts$en206 === void 0 ? void 0 : _texts$en206.autoGearDraftImpactDescription) || autoGearDraftImpactDescription.textContent;
+      var _texts$en208;
+      var _description2 = texts[lang].autoGearDraftImpactDescription || ((_texts$en208 = texts.en) === null || _texts$en208 === void 0 ? void 0 : _texts$en208.autoGearDraftImpactDescription) || autoGearDraftImpactDescription.textContent;
       autoGearDraftImpactDescription.textContent = _description2;
       if (autoGearDraftImpactHeading) {
         autoGearDraftImpactHeading.setAttribute('data-help', _description2);
@@ -8681,22 +8739,24 @@ function updateAutoGearItemButtonState(type) {
       }
     }
     if (autoGearDraftWarningHeading) {
-      var _texts$en207;
-      var _heading3 = texts[lang].autoGearDraftWarningHeading || ((_texts$en207 = texts.en) === null || _texts$en207 === void 0 ? void 0 : _texts$en207.autoGearDraftWarningHeading) || autoGearDraftWarningHeading.textContent;
+      var _texts$en209;
+      var _heading3 = texts[lang].autoGearDraftWarningHeading || ((_texts$en209 = texts.en) === null || _texts$en209 === void 0 ? void 0 : _texts$en209.autoGearDraftWarningHeading) || autoGearDraftWarningHeading.textContent;
       autoGearDraftWarningHeading.textContent = _heading3;
     }
     if (autoGearRemoveItemButton) {
-      updateAutoGearItemButtonState('remove');
+      if (typeof updateAutoGearItemButtonState === 'function') {
+        updateAutoGearItemButtonState('remove');
+      }
     }
     if (autoGearSaveRuleButton) {
-      var _texts$en208;
-      var _label59 = texts[lang].autoGearSaveRule || ((_texts$en208 = texts.en) === null || _texts$en208 === void 0 ? void 0 : _texts$en208.autoGearSaveRule) || autoGearSaveRuleButton.textContent;
+      var _texts$en210;
+      var _label59 = texts[lang].autoGearSaveRule || ((_texts$en210 = texts.en) === null || _texts$en210 === void 0 ? void 0 : _texts$en210.autoGearSaveRule) || autoGearSaveRuleButton.textContent;
       setButtonLabelWithIcon(autoGearSaveRuleButton, _label59);
       autoGearSaveRuleButton.setAttribute('data-help', _label59);
     }
     if (autoGearCancelEditButton) {
-      var _texts$en209;
-      var _label60 = texts[lang].autoGearCancelEdit || ((_texts$en209 = texts.en) === null || _texts$en209 === void 0 ? void 0 : _texts$en209.autoGearCancelEdit) || autoGearCancelEditButton.textContent;
+      var _texts$en211;
+      var _label60 = texts[lang].autoGearCancelEdit || ((_texts$en211 = texts.en) === null || _texts$en211 === void 0 ? void 0 : _texts$en211.autoGearCancelEdit) || autoGearCancelEditButton.textContent;
       setButtonLabelWithIcon(autoGearCancelEditButton, _label60, ICON_GLYPHS.circleX);
       autoGearCancelEditButton.setAttribute('data-help', _label60);
     }
@@ -8738,7 +8798,9 @@ function updateAutoGearItemButtonState(type) {
     callCoreFunctionIfAvailable('renderAutoGearPresetsControls', [], {
       defer: true
     });
-    applyAutoGearBackupVisibility();
+    callCoreFunctionIfAvailable('applyAutoGearBackupVisibility', [], {
+      defer: true
+    });
     var contrastLabel = document.getElementById("settingsHighContrastLabel");
     if (contrastLabel) {
       contrastLabel.textContent = texts[lang].highContrastSetting;
@@ -8759,6 +8821,7 @@ function updateAutoGearItemButtonState(type) {
       backupHeading.textContent = texts[lang].backupHeading;
       backupHeading.setAttribute("data-help", texts[lang].backupHeadingHelp || texts[lang].backupHeading);
     }
+    var projectBackupsHeading = typeof document !== 'undefined' ? document.getElementById('projectBackupsHeading') : null;
     if (projectBackupsHeading) {
       var headingText = texts[lang].projectBackupsHeading || "Project Backups";
       projectBackupsHeading.textContent = headingText;
@@ -8769,6 +8832,7 @@ function updateAutoGearItemButtonState(type) {
         projectBackupsHeading.removeAttribute("data-help");
       }
     }
+    var projectBackupsDescription = typeof document !== 'undefined' ? document.getElementById('projectBackupsDescription') : null;
     if (projectBackupsDescription) {
       var _descriptionText = texts[lang].projectBackupsDescription || "";
       if (_descriptionText) {
@@ -8794,52 +8858,52 @@ function updateAutoGearItemButtonState(type) {
       storageSummaryEmpty.textContent = texts[lang].storageSummaryEmpty;
     }
     if (storageActionsHeading) {
-      var _texts$en210, _texts$en211;
-      var _headingText = texts[lang].storageActionsHeading || ((_texts$en210 = texts.en) === null || _texts$en210 === void 0 ? void 0 : _texts$en210.storageActionsHeading) || storageActionsHeading.textContent;
+      var _texts$en212, _texts$en213;
+      var _headingText = texts[lang].storageActionsHeading || ((_texts$en212 = texts.en) === null || _texts$en212 === void 0 ? void 0 : _texts$en212.storageActionsHeading) || storageActionsHeading.textContent;
       storageActionsHeading.textContent = _headingText;
-      var _headingHelp = texts[lang].storageActionsHeadingHelp || ((_texts$en211 = texts.en) === null || _texts$en211 === void 0 ? void 0 : _texts$en211.storageActionsHeadingHelp) || _headingText;
+      var _headingHelp = texts[lang].storageActionsHeadingHelp || ((_texts$en213 = texts.en) === null || _texts$en213 === void 0 ? void 0 : _texts$en213.storageActionsHeadingHelp) || _headingText;
       storageActionsHeading.setAttribute('data-help', _headingHelp);
     }
     if (storageActionsIntro) {
-      var _texts$en212;
-      storageActionsIntro.textContent = texts[lang].storageActionsIntro || ((_texts$en212 = texts.en) === null || _texts$en212 === void 0 ? void 0 : _texts$en212.storageActionsIntro) || storageActionsIntro.textContent;
+      var _texts$en214;
+      storageActionsIntro.textContent = texts[lang].storageActionsIntro || ((_texts$en214 = texts.en) === null || _texts$en214 === void 0 ? void 0 : _texts$en214.storageActionsIntro) || storageActionsIntro.textContent;
     }
     if (storageBackupNowButton) {
-      var _texts$en213, _texts$en214;
-      var backupLabel = texts[lang].storageBackupNow || ((_texts$en213 = texts.en) === null || _texts$en213 === void 0 ? void 0 : _texts$en213.storageBackupNow) || storageBackupNowButton.textContent;
+      var _texts$en215, _texts$en216;
+      var backupLabel = texts[lang].storageBackupNow || ((_texts$en215 = texts.en) === null || _texts$en215 === void 0 ? void 0 : _texts$en215.storageBackupNow) || storageBackupNowButton.textContent;
       setButtonLabelWithIcon(storageBackupNowButton, backupLabel, ICON_GLYPHS.fileExport);
-      var backupHelp = texts[lang].storageBackupNowHelp || ((_texts$en214 = texts.en) === null || _texts$en214 === void 0 ? void 0 : _texts$en214.storageBackupNowHelp) || backupLabel;
+      var backupHelp = texts[lang].storageBackupNowHelp || ((_texts$en216 = texts.en) === null || _texts$en216 === void 0 ? void 0 : _texts$en216.storageBackupNowHelp) || backupLabel;
       storageBackupNowButton.setAttribute('data-help', backupHelp);
       storageBackupNowButton.setAttribute('title', backupHelp);
     }
     if (storageOpenBackupTabButton) {
-      var _texts$en215, _texts$en216;
-      var openLabel = texts[lang].storageOpenBackupTab || ((_texts$en215 = texts.en) === null || _texts$en215 === void 0 ? void 0 : _texts$en215.storageOpenBackupTab) || storageOpenBackupTabButton.textContent;
+      var _texts$en217, _texts$en218;
+      var openLabel = texts[lang].storageOpenBackupTab || ((_texts$en217 = texts.en) === null || _texts$en217 === void 0 ? void 0 : _texts$en217.storageOpenBackupTab) || storageOpenBackupTabButton.textContent;
       setButtonLabelWithIcon(storageOpenBackupTabButton, openLabel, ICON_GLYPHS.settingsBackup);
-      var openHelp = texts[lang].storageOpenBackupTabHelp || ((_texts$en216 = texts.en) === null || _texts$en216 === void 0 ? void 0 : _texts$en216.storageOpenBackupTabHelp) || openLabel;
+      var openHelp = texts[lang].storageOpenBackupTabHelp || ((_texts$en218 = texts.en) === null || _texts$en218 === void 0 ? void 0 : _texts$en218.storageOpenBackupTabHelp) || openLabel;
       storageOpenBackupTabButton.setAttribute('data-help', openHelp);
       storageOpenBackupTabButton.setAttribute('title', openHelp);
     }
     if (storageStatusHeading) {
-      var _texts$en217, _texts$en218;
-      var statusHeading = texts[lang].storageStatusHeading || ((_texts$en217 = texts.en) === null || _texts$en217 === void 0 ? void 0 : _texts$en217.storageStatusHeading) || storageStatusHeading.textContent;
+      var _texts$en219, _texts$en220;
+      var statusHeading = texts[lang].storageStatusHeading || ((_texts$en219 = texts.en) === null || _texts$en219 === void 0 ? void 0 : _texts$en219.storageStatusHeading) || storageStatusHeading.textContent;
       storageStatusHeading.textContent = statusHeading;
-      var statusHelp = texts[lang].storageStatusHeadingHelp || ((_texts$en218 = texts.en) === null || _texts$en218 === void 0 ? void 0 : _texts$en218.storageStatusHeadingHelp) || statusHeading;
+      var statusHelp = texts[lang].storageStatusHeadingHelp || ((_texts$en220 = texts.en) === null || _texts$en220 === void 0 ? void 0 : _texts$en220.storageStatusHeadingHelp) || statusHeading;
       storageStatusHeading.setAttribute('data-help', statusHelp);
     }
     if (storageStatusLastProjectLabel) {
-      var _texts$en219;
-      storageStatusLastProjectLabel.textContent = texts[lang].storageStatusLastProjectLabel || ((_texts$en219 = texts.en) === null || _texts$en219 === void 0 ? void 0 : _texts$en219.storageStatusLastProjectLabel) || storageStatusLastProjectLabel.textContent;
+      var _texts$en221;
+      storageStatusLastProjectLabel.textContent = texts[lang].storageStatusLastProjectLabel || ((_texts$en221 = texts.en) === null || _texts$en221 === void 0 ? void 0 : _texts$en221.storageStatusLastProjectLabel) || storageStatusLastProjectLabel.textContent;
     }
     if (storageStatusLastAutoBackupLabel) {
-      var _texts$en220;
-      storageStatusLastAutoBackupLabel.textContent = texts[lang].storageStatusLastAutoBackupLabel || ((_texts$en220 = texts.en) === null || _texts$en220 === void 0 ? void 0 : _texts$en220.storageStatusLastAutoBackupLabel) || storageStatusLastAutoBackupLabel.textContent;
+      var _texts$en222;
+      storageStatusLastAutoBackupLabel.textContent = texts[lang].storageStatusLastAutoBackupLabel || ((_texts$en222 = texts.en) === null || _texts$en222 === void 0 ? void 0 : _texts$en222.storageStatusLastAutoBackupLabel) || storageStatusLastAutoBackupLabel.textContent;
     }
     if (storageStatusLastFullBackupLabel) {
-      var _texts$en221;
-      storageStatusLastFullBackupLabel.textContent = texts[lang].storageStatusLastFullBackupLabel || ((_texts$en221 = texts.en) === null || _texts$en221 === void 0 ? void 0 : _texts$en221.storageStatusLastFullBackupLabel) || storageStatusLastFullBackupLabel.textContent;
+      var _texts$en223;
+      storageStatusLastFullBackupLabel.textContent = texts[lang].storageStatusLastFullBackupLabel || ((_texts$en223 = texts.en) === null || _texts$en223 === void 0 ? void 0 : _texts$en223.storageStatusLastFullBackupLabel) || storageStatusLastFullBackupLabel.textContent;
     }
-    var statusDefaultText = texts[lang].storageStatusNever || ((_texts$en222 = texts.en) === null || _texts$en222 === void 0 ? void 0 : _texts$en222.storageStatusNever) || (storageStatusLastProjectValue ? storageStatusLastProjectValue.textContent : '');
+    var statusDefaultText = texts[lang].storageStatusNever || ((_texts$en224 = texts.en) === null || _texts$en224 === void 0 ? void 0 : _texts$en224.storageStatusNever) || (storageStatusLastProjectValue ? storageStatusLastProjectValue.textContent : '');
     if (storageStatusLastProjectValue) {
       storageStatusLastProjectValue.textContent = statusDefaultText;
     }
@@ -8963,16 +9027,16 @@ function updateAutoGearItemButtonState(type) {
       restoreRehearsalStatus.textContent = texts[lang].restoreRehearsalReady || '';
     }
     if (restoreRehearsalRuleHeading) {
-      var _texts$en223;
-      restoreRehearsalRuleHeading.textContent = texts[lang].restoreRehearsalRuleHeading || ((_texts$en223 = texts.en) === null || _texts$en223 === void 0 ? void 0 : _texts$en223.restoreRehearsalRuleHeading) || restoreRehearsalRuleHeading.textContent;
+      var _texts$en225;
+      restoreRehearsalRuleHeading.textContent = texts[lang].restoreRehearsalRuleHeading || ((_texts$en225 = texts.en) === null || _texts$en225 === void 0 ? void 0 : _texts$en225.restoreRehearsalRuleHeading) || restoreRehearsalRuleHeading.textContent;
     }
     if (restoreRehearsalRuleIntro) {
-      var _texts$en224;
-      restoreRehearsalRuleIntro.textContent = texts[lang].restoreRehearsalRuleIntro || ((_texts$en224 = texts.en) === null || _texts$en224 === void 0 ? void 0 : _texts$en224.restoreRehearsalRuleIntro) || restoreRehearsalRuleIntro.textContent;
+      var _texts$en226;
+      restoreRehearsalRuleIntro.textContent = texts[lang].restoreRehearsalRuleIntro || ((_texts$en226 = texts.en) === null || _texts$en226 === void 0 ? void 0 : _texts$en226.restoreRehearsalRuleIntro) || restoreRehearsalRuleIntro.textContent;
     }
     if (restoreRehearsalRuleEmpty) {
-      var _texts$en225;
-      restoreRehearsalRuleEmpty.textContent = texts[lang].restoreRehearsalRuleEmpty || ((_texts$en225 = texts.en) === null || _texts$en225 === void 0 ? void 0 : _texts$en225.restoreRehearsalRuleEmpty) || restoreRehearsalRuleEmpty.textContent;
+      var _texts$en227;
+      restoreRehearsalRuleEmpty.textContent = texts[lang].restoreRehearsalRuleEmpty || ((_texts$en227 = texts.en) === null || _texts$en227 === void 0 ? void 0 : _texts$en227.restoreRehearsalRuleEmpty) || restoreRehearsalRuleEmpty.textContent;
     }
     if (restoreRehearsalTableCaption) {
       restoreRehearsalTableCaption.textContent = texts[lang].restoreRehearsalTableCaption || restoreRehearsalTableCaption.textContent;
@@ -8996,18 +9060,18 @@ function updateAutoGearItemButtonState(type) {
       restoreRehearsalCloseButton.setAttribute('aria-label', _closeLabel);
     }
     if (restoreRehearsalProceedButton) {
-      var _texts$en226, _texts$en227;
-      var proceedLabel = texts[lang].restoreRehearsalProceed || ((_texts$en226 = texts.en) === null || _texts$en226 === void 0 ? void 0 : _texts$en226.restoreRehearsalProceed) || 'Continue rehearsal restore';
-      var proceedHelp = texts[lang].restoreRehearsalProceedHelp || ((_texts$en227 = texts.en) === null || _texts$en227 === void 0 ? void 0 : _texts$en227.restoreRehearsalProceedHelp) || proceedLabel;
+      var _texts$en228, _texts$en229;
+      var proceedLabel = texts[lang].restoreRehearsalProceed || ((_texts$en228 = texts.en) === null || _texts$en228 === void 0 ? void 0 : _texts$en228.restoreRehearsalProceed) || 'Continue rehearsal restore';
+      var proceedHelp = texts[lang].restoreRehearsalProceedHelp || ((_texts$en229 = texts.en) === null || _texts$en229 === void 0 ? void 0 : _texts$en229.restoreRehearsalProceedHelp) || proceedLabel;
       setButtonLabelWithIcon(restoreRehearsalProceedButton, proceedLabel, ICON_GLYPHS.check);
       restoreRehearsalProceedButton.setAttribute('data-help', proceedHelp);
       restoreRehearsalProceedButton.setAttribute('title', proceedHelp);
       restoreRehearsalProceedButton.setAttribute('aria-label', proceedHelp);
     }
     if (restoreRehearsalAbortButton) {
-      var _texts$en228, _texts$en229;
-      var abortLabel = texts[lang].restoreRehearsalAbort || ((_texts$en228 = texts.en) === null || _texts$en228 === void 0 ? void 0 : _texts$en228.restoreRehearsalAbort) || 'Abort rehearsal';
-      var abortHelp = texts[lang].restoreRehearsalAbortHelp || ((_texts$en229 = texts.en) === null || _texts$en229 === void 0 ? void 0 : _texts$en229.restoreRehearsalAbortHelp) || abortLabel;
+      var _texts$en230, _texts$en231;
+      var abortLabel = texts[lang].restoreRehearsalAbort || ((_texts$en230 = texts.en) === null || _texts$en230 === void 0 ? void 0 : _texts$en230.restoreRehearsalAbort) || 'Abort rehearsal';
+      var abortHelp = texts[lang].restoreRehearsalAbortHelp || ((_texts$en231 = texts.en) === null || _texts$en231 === void 0 ? void 0 : _texts$en231.restoreRehearsalAbortHelp) || abortLabel;
       setButtonLabelWithIcon(restoreRehearsalAbortButton, abortLabel, ICON_GLYPHS.circleX);
       restoreRehearsalAbortButton.setAttribute('data-help', abortHelp);
       restoreRehearsalAbortButton.setAttribute('title', abortHelp);
@@ -9026,7 +9090,9 @@ function updateAutoGearItemButtonState(type) {
       aboutHeading.textContent = texts[lang].aboutHeading;
       aboutHeading.setAttribute("data-help", texts[lang].aboutHeadingHelp || texts[lang].aboutHeading);
     }
+    var aboutVersionElem = typeof document !== 'undefined' ? document.getElementById('aboutVersion') : null;
     if (aboutVersionElem) aboutVersionElem.textContent = "".concat(texts[lang].versionLabel, " ").concat(APP_VERSION);
+    var supportLink = typeof document !== 'undefined' ? document.getElementById('supportLink') : null;
     if (supportLink) {
       supportLink.textContent = texts[lang].supportLink;
       var supportHelp = texts[lang].supportLinkHelp || texts[lang].supportLink;
@@ -9034,8 +9100,8 @@ function updateAutoGearItemButtonState(type) {
       supportLink.setAttribute("title", supportHelp);
     }
     if (settingsSave) {
-      var _texts$en230;
-      var _label61 = texts[lang].saveSettings || ((_texts$en230 = texts.en) === null || _texts$en230 === void 0 ? void 0 : _texts$en230.saveSettings) || settingsSave.textContent;
+      var _texts$en232;
+      var _label61 = texts[lang].saveSettings || ((_texts$en232 = texts.en) === null || _texts$en232 === void 0 ? void 0 : _texts$en232.saveSettings) || settingsSave.textContent;
       setButtonLabelWithIcon(settingsSave, _label61);
       var saveHelp = texts[lang].saveSettingsHelp || texts[lang].saveSettings || _label61;
       settingsSave.setAttribute("data-help", saveHelp);
@@ -9043,8 +9109,8 @@ function updateAutoGearItemButtonState(type) {
       settingsSave.setAttribute("aria-label", saveHelp);
     }
     if (settingsCancel) {
-      var _texts$en231;
-      var _cancelLabel = texts[lang].cancelSettings || ((_texts$en231 = texts.en) === null || _texts$en231 === void 0 ? void 0 : _texts$en231.cancelSettings) || settingsCancel.textContent;
+      var _texts$en233;
+      var _cancelLabel = texts[lang].cancelSettings || ((_texts$en233 = texts.en) === null || _texts$en233 === void 0 ? void 0 : _texts$en233.cancelSettings) || settingsCancel.textContent;
       setButtonLabelWithIcon(settingsCancel, _cancelLabel, ICON_GLYPHS.circleX);
       var cancelHelp = texts[lang].cancelSettingsHelp || texts[lang].cancelSettings || _cancelLabel;
       settingsCancel.setAttribute("data-help", cancelHelp);
@@ -9053,9 +9119,9 @@ function updateAutoGearItemButtonState(type) {
     }
     var menuToggle = document.getElementById("menuToggle");
     if (menuToggle) {
-      var _texts$en232, _texts$en233;
-      var menuLabel = texts[lang].menuToggleLabel || ((_texts$en232 = texts.en) === null || _texts$en232 === void 0 ? void 0 : _texts$en232.menuToggleLabel) || menuToggle.getAttribute("aria-label") || "Menu";
-      var _closeLabel2 = texts[lang].sideMenuClose || ((_texts$en233 = texts.en) === null || _texts$en233 === void 0 ? void 0 : _texts$en233.sideMenuClose) || menuToggle.dataset.closeLabel || "Close menu";
+      var _texts$en234, _texts$en235;
+      var menuLabel = texts[lang].menuToggleLabel || ((_texts$en234 = texts.en) === null || _texts$en234 === void 0 ? void 0 : _texts$en234.menuToggleLabel) || menuToggle.getAttribute("aria-label") || "Menu";
+      var _closeLabel2 = texts[lang].sideMenuClose || ((_texts$en235 = texts.en) === null || _texts$en235 === void 0 ? void 0 : _texts$en235.sideMenuClose) || menuToggle.dataset.closeLabel || "Close menu";
       var closeHelp = texts[lang].sideMenuCloseHelp || _closeLabel2;
       menuToggle.setAttribute("title", menuLabel);
       menuToggle.setAttribute("aria-label", menuLabel);
@@ -9077,8 +9143,8 @@ function updateAutoGearItemButtonState(type) {
     }
     var sideMenuTitle = document.getElementById("sideMenuTitle");
     if (sideMenuTitle) {
-      var _texts$en234;
-      var titleLabel = texts[lang].sideMenuTitle || ((_texts$en234 = texts.en) === null || _texts$en234 === void 0 ? void 0 : _texts$en234.sideMenuTitle) || sideMenuTitle.textContent;
+      var _texts$en236;
+      var titleLabel = texts[lang].sideMenuTitle || ((_texts$en236 = texts.en) === null || _texts$en236 === void 0 ? void 0 : _texts$en236.sideMenuTitle) || sideMenuTitle.textContent;
       sideMenuTitle.textContent = titleLabel;
       var titleHelp = texts[lang].sideMenuTitleHelp || texts[lang].sideMenuHelp || titleLabel;
       sideMenuTitle.setAttribute("data-help", titleHelp);
@@ -9086,8 +9152,8 @@ function updateAutoGearItemButtonState(type) {
     var closeMenuButton = document.getElementById("closeMenuButton");
     var closeMenuLabel = document.getElementById("closeMenuLabel");
     if (closeMenuButton) {
-      var _texts$en235;
-      var _closeLabel3 = texts[lang].sideMenuClose || ((_texts$en235 = texts.en) === null || _texts$en235 === void 0 ? void 0 : _texts$en235.sideMenuClose) || closeMenuButton.getAttribute("aria-label") || "Close menu";
+      var _texts$en237;
+      var _closeLabel3 = texts[lang].sideMenuClose || ((_texts$en237 = texts.en) === null || _texts$en237 === void 0 ? void 0 : _texts$en237.sideMenuClose) || closeMenuButton.getAttribute("aria-label") || "Close menu";
       var _closeHelp = texts[lang].sideMenuCloseHelp || _closeLabel3;
       closeMenuButton.setAttribute("aria-label", _closeLabel3);
       closeMenuButton.setAttribute("title", _closeHelp);
@@ -9162,11 +9228,12 @@ function updateAutoGearItemButtonState(type) {
       setButtonLabelWithIcon(exportRevert, texts[lang].exportAndRevertBtn, ICON_GLYPHS.reload);
       exportRevert.setAttribute('data-help', texts[lang].exportAndRevertBtnHelp);
     }
-    if (downloadDiagramBtn) {
-      downloadDiagramBtn.textContent = texts[lang].downloadDiagramBtn;
-      downloadDiagramBtn.setAttribute("title", texts[lang].downloadDiagramBtn);
-      downloadDiagramBtn.setAttribute("aria-label", texts[lang].downloadDiagramBtn);
-      downloadDiagramBtn.setAttribute("data-help", texts[lang].downloadDiagramHelp);
+    var downloadDiagramButton = typeof downloadDiagramBtn !== 'undefined' && downloadDiagramBtn || (typeof document !== 'undefined' && document && typeof document.getElementById === 'function' ? document.getElementById('downloadDiagram') : null);
+    if (downloadDiagramButton) {
+      downloadDiagramButton.textContent = texts[lang].downloadDiagramBtn;
+      downloadDiagramButton.setAttribute("title", texts[lang].downloadDiagramBtn);
+      downloadDiagramButton.setAttribute("aria-label", texts[lang].downloadDiagramBtn);
+      downloadDiagramButton.setAttribute("data-help", texts[lang].downloadDiagramHelp);
     }
     if (gridSnapToggleBtn) {
       setButtonLabelWithIcon(gridSnapToggleBtn, texts[lang].gridSnapToggle, ICON_GLYPHS.magnet);
@@ -9175,24 +9242,28 @@ function updateAutoGearItemButtonState(type) {
       gridSnapToggleBtn.setAttribute("data-help", texts[lang].gridSnapToggleHelp);
       gridSnapToggleBtn.setAttribute("aria-pressed", gridSnap ? "true" : "false");
     }
+    var resetViewBtn = typeof document !== 'undefined' ? document.getElementById('resetView') : null;
     if (resetViewBtn) {
       setButtonLabelWithIcon(resetViewBtn, texts[lang].resetViewBtn, ICON_GLYPHS.resetView);
       resetViewBtn.setAttribute("title", texts[lang].resetViewBtn);
       resetViewBtn.setAttribute("aria-label", texts[lang].resetViewBtn);
       resetViewBtn.setAttribute("data-help", texts[lang].resetViewHelp);
     }
+    var zoomInBtn = typeof document !== 'undefined' ? document.getElementById('zoomIn') : null;
     if (zoomInBtn) {
       setButtonLabelWithIcon(zoomInBtn, '', ICON_GLYPHS.add);
       zoomInBtn.setAttribute("title", texts[lang].zoomInLabel);
       zoomInBtn.setAttribute("aria-label", texts[lang].zoomInLabel);
       zoomInBtn.setAttribute("data-help", texts[lang].zoomInHelp);
     }
+    var zoomOutBtn = typeof document !== 'undefined' ? document.getElementById('zoomOut') : null;
     if (zoomOutBtn) {
       setButtonLabelWithIcon(zoomOutBtn, '', ICON_GLYPHS.minus);
       zoomOutBtn.setAttribute("title", texts[lang].zoomOutLabel);
       zoomOutBtn.setAttribute("aria-label", texts[lang].zoomOutLabel);
       zoomOutBtn.setAttribute("data-help", texts[lang].zoomOutHelp);
     }
+    var diagramHint = typeof document !== 'undefined' ? document.getElementById('diagramHint') : null;
     if (diagramHint) {
       diagramHint.textContent = texts[lang].diagramMoveHint;
     }
@@ -9339,7 +9410,9 @@ function updateAutoGearItemButtonState(type) {
     ensureGearListActions();
     updateDiagramLegend();
     updateStorageSummary();
-    populateFeatureSearch();
+    callCoreFunctionIfAvailable('populateFeatureSearch', [], {
+      defer: true
+    });
   }
   var cameraSelect = document.getElementById("cameraSelect");
   var monitorSelect = document.getElementById("monitorSelect");
@@ -10272,21 +10345,21 @@ function updateAutoGearItemButtonState(type) {
     }
     return true;
   }
-  function findPinkModeAnimationPlacement(_ref34) {
-    var layer = _ref34.layer,
-      hostRect = _ref34.hostRect,
-      hostTop = _ref34.hostTop,
-      visibleTop = _ref34.visibleTop,
-      visibleBottom = _ref34.visibleBottom,
-      horizontalPadding = _ref34.horizontalPadding,
-      verticalPadding = _ref34.verticalPadding,
-      hostWidth = _ref34.hostWidth,
-      size = _ref34.size,
-      avoidRegions = _ref34.avoidRegions,
-      _ref34$leftMarginExte = _ref34.leftMarginExtension,
-      leftMarginExtension = _ref34$leftMarginExte === void 0 ? 0 : _ref34$leftMarginExte,
-      _ref34$rightMarginExt = _ref34.rightMarginExtension,
-      rightMarginExtension = _ref34$rightMarginExt === void 0 ? 0 : _ref34$rightMarginExt;
+  function findPinkModeAnimationPlacement(_ref36) {
+    var layer = _ref36.layer,
+      hostRect = _ref36.hostRect,
+      hostTop = _ref36.hostTop,
+      visibleTop = _ref36.visibleTop,
+      visibleBottom = _ref36.visibleBottom,
+      horizontalPadding = _ref36.horizontalPadding,
+      verticalPadding = _ref36.verticalPadding,
+      hostWidth = _ref36.hostWidth,
+      size = _ref36.size,
+      avoidRegions = _ref36.avoidRegions,
+      _ref36$leftMarginExte = _ref36.leftMarginExtension,
+      leftMarginExtension = _ref36$leftMarginExte === void 0 ? 0 : _ref36$leftMarginExte,
+      _ref36$rightMarginExt = _ref36.rightMarginExtension,
+      rightMarginExtension = _ref36$rightMarginExt === void 0 ? 0 : _ref36$rightMarginExt;
     var minY = Math.max(visibleTop - hostTop + verticalPadding, verticalPadding);
     var maxY = Math.max(visibleBottom - hostTop - verticalPadding, minY);
     var marginLeft = Math.max(0, leftMarginExtension);
@@ -10751,6 +10824,9 @@ function updateAutoGearItemButtonState(type) {
         scheduleNextPinkModeAnimatedIcon(templates);
       }
     }, delay);
+    if (pinkModeAnimatedIconTimeoutId && typeof pinkModeAnimatedIconTimeoutId.unref === 'function') {
+      pinkModeAnimatedIconTimeoutId.unref();
+    }
   }
   function startPinkModeAnimatedIcons() {
     if (pinkModeAnimatedIconsActive) {
@@ -10908,13 +10984,13 @@ function updateAutoGearItemButtonState(type) {
   function configureIconOnlyButton(button, glyph) {
     var options = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {};
     if (!button) return;
-    var _ref35 = options || {},
-      _ref35$contextPaths = _ref35.contextPaths,
-      contextPaths = _ref35$contextPaths === void 0 ? [] : _ref35$contextPaths,
-      _ref35$fallbackContex = _ref35.fallbackContext,
-      fallbackContext = _ref35$fallbackContex === void 0 ? '' : _ref35$fallbackContex,
-      _ref35$actionKey = _ref35.actionKey,
-      actionKey = _ref35$actionKey === void 0 ? 'addEntry' : _ref35$actionKey;
+    var _ref37 = options || {},
+      _ref37$contextPaths = _ref37.contextPaths,
+      contextPaths = _ref37$contextPaths === void 0 ? [] : _ref37$contextPaths,
+      _ref37$fallbackContex = _ref37.fallbackContext,
+      fallbackContext = _ref37$fallbackContex === void 0 ? '' : _ref37$fallbackContex,
+      _ref37$actionKey = _ref37.actionKey,
+      actionKey = _ref37$actionKey === void 0 ? 'addEntry' : _ref37$actionKey;
     setButtonLabelWithIcon(button, '', glyph || ICON_GLYPHS.add);
     var actionLabel = getLocalizedPathText(['projectForm', actionKey], actionKey === 'removeEntry' ? 'Remove' : 'Add');
     var paths = Array.isArray(contextPaths) ? contextPaths : [contextPaths];
@@ -10974,7 +11050,7 @@ function updateAutoGearItemButtonState(type) {
     return label;
   }
   function createCrewRow() {
-    var _texts$en237, _texts$currentLang2, _texts$currentLang3, _texts$en238, _texts$currentLang4, _texts$en239;
+    var _texts$en239, _texts$currentLang2, _texts$currentLang3, _texts$en240, _texts$currentLang4, _texts$en241;
     var data = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
     if (!crewContainer) return;
     var row = document.createElement('div');
@@ -10982,10 +11058,10 @@ function updateAutoGearItemButtonState(type) {
     var roleSel = document.createElement('select');
     roleSel.name = 'crewRole';
     crewRoles.forEach(function (r) {
-      var _texts$currentLang, _texts$en236;
+      var _texts$currentLang, _texts$en238;
       var opt = document.createElement('option');
       opt.value = r;
-      var roleLabels = ((_texts$currentLang = texts[currentLang]) === null || _texts$currentLang === void 0 ? void 0 : _texts$currentLang.crewRoles) || ((_texts$en236 = texts.en) === null || _texts$en236 === void 0 ? void 0 : _texts$en236.crewRoles) || {};
+      var roleLabels = ((_texts$currentLang = texts[currentLang]) === null || _texts$currentLang === void 0 ? void 0 : _texts$currentLang.crewRoles) || ((_texts$en238 = texts.en) === null || _texts$en238 === void 0 ? void 0 : _texts$en238.crewRoles) || {};
       opt.textContent = roleLabels[r] || r;
       roleSel.appendChild(opt);
     });
@@ -10993,7 +11069,7 @@ function updateAutoGearItemButtonState(type) {
     var nameInput = document.createElement('input');
     nameInput.type = 'text';
     nameInput.name = 'crewName';
-    var fallbackProjectForm = ((_texts$en237 = texts.en) === null || _texts$en237 === void 0 ? void 0 : _texts$en237.projectForm) || {};
+    var fallbackProjectForm = ((_texts$en239 = texts.en) === null || _texts$en239 === void 0 ? void 0 : _texts$en239.projectForm) || {};
     var projectFormTexts = ((_texts$currentLang2 = texts[currentLang]) === null || _texts$currentLang2 === void 0 ? void 0 : _texts$currentLang2.projectForm) || fallbackProjectForm;
     nameInput.placeholder = projectFormTexts.crewNamePlaceholder || fallbackProjectForm.crewNamePlaceholder || 'Name';
     nameInput.className = 'person-name';
@@ -11020,8 +11096,8 @@ function updateAutoGearItemButtonState(type) {
     var emailLabel = createHiddenLabel(ensureElementId(emailInput, crewEmailLabelText), crewEmailLabelText);
     var removeBtn = document.createElement('button');
     removeBtn.type = 'button';
-    var removeBase = ((_texts$currentLang3 = texts[currentLang]) === null || _texts$currentLang3 === void 0 || (_texts$currentLang3 = _texts$currentLang3.projectForm) === null || _texts$currentLang3 === void 0 ? void 0 : _texts$currentLang3.removeEntry) || ((_texts$en238 = texts.en) === null || _texts$en238 === void 0 || (_texts$en238 = _texts$en238.projectForm) === null || _texts$en238 === void 0 ? void 0 : _texts$en238.removeEntry) || 'Remove';
-    var crewHeading = ((_texts$currentLang4 = texts[currentLang]) === null || _texts$currentLang4 === void 0 || (_texts$currentLang4 = _texts$currentLang4.projectForm) === null || _texts$currentLang4 === void 0 ? void 0 : _texts$currentLang4.crewHeading) || ((_texts$en239 = texts.en) === null || _texts$en239 === void 0 || (_texts$en239 = _texts$en239.projectForm) === null || _texts$en239 === void 0 ? void 0 : _texts$en239.crewHeading) || 'Crew';
+    var removeBase = ((_texts$currentLang3 = texts[currentLang]) === null || _texts$currentLang3 === void 0 || (_texts$currentLang3 = _texts$currentLang3.projectForm) === null || _texts$currentLang3 === void 0 ? void 0 : _texts$currentLang3.removeEntry) || ((_texts$en240 = texts.en) === null || _texts$en240 === void 0 || (_texts$en240 = _texts$en240.projectForm) === null || _texts$en240 === void 0 ? void 0 : _texts$en240.removeEntry) || 'Remove';
+    var crewHeading = ((_texts$currentLang4 = texts[currentLang]) === null || _texts$currentLang4 === void 0 || (_texts$currentLang4 = _texts$currentLang4.projectForm) === null || _texts$currentLang4 === void 0 ? void 0 : _texts$currentLang4.crewHeading) || ((_texts$en241 = texts.en) === null || _texts$en241 === void 0 || (_texts$en241 = _texts$en241.projectForm) === null || _texts$en241 === void 0 ? void 0 : _texts$en241.crewHeading) || 'Crew';
     var removeCrewLabel = "".concat(removeBase, " ").concat(crewHeading).trim();
     removeBtn.innerHTML = iconMarkup(ICON_GLYPHS.minus, 'btn-icon');
     removeBtn.setAttribute('aria-label', removeCrewLabel);
@@ -11035,7 +11111,7 @@ function updateAutoGearItemButtonState(type) {
     crewContainer.appendChild(row);
   }
   function createPrepRow() {
-    var _texts$currentLang5, _texts$en240, _texts$currentLang6, _texts$en241;
+    var _texts$currentLang5, _texts$en242, _texts$currentLang6, _texts$en243;
     var data = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
     if (!prepContainer) return;
     var row = document.createElement('div');
@@ -11056,8 +11132,8 @@ function updateAutoGearItemButtonState(type) {
     end.setAttribute('aria-labelledby', 'prepLabel');
     var removeBtn = document.createElement('button');
     removeBtn.type = 'button';
-    var removeBase = ((_texts$currentLang5 = texts[currentLang]) === null || _texts$currentLang5 === void 0 || (_texts$currentLang5 = _texts$currentLang5.projectForm) === null || _texts$currentLang5 === void 0 ? void 0 : _texts$currentLang5.removeEntry) || ((_texts$en240 = texts.en) === null || _texts$en240 === void 0 || (_texts$en240 = _texts$en240.projectForm) === null || _texts$en240 === void 0 ? void 0 : _texts$en240.removeEntry) || 'Remove';
-    var prepLabelText = ((_texts$currentLang6 = texts[currentLang]) === null || _texts$currentLang6 === void 0 || (_texts$currentLang6 = _texts$currentLang6.projectForm) === null || _texts$currentLang6 === void 0 ? void 0 : _texts$currentLang6.prepLabel) || ((_texts$en241 = texts.en) === null || _texts$en241 === void 0 || (_texts$en241 = _texts$en241.projectForm) === null || _texts$en241 === void 0 ? void 0 : _texts$en241.prepLabel) || 'Prep';
+    var removeBase = ((_texts$currentLang5 = texts[currentLang]) === null || _texts$currentLang5 === void 0 || (_texts$currentLang5 = _texts$currentLang5.projectForm) === null || _texts$currentLang5 === void 0 ? void 0 : _texts$currentLang5.removeEntry) || ((_texts$en242 = texts.en) === null || _texts$en242 === void 0 || (_texts$en242 = _texts$en242.projectForm) === null || _texts$en242 === void 0 ? void 0 : _texts$en242.removeEntry) || 'Remove';
+    var prepLabelText = ((_texts$currentLang6 = texts[currentLang]) === null || _texts$currentLang6 === void 0 || (_texts$currentLang6 = _texts$currentLang6.projectForm) === null || _texts$currentLang6 === void 0 ? void 0 : _texts$currentLang6.prepLabel) || ((_texts$en243 = texts.en) === null || _texts$en243 === void 0 || (_texts$en243 = _texts$en243.projectForm) === null || _texts$en243 === void 0 ? void 0 : _texts$en243.prepLabel) || 'Prep';
     var removePrepLabel = "".concat(removeBase, " ").concat(prepLabelText).trim();
     removeBtn.innerHTML = iconMarkup(ICON_GLYPHS.minus, 'btn-icon');
     removeBtn.setAttribute('aria-label', removePrepLabel);
@@ -11071,7 +11147,7 @@ function updateAutoGearItemButtonState(type) {
     prepContainer.appendChild(row);
   }
   function createShootRow() {
-    var _texts$currentLang7, _texts$en242, _texts$currentLang8, _texts$en243;
+    var _texts$currentLang7, _texts$en244, _texts$currentLang8, _texts$en245;
     var data = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
     if (!shootContainer) return;
     var row = document.createElement('div');
@@ -11092,8 +11168,8 @@ function updateAutoGearItemButtonState(type) {
     end.setAttribute('aria-labelledby', 'shootLabel');
     var removeBtn = document.createElement('button');
     removeBtn.type = 'button';
-    var removeBase = ((_texts$currentLang7 = texts[currentLang]) === null || _texts$currentLang7 === void 0 || (_texts$currentLang7 = _texts$currentLang7.projectForm) === null || _texts$currentLang7 === void 0 ? void 0 : _texts$currentLang7.removeEntry) || ((_texts$en242 = texts.en) === null || _texts$en242 === void 0 || (_texts$en242 = _texts$en242.projectForm) === null || _texts$en242 === void 0 ? void 0 : _texts$en242.removeEntry) || 'Remove';
-    var shootLabelText = ((_texts$currentLang8 = texts[currentLang]) === null || _texts$currentLang8 === void 0 || (_texts$currentLang8 = _texts$currentLang8.projectForm) === null || _texts$currentLang8 === void 0 ? void 0 : _texts$currentLang8.shootLabel) || ((_texts$en243 = texts.en) === null || _texts$en243 === void 0 || (_texts$en243 = _texts$en243.projectForm) === null || _texts$en243 === void 0 ? void 0 : _texts$en243.shootLabel) || 'Shoot';
+    var removeBase = ((_texts$currentLang7 = texts[currentLang]) === null || _texts$currentLang7 === void 0 || (_texts$currentLang7 = _texts$currentLang7.projectForm) === null || _texts$currentLang7 === void 0 ? void 0 : _texts$currentLang7.removeEntry) || ((_texts$en244 = texts.en) === null || _texts$en244 === void 0 || (_texts$en244 = _texts$en244.projectForm) === null || _texts$en244 === void 0 ? void 0 : _texts$en244.removeEntry) || 'Remove';
+    var shootLabelText = ((_texts$currentLang8 = texts[currentLang]) === null || _texts$currentLang8 === void 0 || (_texts$currentLang8 = _texts$currentLang8.projectForm) === null || _texts$currentLang8 === void 0 ? void 0 : _texts$currentLang8.shootLabel) || ((_texts$en245 = texts.en) === null || _texts$en245 === void 0 || (_texts$en245 = _texts$en245.projectForm) === null || _texts$en245 === void 0 ? void 0 : _texts$en245.shootLabel) || 'Shoot';
     var removeShootLabel = "".concat(removeBase, " ").concat(shootLabelText).trim();
     removeBtn.innerHTML = iconMarkup(ICON_GLYPHS.minus, 'btn-icon');
     removeBtn.setAttribute('aria-label', removeShootLabel);
@@ -11208,38 +11284,38 @@ function updateAutoGearItemButtonState(type) {
     });
   }
   function showPowerWarningDialog(context) {
-    var _texts$en244, _texts$en245, _texts$en246;
+    var _texts$en246, _texts$en247, _texts$en248;
     if (!powerWarningDialog) return;
-    var _ref36 = context || {},
-      batteryName = _ref36.batteryName,
-      current = _ref36.current,
-      hasPinLimit = _ref36.hasPinLimit,
-      pinLimit = _ref36.pinLimit,
-      hasDtapRating = _ref36.hasDtapRating,
-      dtapLimit = _ref36.dtapLimit,
-      dtapAllowed = _ref36.dtapAllowed;
+    var _ref38 = context || {},
+      batteryName = _ref38.batteryName,
+      current = _ref38.current,
+      hasPinLimit = _ref38.hasPinLimit,
+      pinLimit = _ref38.pinLimit,
+      hasDtapRating = _ref38.hasDtapRating,
+      dtapLimit = _ref38.dtapLimit,
+      dtapAllowed = _ref38.dtapAllowed;
     var safeBatteryName = batteryName && batteryName.trim() ? batteryName.trim() : (batterySelect === null || batterySelect === void 0 ? void 0 : batterySelect.value) || '';
     var formattedCurrent = formatCurrentValue(Number(current) || 0);
     var langTexts = texts[currentLang] || texts.en || {};
-    var messageTemplate = langTexts.powerWarningMessage || ((_texts$en244 = texts.en) === null || _texts$en244 === void 0 ? void 0 : _texts$en244.powerWarningMessage) || '';
+    var messageTemplate = langTexts.powerWarningMessage || ((_texts$en246 = texts.en) === null || _texts$en246 === void 0 ? void 0 : _texts$en246.powerWarningMessage) || '';
     var message = messageTemplate ? messageTemplate.replace(/\{battery\}/g, safeBatteryName).replace(/\{current\}/g, formattedCurrent) : "".concat(safeBatteryName, " exceeds every available output (").concat(formattedCurrent, "A).");
     if (powerWarningMessageElem) {
       powerWarningMessageElem.textContent = message;
     }
-    var pinsDetail = hasPinLimit ? (langTexts.powerWarningPinsDetail || ((_texts$en245 = texts.en) === null || _texts$en245 === void 0 ? void 0 : _texts$en245.powerWarningPinsDetail) || 'Pins limit: {max}A').replace(/\{max\}/g, formatCurrentValue(Number(pinLimit) || 0)) : langTexts.powerWarningPinsUnavailable || ((_texts$en246 = texts.en) === null || _texts$en246 === void 0 ? void 0 : _texts$en246.powerWarningPinsUnavailable) || 'Pins limit unavailable.';
+    var pinsDetail = hasPinLimit ? (langTexts.powerWarningPinsDetail || ((_texts$en247 = texts.en) === null || _texts$en247 === void 0 ? void 0 : _texts$en247.powerWarningPinsDetail) || 'Pins limit: {max}A').replace(/\{max\}/g, formatCurrentValue(Number(pinLimit) || 0)) : langTexts.powerWarningPinsUnavailable || ((_texts$en248 = texts.en) === null || _texts$en248 === void 0 ? void 0 : _texts$en248.powerWarningPinsUnavailable) || 'Pins limit unavailable.';
     if (powerWarningPinsDetailElem) {
       powerWarningPinsDetailElem.textContent = pinsDetail;
     }
     var dtapDetail = '';
     if (hasDtapRating && dtapAllowed) {
-      var _texts$en247;
-      dtapDetail = (langTexts.powerWarningDtapDetail || ((_texts$en247 = texts.en) === null || _texts$en247 === void 0 ? void 0 : _texts$en247.powerWarningDtapDetail) || 'D-Tap limit: {max}A').replace(/\{max\}/g, formatCurrentValue(Number(dtapLimit) || 0));
-    } else if (hasDtapRating && !dtapAllowed) {
-      var _texts$en248;
-      dtapDetail = langTexts.powerWarningDtapBlocked || ((_texts$en248 = texts.en) === null || _texts$en248 === void 0 ? void 0 : _texts$en248.powerWarningDtapBlocked) || 'D-Tap cannot be used with the current configuration.';
-    } else {
       var _texts$en249;
-      dtapDetail = langTexts.powerWarningDtapUnavailable || ((_texts$en249 = texts.en) === null || _texts$en249 === void 0 ? void 0 : _texts$en249.powerWarningDtapUnavailable) || 'No D-Tap output is available.';
+      dtapDetail = (langTexts.powerWarningDtapDetail || ((_texts$en249 = texts.en) === null || _texts$en249 === void 0 ? void 0 : _texts$en249.powerWarningDtapDetail) || 'D-Tap limit: {max}A').replace(/\{max\}/g, formatCurrentValue(Number(dtapLimit) || 0));
+    } else if (hasDtapRating && !dtapAllowed) {
+      var _texts$en250;
+      dtapDetail = langTexts.powerWarningDtapBlocked || ((_texts$en250 = texts.en) === null || _texts$en250 === void 0 ? void 0 : _texts$en250.powerWarningDtapBlocked) || 'D-Tap cannot be used with the current configuration.';
+    } else {
+      var _texts$en251;
+      dtapDetail = langTexts.powerWarningDtapUnavailable || ((_texts$en251 = texts.en) === null || _texts$en251 === void 0 ? void 0 : _texts$en251.powerWarningDtapUnavailable) || 'No D-Tap output is available.';
     }
     if (powerWarningDtapDetailElem) {
       powerWarningDtapDetailElem.textContent = dtapDetail;
@@ -11515,21 +11591,21 @@ function updateAutoGearItemButtonState(type) {
     return '';
   }
   function getSharedImportPresetLabel(sharedData) {
-    var _texts$en250, _texts$en251;
+    var _texts$en252, _texts$en253;
     var langTexts = texts[currentLang] || texts.en || {};
-    var fallback = langTexts.sharedImportAutoGearPresetFallback || ((_texts$en250 = texts.en) === null || _texts$en250 === void 0 ? void 0 : _texts$en250.sharedImportAutoGearPresetFallback) || 'Shared automatic gear rules';
+    var fallback = langTexts.sharedImportAutoGearPresetFallback || ((_texts$en252 = texts.en) === null || _texts$en252 === void 0 ? void 0 : _texts$en252.sharedImportAutoGearPresetFallback) || 'Shared automatic gear rules';
     var projectName = getSharedImportProjectName(sharedData);
     if (!projectName) {
       return fallback;
     }
-    var template = langTexts.sharedImportAutoGearPresetName || ((_texts$en251 = texts.en) === null || _texts$en251 === void 0 ? void 0 : _texts$en251.sharedImportAutoGearPresetName) || '%s';
+    var template = langTexts.sharedImportAutoGearPresetName || ((_texts$en253 = texts.en) === null || _texts$en253 === void 0 ? void 0 : _texts$en253.sharedImportAutoGearPresetName) || '%s';
     if (template.includes('%s')) {
-      return formatWithPlaceholders(template, projectName);
+      return formatWithPlaceholdersSafe(template, projectName);
     }
     return "".concat(template, " ").concat(projectName).trim();
   }
   function ensureSharedAutoGearPreset(rules, sharedData) {
-    var _texts$currentLang9, _texts$en252;
+    var _texts$currentLang9, _texts$en254;
     var normalizedRules = Array.isArray(rules) ? rules.map(normalizeAutoGearRule).filter(Boolean) : [];
     if (!normalizedRules.length) return null;
     var label = getSharedImportPresetLabel(sharedData);
@@ -11537,7 +11613,7 @@ function updateAutoGearItemButtonState(type) {
     var preset = autoGearPresets.find(function (entry) {
       return entry.fingerprint === fingerprint;
     }) || null;
-    var fallback = ((_texts$currentLang9 = texts[currentLang]) === null || _texts$currentLang9 === void 0 ? void 0 : _texts$currentLang9.sharedImportAutoGearPresetFallback) || ((_texts$en252 = texts.en) === null || _texts$en252 === void 0 ? void 0 : _texts$en252.sharedImportAutoGearPresetFallback) || 'Shared automatic gear rules';
+    var fallback = ((_texts$currentLang9 = texts[currentLang]) === null || _texts$currentLang9 === void 0 ? void 0 : _texts$currentLang9.sharedImportAutoGearPresetFallback) || ((_texts$en254 = texts.en) === null || _texts$en254 === void 0 ? void 0 : _texts$en254.sharedImportAutoGearPresetFallback) || 'Shared automatic gear rules';
     if (preset) {
       if (label && preset.label !== label && preset.label === fallback) {
         preset = _objectSpread(_objectSpread({}, preset), {}, {
@@ -11754,9 +11830,9 @@ function updateAutoGearItemButtonState(type) {
     var hasShortKeys = false;
     var needsMerge = false;
     for (var index = 0; index < sharedKeyMapKeys.length; index += 1) {
-      var _key2 = sharedKeyMapKeys[index];
-      var hasLongKey = Object.prototype.hasOwnProperty.call(setup, _key2);
-      var short = sharedKeyMap[_key2];
+      var _key3 = sharedKeyMapKeys[index];
+      var hasLongKey = Object.prototype.hasOwnProperty.call(setup, _key3);
+      var short = sharedKeyMap[_key3];
       var hasShortKey = Object.prototype.hasOwnProperty.call(setup, short);
       if (hasLongKey) {
         hasLongKeys = true;
@@ -11813,6 +11889,131 @@ function updateAutoGearItemButtonState(type) {
     }
     return created;
   }();
+  var filterHelperScope = function () {
+    if (typeof CORE_GLOBAL_SCOPE !== 'undefined' && CORE_GLOBAL_SCOPE) return CORE_GLOBAL_SCOPE;
+    if (typeof globalThis !== 'undefined' && globalThis) return globalThis;
+    if (typeof window !== 'undefined' && window) return window;
+    if (typeof self !== 'undefined' && self) return self;
+    if (typeof global !== 'undefined' && global) return global;
+    return null;
+  }();
+  function fallbackFilterSelect(selectElem, filterValue) {
+    if (!selectElem || _typeof(selectElem) !== "object") {
+      return;
+    }
+    var text = (filterValue || "").toLowerCase();
+    Array.from(selectElem.options || []).forEach(function (option) {
+      if (!option || _typeof(option) !== "object") return;
+      var isMatch = option.value === "None" || text === "" || (option.textContent || "").toLowerCase().includes(text);
+      option.hidden = !isMatch;
+      option.disabled = !isMatch;
+    });
+  }
+  function fallbackFilterDeviceList(listElem, filterValue) {
+    if (!listElem || _typeof(listElem) !== "object") {
+      return;
+    }
+    var text = (filterValue || "").toLowerCase();
+    Array.from(listElem.querySelectorAll ? listElem.querySelectorAll("li") : []).forEach(function (item) {
+      if (!item || _typeof(item) !== "object") return;
+      var summary = item.querySelector ? item.querySelector(".device-summary span") : null;
+      var content = summary && typeof summary.textContent === "string" ? summary.textContent.toLowerCase() : "";
+      item.style.display = text === "" || content.includes(text) ? "" : "none";
+    });
+  }
+  function fallbackAddInputClearButton(inputElem, callback) {
+    if (!inputElem || _typeof(inputElem) !== "object" || typeof inputElem.insertAdjacentElement !== "function") {
+      return;
+    }
+    var translationSource = (typeof texts === "undefined" ? "undefined" : _typeof(texts)) === "object" && texts || typeof window !== "undefined" && _typeof(window.texts) === "object" && window.texts || null;
+    var clearLabel = translationSource && translationSource[currentLang] && translationSource[currentLang].clearFilter || "Clear filter";
+    var clearBtn = document.createElement("button");
+    clearBtn.type = "button";
+    clearBtn.className = "clear-input-btn";
+    clearBtn.innerHTML = iconMarkup(ICON_GLYPHS.circleX, "clear-icon");
+    clearBtn.setAttribute("aria-label", clearLabel);
+    clearBtn.title = clearLabel;
+    clearBtn.hidden = true;
+    clearBtn.addEventListener("click", function () {
+      inputElem.value = "";
+      if (typeof callback === "function") {
+        callback();
+      }
+      if (typeof inputElem.focus === "function") {
+        inputElem.focus();
+      }
+    });
+    inputElem.insertAdjacentElement("afterend", clearBtn);
+    var toggle = function toggle() {
+      clearBtn.hidden = !inputElem.value;
+    };
+    inputElem.addEventListener("input", toggle);
+    toggle();
+  }
+  function fallbackBindFilterInput(inputElem, callback) {
+    if (!inputElem || _typeof(inputElem) !== "object") {
+      return;
+    }
+    var handler = typeof callback === "function" ? callback : function () {};
+    inputElem.addEventListener("input", handler);
+    inputElem.addEventListener("keydown", function (event) {
+      if (event && event.key === "Escape") {
+        inputElem.value = "";
+        handler();
+      }
+    });
+    fallbackAddInputClearButton(inputElem, handler);
+  }
+  function ensureFilterHelpers() {
+    var scope = filterHelperScope && _typeof(filterHelperScope) === "object" ? filterHelperScope : {};
+    var attachHelper = function attachHelper(key, fn) {
+      if (typeof scope[key] === "function") {
+        return;
+      }
+      try {
+        scope[key] = fn;
+      } catch (assignError) {
+        try {
+          Object.defineProperty(scope, key, {
+            configurable: true,
+            writable: true,
+            value: fn
+          });
+        } catch (defineError) {
+          void defineError;
+        }
+      }
+    };
+    attachHelper("filterSelect", fallbackFilterSelect);
+    attachHelper("filterDeviceList", fallbackFilterDeviceList);
+    attachHelper("bindFilterInput", fallbackBindFilterInput);
+    attachHelper("addInputClearButton", fallbackAddInputClearButton);
+    return scope;
+  }
+  ensureFilterHelpers();
+  function applyFilters() {
+    var helpers = ensureFilterHelpers();
+    var filterFn = typeof helpers.filterDeviceList === "function" ? helpers.filterDeviceList : fallbackFilterDeviceList;
+    if (!(deviceManagerLists instanceof Map)) {
+      return;
+    }
+    deviceManagerLists.forEach(function (entry) {
+      if (!entry || _typeof(entry) !== "object") {
+        return;
+      }
+      var list = entry.list,
+        filterInput = entry.filterInput;
+      if (!list || _typeof(list) !== "object") {
+        return;
+      }
+      var value = filterInput && typeof filterInput.value === "string" ? filterInput.value : "";
+      try {
+        filterFn(list, value);
+      } catch (filterError) {
+        console.warn("Failed to apply device manager filters", filterError);
+      }
+    });
+  }
   var deviceManagerPreferredOrder = ["cameras", "viewfinders", "monitors", "video", "wirelessReceivers", "directorMonitors", "iosVideo", "lenses", "fiz.motors", "fiz.controllers", "fiz.handUnits", "fiz.distance", "batteries", "batteryHotswaps", "accessories.batteries", "accessories.powerPlates", "accessories.cables", "accessories.cages", "accessories.cameraSupport", "accessories.cameraStabiliser", "accessories.chargers", "accessories.videoAssist", "accessories.media", "accessories.filters", "accessories.matteboxes", "accessories.rigging", "accessories.grip", "accessories.sliders", "accessories.tripodHeads", "accessories.tripods", "accessories.carts"];
   function normalizeCategoryKey(key) {
     var _devices5, _devices6;
@@ -11860,10 +12061,10 @@ function updateAutoGearItemButtonState(type) {
       if (Array.isArray(node.attributes)) {
         addCategory(path.join('.'));
       }
-      Object.entries(node).forEach(function (_ref37) {
-        var _ref38 = _slicedToArray(_ref37, 2),
-          childKey = _ref38[0],
-          value = _ref38[1];
+      Object.entries(node).forEach(function (_ref39) {
+        var _ref40 = _slicedToArray(_ref39, 2),
+          childKey = _ref40[0],
+          value = _ref40[1];
         if (childKey === 'attributes') return;
         if (value && _typeof(value) === 'object') {
           _traverseSchema(value, path.concat(childKey));
@@ -11875,16 +12076,16 @@ function updateAutoGearItemButtonState(type) {
     }
     var addFromData = function addFromData(data) {
       if (!data || _typeof(data) !== 'object' || Array.isArray(data)) return;
-      Object.entries(data).forEach(function (_ref39) {
-        var _ref40 = _slicedToArray(_ref39, 2),
-          key = _ref40[0],
-          value = _ref40[1];
+      Object.entries(data).forEach(function (_ref41) {
+        var _ref42 = _slicedToArray(_ref41, 2),
+          key = _ref42[0],
+          value = _ref42[1];
         if (key === 'accessories') {
           if (value && _typeof(value) === 'object') {
-            Object.entries(value).forEach(function (_ref41) {
-              var _ref42 = _slicedToArray(_ref41, 2),
-                subKey = _ref42[0],
-                subValue = _ref42[1];
+            Object.entries(value).forEach(function (_ref43) {
+              var _ref44 = _slicedToArray(_ref43, 2),
+                subKey = _ref44[0],
+                subValue = _ref44[1];
               if (subValue && _typeof(subValue) === 'object' && !Array.isArray(subValue)) {
                 addCategory("accessories.".concat(subKey));
               }
@@ -11892,10 +12093,10 @@ function updateAutoGearItemButtonState(type) {
           }
         } else if (key === 'fiz') {
           if (value && _typeof(value) === 'object') {
-            Object.entries(value).forEach(function (_ref43) {
-              var _ref44 = _slicedToArray(_ref43, 2),
-                subKey = _ref44[0],
-                subValue = _ref44[1];
+            Object.entries(value).forEach(function (_ref45) {
+              var _ref46 = _slicedToArray(_ref45, 2),
+                subKey = _ref46[0],
+                subValue = _ref46[1];
               if (subValue && _typeof(subValue) === 'object' && !Array.isArray(subValue)) {
                 addCategory("fiz.".concat(subKey));
               }
@@ -12146,10 +12347,10 @@ function updateAutoGearItemButtonState(type) {
       }
       for (var _i10 = 0, _Object$entries7 = Object.entries(deviceSchema); _i10 < _Object$entries7.length; _i10++) {
         var _Object$entries7$_i = _slicedToArray(_Object$entries7[_i10], 2),
-          _key3 = _Object$entries7$_i[0],
+          _key4 = _Object$entries7$_i[0],
           _obj = _Object$entries7$_i[1];
-        if (_key3 === 'accessories' || _key3 === 'fiz') continue;
-        if (_obj && _obj.attributes) addOpt(_key3);
+        if (_key4 === 'accessories' || _key4 === 'fiz') continue;
+        if (_obj && _obj.attributes) addOpt(_key4);
       }
       if (deviceSchema.fiz) {
         for (var _i11 = 0, _Object$entries8 = Object.entries(deviceSchema.fiz); _i11 < _Object$entries8.length; _i11++) {
@@ -12172,20 +12373,20 @@ function updateAutoGearItemButtonState(type) {
       };
       for (var _i12 = 0, _Object$entries9 = Object.entries(devices); _i12 < _Object$entries9.length; _i12++) {
         var _Object$entries9$_i = _slicedToArray(_Object$entries9[_i12], 2),
-          _key4 = _Object$entries9$_i[0],
+          _key5 = _Object$entries9$_i[0],
           _obj3 = _Object$entries9$_i[1];
-        if (_key4 === 'accessories') {
+        if (_key5 === 'accessories') {
           for (var _i13 = 0, _Object$keys = Object.keys(_obj3 || {}); _i13 < _Object$keys.length; _i13++) {
             var _sub3 = _Object$keys[_i13];
             addIfMissing("accessories.".concat(_sub3));
           }
-        } else if (_key4 === 'fiz') {
+        } else if (_key5 === 'fiz') {
           for (var _i14 = 0, _Object$keys2 = Object.keys(_obj3 || {}); _i14 < _Object$keys2.length; _i14++) {
             var _sub4 = _Object$keys2[_i14];
             addIfMissing("fiz.".concat(_sub4));
           }
         } else if (_obj3 && _typeof(_obj3) === 'object' && !Array.isArray(_obj3)) {
-          addIfMissing(_key4);
+          addIfMissing(_key5);
         }
       }
     }
@@ -12193,9 +12394,9 @@ function updateAutoGearItemButtonState(type) {
   }
   populateCategoryOptions();
   function getCategoryContainer(categoryKey, subcategory) {
-    var _ref45 = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {},
-      _ref45$create = _ref45.create,
-      create = _ref45$create === void 0 ? false : _ref45$create;
+    var _ref47 = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {},
+      _ref47$create = _ref47.create,
+      create = _ref47$create === void 0 ? false : _ref47$create;
     if (!categoryKey) {
       return null;
     }
@@ -12549,9 +12750,9 @@ function updateAutoGearItemButtonState(type) {
     if (!category) return schemaFieldConfigs['*'][attr] || null;
     var parts = category.split('.');
     while (parts.length) {
-      var _key5 = parts.join('.');
-      if (schemaFieldConfigs[_key5] && schemaFieldConfigs[_key5][attr]) {
-        return schemaFieldConfigs[_key5][attr];
+      var _key6 = parts.join('.');
+      if (schemaFieldConfigs[_key6] && schemaFieldConfigs[_key6][attr]) {
+        return schemaFieldConfigs[_key6][attr];
       }
       parts.pop();
     }
@@ -12706,10 +12907,10 @@ function updateAutoGearItemButtonState(type) {
     }
     if (data && _typeof(data) === 'object' && !Array.isArray(data)) {
       for (var _i15 = 0, _Object$keys3 = Object.keys(data); _i15 < _Object$keys3.length; _i15++) {
-        var _key6 = _Object$keys3[_i15];
-        if (skip(_key6)) continue;
-        seen.add(_key6);
-        attrs.push(_key6);
+        var _key7 = _Object$keys3[_i15];
+        if (skip(_key7)) continue;
+        seen.add(_key7);
+        attrs.push(_key7);
       }
     }
     return attrs;
@@ -12951,6 +13152,493 @@ function updateAutoGearItemButtonState(type) {
   var iosPwaHelpStep4 = document.getElementById("iosPwaHelpStep4");
   var iosPwaHelpNote = document.getElementById("iosPwaHelpNote");
   var iosPwaHelpClose = document.getElementById("iosPwaHelpClose");
+  var installBannerSetupComplete = false;
+  var currentInstallGuidePlatform = null;
+  var lastActiveBeforeInstallGuide = null;
+  var lastActiveBeforeIosHelp = null;
+  function parseRgbComponent(value) {
+    if (typeof value === 'number' && Number.isFinite(value)) {
+      return Math.max(0, Math.min(255, Math.round(value)));
+    }
+    if (typeof value !== 'string') return null;
+    var trimmed = value.trim();
+    if (!trimmed) return null;
+    if (trimmed.endsWith('%')) {
+      var percent = Number.parseFloat(trimmed.slice(0, -1));
+      if (Number.isNaN(percent)) return null;
+      return Math.max(0, Math.min(255, Math.round(percent / 100 * 255)));
+    }
+    var numeric = Number.parseFloat(trimmed);
+    if (Number.isNaN(numeric)) return null;
+    return Math.max(0, Math.min(255, Math.round(numeric)));
+  }
+  function parseColorToRgb(color) {
+    if (typeof color !== 'string') return null;
+    var trimmed = color.trim();
+    if (!trimmed) return null;
+    var hexMatch = trimmed.match(/^#([0-9a-f]{3}|[0-9a-f]{6})$/i);
+    if (hexMatch) {
+      var hex = hexMatch[1];
+      if (hex.length === 3) {
+        return {
+          r: Number.parseInt(hex[0] + hex[0], 16),
+          g: Number.parseInt(hex[1] + hex[1], 16),
+          b: Number.parseInt(hex[2] + hex[2], 16)
+        };
+      }
+      return {
+        r: Number.parseInt(hex.slice(0, 2), 16),
+        g: Number.parseInt(hex.slice(2, 4), 16),
+        b: Number.parseInt(hex.slice(4, 6), 16)
+      };
+    }
+    var rgbMatch = trimmed.match(/^rgba?\(([^)]+)\)$/i);
+    if (rgbMatch) {
+      var parts = rgbMatch[1].split(',');
+      if (parts.length < 3) return null;
+      var _parts = _slicedToArray(parts, 3),
+        r = _parts[0],
+        g = _parts[1],
+        b = _parts[2];
+      var red = parseRgbComponent(r);
+      var green = parseRgbComponent(g);
+      var blue = parseRgbComponent(b);
+      if ([red, green, blue].some(function (component) {
+        return component === null;
+      })) return null;
+      return {
+        r: red,
+        g: green,
+        b: blue
+      };
+    }
+    return null;
+  }
+  function computeRelativeLuminance(rgb) {
+    if (!rgb || _typeof(rgb) !== 'object') return 0;
+    var clamp = function clamp(component) {
+      var numeric = Number(component);
+      if (!Number.isFinite(numeric)) return 0;
+      return Math.min(1, Math.max(0, numeric / 255));
+    };
+    var transform = function transform(value) {
+      return value <= 0.03928 ? value / 12.92 : Math.pow((value + 0.055) / 1.055, 2.4);
+    };
+    var red = transform(clamp(rgb.r));
+    var green = transform(clamp(rgb.g));
+    var blue = transform(clamp(rgb.b));
+    return 0.2126 * red + 0.7152 * green + 0.0722 * blue;
+  }
+  function isIosDevice() {
+    if (typeof navigator === 'undefined') return false;
+    var ua = navigator.userAgent || '';
+    var platform = navigator.platform || '';
+    var hasTouch = typeof navigator.maxTouchPoints === 'number' && navigator.maxTouchPoints > 1;
+    return /iphone|ipad|ipod/i.test(ua) || platform === 'MacIntel' && hasTouch;
+  }
+  function isAndroidDevice() {
+    if (typeof navigator === 'undefined') return false;
+    var ua = navigator.userAgent || '';
+    var vendor = navigator.vendor || '';
+    return /android/i.test(ua) || /android/i.test(vendor);
+  }
+  function isStandaloneDisplayMode() {
+    if (typeof window === 'undefined') return false;
+    if (typeof window.matchMedia === 'function') {
+      try {
+        if (window.matchMedia('(display-mode: standalone)').matches) {
+          return true;
+        }
+      } catch (error) {
+        console.warn('matchMedia display-mode check failed', error);
+      }
+    }
+    if (typeof navigator !== 'undefined' && typeof navigator.standalone === 'boolean') {
+      return navigator.standalone;
+    }
+    return false;
+  }
+  function hasDismissedIosPwaHelp() {
+    try {
+      return localStorage.getItem(IOS_PWA_HELP_STORAGE_KEY) === '1';
+    } catch (error) {
+      console.warn('Could not read iOS PWA help dismissal flag', error);
+      return false;
+    }
+  }
+  function markIosPwaHelpDismissed() {
+    try {
+      localStorage.setItem(IOS_PWA_HELP_STORAGE_KEY, '1');
+    } catch (error) {
+      console.warn('Could not store iOS PWA help dismissal', error);
+    }
+  }
+  function getInstallBannerDismissedInSession() {
+    if (!installBannerGlobalScope || _typeof(installBannerGlobalScope) !== 'object') {
+      return false;
+    }
+    if (typeof installBannerGlobalScope.installBannerDismissedInSession !== 'boolean') {
+      installBannerGlobalScope.installBannerDismissedInSession = false;
+      return false;
+    }
+    return installBannerGlobalScope.installBannerDismissedInSession;
+  }
+  function setInstallBannerDismissedInSession(value) {
+    if (!installBannerGlobalScope || _typeof(installBannerGlobalScope) !== 'object') {
+      return;
+    }
+    installBannerGlobalScope.installBannerDismissedInSession = Boolean(value);
+  }
+  function hasDismissedInstallBanner() {
+    if (getInstallBannerDismissedInSession()) return true;
+    if (typeof localStorage === 'undefined') return false;
+    try {
+      var storedValue = localStorage.getItem(INSTALL_BANNER_DISMISSED_KEY);
+      var dismissed = storedValue === '1';
+      if (dismissed) {
+        setInstallBannerDismissedInSession(true);
+      }
+      return dismissed;
+    } catch (error) {
+      console.warn('Could not read install banner dismissal flag', error);
+      return getInstallBannerDismissedInSession();
+    }
+  }
+  function markInstallBannerDismissed() {
+    setInstallBannerDismissedInSession(true);
+    if (typeof localStorage === 'undefined') return;
+    try {
+      localStorage.setItem(INSTALL_BANNER_DISMISSED_KEY, '1');
+    } catch (error) {
+      console.warn('Could not store install banner dismissal', error);
+    }
+  }
+  function shouldShowInstallBanner() {
+    if (!installPromptBanner) return false;
+    if (isStandaloneDisplayMode()) return false;
+    if (hasDismissedInstallBanner()) return false;
+    return isIosDevice() || isAndroidDevice();
+  }
+  function updateInstallBannerVisibility() {
+    if (!installPromptBanner) return;
+    var shouldShow = shouldShowInstallBanner();
+    var root = typeof document !== 'undefined' ? document.documentElement : null;
+    if (root && typeof root.classList !== 'undefined') {
+      root.classList.toggle('install-banner-visible', shouldShow);
+    }
+    if (shouldShow) {
+      installPromptBanner.removeAttribute('hidden');
+      updateInstallBannerColors();
+      updateInstallBannerPosition();
+    } else {
+      installPromptBanner.setAttribute('hidden', '');
+      setInstallBannerOffset(0);
+      installPromptBanner.style.removeProperty('top');
+    }
+  }
+  function updateInstallBannerColors() {
+    if (!installPromptBanner) return;
+    if (typeof window === 'undefined' || typeof window.getComputedStyle !== 'function') {
+      return;
+    }
+    try {
+      var root = document.documentElement;
+      if (!root) return;
+      var computed = window.getComputedStyle(root);
+      var accentValue = computed.getPropertyValue('--accent-color').trim();
+      if (!accentValue) {
+        installPromptBanner.style.removeProperty('--install-banner-text-color');
+        return;
+      }
+      var rgb = parseColorToRgb(accentValue);
+      if (!rgb) return;
+      var luminance = computeRelativeLuminance(rgb);
+      var textColor = luminance > 0.55 ? '#000000' : '#ffffff';
+      installPromptBanner.style.setProperty('--install-banner-text-color', textColor);
+    } catch (error) {
+      console.warn('Unable to update install banner colors', error);
+    }
+  }
+  function renderInstallGuideContent(platform) {
+    var lang = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : currentLang;
+    if (!installGuideDialog) return;
+    var fallbackTexts = texts.en || {};
+    var langTexts = texts[lang] || fallbackTexts;
+    var isIos = platform === 'ios';
+    var titleKey = isIos ? 'installHelpTitleIos' : 'installHelpTitleAndroid';
+    var introKey = isIos ? 'installHelpIntroIos' : 'installHelpIntroAndroid';
+    var stepsKey = isIos ? 'installHelpStepsIos' : 'installHelpStepsAndroid';
+    var noteKey = isIos ? 'installHelpNoteIos' : 'installHelpNoteAndroid';
+    var title = langTexts[titleKey] || fallbackTexts[titleKey] || '';
+    if (installGuideTitle) installGuideTitle.textContent = title;
+    var intro = langTexts[introKey] || fallbackTexts[introKey] || '';
+    if (installGuideIntro) installGuideIntro.textContent = intro;
+    var stepsSource = langTexts[stepsKey];
+    var fallbackStepsSource = fallbackTexts[stepsKey];
+    var toArray = function toArray(value) {
+      if (!value) return [];
+      return Array.isArray(value) ? value : [value];
+    };
+    var steps = toArray(stepsSource);
+    var fallbackSteps = toArray(fallbackStepsSource);
+    var effectiveSteps = steps.length ? steps : fallbackSteps;
+    if (installGuideSteps) {
+      installGuideSteps.textContent = '';
+      effectiveSteps.forEach(function (step) {
+        if (!step) return;
+        var li = document.createElement('li');
+        li.textContent = step;
+        installGuideSteps.appendChild(li);
+      });
+    }
+    var note = langTexts[noteKey] || fallbackTexts[noteKey] || '';
+    if (installGuideNote) installGuideNote.textContent = note;
+    installGuideDialog.setAttribute('data-platform', platform);
+    if (!installGuideMigration || !installGuideMigrationTitle || !installGuideMigrationIntro || !installGuideMigrationSteps || !installGuideMigrationNote) {
+      return;
+    }
+    if (isIos) {
+      installGuideMigration.removeAttribute('hidden');
+      var migrationTitle = langTexts.installHelpMigrationTitle || fallbackTexts.installHelpMigrationTitle || '';
+      installGuideMigrationTitle.textContent = migrationTitle;
+      var migrationIntro = langTexts.iosPwaHelpIntro || fallbackTexts.iosPwaHelpIntro || '';
+      installGuideMigrationIntro.textContent = migrationIntro;
+      var migrationSteps = [langTexts.iosPwaHelpStep1 || fallbackTexts.iosPwaHelpStep1, langTexts.iosPwaHelpStep2 || fallbackTexts.iosPwaHelpStep2, langTexts.iosPwaHelpStep3 || fallbackTexts.iosPwaHelpStep3, langTexts.iosPwaHelpStep4 || fallbackTexts.iosPwaHelpStep4].filter(Boolean);
+      installGuideMigrationSteps.textContent = '';
+      migrationSteps.forEach(function (step) {
+        var li = document.createElement('li');
+        li.textContent = step;
+        installGuideMigrationSteps.appendChild(li);
+      });
+      var migrationNote = langTexts.iosPwaHelpNote || fallbackTexts.iosPwaHelpNote || '';
+      installGuideMigrationNote.textContent = migrationNote;
+    } else {
+      installGuideMigration.setAttribute('hidden', '');
+      installGuideMigrationTitle.textContent = '';
+      installGuideMigrationIntro.textContent = '';
+      installGuideMigrationSteps.textContent = '';
+      installGuideMigrationNote.textContent = '';
+    }
+  }
+  function openInstallGuide(platform) {
+    if (!installGuideDialog) return;
+    currentInstallGuidePlatform = platform;
+    lastActiveBeforeInstallGuide = document.activeElement;
+    renderInstallGuideContent(platform);
+    installGuideDialog.removeAttribute('hidden');
+    var focusTarget = installGuideClose || installGuideDialog.querySelector('button, [href], [tabindex]:not([tabindex="-1"])');
+    if (focusTarget && typeof focusTarget.focus === 'function') {
+      try {
+        focusTarget.focus();
+      } catch (_unused4) {
+        focusTarget.focus();
+      }
+    }
+  }
+  function closeInstallGuide() {
+    if (!installGuideDialog) return;
+    installGuideDialog.setAttribute('hidden', '');
+    currentInstallGuidePlatform = null;
+    if (lastActiveBeforeInstallGuide && typeof lastActiveBeforeInstallGuide.focus === 'function') {
+      try {
+        lastActiveBeforeInstallGuide.focus();
+      } catch (_unused5) {
+        lastActiveBeforeInstallGuide.focus();
+      }
+    }
+  }
+  function setupInstallBanner() {
+    if (!installPromptBanner) return false;
+    if (installBannerSetupComplete) {
+      applyInstallTexts(currentLang);
+      updateInstallBannerColors();
+      updateInstallBannerVisibility();
+      updateInstallBannerPosition();
+      return true;
+    }
+    installBannerSetupComplete = true;
+    if (installPromptBannerIcon && typeof applyIconGlyph === 'function') {
+      applyIconGlyph(installPromptBannerIcon, ICON_GLYPHS.installApp);
+    }
+    if (installPromptBannerAction) {
+      installPromptBannerAction.addEventListener('click', function (event) {
+        event.preventDefault();
+        var platform = isIosDevice() ? 'ios' : 'android';
+        openInstallGuide(platform);
+      });
+    }
+    if (installPromptBannerDismiss) {
+      installPromptBannerDismiss.addEventListener('click', function (event) {
+        event.preventDefault();
+        event.stopPropagation();
+        markInstallBannerDismissed();
+        updateInstallBannerVisibility();
+      });
+    }
+    if (installGuideClose) {
+      installGuideClose.addEventListener('click', function () {
+        closeInstallGuide();
+      });
+    }
+    if (installGuideDialog) {
+      installGuideDialog.addEventListener('click', function (event) {
+        if (event.target === installGuideDialog) {
+          closeInstallGuide();
+        }
+      });
+    }
+    applyInstallTexts(currentLang);
+    updateInstallBannerColors();
+    updateInstallBannerVisibility();
+    updateInstallBannerPosition();
+    if (typeof window !== 'undefined') {
+      window.addEventListener('resize', updateInstallBannerPosition);
+      window.addEventListener('appinstalled', updateInstallBannerVisibility);
+      if (typeof window.matchMedia === 'function') {
+        try {
+          var media = window.matchMedia('(display-mode: standalone)');
+          var handleChange = function handleChange() {
+            return updateInstallBannerVisibility();
+          };
+          if (typeof media.addEventListener === 'function') {
+            media.addEventListener('change', handleChange);
+          } else if (typeof media.addListener === 'function') {
+            media.addListener(handleChange);
+          }
+        } catch (error) {
+          console.warn('matchMedia display-mode listener failed', error);
+        }
+      }
+    }
+    return true;
+  }
+  function applyInstallTexts(lang) {
+    var fallbackTexts = texts.en || {};
+    var langTexts = texts[lang] || fallbackTexts;
+    var bannerText = langTexts.installBannerText || fallbackTexts.installBannerText || '';
+    if (installPromptBannerText && bannerText) {
+      installPromptBannerText.textContent = bannerText;
+    }
+    if (installPromptBanner) {
+      if (bannerText) {
+        installPromptBanner.setAttribute('aria-label', bannerText);
+        installPromptBanner.setAttribute('title', bannerText);
+      } else {
+        installPromptBanner.removeAttribute('aria-label');
+        installPromptBanner.removeAttribute('title');
+      }
+    }
+    if (installPromptBannerAction) {
+      if (bannerText) {
+        installPromptBannerAction.setAttribute('aria-label', bannerText);
+        installPromptBannerAction.setAttribute('title', bannerText);
+      } else {
+        installPromptBannerAction.removeAttribute('aria-label');
+        installPromptBannerAction.removeAttribute('title');
+      }
+    }
+    var closeLabel = langTexts.installHelpClose || fallbackTexts.installHelpClose || '';
+    var dismissLabel = langTexts.installBannerDismiss || fallbackTexts.installBannerDismiss || closeLabel || '';
+    if (installPromptBannerDismiss) {
+      var labelText = dismissLabel || '';
+      if (typeof setButtonLabelWithIcon === 'function') {
+        setButtonLabelWithIcon(installPromptBannerDismiss, '', ICON_GLYPHS.circleX);
+      }
+      Array.from(installPromptBannerDismiss.querySelectorAll('.visually-hidden')).forEach(function (node) {
+        if (node && node.parentNode === installPromptBannerDismiss) {
+          installPromptBannerDismiss.removeChild(node);
+        }
+      });
+      if (labelText) {
+        installPromptBannerDismiss.setAttribute('aria-label', labelText);
+        installPromptBannerDismiss.setAttribute('title', labelText);
+        var hiddenLabel = document.createElement('span');
+        hiddenLabel.className = 'visually-hidden';
+        hiddenLabel.textContent = labelText;
+        installPromptBannerDismiss.appendChild(hiddenLabel);
+      } else {
+        installPromptBannerDismiss.removeAttribute('aria-label');
+        installPromptBannerDismiss.removeAttribute('title');
+      }
+    }
+    if (installGuideClose) {
+      if (closeLabel && typeof setButtonLabelWithIcon === 'function') {
+        setButtonLabelWithIcon(installGuideClose, closeLabel, ICON_GLYPHS.circleX);
+        installGuideClose.setAttribute('aria-label', closeLabel);
+        installGuideClose.setAttribute('title', closeLabel);
+      } else if (!closeLabel) {
+        installGuideClose.removeAttribute('aria-label');
+        installGuideClose.removeAttribute('title');
+      }
+    }
+    if (installGuideDialog && !installGuideDialog.hasAttribute('hidden') && currentInstallGuidePlatform) {
+      renderInstallGuideContent(currentInstallGuidePlatform, lang);
+    }
+    updateInstallBannerPosition();
+    updateInstallBannerColors();
+  }
+  function shouldShowIosPwaHelp() {
+    return !!iosPwaHelpDialog && isIosDevice() && isStandaloneDisplayMode() && !hasDismissedIosPwaHelp();
+  }
+  function openIosPwaHelp() {
+    if (!iosPwaHelpDialog) return;
+    if (!shouldShowIosPwaHelp()) return;
+    lastActiveBeforeIosHelp = document.activeElement;
+    iosPwaHelpDialog.removeAttribute('hidden');
+    var focusTarget = iosPwaHelpClose || iosPwaHelpDialog.querySelector('button, [href], [tabindex]:not([tabindex="-1"])');
+    if (focusTarget && typeof focusTarget.focus === 'function') {
+      try {
+        focusTarget.focus();
+      } catch (_unused6) {
+        focusTarget.focus();
+      }
+    }
+  }
+  function closeIosPwaHelp() {
+    var storeDismissal = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : false;
+    if (!iosPwaHelpDialog) return;
+    iosPwaHelpDialog.setAttribute('hidden', '');
+    if (storeDismissal) {
+      markIosPwaHelpDismissed();
+    }
+    if (lastActiveBeforeIosHelp && typeof lastActiveBeforeIosHelp.focus === 'function') {
+      try {
+        lastActiveBeforeIosHelp.focus();
+      } catch (_unused7) {
+        lastActiveBeforeIosHelp.focus();
+      }
+    }
+  }
+  function maybeShowIosPwaHelp() {
+    openIosPwaHelp();
+  }
+  if (iosPwaHelpClose) {
+    iosPwaHelpClose.addEventListener('click', function () {
+      return closeIosPwaHelp(true);
+    });
+  }
+  if (iosPwaHelpDialog) {
+    iosPwaHelpDialog.addEventListener('click', function (event) {
+      if (event.target === iosPwaHelpDialog) {
+        closeIosPwaHelp(true);
+      }
+    });
+  }
+  document.addEventListener('keydown', function (event) {
+    if (event.key !== 'Escape' && event.key !== 'Esc') return;
+    var handled = false;
+    if (iosPwaHelpDialog && !iosPwaHelpDialog.hasAttribute('hidden')) {
+      closeIosPwaHelp(true);
+      handled = true;
+    }
+    if (installGuideDialog && !installGuideDialog.hasAttribute('hidden')) {
+      closeInstallGuide();
+      handled = true;
+    }
+    if (handled) {
+      event.preventDefault();
+    }
+  });
   var hoverHelpButton = document.getElementById("hoverHelpButton");
   var settingsButton = document.getElementById("settingsButton");
   var settingsButtonIcon = settingsButton === null || settingsButton === void 0 || (_settingsButton$query = settingsButton.querySelector) === null || _settingsButton$query === void 0 ? void 0 : _settingsButton$query.call(settingsButton, '.settings-button-icon');
@@ -12989,7 +13677,7 @@ function updateAutoGearItemButtonState(type) {
       } else if (typeof settingsTabsOrientationQuery.addListener === 'function') {
         settingsTabsOrientationQuery.addListener(handleSettingsTabsOrientationChange);
       }
-    } catch (_unused4) {
+    } catch (_unused8) {
       applySettingsTabsOrientation(false);
     }
   } else if (settingsTablist) {
@@ -13052,7 +13740,7 @@ function updateAutoGearItemButtonState(type) {
           left: amount,
           behavior: 'smooth'
         });
-      } catch (_unused5) {
+      } catch (_unused9) {
         settingsTablist.scrollLeft += amount;
       }
     } else {
@@ -13085,7 +13773,7 @@ function updateAutoGearItemButtonState(type) {
         });
         window.addEventListener('testPassive', passiveTestHandler, passiveTestOptions);
         window.removeEventListener('testPassive', passiveTestHandler, passiveTestOptions);
-      } catch (_unused6) {
+      } catch (_unused0) {
         settingsTabsPassiveOptions = false;
       }
     }
@@ -13104,11 +13792,11 @@ function updateAutoGearItemButtonState(type) {
   var settingsTabData = document.getElementById('settingsTab-data');
   var settingsTabAbout = document.getElementById('settingsTab-about');
   var settingsTabIconAssignments = [[settingsTabGeneral, ICON_GLYPHS.settingsGeneral], [settingsTabAutoGear, ICON_GLYPHS.settingsAutoGear], [settingsTabAccessibility, ICON_GLYPHS.settingsAccessibility], [settingsTabBackup, ICON_GLYPHS.settingsBackup], [settingsTabData, ICON_GLYPHS.settingsData], [settingsTabAbout, ICON_GLYPHS.settingsAbout]];
-  settingsTabIconAssignments.forEach(function (_ref46) {
+  settingsTabIconAssignments.forEach(function (_ref48) {
     var _button$querySelector4;
-    var _ref47 = _slicedToArray(_ref46, 2),
-      button = _ref47[0],
-      glyph = _ref47[1];
+    var _ref49 = _slicedToArray(_ref48, 2),
+      button = _ref49[0],
+      glyph = _ref49[1];
     if (!button || !glyph) return;
     var iconElement = (_button$querySelector4 = button.querySelector) === null || _button$querySelector4 === void 0 ? void 0 : _button$querySelector4.call(button, '.settings-tab-icon');
     if (!iconElement) return;
@@ -13155,9 +13843,9 @@ function updateAutoGearItemButtonState(type) {
   function activateSettingsTab(tabId) {
     var options = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
     if (!settingsTabButtons.length) return;
-    var _ref48 = options || {},
-      _ref48$focusTab = _ref48.focusTab,
-      focusTab = _ref48$focusTab === void 0 ? false : _ref48$focusTab;
+    var _ref50 = options || {},
+      _ref50$focusTab = _ref50.focusTab,
+      focusTab = _ref50$focusTab === void 0 ? false : _ref50$focusTab;
     var target = settingsTabButtons.find(function (button) {
       return button.id === tabId;
     });
@@ -13174,7 +13862,7 @@ function updateAutoGearItemButtonState(type) {
           button.focus({
             preventScroll: true
           });
-        } catch (_unused7) {
+        } catch (_unused1) {
           button.focus();
         }
       }
@@ -13199,7 +13887,7 @@ function updateAutoGearItemButtonState(type) {
           inline: 'center',
           behavior: 'smooth'
         });
-      } catch (_unused8) {
+      } catch (_unused10) {
         target.scrollIntoView();
       }
     }
@@ -13256,7 +13944,7 @@ function updateAutoGearItemButtonState(type) {
           backupButton.focus({
             preventScroll: true
           });
-        } catch (_unused9) {
+        } catch (_unused11) {
           backupButton.focus();
         }
       }
@@ -13303,10 +13991,14 @@ function updateAutoGearItemButtonState(type) {
     tripodTypes: createDeferredAutoGearRefresher('refreshAutoGearTripodTypesOptions'),
     tripodSpreader: createDeferredAutoGearRefresher('refreshAutoGearTripodSpreaderOptions'),
     crewPresent: function crewPresent(selected) {
-      return refreshAutoGearCrewOptions(autoGearCrewPresentSelect, selected, 'crewPresent');
+      return callCoreFunctionIfAvailable('refreshAutoGearCrewOptions', [autoGearCrewPresentSelect, selected, 'crewPresent'], {
+        defer: true
+      });
     },
     crewAbsent: function crewAbsent(selected) {
-      return refreshAutoGearCrewOptions(autoGearCrewAbsentSelect, selected, 'crewAbsent');
+      return callCoreFunctionIfAvailable('refreshAutoGearCrewOptions', [autoGearCrewAbsentSelect, selected, 'crewAbsent'], {
+        defer: true
+      });
     },
     wireless: createDeferredAutoGearRefresher('refreshAutoGearWirelessOptions'),
     motors: createDeferredAutoGearRefresher('refreshAutoGearMotorsOptions'),
@@ -13342,10 +14034,10 @@ function updateAutoGearItemButtonState(type) {
     return autoGearActiveConditions.has(key);
   }
   function refreshAutoGearConditionPicker() {
-    var _texts$currentLang0, _texts$en253;
+    var _texts$currentLang0, _texts$en255;
     if (!autoGearConditionSelect) return;
     var previousValue = autoGearConditionSelect.value || '';
-    var placeholderLabel = ((_texts$currentLang0 = texts[currentLang]) === null || _texts$currentLang0 === void 0 ? void 0 : _texts$currentLang0.autoGearConditionPlaceholder) || ((_texts$en253 = texts.en) === null || _texts$en253 === void 0 ? void 0 : _texts$en253.autoGearConditionPlaceholder) || 'Choose a condition';
+    var placeholderLabel = ((_texts$currentLang0 = texts[currentLang]) === null || _texts$currentLang0 === void 0 ? void 0 : _texts$currentLang0.autoGearConditionPlaceholder) || ((_texts$en255 = texts.en) === null || _texts$en255 === void 0 ? void 0 : _texts$en255.autoGearConditionPlaceholder) || 'Choose a condition';
     autoGearConditionSelect.innerHTML = '';
     var placeholder = document.createElement('option');
     placeholder.value = '';
@@ -13395,7 +14087,7 @@ function updateAutoGearItemButtonState(type) {
         autoGearConditionSelect.focus({
           preventScroll: true
         });
-      } catch (_unused0) {
+      } catch (_unused12) {
         autoGearConditionSelect.focus();
       }
     }
@@ -13408,9 +14100,9 @@ function updateAutoGearItemButtonState(type) {
     }
     var section = config.section,
       select = config.select;
-    var _ref49 = options || {},
-      _ref49$flash = _ref49.flash,
-      flash = _ref49$flash === void 0 ? false : _ref49$flash;
+    var _ref51 = options || {},
+      _ref51$flash = _ref51.flash,
+      flash = _ref51$flash === void 0 ? false : _ref51$flash;
     if (section.hidden) {
       section.hidden = false;
       section.setAttribute('aria-hidden', 'false');
@@ -13428,16 +14120,16 @@ function updateAutoGearItemButtonState(type) {
       target.focus({
         preventScroll: true
       });
-    } catch (_unused1) {
+    } catch (_unused13) {
       target.focus();
     }
   }
   function notifyAutoGearConditionRepeat(key) {
-    var _texts$currentLang1, _texts$en254;
+    var _texts$currentLang1, _texts$en256;
     if (typeof showNotification !== 'function') {
       return;
     }
-    var template = ((_texts$currentLang1 = texts[currentLang]) === null || _texts$currentLang1 === void 0 ? void 0 : _texts$currentLang1.autoGearConditionRepeatHint) || ((_texts$en254 = texts.en) === null || _texts$en254 === void 0 ? void 0 : _texts$en254.autoGearConditionRepeatHint) || '';
+    var template = ((_texts$currentLang1 = texts[currentLang]) === null || _texts$currentLang1 === void 0 ? void 0 : _texts$currentLang1.autoGearConditionRepeatHint) || ((_texts$en256 = texts.en) === null || _texts$en256 === void 0 ? void 0 : _texts$en256.autoGearConditionRepeatHint) || '';
     if (!template) return;
     var label = getAutoGearConditionLabel(key);
     var message;
@@ -13472,9 +14164,9 @@ function updateAutoGearItemButtonState(type) {
     focusAutoGearConditionPicker();
   }
   function configureAutoGearConditionButtons() {
-    var _texts$currentLang10, _texts$en255, _texts$currentLang11, _texts$en256;
-    var addLabel = ((_texts$currentLang10 = texts[currentLang]) === null || _texts$currentLang10 === void 0 ? void 0 : _texts$currentLang10.autoGearConditionAddShortcut) || ((_texts$en255 = texts.en) === null || _texts$en255 === void 0 ? void 0 : _texts$en255.autoGearConditionAddShortcut) || 'Add another condition';
-    var removeLabel = ((_texts$currentLang11 = texts[currentLang]) === null || _texts$currentLang11 === void 0 ? void 0 : _texts$currentLang11.autoGearConditionRemove) || ((_texts$en256 = texts.en) === null || _texts$en256 === void 0 ? void 0 : _texts$en256.autoGearConditionRemove) || 'Remove this condition';
+    var _texts$currentLang10, _texts$en257, _texts$currentLang11, _texts$en258;
+    var addLabel = ((_texts$currentLang10 = texts[currentLang]) === null || _texts$currentLang10 === void 0 ? void 0 : _texts$currentLang10.autoGearConditionAddShortcut) || ((_texts$en257 = texts.en) === null || _texts$en257 === void 0 ? void 0 : _texts$en257.autoGearConditionAddShortcut) || 'Add another condition';
+    var removeLabel = ((_texts$currentLang11 = texts[currentLang]) === null || _texts$currentLang11 === void 0 ? void 0 : _texts$currentLang11.autoGearConditionRemove) || ((_texts$en258 = texts.en) === null || _texts$en258 === void 0 ? void 0 : _texts$en258.autoGearConditionRemove) || 'Remove this condition';
     AUTO_GEAR_CONDITION_KEYS.forEach(function (key) {
       var config = getAutoGearConditionConfig(key);
       if (!config) return;
@@ -13509,7 +14201,7 @@ function updateAutoGearItemButtonState(type) {
           config.select.focus({
             preventScroll: true
           });
-        } catch (_unused10) {
+        } catch (_unused14) {
           config.select.focus();
         }
       }
@@ -13565,7 +14257,7 @@ function updateAutoGearItemButtonState(type) {
         config.select.focus({
           preventScroll: true
         });
-      } catch (_unused11) {
+      } catch (_unused15) {
         config.select.focus();
       }
     }
@@ -13658,9 +14350,9 @@ function updateAutoGearItemButtonState(type) {
   }
   function clearAllAutoGearConditions() {
     var options = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
-    var _ref50 = options || {},
-      _ref50$preserveDraft = _ref50.preserveDraft,
-      preserveDraft = _ref50$preserveDraft === void 0 ? false : _ref50$preserveDraft;
+    var _ref52 = options || {},
+      _ref52$preserveDraft = _ref52.preserveDraft,
+      preserveDraft = _ref52$preserveDraft === void 0 ? false : _ref52$preserveDraft;
     Array.from(autoGearActiveConditions).forEach(function (key) {
       removeAutoGearCondition(key, {
         preserveDraft: preserveDraft,
@@ -13836,10 +14528,10 @@ function updateAutoGearItemButtonState(type) {
     autoGearShootingDaysInput.addEventListener('change', handleShootingDaysValueInput);
     autoGearShootingDaysInput.addEventListener('blur', handleShootingDaysValueInput);
   }
-  Object.entries(autoGearConditionLogicSelects).forEach(function (_ref51) {
-    var _ref52 = _slicedToArray(_ref51, 2),
-      key = _ref52[0],
-      select = _ref52[1];
+  Object.entries(autoGearConditionLogicSelects).forEach(function (_ref53) {
+    var _ref54 = _slicedToArray(_ref53, 2),
+      key = _ref54[0],
+      select = _ref54[1];
     if (!select) return;
     var property = AUTO_GEAR_CONDITION_LOGIC_FIELDS[key];
     var handleLogicChange = function handleLogicChange() {
@@ -13954,7 +14646,7 @@ function updateAutoGearItemButtonState(type) {
             bubbles: true
           });
           select.dispatchEvent(evt);
-        } catch (_unused12) {
+        } catch (_unused16) {
           var _evt = document.createEvent('Event');
           _evt.initEvent(type, true, true);
           select.dispatchEvent(_evt);
@@ -13967,7 +14659,7 @@ function updateAutoGearItemButtonState(type) {
           select.focus({
             preventScroll: true
           });
-        } catch (_unused13) {
+        } catch (_unused17) {
           select.focus();
         }
       }
@@ -14071,12 +14763,12 @@ function updateAutoGearItemButtonState(type) {
     });
   }
   function computeAutoGearMultiSelectSize(optionCount) {
-    var _ref53 = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {},
-      fallback = _ref53.fallback,
-      _ref53$minRows = _ref53.minRows,
-      minRows = _ref53$minRows === void 0 ? AUTO_GEAR_MULTI_SELECT_MIN_ROWS : _ref53$minRows,
-      _ref53$maxRows = _ref53.maxRows,
-      maxRows = _ref53$maxRows === void 0 ? AUTO_GEAR_MULTI_SELECT_MAX_ROWS : _ref53$maxRows;
+    var _ref55 = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {},
+      fallback = _ref55.fallback,
+      _ref55$minRows = _ref55.minRows,
+      minRows = _ref55$minRows === void 0 ? AUTO_GEAR_MULTI_SELECT_MIN_ROWS : _ref55$minRows,
+      _ref55$maxRows = _ref55.maxRows,
+      maxRows = _ref55$maxRows === void 0 ? AUTO_GEAR_MULTI_SELECT_MAX_ROWS : _ref55$maxRows;
     var effectiveFallback = Number.isFinite(fallback) && fallback >= minRows ? fallback : minRows;
     if (!Number.isFinite(optionCount) || optionCount <= 0) {
       return effectiveFallback;
@@ -14118,7 +14810,7 @@ function updateAutoGearItemButtonState(type) {
         autoGearSearchInput.focus({
           preventScroll: true
         });
-      } catch (_unused14) {
+      } catch (_unused18) {
         autoGearSearchInput.focus();
       }
     }
@@ -14146,9 +14838,9 @@ function updateAutoGearItemButtonState(type) {
       haystack.push(rule.label);
     }
     if (rule && rule.always) {
-      var _texts$currentLang12, _texts$en257;
+      var _texts$currentLang12, _texts$en259;
       haystack.push('always');
-      var alwaysText = ((_texts$currentLang12 = texts[currentLang]) === null || _texts$currentLang12 === void 0 ? void 0 : _texts$currentLang12.autoGearAlwaysMeta) || ((_texts$en257 = texts.en) === null || _texts$en257 === void 0 ? void 0 : _texts$en257.autoGearAlwaysMeta) || 'Always active';
+      var alwaysText = ((_texts$currentLang12 = texts[currentLang]) === null || _texts$currentLang12 === void 0 ? void 0 : _texts$currentLang12.autoGearAlwaysMeta) || ((_texts$en259 = texts.en) === null || _texts$en259 === void 0 ? void 0 : _texts$en259.autoGearAlwaysMeta) || 'Always active';
       if (alwaysText) {
         haystack.push(alwaysText);
       }
@@ -14169,11 +14861,11 @@ function updateAutoGearItemButtonState(type) {
     pushValues(rule === null || rule === void 0 ? void 0 : rule.distance);
     var shootingCondition = normalizeAutoGearShootingDaysCondition(rule === null || rule === void 0 ? void 0 : rule.shootingDays);
     if (shootingCondition) {
-      var _texts$currentLang13, _texts$en258, _texts$currentLang14, _texts$en259, _texts$currentLang15, _texts$en260, _texts$currentLang16, _texts$en261;
-      var shootingLabel = ((_texts$currentLang13 = texts[currentLang]) === null || _texts$currentLang13 === void 0 ? void 0 : _texts$currentLang13.autoGearShootingDaysLabel) || ((_texts$en258 = texts.en) === null || _texts$en258 === void 0 ? void 0 : _texts$en258.autoGearShootingDaysLabel) || 'Shooting days condition';
-      var minimumLabel = ((_texts$currentLang14 = texts[currentLang]) === null || _texts$currentLang14 === void 0 ? void 0 : _texts$currentLang14.autoGearShootingDaysModeMinimum) || ((_texts$en259 = texts.en) === null || _texts$en259 === void 0 ? void 0 : _texts$en259.autoGearShootingDaysModeMinimum) || 'Minimum';
-      var maximumLabel = ((_texts$currentLang15 = texts[currentLang]) === null || _texts$currentLang15 === void 0 ? void 0 : _texts$currentLang15.autoGearShootingDaysModeMaximum) || ((_texts$en260 = texts.en) === null || _texts$en260 === void 0 ? void 0 : _texts$en260.autoGearShootingDaysModeMaximum) || 'Maximum';
-      var everyLabel = ((_texts$currentLang16 = texts[currentLang]) === null || _texts$currentLang16 === void 0 ? void 0 : _texts$currentLang16.autoGearShootingDaysModeEvery) || ((_texts$en261 = texts.en) === null || _texts$en261 === void 0 ? void 0 : _texts$en261.autoGearShootingDaysModeEvery) || 'Every';
+      var _texts$currentLang13, _texts$en260, _texts$currentLang14, _texts$en261, _texts$currentLang15, _texts$en262, _texts$currentLang16, _texts$en263;
+      var shootingLabel = ((_texts$currentLang13 = texts[currentLang]) === null || _texts$currentLang13 === void 0 ? void 0 : _texts$currentLang13.autoGearShootingDaysLabel) || ((_texts$en260 = texts.en) === null || _texts$en260 === void 0 ? void 0 : _texts$en260.autoGearShootingDaysLabel) || 'Shooting days condition';
+      var minimumLabel = ((_texts$currentLang14 = texts[currentLang]) === null || _texts$currentLang14 === void 0 ? void 0 : _texts$currentLang14.autoGearShootingDaysModeMinimum) || ((_texts$en261 = texts.en) === null || _texts$en261 === void 0 ? void 0 : _texts$en261.autoGearShootingDaysModeMinimum) || 'Minimum';
+      var maximumLabel = ((_texts$currentLang15 = texts[currentLang]) === null || _texts$currentLang15 === void 0 ? void 0 : _texts$currentLang15.autoGearShootingDaysModeMaximum) || ((_texts$en262 = texts.en) === null || _texts$en262 === void 0 ? void 0 : _texts$en262.autoGearShootingDaysModeMaximum) || 'Maximum';
+      var everyLabel = ((_texts$currentLang16 = texts[currentLang]) === null || _texts$currentLang16 === void 0 ? void 0 : _texts$currentLang16.autoGearShootingDaysModeEvery) || ((_texts$en263 = texts.en) === null || _texts$en263 === void 0 ? void 0 : _texts$en263.autoGearShootingDaysModeEvery) || 'Every';
       if (shootingLabel) {
         haystack.push(shootingLabel);
       }
@@ -14210,7 +14902,7 @@ function updateAutoGearItemButtonState(type) {
             haystack.push(item.selector.default);
           }
         }
-        haystack.push(formatAutoGearItemSummary(item));
+        haystack.push(safeFormatAutoGearItemSummary(item));
       });
     };
     collectItems(rule === null || rule === void 0 ? void 0 : rule.add);
@@ -14245,10 +14937,10 @@ function updateAutoGearItemButtonState(type) {
         });
       });
     }
-    return Array.from(options.entries()).map(function (_ref54) {
-      var _ref55 = _slicedToArray(_ref54, 2),
-        value = _ref55[0],
-        label = _ref55[1];
+    return Array.from(options.entries()).map(function (_ref56) {
+      var _ref57 = _slicedToArray(_ref56, 2),
+        value = _ref57[0],
+        label = _ref57[1];
       return {
         value: value,
         label: label
@@ -14258,18 +14950,18 @@ function updateAutoGearItemButtonState(type) {
     });
   }
   function refreshAutoGearScenarioFilterOptions(rules) {
-    var _texts$currentLang17, _texts$en262;
+    var _texts$currentLang17, _texts$en264;
     if (!autoGearFilterScenarioSelect) return autoGearScenarioFilter;
     var options = collectAutoGearScenarioFilterOptions(rules);
-    var anyLabel = ((_texts$currentLang17 = texts[currentLang]) === null || _texts$currentLang17 === void 0 ? void 0 : _texts$currentLang17.autoGearFilterScenarioAny) || ((_texts$en262 = texts.en) === null || _texts$en262 === void 0 ? void 0 : _texts$en262.autoGearFilterScenarioAny) || 'All scenarios';
+    var anyLabel = ((_texts$currentLang17 = texts[currentLang]) === null || _texts$currentLang17 === void 0 ? void 0 : _texts$currentLang17.autoGearFilterScenarioAny) || ((_texts$en264 = texts.en) === null || _texts$en264 === void 0 ? void 0 : _texts$en264.autoGearFilterScenarioAny) || 'All scenarios';
     autoGearFilterScenarioSelect.innerHTML = '';
     var anyOption = document.createElement('option');
     anyOption.value = 'all';
     anyOption.textContent = anyLabel;
     autoGearFilterScenarioSelect.appendChild(anyOption);
-    options.forEach(function (_ref56) {
-      var value = _ref56.value,
-        label = _ref56.label;
+    options.forEach(function (_ref58) {
+      var value = _ref58.value,
+        label = _ref58.label;
       var option = document.createElement('option');
       option.value = value;
       option.textContent = label;
@@ -14468,10 +15160,10 @@ function updateAutoGearItemButtonState(type) {
       });
     }
     if (!hasOptions) {
-      var _texts$currentLang18, _texts$en263;
+      var _texts$currentLang18, _texts$en265;
       var placeholder = document.createElement('option');
       placeholder.value = '';
-      placeholder.textContent = ((_texts$currentLang18 = texts[currentLang]) === null || _texts$currentLang18 === void 0 ? void 0 : _texts$currentLang18.autoGearScenarioPlaceholder) || ((_texts$en263 = texts.en) === null || _texts$en263 === void 0 ? void 0 : _texts$en263.autoGearScenarioPlaceholder) || 'Select scenarios';
+      placeholder.textContent = ((_texts$currentLang18 = texts[currentLang]) === null || _texts$currentLang18 === void 0 ? void 0 : _texts$currentLang18.autoGearScenarioPlaceholder) || ((_texts$en265 = texts.en) === null || _texts$en265 === void 0 ? void 0 : _texts$en265.autoGearScenarioPlaceholder) || 'Select scenarios';
       placeholder.disabled = true;
       placeholder.selected = true;
       autoGearScenariosSelect.appendChild(placeholder);
@@ -14513,11 +15205,11 @@ function updateAutoGearItemButtonState(type) {
     var uniqueValues = Array.from(new Set(values));
     var desiredMode = autoGearEditorDraft ? normalizeAutoGearScenarioLogic(autoGearEditorDraft.scenarioLogic) : normalizeAutoGearScenarioLogic((_autoGearScenarioMode = autoGearScenarioModeSelectElement) === null || _autoGearScenarioMode === void 0 ? void 0 : _autoGearScenarioMode.value);
     if (autoGearScenarioModeSelectElement) {
-      var _texts$currentLang19, _texts$en264, _texts$currentLang20, _texts$en265, _texts$currentLang21, _texts$en266;
+      var _texts$currentLang19, _texts$en266, _texts$currentLang20, _texts$en267, _texts$currentLang21, _texts$en268;
       var modeLabels = {
-        all: ((_texts$currentLang19 = texts[currentLang]) === null || _texts$currentLang19 === void 0 ? void 0 : _texts$currentLang19.autoGearScenarioModeAll) || ((_texts$en264 = texts.en) === null || _texts$en264 === void 0 ? void 0 : _texts$en264.autoGearScenarioModeAll) || 'Require every selected scenario',
-        any: ((_texts$currentLang20 = texts[currentLang]) === null || _texts$currentLang20 === void 0 ? void 0 : _texts$currentLang20.autoGearScenarioModeAny) || ((_texts$en265 = texts.en) === null || _texts$en265 === void 0 ? void 0 : _texts$en265.autoGearScenarioModeAny) || 'Match any selected scenario',
-        multiplier: ((_texts$currentLang21 = texts[currentLang]) === null || _texts$currentLang21 === void 0 ? void 0 : _texts$currentLang21.autoGearScenarioModeMultiplier) || ((_texts$en266 = texts.en) === null || _texts$en266 === void 0 ? void 0 : _texts$en266.autoGearScenarioModeMultiplier) || 'Multiply when combined'
+        all: ((_texts$currentLang19 = texts[currentLang]) === null || _texts$currentLang19 === void 0 ? void 0 : _texts$currentLang19.autoGearScenarioModeAll) || ((_texts$en266 = texts.en) === null || _texts$en266 === void 0 ? void 0 : _texts$en266.autoGearScenarioModeAll) || 'Require every selected scenario',
+        any: ((_texts$currentLang20 = texts[currentLang]) === null || _texts$currentLang20 === void 0 ? void 0 : _texts$currentLang20.autoGearScenarioModeAny) || ((_texts$en267 = texts.en) === null || _texts$en267 === void 0 ? void 0 : _texts$en267.autoGearScenarioModeAny) || 'Match any selected scenario',
+        multiplier: ((_texts$currentLang21 = texts[currentLang]) === null || _texts$currentLang21 === void 0 ? void 0 : _texts$currentLang21.autoGearScenarioModeMultiplier) || ((_texts$en268 = texts.en) === null || _texts$en268 === void 0 ? void 0 : _texts$en268.autoGearScenarioModeMultiplier) || 'Multiply when combined'
       };
       Array.from(autoGearScenarioModeSelectElement.options || []).forEach(function (option) {
         if (!option) return;
@@ -14572,10 +15264,10 @@ function updateAutoGearItemButtonState(type) {
     var previousValue = autoGearScenarioBaseSelect.value || '';
     autoGearScenarioBaseSelect.innerHTML = '';
     if (forceDisable || !uniqueValues.length) {
-      var _texts$currentLang22, _texts$en267;
+      var _texts$currentLang22, _texts$en269;
       var placeholder = document.createElement('option');
       placeholder.value = '';
-      placeholder.textContent = ((_texts$currentLang22 = texts[currentLang]) === null || _texts$currentLang22 === void 0 ? void 0 : _texts$currentLang22.autoGearScenarioBasePlaceholder) || ((_texts$en267 = texts.en) === null || _texts$en267 === void 0 ? void 0 : _texts$en267.autoGearScenarioBasePlaceholder) || 'Select a base scenario';
+      placeholder.textContent = ((_texts$currentLang22 = texts[currentLang]) === null || _texts$currentLang22 === void 0 ? void 0 : _texts$currentLang22.autoGearScenarioBasePlaceholder) || ((_texts$en269 = texts.en) === null || _texts$en269 === void 0 ? void 0 : _texts$en269.autoGearScenarioBasePlaceholder) || 'Select a base scenario';
       placeholder.disabled = true;
       placeholder.selected = true;
       autoGearScenarioBaseSelect.appendChild(placeholder);
@@ -14640,10 +15332,10 @@ function updateAutoGearItemButtonState(type) {
       });
     }
     if (!hasOptions) {
-      var _texts$currentLang23, _texts$en268;
+      var _texts$currentLang23, _texts$en270;
       var placeholder = document.createElement('option');
       placeholder.value = '';
-      placeholder.textContent = ((_texts$currentLang23 = texts[currentLang]) === null || _texts$currentLang23 === void 0 ? void 0 : _texts$currentLang23.autoGearMatteboxPlaceholder) || ((_texts$en268 = texts.en) === null || _texts$en268 === void 0 ? void 0 : _texts$en268.autoGearMatteboxPlaceholder) || 'Select mattebox options';
+      placeholder.textContent = ((_texts$currentLang23 = texts[currentLang]) === null || _texts$currentLang23 === void 0 ? void 0 : _texts$currentLang23.autoGearMatteboxPlaceholder) || ((_texts$en270 = texts.en) === null || _texts$en270 === void 0 ? void 0 : _texts$en270.autoGearMatteboxPlaceholder) || 'Select mattebox options';
       placeholder.disabled = true;
       placeholder.selected = true;
       autoGearMatteboxSelect.appendChild(placeholder);
@@ -14694,10 +15386,10 @@ function updateAutoGearItemButtonState(type) {
       });
     }
     if (!hasOptions) {
-      var _texts$currentLang24, _texts$en269;
+      var _texts$currentLang24, _texts$en271;
       var placeholder = document.createElement('option');
       placeholder.value = '';
-      placeholder.textContent = ((_texts$currentLang24 = texts[currentLang]) === null || _texts$currentLang24 === void 0 ? void 0 : _texts$currentLang24.autoGearCameraHandlePlaceholder) || ((_texts$en269 = texts.en) === null || _texts$en269 === void 0 ? void 0 : _texts$en269.autoGearCameraHandlePlaceholder) || 'Select camera handles';
+      placeholder.textContent = ((_texts$currentLang24 = texts[currentLang]) === null || _texts$currentLang24 === void 0 ? void 0 : _texts$currentLang24.autoGearCameraHandlePlaceholder) || ((_texts$en271 = texts.en) === null || _texts$en271 === void 0 ? void 0 : _texts$en271.autoGearCameraHandlePlaceholder) || 'Select camera handles';
       placeholder.disabled = true;
       placeholder.selected = true;
       autoGearCameraHandleSelect.appendChild(placeholder);
@@ -14729,15 +15421,15 @@ function updateAutoGearItemButtonState(type) {
   }
   function getViewfinderFallbackLabel(value) {
     if (value === '__none__') {
-      var _texts$currentLang25, _texts$en270;
-      return ((_texts$currentLang25 = texts[currentLang]) === null || _texts$currentLang25 === void 0 ? void 0 : _texts$currentLang25.viewfinderExtensionNone) || ((_texts$en270 = texts.en) === null || _texts$en270 === void 0 ? void 0 : _texts$en270.viewfinderExtensionNone) || 'No';
+      var _texts$currentLang25, _texts$en272;
+      return ((_texts$currentLang25 = texts[currentLang]) === null || _texts$currentLang25 === void 0 ? void 0 : _texts$currentLang25.viewfinderExtensionNone) || ((_texts$en272 = texts.en) === null || _texts$en272 === void 0 ? void 0 : _texts$en272.viewfinderExtensionNone) || 'No';
     }
     return value;
   }
   function getVideoDistributionFallbackLabel(value) {
     if (value === '__none__') {
-      var _texts$currentLang26, _texts$en271;
-      return ((_texts$currentLang26 = texts[currentLang]) === null || _texts$currentLang26 === void 0 ? void 0 : _texts$currentLang26.autoGearVideoDistributionNone) || ((_texts$en271 = texts.en) === null || _texts$en271 === void 0 ? void 0 : _texts$en271.autoGearVideoDistributionNone) || 'No video distribution selected';
+      var _texts$currentLang26, _texts$en273;
+      return ((_texts$currentLang26 = texts[currentLang]) === null || _texts$currentLang26 === void 0 ? void 0 : _texts$currentLang26.autoGearVideoDistributionNone) || ((_texts$en273 = texts.en) === null || _texts$en273 === void 0 ? void 0 : _texts$en273.autoGearVideoDistributionNone) || 'No video distribution selected';
     }
     return value;
   }
@@ -14775,10 +15467,10 @@ function updateAutoGearItemButtonState(type) {
       });
     }
     if (!hasOptions) {
-      var _texts$currentLang27, _texts$en272;
+      var _texts$currentLang27, _texts$en274;
       var placeholder = document.createElement('option');
       placeholder.value = '';
-      placeholder.textContent = ((_texts$currentLang27 = texts[currentLang]) === null || _texts$currentLang27 === void 0 ? void 0 : _texts$currentLang27.autoGearViewfinderExtensionPlaceholder) || ((_texts$en272 = texts.en) === null || _texts$en272 === void 0 ? void 0 : _texts$en272.autoGearViewfinderExtensionPlaceholder) || 'Select viewfinder extension options';
+      placeholder.textContent = ((_texts$currentLang27 = texts[currentLang]) === null || _texts$currentLang27 === void 0 ? void 0 : _texts$currentLang27.autoGearViewfinderExtensionPlaceholder) || ((_texts$en274 = texts.en) === null || _texts$en274 === void 0 ? void 0 : _texts$en274.autoGearViewfinderExtensionPlaceholder) || 'Select viewfinder extension options';
       placeholder.disabled = true;
       placeholder.selected = true;
       autoGearViewfinderExtensionSelect.appendChild(placeholder);
@@ -14834,10 +15526,10 @@ function updateAutoGearItemButtonState(type) {
       if (!seen.has(value)) addOption(value, value);
     });
     if (!autoGearDeliveryResolutionSelect.options.length) {
-      var _texts$currentLang28, _texts$en273;
+      var _texts$currentLang28, _texts$en275;
       var placeholder = document.createElement('option');
       placeholder.value = '';
-      placeholder.textContent = ((_texts$currentLang28 = texts[currentLang]) === null || _texts$currentLang28 === void 0 ? void 0 : _texts$currentLang28.autoGearDeliveryResolutionPlaceholder) || ((_texts$en273 = texts.en) === null || _texts$en273 === void 0 ? void 0 : _texts$en273.autoGearDeliveryResolutionPlaceholder) || 'Select delivery resolutions';
+      placeholder.textContent = ((_texts$currentLang28 = texts[currentLang]) === null || _texts$currentLang28 === void 0 ? void 0 : _texts$currentLang28.autoGearDeliveryResolutionPlaceholder) || ((_texts$en275 = texts.en) === null || _texts$en275 === void 0 ? void 0 : _texts$en275.autoGearDeliveryResolutionPlaceholder) || 'Select delivery resolutions';
       placeholder.disabled = true;
       placeholder.selected = true;
       autoGearDeliveryResolutionSelect.appendChild(placeholder);
@@ -14889,10 +15581,10 @@ function updateAutoGearItemButtonState(type) {
       });
     }
     if (!hasOptions) {
-      var _texts$currentLang29, _texts$en274;
+      var _texts$currentLang29, _texts$en276;
       var placeholder = document.createElement('option');
       placeholder.value = '';
-      placeholder.textContent = ((_texts$currentLang29 = texts[currentLang]) === null || _texts$currentLang29 === void 0 ? void 0 : _texts$currentLang29.autoGearVideoDistributionPlaceholder) || ((_texts$en274 = texts.en) === null || _texts$en274 === void 0 ? void 0 : _texts$en274.autoGearVideoDistributionPlaceholder) || 'Select video distribution options';
+      placeholder.textContent = ((_texts$currentLang29 = texts[currentLang]) === null || _texts$currentLang29 === void 0 ? void 0 : _texts$currentLang29.autoGearVideoDistributionPlaceholder) || ((_texts$en276 = texts.en) === null || _texts$en276 === void 0 ? void 0 : _texts$en276.autoGearVideoDistributionPlaceholder) || 'Select video distribution options';
       placeholder.disabled = true;
       placeholder.selected = true;
       autoGearVideoDistributionSelect.appendChild(placeholder);
@@ -14926,15 +15618,15 @@ function updateAutoGearItemButtonState(type) {
     }).filter(Boolean)));
   }
   function getCrewRoleEntries() {
-    var _texts$en275;
+    var _texts$en277;
     var langTexts = texts[currentLang] || texts.en || {};
-    var crewRoleMap = langTexts.crewRoles || ((_texts$en275 = texts.en) === null || _texts$en275 === void 0 ? void 0 : _texts$en275.crewRoles) || {};
+    var crewRoleMap = langTexts.crewRoles || ((_texts$en277 = texts.en) === null || _texts$en277 === void 0 ? void 0 : _texts$en277.crewRoles) || {};
     var seen = new Set();
     var entries = [];
-    Object.entries(crewRoleMap).forEach(function (_ref57) {
-      var _ref58 = _slicedToArray(_ref57, 2),
-        value = _ref58[0],
-        label = _ref58[1];
+    Object.entries(crewRoleMap).forEach(function (_ref59) {
+      var _ref60 = _slicedToArray(_ref59, 2),
+        value = _ref60[0],
+        label = _ref60[1];
       if (typeof value !== 'string') return;
       var trimmedValue = value.trim();
       if (!trimmedValue) return;
@@ -14953,8 +15645,10 @@ function updateAutoGearItemButtonState(type) {
       });
     });
   }
+  exposeCoreRuntimeConstant('setupInstallBanner', setupInstallBanner);
+  exposeCoreRuntimeConstant('maybeShowIosPwaHelp', maybeShowIosPwaHelp);
   exposeCoreRuntimeConstant('updateSelectIconBoxes', updateSelectIconBoxes);
-  exposeCoreRuntimeConstants({
+  var CORE_RUNTIME_CONSTANTS = {
     CORE_GLOBAL_SCOPE: CORE_GLOBAL_SCOPE,
     CORE_BOOT_QUEUE_KEY: CORE_BOOT_QUEUE_KEY,
     CORE_BOOT_QUEUE: CORE_BOOT_QUEUE,
@@ -14970,18 +15664,10 @@ function updateAutoGearItemButtonState(type) {
     TEMPERATURE_UNITS: TEMPERATURE_UNITS,
     TEMPERATURE_SCENARIOS: TEMPERATURE_SCENARIOS,
     FEEDBACK_TEMPERATURE_MIN: FEEDBACK_TEMPERATURE_MIN,
-    FEEDBACK_TEMPERATURE_MAX: FEEDBACK_TEMPERATURE_MAX,
-    // Mount voltage helpers must stay globally accessible for autosave/share flows.
-    SUPPORTED_MOUNT_VOLTAGE_TYPES: SUPPORTED_MOUNT_VOLTAGE_TYPES,
-    DEFAULT_MOUNT_VOLTAGES: DEFAULT_MOUNT_VOLTAGES,
-    mountVoltageInputs: mountVoltageInputs,
-    parseVoltageValue: parseVoltageValue,
-    getMountVoltagePreferencesClone: getMountVoltagePreferencesClone,
-    applyMountVoltagePreferences: applyMountVoltagePreferences,
-    parseStoredMountVoltages: parseStoredMountVoltages,
-    resetMountVoltagePreferences: resetMountVoltagePreferences,
-    updateMountVoltageInputsFromState: updateMountVoltageInputsFromState,
-    // Pink mode animated icon controls are required for theme toggles during imports.
+    FEEDBACK_TEMPERATURE_MAX: FEEDBACK_TEMPERATURE_MAX
+  };
+  Object.assign(CORE_RUNTIME_CONSTANTS, MOUNT_VOLTAGE_RUNTIME_EXPORTS);
+  Object.assign(CORE_RUNTIME_CONSTANTS, {
     startPinkModeAnimatedIcons: startPinkModeAnimatedIcons,
     stopPinkModeAnimatedIcons: stopPinkModeAnimatedIcons,
     pinkModeIcons: pinkModeIcons,
@@ -14991,6 +15677,7 @@ function updateAutoGearItemButtonState(type) {
     PINK_MODE_ICON_ANIMATION_CLASS: PINK_MODE_ICON_ANIMATION_CLASS,
     PINK_MODE_ICON_ANIMATION_RESET_DELAY: PINK_MODE_ICON_ANIMATION_RESET_DELAY
   });
+  exposeCoreRuntimeConstants(CORE_RUNTIME_CONSTANTS);
   exposeCoreRuntimeBindings({
     safeGenerateConnectorSummary: {
       get: function get() {
@@ -15037,7 +15724,7 @@ function updateAutoGearItemButtonState(type) {
         return pinkModeIconRotationTimer;
       },
       set: function set(value) {
-        if (typeof value === 'number' || value === null || typeof value === 'object') {
+        if (typeof value === 'number' || value === null || _typeof(value) === 'object') {
           pinkModeIconRotationTimer = value;
         }
       }

--- a/legacy/scripts/app-core-new-2.js
+++ b/legacy/scripts/app-core-new-2.js
@@ -22,29 +22,18 @@ function _typeof(o) { "@babel/helpers - typeof"; return _typeof = "function" == 
 function _asyncIterator(r) { var n, t, o, e = 2; for ("undefined" != typeof Symbol && (t = Symbol.asyncIterator, o = Symbol.iterator); e--;) { if (t && null != (n = r[t])) return n.call(r); if (o && null != (n = r[o])) return new AsyncFromSyncIterator(n.call(r)); t = "@@asyncIterator", o = "@@iterator"; } throw new TypeError("Object is not async iterable"); }
 function AsyncFromSyncIterator(r) { function AsyncFromSyncIteratorContinuation(r) { if (Object(r) !== r) return Promise.reject(new TypeError(r + " is not an object.")); var n = r.done; return Promise.resolve(r.value).then(function (r) { return { value: r, done: n }; }); } return AsyncFromSyncIterator = function AsyncFromSyncIterator(r) { this.s = r, this.n = r.next; }, AsyncFromSyncIterator.prototype = { s: null, n: null, next: function next() { return AsyncFromSyncIteratorContinuation(this.n.apply(this.s, arguments)); }, return: function _return(r) { var n = this.s.return; return void 0 === n ? Promise.resolve({ value: r, done: !0 }) : AsyncFromSyncIteratorContinuation(n.apply(this.s, arguments)); }, throw: function _throw(r) { var n = this.s.return; return void 0 === n ? Promise.reject(r) : AsyncFromSyncIteratorContinuation(n.apply(this.s, arguments)); } }, new AsyncFromSyncIterator(r); }
 var CORE_PART2_RUNTIME_SCOPE = typeof CORE_GLOBAL_SCOPE !== 'undefined' && CORE_GLOBAL_SCOPE ? CORE_GLOBAL_SCOPE : typeof globalThis !== 'undefined' ? globalThis : typeof window !== 'undefined' ? window : typeof self !== 'undefined' ? self : typeof global !== 'undefined' ? global : null;
-var CORE_PART2_GLOBAL_SCOPES = [
-  CORE_PART2_RUNTIME_SCOPE && _typeof(CORE_PART2_RUNTIME_SCOPE) === 'object' ? CORE_PART2_RUNTIME_SCOPE : null,
-  typeof CORE_GLOBAL_SCOPE !== 'undefined' && CORE_GLOBAL_SCOPE && _typeof(CORE_GLOBAL_SCOPE) === 'object' ? CORE_GLOBAL_SCOPE : null,
-  typeof globalThis !== 'undefined' && _typeof(globalThis) === 'object' ? globalThis : null,
-  typeof window !== 'undefined' && _typeof(window) === 'object' ? window : null,
-  typeof self !== 'undefined' && _typeof(self) === 'object' ? self : null,
-  typeof global !== 'undefined' && _typeof(global) === 'object' ? global : null
-].filter(Boolean);
-
+var CORE_PART2_GLOBAL_SCOPES = [CORE_PART2_RUNTIME_SCOPE && _typeof(CORE_PART2_RUNTIME_SCOPE) === 'object' ? CORE_PART2_RUNTIME_SCOPE : null, typeof CORE_GLOBAL_SCOPE !== 'undefined' && CORE_GLOBAL_SCOPE && (typeof CORE_GLOBAL_SCOPE === "undefined" ? "undefined" : _typeof(CORE_GLOBAL_SCOPE)) === 'object' ? CORE_GLOBAL_SCOPE : null, typeof globalThis !== 'undefined' && (typeof globalThis === "undefined" ? "undefined" : _typeof(globalThis)) === 'object' ? globalThis : null, typeof window !== 'undefined' && (typeof window === "undefined" ? "undefined" : _typeof(window)) === 'object' ? window : null, typeof self !== 'undefined' && (typeof self === "undefined" ? "undefined" : _typeof(self)) === 'object' ? self : null, typeof global !== 'undefined' && (typeof global === "undefined" ? "undefined" : _typeof(global)) === 'object' ? global : null].filter(Boolean);
 var CORE_TEMPERATURE_QUEUE_KEY = '__cinePendingTemperatureNote';
 var CORE_TEMPERATURE_RENDER_NAME = 'renderTemperatureNote';
-
 function assignCoreTemperatureNoteRenderer(renderer) {
   if (typeof renderer !== 'function') {
     return;
   }
-
   for (var index = 0; index < CORE_PART2_GLOBAL_SCOPES.length; index += 1) {
     var scope = CORE_PART2_GLOBAL_SCOPES[index];
     if (!scope || _typeof(scope) !== 'object') {
       continue;
     }
-
     try {
       scope[CORE_TEMPERATURE_RENDER_NAME] = renderer;
       var pending = scope[CORE_TEMPERATURE_QUEUE_KEY];
@@ -73,14 +62,12 @@ function assignCoreTemperatureNoteRenderer(renderer) {
     }
   }
 }
-
 function readGlobalScopeValue(name) {
   for (var index = 0; index < CORE_PART2_GLOBAL_SCOPES.length; index += 1) {
     var scope = CORE_PART2_GLOBAL_SCOPES[index];
     if (!scope || _typeof(scope) !== 'object') {
       continue;
     }
-
     try {
       if (name in scope) {
         return scope[name];
@@ -89,25 +76,50 @@ function readGlobalScopeValue(name) {
       void readError;
     }
   }
-
   return undefined;
 }
-var autoGearAutoPresetId;
-if (typeof autoGearAutoPresetId === 'undefined') {
-  autoGearAutoPresetId = '';
-} else if (typeof autoGearAutoPresetId !== 'string') {
-  autoGearAutoPresetId = '';
+function ensureGlobalFallback(name, fallbackValue) {
+  var fallbackProvider = typeof fallbackValue === 'function' ? fallbackValue : function provideStaticFallback() {
+    return fallbackValue;
+  };
+  for (var index = 0; index < CORE_PART2_GLOBAL_SCOPES.length; index += 1) {
+    var scope = CORE_PART2_GLOBAL_SCOPES[index];
+    try {
+      if (typeof scope[name] === 'undefined') {
+        scope[name] = fallbackProvider();
+      }
+      return scope[name];
+    } catch (ensureError) {
+      void ensureError;
+    }
+  }
+  try {
+    return fallbackProvider();
+  } catch (fallbackError) {
+    void fallbackError;
+    return undefined;
+  }
 }
-var baseAutoGearRules;
-if (typeof baseAutoGearRules === 'undefined') {
-  baseAutoGearRules = [];
-} else if (!Array.isArray(baseAutoGearRules)) {
-  baseAutoGearRules = [];
+function normaliseGlobalValue(name, validator, fallbackValue) {
+  var fallbackProvider = typeof fallbackValue === 'function' ? fallbackValue : function provideStaticFallback() {
+    return fallbackValue;
+  };
+  for (var index = 0; index < CORE_PART2_GLOBAL_SCOPES.length; index += 1) {
+    var scope = CORE_PART2_GLOBAL_SCOPES[index];
+    try {
+      if (!validator(scope[name])) {
+        scope[name] = fallbackProvider();
+      }
+    } catch (normaliseError) {
+      void normaliseError;
+    }
+  }
 }
-var autoGearScenarioModeSelect;
-if (typeof autoGearScenarioModeSelect === 'undefined') {
-  autoGearScenarioModeSelect = null;
-}
+ensureGlobalFallback('autoGearAutoPresetId', '');
+ensureGlobalFallback('baseAutoGearRules', function () {
+  return [];
+});
+ensureGlobalFallback('autoGearScenarioModeSelect', null);
 function createFallbackSafeGenerateConnectorSummary() {
   return function safeGenerateConnectorSummary(device) {
     if (!device || _typeof(device) !== 'object') {
@@ -131,6 +143,35 @@ function createFallbackSafeGenerateConnectorSummary() {
     }
   };
 }
+ensureGlobalFallback('safeGenerateConnectorSummary', function () {
+  return createFallbackSafeGenerateConnectorSummary();
+});
+normaliseGlobalValue('baseAutoGearRules', function validateBaseAutoGearRules(value) {
+  return Array.isArray(value);
+}, function provideBaseAutoGearRulesFallback() {
+  return [];
+});
+normaliseGlobalValue('safeGenerateConnectorSummary', function validateSafeGenerateConnectorSummary(value) {
+  return typeof value === 'function';
+}, function provideSafeGenerateConnectorSummaryFallback() {
+  return createFallbackSafeGenerateConnectorSummary();
+});
+var autoGearAutoPresetId;
+if (typeof autoGearAutoPresetId === 'undefined') {
+  autoGearAutoPresetId = '';
+} else if (typeof autoGearAutoPresetId !== 'string') {
+  autoGearAutoPresetId = '';
+}
+var baseAutoGearRules;
+if (typeof baseAutoGearRules === 'undefined') {
+  baseAutoGearRules = [];
+} else if (!Array.isArray(baseAutoGearRules)) {
+  baseAutoGearRules = [];
+}
+var autoGearScenarioModeSelect;
+if (typeof autoGearScenarioModeSelect === 'undefined') {
+  autoGearScenarioModeSelect = null;
+}
 var safeGenerateConnectorSummary;
 if (typeof safeGenerateConnectorSummary === 'undefined') {
   safeGenerateConnectorSummary = createFallbackSafeGenerateConnectorSummary();
@@ -139,11 +180,9 @@ if (typeof safeGenerateConnectorSummary === 'undefined') {
 }
 function ensureCorePart2Placeholder(name, fallbackValue) {
   var providers = [CORE_PART2_RUNTIME_SCOPE && _typeof(CORE_PART2_RUNTIME_SCOPE) === 'object' ? CORE_PART2_RUNTIME_SCOPE : null, typeof CORE_GLOBAL_SCOPE !== 'undefined' && CORE_GLOBAL_SCOPE && (typeof CORE_GLOBAL_SCOPE === "undefined" ? "undefined" : _typeof(CORE_GLOBAL_SCOPE)) === 'object' ? CORE_GLOBAL_SCOPE : null, typeof globalThis !== 'undefined' && (typeof globalThis === "undefined" ? "undefined" : _typeof(globalThis)) === 'object' ? globalThis : null, typeof window !== 'undefined' && (typeof window === "undefined" ? "undefined" : _typeof(window)) === 'object' ? window : null, typeof self !== 'undefined' && (typeof self === "undefined" ? "undefined" : _typeof(self)) === 'object' ? self : null, typeof global !== 'undefined' && (typeof global === "undefined" ? "undefined" : _typeof(global)) === 'object' ? global : null].filter(Boolean);
-
   var fallbackProvider = typeof fallbackValue === 'function' ? fallbackValue : function provideStaticFallback() {
     return fallbackValue;
   };
-
   for (var index = 0; index < providers.length; index += 1) {
     var scope = providers[index];
     try {
@@ -155,10 +194,8 @@ function ensureCorePart2Placeholder(name, fallbackValue) {
       void placeholderError;
     }
   }
-
   return fallbackProvider();
 }
-
 ensureCorePart2Placeholder('autoGearAutoPresetId', '');
 ensureCorePart2Placeholder('baseAutoGearRules', function () {
   return [];
@@ -264,6 +301,73 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
       return null;
     }
     var CORE_SHARED_LOCAL = typeof CORE_SHARED !== 'undefined' && CORE_SHARED ? CORE_SHARED : resolveCoreSharedPart2() || {};
+    function fallbackNormalizeAutoGearWeightOperator(value) {
+      if (typeof value !== 'string') return 'greater';
+      var normalized = value.trim().toLowerCase();
+      if (!normalized) return 'greater';
+      if (normalized === '>' || normalized === 'gt' || normalized === 'greaterthan' || normalized === 'above' || normalized === 'over') {
+        return 'greater';
+      }
+      if (normalized === '<' || normalized === 'lt' || normalized === 'lessthan' || normalized === 'below' || normalized === 'under') {
+        return 'less';
+      }
+      if (normalized === '=' || normalized === '==' || normalized === 'equal' || normalized === 'equals' || normalized === 'exactly' || normalized === 'match' || normalized === 'matches') {
+        return 'equal';
+      }
+      return 'greater';
+    }
+    function fallbackNormalizeAutoGearWeightValue(value) {
+      if (typeof value === 'number' && Number.isFinite(value)) {
+        var rounded = Math.round(value);
+        return rounded >= 0 ? rounded : null;
+      }
+      if (typeof value === 'string') {
+        var trimmed = value.trim();
+        if (!trimmed) return null;
+        var sanitized = trimmed.replace(/[^0-9.,-]/g, '').replace(/,/g, '.');
+        if (!sanitized) return null;
+        var parsed = Number.parseFloat(sanitized);
+        if (!Number.isFinite(parsed)) return null;
+        var _rounded = Math.round(parsed);
+        return _rounded >= 0 ? _rounded : null;
+      }
+      return null;
+    }
+    function fallbackFormatAutoGearWeight(value) {
+      if (!Number.isFinite(value)) return '';
+      try {
+        if (typeof Intl !== 'undefined' && typeof Intl.NumberFormat === 'function') {
+          return new Intl.NumberFormat().format(value);
+        }
+      } catch (error) {
+        void error;
+      }
+      return String(value);
+    }
+    var normalizeAutoGearWeightOperator = typeof CORE_SHARED_LOCAL.normalizeAutoGearWeightOperator === 'function' ? CORE_SHARED_LOCAL.normalizeAutoGearWeightOperator : fallbackNormalizeAutoGearWeightOperator;
+    var normalizeAutoGearWeightValue = typeof CORE_SHARED_LOCAL.normalizeAutoGearWeightValue === 'function' ? CORE_SHARED_LOCAL.normalizeAutoGearWeightValue : fallbackNormalizeAutoGearWeightValue;
+    var normalizeAutoGearCameraWeightCondition = typeof CORE_SHARED_LOCAL.normalizeAutoGearCameraWeightCondition === 'function' ? CORE_SHARED_LOCAL.normalizeAutoGearCameraWeightCondition : function normalizeAutoGearCameraWeightCondition() {
+      return null;
+    };
+    var formatAutoGearWeight = typeof CORE_SHARED_LOCAL.formatAutoGearWeight === 'function' ? CORE_SHARED_LOCAL.formatAutoGearWeight : fallbackFormatAutoGearWeight;
+    var getAutoGearCameraWeightOperatorLabel = typeof CORE_SHARED_LOCAL.getAutoGearCameraWeightOperatorLabel === 'function' ? CORE_SHARED_LOCAL.getAutoGearCameraWeightOperatorLabel : function getAutoGearCameraWeightOperatorLabel(operator, langTexts) {
+      var textsForLang = langTexts || {};
+      var fallbackTexts = CORE_GLOBAL_SCOPE && CORE_GLOBAL_SCOPE.texts && CORE_GLOBAL_SCOPE.texts.en || {};
+      var normalized = normalizeAutoGearWeightOperator(operator);
+      if (normalized === 'less') {
+        return textsForLang.autoGearCameraWeightOperatorLess || fallbackTexts.autoGearCameraWeightOperatorLess || 'Lighter than';
+      }
+      if (normalized === 'equal') {
+        return textsForLang.autoGearCameraWeightOperatorEqual || fallbackTexts.autoGearCameraWeightOperatorEqual || 'Exactly';
+      }
+      return textsForLang.autoGearCameraWeightOperatorGreater || fallbackTexts.autoGearCameraWeightOperatorGreater || 'Heavier than';
+    };
+    var formatAutoGearCameraWeight = typeof CORE_SHARED_LOCAL.formatAutoGearCameraWeight === 'function' ? CORE_SHARED_LOCAL.formatAutoGearCameraWeight : function formatAutoGearCameraWeight(condition, langTexts) {
+      if (!condition || !Number.isFinite(condition.value)) return '';
+      var label = getAutoGearCameraWeightOperatorLabel(condition.operator, langTexts);
+      var formattedValue = formatAutoGearWeight(condition.value);
+      return "".concat(label, " ").concat(formattedValue, " g");
+    };
     var CORE_RUNTIME_SCOPE_CANDIDATES = [CORE_PART2_RUNTIME_SCOPE && _typeof(CORE_PART2_RUNTIME_SCOPE) === 'object' ? CORE_PART2_RUNTIME_SCOPE : null, typeof CORE_GLOBAL_SCOPE !== 'undefined' && CORE_GLOBAL_SCOPE && (typeof CORE_GLOBAL_SCOPE === "undefined" ? "undefined" : _typeof(CORE_GLOBAL_SCOPE)) === 'object' ? CORE_GLOBAL_SCOPE : null, typeof globalThis !== 'undefined' && (typeof globalThis === "undefined" ? "undefined" : _typeof(globalThis)) === 'object' ? globalThis : null, typeof window !== 'undefined' && (typeof window === "undefined" ? "undefined" : _typeof(window)) === 'object' ? window : null, typeof self !== 'undefined' && (typeof self === "undefined" ? "undefined" : _typeof(self)) === 'object' ? self : null, typeof global !== 'undefined' && (typeof global === "undefined" ? "undefined" : _typeof(global)) === 'object' ? global : null].filter(Boolean);
     function readCoreScopeValue(name) {
       for (var index = 0; index < CORE_RUNTIME_SCOPE_CANDIDATES.length; index += 1) {
@@ -1386,19 +1490,26 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
       if (Array.isArray(baseAutoGearRulesState)) {
         return baseAutoGearRulesState;
       }
-
       var resolved = readCoreScopeValue('baseAutoGearRules');
       if (Array.isArray(resolved)) {
         return resolved;
       }
-
-      if (typeof baseAutoGearRules !== 'undefined' && Array.isArray(baseAutoGearRules)) {
-        return baseAutoGearRules;
+      for (var index = 0; index < CORE_RUNTIME_SCOPE_CANDIDATES.length; index += 1) {
+        var scope = CORE_RUNTIME_SCOPE_CANDIDATES[index];
+        if (!scope || _typeof(scope) !== 'object') {
+          continue;
+        }
+        try {
+          var value = scope.baseAutoGearRules;
+          if (Array.isArray(value)) {
+            return value;
+          }
+        } catch (fallbackError) {
+          void fallbackError;
+        }
       }
-
       return [];
     }
-
     function alignActiveAutoGearPreset() {
       var options = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
       var skipRender = options.skipRender === true;
@@ -4865,20 +4976,20 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
           candidates.push(scope);
         }
       }
-      if (typeof globalThis !== 'undefined' && globalThis && candidates.indexOf(globalThis) === -1) {
+      if (typeof globalThis !== 'undefined' && globalThis && !candidates.includes(globalThis)) {
         candidates.push(globalThis);
       }
-      if (typeof window !== 'undefined' && window && candidates.indexOf(window) === -1) {
+      if (typeof window !== 'undefined' && window && !candidates.includes(window)) {
         candidates.push(window);
       }
-      if (typeof self !== 'undefined' && self && candidates.indexOf(self) === -1) {
+      if (typeof self !== 'undefined' && self && !candidates.includes(self)) {
         candidates.push(self);
       }
-      if (typeof global !== 'undefined' && global && candidates.indexOf(global) === -1) {
+      if (typeof global !== 'undefined' && global && !candidates.includes(global)) {
         candidates.push(global);
       }
-      for (var _index = 0; _index < candidates.length; _index += 1) {
-        var candidate = candidates[_index];
+      for (var _index2 = 0; _index2 < candidates.length; _index2 += 1) {
+        var candidate = candidates[_index2];
         if (candidate && _typeof(candidate) === 'object') {
           return candidate;
         }
@@ -5282,11 +5393,19 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
         return false;
       }
       var matched = 0;
-      for (var _i2 = 0, _REQUIRED_DEVICE_CATE = REQUIRED_DEVICE_CATEGORIES; _i2 < _REQUIRED_DEVICE_CATE.length; _i2++) {
-        var key = _REQUIRED_DEVICE_CATE[_i2];
-        if (Object.prototype.hasOwnProperty.call(candidate, key)) {
-          matched += 1;
+      var _iterator2 = _createForOfIteratorHelper(REQUIRED_DEVICE_CATEGORIES),
+        _step2;
+      try {
+        for (_iterator2.s(); !(_step2 = _iterator2.n()).done;) {
+          var key = _step2.value;
+          if (Object.prototype.hasOwnProperty.call(candidate, key)) {
+            matched += 1;
+          }
         }
+      } catch (err) {
+        _iterator2.e(err);
+      } finally {
+        _iterator2.f();
       }
       return matched >= 3;
     }
@@ -5319,39 +5438,47 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
       }
       var errors = [];
       var missing = [];
-      for (var _i3 = 0, _REQUIRED_DEVICE_CATE2 = REQUIRED_DEVICE_CATEGORIES; _i3 < _REQUIRED_DEVICE_CATE2.length; _i3++) {
-        var category = _REQUIRED_DEVICE_CATE2[_i3];
-        if (category === 'fiz') {
-          if (!isPlainObjectValue(candidate.fiz)) {
-            missing.push('fiz');
+      var _iterator3 = _createForOfIteratorHelper(REQUIRED_DEVICE_CATEGORIES),
+        _step3;
+      try {
+        for (_iterator3.s(); !(_step3 = _iterator3.n()).done;) {
+          var category = _step3.value;
+          if (category === 'fiz') {
+            if (!isPlainObjectValue(candidate.fiz)) {
+              missing.push('fiz');
+              continue;
+            }
+            var expectedFizKeys = collectReferenceFizKeys();
+            var missingFiz = expectedFizKeys.filter(function (key) {
+              return !isPlainObjectValue(candidate.fiz[key]);
+            });
+            if (missingFiz.length) {
+              errors.push("Missing FIZ categories: ".concat(missingFiz.join(', ')));
+            }
             continue;
           }
-          var expectedFizKeys = collectReferenceFizKeys();
-          var missingFiz = expectedFizKeys.filter(function (key) {
-            return !isPlainObjectValue(candidate.fiz[key]);
-          });
-          if (missingFiz.length) {
-            errors.push("Missing FIZ categories: ".concat(missingFiz.join(', ')));
-          }
-          continue;
-        }
-        if (category === 'accessories') {
-          if (!isPlainObjectValue(candidate.accessories)) {
-            missing.push('accessories');
+          if (category === 'accessories') {
+            if (!isPlainObjectValue(candidate.accessories)) {
+              missing.push('accessories');
+              continue;
+            }
+            var expectedAccessoryKeys = collectReferenceAccessoryKeys();
+            var missingAccessories = expectedAccessoryKeys.filter(function (key) {
+              return !isPlainObjectValue(candidate.accessories[key]);
+            });
+            if (missingAccessories.length) {
+              errors.push("Missing accessory categories: ".concat(missingAccessories.join(', ')));
+            }
             continue;
           }
-          var expectedAccessoryKeys = collectReferenceAccessoryKeys();
-          var missingAccessories = expectedAccessoryKeys.filter(function (key) {
-            return !isPlainObjectValue(candidate.accessories[key]);
-          });
-          if (missingAccessories.length) {
-            errors.push("Missing accessory categories: ".concat(missingAccessories.join(', ')));
+          if (!isPlainObjectValue(candidate[category])) {
+            missing.push(category);
           }
-          continue;
         }
-        if (!isPlainObjectValue(candidate[category])) {
-          missing.push(category);
-        }
+      } catch (err) {
+        _iterator3.e(err);
+      } finally {
+        _iterator3.f();
       }
       if (missing.length) {
         errors.push("Missing categories: ".concat(missing.join(', ')));
@@ -5360,8 +5487,8 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
         if (!isPlainObjectValue(candidate.accessories)) {
           errors.push('Accessory collections must be objects.');
         } else {
-          for (var _i4 = 0, _Object$entries2 = Object.entries(candidate.accessories); _i4 < _Object$entries2.length; _i4++) {
-            var _Object$entries2$_i = _slicedToArray(_Object$entries2[_i4], 2),
+          for (var _i2 = 0, _Object$entries2 = Object.entries(candidate.accessories); _i2 < _Object$entries2.length; _i2++) {
+            var _Object$entries2$_i = _slicedToArray(_Object$entries2[_i2], 2),
               subKey = _Object$entries2$_i[0],
               subValue = _Object$entries2$_i[1];
             if (!isPlainObjectValue(subValue)) {
@@ -5374,8 +5501,8 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
         errors.push('Filter options must be provided as an array.');
       }
       if (candidate.fiz && isPlainObjectValue(candidate.fiz)) {
-        for (var _i5 = 0, _Object$entries3 = Object.entries(candidate.fiz); _i5 < _Object$entries3.length; _i5++) {
-          var _Object$entries3$_i = _slicedToArray(_Object$entries3[_i5], 2),
+        for (var _i3 = 0, _Object$entries3 = Object.entries(candidate.fiz); _i3 < _Object$entries3.length; _i3++) {
+          var _Object$entries3$_i = _slicedToArray(_Object$entries3[_i3], 2),
             _subKey = _Object$entries3$_i[0],
             _subValue = _Object$entries3$_i[1];
           if (_subValue !== undefined && !isPlainObjectValue(_subValue)) {
@@ -5389,8 +5516,8 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
         if (!isPlainObjectValue(collection)) {
           return;
         }
-        for (var _i6 = 0, _Object$entries4 = Object.entries(collection); _i6 < _Object$entries4.length; _i6++) {
-          var _Object$entries4$_i = _slicedToArray(_Object$entries4[_i6], 2),
+        for (var _i4 = 0, _Object$entries4 = Object.entries(collection); _i4 < _Object$entries4.length; _i4++) {
+          var _Object$entries4$_i = _slicedToArray(_Object$entries4[_i4], 2),
             name = _Object$entries4$_i[0],
             value = _Object$entries4$_i[1];
           if (name === 'None' || name === 'filterOptions') {
@@ -5416,8 +5543,8 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
         errors.push('The imported database does not contain any devices.');
       }
       var uniqueErrors = [];
-      for (var _i7 = 0, _errors = errors; _i7 < _errors.length; _i7++) {
-        var message = _errors[_i7];
+      for (var _i5 = 0, _errors = errors; _i5 < _errors.length; _i5++) {
+        var message = _errors[_i5];
         if (message && !uniqueErrors.includes(message)) {
           uniqueErrors.push(message);
         }
@@ -5490,8 +5617,8 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
         return options == null ? DEFAULT_INTL_CACHE_KEY : String(options);
       }
       var entries = [];
-      for (var _i8 = 0, _Object$entries5 = Object.entries(options); _i8 < _Object$entries5.length; _i8++) {
-        var _Object$entries5$_i = _slicedToArray(_Object$entries5[_i8], 2),
+      for (var _i6 = 0, _Object$entries5 = Object.entries(options); _i6 < _Object$entries5.length; _i6++) {
+        var _Object$entries5$_i = _slicedToArray(_Object$entries5[_i6], 2),
           key = _Object$entries5$_i[0],
           value = _Object$entries5$_i[1];
         if (typeof value === 'undefined') continue;
@@ -6625,20 +6752,20 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
     };
     var cleanupFeatureSearchHistory = function cleanupFeatureSearchHistory() {
       var changed = false;
-      var _iterator2 = _createForOfIteratorHelper(featureSearchHistory.keys()),
-        _step2;
+      var _iterator4 = _createForOfIteratorHelper(featureSearchHistory.keys()),
+        _step4;
       try {
-        for (_iterator2.s(); !(_step2 = _iterator2.n()).done;) {
-          var key = _step2.value;
+        for (_iterator4.s(); !(_step4 = _iterator4.n()).done;) {
+          var key = _step4.value;
           if (!featureSearchEntryIndex.has(key)) {
             featureSearchHistory.delete(key);
             changed = true;
           }
         }
       } catch (err) {
-        _iterator2.e(err);
+        _iterator4.e(err);
       } finally {
-        _iterator2.f();
+        _iterator4.f();
       }
       if (changed) {
         scheduleFeatureSearchHistorySave();
@@ -6679,11 +6806,11 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
       });
       var options = [];
       var seen = new Set();
-      var _iterator3 = _createForOfIteratorHelper(entries),
-        _step3;
+      var _iterator5 = _createForOfIteratorHelper(entries),
+        _step5;
       try {
-        for (_iterator3.s(); !(_step3 = _iterator3.n()).done;) {
-          var item = _step3.value;
+        for (_iterator5.s(); !(_step5 = _iterator5.n()).done;) {
+          var item = _step5.value;
           if (!item || !item.key) continue;
           var entry = featureSearchEntryIndex.get(item.key);
           if (!entry) continue;
@@ -6694,9 +6821,9 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
           if (options.length >= MAX_FEATURE_SEARCH_RECENTS) break;
         }
       } catch (err) {
-        _iterator3.e(err);
+        _iterator5.e(err);
       } finally {
-        _iterator3.f();
+        _iterator5.f();
       }
       return options;
     };
@@ -6819,8 +6946,8 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
         return a.start - b.start || b.end - a.end;
       });
       var merged = [];
-      for (var _i9 = 0, _ranges = ranges; _i9 < _ranges.length; _i9++) {
-        var range = _ranges[_i9];
+      for (var _i7 = 0, _ranges = ranges; _i7 < _ranges.length; _i7++) {
+        var range = _ranges[_i7];
         var last = merged[merged.length - 1];
         if (last && range.start <= last.end) {
           last.end = Math.max(last.end, range.end);
@@ -6999,11 +7126,11 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
       }
       var normalized = [];
       var fragment = featureList ? document.createDocumentFragment() : null;
-      var _iterator4 = _createForOfIteratorHelper(values),
-        _step4;
+      var _iterator6 = _createForOfIteratorHelper(values),
+        _step6;
       try {
-        for (_iterator4.s(); !(_step4 = _iterator4.n()).done;) {
-          var value = _step4.value;
+        for (_iterator6.s(); !(_step6 = _iterator6.n()).done;) {
+          var value = _step6.value;
           var optionData = normalizeFeatureSearchOption(value);
           if (!optionData || !optionData.value) continue;
           normalized.push(optionData);
@@ -7020,9 +7147,9 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
           fragment.appendChild(option);
         }
       } catch (err) {
-        _iterator4.e(err);
+        _iterator6.e(err);
       } finally {
-        _iterator4.f();
+        _iterator6.f();
       }
       if (featureList) {
         featureList.innerHTML = '';
@@ -7036,33 +7163,33 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
       var values = [];
       var seen = new Set();
       var recentOptions = resolveRecentFeatureSearchOptions();
-      var _iterator5 = _createForOfIteratorHelper(recentOptions),
-        _step5;
+      var _iterator7 = _createForOfIteratorHelper(recentOptions),
+        _step7;
       try {
-        for (_iterator5.s(); !(_step5 = _iterator5.n()).done;) {
-          var option = _step5.value;
+        for (_iterator7.s(); !(_step7 = _iterator7.n()).done;) {
+          var option = _step7.value;
           if (!option || !option.value || seen.has(option.value)) continue;
           seen.add(option.value);
           values.push(option);
         }
       } catch (err) {
-        _iterator5.e(err);
+        _iterator7.e(err);
       } finally {
-        _iterator5.f();
+        _iterator7.f();
       }
-      var _iterator6 = _createForOfIteratorHelper(featureSearchDefaultOptions),
-        _step6;
+      var _iterator8 = _createForOfIteratorHelper(featureSearchDefaultOptions),
+        _step8;
       try {
-        for (_iterator6.s(); !(_step6 = _iterator6.n()).done;) {
-          var _option = _step6.value;
+        for (_iterator8.s(); !(_step8 = _iterator8.n()).done;) {
+          var _option = _step8.value;
           if (!_option || !_option.value || seen.has(_option.value)) continue;
           seen.add(_option.value);
           values.push(_option);
         }
       } catch (err) {
-        _iterator6.e(err);
+        _iterator8.e(err);
       } finally {
-        _iterator6.f();
+        _iterator8.f();
       }
       renderFeatureListOptions(values.length ? values : featureSearchDefaultOptions);
     }
@@ -7253,11 +7380,11 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
       }).filter(Boolean).sort(compareFeatureSearchCandidates);
       var values = [];
       var seen = new Set();
-      var _iterator7 = _createForOfIteratorHelper(scored),
-        _step7;
+      var _iterator9 = _createForOfIteratorHelper(scored),
+        _step9;
       try {
-        for (_iterator7.s(); !(_step7 = _iterator7.n()).done;) {
-          var item = _step7.value;
+        for (_iterator9.s(); !(_step9 = _iterator9.n()).done;) {
+          var item = _step9.value;
           if (values.length >= FEATURE_SEARCH_MAX_RESULTS) break;
           var _optionData = buildFeatureSearchOptionData(item.entry);
           if (!_optionData || !_optionData.value || seen.has(_optionData.value)) continue;
@@ -7265,9 +7392,9 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
           values.push(_optionData);
         }
       } catch (err) {
-        _iterator7.e(err);
+        _iterator9.e(err);
       } finally {
-        _iterator7.f();
+        _iterator9.f();
       }
       if (values.length === 0) {
         var fallback = filteredEntries.slice().sort(function (a, b) {
@@ -7275,11 +7402,11 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
             sensitivity: 'base'
           });
         });
-        var _iterator8 = _createForOfIteratorHelper(fallback),
-          _step8;
+        var _iterator0 = _createForOfIteratorHelper(fallback),
+          _step0;
         try {
-          for (_iterator8.s(); !(_step8 = _iterator8.n()).done;) {
-            var entry = _step8.value;
+          for (_iterator0.s(); !(_step0 = _iterator0.n()).done;) {
+            var entry = _step0.value;
             if (values.length >= FEATURE_SEARCH_MAX_RESULTS) break;
             var optionData = buildFeatureSearchOptionData(entry);
             if (!optionData || !optionData.value || seen.has(optionData.value)) continue;
@@ -7287,9 +7414,9 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
             values.push(optionData);
           }
         } catch (err) {
-          _iterator8.e(err);
+          _iterator0.e(err);
         } finally {
-          _iterator8.f();
+          _iterator0.f();
         }
       }
       renderFeatureListOptions(values);
@@ -7337,11 +7464,11 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
       var candidates = (meaningful.length > 0 ? meaningful : scored).sort(compareFeatureSearchCandidates);
       var values = [];
       var seen = new Set();
-      var _iterator9 = _createForOfIteratorHelper(candidates),
-        _step9;
+      var _iterator1 = _createForOfIteratorHelper(candidates),
+        _step1;
       try {
-        for (_iterator9.s(); !(_step9 = _iterator9.n()).done;) {
-          var item = _step9.value;
+        for (_iterator1.s(); !(_step1 = _iterator1.n()).done;) {
+          var item = _step1.value;
           if (values.length >= FEATURE_SEARCH_MAX_RESULTS) break;
           var optionData = buildFeatureSearchOptionData(item.entry);
           if (!optionData || !optionData.value || seen.has(optionData.value)) continue;
@@ -7349,9 +7476,9 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
           values.push(optionData);
         }
       } catch (err) {
-        _iterator9.e(err);
+        _iterator1.e(err);
       } finally {
-        _iterator9.f();
+        _iterator1.f();
       }
       if (values.length === 0) {
         if (filterType) {
@@ -7783,8 +7910,8 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
           helpCandidates.push(text);
         });
       }
-      for (var _i0 = 0, _helpCandidates = helpCandidates; _i0 < _helpCandidates.length; _i0++) {
-        var candidate = _helpCandidates[_i0];
+      for (var _i8 = 0, _helpCandidates = helpCandidates; _i8 < _helpCandidates.length; _i8++) {
+        var candidate = _helpCandidates[_i8];
         var detail = normalizeFeatureSearchDetail(candidate);
         if (detail && (!base || detail.toLowerCase() !== base)) {
           return detail;
@@ -7813,8 +7940,8 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
           candidates.push(firstListItem.textContent);
         }
       }
-      for (var _i1 = 0, _candidates = candidates; _i1 < _candidates.length; _i1++) {
-        var candidate = _candidates[_i1];
+      for (var _i9 = 0, _candidates = candidates; _i9 < _candidates.length; _i9++) {
+        var candidate = _candidates[_i9];
         var detail = normalizeFeatureSearchDetail(candidate);
         if (detail) return detail;
       }
@@ -7826,20 +7953,20 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
       if (!select) return '';
       var base = normalizeFeatureSearchDetail(entry.label || '').toLowerCase();
       var helpTexts = collectFeatureSearchHelpTexts(select);
-      var _iterator0 = _createForOfIteratorHelper(helpTexts),
-        _step0;
+      var _iterator10 = _createForOfIteratorHelper(helpTexts),
+        _step10;
       try {
-        for (_iterator0.s(); !(_step0 = _iterator0.n()).done;) {
-          var text = _step0.value;
+        for (_iterator10.s(); !(_step10 = _iterator10.n()).done;) {
+          var text = _step10.value;
           var detail = normalizeFeatureSearchDetail(text);
           if (detail && (!base || detail.toLowerCase() !== base)) {
             return detail;
           }
         }
       } catch (err) {
-        _iterator0.e(err);
+        _iterator10.e(err);
       } finally {
-        _iterator0.f();
+        _iterator10.f();
       }
       var contexts = collectFeatureContexts(select, base);
       if (contexts.length) {
@@ -7915,17 +8042,17 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
       }
       var total = 0;
       var matched = 0;
-      var _iterator1 = _createForOfIteratorHelper(validQueryTokens),
-        _step1;
+      var _iterator11 = _createForOfIteratorHelper(validQueryTokens),
+        _step11;
       try {
-        for (_iterator1.s(); !(_step1 = _iterator1.n()).done;) {
-          var token = _step1.value;
+        for (_iterator11.s(); !(_step11 = _iterator11.n()).done;) {
+          var token = _step11.value;
           var best = 0;
-          var _iterator10 = _createForOfIteratorHelper(entryTokens),
-            _step10;
+          var _iterator12 = _createForOfIteratorHelper(entryTokens),
+            _step12;
           try {
-            for (_iterator10.s(); !(_step10 = _iterator10.n()).done;) {
-              var entryToken = _step10.value;
+            for (_iterator12.s(); !(_step12 = _iterator12.n()).done;) {
+              var entryToken = _step12.value;
               if (!entryToken) continue;
               if (entryToken === token) {
                 best = 3;
@@ -7938,9 +8065,9 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
               }
             }
           } catch (err) {
-            _iterator10.e(err);
+            _iterator12.e(err);
           } finally {
-            _iterator10.f();
+            _iterator12.f();
           }
           if (best > 0) {
             matched += 1;
@@ -7948,9 +8075,9 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
           }
         }
       } catch (err) {
-        _iterator1.e(err);
+        _iterator11.e(err);
       } finally {
-        _iterator1.f();
+        _iterator11.f();
       }
       if (matched === 0) {
         return {
@@ -8028,35 +8155,35 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
         }, extras);
       };
       var flattened = [];
-      var _iterator11 = _createForOfIteratorHelper(map.entries()),
-        _step11;
+      var _iterator13 = _createForOfIteratorHelper(map.entries()),
+        _step13;
       try {
-        for (_iterator11.s(); !(_step11 = _iterator11.n()).done;) {
-          var _step11$value = _slicedToArray(_step11.value, 2),
-            _entryKey = _step11$value[0],
-            _entryValue2 = _step11$value[1];
+        for (_iterator13.s(); !(_step13 = _iterator13.n()).done;) {
+          var _step13$value = _slicedToArray(_step13.value, 2),
+            _entryKey = _step13$value[0],
+            _entryValue2 = _step13$value[1];
           if (!_entryValue2) continue;
           if (Array.isArray(_entryValue2)) {
-            var _iterator13 = _createForOfIteratorHelper(_entryValue2),
-              _step13;
+            var _iterator15 = _createForOfIteratorHelper(_entryValue2),
+              _step15;
             try {
-              for (_iterator13.s(); !(_step13 = _iterator13.n()).done;) {
-                var value = _step13.value;
+              for (_iterator15.s(); !(_step15 = _iterator15.n()).done;) {
+                var value = _step15.value;
                 if (value) flattened.push([_entryKey, value]);
               }
             } catch (err) {
-              _iterator13.e(err);
+              _iterator15.e(err);
             } finally {
-              _iterator13.f();
+              _iterator15.f();
             }
           } else {
             flattened.push([_entryKey, _entryValue2]);
           }
         }
       } catch (err) {
-        _iterator11.e(err);
+        _iterator13.e(err);
       } finally {
-        _iterator11.f();
+        _iterator13.f();
       }
       if (hasKey) {
         var exactCandidates = flattened.filter(function (_ref16) {
@@ -8071,12 +8198,12 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
             score: Number.POSITIVE_INFINITY,
             matched: queryTokens.length
           };
-          var _iterator12 = _createForOfIteratorHelper(exactCandidates.slice(1)),
-            _step12;
+          var _iterator14 = _createForOfIteratorHelper(exactCandidates.slice(1)),
+            _step14;
           try {
-            for (_iterator12.s(); !(_step12 = _iterator12.n()).done;) {
-              var _step12$value = _slicedToArray(_step12.value, 2),
-                entryValue = _step12$value[1];
+            for (_iterator14.s(); !(_step14 = _iterator14.n()).done;) {
+              var _step14$value = _slicedToArray(_step14.value, 2),
+                entryValue = _step14$value[1];
               if (!queryTokens.length) break;
               var details = computeTokenMatchDetails((entryValue === null || entryValue === void 0 ? void 0 : entryValue.tokens) || [], queryTokens);
               if (details.score > bestDetails.score || details.score === bestDetails.score && details.matched > bestDetails.matched) {
@@ -8085,9 +8212,9 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
               }
             }
           } catch (err) {
-            _iterator12.e(err);
+            _iterator14.e(err);
           } finally {
-            _iterator12.f();
+            _iterator14.f();
           }
           return toResult(key, bestEntry, 'exactKey', bestDetails.score, bestDetails.matched);
         }
@@ -8111,8 +8238,8 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
       var bestFuzzyDistance = Number.POSITIVE_INFINITY;
       var bestFuzzyLength = Number.POSITIVE_INFINITY;
       var keyLength = hasKey ? key.length : 0;
-      for (var _i10 = 0, _flattened = flattened; _i10 < _flattened.length; _i10++) {
-        var _flattened$_i = _slicedToArray(_flattened[_i10], 2),
+      for (var _i0 = 0, _flattened = flattened; _i0 < _flattened.length; _i0++) {
+        var _flattened$_i = _slicedToArray(_flattened[_i0], 2),
           entryKey = _flattened$_i[0],
           _entryValue = _flattened$_i[1];
         if (!_entryValue) continue;
@@ -8475,20 +8602,20 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
         if (Number.isFinite(computedFontSize) && computedFontSize > 0) {
           baseFontSize = computedFontSize;
         }
-        var _iterator14 = _createForOfIteratorHelper(uiScaleProperties),
-          _step14;
+        var _iterator16 = _createForOfIteratorHelper(uiScaleProperties),
+          _step16;
         try {
-          for (_iterator14.s(); !(_step14 = _iterator14.n()).done;) {
-            var prop = _step14.value;
+          for (_iterator16.s(); !(_step16 = _iterator16.n()).done;) {
+            var prop = _step16.value;
             var value = parseFloat(computedStyle.getPropertyValue(prop));
             if (Number.isFinite(value) && value > 0) {
               baseUIScaleValues[prop] = value;
             }
           }
         } catch (err) {
-          _iterator14.e(err);
+          _iterator16.e(err);
         } finally {
-          _iterator14.f();
+          _iterator16.f();
         }
       } catch (error) {
         console.warn('Unable to read computed styles for UI scaling', error);
@@ -8673,7 +8800,7 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
     }
     function _loadStoredCustomFonts() {
       _loadStoredCustomFonts = _asyncToGenerator(_regenerator().m(function _callee5() {
-        var stored, _iterator17, _step17, entry, normalized, _t5, _t6;
+        var stored, _iterator19, _step19, entry, normalized, _t5, _t6;
         return _regenerator().w(function (_context5) {
           while (1) switch (_context5.p = _context5.n) {
             case 0:
@@ -8684,15 +8811,15 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
               }
               return _context5.a(2);
             case 1:
-              _iterator17 = _createForOfIteratorHelper(stored);
+              _iterator19 = _createForOfIteratorHelper(stored);
               _context5.p = 2;
-              _iterator17.s();
+              _iterator19.s();
             case 3:
-              if ((_step17 = _iterator17.n()).done) {
+              if ((_step19 = _iterator19.n()).done) {
                 _context5.n = 8;
                 break;
               }
-              entry = _step17.value;
+              entry = _step19.value;
               normalized = {
                 id: entry.id,
                 name: sanitizeCustomFontName(entry.name),
@@ -8718,10 +8845,10 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
             case 9:
               _context5.p = 9;
               _t6 = _context5.v;
-              _iterator17.e(_t6);
+              _iterator19.e(_t6);
             case 10:
               _context5.p = 10;
-              _iterator17.f();
+              _iterator19.f();
               return _context5.f(10);
             case 11:
               return _context5.a(2);
@@ -8816,8 +8943,8 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
     }
     function _addCustomFontFromData() {
       _addCustomFontFromData = _asyncToGenerator(_regenerator().m(function _callee6(name, dataUrl) {
-        var _ref44,
-          _ref44$persist,
+        var _ref46,
+          _ref46$persist,
           persist,
           uniqueName,
           value,
@@ -8830,7 +8957,7 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
         return _regenerator().w(function (_context6) {
           while (1) switch (_context6.n) {
             case 0:
-              _ref44 = _args6.length > 2 && _args6[2] !== undefined ? _args6[2] : {}, _ref44$persist = _ref44.persist, persist = _ref44$persist === void 0 ? true : _ref44$persist;
+              _ref46 = _args6.length > 2 && _args6[2] !== undefined ? _args6[2] : {}, _ref46$persist = _ref46.persist, persist = _ref46$persist === void 0 ? true : _ref46$persist;
               uniqueName = ensureUniqueCustomFontName(name);
               value = buildFontFamilyValue(uniqueName);
               _ensureFontFamilyOpti2 = ensureFontFamilyOption(value, uniqueName, localFontsGroup, 'uploaded'), option = _ensureFontFamilyOpti2.option;
@@ -8877,7 +9004,7 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
     }
     function _handleLocalFontFiles() {
       _handleLocalFontFiles = _asyncToGenerator(_regenerator().m(function _callee7(fileList) {
-        var added, unsupported, failed, persistFailure, _i13, _Array$from, file, dataUrl, result, message, _message9, _message0, _t7;
+        var added, unsupported, failed, persistFailure, _i11, _Array$from, file, dataUrl, result, message, _message9, _message0, _t7;
         return _regenerator().w(function (_context7) {
           while (1) switch (_context7.p = _context7.n) {
             case 0:
@@ -8895,13 +9022,13 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
               unsupported = [];
               failed = [];
               persistFailure = false;
-              _i13 = 0, _Array$from = Array.from(fileList);
+              _i11 = 0, _Array$from = Array.from(fileList);
             case 2:
-              if (!(_i13 < _Array$from.length)) {
+              if (!(_i11 < _Array$from.length)) {
                 _context7.n = 9;
                 break;
               }
-              file = _Array$from[_i13];
+              file = _Array$from[_i11];
               if (isSupportedFontFile(file)) {
                 _context7.n = 3;
                 break;
@@ -8937,7 +9064,7 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
               console.warn('Failed to import custom font', _t7);
               failed.push(file && typeof file.name === 'string' ? file.name : '');
             case 8:
-              _i13++;
+              _i11++;
               _context7.n = 2;
               break;
             case 9:
@@ -9229,7 +9356,7 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
     }
     function _requestLocalFonts() {
       _requestLocalFonts = _asyncToGenerator(_regenerator().m(function _callee9() {
-        var fonts, added, duplicates, seenValues, _iterator18, _step18, font, rawName, name, _value3, _ensureFontFamilyOpti3, option, created, _t9, _t0;
+        var fonts, added, duplicates, seenValues, _iterator20, _step20, font, rawName, name, _value4, _ensureFontFamilyOpti3, option, created, _t9, _t0;
         return _regenerator().w(function (_context9) {
           while (1) switch (_context9.p = _context9.n) {
             case 0:
@@ -9255,15 +9382,15 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
               added = [];
               duplicates = [];
               seenValues = new Set();
-              _iterator18 = _createForOfIteratorHelper(fonts);
+              _iterator20 = _createForOfIteratorHelper(fonts);
               _context9.p = 5;
-              _iterator18.s();
+              _iterator20.s();
             case 6:
-              if ((_step18 = _iterator18.n()).done) {
+              if ((_step20 = _iterator20.n()).done) {
                 _context9.n = 11;
                 break;
               }
-              font = _step18.value;
+              font = _step20.value;
               rawName = font && (font.family || font.fullName || font.postscriptName);
               name = rawName ? String(rawName).trim() : '';
               if (name) {
@@ -9272,15 +9399,15 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
               }
               return _context9.a(3, 10);
             case 7:
-              _value3 = buildFontFamilyValue(name);
-              if (!seenValues.has(_value3)) {
+              _value4 = buildFontFamilyValue(name);
+              if (!seenValues.has(_value4)) {
                 _context9.n = 8;
                 break;
               }
               duplicates.push(name);
               return _context9.a(3, 10);
             case 8:
-              _ensureFontFamilyOpti3 = ensureFontFamilyOption(_value3, name, localFontsGroup, 'local'), option = _ensureFontFamilyOpti3.option, created = _ensureFontFamilyOpti3.created;
+              _ensureFontFamilyOpti3 = ensureFontFamilyOption(_value4, name, localFontsGroup, 'local'), option = _ensureFontFamilyOpti3.option, created = _ensureFontFamilyOpti3.created;
               if (option) {
                 _context9.n = 9;
                 break;
@@ -9305,10 +9432,10 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
             case 12:
               _context9.p = 12;
               _t9 = _context9.v;
-              _iterator18.e(_t9);
+              _iterator20.e(_t9);
             case 13:
               _context9.p = 13;
-              _iterator18.f();
+              _iterator20.f();
               return _context9.f(13);
             case 14:
               if (added.length > 0) {
@@ -9387,19 +9514,19 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
         return;
       }
       var scale = numericSize / baseFontSize;
-      var _iterator15 = _createForOfIteratorHelper(uiScaleProperties),
-        _step15;
+      var _iterator17 = _createForOfIteratorHelper(uiScaleProperties),
+        _step17;
       try {
-        for (_iterator15.s(); !(_step15 = _iterator15.n()).done;) {
-          var _prop = _step15.value;
+        for (_iterator17.s(); !(_step17 = _iterator17.n()).done;) {
+          var _prop = _step17.value;
           var baseValue = baseUIScaleValues[_prop];
           if (!Number.isFinite(baseValue) || baseValue <= 0) continue;
           document.documentElement.style.setProperty(_prop, "".concat(baseValue * scale, "px"));
         }
       } catch (err) {
-        _iterator15.e(err);
+        _iterator17.e(err);
       } finally {
-        _iterator15.f();
+        _iterator17.f();
       }
       document.documentElement.style.setProperty('--ui-scale', String(scale));
     }
@@ -9747,11 +9874,11 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
       }
       var overviewCandidates = getOverviewTitleCandidates();
       var lowerText = textValue.toLowerCase();
-      var _iterator16 = _createForOfIteratorHelper(overviewCandidates),
-        _step16;
+      var _iterator18 = _createForOfIteratorHelper(overviewCandidates),
+        _step18;
       try {
-        for (_iterator16.s(); !(_step16 = _iterator16.n()).done;) {
-          var label = _step16.value;
+        for (_iterator18.s(); !(_step18 = _iterator18.n()).done;) {
+          var label = _step18.value;
           var normalizedLabel = label.trim();
           if (!normalizedLabel) continue;
           var lowerLabel = normalizedLabel.toLowerCase();
@@ -9767,9 +9894,9 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
           }
         }
       } catch (err) {
-        _iterator16.e(err);
+        _iterator18.e(err);
       } finally {
-        _iterator16.f();
+        _iterator18.f();
       }
       if (overviewCandidates.some(function (label) {
         return lowerText === label.toLowerCase();
@@ -10211,8 +10338,8 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
                   categoryPath: path
                 };
               }
-              for (var _i11 = 0, _Object$entries6 = Object.entries(node); _i11 < _Object$entries6.length; _i11++) {
-                var _Object$entries6$_i = _slicedToArray(_Object$entries6[_i11], 2),
+              for (var _i1 = 0, _Object$entries6 = Object.entries(node); _i1 < _Object$entries6.length; _i1++) {
+                var _Object$entries6$_i = _slicedToArray(_Object$entries6[_i1], 2),
                   key = _Object$entries6$_i[0],
                   _value2 = _Object$entries6$_i[1];
                 if (!isPlainObjectValue(_value2)) continue;
@@ -11588,7 +11715,6 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
         cameraMediaContainer.appendChild(createRecordingMediaRow());
       }
     };
-
     writeCoreScopeValue('setRecordingMedia', setRecordingMediaLocal);
     function getRecordingMedia() {
       return Array.from(cameraMediaContainer.querySelectorAll('.form-row')).map(function (row) {
@@ -11816,7 +11942,6 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
         batteryPlatesContainer.appendChild(createBatteryPlateRow());
       }
     };
-
     writeCoreScopeValue('setBatteryPlates', setBatteryPlatesLocal);
     function getBatteryPlates() {
       return Array.from(batteryPlatesContainer.querySelectorAll('.form-row')).map(function (row) {
@@ -13006,7 +13131,6 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
       html += "</table>";
       container.innerHTML = html;
     }
-
     assignCoreTemperatureNoteRenderer(renderTemperatureNote);
     function ensureFeedbackTemperatureOptions(select) {
       if (!select) return;
@@ -13050,48 +13174,45 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
         });
       });
     }
-      function updateFeedbackTemperatureLabel() {
-        var lang = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : currentLang;
-        var unit = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : temperatureUnit;
-        var labelTextElem = document.getElementById('fbTemperatureLabelText');
-        var labelElem = document.getElementById('fbTemperatureLabel');
-        var label = "".concat(getTemperatureColumnLabelForLang(lang, unit), ":");
-        if (labelTextElem) {
-          labelTextElem.textContent = label;
-        } else if (labelElem) {
-          labelElem.textContent = label;
-        }
+    function updateFeedbackTemperatureLabel() {
+      var lang = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : currentLang;
+      var unit = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : temperatureUnit;
+      var labelTextElem = document.getElementById('fbTemperatureLabelText');
+      var labelElem = document.getElementById('fbTemperatureLabel');
+      var label = "".concat(getTemperatureColumnLabelForLang(lang, unit), ":");
+      if (labelTextElem) {
+        labelTextElem.textContent = label;
+      } else if (labelElem) {
+        labelElem.textContent = label;
       }
-
-      function refreshFeedbackTemperatureLabel() {
-        var lang = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : currentLang;
-        var unit = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : temperatureUnit;
-        var handled = false;
-        try {
-          if (typeof updateFeedbackTemperatureLabel === 'function') {
-            updateFeedbackTemperatureLabel(lang, unit);
-            handled = true;
-          }
-        } catch (error) {
-          console.warn('Fallback applied while updating feedback temperature label', error);
+    }
+    function refreshFeedbackTemperatureLabel() {
+      var lang = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : currentLang;
+      var unit = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : temperatureUnit;
+      var handled = false;
+      try {
+        if (typeof updateFeedbackTemperatureLabel === 'function') {
+          updateFeedbackTemperatureLabel(lang, unit);
+          handled = true;
         }
-
-        if (handled) {
-          return;
-        }
-
-        var labelTextElem = document.getElementById('fbTemperatureLabelText');
-        var labelElem = document.getElementById('fbTemperatureLabel');
-        if (!labelTextElem && !labelElem) {
-          return;
-        }
-        var label = "".concat(getTemperatureColumnLabelForLang(lang, unit), ":");
-        if (labelTextElem) {
-          labelTextElem.textContent = label;
-        } else if (labelElem) {
-          labelElem.textContent = label;
-        }
+      } catch (error) {
+        console.warn('Fallback applied while updating feedback temperature label', error);
       }
+      if (handled) {
+        return;
+      }
+      var labelTextElem = document.getElementById('fbTemperatureLabelText');
+      var labelElem = document.getElementById('fbTemperatureLabel');
+      if (!labelTextElem && !labelElem) {
+        return;
+      }
+      var label = "".concat(getTemperatureColumnLabelForLang(lang, unit), ":");
+      if (labelTextElem) {
+        labelTextElem.textContent = label;
+      } else if (labelElem) {
+        labelElem.textContent = label;
+      }
+    }
     function applyTemperatureUnitPreference(unit) {
       var options = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
       var normalized = normalizeTemperatureUnit(unit);
@@ -13134,39 +13255,17 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
       });
       var distance = distanceSelect.value;
       var battery = batterySelect.value;
-      var totalPowerTarget = typeof totalPowerElem !== 'undefined'
-        ? totalPowerElem
-        : typeof document !== 'undefined' ? document.getElementById('totalPower') : null;
-      var breakdownListTarget = typeof breakdownListElem !== 'undefined'
-        ? breakdownListElem
-        : typeof document !== 'undefined' ? document.getElementById('breakdownList') : null;
-      var totalCurrent144Target = typeof totalCurrent144Elem !== 'undefined'
-        ? totalCurrent144Elem
-        : typeof document !== 'undefined' ? document.getElementById('totalCurrent144') : null;
-      var totalCurrent12Target = typeof totalCurrent12Elem !== 'undefined'
-        ? totalCurrent12Elem
-        : typeof document !== 'undefined' ? document.getElementById('totalCurrent12') : null;
-      var batteryLifeTarget = typeof batteryLifeElem !== 'undefined'
-        ? batteryLifeElem
-        : typeof document !== 'undefined' ? document.getElementById('batteryLife') : null;
-      var batteryCountTarget = typeof batteryCountElem !== 'undefined'
-        ? batteryCountElem
-        : typeof document !== 'undefined' ? document.getElementById('batteryCount') : null;
-      var batteryLifeLabelTarget = typeof batteryLifeLabelElem !== 'undefined'
-        ? batteryLifeLabelElem
-        : typeof document !== 'undefined' ? document.getElementById('batteryLifeLabel') : null;
-      var runtimeAverageNoteTarget = typeof runtimeAverageNoteElem !== 'undefined'
-        ? runtimeAverageNoteElem
-        : typeof document !== 'undefined' ? document.getElementById('runtimeAverageNote') : null;
-      var pinWarnTarget = typeof pinWarnElem !== 'undefined'
-        ? pinWarnElem
-        : typeof document !== 'undefined' ? document.getElementById('pinWarning') : null;
-      var dtapWarnTarget = typeof dtapWarnElem !== 'undefined'
-        ? dtapWarnElem
-        : typeof document !== 'undefined' ? document.getElementById('dtapWarning') : null;
-      var hotswapWarnTarget = typeof hotswapWarnElem !== 'undefined'
-        ? hotswapWarnElem
-        : typeof document !== 'undefined' ? document.getElementById('hotswapWarning') : null;
+      var totalPowerTarget = typeof totalPowerElem !== 'undefined' ? totalPowerElem : typeof document !== 'undefined' ? document.getElementById('totalPower') : null;
+      var breakdownListTarget = typeof breakdownListElem !== 'undefined' ? breakdownListElem : typeof document !== 'undefined' ? document.getElementById('breakdownList') : null;
+      var totalCurrent144Target = typeof totalCurrent144Elem !== 'undefined' ? totalCurrent144Elem : typeof document !== 'undefined' ? document.getElementById('totalCurrent144') : null;
+      var totalCurrent12Target = typeof totalCurrent12Elem !== 'undefined' ? totalCurrent12Elem : typeof document !== 'undefined' ? document.getElementById('totalCurrent12') : null;
+      var batteryLifeTarget = typeof batteryLifeElem !== 'undefined' ? batteryLifeElem : typeof document !== 'undefined' ? document.getElementById('batteryLife') : null;
+      var batteryCountTarget = typeof batteryCountElem !== 'undefined' ? batteryCountElem : typeof document !== 'undefined' ? document.getElementById('batteryCount') : null;
+      var batteryLifeLabelTarget = typeof batteryLifeLabelElem !== 'undefined' ? batteryLifeLabelElem : typeof document !== 'undefined' ? document.getElementById('batteryLifeLabel') : null;
+      var runtimeAverageNoteTarget = typeof runtimeAverageNoteElem !== 'undefined' ? runtimeAverageNoteElem : typeof document !== 'undefined' ? document.getElementById('runtimeAverageNote') : null;
+      var pinWarnTarget = typeof pinWarnElem !== 'undefined' ? pinWarnElem : typeof document !== 'undefined' ? document.getElementById('pinWarning') : null;
+      var dtapWarnTarget = typeof dtapWarnElem !== 'undefined' ? dtapWarnElem : typeof document !== 'undefined' ? document.getElementById('dtapWarning') : null;
+      var hotswapWarnTarget = typeof hotswapWarnElem !== 'undefined' ? hotswapWarnElem : typeof document !== 'undefined' ? document.getElementById('hotswapWarning') : null;
       var cameraW = 0;
       if (devices.cameras[camera] !== undefined) {
         var camData = devices.cameras[camera];
@@ -13437,15 +13536,14 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
         }
         var pinsCandidates = [];
         var dtapCandidates = [];
-        var nameCollator = typeof collator !== 'undefined' && collator && typeof collator.compare === 'function' ? collator :
-          typeof Intl !== 'undefined' && typeof Intl.Collator === 'function' ? new Intl.Collator(undefined, {
-            numeric: true,
-            sensitivity: 'base'
-          }) : {
-            compare: function compare(a, b) {
-              return String(a).localeCompare(String(b));
-            }
-          };
+        var nameCollator = typeof collator !== 'undefined' && collator && typeof collator.compare === 'function' ? collator : typeof Intl !== 'undefined' && typeof Intl.Collator === 'function' ? new Intl.Collator(undefined, {
+          numeric: true,
+          sensitivity: 'base'
+        }) : {
+          compare: function compare(a, b) {
+            return String(a).localeCompare(String(b));
+          }
+        };
         for (var battName in devices.batteries) {
           if (battName === "None") continue;
           if (selectedCandidate && battName === selectedCandidate.name) continue;
@@ -14963,7 +15061,9 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
           if (target && typeof target.closest === 'function' && target.closest('.diagram-popup')) {
             return;
           }
-          if (!target || typeof target.closest !== 'function' || !target.closest('.diagram-node')) popup.style.display = 'none';
+          if (!target || typeof target.closest !== 'function' || !target.closest('.diagram-node')) {
+            popup.style.display = 'none';
+          }
         };
         if (isTouchDevice) {
           setupDiagramContainer.addEventListener('touchstart', hideOnOutside);
@@ -15372,8 +15472,8 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
         ulElement.appendChild(li);
       };
       if (categoryKey === "accessories.cables") {
-        for (var _i12 = 0, _Object$entries7 = Object.entries(categoryDevices); _i12 < _Object$entries7.length; _i12++) {
-          var _Object$entries7$_i = _slicedToArray(_Object$entries7[_i12], 2),
+        for (var _i10 = 0, _Object$entries7 = Object.entries(categoryDevices); _i10 < _Object$entries7.length; _i10++) {
+          var _Object$entries7$_i = _slicedToArray(_Object$entries7[_i10], 2),
             subcat = _Object$entries7$_i[0],
             devs = _Object$entries7$_i[1];
           for (var name in devs) {
@@ -15400,9 +15500,9 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
     }
     var CORE_PART2_GLOBAL_EXPORTS = {
       populateSelect: populateSelect,
-      refreshAutoGearCameraOptions: refreshAutoGearCameraOptions,
       refreshDeviceLists: refreshDeviceLists,
       hasAnyDeviceSelection: hasAnyDeviceSelection,
+      refreshAutoGearCameraOptions: refreshAutoGearCameraOptions,
       refreshAutoGearCameraWeightCondition: refreshAutoGearCameraWeightCondition,
       refreshAutoGearMonitorOptions: refreshAutoGearMonitorOptions,
       refreshAutoGearTripodHeadOptions: refreshAutoGearTripodHeadOptions,
@@ -15414,6 +15514,7 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
       refreshAutoGearControllersOptions: refreshAutoGearControllersOptions,
       refreshAutoGearCrewOptions: refreshAutoGearCrewOptions,
       refreshAutoGearDistanceOptions: refreshAutoGearDistanceOptions,
+      exportAutoGearRules: exportAutoGearRules,
       updateAutoGearCameraWeightDraft: updateAutoGearCameraWeightDraft,
       updateAutoGearShootingDaysDraft: updateAutoGearShootingDaysDraft,
       checkSetupChanged: checkSetupChanged,
@@ -15447,14 +15548,15 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
       renderSettingsLogoPreview: renderSettingsLogoPreview,
       normalizeSpellingVariants: normalizeSpellingVariants,
       prevAccentColor: prevAccentColor,
+      revertAccentColor: revertAccentColor,
       DEFAULT_ACCENT_COLOR: DEFAULT_ACCENT_COLOR,
       HIGH_CONTRAST_ACCENT_COLOR: HIGH_CONTRAST_ACCENT_COLOR,
       applyAccentColor: applyAccentColor,
       clearAccentColorOverrides: clearAccentColorOverrides,
-      revertAccentColor: revertAccentColor,
       updateAccentColorResetButtonState: updateAccentColorResetButtonState,
       restoringSession: restoringSession,
       currentProjectInfo: currentProjectInfo,
+      deriveProjectInfo: deriveProjectInfo,
       projectForm: projectForm,
       filterSelectElem: filterSelectElem,
       filterDetailsStorage: filterDetailsStorage,
@@ -15466,128 +15568,229 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
       feedbackUseLocationBtn: feedbackUseLocationBtn,
       getSliderBowlValue: getSliderBowlValue,
       getEasyrigValue: getEasyrigValue,
-      setEasyrigValue: setEasyrigValue
+      setEasyrigValue: setEasyrigValue,
+      fontSize: fontSize,
+      fontFamily: fontFamily
     };
-
-    var ADDITIONAL_GLOBAL_EXPORT_ENTRIES = [
-      ['setBatteryPlates', function () { return setBatteryPlatesLocal; }],
-      ['getBatteryPlates', function () { return getBatteryPlates; }],
-      ['setRecordingMedia', function () { return setRecordingMediaLocal; }],
-      ['getRecordingMedia', function () { return getRecordingMedia; }],
-      ['applyDarkMode', function () { return applyDarkMode; }],
-      ['applyPinkMode', function () { return applyPinkMode; }],
-      ['applyHighContrast', function () { return applyHighContrast; }],
-      ['setupInstallBanner', function () { return setupInstallBanner; }],
-      ['generatePrintableOverview', function () { return generatePrintableOverview; }],
-      ['generateGearListHtml', function () { return generateGearListHtml; }],
-      ['displayGearAndRequirements', function () { return displayGearAndRequirements; }],
-      ['ensureZoomRemoteSetup', function () { return ensureZoomRemoteSetup; }],
-      ['encodeSharedSetup', function () { return encodeSharedSetup; }],
-      ['decodeSharedSetup', function () { return decodeSharedSetup; }],
-      ['applySharedSetupFromUrl', function () { return applySharedSetupFromUrl; }],
-      ['applySharedSetup', function () { return applySharedSetup; }],
-      ['updateBatteryPlateVisibility', function () { return updateBatteryPlateVisibility; }],
-      ['updateBatteryOptions', function () { return updateBatteryOptions; }],
-      ['renderSetupDiagram', function () { return renderSetupDiagram; }],
-      ['enableDiagramInteractions', function () { return enableDiagramInteractions; }],
-      ['updateDiagramLegend', function () { return updateDiagramLegend; }],
-      ['cameraFizPort', function () { return cameraFizPort; }],
-      ['controllerCamPort', function () { return controllerCamPort; }],
-      ['controllerDistancePort', function () { return controllerDistancePort; }],
-      ['detectBrand', function () { return detectBrand; }],
-      ['connectionLabel', function () { return connectionLabel; }],
-      ['generateConnectorSummary', function () { return generateConnectorSummary; }],
-      ['diagramConnectorIcons', function () { return diagramConnectorIcons; }],
-      ['DIAGRAM_MONITOR_ICON', function () { return DIAGRAM_MONITOR_ICON; }],
-      ['exportDiagramSvg', function () { return exportDiagramSvg; }],
-      ['fixPowerInput', function () { return fixPowerInput; }],
-      ['powerInputTypes', function () { return powerInputTypes; }],
-      ['ensureList', function () { return ensureList; }],
-      ['normalizeVideoType', function () { return normalizeVideoType; }],
-      ['normalizeFizConnectorType', function () { return normalizeFizConnectorType; }],
-      ['normalizeViewfinderType', function () { return normalizeViewfinderType; }],
-      ['normalizePowerPortType', function () { return normalizePowerPortType; }],
-      ['getCurrentSetupKey', function () { return getCurrentSetupKey; }],
-      ['renderFeedbackTable', function () { return renderFeedbackTable; }],
-      ['saveCurrentGearList', function () { return saveCurrentGearList; }],
-      ['getPowerSelectionSnapshot', function () { return getPowerSelectionSnapshot; }],
-      ['applyStoredPowerSelection', function () { return applyStoredPowerSelection; }],
-      ['getGearListSelectors', function () { return getGearListSelectors; }],
-      ['applyGearListSelectors', function () { return applyGearListSelectors; }],
-      ['scenarioIcons', function () { return scenarioIcons; }],
-      ['collectProjectFormData', function () { return collectProjectFormData; }],
-      ['populateProjectForm', function () { return populateProjectForm; }],
-      ['renderFilterDetails', function () { return renderFilterDetails; }],
-      ['collectFilterSelections', function () { return collectFilterSelections; }],
-      ['parseFilterTokens', function () { return parseFilterTokens; }],
-      ['applyFilterSelectionsToGearList', function () { return applyFilterSelectionsToGearList; }],
-      ['adjustGearListSelectWidth', function () { return adjustGearListSelectWidth; }],
-      ['adjustGearListSelectWidths', function () { return adjustGearListSelectWidths; }],
-      ['deviceMap', function () { return deviceMap; }],
-      ['helpMap', function () { return helpMap; }],
-      ['featureSearchEntries', function () { return featureSearchEntries; }],
-      ['featureSearchDefaultOptions', function () { return featureSearchDefaultOptions; }],
-      ['restoreFeatureSearchDefaults', function () { return restoreFeatureSearchDefaults; }],
-      ['updateFeatureSearchSuggestions', function () { return updateFeatureSearchSuggestions; }],
-      ['setCurrentProjectInfo', function () { return setCurrentProjectInfo; }],
-      ['getCurrentProjectInfo', function () { return getCurrentProjectInfo; }],
-      ['getCurrentSetupState', function () { return getCurrentSetupState; }],
-      ['setSliderBowlValue', function () { return setSliderBowlValue; }],
-      ['crewRoles', function () { return crewRoles; }],
-      ['formatFullBackupFilename', function () { return formatFullBackupFilename; }],
-      ['computeGearListCount', function () { return computeGearListCount; }],
-      ['autoBackup', function () { return autoBackup; }],
-      ['createSettingsBackup', function () { return createSettingsBackup; }],
-      ['captureStorageSnapshot', function () { return captureStorageSnapshot; }],
-      ['sanitizeBackupPayload', function () { return sanitizeBackupPayload; }],
-      ['extractBackupSections', function () { return extractBackupSections; }],
-      ['searchKey', function () { return searchKey; }],
-      ['searchTokens', function () { return searchTokens; }],
-      ['findBestSearchMatch', function () { return findBestSearchMatch; }],
-      ['runFeatureSearch', function () { return runFeatureSearch; }],
-      ['collectAutoGearCatalogNames', function () { return collectAutoGearCatalogNames; }],
-      ['featureMap', function () { return featureMap; }],
-      ['buildDefaultVideoDistributionAutoGearRules', function () { return buildDefaultVideoDistributionAutoGearRules; }],
-      ['applyAutoGearRulesToTableHtml', function () { return applyAutoGearRulesToTableHtml; }],
-      ['importAutoGearRulesFromData', function () { return importAutoGearRulesFromData; }],
-      ['createAutoGearBackup', function () { return createAutoGearBackup; }],
-      ['restoreAutoGearBackup', function () { return restoreAutoGearBackup; }],
-      ['getAutoGearRules', function () { return getAutoGearRules; }],
-      ['syncAutoGearRulesFromStorage', function () { return syncAutoGearRulesFromStorage; }],
-      ['normalizeAutoGearCameraWeightCondition', function () { return normalizeAutoGearCameraWeightCondition; }],
-      ['updateAutoGearItemButtonState', function () { return updateAutoGearItemButtonState; }],
-      ['loadStoredLogoPreview', function () { return loadStoredLogoPreview; }],
-      ['normalizeSpellingVariants', function () { return normalizeSpellingVariants; }],
-      ['parseDeviceDatabaseImport', function () { return parseDeviceDatabaseImport; }],
-      ['countDeviceDatabaseEntries', function () { return countDeviceDatabaseEntries; }],
-      ['sanitizeShareFilename', function () { return sanitizeShareFilename; }],
-      ['ensureJsonExtension', function () { return ensureJsonExtension; }],
-      ['getDefaultShareFilename', function () { return getDefaultShareFilename; }],
-      ['promptForSharedFilename', function () { return promptForSharedFilename; }],
-      ['downloadSharedProject', function () { return downloadSharedProject; }],
-      ['confirmAutoGearSelection', function () { return confirmAutoGearSelection; }],
-      ['configureSharedImportOptions', function () { return configureSharedImportOptions; }],
-      ['resolveSharedImportMode', function () { return resolveSharedImportMode; }],
-      ['resetPlannerStateAfterFactoryReset', function () { return resetPlannerStateAfterFactoryReset; }],
-      ['updateStorageSummary', function () { return updateStorageSummary; }],
-      ['normaliseMarkVariants', function () { return normaliseMarkVariants; }],
-      ['storeLoadedSetupState', function () { return storeLoadedSetupState; }]
-    ];
-
-    var resolvedAdditionalExports = ADDITIONAL_GLOBAL_EXPORT_ENTRIES.reduce(function (acc, entry) {
-      var exportName = entry[0];
-      var getter = entry[1];
+    var ADDITIONAL_GLOBAL_EXPORT_ENTRIES = [['setBatteryPlates', function () {
+      return setBatteryPlatesLocal;
+    }], ['getBatteryPlates', function () {
+      return getBatteryPlates;
+    }], ['setRecordingMedia', function () {
+      return setRecordingMediaLocal;
+    }], ['getRecordingMedia', function () {
+      return getRecordingMedia;
+    }], ['applyDarkMode', function () {
+      return applyDarkMode;
+    }], ['applyPinkMode', function () {
+      return applyPinkMode;
+    }], ['applyHighContrast', function () {
+      return applyHighContrast;
+    }], ['setupInstallBanner', function () {
+      return setupInstallBanner;
+    }], ['generatePrintableOverview', function () {
+      return generatePrintableOverview;
+    }], ['generateGearListHtml', function () {
+      return generateGearListHtml;
+    }], ['displayGearAndRequirements', function () {
+      return displayGearAndRequirements;
+    }], ['ensureZoomRemoteSetup', function () {
+      return ensureZoomRemoteSetup;
+    }], ['encodeSharedSetup', function () {
+      return encodeSharedSetup;
+    }], ['decodeSharedSetup', function () {
+      return decodeSharedSetup;
+    }], ['applySharedSetupFromUrl', function () {
+      return applySharedSetupFromUrl;
+    }], ['applySharedSetup', function () {
+      return applySharedSetup;
+    }], ['updateBatteryPlateVisibility', function () {
+      return updateBatteryPlateVisibility;
+    }], ['updateBatteryOptions', function () {
+      return updateBatteryOptions;
+    }], ['renderSetupDiagram', function () {
+      return renderSetupDiagram;
+    }], ['enableDiagramInteractions', function () {
+      return enableDiagramInteractions;
+    }], ['updateDiagramLegend', function () {
+      return updateDiagramLegend;
+    }], ['cameraFizPort', function () {
+      return cameraFizPort;
+    }], ['controllerCamPort', function () {
+      return controllerCamPort;
+    }], ['controllerDistancePort', function () {
+      return controllerDistancePort;
+    }], ['detectBrand', function () {
+      return detectBrand;
+    }], ['connectionLabel', function () {
+      return connectionLabel;
+    }], ['generateConnectorSummary', function () {
+      return generateConnectorSummary;
+    }], ['diagramConnectorIcons', function () {
+      return diagramConnectorIcons;
+    }], ['DIAGRAM_MONITOR_ICON', function () {
+      return DIAGRAM_MONITOR_ICON;
+    }], ['exportDiagramSvg', function () {
+      return exportDiagramSvg;
+    }], ['fixPowerInput', function () {
+      return fixPowerInput;
+    }], ['powerInputTypes', function () {
+      return powerInputTypes;
+    }], ['ensureList', function () {
+      return ensureList;
+    }], ['normalizeVideoType', function () {
+      return normalizeVideoType;
+    }], ['normalizeFizConnectorType', function () {
+      return normalizeFizConnectorType;
+    }], ['normalizeViewfinderType', function () {
+      return normalizeViewfinderType;
+    }], ['normalizePowerPortType', function () {
+      return normalizePowerPortType;
+    }], ['getCurrentSetupKey', function () {
+      return getCurrentSetupKey;
+    }], ['renderFeedbackTable', function () {
+      return renderFeedbackTable;
+    }], ['saveCurrentGearList', function () {
+      return saveCurrentGearList;
+    }], ['getPowerSelectionSnapshot', function () {
+      return getPowerSelectionSnapshot;
+    }], ['applyStoredPowerSelection', function () {
+      return applyStoredPowerSelection;
+    }], ['getGearListSelectors', function () {
+      return getGearListSelectors;
+    }], ['applyGearListSelectors', function () {
+      return applyGearListSelectors;
+    }], ['scenarioIcons', function () {
+      return scenarioIcons;
+    }], ['collectProjectFormData', function () {
+      return collectProjectFormData;
+    }], ['populateProjectForm', function () {
+      return populateProjectForm;
+    }], ['renderFilterDetails', function () {
+      return renderFilterDetails;
+    }], ['collectFilterSelections', function () {
+      return collectFilterSelections;
+    }], ['parseFilterTokens', function () {
+      return parseFilterTokens;
+    }], ['applyFilterSelectionsToGearList', function () {
+      return applyFilterSelectionsToGearList;
+    }], ['adjustGearListSelectWidth', function () {
+      return adjustGearListSelectWidth;
+    }], ['adjustGearListSelectWidths', function () {
+      return adjustGearListSelectWidths;
+    }], ['deviceMap', function () {
+      return deviceMap;
+    }], ['helpMap', function () {
+      return helpMap;
+    }], ['featureSearchEntries', function () {
+      return featureSearchEntries;
+    }], ['featureSearchDefaultOptions', function () {
+      return featureSearchDefaultOptions;
+    }], ['restoreFeatureSearchDefaults', function () {
+      return restoreFeatureSearchDefaults;
+    }], ['updateFeatureSearchSuggestions', function () {
+      return updateFeatureSearchSuggestions;
+    }], ['setCurrentProjectInfo', function () {
+      return setCurrentProjectInfo;
+    }], ['getCurrentProjectInfo', function () {
+      return getCurrentProjectInfo;
+    }], ['getCurrentSetupState', function () {
+      return getCurrentSetupState;
+    }], ['setSliderBowlValue', function () {
+      return setSliderBowlValue;
+    }], ['crewRoles', function () {
+      return crewRoles;
+    }], ['formatFullBackupFilename', function () {
+      return formatFullBackupFilename;
+    }], ['computeGearListCount', function () {
+      return computeGearListCount;
+    }], ['autoBackup', function () {
+      return autoBackup;
+    }], ['createSettingsBackup', function () {
+      return createSettingsBackup;
+    }], ['captureStorageSnapshot', function () {
+      return captureStorageSnapshot;
+    }], ['sanitizeBackupPayload', function () {
+      return sanitizeBackupPayload;
+    }], ['extractBackupSections', function () {
+      return extractBackupSections;
+    }], ['searchKey', function () {
+      return searchKey;
+    }], ['searchTokens', function () {
+      return searchTokens;
+    }], ['findBestSearchMatch', function () {
+      return findBestSearchMatch;
+    }], ['runFeatureSearch', function () {
+      return runFeatureSearch;
+    }], ['collectAutoGearCatalogNames', function () {
+      return collectAutoGearCatalogNames;
+    }], ['featureMap', function () {
+      return featureMap;
+    }], ['buildDefaultVideoDistributionAutoGearRules', function () {
+      return buildDefaultVideoDistributionAutoGearRules;
+    }], ['applyAutoGearRulesToTableHtml', function () {
+      return applyAutoGearRulesToTableHtml;
+    }], ['importAutoGearRulesFromData', function () {
+      return importAutoGearRulesFromData;
+    }], ['createAutoGearBackup', function () {
+      return createAutoGearBackup;
+    }], ['restoreAutoGearBackup', function () {
+      return restoreAutoGearBackup;
+    }], ['getAutoGearRules', function () {
+      return getAutoGearRules;
+    }], ['syncAutoGearRulesFromStorage', function () {
+      return syncAutoGearRulesFromStorage;
+    }], ['normalizeAutoGearCameraWeightCondition', function () {
+      return normalizeAutoGearCameraWeightCondition;
+    }], ['updateAutoGearItemButtonState', function () {
+      return updateAutoGearItemButtonState;
+    }], ['loadStoredLogoPreview', function () {
+      return loadStoredLogoPreview;
+    }], ['normalizeSpellingVariants', function () {
+      return normalizeSpellingVariants;
+    }], ['parseDeviceDatabaseImport', function () {
+      return parseDeviceDatabaseImport;
+    }], ['countDeviceDatabaseEntries', function () {
+      return countDeviceDatabaseEntries;
+    }], ['sanitizeShareFilename', function () {
+      return sanitizeShareFilename;
+    }], ['ensureJsonExtension', function () {
+      return ensureJsonExtension;
+    }], ['getDefaultShareFilename', function () {
+      return getDefaultShareFilename;
+    }], ['promptForSharedFilename', function () {
+      return promptForSharedFilename;
+    }], ['downloadSharedProject', function () {
+      return downloadSharedProject;
+    }], ['confirmAutoGearSelection', function () {
+      return confirmAutoGearSelection;
+    }], ['configureSharedImportOptions', function () {
+      return configureSharedImportOptions;
+    }], ['resolveSharedImportMode', function () {
+      return resolveSharedImportMode;
+    }], ['resetPlannerStateAfterFactoryReset', function () {
+      return resetPlannerStateAfterFactoryReset;
+    }], ['updateStorageSummary', function () {
+      return updateStorageSummary;
+    }], ['normaliseMarkVariants', function () {
+      return normaliseMarkVariants;
+    }], ['storeLoadedSetupState', function () {
+      return storeLoadedSetupState;
+    }]];
+    var resolvedAdditionalExports = ADDITIONAL_GLOBAL_EXPORT_ENTRIES.reduce(function (acc, _ref42) {
+      var _ref43 = _slicedToArray(_ref42, 2),
+        exportName = _ref43[0],
+        getter = _ref43[1];
       try {
-        var value = getter();
-        if (typeof value !== 'undefined') {
-          acc[exportName] = value;
+        var _value3 = getter();
+        if (typeof _value3 !== 'undefined') {
+          acc[exportName] = _value3;
         }
       } catch (error) {
         void error;
       }
       return acc;
     }, {});
-
     Object.assign(CORE_PART2_GLOBAL_EXPORTS, resolvedAdditionalExports);
     var CORE_PART2_GLOBAL_SCOPE = CORE_SHARED_SCOPE_PART2 || (typeof globalThis !== 'undefined' ? globalThis : null) || (typeof window !== 'undefined' ? window : null) || (typeof self !== 'undefined' ? self : null) || (typeof global !== 'undefined' ? global : null);
     var CORE_PART2_RUNTIME = function resolvePart2Runtime(scope) {
@@ -15601,10 +15804,10 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
       }
       return null;
     }(CORE_PART2_GLOBAL_SCOPE);
-    Object.entries(CORE_PART2_GLOBAL_EXPORTS).forEach(function (_ref42) {
-      var _ref43 = _slicedToArray(_ref42, 2),
-        name = _ref43[0],
-        value = _ref43[1];
+    Object.entries(CORE_PART2_GLOBAL_EXPORTS).forEach(function (_ref44) {
+      var _ref45 = _slicedToArray(_ref44, 2),
+        name = _ref45[0],
+        value = _ref45[1];
       if (CORE_PART2_GLOBAL_SCOPE && Object.isExtensible(CORE_PART2_GLOBAL_SCOPE)) {
         CORE_PART2_GLOBAL_SCOPE[name] = value;
       }

--- a/legacy/scripts/app-events.js
+++ b/legacy/scripts/app-events.js
@@ -30,7 +30,6 @@ function markAutoBackupDataAsRenamed(value) {
     }
   }
 }
-
 function callEventsCoreFunction(functionName) {
   var args = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : [];
   var options = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {};
@@ -61,7 +60,70 @@ function callEventsCoreFunction(functionName) {
   }
   return options && Object.prototype.hasOwnProperty.call(options, 'defaultValue') ? options.defaultValue : undefined;
 }
-
+function readCoreDeviceSelectionHelper() {
+  if (typeof globalThis !== 'undefined' && typeof globalThis.hasAnyDeviceSelection === 'function') {
+    return globalThis.hasAnyDeviceSelection;
+  }
+  if (typeof window !== 'undefined' && typeof window.hasAnyDeviceSelection === 'function') {
+    return window.hasAnyDeviceSelection;
+  }
+  if (typeof self !== 'undefined' && typeof self.hasAnyDeviceSelection === 'function') {
+    return self.hasAnyDeviceSelection;
+  }
+  if (typeof global !== 'undefined' && typeof global.hasAnyDeviceSelection === 'function') {
+    return global.hasAnyDeviceSelection;
+  }
+  return null;
+}
+function hasAnyDeviceSelectionSafe(state) {
+  var coreHelper = readCoreDeviceSelectionHelper();
+  if (coreHelper) {
+    try {
+      return coreHelper(state);
+    } catch (error) {
+      if (typeof console !== 'undefined' && typeof console.warn === 'function') {
+        console.warn('Failed to evaluate device selections via core helper', error);
+      }
+    }
+  }
+  if (!state || _typeof(state) !== 'object') {
+    return false;
+  }
+  var _isMeaningfulSelection = function isMeaningfulSelection(value) {
+    if (Array.isArray(value)) {
+      return value.some(function (item) {
+        return _isMeaningfulSelection(item);
+      });
+    }
+    if (value == null) {
+      return false;
+    }
+    var normalized = typeof value === 'string' ? value.trim() : value;
+    if (!normalized) {
+      return false;
+    }
+    if (typeof normalized === 'string' && normalized.toLowerCase() === 'none') {
+      return false;
+    }
+    return true;
+  };
+  var primarySelections = [state.camera, state.monitor, state.video, state.cage, state.batteryPlate, state.battery, state.batteryHotswap];
+  if (primarySelections.some(function (value) {
+    return _isMeaningfulSelection(value);
+  })) {
+    return true;
+  }
+  if (_isMeaningfulSelection(state.motors)) {
+    return true;
+  }
+  if (_isMeaningfulSelection(state.controllers)) {
+    return true;
+  }
+  if (_isMeaningfulSelection(state.distance)) {
+    return true;
+  }
+  return false;
+}
 function getEventsCoreValue(functionName) {
   var options = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
   var defaultValue = Object.prototype.hasOwnProperty.call(options, 'defaultValue') ? options.defaultValue : '';
@@ -164,7 +226,7 @@ function handleSaveSetupClick() {
   var currentSetup = _objectSpread({}, getCurrentSetupState());
   var langTexts = texts[currentLang] || {};
   var fallbackTexts = texts.en || {};
-  if (!hasAnyDeviceSelection(currentSetup)) {
+  if (!hasAnyDeviceSelectionSafe(currentSetup)) {
     var message = langTexts.alertSetupNeedsDevice || fallbackTexts.alertSetupNeedsDevice || 'Please select at least one device before saving a project.';
     alert(message);
     return;
@@ -706,7 +768,7 @@ addSafeEventListener(setupSelectTarget, "change", function (event) {
     storeLoadedSetupStateSafe(getCurrentSetupState());
   }
   finalizeSetupSelection(setupName);
-  });
+});
 function populateSetupSelect() {
   var setupsProvider = typeof getSetups === 'function' ? getSetups : null;
   var setupSelectTarget = getSetupSelectElement();
@@ -714,7 +776,7 @@ function populateSetupSelect() {
     console.warn('populateSetupSelect: setup select element unavailable, aborting populate');
     return;
   }
-  var textBundle = _typeof(texts) === 'object' && texts ? texts[currentLang] || texts.en || {} : {};
+  var textBundle = (typeof texts === "undefined" ? "undefined" : _typeof(texts)) === 'object' && texts ? texts[currentLang] || texts.en || {} : {};
   var newSetupOptionLabel = typeof textBundle.newSetupOption === 'string' && textBundle.newSetupOption.trim() ? textBundle.newSetupOption : 'New setup';
   if (!setupsProvider) {
     console.warn('populateSetupSelect: getSetups is unavailable, using empty setup list');
@@ -997,9 +1059,7 @@ function toggleDeviceManagerSection() {
     hideDeviceManagerSection();
   }
 }
-if (toggleDeviceBtn) {
-  addSafeEventListener(toggleDeviceBtn, 'click', toggleDeviceManagerSection);
-}
+addSafeEventListener(toggleDeviceBtn, 'click', toggleDeviceManagerSection);
 function getEventsLanguageTexts() {
   var scope = typeof globalThis !== 'undefined' && globalThis || typeof window !== 'undefined' && window || typeof self !== 'undefined' && self || typeof global !== 'undefined' && global || null;
   var allTexts = typeof texts !== 'undefined' && texts || (scope && _typeof(scope.texts) === 'object' ? scope.texts : null);
@@ -1822,10 +1882,10 @@ if (exportAndRevertBtn) {
     }
   });
 }
-  addSafeEventListener(importDataBtn, "click", function () {
+addSafeEventListener(importDataBtn, "click", function () {
   importFileInput.click();
 });
-  addSafeEventListener(importFileInput, "change", function (event) {
+addSafeEventListener(importFileInput, "change", function (event) {
   var file = event.target.files[0];
   if (!file) {
     return;

--- a/legacy/scripts/app-session.js
+++ b/legacy/scripts/app-session.js
@@ -1,4 +1,3 @@
-/* global enqueueCoreBootTask, updateFavoriteButton, adjustGearListSelectWidth */
 var _excluded = ["parsed", "timestamp"];
 function _regenerator() { var e, t, r = "function" == typeof Symbol ? Symbol : {}, n = r.iterator || "@@iterator", o = r.toStringTag || "@@toStringTag"; function i(r, n, o, i) { var c = n && n.prototype instanceof Generator ? n : Generator, u = Object.create(c.prototype); return _regeneratorDefine2(u, "_invoke", function (r, n, o) { var i, c, u, f = 0, p = o || [], y = !1, G = { p: 0, n: 0, v: e, a: d, f: d.bind(e, 4), d: function d(t, r) { return i = t, c = 0, u = e, G.n = r, a; } }; function d(r, n) { for (c = r, u = n, t = 0; !y && f && !o && t < p.length; t++) { var o, i = p[t], d = G.p, l = i[2]; r > 3 ? (o = l === n) && (u = i[(c = i[4]) ? 5 : (c = 3, 3)], i[4] = i[5] = e) : i[0] <= d && ((o = r < 2 && d < i[1]) ? (c = 0, G.v = n, G.n = i[1]) : d < l && (o = r < 3 || i[0] > n || n > l) && (i[4] = r, i[5] = n, G.n = l, c = 0)); } if (o || r > 1) return a; throw y = !0, n; } return function (o, p, l) { if (f > 1) throw TypeError("Generator is already running"); for (y && 1 === p && d(p, l), c = p, u = l; (t = c < 2 ? e : u) || !y;) { i || (c ? c < 3 ? (c > 1 && (G.n = -1), d(c, u)) : G.n = u : G.v = u); try { if (f = 2, i) { if (c || (o = "next"), t = i[o]) { if (!(t = t.call(i, u))) throw TypeError("iterator result is not an object"); if (!t.done) return t; u = t.value, c < 2 && (c = 0); } else 1 === c && (t = i.return) && t.call(i), c < 2 && (u = TypeError("The iterator does not provide a '" + o + "' method"), c = 1); i = e; } else if ((t = (y = G.n < 0) ? u : r.call(n, G)) !== a) break; } catch (t) { i = e, c = 1, u = t; } finally { f = 1; } } return { value: t, done: y }; }; }(r, o, i), !0), u; } var a = {}; function Generator() {} function GeneratorFunction() {} function GeneratorFunctionPrototype() {} t = Object.getPrototypeOf; var c = [][n] ? t(t([][n]())) : (_regeneratorDefine2(t = {}, n, function () { return this; }), t), u = GeneratorFunctionPrototype.prototype = Generator.prototype = Object.create(c); function f(e) { return Object.setPrototypeOf ? Object.setPrototypeOf(e, GeneratorFunctionPrototype) : (e.__proto__ = GeneratorFunctionPrototype, _regeneratorDefine2(e, o, "GeneratorFunction")), e.prototype = Object.create(u), e; } return GeneratorFunction.prototype = GeneratorFunctionPrototype, _regeneratorDefine2(u, "constructor", GeneratorFunctionPrototype), _regeneratorDefine2(GeneratorFunctionPrototype, "constructor", GeneratorFunction), GeneratorFunction.displayName = "GeneratorFunction", _regeneratorDefine2(GeneratorFunctionPrototype, o, "GeneratorFunction"), _regeneratorDefine2(u), _regeneratorDefine2(u, o, "Generator"), _regeneratorDefine2(u, n, function () { return this; }), _regeneratorDefine2(u, "toString", function () { return "[object Generator]"; }), (_regenerator = function _regenerator() { return { w: i, m: f }; })(); }
 function _regeneratorDefine2(e, r, n, t) { var i = Object.defineProperty; try { i({}, "", {}); } catch (e) { i = 0; } _regeneratorDefine2 = function _regeneratorDefine(e, r, n, t) { if (r) i ? i(e, r, { value: n, enumerable: !t, configurable: !t, writable: !t }) : e[r] = n;else { function o(r, n) { _regeneratorDefine2(e, r, function (e) { return this._invoke(r, n, e); }); } o("next", 0), o("throw", 1), o("return", 2); } }, _regeneratorDefine2(e, r, n, t); }
@@ -29,14 +28,12 @@ function _toPrimitive(t, r) { if ("object" != _typeof(t) || !t) return t; var e 
 function _typeof(o) { "@babel/helpers - typeof"; return _typeof = "function" == typeof Symbol && "symbol" == typeof Symbol.iterator ? function (o) { return typeof o; } : function (o) { return o && "function" == typeof Symbol && o.constructor === Symbol && o !== Symbol.prototype ? "symbol" : typeof o; }, _typeof(o); }
 function ensureSessionRuntimePlaceholder(name, fallbackValue) {
   var scope = typeof globalThis !== 'undefined' && globalThis || typeof window !== 'undefined' && window || typeof self !== 'undefined' && self || typeof global !== 'undefined' && global || null;
-  var fallbackProvider = typeof fallbackValue === 'function' ? fallbackValue : function provideStaticFallback() {
+  var fallbackProvider = typeof fallbackValue === 'function' ? fallbackValue : function () {
     return fallbackValue;
   };
-
   if (!scope || _typeof(scope) !== 'object') {
     return fallbackProvider();
   }
-
   try {
     if (typeof scope[name] === 'undefined') {
       scope[name] = fallbackProvider();
@@ -47,7 +44,6 @@ function ensureSessionRuntimePlaceholder(name, fallbackValue) {
     return fallbackProvider();
   }
 }
-
 function getSessionRuntimeScopes() {
   var scopes = [];
   var addScope = function addScope(candidate) {
@@ -58,7 +54,6 @@ function getSessionRuntimeScopes() {
       scopes.push(candidate);
     }
   };
-
   try {
     if (typeof CORE_GLOBAL_SCOPE !== 'undefined' && CORE_GLOBAL_SCOPE) {
       addScope(CORE_GLOBAL_SCOPE);
@@ -66,20 +61,16 @@ function getSessionRuntimeScopes() {
   } catch (coreScopeError) {
     void coreScopeError;
   }
-
   addScope(typeof globalThis !== 'undefined' ? globalThis : null);
   addScope(typeof window !== 'undefined' ? window : null);
   addScope(typeof self !== 'undefined' ? self : null);
   addScope(typeof global !== 'undefined' ? global : null);
-
   return scopes;
 }
-
 function getSessionRuntimeFunction(name) {
   if (typeof name !== 'string' || !name) {
     return null;
   }
-
   var scopes = getSessionRuntimeScopes();
   for (var index = 0; index < scopes.length; index += 1) {
     var scope = scopes[index];
@@ -90,48 +81,51 @@ function getSessionRuntimeFunction(name) {
       candidate = null;
       void resolveError;
     }
-
     if (typeof candidate === 'function') {
       return candidate;
     }
   }
-
   return null;
 }
-
 function invokeSessionRevertAccentColor() {
   var revertFn = getSessionRuntimeFunction('revertAccentColor');
   if (typeof revertFn !== 'function') {
     return;
   }
-
   try {
     revertFn();
   } catch (revertError) {
     console.warn('Failed to revert accent color', revertError);
   }
 }
-
 function invokeSessionOpenAutoGearEditor() {
   var openFn = getSessionRuntimeFunction('openAutoGearEditor');
   if (typeof openFn !== 'function') {
     console.warn('Auto Gear editor runtime is not available yet.');
     return;
   }
-
   try {
     openFn.apply(void 0, arguments);
   } catch (openError) {
     console.warn('Failed to open Auto Gear editor', openError);
   }
 }
-
 ensureSessionRuntimePlaceholder('autoGearScenarioModeSelect', null);
-var gridSnapToggleBtn = ensureSessionRuntimePlaceholder('gridSnapToggleBtn', function () {
+var downloadDiagramButton = ensureSessionRuntimePlaceholder('downloadDiagramBtn', function () {
   if (typeof document === 'undefined' || !document || typeof document.getElementById !== 'function') {
     return null;
   }
-
+  try {
+    return document.getElementById('downloadDiagram');
+  } catch (resolveError) {
+    void resolveError;
+    return null;
+  }
+});
+var gridSnapToggleButton = ensureSessionRuntimePlaceholder('gridSnapToggleBtn', function () {
+  if (typeof document === 'undefined' || !document || typeof document.getElementById !== 'function') {
+    return null;
+  }
   try {
     return document.getElementById('gridSnapToggle');
   } catch (resolveError) {
@@ -194,6 +188,16 @@ function registerCineUiEntries(registry, entries, warningMessage) {
     }
   }
 }
+function safeLoadStoredLogoPreview() {
+  if (typeof loadStoredLogoPreview !== 'function') {
+    return;
+  }
+  try {
+    loadStoredLogoPreview();
+  } catch (error) {
+    console.warn('Failed to load stored logo preview', error);
+  }
+}
 function areSessionEntriesRegistered(cineUi) {
   if (!cineUi || _typeof(cineUi) !== 'object') {
     return false;
@@ -228,19 +232,10 @@ function enqueueCineUiRegistration(callback) {
   scope[key].push(callback);
 }
 enqueueCineUiRegistration(registerSessionCineUiInternal);
-
-var SESSION_GLOBAL_SCOPE =
-  typeof CORE_GLOBAL_SCOPE === 'object' && CORE_GLOBAL_SCOPE
-    || typeof globalThis !== 'undefined' && globalThis
-    || typeof window !== 'undefined' && window
-    || typeof self !== 'undefined' && self
-    || typeof global !== 'undefined' && global
-    || null;
-
+var SESSION_GLOBAL_SCOPE = (typeof CORE_GLOBAL_SCOPE === "undefined" ? "undefined" : _typeof(CORE_GLOBAL_SCOPE)) === 'object' && CORE_GLOBAL_SCOPE || (typeof globalThis !== 'undefined' ? globalThis : null) || (typeof window !== 'undefined' ? window : null) || (typeof self !== 'undefined' ? self : null) || (typeof global !== 'undefined' ? global : null) || null;
 var SESSION_DEFAULT_ACCENT_COLOR_FALLBACK = '#001589';
 var SESSION_HIGH_CONTRAST_ACCENT_COLOR_FALLBACK = '#ffffff';
-
-var resolvedDefaultAccentColor = (function () {
+var resolvedDefaultAccentColor = function () {
   if (SESSION_GLOBAL_SCOPE && typeof SESSION_GLOBAL_SCOPE.DEFAULT_ACCENT_COLOR === 'string') {
     var candidate = SESSION_GLOBAL_SCOPE.DEFAULT_ACCENT_COLOR.trim();
     if (candidate) {
@@ -254,27 +249,18 @@ var resolvedDefaultAccentColor = (function () {
     }
   }
   return SESSION_DEFAULT_ACCENT_COLOR_FALLBACK;
-})();
-
-var resolvedDefaultAccentNormalized =
-  typeof resolvedDefaultAccentColor === 'string'
-    ? resolvedDefaultAccentColor.toLowerCase()
-    : SESSION_DEFAULT_ACCENT_COLOR_FALLBACK.toLowerCase();
-
-var resolvedHighContrastAccentColor = (function () {
-  if (
-    SESSION_GLOBAL_SCOPE
-    && typeof SESSION_GLOBAL_SCOPE.HIGH_CONTRAST_ACCENT_COLOR === 'string'
-  ) {
+}();
+var resolvedDefaultAccentNormalized = typeof resolvedDefaultAccentColor === 'string' ? resolvedDefaultAccentColor.toLowerCase() : SESSION_DEFAULT_ACCENT_COLOR_FALLBACK.toLowerCase();
+var resolvedHighContrastAccentColor = function () {
+  if (SESSION_GLOBAL_SCOPE && typeof SESSION_GLOBAL_SCOPE.HIGH_CONTRAST_ACCENT_COLOR === 'string') {
     var candidate = SESSION_GLOBAL_SCOPE.HIGH_CONTRAST_ACCENT_COLOR.trim();
     if (candidate) {
       return candidate;
     }
   }
   return SESSION_HIGH_CONTRAST_ACCENT_COLOR_FALLBACK;
-})();
-
-var resolvedAccentColor = (function () {
+}();
+var resolvedAccentColor = function () {
   if (SESSION_GLOBAL_SCOPE && typeof SESSION_GLOBAL_SCOPE.accentColor === 'string') {
     var candidate = SESSION_GLOBAL_SCOPE.accentColor.trim();
     if (candidate) {
@@ -282,50 +268,82 @@ var resolvedAccentColor = (function () {
     }
   }
   return resolvedDefaultAccentColor;
-})();
-
-if (
-  typeof DEFAULT_ACCENT_COLOR === 'undefined'
-  || typeof DEFAULT_ACCENT_COLOR !== 'string'
-  || !DEFAULT_ACCENT_COLOR.trim()
-) {
-  DEFAULT_ACCENT_COLOR = resolvedDefaultAccentColor;
+}();
+var hasDefaultAccentColor = typeof DEFAULT_ACCENT_COLOR === 'string' && DEFAULT_ACCENT_COLOR.trim();
+if (!hasDefaultAccentColor) {
+  try {
+    DEFAULT_ACCENT_COLOR = resolvedDefaultAccentColor;
+  } catch (assignDefaultAccentError) {
+    if (SESSION_GLOBAL_SCOPE && _typeof(SESSION_GLOBAL_SCOPE) === 'object') {
+      SESSION_GLOBAL_SCOPE.DEFAULT_ACCENT_COLOR = resolvedDefaultAccentColor;
+    }
+    void assignDefaultAccentError;
+  }
 }
-if (
-  typeof DEFAULT_ACCENT_NORMALIZED === 'undefined'
-  || typeof DEFAULT_ACCENT_NORMALIZED !== 'string'
-  || !DEFAULT_ACCENT_NORMALIZED
-) {
-  DEFAULT_ACCENT_NORMALIZED = resolvedDefaultAccentNormalized;
+var hasDefaultAccentNormalized = typeof DEFAULT_ACCENT_NORMALIZED === 'string' && DEFAULT_ACCENT_NORMALIZED;
+if (!hasDefaultAccentNormalized) {
+  try {
+    DEFAULT_ACCENT_NORMALIZED = resolvedDefaultAccentNormalized;
+  } catch (assignNormalizedAccentError) {
+    if (SESSION_GLOBAL_SCOPE && _typeof(SESSION_GLOBAL_SCOPE) === 'object') {
+      SESSION_GLOBAL_SCOPE.DEFAULT_ACCENT_NORMALIZED = resolvedDefaultAccentNormalized;
+    }
+    void assignNormalizedAccentError;
+  }
 }
-if (
-  typeof HIGH_CONTRAST_ACCENT_COLOR === 'undefined'
-  || typeof HIGH_CONTRAST_ACCENT_COLOR !== 'string'
-  || !HIGH_CONTRAST_ACCENT_COLOR.trim()
-) {
-  HIGH_CONTRAST_ACCENT_COLOR = resolvedHighContrastAccentColor;
+var hasHighContrastAccent = typeof HIGH_CONTRAST_ACCENT_COLOR === 'string' && HIGH_CONTRAST_ACCENT_COLOR.trim();
+if (!hasHighContrastAccent) {
+  try {
+    HIGH_CONTRAST_ACCENT_COLOR = resolvedHighContrastAccentColor;
+  } catch (assignHighContrastAccentError) {
+    if (SESSION_GLOBAL_SCOPE && _typeof(SESSION_GLOBAL_SCOPE) === 'object') {
+      SESSION_GLOBAL_SCOPE.HIGH_CONTRAST_ACCENT_COLOR = resolvedHighContrastAccentColor;
+    }
+    void assignHighContrastAccentError;
+  }
 }
-if (
-  typeof accentColor === 'undefined'
-  || typeof accentColor !== 'string'
-  || !accentColor.trim()
-) {
-  accentColor = resolvedAccentColor;
+var hasAccentColor = typeof accentColor === 'string' && accentColor.trim();
+if (!hasAccentColor) {
+  try {
+    accentColor = resolvedAccentColor;
+  } catch (assignAccentColorError) {
+    if (SESSION_GLOBAL_SCOPE && _typeof(SESSION_GLOBAL_SCOPE) === 'object') {
+      SESSION_GLOBAL_SCOPE.accentColor = resolvedAccentColor;
+    }
+    void assignAccentColorError;
+  }
 }
-if (
-  typeof prevAccentColor === 'undefined'
-  || typeof prevAccentColor !== 'string'
-  || !prevAccentColor.trim()
-) {
-  prevAccentColor = resolvedAccentColor;
+var hasPrevAccentColor = typeof prevAccentColor === 'string' && prevAccentColor.trim();
+if (!hasPrevAccentColor) {
+  try {
+    prevAccentColor = resolvedAccentColor;
+  } catch (assignPrevAccentError) {
+    if (SESSION_GLOBAL_SCOPE && _typeof(SESSION_GLOBAL_SCOPE) === 'object') {
+      SESSION_GLOBAL_SCOPE.prevAccentColor = resolvedAccentColor;
+    }
+    void assignPrevAccentError;
+  }
 }
-if (typeof restoringSession === 'undefined') {
-  restoringSession = false;
+if (typeof restoringSession !== 'boolean') {
+  try {
+    restoringSession = false;
+  } catch (assignRestoringSessionError) {
+    if (SESSION_GLOBAL_SCOPE && _typeof(SESSION_GLOBAL_SCOPE) === 'object') {
+      SESSION_GLOBAL_SCOPE.restoringSession = false;
+    }
+    void assignRestoringSessionError;
+  }
 }
 if (typeof filterSelectElem === 'undefined') {
-  filterSelectElem = null;
+  try {
+    filterSelectElem = null;
+  } catch (assignFilterSelectError) {
+    if (SESSION_GLOBAL_SCOPE && _typeof(SESSION_GLOBAL_SCOPE) === 'object') {
+      SESSION_GLOBAL_SCOPE.filterSelectElem = null;
+    }
+    void assignFilterSelectError;
+  }
 }
-
 function callSessionCoreFunction(functionName) {
   var args = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : [];
   var options = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {};
@@ -356,7 +374,24 @@ function callSessionCoreFunction(functionName) {
   }
   return options && Object.prototype.hasOwnProperty.call(options, 'defaultValue') ? options.defaultValue : undefined;
 }
-
+function ensureSessionRuntimeFunction(functionName) {
+  var options = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+  return ensureSessionRuntimePlaceholder(functionName, function () {
+    return function () {
+      for (var _len = arguments.length, invocationArgs = new Array(_len), _key = 0; _key < _len; _key++) {
+        invocationArgs[_key] = arguments[_key];
+      }
+      return callSessionCoreFunction(functionName, invocationArgs, options);
+    };
+  });
+}
+var AUTO_GEAR_RUNTIME_HANDLERS = ['handleAutoGearImportSelection', 'handleAutoGearPresetSelection', 'handleAutoGearSavePreset', 'handleAutoGearDeletePreset', 'handleAutoGearShowBackupsToggle', 'handleAutoGearConditionShortcut'];
+for (var index = 0; index < AUTO_GEAR_RUNTIME_HANDLERS.length; index += 1) {
+  var handlerName = AUTO_GEAR_RUNTIME_HANDLERS[index];
+  ensureSessionRuntimeFunction(handlerName, {
+    defer: true
+  });
+}
 function getSessionCoreValue(functionName) {
   var options = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
   var defaultValue = Object.prototype.hasOwnProperty.call(options, 'defaultValue') ? options.defaultValue : '';
@@ -872,8 +907,8 @@ function hasAnyRestoreRehearsalKeys(source, keys) {
   if (!isPlainObject(source)) {
     return false;
   }
-  for (var index = 0; index < keys.length; index += 1) {
-    var key = keys[index];
+  for (var _index = 0; _index < keys.length; _index += 1) {
+    var key = keys[_index];
     if (Object.prototype.hasOwnProperty.call(source, key)) {
       return true;
     }
@@ -2070,17 +2105,16 @@ function setSelectValue(select, value) {
   if (typeof updateFavoriteButton === 'function') {
     updateFavoriteButton(select);
   } else if (typeof enqueueCoreBootTask === 'function') {
-    enqueueCoreBootTask(() => {
+    enqueueCoreBootTask(function () {
       if (typeof updateFavoriteButton === 'function') {
         updateFavoriteButton(select);
       }
     });
   }
-
   if (typeof adjustGearListSelectWidth === 'function') {
     adjustGearListSelectWidth(select);
   } else if (typeof enqueueCoreBootTask === 'function') {
-    enqueueCoreBootTask(() => {
+    enqueueCoreBootTask(function () {
       if (typeof adjustGearListSelectWidth === 'function') {
         adjustGearListSelectWidth(select);
       }
@@ -2521,8 +2555,8 @@ function buildSearchWithoutShared(search) {
   }
   var preserved = [];
   var pairs = query.split('&');
-  for (var index = 0; index < pairs.length; index += 1) {
-    var pair = pairs[index];
+  for (var _index2 = 0; _index2 < pairs.length; _index2 += 1) {
+    var pair = pairs[_index2];
     if (!pair) {
       continue;
     }
@@ -2637,7 +2671,7 @@ function forEachTrackedSelect(collection, handler) {
   list.forEach(handler);
 }
 forEachTrackedSelect(getTrackedPowerSelects(), function (sel) {
-  sel.addEventListener("change", updateCalculations);
+  sel.addEventListener('change', updateCalculations);
 });
 if (cameraSelect) {
   cameraSelect.addEventListener('change', function () {
@@ -2663,19 +2697,19 @@ if (batteryPlateSelect) batteryPlateSelect.addEventListener('change', updateBatt
 if (batterySelect) batterySelect.addEventListener('change', updateBatteryOptions);
 if (hotswapSelect) hotswapSelect.addEventListener('change', updateCalculations);
 forEachTrackedSelect(motorSelects, function (sel) {
-  if (sel) sel.addEventListener("change", updateCalculations);
+  if (sel) sel.addEventListener('change', updateCalculations);
 });
 forEachTrackedSelect(controllerSelects, function (sel) {
-  if (sel) sel.addEventListener("change", updateCalculations);
+  if (sel) sel.addEventListener('change', updateCalculations);
 });
 forEachTrackedSelect(getTrackedPowerSelectsWithSetup(), function (sel) {
-  sel.addEventListener("change", saveCurrentSession);
+  sel.addEventListener('change', saveCurrentSession);
 });
 forEachTrackedSelect(motorSelects, function (sel) {
-  if (sel) sel.addEventListener("change", saveCurrentSession);
+  if (sel) sel.addEventListener('change', saveCurrentSession);
 });
 forEachTrackedSelect(controllerSelects, function (sel) {
-  if (sel) sel.addEventListener("change", saveCurrentSession);
+  if (sel) sel.addEventListener('change', saveCurrentSession);
 });
 if (setupNameInput) {
   var handleSetupNameInput = function handleSetupNameInput() {
@@ -2689,34 +2723,34 @@ if (setupNameInput) {
   setupNameInput.addEventListener("input", handleSetupNameInput);
 }
 forEachTrackedSelect(getTrackedPowerSelects(), function (sel) {
-  sel.addEventListener("change", saveCurrentGearList);
+  sel.addEventListener('change', saveCurrentGearList);
 });
 forEachTrackedSelect(motorSelects, function (sel) {
-  if (sel) sel.addEventListener("change", saveCurrentGearList);
+  if (sel) sel.addEventListener('change', saveCurrentGearList);
 });
 forEachTrackedSelect(controllerSelects, function (sel) {
-  if (sel) sel.addEventListener("change", saveCurrentGearList);
+  if (sel) sel.addEventListener('change', saveCurrentGearList);
 });
 forEachTrackedSelect(getTrackedPowerSelects(), function (sel) {
-  sel.addEventListener("change", checkSetupChanged);
+  sel.addEventListener('change', checkSetupChanged);
 });
 forEachTrackedSelect(motorSelects, function (sel) {
-  if (sel) sel.addEventListener("change", checkSetupChanged);
+  if (sel) sel.addEventListener('change', checkSetupChanged);
 });
 forEachTrackedSelect(controllerSelects, function (sel) {
-  if (sel) sel.addEventListener("change", checkSetupChanged);
+  if (sel) sel.addEventListener('change', checkSetupChanged);
 });
-if (setupNameInput) setupNameInput.addEventListener("input", checkSetupChanged);
+if (setupNameInput) setupNameInput.addEventListener('input', checkSetupChanged);
 forEachTrackedSelect(getTrackedPowerSelects(), function (sel) {
-  sel.addEventListener("change", autoSaveCurrentSetup);
+  sel.addEventListener('change', autoSaveCurrentSetup);
 });
 forEachTrackedSelect(motorSelects, function (sel) {
-  if (sel) sel.addEventListener("change", autoSaveCurrentSetup);
+  if (sel) sel.addEventListener('change', autoSaveCurrentSetup);
 });
 forEachTrackedSelect(controllerSelects, function (sel) {
-  if (sel) sel.addEventListener("change", autoSaveCurrentSetup);
+  if (sel) sel.addEventListener('change', autoSaveCurrentSetup);
 });
-if (setupNameInput) setupNameInput.addEventListener("change", autoSaveCurrentSetup);
+if (setupNameInput) setupNameInput.addEventListener('change', autoSaveCurrentSetup);
 var flushProjectAutoSaveOnExit = function flushProjectAutoSaveOnExit() {
   if (factoryResetInProgress) return;
   scheduleProjectAutoSave(true);
@@ -2778,7 +2812,7 @@ function setToggleIcon(button, glyph) {
 }
 function getIconGlyphSafe(name) {
   if (!name) return null;
-  if (_typeof(ICON_GLYPHS) !== 'object' || !ICON_GLYPHS) {
+  if ((typeof ICON_GLYPHS === "undefined" ? "undefined" : _typeof(ICON_GLYPHS)) !== 'object' || !ICON_GLYPHS) {
     return null;
   }
   return ICON_GLYPHS[name] || null;
@@ -2993,6 +3027,9 @@ function startPinkModeIconRotation() {
       animate: true
     });
   }, PINK_MODE_ICON_INTERVAL_MS);
+  if (pinkModeIconRotationTimer && typeof pinkModeIconRotationTimer.unref === 'function') {
+    pinkModeIconRotationTimer.unref();
+  }
 }
 function applyPinkMode(enabled) {
   if (enabled) {
@@ -3037,7 +3074,7 @@ var pinkModeEnabled = false;
 var settingsInitialPinkMode = isPinkModeActive();
 var settingsInitialTemperatureUnit = typeof temperatureUnit === 'string' ? temperatureUnit : 'celsius';
 var settingsInitialShowAutoBackups = Boolean(showAutoBackups);
-var settingsInitialMountVoltages = getMountVoltagePreferencesClone();
+var settingsInitialMountVoltages = getSessionMountVoltagePreferencesClone();
 function persistPinkModePreference(enabled) {
   pinkModeEnabled = !!enabled;
   applyPinkMode(pinkModeEnabled);
@@ -3180,8 +3217,8 @@ mountVoltageInputNodes.forEach(function (input) {
 });
 var mountVoltageResetButtonRef = function () {
   var candidateScopes = [typeof CORE_GLOBAL_SCOPE !== 'undefined' && CORE_GLOBAL_SCOPE && (typeof CORE_GLOBAL_SCOPE === "undefined" ? "undefined" : _typeof(CORE_GLOBAL_SCOPE)) === 'object' ? CORE_GLOBAL_SCOPE : null, typeof globalThis !== 'undefined' && (typeof globalThis === "undefined" ? "undefined" : _typeof(globalThis)) === 'object' ? globalThis : null, typeof window !== 'undefined' && (typeof window === "undefined" ? "undefined" : _typeof(window)) === 'object' ? window : null, typeof self !== 'undefined' && (typeof self === "undefined" ? "undefined" : _typeof(self)) === 'object' ? self : null, typeof global !== 'undefined' && (typeof global === "undefined" ? "undefined" : _typeof(global)) === 'object' ? global : null].filter(Boolean);
-  for (var index = 0; index < candidateScopes.length; index += 1) {
-    var scope = candidateScopes[index];
+  for (var _index3 = 0; _index3 < candidateScopes.length; _index3 += 1) {
+    var scope = candidateScopes[_index3];
     var button = scope && scope.mountVoltageResetButton;
     if (button) {
       return button;
@@ -3191,11 +3228,29 @@ var mountVoltageResetButtonRef = function () {
 }();
 if (mountVoltageResetButtonRef) {
   mountVoltageResetButtonRef.addEventListener('click', function () {
-    resetMountVoltagePreferences({
-      persist: false,
-      triggerUpdate: true
-    });
-    updateMountVoltageInputsFromState();
+    var resetMountVoltagePreferencesFn = getSessionRuntimeFunction('resetMountVoltagePreferences');
+    if (resetMountVoltagePreferencesFn) {
+      try {
+        resetMountVoltagePreferencesFn({
+          persist: false,
+          triggerUpdate: true
+        });
+      } catch (resetError) {
+        warnMissingMountVoltageHelper('resetMountVoltagePreferences', resetError);
+      }
+    } else {
+      warnMissingMountVoltageHelper('resetMountVoltagePreferences');
+    }
+    var updateMountVoltageInputsFromStateFn = getSessionRuntimeFunction('updateMountVoltageInputsFromState');
+    if (updateMountVoltageInputsFromStateFn) {
+      try {
+        updateMountVoltageInputsFromStateFn();
+      } catch (updateError) {
+        warnMissingMountVoltageHelper('updateMountVoltageInputsFromState', updateError);
+      }
+    } else {
+      warnMissingMountVoltageHelper('updateMountVoltageInputsFromState');
+    }
   });
 }
 if (settingsButton && settingsDialog) {
@@ -3205,7 +3260,16 @@ if (settingsButton && settingsDialog) {
     rememberSettingsTemperatureUnitBaseline();
     rememberSettingsShowAutoBackupsBaseline();
     rememberSettingsMountVoltagesBaseline();
-    updateMountVoltageInputsFromState();
+    var updateMountVoltageInputsFromStateFn = getSessionRuntimeFunction('updateMountVoltageInputsFromState');
+    if (updateMountVoltageInputsFromStateFn) {
+      try {
+        updateMountVoltageInputsFromStateFn();
+      } catch (updateError) {
+        warnMissingMountVoltageHelper('updateMountVoltageInputsFromState', updateError);
+      }
+    } else {
+      warnMissingMountVoltageHelper('updateMountVoltageInputsFromState');
+    }
     if (settingsLanguage) settingsLanguage.value = currentLang;
     if (settingsDarkMode) settingsDarkMode.checked = document.body.classList.contains('dark-mode');
     if (settingsPinkMode) settingsPinkMode.checked = document.body.classList.contains('pink-mode');
@@ -3230,7 +3294,7 @@ if (settingsButton && settingsDialog) {
     if (settingsFontSize) settingsFontSize.value = fontSize;
     if (settingsFontFamily) settingsFontFamily.value = fontFamily;
     if (settingsLogo) settingsLogo.value = '';
-    if (settingsLogoPreview) loadStoredLogoPreview();
+    if (settingsLogoPreview) safeLoadStoredLogoPreview();
     updateStorageSummary();
     if (autoGearEditor) {
       closeAutoGearEditor();
@@ -3284,7 +3348,7 @@ if (settingsButton && settingsDialog) {
       rememberSettingsMountVoltagesBaseline();
       invokeSessionRevertAccentColor();
       if (settingsLogo) settingsLogo.value = '';
-      if (settingsLogoPreview) loadStoredLogoPreview();
+      if (settingsLogoPreview) safeLoadStoredLogoPreview();
       closeAutoGearEditor();
       collapseBackupDiffSection();
       closeDialog(settingsDialog);
@@ -3362,7 +3426,7 @@ if (settingsButton && settingsDialog) {
         applyTemperatureUnitPreference(settingsTemperatureUnit.value);
         rememberSettingsTemperatureUnitBaseline();
       }
-      applyMountVoltagePreferences(collectMountVoltageFormValues(), {
+      applySessionMountVoltagePreferences(collectMountVoltageFormValues(), {
         persist: true,
         triggerUpdate: true
       });
@@ -3403,7 +3467,7 @@ if (settingsButton && settingsDialog) {
         } else {
           showNotification('error', texts[currentLang].logoFormatError || 'Unsupported logo format');
           if (settingsLogo) settingsLogo.value = '';
-          loadStoredLogoPreview();
+          safeLoadStoredLogoPreview();
         }
       }
       closeAutoGearEditor();
@@ -3428,7 +3492,7 @@ if (settingsButton && settingsDialog) {
       rememberSettingsMountVoltagesBaseline();
       invokeSessionRevertAccentColor();
       if (settingsLogo) settingsLogo.value = '';
-      if (settingsLogoPreview) loadStoredLogoPreview();
+      if (settingsLogoPreview) safeLoadStoredLogoPreview();
       closeAutoGearEditor();
       collapseBackupDiffSection();
       closeDialog(settingsDialog);
@@ -3447,7 +3511,7 @@ if (settingsButton && settingsDialog) {
     rememberSettingsMountVoltagesBaseline();
     invokeSessionRevertAccentColor();
     if (settingsLogo) settingsLogo.value = '';
-    if (settingsLogoPreview) loadStoredLogoPreview();
+    if (settingsLogoPreview) safeLoadStoredLogoPreview();
     closeAutoGearEditor();
     collapseBackupDiffSection();
     closeDialog(settingsDialog);
@@ -3468,9 +3532,8 @@ if (settingsButton && settingsDialog) {
       addAutoGearConditionFromPicker();
     });
   }
-  var autoGearScenarioModeSelectHandle = function resolveAutoGearScenarioModeSelectHandle() {
+  var autoGearScenarioModeSelectHandle = function () {
     var resolvedHandle = null;
-
     try {
       if (typeof autoGearScenarioModeSelect !== 'undefined') {
         resolvedHandle = autoGearScenarioModeSelect;
@@ -3478,15 +3541,12 @@ if (settingsButton && settingsDialog) {
     } catch (resolveAutoGearScenarioModeSelectError) {
       void resolveAutoGearScenarioModeSelectError;
     }
-
     if (!resolvedHandle) {
       var scope = typeof globalThis !== 'undefined' && globalThis || typeof window !== 'undefined' && window || typeof self !== 'undefined' && self || typeof global !== 'undefined' && global || null;
-
       if (scope && _typeof(scope) === 'object' && 'autoGearScenarioModeSelect' in scope) {
         resolvedHandle = scope.autoGearScenarioModeSelect || null;
       }
     }
-
     if (!resolvedHandle && typeof document !== 'undefined' && document && typeof document.getElementById === 'function') {
       try {
         resolvedHandle = document.getElementById('autoGearScenarioMode') || null;
@@ -3494,17 +3554,14 @@ if (settingsButton && settingsDialog) {
         void resolveAutoGearScenarioModeSelectElementError;
       }
     }
-
     return resolvedHandle;
   }();
-
   if (autoGearScenarioModeSelectHandle && typeof autoGearScenarioModeSelectHandle.addEventListener === 'function') {
     autoGearScenarioModeSelectHandle.addEventListener('change', function () {
       if (autoGearEditorDraft) {
         var selectValue = typeof autoGearScenarioModeSelectHandle.value === 'string' ? autoGearScenarioModeSelectHandle.value : '';
         autoGearEditorDraft.scenarioLogic = normalizeAutoGearScenarioLogic(selectValue);
       }
-
       applyAutoGearScenarioSettings(getAutoGearScenarioSelectedValues());
     });
   }
@@ -3696,11 +3753,11 @@ if (settingsButton && settingsDialog) {
         var itemId = target.dataset.itemId;
         if (!autoGearEditorDraft || !itemId) return;
         var list = normalizedType === 'remove' ? autoGearEditorDraft.remove : autoGearEditorDraft.add;
-        var index = list.findIndex(function (item) {
+        var _index4 = list.findIndex(function (item) {
           return item.id === itemId;
         });
-        if (index >= 0) {
-          list.splice(index, 1);
+        if (_index4 >= 0) {
+          list.splice(_index4, 1);
           if (autoGearEditorActiveItem && autoGearEditorActiveItem.listType === normalizedType && autoGearEditorActiveItem.itemId === itemId) {
             clearAutoGearDraftItemEdit(normalizedType, {
               skipRender: true
@@ -4091,8 +4148,8 @@ function sanitizeBackupPayload(raw) {
       try {
         var result = '';
         var CHUNK_SIZE = 0x8000;
-        for (var index = 0; index < array.length; index += CHUNK_SIZE) {
-          var slice = array.subarray(index, index + CHUNK_SIZE);
+        for (var _index5 = 0; _index5 < array.length; _index5 += CHUNK_SIZE) {
+          var slice = array.subarray(_index5, _index5 + CHUNK_SIZE);
           result += String.fromCharCode.apply(null, slice);
         }
         return result;
@@ -5470,12 +5527,12 @@ function formatDiffListIndex(part) {
   }
   var indexMatch = part.match(/^\[(\d+)\]$/);
   if (indexMatch) {
-    var index = Number(indexMatch[1]);
-    if (!Number.isFinite(index) || index < 0) {
+    var _index6 = Number(indexMatch[1]);
+    if (!Number.isFinite(_index6) || _index6 < 0) {
       return null;
     }
     var template = getDiffText('versionCompareListItemLabel', 'Item %s');
-    return template.replace('%s', formatNumberForComparison(index + 1));
+    return template.replace('%s', formatNumberForComparison(_index6 + 1));
   }
   var keyedSegment = parseKeyedDiffPathSegment(part);
   if (keyedSegment) {
@@ -5659,26 +5716,26 @@ function computeSetupDiff(baseline, comparison) {
         return;
       }
       var maxLength = Math.max(baseValue.length, compareValue.length);
-      for (var index = 0; index < maxLength; index += 1) {
-        var hasBase = index < baseValue.length;
-        var hasCompare = index < compareValue.length;
-        var nextPath = path.concat("[".concat(index, "]"));
+      for (var _index7 = 0; _index7 < maxLength; _index7 += 1) {
+        var hasBase = _index7 < baseValue.length;
+        var hasCompare = _index7 < compareValue.length;
+        var nextPath = path.concat("[".concat(_index7, "]"));
         if (!hasBase) {
           entries.push({
             type: 'added',
             path: nextPath,
             before: undefined,
-            after: compareValue[index]
+            after: compareValue[_index7]
           });
         } else if (!hasCompare) {
           entries.push({
             type: 'removed',
             path: nextPath,
-            before: baseValue[index],
+            before: baseValue[_index7],
             after: undefined
           });
         } else {
-          walk(baseValue[index], compareValue[index], nextPath);
+          walk(baseValue[_index7], compareValue[_index7], nextPath);
         }
       }
       return;
@@ -6193,11 +6250,20 @@ function applyPreferencesFromStorage(safeGetItem) {
       }
     }
     if (parsedVoltages) {
-      applyMountVoltagePreferences(parsedVoltages, {
+      applySessionMountVoltagePreferences(parsedVoltages, {
         persist: shouldPersistVoltages,
         triggerUpdate: true
       });
-      updateMountVoltageInputsFromState();
+      var updateMountVoltageInputsFromStateFn = getSessionRuntimeFunction('updateMountVoltageInputsFromState');
+      if (updateMountVoltageInputsFromStateFn) {
+        try {
+          updateMountVoltageInputsFromStateFn();
+        } catch (updateError) {
+          warnMissingMountVoltageHelper('updateMountVoltageInputsFromState', updateError);
+        }
+      } else {
+        warnMissingMountVoltageHelper('updateMountVoltageInputsFromState');
+      }
       rememberSettingsMountVoltagesBaseline();
     }
   } catch (voltageError) {
@@ -6725,7 +6791,7 @@ function handleRestoreSettingsInputChange() {
       console.warn('Failed to restore sessionStorage snapshot after restore failure', sessionError);
     }
     try {
-      loadStoredLogoPreview();
+      safeLoadStoredLogoPreview();
     } catch (logoError) {
       console.warn('Failed to refresh logo preview after restore failure', logoError);
     }
@@ -6831,7 +6897,7 @@ function handleRestoreSettingsInputChange() {
         });
       }
       try {
-        loadStoredLogoPreview();
+        safeLoadStoredLogoPreview();
       } catch (logoError) {
         console.warn('Failed to refresh logo preview after restore', logoError);
       }
@@ -7181,9 +7247,7 @@ function resetPlannerStateAfterFactoryReset() {
     console.warn('Failed to reset battery options during factory reset', error);
   }
   try {
-    if (typeof loadStoredLogoPreview === 'function') {
-      loadStoredLogoPreview();
-    }
+    safeLoadStoredLogoPreview();
   } catch (error) {
     console.warn('Failed to reset custom logo preview during factory reset', error);
   }
@@ -7307,11 +7371,21 @@ if (factoryResetButton) {
         console.warn('Failed to reset accent color during factory reset', accentError);
       }
       try {
-        resetMountVoltagePreferences({
-          persist: true,
-          triggerUpdate: true
-        });
-        updateMountVoltageInputsFromState();
+        var resetMountVoltagePreferencesFn = getSessionRuntimeFunction('resetMountVoltagePreferences');
+        if (resetMountVoltagePreferencesFn) {
+          resetMountVoltagePreferencesFn({
+            persist: true,
+            triggerUpdate: true
+          });
+        } else {
+          warnMissingMountVoltageHelper('resetMountVoltagePreferences');
+        }
+        var updateMountVoltageInputsFromStateFn = getSessionRuntimeFunction('updateMountVoltageInputsFromState');
+        if (updateMountVoltageInputsFromStateFn) {
+          updateMountVoltageInputsFromStateFn();
+        } else {
+          warnMissingMountVoltageHelper('updateMountVoltageInputsFromState');
+        }
         rememberSettingsMountVoltagesBaseline();
       } catch (voltageResetError) {
         console.warn('Failed to reset mount voltages during factory reset', voltageResetError);
@@ -7742,8 +7816,8 @@ function copyTextToClipboardBestEffort(text) {
     }
   }
 }
-if (downloadDiagramBtn) {
-  downloadDiagramBtn.addEventListener('click', function (e) {
+if (downloadDiagramButton) {
+  downloadDiagramButton.addEventListener('click', function (e) {
     var source = exportDiagramSvg();
     if (!source) return;
     copyTextToClipboardBestEffort(source);
@@ -7788,11 +7862,11 @@ if (downloadDiagramBtn) {
     }
   });
 }
-if (gridSnapToggleBtn) {
-  gridSnapToggleBtn.addEventListener('click', function () {
+if (gridSnapToggleButton) {
+  gridSnapToggleButton.addEventListener('click', function () {
     gridSnap = !gridSnap;
-    gridSnapToggleBtn.classList.toggle('active', gridSnap);
-    gridSnapToggleBtn.setAttribute('aria-pressed', gridSnap ? 'true' : 'false');
+    gridSnapToggleButton.classList.toggle('active', gridSnap);
+    gridSnapToggleButton.setAttribute('aria-pressed', gridSnap ? 'true' : 'false');
     if (setupDiagramContainer) {
       setupDiagramContainer.classList.toggle('grid-snap', gridSnap);
     }
@@ -8172,7 +8246,9 @@ if (helpButton && helpDialog) {
       normalized = normalized.normalize('NFD');
     }
     normalized = normalized.replace(/[\u0300-\u036f]/g, '').replace(/ß/g, 'ss').replace(/æ/g, 'ae').replace(/œ/g, 'oe').replace(/ø/g, 'o').replace(/&/g, 'and').replace(/\+/g, 'plus').replace(/[°º˚]/g, 'deg').replace(/\bdegrees?\b/g, 'deg').replace(/[×✕✖✗✘]/g, 'x');
-    normalized = normalizeSpellingVariants(normalized);
+    if (typeof normalizeSpellingVariants === 'function') {
+      normalized = normalizeSpellingVariants(normalized);
+    }
     normalized = normaliseMarkVariants(normalized);
     return normalized.replace(/[^a-z0-9]+/g, '');
   };
@@ -9754,16 +9830,12 @@ function initApp() {
   populateUserButtonDropdowns();
   document.querySelectorAll('#projectForm select').forEach(function (sel) {
     attachSelectSearch(sel);
-    initFavoritableSelect(sel);
+    callSessionCoreFunction('initFavoritableSelect', [sel], {
+      defer: true
+    });
   });
-  if (
-    typeof globalThis !== 'undefined' &&
-    globalThis &&
-    typeof globalThis.setupInstallBanner === 'function'
-  ) {
+  if (typeof globalThis !== 'undefined' && typeof globalThis.setupInstallBanner === 'function') {
     globalThis.setupInstallBanner();
-  } else if (typeof setupInstallBanner === 'function') {
-    setupInstallBanner();
   }
   setLanguage(currentLang);
   maybeShowIosPwaHelp();
@@ -9833,7 +9905,7 @@ function updateFeedbackTemperatureOptionsSafe() {
       option.textContent = '';
       return;
     }
-    option.textContent = "".concat(option.value, "°C");
+    option.textContent = "".concat(option.value, "\xB0C");
   });
 }
 function populateEnvironmentDropdowns() {
@@ -10782,6 +10854,11 @@ if (typeof module !== "undefined" && module.exports) {
         pendingSharedLinkListener = typeof listener === 'function' ? listener : null;
       }
     },
+    __mountVoltageInternals: {
+      getSessionMountVoltagePreferencesClone: getSessionMountVoltagePreferencesClone,
+      applySessionMountVoltagePreferences: applySessionMountVoltagePreferences,
+      cloneMountVoltageDefaultsForSession: cloneMountVoltageDefaultsForSession
+    },
     collectAutoGearCatalogNames: collectAutoGearCatalogNames,
     buildDefaultVideoDistributionAutoGearRules: buildDefaultVideoDistributionAutoGearRules,
     applyAutoGearRulesToTableHtml: applyAutoGearRulesToTableHtml,
@@ -10811,45 +10888,175 @@ if (typeof module !== "undefined" && module.exports) {
     }
   };
 }
+var missingMountVoltageWarnings = new Set();
+function warnMissingMountVoltageHelper(helperName, error) {
+  var key = typeof helperName === 'string' && helperName ? helperName : 'unknown';
+  if (missingMountVoltageWarnings.has(key)) {
+    return;
+  }
+  missingMountVoltageWarnings.add(key);
+  if (typeof console !== 'undefined' && typeof console.warn === 'function') {
+    var message = "Mount voltage helper \"".concat(key, "\" is unavailable; using defaults to protect user data.");
+    if (error) {
+      console.warn(message, error);
+    } else {
+      console.warn(message);
+    }
+  }
+}
+function cloneMountVoltageDefaultsForSession() {
+  var runtimeCloneMountVoltageMap = getSessionRuntimeFunction('cloneMountVoltageMap');
+  if (runtimeCloneMountVoltageMap) {
+    try {
+      return runtimeCloneMountVoltageMap(DEFAULT_MOUNT_VOLTAGES);
+    } catch (cloneError) {
+      warnMissingMountVoltageHelper('cloneMountVoltageMap', cloneError);
+    }
+  } else {
+    warnMissingMountVoltageHelper('cloneMountVoltageMap');
+  }
+  if (DEFAULT_MOUNT_VOLTAGES && (typeof DEFAULT_MOUNT_VOLTAGES === "undefined" ? "undefined" : _typeof(DEFAULT_MOUNT_VOLTAGES)) === 'object') {
+    try {
+      return JSON.parse(JSON.stringify(DEFAULT_MOUNT_VOLTAGES));
+    } catch (serializationError) {
+      void serializationError;
+    }
+  }
+  var clone = {};
+  var parse = typeof parseVoltageValue === 'function' ? function (value, fallback) {
+    return parseVoltageValue(value, fallback);
+  } : function (value, fallback) {
+    var numeric = Number(value);
+    if (Number.isFinite(numeric)) {
+      return numeric;
+    }
+    var fallbackNumeric = Number(fallback);
+    return Number.isFinite(fallbackNumeric) ? fallbackNumeric : 0;
+  };
+  if (Array.isArray(SUPPORTED_MOUNT_VOLTAGE_TYPES)) {
+    SUPPORTED_MOUNT_VOLTAGE_TYPES.forEach(function (type) {
+      var _DEFAULT_MOUNT_VOLTAG;
+      var defaults = ((_DEFAULT_MOUNT_VOLTAG = DEFAULT_MOUNT_VOLTAGES) === null || _DEFAULT_MOUNT_VOLTAG === void 0 ? void 0 : _DEFAULT_MOUNT_VOLTAG[type]) || {};
+      clone[type] = {
+        high: parse(defaults.high, defaults.high),
+        low: parse(defaults.low, defaults.low)
+      };
+    });
+  }
+  return clone;
+}
+function getSessionMountVoltagePreferencesClone() {
+  var getMountVoltagePreferencesCloneFn = getSessionRuntimeFunction('getMountVoltagePreferencesClone');
+  if (getMountVoltagePreferencesCloneFn) {
+    try {
+      var clone = getMountVoltagePreferencesCloneFn();
+      if (clone && _typeof(clone) === 'object') {
+        return clone;
+      }
+    } catch (helperError) {
+      warnMissingMountVoltageHelper('getMountVoltagePreferencesClone', helperError);
+    }
+  } else {
+    warnMissingMountVoltageHelper('getMountVoltagePreferencesClone');
+  }
+  return cloneMountVoltageDefaultsForSession();
+}
+function applySessionMountVoltagePreferences(preferences) {
+  var options = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+  var applyMountVoltagePreferencesFn = getSessionRuntimeFunction('applyMountVoltagePreferences');
+  if (applyMountVoltagePreferencesFn) {
+    try {
+      applyMountVoltagePreferencesFn(preferences, options);
+      return;
+    } catch (helperError) {
+      warnMissingMountVoltageHelper('applyMountVoltagePreferences', helperError);
+    }
+  } else {
+    warnMissingMountVoltageHelper('applyMountVoltagePreferences');
+  }
+  if (options && options.triggerUpdate) {
+    var updateMountVoltageInputsFromStateFn = getSessionRuntimeFunction('updateMountVoltageInputsFromState');
+    if (updateMountVoltageInputsFromStateFn) {
+      try {
+        updateMountVoltageInputsFromStateFn();
+      } catch (updateError) {
+        void updateError;
+      }
+    }
+  }
+}
 function rememberSettingsMountVoltagesBaseline() {
-  settingsInitialMountVoltages = getMountVoltagePreferencesClone();
+  settingsInitialMountVoltages = getSessionMountVoltagePreferencesClone();
 }
 function revertSettingsMountVoltagesIfNeeded() {
-  var baseline = settingsInitialMountVoltages || getMountVoltagePreferencesClone();
-  var current = getMountVoltagePreferencesClone();
+  var baseline = settingsInitialMountVoltages || getSessionMountVoltagePreferencesClone();
+  var current = getSessionMountVoltagePreferencesClone();
   var changed = SUPPORTED_MOUNT_VOLTAGE_TYPES.some(function (type) {
     var baselineEntry = baseline[type] || DEFAULT_MOUNT_VOLTAGES[type];
     var currentEntry = current[type] || DEFAULT_MOUNT_VOLTAGES[type];
     return Number(baselineEntry.high) !== Number(currentEntry.high) || Number(baselineEntry.low) !== Number(currentEntry.low);
   });
   if (changed) {
-    applyMountVoltagePreferences(baseline, {
+    applySessionMountVoltagePreferences(baseline, {
       persist: true,
       triggerUpdate: true
     });
   } else {
-    updateMountVoltageInputsFromState();
+    var updateMountVoltageInputsFromStateFn = getSessionRuntimeFunction('updateMountVoltageInputsFromState');
+    if (updateMountVoltageInputsFromStateFn) {
+      try {
+        updateMountVoltageInputsFromStateFn();
+      } catch (updateError) {
+        warnMissingMountVoltageHelper('updateMountVoltageInputsFromState', updateError);
+      }
+    } else {
+      warnMissingMountVoltageHelper('updateMountVoltageInputsFromState');
+    }
   }
 }
 function collectMountVoltageFormValues() {
-  var updated = getMountVoltagePreferencesClone();
+  var updated = getSessionMountVoltagePreferencesClone();
+  var parse = typeof parseVoltageValue === 'function' ? function (value, fallback) {
+    return parseVoltageValue(value, fallback);
+  } : function (value, fallback) {
+    var numeric = Number(value);
+    if (Number.isFinite(numeric)) {
+      return numeric;
+    }
+    var fallbackNumeric = Number(fallback);
+    return Number.isFinite(fallbackNumeric) ? fallbackNumeric : 0;
+  };
+  var defaultClones = cloneMountVoltageDefaultsForSession();
   SUPPORTED_MOUNT_VOLTAGE_TYPES.forEach(function (type) {
-    var _mountVoltageInputs;
+    var _mountVoltageInputs, _DEFAULT_MOUNT_VOLTAG2;
     var fields = (_mountVoltageInputs = mountVoltageInputs) === null || _mountVoltageInputs === void 0 ? void 0 : _mountVoltageInputs[type];
     if (!fields) return;
-    var baselineEntry = updated[type] || DEFAULT_MOUNT_VOLTAGES[type];
+    var defaults = ((_DEFAULT_MOUNT_VOLTAG2 = DEFAULT_MOUNT_VOLTAGES) === null || _DEFAULT_MOUNT_VOLTAG2 === void 0 ? void 0 : _DEFAULT_MOUNT_VOLTAG2[type]) || {
+      high: 0,
+      low: 0
+    };
+    var target = updated[type];
+    if (!target || _typeof(target) !== 'object') {
+      target = defaultClones[type] ? _objectSpread({}, defaultClones[type]) : {
+        high: defaults.high,
+        low: defaults.low
+      };
+      updated[type] = target;
+    }
     if (fields.high) {
-      updated[type].high = parseVoltageValue(fields.high.value, baselineEntry.high);
+      var _target$high;
+      target.high = parse(fields.high.value, (_target$high = target.high) !== null && _target$high !== void 0 ? _target$high : defaults.high);
     }
     if (fields.low) {
-      updated[type].low = parseVoltageValue(fields.low.value, baselineEntry.low);
+      var _target$low;
+      target.low = parse(fields.low.value, (_target$low = target.low) !== null && _target$low !== void 0 ? _target$low : defaults.low);
     }
   });
   return updated;
 }
 function handleMountVoltageInputChange() {
   var values = collectMountVoltageFormValues();
-  applyMountVoltagePreferences(values, {
+  applySessionMountVoltagePreferences(values, {
     persist: false,
     triggerUpdate: true
   });

--- a/legacy/scripts/app-setups.js
+++ b/legacy/scripts/app-setups.js
@@ -1,9 +1,4 @@
 function _createForOfIteratorHelper(r, e) { var t = "undefined" != typeof Symbol && r[Symbol.iterator] || r["@@iterator"]; if (!t) { if (Array.isArray(r) || (t = _unsupportedIterableToArray(r)) || e && r && "number" == typeof r.length) { t && (r = t); var _n = 0, F = function F() {}; return { s: F, n: function n() { return _n >= r.length ? { done: !0 } : { done: !1, value: r[_n++] }; }, e: function e(r) { throw r; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var o, a = !0, u = !1; return { s: function s() { t = t.call(r); }, n: function n() { var r = t.next(); return a = r.done, r; }, e: function e(r) { u = !0, o = r; }, f: function f() { try { a || null == t.return || t.return(); } finally { if (u) throw o; } } }; }
-function ownKeys(e, r) { var t = Object.keys(e); if (Object.getOwnPropertySymbols) { var o = Object.getOwnPropertySymbols(e); r && (o = o.filter(function (r) { return Object.getOwnPropertyDescriptor(e, r).enumerable; })), t.push.apply(t, o); } return t; }
-function _objectSpread(e) { for (var r = 1; r < arguments.length; r++) { var t = null != arguments[r] ? arguments[r] : {}; r % 2 ? ownKeys(Object(t), !0).forEach(function (r) { _defineProperty(e, r, t[r]); }) : Object.getOwnPropertyDescriptors ? Object.defineProperties(e, Object.getOwnPropertyDescriptors(t)) : ownKeys(Object(t)).forEach(function (r) { Object.defineProperty(e, r, Object.getOwnPropertyDescriptor(t, r)); }); } return e; }
-function _defineProperty(e, r, t) { return (r = _toPropertyKey(r)) in e ? Object.defineProperty(e, r, { value: t, enumerable: !0, configurable: !0, writable: !0 }) : e[r] = t, e; }
-function _toPropertyKey(t) { var i = _toPrimitive(t, "string"); return "symbol" == _typeof(i) ? i : i + ""; }
-function _toPrimitive(t, r) { if ("object" != _typeof(t) || !t) return t; var e = t[Symbol.toPrimitive]; if (void 0 !== e) { var i = e.call(t, r || "default"); if ("object" != _typeof(i)) return i; throw new TypeError("@@toPrimitive must return a primitive value."); } return ("string" === r ? String : Number)(t); }
 function _toConsumableArray(r) { return _arrayWithoutHoles(r) || _iterableToArray(r) || _unsupportedIterableToArray(r) || _nonIterableSpread(); }
 function _nonIterableSpread() { throw new TypeError("Invalid attempt to spread non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
 function _iterableToArray(r) { if ("undefined" != typeof Symbol && null != r[Symbol.iterator] || null != r["@@iterator"]) return Array.from(r); }
@@ -14,6 +9,11 @@ function _unsupportedIterableToArray(r, a) { if (r) { if ("string" == typeof r) 
 function _arrayLikeToArray(r, a) { (null == a || a > r.length) && (a = r.length); for (var e = 0, n = Array(a); e < a; e++) n[e] = r[e]; return n; }
 function _iterableToArrayLimit(r, l) { var t = null == r ? null : "undefined" != typeof Symbol && r[Symbol.iterator] || r["@@iterator"]; if (null != t) { var e, n, i, u, a = [], f = !0, o = !1; try { if (i = (t = t.call(r)).next, 0 === l) { if (Object(t) !== t) return; f = !1; } else for (; !(f = (e = i.call(t)).done) && (a.push(e.value), a.length !== l); f = !0); } catch (r) { o = !0, n = r; } finally { try { if (!f && null != t.return && (u = t.return(), Object(u) !== u)) return; } finally { if (o) throw n; } } return a; } }
 function _arrayWithHoles(r) { if (Array.isArray(r)) return r; }
+function ownKeys(e, r) { var t = Object.keys(e); if (Object.getOwnPropertySymbols) { var o = Object.getOwnPropertySymbols(e); r && (o = o.filter(function (r) { return Object.getOwnPropertyDescriptor(e, r).enumerable; })), t.push.apply(t, o); } return t; }
+function _objectSpread(e) { for (var r = 1; r < arguments.length; r++) { var t = null != arguments[r] ? arguments[r] : {}; r % 2 ? ownKeys(Object(t), !0).forEach(function (r) { _defineProperty(e, r, t[r]); }) : Object.getOwnPropertyDescriptors ? Object.defineProperties(e, Object.getOwnPropertyDescriptors(t)) : ownKeys(Object(t)).forEach(function (r) { Object.defineProperty(e, r, Object.getOwnPropertyDescriptor(t, r)); }); } return e; }
+function _defineProperty(e, r, t) { return (r = _toPropertyKey(r)) in e ? Object.defineProperty(e, r, { value: t, enumerable: !0, configurable: !0, writable: !0 }) : e[r] = t, e; }
+function _toPropertyKey(t) { var i = _toPrimitive(t, "string"); return "symbol" == _typeof(i) ? i : i + ""; }
+function _toPrimitive(t, r) { if ("object" != _typeof(t) || !t) return t; var e = t[Symbol.toPrimitive]; if (void 0 !== e) { var i = e.call(t, r || "default"); if ("object" != _typeof(i)) return i; throw new TypeError("@@toPrimitive must return a primitive value."); } return ("string" === r ? String : Number)(t); }
 function _typeof(o) { "@babel/helpers - typeof"; return _typeof = "function" == typeof Symbol && "symbol" == typeof Symbol.iterator ? function (o) { return typeof o; } : function (o) { return o && "function" == typeof Symbol && o.constructor === Symbol && o !== Symbol.prototype ? "symbol" : typeof o; }, _typeof(o); }
 var AUTO_GEAR_ANY_MOTOR_TOKEN_FALLBACK = typeof globalThis !== 'undefined' && globalThis.AUTO_GEAR_ANY_MOTOR_TOKEN ? globalThis.AUTO_GEAR_ANY_MOTOR_TOKEN : '__any__';
 function hasMeaningfulPowerSelection(value) {
@@ -37,7 +37,72 @@ function assignSelectValue(select, value) {
     select.value = value;
   }
 }
-
+function getGlobalScope() {
+  return typeof globalThis !== 'undefined' && globalThis || typeof window !== 'undefined' && window || typeof self !== 'undefined' && self || typeof global !== 'undefined' && global || null;
+}
+function resolveElementById(id, globalName) {
+  var doc = typeof document !== 'undefined' ? document : null;
+  if (doc && typeof doc.getElementById === 'function') {
+    var element = doc.getElementById(id);
+    if (element) {
+      return element;
+    }
+  }
+  var scope = getGlobalScope();
+  if (scope && globalName && _typeof(scope) === 'object') {
+    try {
+      var candidate = scope[globalName];
+      if (candidate) {
+        return candidate;
+      }
+    } catch (error) {
+      void error;
+    }
+  }
+  return null;
+}
+function buildShareUiContext() {
+  return {
+    dialog: resolveElementById('shareDialog', 'shareDialog'),
+    form: resolveElementById('shareForm', 'shareForm'),
+    filenameInput: resolveElementById('shareFilename', 'shareFilenameInput'),
+    filenameMessage: resolveElementById('shareFilenameMessage', 'shareFilenameMessage'),
+    linkMessage: resolveElementById('shareLinkMessage', 'shareLinkMessage'),
+    includeAutoGearCheckbox: resolveElementById('shareIncludeAutoGear', 'shareIncludeAutoGearCheckbox'),
+    includeAutoGearLabel: resolveElementById('shareIncludeAutoGearLabel', 'shareIncludeAutoGearLabelElem'),
+    cancelButton: resolveElementById('shareCancelBtn', 'shareCancelBtn'),
+    sharedLinkInput: resolveElementById('sharedLinkInput', 'sharedLinkInput'),
+    applySharedLinkButton: resolveElementById('applySharedLinkBtn', 'applySharedLinkBtn')
+  };
+}
+function buildSharedImportUiContext() {
+  return {
+    dialog: resolveElementById('sharedImportDialog', 'sharedImportDialog'),
+    form: resolveElementById('sharedImportForm', 'sharedImportForm'),
+    modeSelect: resolveElementById('sharedImportModeSelect', 'sharedImportModeSelect'),
+    cancelButton: resolveElementById('sharedImportCancelBtn', 'sharedImportCancelBtn')
+  };
+}
+var cachedShareUiContext = null;
+var cachedSharedImportUiContext = null;
+function getShareUiContext(scope) {
+  if (scope && _typeof(scope) === 'object' && scope.context && _typeof(scope.context) === 'object') {
+    return scope.context;
+  }
+  if (!cachedShareUiContext) {
+    cachedShareUiContext = buildShareUiContext();
+  }
+  return cachedShareUiContext;
+}
+function getSharedImportUiContext(scope) {
+  if (scope && _typeof(scope) === 'object' && scope.context && _typeof(scope.context) === 'object') {
+    return scope.context;
+  }
+  if (!cachedSharedImportUiContext) {
+    cachedSharedImportUiContext = buildSharedImportUiContext();
+  }
+  return cachedSharedImportUiContext;
+}
 function callSetupsCoreFunction(functionName) {
   var args = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : [];
   var options = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {};
@@ -68,7 +133,6 @@ function callSetupsCoreFunction(functionName) {
   }
   return options && Object.prototype.hasOwnProperty.call(options, 'defaultValue') ? options.defaultValue : undefined;
 }
-
 function getSetupsCoreValue(functionName) {
   var options = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
   var defaultValue = Object.prototype.hasOwnProperty.call(options, 'defaultValue') ? options.defaultValue : '';
@@ -176,7 +240,6 @@ function enqueueCineUiRegistration(callback) {
   }
   scope[key].push(callback);
 }
-enqueueCineUiRegistration(registerSetupsCineUiInternal);
 function getPowerSelectionSnapshot() {
   if (!batterySelect && !batteryPlateSelect && !hotswapSelect) return null;
   var rawBattery = batterySelect ? normalizePowerSelectionString(batterySelect.value) : '';
@@ -364,6 +427,10 @@ if (projectForm) {
 function downloadSharedProject(shareFileName, includeAutoGear) {
   var _texts;
   if (!shareFileName) return;
+  var shareContext = getShareUiContext(this);
+  var shareLinkMessage = shareContext.linkMessage;
+  var shareIncludeAutoGearCheckbox = shareContext.includeAutoGearCheckbox;
+  var shareIncludeAutoGearLabelElem = shareContext.includeAutoGearLabel;
   var setupName = getCurrentProjectName();
   var readPowerSelectValue = function readPowerSelectValue(select) {
     return select && typeof select.value === 'string' ? normalizePowerSelectionString(select.value) : '';
@@ -510,6 +577,13 @@ function downloadSharedProject(shareFileName, includeAutoGear) {
   }
 }
 function handleShareSetupClick() {
+  var shareContext = getShareUiContext(this);
+  var shareDialog = shareContext.dialog;
+  var shareForm = shareContext.form;
+  var shareFilenameInput = shareContext.filenameInput;
+  var shareFilenameMessage = shareContext.filenameMessage;
+  var shareIncludeAutoGearCheckbox = shareContext.includeAutoGearCheckbox;
+  var shareIncludeAutoGearLabelElem = shareContext.includeAutoGearLabel;
   saveCurrentGearList();
   var setupName = getCurrentProjectName();
   var defaultName = getDefaultShareFilename(setupName);
@@ -562,9 +636,16 @@ function handleShareSetupClick() {
     }, 0);
   }
 }
-shareSetupBtn.addEventListener('click', handleShareSetupClick);
+var shareSetupButton = resolveElementById('shareSetupBtn', 'shareSetupBtn');
+if (shareSetupButton) {
+  shareSetupButton.addEventListener('click', handleShareSetupClick);
+}
 function handleShareFormSubmit(event) {
   event.preventDefault();
+  var shareContext = getShareUiContext(this);
+  var shareFilenameInput = shareContext.filenameInput;
+  var shareDialog = shareContext.dialog;
+  var shareIncludeAutoGearCheckbox = shareContext.includeAutoGearCheckbox;
   if (!shareFilenameInput) return;
   var sanitized = sanitizeShareFilename(shareFilenameInput.value);
   if (!sanitized) {
@@ -579,39 +660,47 @@ function handleShareFormSubmit(event) {
   closeDialog(shareDialog);
   downloadSharedProject(shareFileName, includeAutoGear);
 }
-if (shareForm) {
-  shareForm.addEventListener('submit', handleShareFormSubmit);
-}
 function handleShareCancelClick() {
+  var shareContext = getShareUiContext(this);
+  var shareFilenameInput = shareContext.filenameInput;
+  var shareDialog = shareContext.dialog;
   if (shareFilenameInput) {
     shareFilenameInput.setCustomValidity('');
   }
   closeDialog(shareDialog);
-}
-if (shareCancelBtn) {
-  shareCancelBtn.addEventListener('click', handleShareCancelClick);
 }
 function handleShareDialogCancel(event) {
   event.preventDefault();
+  var shareContext = getShareUiContext(this);
+  var shareFilenameInput = shareContext.filenameInput;
+  var shareDialog = shareContext.dialog;
   if (shareFilenameInput) {
     shareFilenameInput.setCustomValidity('');
   }
   closeDialog(shareDialog);
 }
-if (shareDialog) {
-  shareDialog.addEventListener('cancel', handleShareDialogCancel);
+var initialShareUiContext = getShareUiContext();
+if (initialShareUiContext.form) {
+  initialShareUiContext.form.addEventListener('submit', handleShareFormSubmit);
+}
+if (initialShareUiContext.cancelButton) {
+  initialShareUiContext.cancelButton.addEventListener('click', handleShareCancelClick);
+}
+if (initialShareUiContext.dialog) {
+  initialShareUiContext.dialog.addEventListener('cancel', handleShareDialogCancel);
 }
 function handleSharedLinkInputChange() {
-  if (pendingSharedLinkListener) return;
+  var shareContext = getShareUiContext(this);
+  var sharedLinkInput = shareContext.sharedLinkInput;
+  if (!sharedLinkInput || pendingSharedLinkListener) return;
   var file = sharedLinkInput.files && sharedLinkInput.files[0];
   if (file) {
     readSharedProjectFile(file);
   }
 }
-if (sharedLinkInput) {
-  sharedLinkInput.addEventListener('change', handleSharedLinkInputChange);
-}
 function handleApplySharedLinkClick() {
+  var shareContext = getShareUiContext(this);
+  var sharedLinkInput = shareContext.sharedLinkInput;
   if (!sharedLinkInput) {
     return;
   }
@@ -635,40 +724,45 @@ function handleApplySharedLinkClick() {
     _handleSelection();
   }
 }
-if (applySharedLinkBtn && sharedLinkInput) {
-  applySharedLinkBtn.addEventListener('click', handleApplySharedLinkClick);
+if (initialShareUiContext.sharedLinkInput) {
+  initialShareUiContext.sharedLinkInput.addEventListener('change', handleSharedLinkInputChange);
+}
+if (initialShareUiContext.applySharedLinkButton && initialShareUiContext.sharedLinkInput) {
+  initialShareUiContext.applySharedLinkButton.addEventListener('click', handleApplySharedLinkClick);
 }
 function handleSharedImportModeChange() {
   if (sharedImportPromptActive) return;
   if (lastSharedSetupData === null) return;
   reapplySharedImportSelection();
 }
-if (sharedImportModeSelect) {
-  sharedImportModeSelect.addEventListener('change', handleSharedImportModeChange);
-}
 function handleSharedImportSubmit(event) {
   event.preventDefault();
   finalizeSharedImportPrompt();
   applyStoredSharedImport();
 }
-if (sharedImportForm) {
-  sharedImportForm.addEventListener('submit', handleSharedImportSubmit);
-}
 function handleSharedImportCancel() {
   finalizeSharedImportPrompt();
   clearStoredSharedImportData();
-}
-if (sharedImportCancelBtn) {
-  sharedImportCancelBtn.addEventListener('click', handleSharedImportCancel);
 }
 function handleSharedImportDialogCancel(event) {
   event.preventDefault();
   finalizeSharedImportPrompt();
   clearStoredSharedImportData();
 }
-if (sharedImportDialog) {
-  sharedImportDialog.addEventListener('cancel', handleSharedImportDialogCancel);
+var initialSharedImportUiContext = getSharedImportUiContext();
+if (initialSharedImportUiContext.modeSelect) {
+  initialSharedImportUiContext.modeSelect.addEventListener('change', handleSharedImportModeChange);
 }
+if (initialSharedImportUiContext.form) {
+  initialSharedImportUiContext.form.addEventListener('submit', handleSharedImportSubmit);
+}
+if (initialSharedImportUiContext.cancelButton) {
+  initialSharedImportUiContext.cancelButton.addEventListener('click', handleSharedImportCancel);
+}
+if (initialSharedImportUiContext.dialog) {
+  initialSharedImportUiContext.dialog.addEventListener('cancel', handleSharedImportDialogCancel);
+}
+enqueueCineUiRegistration(registerSetupsCineUiInternal);
 function getSafeLanguageTexts() {
   var scope = typeof globalThis !== 'undefined' && globalThis || typeof window !== 'undefined' && window || typeof self !== 'undefined' && self || typeof global !== 'undefined' && global || null;
   var allTexts = typeof texts !== 'undefined' && texts || (scope && _typeof(scope.texts) === 'object' ? scope.texts : null);
@@ -684,9 +778,12 @@ function registerSetupsCineUiInternal(cineUi) {
   if (!cineUi || setupsCineUiRegistered) {
     return;
   }
+  var shareContext = getShareUiContext();
+  var sharedImportContext = getSharedImportUiContext();
   registerCineUiEntries(cineUi.controllers, [{
     name: 'shareDialog',
     value: {
+      context: shareContext,
       open: handleShareSetupClick,
       submit: handleShareFormSubmit,
       cancel: handleShareCancelClick,
@@ -695,6 +792,7 @@ function registerSetupsCineUiInternal(cineUi) {
   }, {
     name: 'sharedImportDialog',
     value: {
+      context: sharedImportContext,
       submit: handleSharedImportSubmit,
       cancel: handleSharedImportCancel,
       dismiss: handleSharedImportDialogCancel,
@@ -3147,6 +3245,15 @@ function generateGearListHtml() {
   var supportAccNoCages = cameraSupportAcc.filter(function (item) {
     return !compatibleCages.includes(item);
   });
+  if (selectedNames.viewfinder) {
+    var normalizedSupport = new Set(supportAccNoCages.map(function (item) {
+      return normalizeGearNameForComparison(item);
+    }));
+    var normalizedViewfinder = normalizeGearNameForComparison(selectedNames.viewfinder);
+    if (!normalizedSupport.has(normalizedViewfinder)) {
+      supportAccNoCages.push(selectedNames.viewfinder);
+    }
+  }
   var scenarios = info.requiredScenarios ? info.requiredScenarios.split(',').map(function (s) {
     return s.trim();
   }).filter(Boolean) : [];
@@ -3755,9 +3862,6 @@ function generateGearListHtml() {
   addRow('Camera Batteries', batteryItems);
   var monitoringItems = '';
   var monitorSizes = [];
-  if (selectedNames.viewfinder) {
-    monitoringItems += "1x <strong>Viewfinder</strong> - ".concat(escapeHtml(addArriKNumber(selectedNames.viewfinder)));
-  }
   if (selectedNames.monitor) {
     var _devices2;
     var size = (_devices2 = devices) === null || _devices2 === void 0 || (_devices2 = _devices2.monitors) === null || _devices2 === void 0 || (_devices2 = _devices2[selectedNames.monitor]) === null || _devices2 === void 0 ? void 0 : _devices2.screenSizeInches;
@@ -4582,21 +4686,26 @@ function saveCurrentGearList() {
   var typedStorageKey = nameState ? nameState.typedName : fallbackNormalize(setupNameInput && typeof setupNameInput.value === 'string' ? setupNameInput.value : '');
   var projectStorageKey = nameState ? nameState.storageKey : selectedStorageKey || typedStorageKey;
   var renameInProgress = nameState ? nameState.renameInProgress : Boolean(selectedStorageKey && typedStorageKey && selectedStorageKey !== typedStorageKey);
+  var effectiveStorageKey = renameInProgress ? selectedStorageKey || projectStorageKey : projectStorageKey;
   var projectInfoForStorage = typeof createProjectInfoSnapshotForStorage === 'function' ? createProjectInfoSnapshotForStorage(currentProjectInfo, {
-    projectNameOverride: renameInProgress ? selectedStorageKey : undefined
+    projectNameOverride: renameInProgress ? selectedStorageKey || projectStorageKey : undefined
   }) : currentProjectInfo;
   var projectInfoSnapshot = cloneProjectInfoForStorage(projectInfoForStorage);
   var projectInfoSignature = projectInfoSnapshot ? stableStringify(projectInfoSnapshot) : '';
   var projectInfoSnapshotForSetups = projectInfoSnapshot ? cloneProjectInfoForStorage(projectInfoSnapshot) : null;
-  var projectRules = getProjectScopedAutoGearRules();
-  var diagramPositions = null;
+  var projectRulesRaw = getProjectScopedAutoGearRules();
+  var projectRulesSnapshot = projectRulesRaw && projectRulesRaw.length ? cloneProjectInfoForStorage(projectRulesRaw) : null;
+  var projectRulesSnapshotForSetups = projectRulesSnapshot ? cloneProjectInfoForStorage(projectRulesSnapshot) : null;
+  var diagramPositionsSnapshot = null;
+  var diagramPositionsSnapshotForSetups = null;
   if (typeof getDiagramManualPositions === 'function') {
     var positions = getDiagramManualPositions();
     if (positions && Object.keys(positions).length) {
-      diagramPositions = positions;
+      diagramPositionsSnapshot = cloneProjectInfoForStorage(positions);
+      diagramPositionsSnapshotForSetups = cloneProjectInfoForStorage(diagramPositionsSnapshot);
     }
   }
-  if (typeof saveProject === 'function' && typeof projectStorageKey === 'string' && projectStorageKey) {
+  if (typeof saveProject === 'function' && typeof effectiveStorageKey === 'string' && effectiveStorageKey) {
     var payload = {
       projectInfo: projectInfoSnapshot,
       gearList: html
@@ -4607,18 +4716,18 @@ function saveCurrentGearList() {
     if (hasGearSelectors) {
       payload.gearSelectors = gearSelectors;
     }
-    if (diagramPositions) {
-      payload.diagramPositions = diagramPositions;
+    if (diagramPositionsSnapshot) {
+      payload.diagramPositions = diagramPositionsSnapshot;
     }
-    if (projectRules && projectRules.length) {
-      payload.autoGearRules = projectRules;
+    if (projectRulesSnapshot && projectRulesSnapshot.length) {
+      payload.autoGearRules = projectRulesSnapshot;
     }
-    saveProject(projectStorageKey, payload);
+    saveProject(effectiveStorageKey, payload);
   }
   if (!selectedStorageKey) return;
   var setups = getSetups();
   var existing = setups[selectedStorageKey];
-  if (!existing && !html && !currentProjectInfo && !(projectRules && projectRules.length) && !diagramPositions) {
+  if (!existing && !html && !currentProjectInfo && !(projectRulesSnapshot && projectRulesSnapshot.length) && !diagramPositionsSnapshot) {
     return;
   }
   var setup = existing || {};
@@ -4643,11 +4752,11 @@ function saveCurrentGearList() {
     delete setup.projectInfo;
     changed = true;
   }
-  if (diagramPositions) {
+  if (diagramPositionsSnapshotForSetups) {
     var existingDiagramSig = setup.diagramPositions ? stableStringify(setup.diagramPositions) : '';
-    var newDiagramSig = stableStringify(diagramPositions);
+    var newDiagramSig = stableStringify(diagramPositionsSnapshotForSetups);
     if (existingDiagramSig !== newDiagramSig) {
-      setup.diagramPositions = diagramPositions;
+      setup.diagramPositions = diagramPositionsSnapshotForSetups;
       changed = true;
     }
   } else if (Object.prototype.hasOwnProperty.call(setup, 'diagramPositions')) {
@@ -4656,10 +4765,10 @@ function saveCurrentGearList() {
   }
   var existingRules = setup.autoGearRules;
   var existingRulesSig = existingRules && existingRules.length ? stableStringify(existingRules) : '';
-  var newRulesSig = projectRules && projectRules.length ? stableStringify(projectRules) : '';
+  var newRulesSig = projectRulesSnapshot && projectRulesSnapshot.length ? stableStringify(projectRulesSnapshot) : '';
   if (newRulesSig) {
     if (existingRulesSig !== newRulesSig) {
-      setup.autoGearRules = projectRules;
+      setup.autoGearRules = projectRulesSnapshotForSetups;
       changed = true;
     }
   } else if (Object.prototype.hasOwnProperty.call(setup, 'autoGearRules')) {

--- a/legacy/scripts/globals-bootstrap.js
+++ b/legacy/scripts/globals-bootstrap.js
@@ -1,23 +1,15 @@
+function _typeof(o) { "@babel/helpers - typeof"; return _typeof = "function" == typeof Symbol && "symbol" == typeof Symbol.iterator ? function (o) { return typeof o; } : function (o) { return o && "function" == typeof Symbol && o.constructor === Symbol && o !== Symbol.prototype ? "symbol" : typeof o; }, _typeof(o); }
 function __cineIsArray(value) {
   if (typeof Array !== 'undefined' && typeof Array.isArray === 'function') {
     return Array.isArray(value);
   }
-
   return Object.prototype.toString.call(value) === '[object Array]';
 }
-
 (function bootstrapCoreRuntimeGlobals() {
-  var scope =
-    (typeof globalThis !== 'undefined' && globalThis) ||
-    (typeof window !== 'undefined' && window) ||
-    (typeof self !== 'undefined' && self) ||
-    (typeof global !== 'undefined' && global) ||
-    null;
-
-  if (!scope || (typeof scope !== 'object' && typeof scope !== 'function')) {
+  var scope = typeof globalThis !== 'undefined' && globalThis || typeof window !== 'undefined' && window || typeof self !== 'undefined' && self || typeof global !== 'undefined' && global || null;
+  if (!scope || _typeof(scope) !== 'object' && typeof scope !== 'function') {
     return;
   }
-
   function ensureString(name, fallback) {
     var value;
     try {
@@ -26,20 +18,16 @@ function __cineIsArray(value) {
       value = undefined;
       void readError;
     }
-
     if (typeof value !== 'string') {
       value = fallback;
     }
-
     try {
       scope[name] = value;
     } catch (assignError) {
       void assignError;
     }
-
     return value;
   }
-
   function ensureArray(name) {
     var value;
     try {
@@ -48,20 +36,16 @@ function __cineIsArray(value) {
       value = undefined;
       void readError;
     }
-
     if (!__cineIsArray(value)) {
       value = [];
     }
-
     try {
       scope[name] = value;
     } catch (assignError) {
       void assignError;
     }
-
     return value;
   }
-
   function ensureFunction(name, fallback) {
     var value;
     try {
@@ -70,20 +54,16 @@ function __cineIsArray(value) {
       value = undefined;
       void readError;
     }
-
     if (typeof value !== 'function') {
       value = fallback;
     }
-
     try {
       scope[name] = value;
     } catch (assignError) {
       void assignError;
     }
-
     return value;
   }
-
   function ensureNullableObject(name) {
     var value;
     try {
@@ -92,25 +72,20 @@ function __cineIsArray(value) {
       value = undefined;
       void readError;
     }
-
     if (typeof value === 'undefined') {
       value = null;
     }
-
     try {
       scope[name] = value;
     } catch (assignError) {
       void assignError;
     }
-
     return value;
   }
-
   function fallbackSafeGenerateConnectorSummary(device) {
-    if (!device || typeof device !== 'object') {
+    if (!device || _typeof(device) !== 'object') {
       return '';
     }
-
     var keys;
     try {
       keys = Object.keys(device);
@@ -118,35 +93,24 @@ function __cineIsArray(value) {
       void keyError;
       return '';
     }
-
     if (!keys || !keys.length) {
       return '';
     }
-
     var primaryKey = keys[0];
     var value = device[primaryKey];
     var label = typeof primaryKey === 'string' ? primaryKey.replace(/_/g, ' ') : 'connector';
     return value ? label + ': ' + value : label;
   }
-
   ensureString('autoGearAutoPresetId', '');
   ensureArray('baseAutoGearRules');
   ensureNullableObject('autoGearScenarioModeSelect');
   ensureFunction('safeGenerateConnectorSummary', fallbackSafeGenerateConnectorSummary);
 })();
-
 function __cineResolveGlobalValue(name, fallback) {
-  var scope =
-    (typeof globalThis !== 'undefined' && globalThis) ||
-    (typeof window !== 'undefined' && window) ||
-    (typeof self !== 'undefined' && self) ||
-    (typeof global !== 'undefined' && global) ||
-    null;
-
-  if (!scope || (typeof scope !== 'object' && typeof scope !== 'function')) {
+  var scope = typeof globalThis !== 'undefined' && globalThis || typeof window !== 'undefined' && window || typeof self !== 'undefined' && self || typeof global !== 'undefined' && global || null;
+  if (!scope || _typeof(scope) !== 'object' && typeof scope !== 'function') {
     return fallback;
   }
-
   var value;
   try {
     value = scope[name];
@@ -154,58 +118,36 @@ function __cineResolveGlobalValue(name, fallback) {
     value = undefined;
     void readError;
   }
-
   return typeof value === 'undefined' ? fallback : value;
 }
-
-var autoGearAutoPresetId =
-  typeof autoGearAutoPresetId !== 'undefined'
-    ? autoGearAutoPresetId
-    : (function resolveAutoGearAutoPresetId() {
-        var value = __cineResolveGlobalValue('autoGearAutoPresetId', '');
-        return typeof value === 'string' ? value : '';
-      })();
-
-var baseAutoGearRules =
-  typeof baseAutoGearRules !== 'undefined'
-    ? baseAutoGearRules
-    : (function resolveBaseAutoGearRules() {
-        var value = __cineResolveGlobalValue('baseAutoGearRules', []);
-        return __cineIsArray(value) ? value : [];
-      })();
-
-var autoGearScenarioModeSelect =
-  typeof autoGearScenarioModeSelect !== 'undefined'
-    ? autoGearScenarioModeSelect
-    : __cineResolveGlobalValue('autoGearScenarioModeSelect', null);
-
-var safeGenerateConnectorSummary =
-  typeof safeGenerateConnectorSummary !== 'undefined'
-    ? safeGenerateConnectorSummary
-    : (function resolveSafeGenerateConnectorSummary() {
-        var value = __cineResolveGlobalValue('safeGenerateConnectorSummary', null);
-        return typeof value === 'function'
-          ? value
-          : function fallbackSafeGenerateConnectorSummary(device) {
-            if (!device || typeof device !== 'object') {
-              return '';
-            }
-
-            var keys;
-            try {
-              keys = Object.keys(device);
-            } catch (keyError) {
-              void keyError;
-              return '';
-            }
-
-              if (!keys || !keys.length) {
-                return '';
-              }
-
-              var primaryKey = keys[0];
-              var result = device[primaryKey];
-              var label = typeof primaryKey === 'string' ? primaryKey.replace(/_/g, ' ') : 'connector';
-              return result ? label + ': ' + result : label;
-            };
-      })();
+var autoGearAutoPresetId = typeof autoGearAutoPresetId !== 'undefined' ? autoGearAutoPresetId : function resolveAutoGearAutoPresetId() {
+  var value = __cineResolveGlobalValue('autoGearAutoPresetId', '');
+  return typeof value === 'string' ? value : '';
+}();
+var baseAutoGearRules = typeof baseAutoGearRules !== 'undefined' ? baseAutoGearRules : function resolveBaseAutoGearRules() {
+  var value = __cineResolveGlobalValue('baseAutoGearRules', []);
+  return __cineIsArray(value) ? value : [];
+}();
+var autoGearScenarioModeSelect = typeof autoGearScenarioModeSelect !== 'undefined' ? autoGearScenarioModeSelect : __cineResolveGlobalValue('autoGearScenarioModeSelect', null);
+var safeGenerateConnectorSummary = typeof safeGenerateConnectorSummary !== 'undefined' ? safeGenerateConnectorSummary : function resolveSafeGenerateConnectorSummary() {
+  var value = __cineResolveGlobalValue('safeGenerateConnectorSummary', null);
+  return typeof value === 'function' ? value : function fallbackSafeGenerateConnectorSummary(device) {
+    if (!device || _typeof(device) !== 'object') {
+      return '';
+    }
+    var keys;
+    try {
+      keys = Object.keys(device);
+    } catch (keyError) {
+      void keyError;
+      return '';
+    }
+    if (!keys || !keys.length) {
+      return '';
+    }
+    var primaryKey = keys[0];
+    var result = device[primaryKey];
+    var label = typeof primaryKey === 'string' ? primaryKey.replace(/_/g, ' ') : 'connector';
+    return result ? label + ': ' + result : label;
+  };
+}();

--- a/legacy/scripts/globals-legacy-shim.js
+++ b/legacy/scripts/globals-legacy-shim.js
@@ -1,0 +1,76 @@
+function _typeof(o) { "@babel/helpers - typeof"; return _typeof = "function" == typeof Symbol && "symbol" == typeof Symbol.iterator ? function (o) { return typeof o; } : function (o) { return o && "function" == typeof Symbol && o.constructor === Symbol && o !== Symbol.prototype ? "symbol" : typeof o; }, _typeof(o); }
+(function ensureLegacyCoreGlobals() {
+  var scope = typeof globalThis !== 'undefined' && globalThis || typeof window !== 'undefined' && window || typeof self !== 'undefined' && self || typeof global !== 'undefined' && global || null;
+  if (!scope || _typeof(scope) !== 'object' && typeof scope !== 'function') {
+    return;
+  }
+  function fallbackSafeGenerateConnectorSummary(device) {
+    if (!device || _typeof(device) !== 'object') {
+      return '';
+    }
+    try {
+      var keys = Object.keys(device);
+      if (!keys.length) {
+        return '';
+      }
+      var primaryKey = keys[0];
+      var value = device[primaryKey];
+      var label = typeof primaryKey === 'string' ? primaryKey.replace(/_/g, ' ') : 'connector';
+      return value ? label + ': ' + value : label;
+    } catch (error) {
+      void error;
+      return '';
+    }
+  }
+  function ensureBinding(name, validator, fallbackProvider) {
+    var value;
+    try {
+      value = scope[name];
+    } catch (readError) {
+      void readError;
+      value = undefined;
+    }
+    if (!validator(value)) {
+      try {
+        value = fallbackProvider();
+      } catch (fallbackError) {
+        void fallbackError;
+        value = undefined;
+      }
+    }
+    if (!validator(value)) {
+      return;
+    }
+    try {
+      scope[name] = value;
+    } catch (assignError) {
+      void assignError;
+    }
+    try {
+      var bind = scope.Function || Function;
+      bind('value', "try { if (typeof " + name + " === 'undefined') { " + name + " = value; } } catch (bindingError) { try { " + name + " = value; } catch (assignError) { void assignError; } } return value;")(value);
+    } catch (bindingError) {
+      void bindingError;
+    }
+  }
+  ensureBinding('autoGearAutoPresetId', function validateAutoPresetId(candidate) {
+    return typeof candidate === 'string';
+  }, function provideAutoPresetIdFallback() {
+    return '';
+  });
+  ensureBinding('baseAutoGearRules', function validateBaseRules(candidate) {
+    return Array.isArray(candidate);
+  }, function provideBaseRulesFallback() {
+    return [];
+  });
+  ensureBinding('autoGearScenarioModeSelect', function validateScenarioSelect(candidate) {
+    return candidate === null || _typeof(candidate) === 'object';
+  }, function provideScenarioSelectFallback() {
+    return null;
+  });
+  ensureBinding('safeGenerateConnectorSummary', function validateConnectorSummary(candidate) {
+    return typeof candidate === 'function';
+  }, function provideConnectorSummaryFallback() {
+    return fallbackSafeGenerateConnectorSummary;
+  });
+})();

--- a/legacy/scripts/modules/base.js
+++ b/legacy/scripts/modules/base.js
@@ -1,3 +1,9 @@
+function ownKeys(e, r) { var t = Object.keys(e); if (Object.getOwnPropertySymbols) { var o = Object.getOwnPropertySymbols(e); r && (o = o.filter(function (r) { return Object.getOwnPropertyDescriptor(e, r).enumerable; })), t.push.apply(t, o); } return t; }
+function _objectSpread(e) { for (var r = 1; r < arguments.length; r++) { var t = null != arguments[r] ? arguments[r] : {}; r % 2 ? ownKeys(Object(t), !0).forEach(function (r) { _defineProperty(e, r, t[r]); }) : Object.getOwnPropertyDescriptors ? Object.defineProperties(e, Object.getOwnPropertyDescriptors(t)) : ownKeys(Object(t)).forEach(function (r) { Object.defineProperty(e, r, Object.getOwnPropertyDescriptor(t, r)); }); } return e; }
+function _defineProperty(e, r, t) { return (r = _toPropertyKey(r)) in e ? Object.defineProperty(e, r, { value: t, enumerable: !0, configurable: !0, writable: !0 }) : e[r] = t, e; }
+function _toPropertyKey(t) { var i = _toPrimitive(t, "string"); return "symbol" == _typeof(i) ? i : i + ""; }
+function _toPrimitive(t, r) { if ("object" != _typeof(t) || !t) return t; var e = t[Symbol.toPrimitive]; if (void 0 !== e) { var i = e.call(t, r || "default"); if ("object" != _typeof(i)) return i; throw new TypeError("@@toPrimitive must return a primitive value."); } return ("string" === r ? String : Number)(t); }
+function _typeof(o) { "@babel/helpers - typeof"; return _typeof = "function" == typeof Symbol && "symbol" == typeof Symbol.iterator ? function (o) { return typeof o; } : function (o) { return o && "function" == typeof Symbol && o.constructor === Symbol && o !== Symbol.prototype ? "symbol" : typeof o; }, _typeof(o); }
 (function () {
   function detectGlobalScope() {
     if (typeof globalThis !== 'undefined') {
@@ -14,35 +20,28 @@
     }
     return {};
   }
-
   var PRIMARY_SCOPE = detectGlobalScope();
-
   function collectCandidateScopes(primary) {
     var scopes = [];
-
     function pushScope(scope) {
-      if (!scope || (typeof scope !== 'object' && typeof scope !== 'function')) {
+      if (!scope || _typeof(scope) !== 'object' && typeof scope !== 'function') {
         return;
       }
       if (scopes.indexOf(scope) === -1) {
         scopes.push(scope);
       }
     }
-
     pushScope(primary);
     if (typeof globalThis !== 'undefined') pushScope(globalThis);
     if (typeof window !== 'undefined') pushScope(window);
     if (typeof self !== 'undefined') pushScope(self);
     if (typeof global !== 'undefined') pushScope(global);
-
     return scopes;
   }
-
   function baseTryRequire(modulePath) {
     if (typeof require !== 'function') {
       return null;
     }
-
     try {
       return require(modulePath);
     } catch (error) {
@@ -50,29 +49,24 @@
       return null;
     }
   }
-
   function baseResolveModuleRegistry(scope) {
     var required = baseTryRequire('./registry.js');
-    if (required && typeof required === 'object') {
+    if (required && _typeof(required) === 'object') {
       return required;
     }
-
     var scopes = collectCandidateScopes(scope || PRIMARY_SCOPE);
     for (var index = 0; index < scopes.length; index += 1) {
       var candidate = scopes[index];
-      if (candidate && typeof candidate.cineModules === 'object') {
+      if (candidate && _typeof(candidate.cineModules) === 'object') {
         return candidate.cineModules;
       }
     }
-
     return null;
   }
-
   var cachedModuleRegistry = null;
   var hasResolvedRegistry = false;
-
   function getModuleRegistry(scope) {
-    if (!hasResolvedRegistry || (scope && scope !== PRIMARY_SCOPE)) {
+    if (!hasResolvedRegistry || scope && scope !== PRIMARY_SCOPE) {
       var resolved = baseResolveModuleRegistry(scope);
       if (scope && scope !== PRIMARY_SCOPE) {
         return resolved;
@@ -80,28 +74,23 @@
       cachedModuleRegistry = resolved;
       hasResolvedRegistry = true;
     }
-
     return cachedModuleRegistry;
   }
-
   var PENDING_QUEUE_KEY = '__cinePendingModuleRegistrations__';
-
   function ensureQueue(scope) {
-    if (!scope || typeof scope !== 'object') {
+    if (!scope || _typeof(scope) !== 'object') {
       return null;
     }
-
     var queue = scope[PENDING_QUEUE_KEY];
     if (Array.isArray(queue)) {
       return queue;
     }
-
     try {
       Object.defineProperty(scope, PENDING_QUEUE_KEY, {
         configurable: true,
         enumerable: false,
         writable: true,
-        value: [],
+        value: []
       });
       queue = scope[PENDING_QUEUE_KEY];
     } catch (error) {
@@ -116,41 +105,26 @@
         return null;
       }
     }
-
     return queue;
   }
-
-  function queueModuleRegistration(scope, name, api, options) {
+  function _queueModuleRegistration(scope, name, api, options) {
     var queue = ensureQueue(scope);
     if (!queue) {
       return false;
     }
-
     var payload = Object.freeze({
       name: name,
       api: api,
-      options: Object.freeze(Object.assign ? Object.assign({}, options || {}) : (function cloneOptions(source) {
-        if (!source) return {};
-        var target = {};
-        for (var key in source) {
-          if (Object.prototype.hasOwnProperty.call(source, key)) {
-            target[key] = source[key];
-          }
-        }
-        return target;
-      })(options)),
+      options: Object.freeze(_objectSpread({}, options || {}))
     });
-
     try {
       queue.push(payload);
     } catch (error) {
       void error;
       queue[queue.length] = payload;
     }
-
     return true;
   }
-
   function baseRegisterOrQueueModule(scope, registry, name, api, options, onError) {
     if (registry && typeof registry.register === 'function') {
       try {
@@ -164,45 +138,33 @@
         }
       }
     }
-
-    queueModuleRegistration(scope, name, api, options);
+    _queueModuleRegistration(scope, name, api, options);
     return false;
   }
-
-  function baseFreezeDeep(value, seen) {
-    if (!value || (typeof value !== 'object' && typeof value !== 'function')) {
+  function baseFreezeDeep(value) {
+    var seen = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : new WeakSet();
+    if (!value || _typeof(value) !== 'object' && typeof value !== 'function') {
       return value;
     }
-
-    var tracker = seen;
-    if (!tracker) {
-      tracker = new WeakSet();
-    }
-
-    if (tracker.has(value)) {
+    if (seen.has(value)) {
       return value;
     }
-
-    tracker.add(value);
-
+    seen.add(value);
     var keys = Object.getOwnPropertyNames(value);
     for (var index = 0; index < keys.length; index += 1) {
       var key = keys[index];
       var descriptor = Object.getOwnPropertyDescriptor(value, key);
-      if (!descriptor || ('get' in descriptor) || ('set' in descriptor)) {
+      if (!descriptor || 'get' in descriptor || 'set' in descriptor) {
         continue;
       }
-      baseFreezeDeep(descriptor.value, tracker);
+      baseFreezeDeep(descriptor.value, seen);
     }
-
     return Object.freeze(value);
   }
-
   function baseSafeWarn(message, detail) {
     if (typeof console === 'undefined' || typeof console.warn !== 'function') {
       return;
     }
-
     try {
       if (typeof detail === 'undefined') {
         console.warn(message);
@@ -213,20 +175,18 @@
       void error;
     }
   }
-
-  function exposeGlobal(name, value, scope, options) {
+  function exposeGlobal(name, value, scope) {
+    var options = arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : {};
     var targetScope = scope || PRIMARY_SCOPE;
-    if (!targetScope || typeof targetScope !== 'object') {
+    if (!targetScope || _typeof(targetScope) !== 'object') {
       return false;
     }
-
     var descriptor = {
-      configurable: !options || options.configurable !== false,
-      enumerable: options && options.enumerable === true,
+      configurable: options.configurable !== false,
+      enumerable: !!options.enumerable,
       value: value,
-      writable: options && options.writable === true,
+      writable: options.writable === true
     };
-
     try {
       Object.defineProperty(targetScope, name, descriptor);
       return true;
@@ -241,7 +201,6 @@
       }
     }
   }
-
   var baseApi = baseFreezeDeep({
     getGlobalScope: function getGlobalScope() {
       return PRIMARY_SCOPE;
@@ -250,10 +209,10 @@
     tryRequire: baseTryRequire,
     resolveModuleRegistry: baseResolveModuleRegistry,
     getModuleRegistry: getModuleRegistry,
-    queueModuleRegistration: function queueModuleRegistrationWrapper(name, api, options, scope) {
-      return queueModuleRegistration(scope || PRIMARY_SCOPE, name, api, options);
+    queueModuleRegistration: function queueModuleRegistration(name, api, options, scope) {
+      return _queueModuleRegistration(scope || PRIMARY_SCOPE, name, api, options);
     },
-    registerOrQueueModule: function registerOrQueueModuleWrapper(name, api, options, onError, scope, registry) {
+    registerOrQueueModule: function registerOrQueueModule(name, api, options, onError, scope, registry) {
       var targetScope = scope || PRIMARY_SCOPE;
       var moduleRegistry = registry || getModuleRegistry(targetScope);
       return baseRegisterOrQueueModule(targetScope, moduleRegistry, name, api, options, onError);
@@ -261,31 +220,21 @@
     freezeDeep: baseFreezeDeep,
     safeWarn: baseSafeWarn,
     exposeGlobal: exposeGlobal,
-    PENDING_QUEUE_KEY: PENDING_QUEUE_KEY,
+    PENDING_QUEUE_KEY: PENDING_QUEUE_KEY
   });
-
   var registry = getModuleRegistry();
-  baseRegisterOrQueueModule(
-    PRIMARY_SCOPE,
-    registry,
-    'cineModuleBase',
-    baseApi,
-    {
-      category: 'infrastructure',
-      description: 'Shared helpers for module registration, freezing, and safe global exposure.',
-      replace: true,
-    },
-    function (error) {
-      baseSafeWarn('Unable to register cineModuleBase.', error);
-    }
-  );
-
+  baseRegisterOrQueueModule(PRIMARY_SCOPE, registry, 'cineModuleBase', baseApi, {
+    category: 'infrastructure',
+    description: 'Shared helpers for module registration, freezing and safe global exposure.',
+    replace: true
+  }, function (error) {
+    baseSafeWarn('Unable to register cineModuleBase.', error);
+  });
   exposeGlobal('cineModuleBase', baseApi, PRIMARY_SCOPE, {
     configurable: true,
     enumerable: false,
-    writable: false,
+    writable: false
   });
-
   if (typeof module !== 'undefined' && module && module.exports) {
     module.exports = baseApi;
   }

--- a/legacy/scripts/modules/persistence.js
+++ b/legacy/scripts/modules/persistence.js
@@ -5,8 +5,46 @@ function _toPropertyKey(t) { var i = _toPrimitive(t, "string"); return "symbol" 
 function _toPrimitive(t, r) { if ("object" != _typeof(t) || !t) return t; var e = t[Symbol.toPrimitive]; if (void 0 !== e) { var i = e.call(t, r || "default"); if ("object" != _typeof(i)) return i; throw new TypeError("@@toPrimitive must return a primitive value."); } return ("string" === r ? String : Number)(t); }
 function _typeof(o) { "@babel/helpers - typeof"; return _typeof = "function" == typeof Symbol && "symbol" == typeof Symbol.iterator ? function (o) { return typeof o; } : function (o) { return o && "function" == typeof Symbol && o.constructor === Symbol && o !== Symbol.prototype ? "symbol" : typeof o; }, _typeof(o); }
 (function () {
-  var GLOBAL_SCOPE = typeof globalThis !== 'undefined' ? globalThis : typeof window !== 'undefined' ? window : typeof global !== 'undefined' ? global : typeof self !== 'undefined' ? self : {};
-  function tryRequire(modulePath) {
+  function detectGlobalScope() {
+    if (typeof globalThis !== 'undefined') {
+      return globalThis;
+    }
+    if (typeof window !== 'undefined') {
+      return window;
+    }
+    if (typeof global !== 'undefined') {
+      return global;
+    }
+    if (typeof self !== 'undefined') {
+      return self;
+    }
+    return {};
+  }
+  var FALLBACK_SCOPE = detectGlobalScope();
+  function resolveModuleBase() {
+    if (typeof require === 'function') {
+      try {
+        return require('./base.js');
+      } catch (error) {
+        void error;
+      }
+    }
+    var candidates = [FALLBACK_SCOPE];
+    if (typeof globalThis !== 'undefined' && candidates.indexOf(globalThis) === -1) candidates.push(globalThis);
+    if (typeof window !== 'undefined' && candidates.indexOf(window) === -1) candidates.push(window);
+    if (typeof self !== 'undefined' && candidates.indexOf(self) === -1) candidates.push(self);
+    if (typeof global !== 'undefined' && candidates.indexOf(global) === -1) candidates.push(global);
+    for (var index = 0; index < candidates.length; index += 1) {
+      var scope = candidates[index];
+      if (scope && _typeof(scope.cineModuleBase) === 'object') {
+        return scope.cineModuleBase;
+      }
+    }
+    return null;
+  }
+  var MODULE_BASE = resolveModuleBase();
+  var GLOBAL_SCOPE = MODULE_BASE && typeof MODULE_BASE.getGlobalScope === 'function' ? MODULE_BASE.getGlobalScope() || FALLBACK_SCOPE : FALLBACK_SCOPE;
+  var tryRequire = MODULE_BASE && typeof MODULE_BASE.tryRequire === 'function' ? MODULE_BASE.tryRequire : function tryRequire(modulePath) {
     if (typeof require !== 'function') {
       return null;
     }
@@ -16,8 +54,10 @@ function _typeof(o) { "@babel/helpers - typeof"; return _typeof = "function" == 
       void error;
       return null;
     }
-  }
-  function resolveModuleRegistry() {
+  };
+  var resolveModuleRegistry = MODULE_BASE && typeof MODULE_BASE.resolveModuleRegistry === 'function' ? function resolveModuleRegistry(scope) {
+    return MODULE_BASE.resolveModuleRegistry(scope || GLOBAL_SCOPE);
+  } : function resolveModuleRegistry() {
     var required = tryRequire('./registry.js');
     if (required && _typeof(required) === 'object') {
       return required;
@@ -34,9 +74,12 @@ function _typeof(o) { "@babel/helpers - typeof"; return _typeof = "function" == 
       }
     }
     return null;
-  }
-  var MODULE_REGISTRY = resolveModuleRegistry();
-  var PENDING_QUEUE_KEY = '__cinePendingModuleRegistrations__';
+  };
+  var MODULE_REGISTRY = function () {
+    var provided = MODULE_BASE && typeof MODULE_BASE.getModuleRegistry === 'function' ? MODULE_BASE.getModuleRegistry(GLOBAL_SCOPE) : null;
+    return provided || resolveModuleRegistry();
+  }();
+  var PENDING_QUEUE_KEY = MODULE_BASE && typeof MODULE_BASE.PENDING_QUEUE_KEY === 'string' ? MODULE_BASE.PENDING_QUEUE_KEY : '__cinePendingModuleRegistrations__';
   function queueModuleRegistration(name, api, options) {
     if (!GLOBAL_SCOPE || _typeof(GLOBAL_SCOPE) !== 'object') {
       return false;
@@ -77,7 +120,9 @@ function _typeof(o) { "@babel/helpers - typeof"; return _typeof = "function" == 
     }
     return true;
   }
-  function registerOrQueueModule(name, api, options, onError) {
+  var registerOrQueueModule = MODULE_BASE && typeof MODULE_BASE.registerOrQueueModule === 'function' ? function registerOrQueueModule(name, api, options, onError) {
+    return MODULE_BASE.registerOrQueueModule(name, api, options, onError, GLOBAL_SCOPE, MODULE_REGISTRY);
+  } : function registerOrQueueModule(name, api, options, onError) {
     if (MODULE_REGISTRY && typeof MODULE_REGISTRY.register === 'function') {
       try {
         MODULE_REGISTRY.register(name, api, options);
@@ -92,41 +137,8 @@ function _typeof(o) { "@babel/helpers - typeof"; return _typeof = "function" == 
     }
     queueModuleRegistration(name, api, options);
     return false;
-  }
-  var providerModules = [];
-  providerModules.push(GLOBAL_SCOPE);
-  var storageModule = tryRequire('../storage.js');
-  if (storageModule && _typeof(storageModule) === 'object') {
-    providerModules.push(storageModule);
-  }
-  var sessionModule = tryRequire('../app-session.js');
-  if (sessionModule && _typeof(sessionModule) === 'object') {
-    providerModules.push(sessionModule);
-  }
-  var setupsModule = tryRequire('../app-setups.js');
-  if (setupsModule && _typeof(setupsModule) === 'object') {
-    providerModules.push(setupsModule);
-  }
-  function resolveFunction(name) {
-    for (var index = 0; index < providerModules.length; index += 1) {
-      var provider = providerModules[index];
-      if (!provider || _typeof(provider) !== 'object') {
-        continue;
-      }
-      var candidate = provider[name];
-      if (typeof candidate === 'function') {
-        return candidate;
-      }
-    }
-    throw new Error("cinePersistence could not resolve function \"".concat(name, "\"."));
-  }
-  function createWrapper(name) {
-    return function persistenceWrapper() {
-      var fn = resolveFunction(name);
-      return fn.apply(this, arguments);
-    };
-  }
-  function freezeDeep(value) {
+  };
+  var freezeDeep = MODULE_BASE && typeof MODULE_BASE.freezeDeep === 'function' ? MODULE_BASE.freezeDeep : function freezeDeep(value) {
     var seen = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : new WeakSet();
     if (!value || _typeof(value) !== 'object') {
       return value;
@@ -135,9 +147,9 @@ function _typeof(o) { "@babel/helpers - typeof"; return _typeof = "function" == 
       return value;
     }
     seen.add(value);
-    var propertyNames = Object.getOwnPropertyNames(value);
-    for (var index = 0; index < propertyNames.length; index += 1) {
-      var key = propertyNames[index];
+    var keys = Object.getOwnPropertyNames(value);
+    for (var index = 0; index < keys.length; index += 1) {
+      var key = keys[index];
       var descriptor = Object.getOwnPropertyDescriptor(value, key);
       if (!descriptor || 'get' in descriptor || 'set' in descriptor) {
         continue;
@@ -145,6 +157,194 @@ function _typeof(o) { "@babel/helpers - typeof"; return _typeof = "function" == 
       freezeDeep(descriptor.value, seen);
     }
     return Object.freeze(value);
+  };
+  var exposeGlobal = MODULE_BASE && typeof MODULE_BASE.exposeGlobal === 'function' ? function exposeGlobal(name, value, options) {
+    return MODULE_BASE.exposeGlobal(name, value, GLOBAL_SCOPE, options);
+  } : function exposeGlobal(name, value) {
+    if (!GLOBAL_SCOPE || _typeof(GLOBAL_SCOPE) !== 'object') {
+      return false;
+    }
+    try {
+      Object.defineProperty(GLOBAL_SCOPE, name, {
+        configurable: true,
+        enumerable: false,
+        value: value,
+        writable: false
+      });
+      return true;
+    } catch (error) {
+      void error;
+      try {
+        GLOBAL_SCOPE[name] = value;
+        return true;
+      } catch (assignmentError) {
+        void assignmentError;
+        return false;
+      }
+    }
+  };
+  var providerModules = [];
+  function addProviderModule(reference, label) {
+    if (!reference || _typeof(reference) !== 'object') {
+      return;
+    }
+    providerModules.push({
+      ref: reference,
+      name: label || null
+    });
+  }
+  addProviderModule(GLOBAL_SCOPE, 'global');
+  var storageModule = tryRequire('../storage.js');
+  if (storageModule && _typeof(storageModule) === 'object') {
+    addProviderModule(storageModule, 'storage');
+  }
+  var sessionModule = tryRequire('../app-session.js');
+  if (sessionModule && _typeof(sessionModule) === 'object') {
+    addProviderModule(sessionModule, 'session');
+  }
+  var setupsModule = tryRequire('../app-setups.js');
+  if (setupsModule && _typeof(setupsModule) === 'object') {
+    addProviderModule(setupsModule, 'setups');
+  }
+  var bindingState = Object.create(null);
+  var bindingNames = [];
+  function identifyProvider(providerEntry) {
+    if (!providerEntry) {
+      return null;
+    }
+    if (providerEntry.name) {
+      return providerEntry.name;
+    }
+    var ref = providerEntry.ref;
+    if (!ref || _typeof(ref) !== 'object') {
+      return null;
+    }
+    if (ref === GLOBAL_SCOPE) {
+      return 'global';
+    }
+    if (typeof ref.constructor === 'function' && ref.constructor.name) {
+      return ref.constructor.name;
+    }
+    return null;
+  }
+  function ensureBindingEntry(bindingKey, implementationName) {
+    var key = String(bindingKey);
+    var entry = bindingState[key];
+    if (!entry) {
+      entry = {
+        name: key,
+        implementationName: implementationName || key,
+        available: false,
+        providerIndex: -1,
+        providerName: null,
+        lastChecked: null,
+        implementation: null
+      };
+      bindingState[key] = entry;
+      bindingNames.push(key);
+    } else if (implementationName && entry.implementationName !== implementationName) {
+      entry.implementationName = implementationName;
+    }
+    return entry;
+  }
+  function resolveBinding(name) {
+    var options = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+    var refresh = options && Object.prototype.hasOwnProperty.call(options, 'refresh') ? options.refresh : true;
+    var entry = ensureBindingEntry(name);
+    var implementationName = entry.implementationName || String(name);
+    if (!refresh && entry.implementation && typeof entry.implementation === 'function') {
+      return entry;
+    }
+    var resolved = null;
+    for (var index = 0; index < providerModules.length; index += 1) {
+      var providerEntry = providerModules[index];
+      var provider = providerEntry && providerEntry.ref;
+      if (!provider || _typeof(provider) !== 'object') {
+        continue;
+      }
+      var candidate = provider[implementationName];
+      if (typeof candidate === 'function') {
+        resolved = {
+          implementation: candidate,
+          providerIndex: index,
+          providerName: identifyProvider(providerEntry)
+        };
+        break;
+      }
+    }
+    entry.available = !!resolved;
+    entry.providerIndex = resolved ? resolved.providerIndex : -1;
+    entry.providerName = resolved ? resolved.providerName : null;
+    entry.lastChecked = Date.now();
+    entry.implementation = resolved ? resolved.implementation : null;
+    return entry;
+  }
+  function requireBinding(name) {
+    var detail = resolveBinding(name, {
+      refresh: true
+    });
+    if (!detail || typeof detail.implementation !== 'function') {
+      var error = new Error("cinePersistence could not resolve function \"".concat(name, "\"."));
+      error.code = 'CINE_PERSISTENCE_BINDING_MISSING';
+      error.binding = name;
+      error.detail = {
+        name: name,
+        available: detail ? detail.available : false,
+        providerName: detail ? detail.providerName : null
+      };
+      throw error;
+    }
+    return detail.implementation;
+  }
+  function snapshotBinding(detail) {
+    if (!detail) {
+      return null;
+    }
+    return Object.freeze({
+      name: detail.name,
+      available: !!detail.available,
+      providerIndex: typeof detail.providerIndex === 'number' ? detail.providerIndex : -1,
+      providerName: detail.providerName || null,
+      lastChecked: detail.lastChecked || null,
+      implementation: detail.implementationName || detail.name
+    });
+  }
+  function createWrapper(name, alias) {
+    var bindingKey = alias || name;
+    ensureBindingEntry(bindingKey, name);
+    return function persistenceWrapper() {
+      var fn = requireBinding(bindingKey);
+      return fn.apply(this, arguments);
+    };
+  }
+  function _inspectBinding(name) {
+    var options = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+    var normalized = String(name);
+    var refresh = options && Object.prototype.hasOwnProperty.call(options, 'refresh') ? options.refresh : true;
+    var detail = resolveBinding(normalized, {
+      refresh: refresh
+    });
+    return snapshotBinding(detail);
+  }
+  function inspectAllBindings() {
+    var options = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
+    var refresh = options && Object.prototype.hasOwnProperty.call(options, 'refresh') ? options.refresh : true;
+    if (refresh) {
+      for (var index = 0; index < bindingNames.length; index += 1) {
+        resolveBinding(bindingNames[index], {
+          refresh: true
+        });
+      }
+    }
+    var snapshot = {};
+    for (var _index = 0; _index < bindingNames.length; _index += 1) {
+      var name = bindingNames[_index];
+      snapshot[name] = snapshotBinding(bindingState[name]);
+    }
+    return freezeDeep(snapshot);
+  }
+  function listBindings() {
+    return bindingNames.slice();
   }
   var persistenceAPI = {
     storage: {
@@ -172,8 +372,11 @@ function _typeof(o) { "@babel/helpers - typeof"; return _typeof = "function" == 
       saveAutoGearRules: createWrapper('saveAutoGearRules'),
       loadAutoGearBackups: createWrapper('loadAutoGearBackups'),
       saveAutoGearBackups: createWrapper('saveAutoGearBackups'),
+      loadAutoGearSeedFlag: createWrapper('loadAutoGearSeedFlag'),
+      saveAutoGearSeedFlag: createWrapper('saveAutoGearSeedFlag'),
       loadAutoGearBackupRetention: createWrapper('loadAutoGearBackupRetention'),
       saveAutoGearBackupRetention: createWrapper('saveAutoGearBackupRetention'),
+      getAutoGearBackupRetentionDefault: createWrapper('getAutoGearBackupRetentionDefault'),
       loadAutoGearPresets: createWrapper('loadAutoGearPresets'),
       saveAutoGearPresets: createWrapper('saveAutoGearPresets'),
       loadAutoGearActivePresetId: createWrapper('loadAutoGearActivePresetId'),
@@ -186,12 +389,16 @@ function _typeof(o) { "@babel/helpers - typeof"; return _typeof = "function" == 
       saveAutoGearBackupVisibility: createWrapper('saveAutoGearBackupVisibility'),
       loadFullBackupHistory: createWrapper('loadFullBackupHistory'),
       saveFullBackupHistory: createWrapper('saveFullBackupHistory'),
-      recordFullBackupHistoryEntry: createWrapper('recordFullBackupHistoryEntry')
+      recordFullBackupHistoryEntry: createWrapper('recordFullBackupHistoryEntry'),
+      requestPersistentStorage: createWrapper('requestPersistentStorage'),
+      clearUiCacheStorageEntries: createWrapper('clearUiCacheStorageEntries'),
+      ensureCriticalStorageBackups: createWrapper('ensureCriticalStorageBackups'),
+      getLastCriticalStorageGuardResult: createWrapper('getLastCriticalStorageGuardResult')
     },
     autosave: {
-      saveSession: createWrapper('saveCurrentSession'),
-      autoSaveSetup: createWrapper('autoSaveCurrentSetup'),
-      saveGearList: createWrapper('saveCurrentGearList'),
+      saveSession: createWrapper('saveCurrentSession', 'saveSession'),
+      autoSaveSetup: createWrapper('autoSaveCurrentSetup', 'autoSaveSetup'),
+      saveGearList: createWrapper('saveCurrentGearList', 'saveGearList'),
       restoreSessionState: createWrapper('restoreSessionState')
     },
     backups: {
@@ -201,20 +408,27 @@ function _typeof(o) { "@babel/helpers - typeof"; return _typeof = "function" == 
       sanitizeBackupPayload: createWrapper('sanitizeBackupPayload'),
       autoBackup: createWrapper('autoBackup'),
       formatFullBackupFilename: createWrapper('formatFullBackupFilename'),
-      downloadPayload: createWrapper('downloadBackupPayload'),
+      downloadPayload: createWrapper('downloadBackupPayload', 'downloadPayload'),
       recordFullBackupHistoryEntry: createWrapper('recordFullBackupHistoryEntry')
     },
     restore: {
-      proceed: createWrapper('handleRestoreRehearsalProceed'),
-      abort: createWrapper('handleRestoreRehearsalAbort')
+      proceed: createWrapper('handleRestoreRehearsalProceed', 'proceed'),
+      abort: createWrapper('handleRestoreRehearsalAbort', 'abort')
     },
     share: {
-      downloadProject: createWrapper('downloadSharedProject'),
+      downloadProject: createWrapper('downloadSharedProject', 'downloadProject'),
       encodeSharedSetup: createWrapper('encodeSharedSetup'),
       decodeSharedSetup: createWrapper('decodeSharedSetup'),
       applySharedSetup: createWrapper('applySharedSetup'),
       applySharedSetupFromUrl: createWrapper('applySharedSetupFromUrl')
-    }
+    },
+    __internal: freezeDeep({
+      listBindings: listBindings,
+      inspectBinding: function inspectBinding(name, options) {
+        return _inspectBinding(name, options) || null;
+      },
+      inspectAllBindings: inspectAllBindings
+    })
   };
   freezeDeep(persistenceAPI);
   registerOrQueueModule('cinePersistence', persistenceAPI, {
@@ -223,18 +437,21 @@ function _typeof(o) { "@babel/helpers - typeof"; return _typeof = "function" == 
     replace: true
   });
   if (GLOBAL_SCOPE && _typeof(GLOBAL_SCOPE) === 'object') {
+    var existingPersistence = null;
     try {
-      if (GLOBAL_SCOPE.cinePersistence !== persistenceAPI) {
-        Object.defineProperty(GLOBAL_SCOPE, 'cinePersistence', {
-          configurable: true,
-          enumerable: false,
-          value: persistenceAPI,
-          writable: false
-        });
-      }
+      existingPersistence = GLOBAL_SCOPE.cinePersistence || null;
     } catch (error) {
-      if (typeof console !== 'undefined' && typeof console.warn === 'function') {
-        console.warn('Unable to expose cinePersistence globally.', error);
+      void error;
+      existingPersistence = null;
+    }
+    if (existingPersistence !== persistenceAPI) {
+      var exposed = exposeGlobal('cinePersistence', persistenceAPI, {
+        configurable: true,
+        enumerable: false,
+        writable: false
+      });
+      if (!exposed && typeof console !== 'undefined' && typeof console.warn === 'function') {
+        console.warn('Unable to expose cinePersistence globally.');
       }
     }
   }


### PR DESCRIPTION
## Summary
- rebuild the legacy scripts so they expose the new module base helpers
- refresh persistence, loader, and related modules to include the latest backup and offline safeguards
- add the transpiled legacy global shim to keep auto gear globals safe on older browsers

## Testing
- npm run build:legacy

------
https://chatgpt.com/codex/tasks/task_e_68e2aa9bc08083208ce7fc398fd1e393