### PR TITLE
Fix help dialog by restoring missing diff text helper

### DIFF
--- a/src/scripts/app-session.js
+++ b/src/scripts/app-session.js
@@ -4543,6 +4543,47 @@ function formatTimestampForComparison(date, includeSeconds) {
   return date.toISOString();
 }
 
+const getDiffText = (key, fallbackValue = '') => {
+  if (typeof key !== 'string' || !key) {
+    return typeof fallbackValue === 'string' ? fallbackValue : `${fallbackValue ?? ''}`;
+  }
+
+  const normalizedFallback =
+    typeof fallbackValue === 'string' ? fallbackValue : `${fallbackValue ?? ''}`;
+  const langTexts =
+    texts && typeof currentLang === 'string' && currentLang && texts[currentLang]
+      ? texts[currentLang]
+      : null;
+  const defaultTexts = texts && typeof texts.en === 'object' ? texts.en : null;
+
+  const resolveCandidate = source => {
+    if (!source || typeof source !== 'object') {
+      return null;
+    }
+    if (!Object.prototype.hasOwnProperty.call(source, key)) {
+      return null;
+    }
+    const value = source[key];
+    if (typeof value !== 'string') {
+      return null;
+    }
+    const trimmed = value.trim();
+    return trimmed ? trimmed : null;
+  };
+
+  const localized = resolveCandidate(langTexts);
+  if (localized) {
+    return localized;
+  }
+
+  const fallbackLocalized = resolveCandidate(defaultTexts);
+  if (fallbackLocalized) {
+    return fallbackLocalized;
+  }
+
+  return normalizedFallback;
+};
+
 function formatComparisonOptionLabel(name, parsedDetails) {
   if (typeof name !== 'string') {
     return '';


### PR DESCRIPTION
## Summary
- restore the missing `getDiffText` helper in the modern session runtime so help wiring no longer throws at startup
- reuse the localized fallback resolution used by the legacy bundle to populate comparison labels safely

## Testing
- npm run test:unit *(fails: environmentContext tests expect module-system stubs that are unavailable in this container)*

------
https://chatgpt.com/codex/tasks/task_e_68e2ea66514c832090c497a0c03da0f9