### PR TITLE
Fix registerDevice merge to avoid mutating frozen entries

### DIFF
--- a/src/data/devices/index.js
+++ b/src/data/devices/index.js
@@ -8,8 +8,13 @@ function registerDevice(path, data) {
     obj = obj[part] = obj[part] || {};
   }
   var last = parts[0];
-  if (obj[last] && typeof obj[last] === 'object' && typeof data === 'object' && !Array.isArray(data)) {
-    obj[last] = Object.assign(obj[last], data);
+  if (
+    obj[last] &&
+    typeof obj[last] === 'object' &&
+    typeof data === 'object' &&
+    !Array.isArray(data)
+  ) {
+    obj[last] = Object.assign({}, obj[last], data);
   } else {
     obj[last] = data;
   }


### PR DESCRIPTION
## Summary
- clone existing device entries before merging new data so we never mutate frozen registries
- prevent runtime TypeError when refreshing calculations after voltage changes

## Testing
- npm test -- --watch=false *(fails: Jest runner attempts to augment a frozen console object in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e2da74fe588320ba31fb05b1b44c4b