### PR TITLE
Improve auto gear backup quota handling

### DIFF
--- a/legacy/scripts/app-core-new-1.js
+++ b/legacy/scripts/app-core-new-1.js
@@ -3624,13 +3624,14 @@ if (CORE_PART1_RUNTIME_SCOPE && CORE_PART1_RUNTIME_SCOPE.__cineCorePart1Initiali
       };
     }) : [];
     if (typeof saveAutoGearBackups === 'function') {
-      saveAutoGearBackups(payload);
-      return;
+      var storedPayload = saveAutoGearBackups(payload);
+      return Array.isArray(storedPayload) ? storedPayload : payload;
     }
     if (typeof localStorage === 'undefined') {
       throw new Error('Storage unavailable');
     }
     localStorage.setItem(AUTO_GEAR_BACKUPS_KEY, JSON.stringify(payload));
+    return payload;
   }
   function enforceAutoGearBackupRetentionLimit(limit) {
     var normalized = clampAutoGearBackupRetentionLimit(limit);
@@ -3664,8 +3665,12 @@ if (CORE_PART1_RUNTIME_SCOPE && CORE_PART1_RUNTIME_SCOPE.__cineCorePart1Initiali
       var updatedBackups = autoGearBackups.slice(0, normalized);
       trimmedEntries.push.apply(trimmedEntries, _toConsumableArray(autoGearBackups.slice(normalized)));
       try {
-        persistAutoGearBackups(updatedBackups);
-        autoGearBackups = updatedBackups;
+        var persistedBackups = persistAutoGearBackups(updatedBackups) || [];
+        var finalBackups = Array.isArray(persistedBackups) ? persistedBackups : [];
+        if (finalBackups.length < updatedBackups.length) {
+          trimmedEntries.push.apply(trimmedEntries, _toConsumableArray(updatedBackups.slice(finalBackups.length)));
+        }
+        autoGearBackups = finalBackups;
       } catch (error) {
         console.warn('Failed to trim automatic gear backups to retention limit', error);
         autoGearBackupRetention = previousLimit;

--- a/legacy/scripts/app-core-new-2.js
+++ b/legacy/scripts/app-core-new-2.js
@@ -5159,10 +5159,13 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
       var effectiveLimit = Math.max(1, retentionLimit);
       var updatedBackups = [entry].concat(_toConsumableArray(autoGearBackups)).slice(0, effectiveLimit);
       try {
-        persistAutoGearBackups(updatedBackups);
-        autoGearBackups = updatedBackups;
-        autoGearRulesLastBackupSignature = signature;
-        autoGearRulesLastPersistedSignature = signature;
+        var persistedBackups = persistAutoGearBackups(updatedBackups) || [];
+        var finalBackups = Array.isArray(persistedBackups) ? persistedBackups : [];
+        autoGearBackups = finalBackups;
+        var persistedEntry = finalBackups[0] || entry;
+        var persistedSignature = finalBackups.length ? getAutoGearConfigurationSignature(finalBackups[0].rules, finalBackups[0].monitorDefaults) : signature;
+        autoGearRulesLastBackupSignature = persistedSignature;
+        autoGearRulesLastPersistedSignature = persistedSignature;
         autoGearRulesDirtySinceBackup = false;
         renderAutoGearBackupControls();
         renderAutoGearBackupRetentionControls();
@@ -5173,7 +5176,7 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
         }
         return {
           status: 'created',
-          entry: entry
+          entry: persistedEntry
         };
       } catch (error) {
         console.warn('Automatic gear backup failed', error);


### PR DESCRIPTION
## Summary
- ensure automatic gear backup storage copies incoming data, trims the oldest snapshot when quota errors occur, and returns the stored payload
- propagate the persisted backup list through the modern and legacy runtime flows so signatures and in-memory state stay in sync after trimming
- add a unit test that isolates storage to verify the quota recovery path and mirror the storage changes in the legacy bundle

## Testing
- npx jest --runInBand tests/unit/storage.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e2e40f3c5483209a75b64a93c5a555