### PR TITLE
Fix missing feature search value export

### DIFF
--- a/legacy/scripts/app-core-new-2.js
+++ b/legacy/scripts/app-core-new-2.js
@@ -16517,6 +16517,8 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
       return populateFeatureSearch;
     }], ['restoreFeatureSearchDefaults', function () {
       return restoreFeatureSearchDefaults;
+    }], ['updateFeatureSearchValue', function () {
+      return updateFeatureSearchValue;
     }], ['updateFeatureSearchSuggestions', function () {
       return updateFeatureSearchSuggestions;
     }], ['setCurrentProjectInfo', function () {

--- a/src/scripts/app-core-new-2.js
+++ b/src/scripts/app-core-new-2.js
@@ -17340,6 +17340,7 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
       ['featureSearchDefaultOptions', () => featureSearchDefaultOptions],
       ['populateFeatureSearch', () => populateFeatureSearch],
       ['restoreFeatureSearchDefaults', () => restoreFeatureSearchDefaults],
+      ['updateFeatureSearchValue', () => updateFeatureSearchValue],
       ['updateFeatureSearchSuggestions', () => updateFeatureSearchSuggestions],
       ['setCurrentProjectInfo', () => setCurrentProjectInfo],
       ['getCurrentProjectInfo', () => getCurrentProjectInfo],


### PR DESCRIPTION
## Summary
- expose updateFeatureSearchValue through the core runtime global export map
- ensure both modern and legacy bundles provide the helper used by feature search suggestions

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2f22441cc83208ea391b628a013c5