### PR TITLE
Hide diagram drag hint in overview exports

### DIFF
--- a/legacy/scripts/overview.js
+++ b/legacy/scripts/overview.js
@@ -271,12 +271,8 @@ function generatePrintableOverview() {
     legendClone.setAttribute('data-diagram-legend', 'overview');
     diagramLegendHtml = legendClone.outerHTML;
   }
-  if (diagramHint) {
-    var hintClone = diagramHint.cloneNode(true);
-    hintClone.id = 'diagramHintOverview';
-    hintClone.setAttribute('data-diagram-hint', 'overview');
-    diagramHintHtml = hintClone.outerHTML;
-  }
+  // Skip the interactive drag hint in the overview/print output so the static
+  // summary remains focused on non-interactive guidance.
   var diagramDescElem = typeof document !== 'undefined' ? document.getElementById('diagramDesc') : null;
   if (diagramDescElem) {
     var descClone = diagramDescElem.cloneNode(true);

--- a/src/scripts/overview.js
+++ b/src/scripts/overview.js
@@ -326,13 +326,9 @@ function generatePrintableOverview(config = {}) {
         diagramLegendHtml = legendClone.outerHTML;
     }
 
-    const sourceDiagramHint = resolveDiagramElement('diagramHint', 'diagramHint');
-    if (sourceDiagramHint) {
-        const hintClone = sourceDiagramHint.cloneNode(true);
-        hintClone.id = 'diagramHintOverview';
-        hintClone.setAttribute('data-diagram-hint', 'overview');
-        diagramHintHtml = hintClone.outerHTML;
-    }
+    // Intentionally omit the interactive drag hint from the overview/print output
+    // so the static summary focuses on content that applies outside of the live
+    // editor.
 
     const diagramDescElem = typeof document !== 'undefined'
         ? document.getElementById('diagramDesc')


### PR DESCRIPTION
## Summary
- omit the interactive drag hint text from the generated overview and print export
- mirror the same behaviour in the legacy overview builder to keep outputs consistent

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e2e4fa16708320956bd6718298c7e0