### PR TITLE
Ensure print results warnings use black text

### DIFF
--- a/src/styles/overview-print.css
+++ b/src/styles/overview-print.css
@@ -305,6 +305,10 @@ h2, h3, table, .device-block, .device-category, .requirement-box {
   margin-top: 0.5em;
 }
 
+#overviewDialogContent #resultsSection .results-warnings .status-message--warning {
+  color: #000 !important;
+}
+
 .device-category-container,
 .device-block-grid {
   page-break-inside: avoid;


### PR DESCRIPTION
## Summary
- force results section warning messages to print with black text regardless of overview theme

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2d147e2948320b508581ad21ee5a2