### PR TITLE
Ensure success status prints in black

### DIFF
--- a/src/styles/overview-print.css
+++ b/src/styles/overview-print.css
@@ -80,6 +80,7 @@ body.dark-mode {
   --video-conn-bg: rgba(51, 102, 153, 0.15);
   --neutral-conn-bg: rgba(158, 158, 158, 0.15);
   --status-warning-bg: #ff6b6b;
+  --status-success-text-color: #000;
   --status-warning-text-color: #000000;
   --status-error-text-color: #000;
   --nd-grad-border-color: var(--accent-color);
@@ -124,6 +125,7 @@ strong {
   --video-conn-bg: rgba(51, 102, 153, 0.15);
   --neutral-conn-bg: rgba(158, 158, 158, 0.15);
   --status-warning-bg: #ff6b6b;
+  --status-success-text-color: #000;
   --status-warning-text-color: #000000;
   --status-error-text-color: #000;
   --diagram-node-fill: #f0f0f0;

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -7835,11 +7835,16 @@ body.pink-mode,
   html,
   body,
   #overviewDialogContent {
+    --status-success-text-color: #000 !important;
     --status-warning-text-color: #000 !important;
     --status-error-text-color: #000 !important;
   }
 
   .status-message--warning {
+    color: #000 !important;
+  }
+
+  .status-message--success {
     color: #000 !important;
   }
 


### PR DESCRIPTION
## Summary
- force print styles to render success status messages in black text for clarity
- align the overview print stylesheet variables to use black text for success messages

## Testing
- not run (CSS-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e2e56db870832099ce080adcff29cb