### PR TITLE
Increase project dialog select height

### DIFF
--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -6524,6 +6524,7 @@ body.dark-mode.dark-accent-boost:not(.pink-mode) .settings-content.modal-surface
 
 /* Project requirements dialog */
 #projectDialog {
+  --select-height: calc(var(--button-size) * 1.2);
   border: none;
   padding: 0;
   background: transparent;


### PR DESCRIPTION
## Summary
- restore the original select sizing rules in shared, overview, and print styles so the rest of the app keeps its expected layout
- increase the select height variable inside the project requirements dialog so taller translated labels render without being clipped

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e2ed0379488320948b46b602f46be7