### PR TITLE
Preserve blank project state when saving gear lists

### DIFF
--- a/src/scripts/app-setups.js
+++ b/src/scripts/app-setups.js
@@ -4777,8 +4777,8 @@ function saveCurrentGearList() {
             setup.gearList = html;
             changed = true;
         }
-    } else if (Object.prototype.hasOwnProperty.call(setup, 'gearList')) {
-        delete setup.gearList;
+    } else if (setup.gearList !== '') {
+        setup.gearList = '';
         changed = true;
     }
 
@@ -4787,6 +4787,11 @@ function saveCurrentGearList() {
         const existingInfoSignature = existingInfo ? stableStringify(existingInfo) : '';
         if (existingInfoSignature !== projectInfoSignature) {
             setup.projectInfo = projectInfoSnapshotForSetups;
+            changed = true;
+        }
+    } else if (projectInfoSnapshot === null) {
+        if (setup.projectInfo !== null) {
+            setup.projectInfo = null;
             changed = true;
         }
     } else if (Object.prototype.hasOwnProperty.call(setup, 'projectInfo')) {


### PR DESCRIPTION
## Summary
- ensure saveCurrentGearList keeps empty gear list HTML instead of deleting the property
- retain explicit null projectInfo snapshots so blank projects stay blank

## Testing
- npm run lint
- npm run check-consistency
- npm run test:jest -- --runInBand --runTestsByPath tests/unit/storageFallback.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e2a8668cb8832093b0ef602adf8e71