### PR TITLE
Ensure battery comparison heading stays with table in print

### DIFF
--- a/src/styles/overview-print.css
+++ b/src/styles/overview-print.css
@@ -347,6 +347,17 @@ table, th, td {
   padding-left: 0;
   padding-right: 0;
 }
+
+#overviewDialogContent #batteryComparison {
+  break-inside: avoid;
+  page-break-inside: avoid;
+}
+
+#overviewDialogContent #batteryComparisonHeading {
+  break-after: avoid;
+  break-after: avoid-page;
+  page-break-after: avoid;
+}
 #overviewDialogContent #setupDiagram {
   background: none !important;
   border: none !important;


### PR DESCRIPTION
## Summary
- prevent page breaks from splitting the Battery Comparison heading and table in the print stylesheet

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e2cf7aeca08320a0d458790f9396c4