### PR TITLE
Enhance hover help guidance overlay

### DIFF
--- a/src/scripts/app-session.js
+++ b/src/scripts/app-session.js
@@ -9549,6 +9549,13 @@ if (helpButton && helpDialog) {
   let hoverHelpHighlightedTarget = null;
   let hoverHelpPointerClientX = null;
   let hoverHelpPointerClientY = null;
+  let hoverHelpStatus = null;
+  let hoverHelpStatusHeading = null;
+  let hoverHelpStatusBody = null;
+  let hoverHelpStatusShortcuts = null;
+  let hoverHelpStatusShortcutsHeading = null;
+  let hoverHelpStatusShortcutsList = null;
+  let hoverHelpStatusHint = null;
 
   const parseHoverHelpSelectorList = value => {
     if (typeof value !== 'string') return [];
@@ -10219,11 +10226,143 @@ if (helpButton && helpDialog) {
     return fragment;
   };
 
+  const removeHoverHelpStatus = () => {
+    if (hoverHelpStatus) {
+      hoverHelpStatus.remove();
+    }
+    hoverHelpStatus = null;
+    hoverHelpStatusHeading = null;
+    hoverHelpStatusBody = null;
+    hoverHelpStatusShortcuts = null;
+    hoverHelpStatusShortcutsHeading = null;
+    hoverHelpStatusShortcutsList = null;
+    hoverHelpStatusHint = null;
+  };
+
+  const setElementHidden = (element, hidden) => {
+    if (!element) return;
+    if (hidden) {
+      element.setAttribute('hidden', '');
+    } else {
+      element.removeAttribute('hidden');
+    }
+  };
+
+  const ensureHoverHelpStatus = () => {
+    if (hoverHelpStatus && hoverHelpStatus.isConnected) {
+      return hoverHelpStatus;
+    }
+    const body = document?.body;
+    if (!body) {
+      return null;
+    }
+    removeHoverHelpStatus();
+    hoverHelpStatus = document.createElement('div');
+    hoverHelpStatus.id = 'hoverHelpStatus';
+    hoverHelpStatus.setAttribute('role', 'status');
+    hoverHelpStatus.setAttribute('aria-live', 'polite');
+    hoverHelpStatus.setAttribute('aria-atomic', 'true');
+
+    hoverHelpStatusHeading = document.createElement('div');
+    hoverHelpStatusHeading.className = 'hover-help-status-heading';
+    hoverHelpStatus.appendChild(hoverHelpStatusHeading);
+
+    hoverHelpStatusBody = document.createElement('div');
+    hoverHelpStatusBody.className = 'hover-help-status-body';
+    hoverHelpStatus.appendChild(hoverHelpStatusBody);
+
+    hoverHelpStatusShortcuts = document.createElement('div');
+    hoverHelpStatusShortcuts.className = 'hover-help-status-shortcuts';
+    hoverHelpStatusShortcutsHeading = document.createElement('div');
+    hoverHelpStatusShortcutsHeading.className = 'hover-help-status-shortcuts-heading';
+    hoverHelpStatusShortcuts.appendChild(hoverHelpStatusShortcutsHeading);
+    hoverHelpStatusShortcutsList = document.createElement('ul');
+    hoverHelpStatusShortcutsList.className = 'hover-help-status-shortcuts-list';
+    hoverHelpStatusShortcuts.appendChild(hoverHelpStatusShortcutsList);
+    hoverHelpStatus.appendChild(hoverHelpStatusShortcuts);
+    setElementHidden(hoverHelpStatusShortcuts, true);
+
+    hoverHelpStatusHint = document.createElement('div');
+    hoverHelpStatusHint.className = 'hover-help-status-hint';
+    hoverHelpStatus.appendChild(hoverHelpStatusHint);
+
+    body.appendChild(hoverHelpStatus);
+    return hoverHelpStatus;
+  };
+
+  const updateHoverHelpStatus = ({ heading = '', details = [], shortcuts = [], hint } = {}) => {
+    const statusEl = ensureHoverHelpStatus();
+    if (!statusEl) {
+      return;
+    }
+    if (hoverHelpStatusHeading) {
+      hoverHelpStatusHeading.textContent = heading || '';
+      setElementHidden(hoverHelpStatusHeading, !heading);
+    }
+    if (hoverHelpStatusBody) {
+      hoverHelpStatusBody.textContent = '';
+      const detailList = Array.isArray(details) ? details.filter(Boolean) : [];
+      if (detailList.length) {
+        hoverHelpStatusBody.appendChild(createHoverHelpDetailsFragment(detailList));
+        setElementHidden(hoverHelpStatusBody, false);
+      } else {
+        setElementHidden(hoverHelpStatusBody, true);
+      }
+    }
+    if (hoverHelpStatusShortcuts && hoverHelpStatusShortcutsList) {
+      hoverHelpStatusShortcutsList.textContent = '';
+      const shortcutItems = Array.isArray(shortcuts) ? shortcuts.filter(Boolean) : [];
+      if (shortcutItems.length) {
+        const headingText = getHoverHelpLocaleValue('hoverHelpShortcutsHeading');
+        if (hoverHelpStatusShortcutsHeading) {
+          hoverHelpStatusShortcutsHeading.textContent = headingText || '';
+          setElementHidden(hoverHelpStatusShortcutsHeading, !headingText);
+        }
+        shortcutItems.forEach(text => {
+          const item = document.createElement('li');
+          item.textContent = text;
+          hoverHelpStatusShortcutsList.appendChild(item);
+        });
+        setElementHidden(hoverHelpStatusShortcuts, false);
+      } else {
+        setElementHidden(hoverHelpStatusShortcuts, true);
+      }
+    }
+    if (hoverHelpStatusHint) {
+      const resolvedHint =
+        typeof hint === 'string' && hint.trim()
+          ? hint
+          : getHoverHelpLocaleValue('hoverHelpExitHint');
+      hoverHelpStatusHint.textContent = resolvedHint || '';
+      setElementHidden(hoverHelpStatusHint, !resolvedHint);
+    }
+  };
+
+  const renderHoverHelpStatusIntro = () => {
+    const heading = getHoverHelpLocaleValue('hoverHelpButtonLabel');
+    const description = getHoverHelpLocaleValue('hoverHelpButtonHelp');
+    const details = description ? [description] : [];
+    updateHoverHelpStatus({ heading, details });
+  };
+
+  const renderHoverHelpStatusForTarget = (label, detailText, shortcutList) => {
+    const heading = label && label.trim()
+      ? label.trim()
+      : getHoverHelpLocaleValue('hoverHelpButtonLabel');
+    const details = Array.isArray(detailText) ? detailText.filter(Boolean) : [];
+    const resolvedDetails = details.length ? details : [getHoverHelpLocaleValue('hoverHelpFallbackGeneric')];
+    const shortcuts = Array.isArray(shortcutList) ? shortcutList.filter(Boolean) : [];
+    updateHoverHelpStatus({ heading, details: resolvedDetails, shortcuts });
+  };
+
   const updateHoverHelpTooltip = target => {
     hoverHelpCurrentTarget = target || null;
     setHoverHelpHighlight(target || null);
     if (!hoverHelpActive || !hoverHelpTooltip || !target) {
       hideHoverHelpTooltip();
+      if (hoverHelpActive) {
+        renderHoverHelpStatusIntro();
+      }
       return;
     }
     const { label, details, shortcuts } = collectHoverHelpContent(target);
@@ -10234,6 +10373,7 @@ if (helpButton && helpDialog) {
       : [];
     if (!hasLabel && detailText.length === 0 && shortcutList.length === 0) {
       hideHoverHelpTooltip();
+      renderHoverHelpStatusIntro();
       return;
     }
     hoverHelpTooltip.textContent = '';
@@ -10283,6 +10423,7 @@ if (helpButton && helpDialog) {
       hoverHelpTooltip.style.removeProperty('visibility');
     }
     hoverHelpTooltip.removeAttribute('hidden');
+    renderHoverHelpStatusForTarget(hasLabel ? label : '', detailText, shortcutList);
   };
 
   const canInteractDuringHoverHelp = target => {
@@ -10301,6 +10442,7 @@ if (helpButton && helpDialog) {
     clearHoverHelpHighlight();
     document.body.style.cursor = '';
     document.body.classList.remove('hover-help-active');
+    removeHoverHelpStatus();
   };
 
   // Start hover-help mode: close the dialog, create the tooltip element and
@@ -10316,6 +10458,7 @@ if (helpButton && helpDialog) {
     hoverHelpTooltip.setAttribute('role', 'tooltip');
     hoverHelpTooltip.setAttribute('hidden', '');
     document.body.appendChild(hoverHelpTooltip);
+    renderHoverHelpStatusIntro();
   };
 
   const refreshTooltipPosition = () => {

--- a/src/scripts/translations.js
+++ b/src/scripts/translations.js
@@ -1277,6 +1277,7 @@ const texts = {
     hoverHelpButtonLabel: "Hover for help",
     hoverHelpButtonHelp:
       "Activate hover help so moving the cursor over buttons, fields, dropdowns or headers reveals brief explanations. You can open Settings while hover help is active to explore preferences without leaving this mode. Hovered controls are outlined and the tooltip shows their title alongside any available details. Longer descriptions are automatically broken into readable steps or bullet lists when available. Keyboard shortcuts are displayed whenever they exist so you can learn faster ways to use each control. When a control doesn't have custom guidance, the planner fills in contextual descriptions automatically so every interface element explains itself.",
+    hoverHelpExitHint: "Press Esc or click anywhere to exit hover help.",
     hoverHelpShortcutsHeading: "Shortcuts",
     hoverHelpFallbackGeneric: "Interactive control.",
     hoverHelpFallbackButton: "Button. Activate to perform this action.",
@@ -2618,6 +2619,8 @@ const texts = {
     hoverHelpButtonLabel: "Aiuto al passaggio",
     hoverHelpButtonHelp:
       "Attiva i suggerimenti al passaggio del mouse: spostando il cursore su pulsanti, campi, menu a discesa o intestazioni compaiono brevi spiegazioni. Puoi aprire Impostazioni mentre la modalità è attiva per esplorare le preferenze senza uscirne. Gli elementi sotto il cursore vengono evidenziati e il tooltip mostra il titolo insieme ai dettagli disponibili. Le descrizioni più lunghe vengono suddivise automaticamente in passaggi leggibili o elenchi puntati quando disponibili. Quando disponibili vengono mostrati anche i tasti di scelta rapida per imparare più velocemente ogni controllo. Quando un controllo non ha istruzioni dedicate, il planner aggiunge automaticamente descrizioni contestuali così ogni elemento dell'interfaccia si spiega da solo.",
+    hoverHelpExitHint:
+      "Premi Esc o fai clic in un punto qualsiasi per uscire dall'aiuto al passaggio.",
     hoverHelpShortcutsHeading: "Scorciatoie",
     hoverHelpFallbackGeneric: "Controllo interattivo.",
     hoverHelpFallbackButton: "Pulsante. Attivalo per eseguire questa azione.",
@@ -3966,6 +3969,8 @@ const texts = {
     hoverHelpButtonLabel: "Ayuda al pasar el cursor",
     hoverHelpButtonHelp:
       "Activa la ayuda al pasar el cursor para que, al moverlo sobre botones, campos, menús desplegables o encabezados, aparezcan explicaciones breves. Puedes abrir Ajustes mientras el modo está activo para explorar las preferencias sin salir de él. Los controles bajo el cursor se resaltan y la información emergente muestra el título junto con los detalles disponibles. Las descripciones más largas se dividen automáticamente en pasos legibles o listas con viñetas cuando están disponibles. Los atajos de teclado aparecen cuando existen para que descubras formas más rápidas de usar cada control. Cuando un control no tiene indicaciones personalizadas, el planificador añade automáticamente descripciones contextuales para que cada elemento de la interfaz se explique por sí mismo.",
+    hoverHelpExitHint:
+      "Pulsa Esc o haz clic en cualquier parte para salir de la ayuda al pasar el cursor.",
     hoverHelpShortcutsHeading: "Atajos",
     hoverHelpFallbackGeneric: "Control interactivo.",
     hoverHelpFallbackButton: "Botón. Actívalo para ejecutar esta acción.",
@@ -5324,6 +5329,8 @@ const texts = {
     hoverHelpButtonLabel: "Aide au survol",
     hoverHelpButtonHelp:
       "Activez l'aide contextuelle au survol : en déplaçant le curseur sur les boutons, champs, menus déroulants ou en-têtes, de brèves explications apparaissent. Vous pouvez ouvrir Paramètres pendant que le mode est actif afin d'explorer les préférences sans quitter cette vue. Les commandes survolées sont mises en évidence et l'infobulle affiche leur titre ainsi que les détails disponibles. Les descriptions plus longues sont automatiquement découpées en étapes lisibles ou en listes à puces lorsque c'est possible. Les raccourcis clavier sont affichés lorsqu'ils existent afin de découvrir plus rapidement chaque commande. Lorsqu'un contrôle ne possède pas d'indications spécifiques, le planificateur ajoute automatiquement des descriptions contextuelles pour que chaque élément de l'interface s'explique.",
+    hoverHelpExitHint:
+      "Appuyez sur Échap ou cliquez n'importe où pour quitter l'aide au survol.",
     hoverHelpShortcutsHeading: "Raccourcis",
     hoverHelpFallbackGeneric: "Contrôle interactif.",
     hoverHelpFallbackButton: "Bouton. Activez-le pour exécuter cette action.",
@@ -6687,6 +6694,8 @@ const texts = {
     hoverHelpButtonLabel: "Hover-Hilfe aktivieren",
     hoverHelpButtonHelp:
       "Aktiviere die Hover-Hilfe: Beim Überfahren von Schaltflächen, Feldern, Dropdowns oder Überschriften erscheinen kurze Erklärungen. Du kannst die Einstellungen öffnen, während der Modus aktiv ist, um Optionen zu erkunden, ohne ihn zu verlassen. Überfahrene Elemente werden hervorgehoben und das Tooltip zeigt ihren Titel zusammen mit allen verfügbaren Details. Längere Beschreibungen werden automatisch in gut lesbare Schritte oder Aufzählungslisten unterteilt, sobald sie verfügbar sind. Verfügbare Tastenkürzel werden eingeblendet, damit du schneller Arbeitswege lernst. Wenn ein Steuerelement keine eigene Anleitung besitzt, ergänzt der Planner automatisch kontextabhängige Beschreibungen, damit jedes Element seinen Zweck erklärt.",
+    hoverHelpExitHint:
+      "Drücke Esc oder klicke irgendwo, um die Hover-Hilfe zu beenden.",
     hoverHelpShortcutsHeading: "Tastenkürzel",
     hoverHelpFallbackGeneric: "Interaktives Bedienelement.",
     hoverHelpFallbackButton: "Schaltfläche. Aktivieren, um diese Aktion auszuführen.",

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -4205,6 +4205,106 @@ body.high-contrast #hoverHelpTooltip .hover-help-shortcut {
   border-color: currentColor;
 }
 
+#hoverHelpStatus {
+  position: fixed;
+  right: calc(16px + env(safe-area-inset-right, 0px));
+  bottom: calc(16px + env(safe-area-inset-bottom, 0px));
+  z-index: 999;
+  max-width: min(360px, 90vw);
+  background: var(--surface-color);
+  color: var(--text-color);
+  border: 1px solid color-mix(in srgb, var(--accent-color) 60%, transparent);
+  box-shadow: var(--panel-shadow);
+  border-radius: 8px;
+  padding: 12px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: calc(var(--font-size-base) * var(--font-scale-compact));
+}
+
+#hoverHelpStatus[hidden] {
+  display: none;
+}
+
+#hoverHelpStatus .hover-help-status-heading {
+  font-weight: 600;
+  letter-spacing: 0.01em;
+}
+
+#hoverHelpStatus .hover-help-status-body {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  line-height: 1.4;
+}
+
+#hoverHelpStatus .hover-help-status-body p {
+  margin: 0;
+}
+
+#hoverHelpStatus .hover-help-status-body ul {
+  margin: 0;
+  padding-inline-start: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+#hoverHelpStatus .hover-help-status-shortcuts {
+  border-top: 1px solid color-mix(in srgb, var(--accent-color) 40%, transparent);
+  padding-top: 6px;
+  margin-top: 2px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+#hoverHelpStatus .hover-help-status-shortcuts-heading {
+  font-weight: 600;
+  font-size: calc(var(--font-size-base) * var(--font-scale-compact));
+  letter-spacing: 0.01em;
+}
+
+#hoverHelpStatus .hover-help-status-shortcuts-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+#hoverHelpStatus .hover-help-status-shortcuts-list li {
+  background: color-mix(in srgb, var(--accent-color) 18%, transparent);
+  border: 1px solid color-mix(in srgb, var(--accent-color) 45%, transparent);
+  border-radius: 4px;
+  padding: 2px 6px;
+  font-family: var(--font-family-mono, var(--font-family));
+  font-size: calc(var(--font-size-base) * 0.78);
+  line-height: 1.2;
+  white-space: nowrap;
+}
+
+#hoverHelpStatus .hover-help-status-hint {
+  font-size: calc(var(--font-size-base) * 0.82);
+  color: color-mix(in srgb, var(--text-color) 70%, transparent);
+}
+
+body.dark-mode #hoverHelpStatus .hover-help-status-shortcuts-list li {
+  background: color-mix(in srgb, var(--accent-color) 35%, rgba(0, 0, 0, 0.45));
+  border-color: color-mix(in srgb, var(--accent-color) 60%, transparent);
+}
+
+body.high-contrast #hoverHelpStatus {
+  border-color: currentColor;
+}
+
+body.high-contrast #hoverHelpStatus .hover-help-status-shortcuts-list li {
+  background: color-mix(in srgb, var(--surface-color) 70%, transparent);
+  border-color: currentColor;
+}
+
 .hover-help-highlight {
   outline: 2px solid color-mix(in srgb, var(--accent-color) 75%, transparent);
   outline-offset: 3px;


### PR DESCRIPTION
## Summary
- add a persistent hover help status panel that mirrors tooltip content and exit guidance
- style the new hover help status area for all themes
- localize the new exit hint string in every supported language

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e2c3dbd78c83208e048e96b98b602d