### PR TITLE
Ensure auto gear globals exist before loader runs

### DIFF
--- a/legacy/scripts/globals-bootstrap.js
+++ b/legacy/scripts/globals-bootstrap.js
@@ -1,23 +1,15 @@
+function _typeof(o) { "@babel/helpers - typeof"; return _typeof = "function" == typeof Symbol && "symbol" == typeof Symbol.iterator ? function (o) { return typeof o; } : function (o) { return o && "function" == typeof Symbol && o.constructor === Symbol && o !== Symbol.prototype ? "symbol" : typeof o; }, _typeof(o); }
 function __cineIsArray(value) {
   if (typeof Array !== 'undefined' && typeof Array.isArray === 'function') {
     return Array.isArray(value);
   }
-
   return Object.prototype.toString.call(value) === '[object Array]';
 }
-
 (function bootstrapCoreRuntimeGlobals() {
-  var scope =
-    (typeof globalThis !== 'undefined' && globalThis) ||
-    (typeof window !== 'undefined' && window) ||
-    (typeof self !== 'undefined' && self) ||
-    (typeof global !== 'undefined' && global) ||
-    null;
-
-  if (!scope || (typeof scope !== 'object' && typeof scope !== 'function')) {
+  var scope = typeof globalThis !== 'undefined' && globalThis || typeof window !== 'undefined' && window || typeof self !== 'undefined' && self || typeof global !== 'undefined' && global || null;
+  if (!scope || _typeof(scope) !== 'object' && typeof scope !== 'function') {
     return;
   }
-
   function ensureString(name, fallback) {
     var value;
     try {
@@ -26,20 +18,16 @@ function __cineIsArray(value) {
       value = undefined;
       void readError;
     }
-
     if (typeof value !== 'string') {
       value = fallback;
     }
-
     try {
       scope[name] = value;
     } catch (assignError) {
       void assignError;
     }
-
     return value;
   }
-
   function ensureArray(name) {
     var value;
     try {
@@ -48,20 +36,16 @@ function __cineIsArray(value) {
       value = undefined;
       void readError;
     }
-
     if (!__cineIsArray(value)) {
       value = [];
     }
-
     try {
       scope[name] = value;
     } catch (assignError) {
       void assignError;
     }
-
     return value;
   }
-
   function ensureFunction(name, fallback) {
     var value;
     try {
@@ -70,20 +54,16 @@ function __cineIsArray(value) {
       value = undefined;
       void readError;
     }
-
     if (typeof value !== 'function') {
       value = fallback;
     }
-
     try {
       scope[name] = value;
     } catch (assignError) {
       void assignError;
     }
-
     return value;
   }
-
   function ensureNullableObject(name) {
     var value;
     try {
@@ -92,25 +72,20 @@ function __cineIsArray(value) {
       value = undefined;
       void readError;
     }
-
     if (typeof value === 'undefined') {
       value = null;
     }
-
     try {
       scope[name] = value;
     } catch (assignError) {
       void assignError;
     }
-
     return value;
   }
-
   function fallbackSafeGenerateConnectorSummary(device) {
-    if (!device || typeof device !== 'object') {
+    if (!device || _typeof(device) !== 'object') {
       return '';
     }
-
     var keys;
     try {
       keys = Object.keys(device);
@@ -118,35 +93,28 @@ function __cineIsArray(value) {
       void keyError;
       return '';
     }
-
     if (!keys || !keys.length) {
       return '';
     }
-
     var primaryKey = keys[0];
     var value = device[primaryKey];
     var label = typeof primaryKey === 'string' ? primaryKey.replace(/_/g, ' ') : 'connector';
     return value ? label + ': ' + value : label;
   }
-
   ensureString('autoGearAutoPresetId', '');
   ensureArray('baseAutoGearRules');
   ensureNullableObject('autoGearScenarioModeSelect');
+  ensureNullableObject('autoGearRuleNameInput');
+  ensureString('autoGearSummaryFocus', 'all');
+  ensureArray('autoGearMonitorDefaultControls');
+  ensureNullableObject('totalPowerElem');
   ensureFunction('safeGenerateConnectorSummary', fallbackSafeGenerateConnectorSummary);
 })();
-
 function __cineResolveGlobalValue(name, fallback) {
-  var scope =
-    (typeof globalThis !== 'undefined' && globalThis) ||
-    (typeof window !== 'undefined' && window) ||
-    (typeof self !== 'undefined' && self) ||
-    (typeof global !== 'undefined' && global) ||
-    null;
-
-  if (!scope || (typeof scope !== 'object' && typeof scope !== 'function')) {
+  var scope = typeof globalThis !== 'undefined' && globalThis || typeof window !== 'undefined' && window || typeof self !== 'undefined' && self || typeof global !== 'undefined' && global || null;
+  if (!scope || _typeof(scope) !== 'object' && typeof scope !== 'function') {
     return fallback;
   }
-
   var value;
   try {
     value = scope[name];
@@ -154,58 +122,49 @@ function __cineResolveGlobalValue(name, fallback) {
     value = undefined;
     void readError;
   }
-
   return typeof value === 'undefined' ? fallback : value;
 }
-
-var autoGearAutoPresetId =
-  typeof autoGearAutoPresetId !== 'undefined'
-    ? autoGearAutoPresetId
-    : (function resolveAutoGearAutoPresetId() {
-        var value = __cineResolveGlobalValue('autoGearAutoPresetId', '');
-        return typeof value === 'string' ? value : '';
-      })();
-
-var baseAutoGearRules =
-  typeof baseAutoGearRules !== 'undefined'
-    ? baseAutoGearRules
-    : (function resolveBaseAutoGearRules() {
-        var value = __cineResolveGlobalValue('baseAutoGearRules', []);
-        return __cineIsArray(value) ? value : [];
-      })();
-
-var autoGearScenarioModeSelect =
-  typeof autoGearScenarioModeSelect !== 'undefined'
-    ? autoGearScenarioModeSelect
-    : __cineResolveGlobalValue('autoGearScenarioModeSelect', null);
-
-var safeGenerateConnectorSummary =
-  typeof safeGenerateConnectorSummary !== 'undefined'
-    ? safeGenerateConnectorSummary
-    : (function resolveSafeGenerateConnectorSummary() {
-        var value = __cineResolveGlobalValue('safeGenerateConnectorSummary', null);
-        return typeof value === 'function'
-          ? value
-          : function fallbackSafeGenerateConnectorSummary(device) {
-            if (!device || typeof device !== 'object') {
-              return '';
-            }
-
-            var keys;
-            try {
-              keys = Object.keys(device);
-            } catch (keyError) {
-              void keyError;
-              return '';
-            }
-
-              if (!keys || !keys.length) {
-                return '';
-              }
-
-              var primaryKey = keys[0];
-              var result = device[primaryKey];
-              var label = typeof primaryKey === 'string' ? primaryKey.replace(/_/g, ' ') : 'connector';
-              return result ? label + ': ' + result : label;
-            };
-      })();
+var autoGearAutoPresetId = typeof autoGearAutoPresetId !== 'undefined' ? autoGearAutoPresetId : function resolveAutoGearAutoPresetId() {
+  var value = __cineResolveGlobalValue('autoGearAutoPresetId', '');
+  return typeof value === 'string' ? value : '';
+}();
+var baseAutoGearRules = typeof baseAutoGearRules !== 'undefined' ? baseAutoGearRules : function resolveBaseAutoGearRules() {
+  var value = __cineResolveGlobalValue('baseAutoGearRules', []);
+  return __cineIsArray(value) ? value : [];
+}();
+var autoGearScenarioModeSelect = typeof autoGearScenarioModeSelect !== 'undefined' ? autoGearScenarioModeSelect : __cineResolveGlobalValue('autoGearScenarioModeSelect', null);
+var autoGearRuleNameInput = typeof autoGearRuleNameInput !== 'undefined' ? autoGearRuleNameInput : __cineResolveGlobalValue('autoGearRuleNameInput', null);
+var autoGearSummaryFocus = typeof autoGearSummaryFocus !== 'undefined' ? autoGearSummaryFocus : function resolveAutoGearSummaryFocus() {
+  var value = __cineResolveGlobalValue('autoGearSummaryFocus', 'all');
+  return typeof value === 'string' ? value : 'all';
+}();
+var autoGearMonitorDefaultControls = typeof autoGearMonitorDefaultControls !== 'undefined' ? autoGearMonitorDefaultControls : function resolveAutoGearMonitorDefaultControls() {
+  var value = __cineResolveGlobalValue('autoGearMonitorDefaultControls', []);
+  return __cineIsArray(value) ? value : [];
+}();
+var safeGenerateConnectorSummary = typeof safeGenerateConnectorSummary !== 'undefined' ? safeGenerateConnectorSummary : function resolveSafeGenerateConnectorSummary() {
+  var value = __cineResolveGlobalValue('safeGenerateConnectorSummary', null);
+  return typeof value === 'function' ? value : function fallbackSafeGenerateConnectorSummary(device) {
+    if (!device || _typeof(device) !== 'object') {
+      return '';
+    }
+    var keys;
+    try {
+      keys = Object.keys(device);
+    } catch (keyError) {
+      void keyError;
+      return '';
+    }
+    if (!keys || !keys.length) {
+      return '';
+    }
+    var primaryKey = keys[0];
+    var result = device[primaryKey];
+    var label = typeof primaryKey === 'string' ? primaryKey.replace(/_/g, ' ') : 'connector';
+    return result ? label + ': ' + result : label;
+  };
+}();
+var totalPowerElem = typeof totalPowerElem !== 'undefined' ? totalPowerElem : function resolveTotalPowerElem() {
+  var value = __cineResolveGlobalValue('totalPowerElem', null);
+  return typeof value === 'undefined' ? null : value;
+}();

--- a/legacy/scripts/globals-legacy-shim.js
+++ b/legacy/scripts/globals-legacy-shim.js
@@ -1,0 +1,96 @@
+function _typeof(o) { "@babel/helpers - typeof"; return _typeof = "function" == typeof Symbol && "symbol" == typeof Symbol.iterator ? function (o) { return typeof o; } : function (o) { return o && "function" == typeof Symbol && o.constructor === Symbol && o !== Symbol.prototype ? "symbol" : typeof o; }, _typeof(o); }
+(function ensureLegacyCoreGlobals() {
+  var scope = typeof globalThis !== 'undefined' && globalThis || typeof window !== 'undefined' && window || typeof self !== 'undefined' && self || typeof global !== 'undefined' && global || null;
+  if (!scope || _typeof(scope) !== 'object' && typeof scope !== 'function') {
+    return;
+  }
+  function fallbackSafeGenerateConnectorSummary(device) {
+    if (!device || _typeof(device) !== 'object') {
+      return '';
+    }
+    try {
+      var keys = Object.keys(device);
+      if (!keys.length) {
+        return '';
+      }
+      var primaryKey = keys[0];
+      var value = device[primaryKey];
+      var label = typeof primaryKey === 'string' ? primaryKey.replace(/_/g, ' ') : 'connector';
+      return value ? label + ': ' + value : label;
+    } catch (error) {
+      void error;
+      return '';
+    }
+  }
+  function ensureBinding(name, validator, fallbackProvider) {
+    var value;
+    try {
+      value = scope[name];
+    } catch (readError) {
+      void readError;
+      value = undefined;
+    }
+    if (!validator(value)) {
+      try {
+        value = fallbackProvider();
+      } catch (fallbackError) {
+        void fallbackError;
+        value = undefined;
+      }
+    }
+    if (!validator(value)) {
+      return;
+    }
+    try {
+      scope[name] = value;
+    } catch (assignError) {
+      void assignError;
+    }
+    try {
+      var bind = scope.Function || Function;
+      bind('value', "try { if (typeof " + name + " === 'undefined') { " + name + " = value; } } catch (bindingError) { try { " + name + " = value; } catch (assignError) { void assignError; } } return value;")(value);
+    } catch (bindingError) {
+      void bindingError;
+    }
+  }
+  ensureBinding('autoGearAutoPresetId', function validateAutoPresetId(candidate) {
+    return typeof candidate === 'string';
+  }, function provideAutoPresetIdFallback() {
+    return '';
+  });
+  ensureBinding('baseAutoGearRules', function validateBaseRules(candidate) {
+    return Array.isArray(candidate);
+  }, function provideBaseRulesFallback() {
+    return [];
+  });
+  ensureBinding('autoGearScenarioModeSelect', function validateScenarioSelect(candidate) {
+    return candidate === null || _typeof(candidate) === 'object';
+  }, function provideScenarioSelectFallback() {
+    return null;
+  });
+  ensureBinding('autoGearRuleNameInput', function validateAutoGearRuleNameInput(candidate) {
+    return typeof candidate === 'undefined' || candidate === null || _typeof(candidate) === 'object';
+  }, function provideAutoGearRuleNameInputFallback() {
+    return null;
+  });
+  ensureBinding('autoGearSummaryFocus', function validateAutoGearSummaryFocus(candidate) {
+    return typeof candidate === 'string';
+  }, function provideAutoGearSummaryFocusFallback() {
+    return 'all';
+  });
+  ensureBinding('autoGearMonitorDefaultControls', function validateAutoGearMonitorDefaultControls(candidate) {
+    return Array.isArray(candidate);
+  }, function provideAutoGearMonitorDefaultControlsFallback() {
+    return [];
+  });
+  ensureBinding('safeGenerateConnectorSummary', function validateConnectorSummary(candidate) {
+    return typeof candidate === 'function';
+  }, function provideConnectorSummaryFallback() {
+    return fallbackSafeGenerateConnectorSummary;
+  });
+  ensureBinding('totalPowerElem', function validateTotalPowerElem(candidate) {
+    return typeof candidate === 'undefined' || candidate === null || _typeof(candidate) === 'object';
+  }, function provideTotalPowerElemFallback() {
+    return null;
+  });
+})();

--- a/src/scripts/globals-bootstrap.js
+++ b/src/scripts/globals-bootstrap.js
@@ -132,6 +132,10 @@ function __cineIsArray(value) {
   ensureString('autoGearAutoPresetId', '');
   ensureArray('baseAutoGearRules');
   ensureNullableObject('autoGearScenarioModeSelect');
+  ensureNullableObject('autoGearRuleNameInput');
+  ensureString('autoGearSummaryFocus', 'all');
+  ensureArray('autoGearMonitorDefaultControls');
+  ensureNullableObject('totalPowerElem');
   ensureFunction('safeGenerateConnectorSummary', fallbackSafeGenerateConnectorSummary);
 })();
 
@@ -179,6 +183,27 @@ var autoGearScenarioModeSelect =
     ? autoGearScenarioModeSelect
     : __cineResolveGlobalValue('autoGearScenarioModeSelect', null);
 
+var autoGearRuleNameInput =
+  typeof autoGearRuleNameInput !== 'undefined'
+    ? autoGearRuleNameInput
+    : __cineResolveGlobalValue('autoGearRuleNameInput', null);
+
+var autoGearSummaryFocus =
+  typeof autoGearSummaryFocus !== 'undefined'
+    ? autoGearSummaryFocus
+    : (function resolveAutoGearSummaryFocus() {
+        var value = __cineResolveGlobalValue('autoGearSummaryFocus', 'all');
+        return typeof value === 'string' ? value : 'all';
+      })();
+
+var autoGearMonitorDefaultControls =
+  typeof autoGearMonitorDefaultControls !== 'undefined'
+    ? autoGearMonitorDefaultControls
+    : (function resolveAutoGearMonitorDefaultControls() {
+        var value = __cineResolveGlobalValue('autoGearMonitorDefaultControls', []);
+        return __cineIsArray(value) ? value : [];
+      })();
+
 var safeGenerateConnectorSummary =
   typeof safeGenerateConnectorSummary !== 'undefined'
     ? safeGenerateConnectorSummary
@@ -206,6 +231,14 @@ var safeGenerateConnectorSummary =
               var primaryKey = keys[0];
               var result = device[primaryKey];
               var label = typeof primaryKey === 'string' ? primaryKey.replace(/_/g, ' ') : 'connector';
-              return result ? label + ': ' + result : label;
-            };
+            return result ? label + ': ' + result : label;
+          };
+      })();
+
+var totalPowerElem =
+  typeof totalPowerElem !== 'undefined'
+    ? totalPowerElem
+    : (function resolveTotalPowerElem() {
+        var value = __cineResolveGlobalValue('totalPowerElem', null);
+        return typeof value === 'undefined' ? null : value;
       })();

--- a/src/scripts/globals-legacy-shim.js
+++ b/src/scripts/globals-legacy-shim.js
@@ -108,12 +108,60 @@
   );
 
   ensureBinding(
+    'autoGearRuleNameInput',
+    function validateAutoGearRuleNameInput(candidate) {
+      return (
+        typeof candidate === 'undefined' ||
+        candidate === null ||
+        typeof candidate === 'object'
+      );
+    },
+    function provideAutoGearRuleNameInputFallback() {
+      return null;
+    }
+  );
+
+  ensureBinding(
+    'autoGearSummaryFocus',
+    function validateAutoGearSummaryFocus(candidate) {
+      return typeof candidate === 'string';
+    },
+    function provideAutoGearSummaryFocusFallback() {
+      return 'all';
+    }
+  );
+
+  ensureBinding(
+    'autoGearMonitorDefaultControls',
+    function validateAutoGearMonitorDefaultControls(candidate) {
+      return Array.isArray(candidate);
+    },
+    function provideAutoGearMonitorDefaultControlsFallback() {
+      return [];
+    }
+  );
+
+  ensureBinding(
     'safeGenerateConnectorSummary',
     function validateConnectorSummary(candidate) {
       return typeof candidate === 'function';
     },
     function provideConnectorSummaryFallback() {
       return fallbackSafeGenerateConnectorSummary;
+    }
+  );
+
+  ensureBinding(
+    'totalPowerElem',
+    function validateTotalPowerElem(candidate) {
+      return (
+        typeof candidate === 'undefined' ||
+        candidate === null ||
+        typeof candidate === 'object'
+      );
+    },
+    function provideTotalPowerElemFallback() {
+      return null;
     }
   );
 })();

--- a/tests/unit/globalsBootstrapSafety.test.js
+++ b/tests/unit/globalsBootstrapSafety.test.js
@@ -1,0 +1,56 @@
+const fs = require('fs');
+const path = require('path');
+
+describe('core runtime global bootstrapping', () => {
+  const modernBootstrap = fs.readFileSync(
+    path.join(__dirname, '..', '..', 'src', 'scripts', 'globals-bootstrap.js'),
+    'utf8',
+  );
+  const legacyBootstrap = fs.readFileSync(
+    path.join(__dirname, '..', '..', 'legacy', 'scripts', 'globals-bootstrap.js'),
+    'utf8',
+  );
+  const modernShim = fs.readFileSync(
+    path.join(__dirname, '..', '..', 'src', 'scripts', 'globals-legacy-shim.js'),
+    'utf8',
+  );
+  const legacyShim = fs.readFileSync(
+    path.join(__dirname, '..', '..', 'legacy', 'scripts', 'globals-legacy-shim.js'),
+    'utf8',
+  );
+
+  const criticalNames = [
+    'autoGearAutoPresetId',
+    'baseAutoGearRules',
+    'autoGearScenarioModeSelect',
+    'autoGearRuleNameInput',
+    'autoGearSummaryFocus',
+    'autoGearMonitorDefaultControls',
+    'safeGenerateConnectorSummary',
+    'totalPowerElem',
+  ];
+
+  test('modern bootstrap defines critical global fallbacks', () => {
+    criticalNames.forEach(name => {
+      expect(modernBootstrap).toContain(name);
+    });
+  });
+
+  test('legacy bootstrap mirrors critical global fallbacks', () => {
+    criticalNames.forEach(name => {
+      expect(legacyBootstrap).toContain(name);
+    });
+  });
+
+  test('modern shim ensures critical globals bind safely', () => {
+    criticalNames.forEach(name => {
+      expect(modernShim).toContain(name);
+    });
+  });
+
+  test('legacy shim ensures critical globals bind safely', () => {
+    criticalNames.forEach(name => {
+      expect(legacyShim).toContain(name);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- predeclare additional auto gear globals in the modern bootstrap shim so Safari never throws "Can't find variable" errors before the loader runs
- mirror the same safeguards in the legacy bootstrap/shim and add a regression test that asserts all critical global names stay protected in both bundles

## Testing
- npm run lint
- node --max-old-space-size=1024 ./node_modules/jest/bin/jest.js --runInBand --selectProjects unit --runTestsByPath tests/unit/globalsBootstrapSafety.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e2a80019248320baa94bb7c4250e5e