### PR TITLE
Fix force reload bypass in service worker

### DIFF
--- a/tests/unit/service-worker.test.js
+++ b/tests/unit/service-worker.test.js
@@ -1,4 +1,8 @@
-const { ASSETS, CACHE_NAME } = require('../../service-worker.js');
+const {
+  ASSETS,
+  CACHE_NAME,
+  __private__: { shouldBypassCache },
+} = require('../../service-worker.js');
 
 describe('service worker configuration', () => {
   test('caches overview assets for offline usage', () => {
@@ -63,5 +67,17 @@ describe('service worker configuration', () => {
   test('exposes a cache name', () => {
     expect(typeof CACHE_NAME).toBe('string');
     expect(CACHE_NAME).not.toBe('');
+  });
+
+  test('treats forceReload navigation requests as cache bypass candidates', () => {
+    const mockRequest = {
+      cache: 'default',
+      headers: {
+        get: () => null,
+      },
+    };
+    const url = new URL('https://example.test/app?forceReload=abc123');
+
+    expect(shouldBypassCache(mockRequest, url)).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- treat requests that include the forceReload query parameter as bypassing the service worker cache so that a forced reload hits the network
- keep navigation cache lookups from ignoring query strings whenever a forceReload hint is present
- expose the cache bypass helper for testing and cover the new behavior with a unit test

## Testing
- npm run test:jest -- --runTestsByPath tests/unit/service-worker.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e2f05655748320b04a7eb46dbe0a63