### PR TITLE
Add module test harness for module architecture

### DIFF
--- a/tests/helpers/moduleHarness.js
+++ b/tests/helpers/moduleHarness.js
@@ -1,0 +1,224 @@
+const path = require('path');
+const { createRequire } = require('module');
+
+const ROOT_DIR = path.join(__dirname, '..', '..');
+const MODULES_DIR = path.join(ROOT_DIR, 'src', 'scripts', 'modules');
+const GLOBALS_PATH = path.join(MODULES_DIR, 'globals.js');
+const RUNTIME_PATH = path.join(MODULES_DIR, 'runtime.js');
+const PENDING_QUEUE_KEY = '__cinePendingModuleRegistrations__';
+
+const modulesRequire = createRequire(RUNTIME_PATH);
+
+function safeFreezeDeep(value, seen = new WeakSet()) {
+  if (!value || (typeof value !== 'object' && typeof value !== 'function')) {
+    return value;
+  }
+
+  if (
+    value === global
+    || value === globalThis
+    || value === process
+    || value === process?.stdout
+    || value === process?.stderr
+    || value === process?.stdin
+    || value === console
+  ) {
+    return value;
+  }
+
+  if (seen.has(value)) {
+    return value;
+  }
+
+  seen.add(value);
+
+  const keys = Object.getOwnPropertyNames(value);
+  for (let index = 0; index < keys.length; index += 1) {
+    const key = keys[index];
+    const descriptor = Object.getOwnPropertyDescriptor(value, key);
+    if (!descriptor || descriptor.get || descriptor.set) {
+      continue;
+    }
+
+    safeFreezeDeep(descriptor.value, seen);
+  }
+
+  try {
+    return Object.freeze(value);
+  } catch (error) {
+    void error;
+  }
+
+  return value;
+}
+
+function setupModuleHarness() {
+  jest.resetModules();
+
+  const registryPath = path.join(MODULES_DIR, 'registry.js');
+  const registry = require(registryPath);
+  if (registry && typeof registry.__internalResetForTests === 'function') {
+    registry.__internalResetForTests({ force: true });
+  }
+
+  const recordedModules = new Map();
+  const pendingWaiters = new Map();
+
+  function notifyWaiters(name, api) {
+    const callbacks = pendingWaiters.get(name);
+    if (!callbacks) {
+      return;
+    }
+
+    pendingWaiters.delete(name);
+    callbacks.forEach((callback) => {
+      try {
+        callback(api);
+      } catch (error) {
+        void error;
+      }
+    });
+  }
+
+  function recordModule(name, api) {
+    recordedModules.set(name, api);
+    notifyWaiters(name, api);
+    return true;
+  }
+
+  function registerModule(name, api, options = {}, onError, targetRegistry) {
+    const registryInstance = targetRegistry || registry;
+    const normalizedOptions = { ...options };
+    if (typeof normalizedOptions.freeze === 'undefined') {
+      normalizedOptions.freeze = true;
+    }
+
+    try {
+      registryInstance.register(name, api, normalizedOptions);
+      recordModule(name, api);
+      return true;
+    } catch (error) {
+      if (typeof onError === 'function') {
+        try {
+          onError(error);
+        } catch (handlerError) {
+          void handlerError;
+        }
+      }
+      return false;
+    }
+  }
+
+  const moduleGlobals = {
+    scope: global,
+    freezeDeep: safeFreezeDeep,
+    safeWarn: jest.fn((message, detail) => {
+      if (typeof console === 'undefined' || typeof console.warn !== 'function') {
+        return;
+      }
+      try {
+        if (typeof detail === 'undefined') {
+          console.warn(message);
+        } else {
+          console.warn(message, detail);
+        }
+      } catch (error) {
+        void error;
+      }
+    }),
+    exposeGlobal: jest.fn((name, value, options = {}) => {
+      const descriptor = {
+        configurable: options.configurable !== false,
+        enumerable: !!options.enumerable,
+        writable: !!options.writable,
+        value,
+      };
+
+      try {
+        Object.defineProperty(global, name, descriptor);
+        return true;
+      } catch (error) {
+        void error;
+      }
+
+      try {
+        global[name] = value;
+        return true;
+      } catch (assignmentError) {
+        void assignmentError;
+      }
+
+      return false;
+    }),
+    collectCandidateScopes: jest.fn(() => {
+      const scopes = [];
+      if (typeof globalThis !== 'undefined') {
+        scopes.push(globalThis);
+      }
+      if (typeof window !== 'undefined') {
+        scopes.push(window);
+      }
+      if (typeof self !== 'undefined') {
+        scopes.push(self);
+      }
+      scopes.push(global);
+      return scopes;
+    }),
+    getPendingQueueKey: jest.fn(() => PENDING_QUEUE_KEY),
+    ensureQueue: jest.fn(() => []),
+    getModuleRegistry: jest.fn(() => registry),
+    resolveModuleRegistry: jest.fn(() => registry),
+    tryRequire: jest.fn((modulePath) => {
+      try {
+        return modulesRequire(modulePath);
+      } catch (error) {
+        void error;
+        return null;
+      }
+    }),
+    queueModuleRegistration: jest.fn((name, api, options = {}, scope, targetRegistry) => (
+      registerModule(name, api, options, null, targetRegistry)
+    )),
+    registerOrQueueModule: jest.fn((name, api, options = {}, onError, scope, targetRegistry) => (
+      registerModule(name, api, options, onError, targetRegistry)
+    )),
+    recordModule: jest.fn(recordModule),
+    getModule: jest.fn(name => recordedModules.get(name) || null),
+    whenModuleAvailable: jest.fn((name, callback) => {
+      if (recordedModules.has(name)) {
+        if (typeof callback === 'function') {
+          callback(recordedModules.get(name));
+        }
+        return true;
+      }
+
+      if (typeof callback === 'function') {
+        const callbacks = pendingWaiters.get(name) || [];
+        callbacks.push(callback);
+        pendingWaiters.set(name, callbacks);
+      }
+
+      return false;
+    }),
+    listRecordedModules: jest.fn(() => Array.from(recordedModules.keys())),
+  };
+
+  jest.doMock(GLOBALS_PATH, () => moduleGlobals, { virtual: true });
+  global.cineModuleGlobals = moduleGlobals;
+
+  return {
+    registry,
+    moduleGlobals,
+    recordedModules,
+    safeFreezeDeep,
+    teardown() {
+      delete global.cineModuleGlobals;
+      jest.resetModules();
+    },
+  };
+}
+
+module.exports = {
+  setupModuleHarness,
+};
+

