### PR TITLE
Adjust Steadicam/Trinity rigging defaults

### DIFF
--- a/legacy/scripts/app-setups.js
+++ b/legacy/scripts/app-setups.js
@@ -3164,11 +3164,9 @@ function generateGearListHtml() {
   if (isAnyScenarioActive(['Trinity', 'Steadicam'])) {
     for (var i = 0; i < 2; i++) {
       riggingAcc.push('D-Tap Splitter');
-      riggingAcc.push('D-Tap Extension 50 cm (Steadicam/Trinity)');
     }
-    for (var _i13 = 0; _i13 < 2; _i13++) {
-      riggingAcc.push('D-Tap Extension 50 cm (Spare)');
-    }
+    riggingAcc.push('D-Tap Extension 50 cm (Steadicam/Trinity)');
+    riggingAcc.push('D-Tap Extension 50 cm (Spare)');
   }
   var handleSelections = info.cameraHandle ? info.cameraHandle.split(',').map(function (r) {
     return r.trim();

--- a/src/scripts/app-setups.js
+++ b/src/scripts/app-setups.js
@@ -3428,11 +3428,9 @@ function generateGearListHtml(info = {}) {
     if (isAnyScenarioActive(['Trinity', 'Steadicam'])) {
         for (let i = 0; i < 2; i++) {
             riggingAcc.push('D-Tap Splitter');
-            riggingAcc.push('D-Tap Extension 50 cm (Steadicam/Trinity)');
         }
-        for (let i = 0; i < 2; i++) {
-            riggingAcc.push('D-Tap Extension 50 cm (Spare)');
-        }
+        riggingAcc.push('D-Tap Extension 50 cm (Steadicam/Trinity)');
+        riggingAcc.push('D-Tap Extension 50 cm (Spare)');
     }
     const handleSelections = info.cameraHandle
         ? info.cameraHandle.split(',').map(r => r.trim()).filter(Boolean)


### PR DESCRIPTION
## Summary
- update the Trinity/Steadicam scenario auto gear rule to add two D-Tap splitters and one of each 50 cm extension cable (Steadicam/Trinity and Spare)

## Testing
- npm run lint
- npm test -- --watch=false --runTestsByPath tests/script/backupCompatibility.test.js *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68e2c264c3d48320aeba2832cd96c9aa