### PR TITLE
Guard restore rehearsal close button localization

### DIFF
--- a/legacy/scripts/app-core-new-1.js
+++ b/legacy/scripts/app-core-new-1.js
@@ -8969,11 +8969,15 @@ function updateAutoGearItemButtonState(type) {
     if (restoreRehearsalDifferenceHeader) {
       restoreRehearsalDifferenceHeader.textContent = texts[lang].restoreRehearsalDifferenceColumn || restoreRehearsalDifferenceHeader.textContent;
     }
-    if (restoreRehearsalCloseButton) {
+    var resolvedRestoreRehearsalCloseButton =
+      typeof restoreRehearsalCloseButton !== 'undefined'
+        ? restoreRehearsalCloseButton
+        : resolveElement('restoreRehearsalCloseButton', 'restoreRehearsalClose');
+    if (resolvedRestoreRehearsalCloseButton) {
       var _closeLabel = texts[lang].restoreRehearsalClose || texts[lang].cancelSettings || 'Close';
-      setButtonLabelWithIcon(restoreRehearsalCloseButton, _closeLabel, ICON_GLYPHS.circleX);
-      restoreRehearsalCloseButton.setAttribute('title', _closeLabel);
-      restoreRehearsalCloseButton.setAttribute('aria-label', _closeLabel);
+      setButtonLabelWithIcon(resolvedRestoreRehearsalCloseButton, _closeLabel, ICON_GLYPHS.circleX);
+      resolvedRestoreRehearsalCloseButton.setAttribute('title', _closeLabel);
+      resolvedRestoreRehearsalCloseButton.setAttribute('aria-label', _closeLabel);
     }
     if (restoreRehearsalProceedButton) {
       var _texts$en226, _texts$en227;

--- a/src/scripts/app-core-new-1.js
+++ b/src/scripts/app-core-new-1.js
@@ -10111,11 +10111,16 @@ function setLanguage(lang) {
   if (restoreRehearsalDifferenceHeader) {
     restoreRehearsalDifferenceHeader.textContent = texts[lang].restoreRehearsalDifferenceColumn || restoreRehearsalDifferenceHeader.textContent;
   }
-  if (restoreRehearsalCloseButton) {
+  const resolvedRestoreRehearsalCloseButton =
+    typeof restoreRehearsalCloseButton !== 'undefined'
+      ? restoreRehearsalCloseButton
+      : resolveElement('restoreRehearsalCloseButton', 'restoreRehearsalClose');
+
+  if (resolvedRestoreRehearsalCloseButton) {
     const closeLabel = texts[lang].restoreRehearsalClose || texts[lang].cancelSettings || 'Close';
-    setButtonLabelWithIcon(restoreRehearsalCloseButton, closeLabel, ICON_GLYPHS.circleX);
-    restoreRehearsalCloseButton.setAttribute('title', closeLabel);
-    restoreRehearsalCloseButton.setAttribute('aria-label', closeLabel);
+    setButtonLabelWithIcon(resolvedRestoreRehearsalCloseButton, closeLabel, ICON_GLYPHS.circleX);
+    resolvedRestoreRehearsalCloseButton.setAttribute('title', closeLabel);
+    resolvedRestoreRehearsalCloseButton.setAttribute('aria-label', closeLabel);
   }
   if (restoreRehearsalProceedButton) {
     const proceedLabel = texts[lang].restoreRehearsalProceed


### PR DESCRIPTION
## Summary
- guard the restore rehearsal close button localization against missing references by re-resolving safely
- mirror the same safeguard in the legacy bundle to keep behaviour consistent

## Testing
- npm test -- --watchAll=false *(terminated manually after extended runtime)*

------
https://chatgpt.com/codex/tasks/task_e_68e2a953b3a08320864deff13267385c