### PR TITLE
Fix module environment scope freezing

### DIFF
--- a/src/scripts/modules/environment.js
+++ b/src/scripts/modules/environment.js
@@ -368,8 +368,6 @@
     const registry = options && options.registry ? options.registry : getModuleRegistry(scope);
 
     const environment = {
-      scope,
-      registry,
       tryRequire(modulePath) {
         return getTryRequire()(modulePath);
       },
@@ -389,6 +387,23 @@
       },
       PENDING_QUEUE_KEY: getPendingQueueKey(),
     };
+
+    Object.defineProperties(environment, {
+      scope: {
+        configurable: false,
+        enumerable: true,
+        get() {
+          return scope;
+        },
+      },
+      registry: {
+        configurable: false,
+        enumerable: true,
+        get() {
+          return registry;
+        },
+      },
+    });
 
     return freezeDeep(environment);
   }

--- a/tests/unit/moduleEnvironment.test.js
+++ b/tests/unit/moduleEnvironment.test.js
@@ -1,0 +1,64 @@
+const path = require('path');
+
+describe('module environment', () => {
+  let environment;
+
+  beforeEach(() => {
+    jest.resetModules();
+    const modulePath = path.resolve(__dirname, '../../src/scripts/modules/environment.js');
+    const basePath = path.resolve(__dirname, '../../src/scripts/modules/base.js');
+
+    jest.isolateModules(() => {
+      jest.doMock(basePath, () => ({
+        getModuleBase: () => null,
+        getGlobalScope: () => global,
+        collectCandidateScopes: () => [global],
+        tryRequire: () => null,
+        resolveModuleRegistry: () => null,
+        getModuleRegistry: () => null,
+        queueModuleRegistration: () => true,
+        registerOrQueueModule: () => true,
+        freezeDeep: value => value,
+        safeWarn: jest.fn(),
+        exposeGlobal: jest.fn(),
+        PENDING_QUEUE_KEY: '__mockPending__',
+      }), { virtual: true });
+
+      environment = require(modulePath);
+    });
+  });
+
+  test('scoped environments expose the provided scope without freezing it', () => {
+    const scope = {};
+    Object.defineProperty(scope, 'mutable', {
+      configurable: true,
+      enumerable: true,
+      value: 1,
+      writable: true,
+    });
+
+    const scoped = environment.createScopedEnvironment({ scope });
+
+    expect(scoped.scope).toBe(scope);
+    expect(Object.isFrozen(scope)).toBe(false);
+
+    scope.mutable = 2;
+    expect(scope.mutable).toBe(2);
+
+    expect(() => {
+      delete scope.mutable;
+    }).not.toThrow();
+    expect(Object.prototype.hasOwnProperty.call(scope, 'mutable')).toBe(false);
+  });
+
+  test('scoped environments reuse provided registries and do not mutate them', () => {
+    const registry = { register: jest.fn() };
+    const scoped = environment.createScopedEnvironment({ registry });
+
+    expect(scoped.registry).toBe(registry);
+    expect(Object.isFrozen(registry)).toBe(false);
+    expect(() => {
+      registry.register('example', {});
+    }).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- expose module environment `scope` and `registry` through accessors to avoid freezing shared host objects
- add unit tests covering `createScopedEnvironment` to ensure provided scopes and registries remain mutable

## Testing
- npm run test:jest -- --runTestsByPath tests/unit/moduleEnvironment.test.js
- npm run test:jest -- --runTestsByPath tests/unit/runtimeModule.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e2b70518f88320b2766b4806b77280