### PR TITLE
Fix grid snap state access and expose search normalizer

### DIFF
--- a/legacy/scripts/app-core-new-2.js
+++ b/legacy/scripts/app-core-new-2.js
@@ -6703,6 +6703,7 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
     var normalizeSearchValue = function normalizeSearchValue(value) {
       return typeof value === 'string' ? value.trim().toLowerCase() : '';
     };
+    exposeCoreRuntimeConstant('normalizeSearchValue', normalizeSearchValue);
     var FEATURE_SEARCH_EXTRA_SELECTOR = '[data-feature-search]';
     var FEATURE_SEARCH_TYPE_LABEL_KEYS = {
       feature: 'featureSearchTypeFeature',
@@ -10622,6 +10623,30 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
     var resetViewBtn = document.getElementById("resetView");
     var gridSnapToggleBtn = document.getElementById("gridSnapToggle");
     var diagramHint = document.getElementById("diagramHint");
+    var getCurrentGridSnap = function getCurrentGridSnap() {
+      try {
+        if (typeof getGridSnapState === 'function') {
+          return Boolean(getGridSnapState());
+        }
+      } catch (gridSnapStateError) {
+        void gridSnapStateError;
+      }
+
+      var scopedValue = readGlobalScopeValue('gridSnap');
+      if (typeof scopedValue === 'boolean') {
+        return scopedValue;
+      }
+
+      if (typeof gridSnap !== 'undefined') {
+        try {
+          return Boolean(gridSnap);
+        } catch (legacyGridSnapReadError) {
+          void legacyGridSnapReadError;
+        }
+      }
+
+      return false;
+    };
     var manualPositions = {};
     var lastDiagramPositions = {};
     function normalizeDiagramPositionsInput(positions) {
@@ -10657,7 +10682,6 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
         renderSetupDiagram();
       }
     }
-    var gridSnap = false;
     var cleanupDiagramInteractions = null;
     var diagramCssLight = "\n    .node-box{fill:#f0f0f0;stroke:none;}\n    .node-box.first-fiz{stroke:none;}\n    .first-fiz-highlight{stroke:url(#firstFizGrad);stroke-width:1px;fill:none;}\n    .node-icon{font-size:var(--font-size-diagram-icon, 24px);font-family:'UiconsThinStraightV2',system-ui,sans-serif;font-style:normal;}\n    .node-icon[data-icon-font='essential']{font-family:'EssentialIconsV2',system-ui,sans-serif;}\n    .conn{stroke:none;}\n    .conn.red{fill:#d33;}\n    .conn.blue{fill:#369;}\n    .conn.green{fill:#090;}\n    text{font-family:system-ui,sans-serif;}\n    .edge-label{font-size:var(--font-size-diagram-label, 11px);}\n    line{stroke:#333;stroke-width:2px;}\n    path.edge-path{stroke:#333;stroke-width:2px;fill:none;}\n    path.power{stroke:#d33;}\n    path.video{stroke:#369;}\n    path.fiz{stroke:#090;}\n    .diagram-placeholder{font-style:italic;color:#666;margin:0;}\n    ";
     var diagramCssDark = "\n    .node-box{fill:#444;stroke:none;}\n    .node-box.first-fiz{stroke:none;}\n    .first-fiz-highlight{stroke:url(#firstFizGrad);}\n    .node-icon{font-size:var(--font-size-diagram-icon, 24px);font-family:'UiconsThinStraightV2',system-ui,sans-serif;font-style:normal;}\n    .node-icon[data-icon-font='essential']{font-family:'EssentialIconsV2',system-ui,sans-serif;}\n    text{fill:#fff;font-family:system-ui,sans-serif;}\n    .edge-label{font-size:var(--font-size-diagram-label, 11px);}\n    line{stroke:#fff;}\n    path.edge-path{stroke:#fff;}\n    path.power{stroke:#ff6666;}\n    path.video{stroke:#7ec8ff;}\n    path.fiz{stroke:#6f6;}\n    .conn.red{fill:#ff6666;}\n    .conn.blue{fill:#7ec8ff;}\n    .conn.green{fill:#6f6;}\n    .diagram-placeholder{color:#bbb;}\n    ";