--- a/tests/unit/coreShared.test.js
+++ b/tests/unit/coreShared.test.js
@@ -1,6 +1,10 @@
 const path = require('path');
 
+const { setupModuleHarness } = require('../helpers/moduleHarness');
+
 describe('core shared utilities', () => {
+  let harness;
+
   function cleanupGlobals() {
     delete global.generateConnectorSummary;
     delete global.cineCoreShared;
@@ -10,7 +14,7 @@ describe('core shared utilities', () => {
   }
 
   beforeEach(() => {
-    jest.resetModules();
+    harness = setupModuleHarness();
     cleanupGlobals();
     jest.spyOn(console, 'warn').mockImplementation(() => {});
   });
@@ -20,6 +24,10 @@ describe('core shared utilities', () => {
       console.warn.mockRestore();
     }
     cleanupGlobals();
+    if (harness) {
+      harness.teardown();
+      harness = null;
+    }
   });
 
   function loadCoreShared() {

--- a/tests/unit/offlineModule.test.js
+++ b/tests/unit/offlineModule.test.js
@@ -1,12 +1,15 @@
 const path = require('path');
 
+const { setupModuleHarness } = require('../helpers/moduleHarness');
+
 describe('cineOffline module', () => {
   let offline;
   let internal;
   let consoleWarnSpy;
+  let harness;
 
   beforeEach(() => {
-    jest.resetModules();
+    harness = setupModuleHarness();
     delete global.cineOffline;
     offline = require(path.join('..', '..', 'src', 'scripts', 'modules', 'offline.js'));
     internal = offline.__internal;
@@ -19,7 +22,10 @@ describe('cineOffline module', () => {
       consoleWarnSpy.mockRestore();
       consoleWarnSpy = null;
     }
-    jest.resetModules();
+    if (harness) {
+      harness.teardown();
+      harness = null;
+    }
   });
 
   function createStorageSpy() {

--- a/tests/unit/persistenceModule.test.js
+++ b/tests/unit/persistenceModule.test.js
@@ -2,6 +2,8 @@ jest.mock('../../src/scripts/storage.js', () => ({}));
 jest.mock('../../src/scripts/app-session.js', () => ({}));
 jest.mock('../../src/scripts/app-setups.js', () => ({}));
 
+const { setupModuleHarness } = require('../helpers/moduleHarness');
+
 const STORAGE_FUNCTIONS = [
   'loadDeviceData',
   'saveDeviceData',
@@ -86,9 +88,10 @@ const UNIQUE_FUNCTIONS = Array.from(new Set([
 describe('cinePersistence module', () => {
   let persistence;
   let stubs;
+  let harness;
 
   beforeEach(() => {
-    jest.resetModules();
+    harness = setupModuleHarness();
     stubs = {};
 
     UNIQUE_FUNCTIONS.forEach((name) => {
@@ -105,7 +108,10 @@ describe('cinePersistence module', () => {
       delete global[name];
     });
     delete global.cinePersistence;
-    jest.resetModules();
+    if (harness) {
+      harness.teardown();
+      harness = null;
+    }
   });
 
   function expectDelegation(wrapper, stub, name) {

--- a/tests/unit/runtimeModule.test.js
+++ b/tests/unit/runtimeModule.test.js
@@ -1,5 +1,7 @@
 const path = require('path');
 
+const { setupModuleHarness } = require('../helpers/moduleHarness');
+
 const STORAGE_FUNCTIONS = [
   'loadDeviceData',
   'saveDeviceData',
@@ -133,6 +135,7 @@ describe('cineRuntime module', () => {
   let offlineStub;
   let uiStub;
   let registry;
+  let harness;
 
   function buildPersistenceStub(options = {}) {
     const missingWrappers = new Set((options.missingWrappers || []).map(String));
@@ -364,9 +367,8 @@ describe('cineRuntime module', () => {
   }
 
   beforeEach(() => {
-    jest.resetModules();
-    registry = require(path.join('..', '..', 'src', 'scripts', 'modules', 'registry.js'));
-    registry.__internalResetForTests({ force: true });
+    harness = setupModuleHarness();
+    registry = harness.registry;
 
     persistenceStub = buildPersistenceStub();
     offlineStub = buildOfflineStub();
@@ -392,6 +394,10 @@ describe('cineRuntime module', () => {
       registry.__internalResetForTests({ force: true });
     }
     registry = null;
+    if (harness) {
+      harness.teardown();
+      harness = null;
+    }
   });
 
   test('exposes frozen runtime API and module getters', () => {

--- a/tests/unit/uiModule.test.js
+++ b/tests/unit/uiModule.test.js
@@ -1,10 +1,13 @@
 const path = require('path');
 
+const { setupModuleHarness } = require('../helpers/moduleHarness');
+
 describe('cineUi module', () => {
   let cineUi;
+  let harness;
 
   function loadModule() {
-    jest.resetModules();
+    harness = setupModuleHarness();
     jest.isolateModules(() => {
       cineUi = require(path.join('..', '..', 'src', 'scripts', 'modules', 'ui.js'));
     });
@@ -20,6 +23,10 @@ describe('cineUi module', () => {
   afterEach(() => {
     if (cineUi && cineUi.__internal && typeof cineUi.__internal.clearRegistries === 'function') {
       cineUi.__internal.clearRegistries();
+    }
+    if (harness) {
+      harness.teardown();
+      harness = null;
     }
   });
 


### PR DESCRIPTION
## Summary
- add a Jest module harness that supplies safe cineModuleGlobals helpers for the module-based architecture without freezing Node internals
- update the module-focused unit tests to rely on the harness for consistent setup and teardown across persistence, offline, UI, runtime, and core shared suites

## Testing
- npm test -- --runTestsByPath tests/unit/persistenceModule.test.js
- npm test -- --runTestsByPath tests/unit/offlineModule.test.js
- npm test -- --runTestsByPath tests/unit/runtimeModule.test.js
- npm test -- --runTestsByPath tests/unit/uiModule.test.js tests/unit/coreShared.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e2daea048c8320bd2793f38e0fce1f