### PR TITLE
Prevent overview diagram generation from missing container

### DIFF
--- a/src/scripts/overview.js
+++ b/src/scripts/overview.js
@@ -263,15 +263,17 @@ function generatePrintableOverview(config = {}) {
     const diagramCss = typeof getDiagramCss === 'function' ? getDiagramCss(false) : '';
 
     let diagramAreaHtml = '';
-    if (setupDiagramContainer) {
-      const areaClone = setupDiagramContainer.cloneNode(true);
-      const svg = areaClone.querySelector('svg');
-      if (svg) {
-        const style = document.createElement('style');
-        style.textContent = diagramCss;
-        svg.insertBefore(style, svg.firstChild);
-      }
-      diagramAreaHtml = areaClone.outerHTML;
+    const hasSetupDiagramContainer =
+        typeof setupDiagramContainer !== 'undefined' && setupDiagramContainer;
+    if (hasSetupDiagramContainer) {
+        const areaClone = setupDiagramContainer.cloneNode(true);
+        const svg = areaClone.querySelector('svg');
+        if (svg) {
+            const style = document.createElement('style');
+            style.textContent = diagramCss;
+            svg.insertBefore(style, svg.firstChild);
+        }
+        diagramAreaHtml = areaClone.outerHTML;
     }
     const diagramLegendHtml = diagramLegend ? diagramLegend.outerHTML : '';
     const diagramHintHtml = diagramHint ? diagramHint.outerHTML : '';


### PR DESCRIPTION
## Summary
- guard the printable overview diagram generation so it only runs when the global container is defined
- avoid ReferenceError when the overview is rendered before the diagram container exists

## Testing
- `npm test -- overview` *(fails: No tests found, exiting with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68e2c1a869488320be149dba1a38586e