### PR TITLE
Fix search strong match fallback

### DIFF
--- a/src/scripts/app-session.js
+++ b/src/scripts/app-session.js
@@ -30,6 +30,10 @@
           helpResultsSummary, helpResultsAssist */
 /* eslint-enable no-redeclare */
 /* global enqueueCoreBootTask */
+const FALLBACK_STRONG_SEARCH_MATCH_TYPES = new Set(['exactKey', 'keyPrefix', 'keySubset']);
+if (typeof globalThis !== 'undefined' && typeof globalThis.STRONG_SEARCH_MATCH_TYPES === 'undefined') {
+  globalThis.STRONG_SEARCH_MATCH_TYPES = FALLBACK_STRONG_SEARCH_MATCH_TYPES;
+}
 /* global triggerPinkModeIconRain, loadDeviceData, loadSetups, loadSessionState,
           loadFeedback, loadFavorites, loadAutoGearBackups,
           loadAutoGearPresets, loadAutoGearSeedFlag, loadAutoGearActivePresetId,
@@ -10452,8 +10456,14 @@ if (helpButton && helpDialog) {
     const helpScore = helpMatch?.score || 0;
     const deviceScore = deviceMatch?.score || 0;
     const featureScore = featureMatch?.score || 0;
-    const deviceStrong = deviceMatch ? STRONG_SEARCH_MATCH_TYPES.has(deviceMatch.matchType) : false;
-    const featureStrong = featureMatch ? STRONG_SEARCH_MATCH_TYPES.has(featureMatch.matchType) : false;
+    const strongSearchMatchTypes =
+      typeof STRONG_SEARCH_MATCH_TYPES !== 'undefined' &&
+      STRONG_SEARCH_MATCH_TYPES instanceof Set
+        ? STRONG_SEARCH_MATCH_TYPES
+        : FALLBACK_STRONG_SEARCH_MATCH_TYPES;
+
+    const deviceStrong = deviceMatch ? strongSearchMatchTypes.has(deviceMatch.matchType) : false;
+    const featureStrong = featureMatch ? strongSearchMatchTypes.has(featureMatch.matchType) : false;
     const bestNonHelpScore = Math.max(deviceScore, featureScore);
     const hasStrongNonHelp = deviceStrong || featureStrong;
     const preferHelp =


### PR DESCRIPTION
## Summary
- ensure the feature search logic has a resilient STRONG_SEARCH_MATCH_TYPES fallback when the global is unavailable
- reuse the shared fallback set so suggestion scoring continues to prefer exact matches without runtime errors

## Testing
- npm run lint
- npm run check-consistency
- npm run test:jest -- --runTestsByPath tests/unit/runtimeModule.test.js --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68e2c2f049f08320be2e4da973e2b64b