### PR TITLE
Ensure project requirements render after reload without stored gear list

### DIFF
--- a/src/scripts/app-session.js
+++ b/src/scripts/app-session.js
@@ -2785,6 +2785,27 @@ function restoreSessionState() {
         // Ensure the generator button reflects the restored gear list state
         updateGearListButtonVisibility();
       }
+    } else if (currentProjectInfo && typeof generateGearListHtml === 'function') {
+      const regeneratedHtml = generateGearListHtml(currentProjectInfo || {});
+      if (regeneratedHtml) {
+        displayGearAndRequirements(regeneratedHtml);
+        if (gearListOutput) {
+          gearListOutput.classList.remove('hidden');
+          skipNextGearListRefresh = true;
+          ensureGearListActions();
+          bindGearListCageListener();
+          bindGearListEasyrigListener();
+          bindGearListSliderBowlListener();
+          bindGearListEyeLeatherListener();
+          bindGearListProGaffTapeListener();
+          bindGearListDirectorMonitorListener();
+          if (state) {
+            setSliderBowlValue(state.sliderBowl);
+            setEasyrigValue(state.easyrig);
+          }
+          updateGearListButtonVisibility();
+        }
+      }
     }
   }
   const highlightPreference = state && Object.prototype.hasOwnProperty.call(state, 'autoGearHighlight')


### PR DESCRIPTION
## Summary
- regenerate the project requirements and gear list markup during session restore when no stored project payload exists
- reapply gear list bindings and session values so restored requirements stay visible after reloads

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e2ba73806483209f88410dc12b394a