### PR TITLE
Add localized description to battery comparison table

### DIFF
--- a/index.html
+++ b/index.html
@@ -463,6 +463,7 @@
 
   <section id="batteryComparison" class="battery-comparison-section" style="display: none;">
     <h2 id="batteryComparisonHeading">Battery Comparison</h2>
+    <p id="batteryComparisonDescription" class="section-description"></p>
     <div id="batteryTableContainer" class="battery-table-container">
       <table id="batteryTable"></table>
     </div>

--- a/legacy/scripts/app-core-new-1.js
+++ b/legacy/scripts/app-core-new-1.js
@@ -7613,6 +7613,10 @@ if (CORE_PART1_RUNTIME_SCOPE && CORE_PART1_RUNTIME_SCOPE.__cineCorePart1Initiali
     var batteryComparisonHeadingElem = document.getElementById("batteryComparisonHeading");
     batteryComparisonHeadingElem.textContent = texts[lang].batteryComparisonHeading;
     batteryComparisonHeadingElem.setAttribute("data-help", texts[lang].batteryComparisonHeadingHelp);
+    var batteryComparisonDescriptionElem = document.getElementById("batteryComparisonDescription");
+    if (batteryComparisonDescriptionElem) {
+      batteryComparisonDescriptionElem.textContent = texts[lang].batteryComparisonDescription;
+    }
     var setupDiagramHeadingElem = document.getElementById("setupDiagramHeading");
     setupDiagramHeadingElem.textContent = texts[lang].setupDiagramHeading;
     setupDiagramHeadingElem.setAttribute("data-help", texts[lang].setupDiagramHeadingHelp);

--- a/legacy/scripts/translations.js
+++ b/legacy/scripts/translations.js
@@ -40,6 +40,8 @@ var texts = {
     resultsHeading: "Power Summary",
     deviceManagerHeading: "Device Library",
     batteryComparisonHeading: "Battery Comparison",
+    batteryComparisonDescription:
+      "Review every compatible battery to see runtime estimates for your current setup.",
     setupDiagramHeading: "Connection Diagram",
     diagramPdfNote: "The visual connection diagram is not included in the PDF export. Open the print view to review the layout.",
     projectRequirementsNav: "Project Requirements",
@@ -1192,6 +1194,8 @@ var texts = {
     pdfWarningsHeading: "Avvisi",
     deviceManagerHeading: "Libreria dispositivi",
     batteryComparisonHeading: "Confronto batterie",
+    batteryComparisonDescription:
+      "Esamina tutte le batterie compatibili per vedere le stime di autonomia con la configurazione attuale.",
     setupDiagramHeading: "Diagramma delle connessioni",
     diagramPdfNote: "Il diagramma delle connessioni non è incluso nell'esportazione PDF. Apri la vista di stampa per consultare il layout.",
     projectRequirementsNav: "Requisiti di progetto",
@@ -2343,6 +2347,8 @@ var texts = {
     pdfWarningsHeading: "Avisos",
     deviceManagerHeading: "Biblioteca de dispositivos",
     batteryComparisonHeading: "Comparación de baterías",
+    batteryComparisonDescription:
+      "Revisa cada batería compatible para ver las estimaciones de autonomía con tu configuración actual.",
     setupDiagramHeading: "Diagrama de conexiones",
     diagramPdfNote: "El diagrama de conexiones no se incluye en la exportación PDF. Abre la vista de impresión para ver el diseño.",
     projectRequirementsNav: "Requisitos del proyecto",
@@ -3494,6 +3500,8 @@ var texts = {
     pdfWarningsHeading: "Avertissements",
     deviceManagerHeading: "Bibliothèque d’appareils",
     batteryComparisonHeading: "Comparaison des batteries",
+    batteryComparisonDescription:
+      "Passez en revue chaque batterie compatible pour voir les estimations d’autonomie pour votre configuration actuelle.",
     setupDiagramHeading: "Schéma de connexion",
     diagramPdfNote: "Le schéma de connexion n’est pas inclus dans l’export PDF. Ouvrez la vue d’impression pour vérifier la mise en page.",
     projectRequirementsNav: "Exigences du projet",
@@ -4645,6 +4653,8 @@ var texts = {
     pdfWarningsHeading: "Warnungen",
     deviceManagerHeading: "Gerätebibliothek",
     batteryComparisonHeading: "Akkuvergleich",
+    batteryComparisonDescription:
+      "Prüfe alle kompatiblen Akkus, um die Laufzeitschätzungen für deine aktuelle Konfiguration zu sehen.",
     setupDiagramHeading: "Verbindungsdiagramm",
     diagramPdfNote: "Das Verbindungsdiagramm ist nicht im PDF-Export enthalten. Öffnen Sie die Druckansicht, um das Layout zu sehen.",
     projectRequirementsNav: "Projektanforderungen",

--- a/src/scripts/app-core-new-1.js
+++ b/src/scripts/app-core-new-1.js
@@ -8433,6 +8433,14 @@ function setLanguage(lang) {
     texts[lang].batteryComparisonHeadingHelp
   );
 
+  const batteryComparisonDescriptionElem = document.getElementById(
+    "batteryComparisonDescription"
+  );
+  if (batteryComparisonDescriptionElem) {
+    batteryComparisonDescriptionElem.textContent =
+      texts[lang].batteryComparisonDescription;
+  }
+
   const setupDiagramHeadingElem = document.getElementById("setupDiagramHeading");
   setupDiagramHeadingElem.textContent = texts[lang].setupDiagramHeading;
   setupDiagramHeadingElem.setAttribute(

--- a/src/scripts/translations.js
+++ b/src/scripts/translations.js
@@ -49,6 +49,8 @@ const texts = {
     resultsHeading: "Power Summary",
     deviceManagerHeading: "Device Library",
     batteryComparisonHeading: "Battery Comparison",
+    batteryComparisonDescription:
+      "Review every compatible battery to see runtime estimates for your current setup.",
     setupDiagramHeading: "Connection Diagram",
     diagramPdfNote:
       "The visual connection diagram is not included in the PDF export. Open the print view to review the layout.",
@@ -1400,6 +1402,8 @@ const texts = {
     pdfWarningsHeading: "Avvisi",
     deviceManagerHeading: "Libreria dispositivi",
     batteryComparisonHeading: "Confronto batterie",
+    batteryComparisonDescription:
+      "Esamina tutte le batterie compatibili per vedere le stime di autonomia con la configurazione attuale.",
     setupDiagramHeading: "Diagramma delle connessioni",
     diagramPdfNote:
       "Il diagramma delle connessioni non è incluso nell'esportazione PDF. Apri la vista di stampa per consultare il layout.",
@@ -2737,6 +2741,8 @@ const texts = {
     pdfWarningsHeading: "Avisos",
     deviceManagerHeading: "Biblioteca de dispositivos",
     batteryComparisonHeading: "Comparación de baterías",
+    batteryComparisonDescription:
+      "Revisa cada batería compatible para ver las estimaciones de autonomía con tu configuración actual.",
     setupDiagramHeading: "Diagrama de conexiones",
     diagramPdfNote:
       "El diagrama de conexiones no se incluye en la exportación PDF. Abre la vista de impresión para ver el diseño.",
@@ -4088,6 +4094,8 @@ const texts = {
     pdfWarningsHeading: "Avertissements",
     deviceManagerHeading: "Bibliothèque d’appareils",
     batteryComparisonHeading: "Comparaison des batteries",
+    batteryComparisonDescription:
+      "Passez en revue chaque batterie compatible pour voir les estimations d’autonomie pour votre configuration actuelle.",
     setupDiagramHeading: "Schéma de connexion",
     diagramPdfNote:
       "Le schéma de connexion n’est pas inclus dans l’export PDF. Ouvrez la vue d’impression pour vérifier la mise en page.",
@@ -5450,6 +5458,8 @@ const texts = {
     pdfWarningsHeading: "Warnungen",
     deviceManagerHeading: "Gerätebibliothek",
     batteryComparisonHeading: "Akkuvergleich",
+    batteryComparisonDescription:
+      "Prüfe alle kompatiblen Akkus, um die Laufzeitschätzungen für deine aktuelle Konfiguration zu sehen.",
     setupDiagramHeading: "Verbindungsdiagramm",
     diagramPdfNote:
       "Das Verbindungsdiagramm ist nicht im PDF-Export enthalten. Öffnen Sie die Druckansicht, um das Layout zu sehen.",

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -5928,6 +5928,14 @@ body:not(.light-mode) #temperatureNote th {
   background-color: var(--panel-bg);
 }
 
+/* Shared section description helper */
+.section-description {
+  margin: 0 0 0.75em;
+  color: var(--muted-text-color);
+  font-size: calc(var(--font-size-relative-base) * var(--font-scale-sm));
+  line-height: var(--line-height-supporting);
+}
+
 /* Battery comparison section */
 .battery-comparison-section {
   background: var(--panel-bg); /* Match section background */


### PR DESCRIPTION
## Summary
- add a localized description under the Battery Comparison heading to explain the table
- style shared section descriptions for consistent presentation across modes
- update modern and legacy bundles to inject the translated copy

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e2e6c0e19883208002fb0b1b7e6fc4