### PR TITLE
Fix dark mode contrast for rule coverage overview

### DIFF
--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -2889,16 +2889,24 @@ body.high-contrast .settings-tab[aria-selected="true"] {
 }
 
 body.dark-mode:not(.high-contrast) .auto-gear-summary {
-  background: color-mix(in srgb, var(--surface-color) 70%, #ffffff 30%);
+  background: color-mix(in srgb, var(--surface-color) 85%, #000000 15%);
   border-color: color-mix(in srgb, var(--panel-border) 65%, transparent);
   box-shadow: 0 6px 18px rgba(0, 0, 0, 0.45);
 }
 
 body.dark-mode:not(.high-contrast) .auto-gear-summary-card {
-  background: color-mix(in srgb, var(--surface-color) 55%, #ffffff 45%);
+  background: color-mix(in srgb, var(--control-bg) 80%, #000000 20%);
   border-color: color-mix(in srgb, var(--panel-border) 65%, transparent);
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.5);
   color: var(--inverse-text-color);
+}
+
+body.dark-mode:not(.high-contrast) .auto-gear-summary-list button,
+body.dark-mode:not(.high-contrast) .auto-gear-summary-details button[data-auto-gear-rule],
+body.dark-mode:not(.high-contrast) .auto-gear-summary-details button[data-auto-gear-scenario],
+body.dark-mode:not(.high-contrast) .auto-gear-summary-reset {
+  color: var(--inverse-text-color);
+  text-decoration-color: currentColor;
 }
 
 body.dark-mode:not(.high-contrast) .auto-gear-summary-label,
@@ -2909,16 +2917,24 @@ body.dark-mode:not(.high-contrast) .auto-gear-summary-detail-text {
 
 @media (prefers-color-scheme: dark) {
   body:not(.light-mode):not(.high-contrast) .auto-gear-summary {
-    background: color-mix(in srgb, var(--surface-color) 70%, #ffffff 30%);
+    background: color-mix(in srgb, var(--surface-color) 85%, #000000 15%);
     border-color: color-mix(in srgb, var(--panel-border) 65%, transparent);
     box-shadow: 0 6px 18px rgba(0, 0, 0, 0.45);
   }
 
   body:not(.light-mode):not(.high-contrast) .auto-gear-summary-card {
-    background: color-mix(in srgb, var(--surface-color) 55%, #ffffff 45%);
+    background: color-mix(in srgb, var(--control-bg) 80%, #000000 20%);
     border-color: color-mix(in srgb, var(--panel-border) 65%, transparent);
     box-shadow: 0 2px 6px rgba(0, 0, 0, 0.5);
     color: var(--inverse-text-color);
+  }
+
+  body:not(.light-mode):not(.high-contrast) .auto-gear-summary-list button,
+  body:not(.light-mode):not(.high-contrast) .auto-gear-summary-details button[data-auto-gear-rule],
+  body:not(.light-mode):not(.high-contrast) .auto-gear-summary-details button[data-auto-gear-scenario],
+  body:not(.light-mode):not(.high-contrast) .auto-gear-summary-reset {
+    color: var(--inverse-text-color);
+    text-decoration-color: currentColor;
   }
 
   body:not(.light-mode):not(.high-contrast) .auto-gear-summary-label,


### PR DESCRIPTION
## Summary
- adjust the dark theme background for the rule coverage overview summary container to stay consistent with the rest of dark mode surfaces
- update the dark theme card styling to rely on existing dark controls so text remains bright while the panel stays dark
- ensure the rule coverage overview links and actions inherit the inverse text color in dark mode so they remain bright and legible

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2c18c0cb083209dd5021fac206597