### PR TITLE
Fix missing diff text helper in legacy session script

### DIFF
--- a/legacy/scripts/app-session.js
+++ b/legacy/scripts/app-session.js
@@ -18,6 +18,29 @@ function _iterableToArrayLimit(r, l) { var t = null == r ? null : "undefined" !=
 function _arrayWithHoles(r) { if (Array.isArray(r)) return r; }
 function ownKeys(e, r) { var t = Object.keys(e); if (Object.getOwnPropertySymbols) { var o = Object.getOwnPropertySymbols(e); r && (o = o.filter(function (r) { return Object.getOwnPropertyDescriptor(e, r).enumerable; })), t.push.apply(t, o); } return t; }
 function _objectSpread(e) { for (var r = 1; r < arguments.length; r++) { var t = null != arguments[r] ? arguments[r] : {}; r % 2 ? ownKeys(Object(t), !0).forEach(function (r) { _defineProperty(e, r, t[r]); }) : Object.getOwnPropertyDescriptors ? Object.defineProperties(e, Object.getOwnPropertyDescriptors(t)) : ownKeys(Object(t)).forEach(function (r) { Object.defineProperty(e, r, Object.getOwnPropertyDescriptor(t, r)); }); } return e; }
+function getDiffText(e, t) {
+  var n = '';
+  if ("string" != typeof e || !e) return "string" == typeof t ? t : null == t ? n : String(t);
+  n = "string" == typeof t ? t : null == t ? n : String(t);
+  var r = "undefined" != typeof texts && texts && "object" == typeof texts ? texts : null,
+    o = "undefined" != typeof currentLang && "string" == typeof currentLang && currentLang ? currentLang : "en",
+    i = r && "object" == typeof r[o] ? r[o] : null;
+  if (i && Object.prototype.hasOwnProperty.call(i, e)) {
+    var a = i[e];
+    if ("string" == typeof a) {
+      var c = a.trim();
+      if (c) return c;
+    }
+  }
+  if ("en" !== o && r && "object" == typeof r.en && Object.prototype.hasOwnProperty.call(r.en, e)) {
+    var u = r.en[e];
+    if ("string" == typeof u) {
+      var f = u.trim();
+      if (f) return f;
+    }
+  }
+  return n;
+}
 function _defineProperty(e, r, t) { return (r = _toPropertyKey(r)) in e ? Object.defineProperty(e, r, { value: t, enumerable: !0, configurable: !0, writable: !0 }) : e[r] = t, e; }
 function _toPropertyKey(t) { var i = _toPrimitive(t, "string"); return "symbol" == _typeof(i) ? i : i + ""; }
 function _toPrimitive(t, r) { if ("object" != _typeof(t) || !t) return t; var e = t[Symbol.toPrimitive]; if (void 0 !== e) { var i = e.call(t, r || "default"); if ("object" != _typeof(i)) return i; throw new TypeError("@@toPrimitive must return a primitive value."); } return ("string" === r ? String : Number)(t); }


### PR DESCRIPTION
## Summary
- add a legacy-friendly getDiffText helper so the legacy session script can resolve comparison strings without throwing reference errors

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e2ec9054088320afe3c8ba4022a36d