### PR TITLE
Export populateFeatureSearch to restore help suggestions

### DIFF
--- a/src/scripts/app-core-new-2.js
+++ b/src/scripts/app-core-new-2.js
@@ -16362,6 +16362,7 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
       ['helpMap', () => helpMap],
       ['featureSearchEntries', () => featureSearchEntries],
       ['featureSearchDefaultOptions', () => featureSearchDefaultOptions],
+      ['populateFeatureSearch', () => populateFeatureSearch],
       ['restoreFeatureSearchDefaults', () => restoreFeatureSearchDefaults],
       ['updateFeatureSearchSuggestions', () => updateFeatureSearchSuggestions],
       ['setCurrentProjectInfo', () => setCurrentProjectInfo],


### PR DESCRIPTION
## Summary
- expose `populateFeatureSearch` through the core export map so boot tasks can run the feature/help search population logic

## Testing
- npm run lint
- npm run check-consistency

------
https://chatgpt.com/codex/tasks/task_e_68e2b6d2c8b083208315e25601b9ceee