### PR TITLE
Fix feature search navigation for hidden sections

### DIFF
--- a/src/scripts/app-session.js
+++ b/src/scripts/app-session.js
@@ -7632,8 +7632,48 @@ if (helpButton && helpDialog) {
     return Array.from(labels);
   };
 
+  const ensureFeatureSearchVisibility = element => {
+    if (!element) return;
+
+    if (
+      backupDiffSectionEl &&
+      backupDiffSectionEl.contains(element) &&
+      backupDiffSectionEl.hasAttribute('hidden')
+    ) {
+      if (typeof showBackupDiffSection === 'function') {
+        try {
+          showBackupDiffSection();
+        } catch (error) {
+          console.warn('Unable to open backup diff section for feature search target', error);
+          backupDiffSectionEl.removeAttribute('hidden');
+        }
+      } else {
+        backupDiffSectionEl.removeAttribute('hidden');
+      }
+    }
+
+    if (
+      restoreRehearsalSectionEl &&
+      restoreRehearsalSectionEl.contains(element) &&
+      restoreRehearsalSectionEl.hasAttribute('hidden')
+    ) {
+      if (typeof openRestoreRehearsal === 'function') {
+        try {
+          openRestoreRehearsal();
+        } catch (error) {
+          console.warn('Unable to open restore rehearsal section for feature search target', error);
+          restoreRehearsalSectionEl.removeAttribute('hidden');
+        }
+      } else {
+        restoreRehearsalSectionEl.removeAttribute('hidden');
+      }
+    }
+  };
+
   const focusFeatureElement = element => {
     if (!element) return;
+
+    ensureFeatureSearchVisibility(element);
 
     const settingsSection = element.closest('#settingsDialog');
     const settingsPanel = element.closest('.settings-panel');


### PR DESCRIPTION
## Summary
- ensure the feature search reveals hidden backup diff and restore rehearsal sections before focusing matched controls

## Testing
- npm test *(fails: existing eslint undefined-variable reports in the project)*

------
https://chatgpt.com/codex/tasks/task_e_68e2f2fd583c8320a32632b0972ebac6