### PR TITLE
Add tests for mount voltage storage key helpers

### DIFF
--- a/src/scripts/storage.js
+++ b/src/scripts/storage.js
@@ -6590,6 +6590,8 @@ var STORAGE_API = {
   loadSetup,
   deleteSetup,
   renameSetup,
+  getMountVoltageStorageKeyName,
+  getMountVoltageStorageBackupKeyName,
   loadProject,
   saveProject,
   deleteProject,

--- a/tests/unit/mountVoltageStorageKey.test.js
+++ b/tests/unit/mountVoltageStorageKey.test.js
@@ -113,6 +113,36 @@ describe('mount voltage storage key resolution', () => {
     restoreGlobals(snapshot);
   });
 
+  test('getMountVoltageStorageKeyName returns the fallback key when no overrides are present', () => {
+    delete global.MOUNT_VOLTAGE_STORAGE_KEY;
+    delete global[MOUNT_VOLTAGE_SYMBOL];
+
+    const storage = loadStorageModule();
+
+    expect(storage.getMountVoltageStorageKeyName()).toBe(DEFAULT_KEY);
+    expect(storage.getMountVoltageStorageBackupKeyName()).toBe(`${DEFAULT_KEY}__backup`);
+  });
+
+  test('getMountVoltageStorageKeyName prefers the shared symbol override when defined', () => {
+    delete global.MOUNT_VOLTAGE_STORAGE_KEY;
+    global[MOUNT_VOLTAGE_SYMBOL] = 'symbolBasedKey';
+
+    const storage = loadStorageModule();
+
+    expect(storage.getMountVoltageStorageKeyName()).toBe('symbolBasedKey');
+    expect(storage.getMountVoltageStorageBackupKeyName()).toBe('symbolBasedKey__backup');
+  });
+
+  test('getMountVoltageStorageKeyName respects a global string override when provided', () => {
+    delete global[MOUNT_VOLTAGE_SYMBOL];
+    global.MOUNT_VOLTAGE_STORAGE_KEY = 'customVoltageKey';
+
+    const storage = loadStorageModule();
+
+    expect(storage.getMountVoltageStorageKeyName()).toBe('customVoltageKey');
+    expect(storage.getMountVoltageStorageBackupKeyName()).toBe('customVoltageKey__backup');
+  });
+
   test('exportAllData prefers the globally exposed symbol key', () => {
     global[MOUNT_VOLTAGE_SYMBOL] = 'symbolBasedKey';
 


### PR DESCRIPTION
## Summary
- expose the mount voltage storage key helper functions through the shared storage API
- expand the mount voltage storage key test suite to cover fallback, symbol, and explicit global overrides

## Testing
- npm run test:unit *(fails: featureSearchSynonyms.test.js and checkConsistency.test.js under Node 22 because the BufferedConsole proxy marks methods like trace as read-only)*

------
https://chatgpt.com/codex/tasks/task_e_68e2e20a44c88320bd019572ba2cc968