### PR TITLE
Fix lens selector population timing

### DIFF
--- a/src/scripts/app-core-new-1.js
+++ b/src/scripts/app-core-new-1.js
@@ -2149,6 +2149,12 @@ function updateGlobalDevicesReference(value) {
       }
     }
   }
+
+  // Ensure dependent UI components refresh once the device database is ready.
+  // The defer flag guarantees the session layer can react even if it has not
+  // been initialised yet (for example, when this runs before app-session.js
+  // loads during boot).
+  callCoreFunctionIfAvailable('populateLensDropdown', [], { defer: true });
 }
 
 function initializeDeviceDatabase() {

--- a/src/scripts/app-session.js
+++ b/src/scripts/app-session.js
@@ -9997,35 +9997,47 @@ function populateEnvironmentDropdowns() {
 function populateLensDropdown() {
   if (!lensSelect) return;
 
-  lensSelect.innerHTML = '';
-  const lensData = devices && devices.lenses;
+  const lensData =
+    (devices && devices.lenses && Object.keys(devices.lenses).length ? devices.lenses : null)
+    || (devices && devices.accessories && devices.accessories.lenses)
+    || null;
 
   if (!lensData || Object.keys(lensData).length === 0) {
     return;
   }
+
+  const previousSelection = new Set(Array.from(lensSelect.selectedOptions || []).map(opt => opt.value));
+
+  lensSelect.innerHTML = '';
 
   if (!lensSelect.multiple) {
     const emptyOpt = document.createElement('option');
     emptyOpt.value = '';
     lensSelect.appendChild(emptyOpt);
   }
-  Object.keys(lensData).sort(localeSort).forEach(name => {
-    const opt = document.createElement('option');
-    opt.value = name;
-    const lens = lensData[name] || {};
-    const attrs = [];
-    if (lens.weight_g) attrs.push(`${lens.weight_g}g`);
-    if (lens.clampOn) {
-      if (lens.frontDiameterMm) attrs.push(`${lens.frontDiameterMm}mm clamp-on`);
-      else attrs.push('clamp-on');
-    } else if (lens.clampOn === false) {
-      attrs.push('no clamp-on');
-    }
-    const minFocus = lens.minFocusMeters ?? lens.minFocus ?? (lens.minFocusCm ? lens.minFocusCm / 100 : null);
-    if (minFocus) attrs.push(`${minFocus}m min focus`);
-    opt.textContent = attrs.length ? `${name} (${attrs.join(', ')})` : name;
-    lensSelect.appendChild(opt);
-  });
+
+  Object.keys(lensData)
+    .sort(localeSort)
+    .forEach(name => {
+      const opt = document.createElement('option');
+      opt.value = name;
+      const lens = lensData[name] || {};
+      const attrs = [];
+      if (lens.weight_g) attrs.push(`${lens.weight_g}g`);
+      if (lens.clampOn) {
+        if (lens.frontDiameterMm) attrs.push(`${lens.frontDiameterMm}mm clamp-on`);
+        else attrs.push('clamp-on');
+      } else if (lens.clampOn === false) {
+        attrs.push('no clamp-on');
+      }
+      const minFocus = lens.minFocusMeters ?? lens.minFocus ?? (lens.minFocusCm ? lens.minFocusCm / 100 : null);
+      if (minFocus) attrs.push(`${minFocus}m min focus`);
+      opt.textContent = attrs.length ? `${name} (${attrs.join(', ')})` : name;
+      if (previousSelection.has(name)) {
+        opt.selected = true;
+      }
+      lensSelect.appendChild(opt);
+    });
 }
 
 function populateCameraPropertyDropdown(selectId, property, selected = '') {


### PR DESCRIPTION
## Summary
- trigger a deferred lens dropdown refresh whenever the device database is (re)loaded
- rebuild the lens selector while preserving any existing selections and handling legacy data shapes

## Testing
- npm run test:unit *(fails: legacy storage migration tests expect unsuffixed project names in current baseline)*

------
https://chatgpt.com/codex/tasks/task_e_68e2ed645f3083209ea1caf55ddb6f2b