### PR TITLE
Add fallback for isPlainObject in session runtime

### DIFF
--- a/src/scripts/app-session.js
+++ b/src/scripts/app-session.js
@@ -173,6 +173,24 @@ const normalizeAccentValueSafe = ensureSessionRuntimePlaceholder(
   () => value => (typeof value === 'string' ? value.trim().toLowerCase() : ''),
 );
 
+const isPlainObjectFallback = value => {
+  if (value === null || typeof value !== 'object') {
+    return false;
+  }
+
+  if (Array.isArray(value)) {
+    return false;
+  }
+
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+};
+
+const isPlainObject = ensureSessionRuntimePlaceholder(
+  'isPlainObject',
+  () => isPlainObjectFallback,
+);
+
 const applyFontSizeSafe = ensureSessionRuntimePlaceholder(
   'applyFontSize',
   () => {


### PR DESCRIPTION
## Summary
- add a local fallback implementation of `isPlainObject` for the session runtime
- ensure the helper is registered through the runtime placeholder system so session logic can always access it

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e2f04c5ccc8320a8ce55db74a9abe2