### PR TITLE
Globalize loader fallbacks for runtime and icon globals

### DIFF
--- a/docs/offline-readiness.md
+++ b/docs/offline-readiness.md
@@ -52,7 +52,10 @@ time:
    updated as expected. Confirm the **Backup guardian** row reports an active or mirrored
    state so every critical key already has a redundant copy before rehearsals continue,
    check the **Latest activity** board for the new save entries and capture a backup through
-   **Quick safeguards** if you need an extra offline copy.
+   **Quick safeguards** if you need an extra offline copy. The sequential loader now
+   predeclares the grid snap flag, the runtime guard stub and the icon glyph helpers on the
+   global scope before it injects the core bundles, preventing older Safari builds from
+   throwing reference errors while you are offline.【F:src/scripts/loader.js†L193-L307】【F:src/scripts/loader.js†L310-L370】
 4. **Check the runtime guard.** Open the browser console and inspect
    `window.__cineRuntimeIntegrity`. It should report `{ ok: true }` with an empty
    `missing` list. Run `window.cineRuntime.verifyCriticalFlows()` if you need a fresh


### PR DESCRIPTION
## Summary
- declare additional critical globals (grid snap state, runtime stub, icon metadata) up front in the loader so browsers without property bindings do not crash before the core bundles load
- add safe fallback helpers for icon font keys and glyph objects to guarantee usable defaults during early bootstrap
- note the new loader guarantees in the offline readiness runbook so operators understand the safeguard

## Testing
- npm test -- --runTestsByPath tests/script/scriptIntegrity.test.js *(fails: heavy script suite disabled without RUN_HEAVY_TESTS)*
- RUN_HEAVY_TESTS=true npm run test:jest -- scriptIntegrity.test.js *(terminated after hanging during the heavy script suite)*

------
https://chatgpt.com/codex/tasks/task_e_68e2c0c0095c8320b2f4d62f3f29b911