### PR TITLE
Scope stacked auto gear highlight to highlight toggle

### DIFF
--- a/docs/auto-gear-rule-options.md
+++ b/docs/auto-gear-rule-options.md
@@ -32,3 +32,11 @@ planner predictable, offline-ready and data-safe.
   saving or sharing projects.【F:src/scripts/app-core-new-1.js†L3456-L3502】
 * When exporting or backing up, store these rules using the existing automatic gear backup and
   preset infrastructure so user data remains safe and offline-capable.
+
+## Draft impact preview cues
+
+* The draft impact preview surfaces stacked changes whenever multiple rules touch the same gear
+  entry. Turn the **Highlight automatic gear** toggle **On** to activate the multicolour stacked
+  indicator while auditing rule changes. The preview falls back to the standard positive/negative
+  borders whenever the highlight overlay is disabled so the behaviour remains predictable during
+  offline reviews.

--- a/src/scripts/app-core-new-2.js
+++ b/src/scripts/app-core-new-2.js
@@ -4479,6 +4479,9 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
           } else if (entry.delta < 0) {
             li.classList.add('auto-gear-impact-negative');
           }
+          if (entry.stacked) {
+            li.classList.add('auto-gear-impact-stacked');
+          }
           const summary = document.createElement('div');
           summary.className = 'auto-gear-impact-summary';
           summary.textContent = formatAutoGearDraftItemLabel(entry.item, entry.previewNet || entry.baseNet || entry.delta);

--- a/src/scripts/app-setups.js
+++ b/src/scripts/app-setups.js
@@ -5184,6 +5184,7 @@ function deleteCurrentGearList() {
 }
 
 const AUTO_GEAR_HIGHLIGHT_CLASS = 'show-auto-gear-highlight';
+const AUTO_GEAR_HIGHLIGHT_CONTEXT_CLASS = 'auto-gear-highlight-context';
 const AUTO_GEAR_HIGHLIGHT_ICON = '\uE8AF';
 const AUTO_GEAR_HIGHLIGHT_LABEL_FALLBACK = 'Highlight automatic gear';
 const AUTO_GEAR_HIGHLIGHT_HELP_FALLBACK =
@@ -5481,6 +5482,19 @@ function getAutoGearHighlightStateText(isActive) {
     return fallback;
 }
 
+function applyAutoGearHighlightContext(isActive) {
+    if (typeof document === 'undefined') {
+        return;
+    }
+    const enable = !!isActive;
+    const targets = [document.documentElement, document.body, document.getElementById('autoGearDraftImpact')];
+    targets.forEach(node => {
+        if (node && node.classList) {
+            node.classList.toggle(AUTO_GEAR_HIGHLIGHT_CONTEXT_CLASS, enable);
+        }
+    });
+}
+
 function setAutoGearHighlightEnabled(enabled) {
     const nextState = !!enabled;
     if (gearListOutput && gearListOutput.classList) {
@@ -5508,6 +5522,7 @@ function updateAutoGearHighlightToggleButton() {
     toggle.setAttribute('data-help', help);
     toggle.setAttribute('aria-label', help);
     const active = isAutoGearHighlightEnabled();
+    applyAutoGearHighlightContext(active);
     const stateText = getAutoGearHighlightStateText(active);
     if (stateContainer) {
         stateContainer.textContent = stateText;

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -3442,6 +3442,31 @@ body.pink-mode:not(.dark-mode) #settingsPanel-autoGear .auto-gear-rule-items-lab
   border-left-color: var(--warning-color, #ff9f1c);
 }
 
+body.auto-gear-highlight-context .auto-gear-impact-item.auto-gear-impact-stacked,
+.auto-gear-highlight-context .auto-gear-impact-item.auto-gear-impact-stacked {
+  border-left-color: transparent;
+  border-image: linear-gradient(
+      180deg,
+      var(--accent-color, #007aff),
+      var(--warning-color, #ff9f1c)
+    )
+    1;
+  padding: 8px 12px 8px 12px;
+  gap: 6px;
+  border-radius: var(--border-radius, 8px);
+  background-color: var(--surface-color, #ffffff);
+  background-image: linear-gradient(
+    135deg,
+    rgba(0, 122, 255, 0.16),
+    rgba(255, 159, 28, 0.16)
+  );
+}
+
+body.auto-gear-highlight-context.dark-mode .auto-gear-impact-item.auto-gear-impact-stacked,
+.auto-gear-highlight-context.dark-mode .auto-gear-impact-item.auto-gear-impact-stacked {
+  background-color: color-mix(in srgb, var(--surface-color, #111111) 85%, transparent);
+}
+
 .auto-gear-impact-summary {
   font-weight: 600;
 }


### PR DESCRIPTION
## Summary
- gate the stacked auto-gear draft impact styling behind the Highlight automatic gear toggle
- synchronize a shared highlight context class across the document so dark mode and previews react together
- document how to enable the stacked preview indicator while auditing rules

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e2e6f7668c8320b9ec05028ca6519f