@@ -15151,7 +15175,7 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
         var dy = delta.y;
         var newX = start.x + dx;
         var newY = start.y + dy;
-        if (gridSnap) {
+        if (getCurrentGridSnap()) {
           var g = 20;
           newX = Math.round(newX / g) * g;
           newY = Math.round(newY / g) * g;
@@ -15171,7 +15195,7 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
           var dy = delta.y;
           var newX = start.x + dx;
           var newY = start.y + dy;
-          if (gridSnap) {
+          if (getCurrentGridSnap()) {
             var g = 20;
             newX = Math.round(newX / g) * g;
             newY = Math.round(newY / g) * g;

--- a/legacy/scripts/app-session.js
+++ b/legacy/scripts/app-session.js
@@ -1,4 +1,5 @@
 /* global enqueueCoreBootTask, updateFavoriteButton, adjustGearListSelectWidth */
+/* global getGridSnapState: true, setGridSnapState: true */
 var _excluded = ["parsed", "timestamp"];
 function _regenerator() { var e, t, r = "function" == typeof Symbol ? Symbol : {}, n = r.iterator || "@@iterator", o = r.toStringTag || "@@toStringTag"; function i(r, n, o, i) { var c = n && n.prototype instanceof Generator ? n : Generator, u = Object.create(c.prototype); return _regeneratorDefine2(u, "_invoke", function (r, n, o) { var i, c, u, f = 0, p = o || [], y = !1, G = { p: 0, n: 0, v: e, a: d, f: d.bind(e, 4), d: function d(t, r) { return i = t, c = 0, u = e, G.n = r, a; } }; function d(r, n) { for (c = r, u = n, t = 0; !y && f && !o && t < p.length; t++) { var o, i = p[t], d = G.p, l = i[2]; r > 3 ? (o = l === n) && (u = i[(c = i[4]) ? 5 : (c = 3, 3)], i[4] = i[5] = e) : i[0] <= d && ((o = r < 2 && d < i[1]) ? (c = 0, G.v = n, G.n = i[1]) : d < l && (o = r < 3 || i[0] > n || n > l) && (i[4] = r, i[5] = n, G.n = l, c = 0)); } if (o || r > 1) return a; throw y = !0, n; } return function (o, p, l) { if (f > 1) throw TypeError("Generator is already running"); for (y && 1 === p && d(p, l), c = p, u = l; (t = c < 2 ? e : u) || !y;) { i || (c ? c < 3 ? (c > 1 && (G.n = -1), d(c, u)) : G.n = u : G.v = u); try { if (f = 2, i) { if (c || (o = "next"), t = i[o]) { if (!(t = t.call(i, u))) throw TypeError("iterator result is not an object"); if (!t.done) return t; u = t.value, c < 2 && (c = 0); } else 1 === c && (t = i.return) && t.call(i), c < 2 && (u = TypeError("The iterator does not provide a '" + o + "' method"), c = 1); i = e; } else if ((t = (y = G.n < 0) ? u : r.call(n, G)) !== a) break; } catch (t) { i = e, c = 1, u = t; } finally { f = 1; } } return { value: t, done: y }; }; }(r, o, i), !0), u; } var a = {}; function Generator() {} function GeneratorFunction() {} function GeneratorFunctionPrototype() {} t = Object.getPrototypeOf; var c = [][n] ? t(t([][n]())) : (_regeneratorDefine2(t = {}, n, function () { return this; }), t), u = GeneratorFunctionPrototype.prototype = Generator.prototype = Object.create(c); function f(e) { return Object.setPrototypeOf ? Object.setPrototypeOf(e, GeneratorFunctionPrototype) : (e.__proto__ = GeneratorFunctionPrototype, _regeneratorDefine2(e, o, "GeneratorFunction")), e.prototype = Object.create(u), e; } return GeneratorFunction.prototype = GeneratorFunctionPrototype, _regeneratorDefine2(u, "constructor", GeneratorFunctionPrototype), _regeneratorDefine2(GeneratorFunctionPrototype, "constructor", GeneratorFunction), GeneratorFunction.displayName = "GeneratorFunction", _regeneratorDefine2(GeneratorFunctionPrototype, o, "GeneratorFunction"), _regeneratorDefine2(u), _regeneratorDefine2(u, o, "Generator"), _regeneratorDefine2(u, n, function () { return this; }), _regeneratorDefine2(u, "toString", function () { return "[object Generator]"; }), (_regenerator = function _regenerator() { return { w: i, m: f }; })(); }
 function _regeneratorDefine2(e, r, n, t) { var i = Object.defineProperty; try { i({}, "", {}); } catch (e) { i = 0; } _regeneratorDefine2 = function _regeneratorDefine(e, r, n, t) { if (r) i ? i(e, r, { value: n, enumerable: !t, configurable: !t, writable: !t }) : e[r] = n;else { function o(r, n) { _regeneratorDefine2(e, r, function (e) { return this._invoke(r, n, e); }); } o("next", 0), o("throw", 1), o("return", 2); } }, _regeneratorDefine2(e, r, n, t); }
@@ -125,6 +126,131 @@ var gridSnapToggleBtn = ensureSessionRuntimePlaceholder('gridSnapToggleBtn', fun
     return null;
   }
 });
+
+var GRID_SNAP_STORAGE_KEY = '__cineGridSnapState';
+
+function readGridSnapState() {
+  try {
+    if (typeof getGridSnapState === 'function') {
+      return Boolean(getGridSnapState());
+    }
+  } catch (gridSnapReadError) {
+    void gridSnapReadError;
+  }
+
+  if (typeof gridSnap !== 'undefined') {
+    try {
+      return Boolean(gridSnap);
+    } catch (legacyGridSnapError) {
+      void legacyGridSnapError;
+    }
+  }
+
+  var scopes = getSessionRuntimeScopes();
+  for (var index = 0; index < scopes.length; index += 1) {
+    var scope = scopes[index];
+    if (!scope || _typeof(scope) !== 'object') {
+      continue;
+    }
+
+    try {
+      var stored = scope[GRID_SNAP_STORAGE_KEY];
+      if (typeof stored === 'boolean') {
+        return stored;
+      }
+    } catch (storedReadError) {
+      void storedReadError;
+    }
+
+    try {
+      var legacy = scope.gridSnap;
+      if (typeof legacy === 'boolean') {
+        return legacy;
+      }
+    } catch (legacyScopeError) {
+      void legacyScopeError;
+    }
+  }
+
+  return false;
+}
+
+function writeGridSnapState(value) {
+  var desired = value === true;
+
+  try {
+    if (typeof setGridSnapState === 'function') {
+      return Boolean(setGridSnapState(desired));
+    }
+  } catch (gridSnapWriteError) {
+    void gridSnapWriteError;
+  }
+
+  var scopes = getSessionRuntimeScopes();
+  for (var index = 0; index < scopes.length; index += 1) {
+    var scope = scopes[index];
+    if (!scope || _typeof(scope) !== 'object') {
+      continue;
+    }
+
+    try {
+      scope[GRID_SNAP_STORAGE_KEY] = desired;
+    } catch (assignStorageError) {
+      try {
+        Object.defineProperty(scope, GRID_SNAP_STORAGE_KEY, {
+          configurable: true,
+          writable: true,
+          value: desired
+        });
+      } catch (defineStorageError) {
+        void defineStorageError;
+      }
+    }
+
+    try {
+      scope.gridSnap = desired;
+    } catch (assignLegacyError) {
+      try {
+        Object.defineProperty(scope, 'gridSnap', {
+          configurable: true,
+          writable: true,
+          value: desired
+        });
+      } catch (defineLegacyError) {
+        void defineLegacyError;
+      }
+    }
+  }
+
+  return desired;
+}
+
+function resolveDiagramContainer() {
+  if (typeof setupDiagramContainer !== 'undefined' && setupDiagramContainer) {
+    return setupDiagramContainer;
+  }
+  if (typeof document !== 'undefined' && document && typeof document.getElementById === 'function') {
+    try {
+      return document.getElementById('diagramArea');
+    } catch (diagramResolveError) {
+      void diagramResolveError;
+    }
+  }
+  return null;
+}
+
+function applyGridSnapUiState(enabled) {
+  var diagramContainer = resolveDiagramContainer();
+  if (gridSnapToggleBtn) {
+    gridSnapToggleBtn.classList.toggle('active', enabled);
+    gridSnapToggleBtn.setAttribute('aria-pressed', enabled ? 'true' : 'false');
+  }
+  if (diagramContainer) {
+    diagramContainer.classList.toggle('grid-snap', enabled);
+  }
+}
+
+applyGridSnapUiState(readGridSnapState());
 function getGlobalCineUi() {
   var scope = typeof globalThis !== 'undefined' && globalThis || typeof window !== 'undefined' && window || typeof self !== 'undefined' && self || typeof global !== 'undefined' && global || null;
   if (!scope || _typeof(scope) !== 'object') {
@@ -7776,12 +7902,9 @@ if (downloadDiagramBtn) {
 }
 if (gridSnapToggleBtn) {
   gridSnapToggleBtn.addEventListener('click', function () {
-    gridSnap = !gridSnap;
-    gridSnapToggleBtn.classList.toggle('active', gridSnap);
-    gridSnapToggleBtn.setAttribute('aria-pressed', gridSnap ? 'true' : 'false');
-    if (setupDiagramContainer) {
-      setupDiagramContainer.classList.toggle('grid-snap', gridSnap);
-    }
+    var nextState = !readGridSnapState();
+    var finalState = writeGridSnapState(nextState);
+    applyGridSnapUiState(finalState);
   });
 }
 if (helpButton && helpDialog) {

--- a/src/scripts/app-core-new-1.js
+++ b/src/scripts/app-core-new-1.js
@@ -604,6 +604,155 @@ function callCoreFunctionIfAvailable(functionName, args = [], options = {}) {
     : undefined;
 }
 
+const GRID_SNAP_STATE_STORAGE_KEY = '__cineGridSnapState';
+
+function getGridSnapStateScopes() {
+  const scopes = [];
+  const pushIfObject = candidate => {
+    if (candidate && typeof candidate === 'object' && scopes.indexOf(candidate) === -1) {
+      scopes.push(candidate);
+    }
+  };
+
+  try {
+    if (CORE_GLOBAL_SCOPE && typeof CORE_GLOBAL_SCOPE === 'object') {
+      pushIfObject(CORE_GLOBAL_SCOPE);
+    }
+  } catch (coreScopeError) {
+    void coreScopeError;
+  }
+
+  pushIfObject(typeof globalThis !== 'undefined' ? globalThis : null);
+  pushIfObject(typeof window !== 'undefined' ? window : null);
+  pushIfObject(typeof self !== 'undefined' ? self : null);
+  pushIfObject(typeof global !== 'undefined' ? global : null);
+
+  return scopes;
+}
+
+function normaliseGridSnapPreference(value, fallback = false) {
+  if (value === true || value === false) {
+    return value === true;
+  }
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase();
+    if (!normalized) {
+      return fallback;
+    }
+    if (['true', '1', 'yes', 'on', 'enabled', 'enable'].includes(normalized)) {
+      return true;
+    }
+    if (['false', '0', 'no', 'off', 'disabled', 'disable'].includes(normalized)) {
+      return false;
+    }
+    return fallback;
+  }
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) {
+      return fallback;
+    }
+    return value > 0;
+  }
+  if (value && typeof value === 'object') {
+    if (Object.prototype.hasOwnProperty.call(value, 'enabled')) {
+      return normaliseGridSnapPreference(value.enabled, fallback);
+    }
+    if (Object.prototype.hasOwnProperty.call(value, 'value')) {
+      return normaliseGridSnapPreference(value.value, fallback);
+    }
+  }
+  return fallback;
+}
+
+function readInitialGridSnapPreference() {
+  const scopes = getGridSnapStateScopes();
+  for (let index = 0; index < scopes.length; index += 1) {
+    const scope = scopes[index];
+    if (!scope || typeof scope !== 'object') {
+      continue;
+    }
+
+    try {
+      if (Object.prototype.hasOwnProperty.call(scope, GRID_SNAP_STATE_STORAGE_KEY)) {
+        const stored = scope[GRID_SNAP_STATE_STORAGE_KEY];
+        const normalized = normaliseGridSnapPreference(stored, undefined);
+        if (typeof normalized === 'boolean') {
+          return normalized;
+        }
+      }
+    } catch (storageReadError) {
+      void storageReadError;
+    }
+
+    try {
+      if (Object.prototype.hasOwnProperty.call(scope, 'gridSnap')) {
+        const legacy = scope.gridSnap;
+        const normalizedLegacy = normaliseGridSnapPreference(legacy, undefined);
+        if (typeof normalizedLegacy === 'boolean') {
+          return normalizedLegacy;
+        }
+      }
+    } catch (legacyReadError) {
+      void legacyReadError;
+    }
+  }
+
+  return undefined;
+}
+
+let gridSnapState = normaliseGridSnapPreference(readInitialGridSnapPreference(), false);
+
+function syncGridSnapStateToScopes(value) {
+  const scopes = getGridSnapStateScopes();
+  for (let index = 0; index < scopes.length; index += 1) {
+    const scope = scopes[index];
+    if (!scope || typeof scope !== 'object') {
+      continue;
+    }
+
+    try {
+      scope[GRID_SNAP_STATE_STORAGE_KEY] = value;
+    } catch (assignStorageError) {
+      try {
+        Object.defineProperty(scope, GRID_SNAP_STATE_STORAGE_KEY, {
+          configurable: true,
+          writable: true,
+          value,
+        });
+      } catch (defineStorageError) {
+        void defineStorageError;
+      }
+    }
+
+    try {
+      scope.gridSnap = value;
+    } catch (assignLegacyError) {
+      try {
+        Object.defineProperty(scope, 'gridSnap', {
+          configurable: true,
+          writable: true,
+          value,
+        });
+      } catch (defineLegacyError) {
+        void defineLegacyError;
+      }
+    }
+  }
+}
+
+function getGridSnapState() {
+  return gridSnapState;
+}
+
+function setGridSnapState(value) {
+  const normalized = normaliseGridSnapPreference(value, gridSnapState);
+  gridSnapState = normalized;
+  syncGridSnapStateToScopes(normalized);
+  return gridSnapState;
+}
+
+syncGridSnapStateToScopes(gridSnapState);
+
 function safeFormatAutoGearItemSummary(item, options = {}) {
   if (typeof formatAutoGearItemSummary === 'function') {
     try {
@@ -10379,7 +10528,18 @@ function setLanguage(lang) {
     gridSnapToggleBtn.setAttribute("title", texts[lang].gridSnapToggle);
     gridSnapToggleBtn.setAttribute("aria-label", texts[lang].gridSnapToggle);
     gridSnapToggleBtn.setAttribute("data-help", texts[lang].gridSnapToggleHelp);
-    gridSnapToggleBtn.setAttribute("aria-pressed", gridSnap ? "true" : "false");
+    let snapActive = false;
+    try {
+      snapActive = Boolean(getGridSnapState());
+    } catch (gridSnapReadError) {
+      void gridSnapReadError;
+      try {
+        snapActive = Boolean(gridSnap);
+      } catch (legacyGridSnapError) {
+        void legacyGridSnapError;
+      }
+    }
+    gridSnapToggleBtn.setAttribute('aria-pressed', snapActive ? 'true' : 'false');
   }
   const resetViewBtn =
     typeof document !== 'undefined' ? document.getElementById('resetView') : null;
@@ -17328,6 +17488,8 @@ Object.assign(CORE_RUNTIME_CONSTANTS, {
   PINK_MODE_ICON_INTERVAL_MS,
   PINK_MODE_ICON_ANIMATION_CLASS,
   PINK_MODE_ICON_ANIMATION_RESET_DELAY,
+  getGridSnapState,
+  setGridSnapState,
 });
 
 exposeCoreRuntimeConstants(CORE_RUNTIME_CONSTANTS);

--- a/src/scripts/app-core-new-2.js
+++ b/src/scripts/app-core-new-2.js
@@ -7486,6 +7486,7 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
     
     var normalizeSearchValue = value =>
       typeof value === 'string' ? value.trim().toLowerCase() : '';
+    exposeCoreRuntimeConstant('normalizeSearchValue', normalizeSearchValue);
     const FEATURE_SEARCH_EXTRA_SELECTOR = '[data-feature-search]';
     
     const FEATURE_SEARCH_TYPE_LABEL_KEYS = {
@@ -11442,7 +11443,32 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
     const resetViewBtn = document.getElementById("resetView");
     var gridSnapToggleBtn = document.getElementById("gridSnapToggle");
     const diagramHint = document.getElementById("diagramHint");
-    
+
+    const getCurrentGridSnap = () => {
+      try {
+        if (typeof getGridSnapState === 'function') {
+          return Boolean(getGridSnapState());
+        }
+      } catch (gridSnapStateError) {
+        void gridSnapStateError;
+      }
+
+      const scopedValue = readGlobalScopeValue('gridSnap');
+      if (typeof scopedValue === 'boolean') {
+        return scopedValue;
+      }
+
+      if (typeof gridSnap !== 'undefined') {
+        try {
+          return Boolean(gridSnap);
+        } catch (legacyGridSnapReadError) {
+          void legacyGridSnapReadError;
+        }
+      }
+
+      return false;
+    };
+
     let manualPositions = {};
     let lastDiagramPositions = {};
     
@@ -11474,7 +11500,6 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
         renderSetupDiagram();
       }
     }
-    var gridSnap = false;
     let cleanupDiagramInteractions = null;
     
     // CSS used when exporting the setup diagram
@@ -15953,7 +15978,7 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
         const dy = delta.y;
         let newX = start.x + dx;
         let newY = start.y + dy;
-        if (gridSnap) {
+        if (getCurrentGridSnap()) {
           const g = 20;
           newX = Math.round(newX / g) * g;
           newY = Math.round(newY / g) * g;
@@ -15973,7 +15998,7 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
           const dy = delta.y;
           let newX = start.x + dx;
           let newY = start.y + dy;
-          if (gridSnap) {
+          if (getCurrentGridSnap()) {
             const g = 20;
             newX = Math.round(newX / g) * g;
             newY = Math.round(newY / g) * g;

--- a/tools/appScriptGlobals.json
+++ b/tools/appScriptGlobals.json
@@ -14,6 +14,8 @@
     "loadDeviceData",
     "loadFeedback",
     "loadSetups",
+    "getGridSnapState",
+    "setGridSnapState",
     "populateProjectForm",
     "refreshGearListIfVisible",
     "renderFilterDetails",


### PR DESCRIPTION
## Summary
- add shared grid snap state helpers for modern and legacy core bundles and expose them as runtime globals
- update session UI logic and diagram interactions to rely on the shared grid snap state, preventing undefined references
- expose the feature-search normalizer globally and register the new grid snap helpers in the globals manifest

## Testing
- npm test -- --watchAll=false *(hangs during dom suite; aborted after partial completion)*

------
https://chatgpt.com/codex/tasks/task_e_68e2a88be5fc8320bd830cbcef3f7c94