### PR TITLE
Mirror critical backups for legacy storage prefixes

### DIFF
--- a/legacy/scripts/storage.js
+++ b/legacy/scripts/storage.js
@@ -459,13 +459,31 @@ function _typeof(o) { "@babel/helpers - typeof"; return _typeof = "function" == 
       if (!entry) {
         return;
       }
-      var storageId = entry.storage || null;
-      var id = "".concat(entry.key, "__").concat(storageId ? String(storageId) : 'default');
-      if (seen.has(id)) {
-        return;
+      var variants = getStorageKeyVariants(entry.key);
+      var expectedBaseBackupKey = "".concat(entry.key).concat(STORAGE_BACKUP_SUFFIX);
+      for (var index = 0; index < variants.length; index += 1) {
+        var variantKey = variants[index];
+        if (typeof variantKey !== 'string' || !variantKey) {
+          continue;
+        }
+        var resolvedBackupKey = entry.backupKey;
+        if (variantKey !== entry.key) {
+          if (entry.backupKey === expectedBaseBackupKey) {
+            resolvedBackupKey = "".concat(variantKey).concat(STORAGE_BACKUP_SUFFIX);
+          }
+        }
+        var variantEntry = variantKey === entry.key ? entry : _objectSpread(_objectSpread({}, entry), {}, {
+          key: variantKey,
+          backupKey: resolvedBackupKey
+        });
+        var storageId = variantEntry.storage || null;
+        var id = "".concat(variantEntry.key, "__").concat(storageId ? String(storageId) : 'default');
+        if (seen.has(id)) {
+          continue;
+        }
+        seen.add(id);
+        entries.push(variantEntry);
       }
-      seen.add(id);
-      entries.push(entry);
     };
     for (var i = 0; i < CRITICAL_BACKUP_KEY_PROVIDERS.length; i += 1) {
       var provider = CRITICAL_BACKUP_KEY_PROVIDERS[i];

--- a/tests/unit/storage-critical-backup-variants.test.js
+++ b/tests/unit/storage-critical-backup-variants.test.js
@@ -1,0 +1,128 @@
+describe('critical storage guard mirrors prefixed variants', () => {
+  const SCHEMA_KEY = 'cinePowerPlanner_schemaCache';
+  const SCHEMA_BACKUP_KEY = `${SCHEMA_KEY}__backup`;
+
+  const createControlledStorage = () => {
+    const data = new Map();
+
+    const storage = {
+      setItem(key, value) {
+        data.set(String(key), String(value));
+      },
+      getItem(key) {
+        return data.has(String(key)) ? data.get(String(key)) : null;
+      },
+      removeItem(key) {
+        data.delete(String(key));
+      },
+      clear() {
+        data.clear();
+      },
+      key(index) {
+        const keys = Array.from(data.keys());
+        return index >= 0 && index < keys.length ? keys[index] : null;
+      },
+    };
+
+    Object.defineProperty(storage, 'length', {
+      configurable: true,
+      enumerable: false,
+      get() {
+        return data.size;
+      },
+    });
+
+    return storage;
+  };
+
+  let originalWindow;
+  let hadWindow;
+  let win;
+  let originalLocalStorageDescriptor;
+  let originalSessionStorageDescriptor;
+  let originalLocalStorageInstance;
+  let originalSessionStorageInstance;
+  let controlledStorage;
+  let consoleInfoSpy;
+
+  beforeEach(() => {
+    jest.resetModules();
+
+    hadWindow = Object.prototype.hasOwnProperty.call(global, 'window');
+    originalWindow = global.window;
+    if (!hadWindow || typeof global.window !== 'object') {
+      global.window = {};
+    }
+    win = global.window;
+
+    controlledStorage = createControlledStorage();
+
+    originalLocalStorageDescriptor = Object.getOwnPropertyDescriptor(win, 'localStorage');
+    originalSessionStorageDescriptor = Object.getOwnPropertyDescriptor(win, 'sessionStorage');
+
+    originalLocalStorageInstance =
+      originalLocalStorageDescriptor && typeof originalLocalStorageDescriptor.get === 'function'
+        ? originalLocalStorageDescriptor.get.call(win)
+        : originalLocalStorageDescriptor
+          ? originalLocalStorageDescriptor.value
+          : undefined;
+
+    originalSessionStorageInstance =
+      originalSessionStorageDescriptor && typeof originalSessionStorageDescriptor.get === 'function'
+        ? originalSessionStorageDescriptor.get.call(win)
+        : originalSessionStorageDescriptor
+          ? originalSessionStorageDescriptor.value
+          : undefined;
+
+    Object.defineProperty(win, 'localStorage', {
+      configurable: true,
+      value: controlledStorage,
+    });
+    Object.defineProperty(win, 'sessionStorage', {
+      configurable: true,
+      value: controlledStorage,
+    });
+
+    global.localStorage = controlledStorage;
+    global.sessionStorage = controlledStorage;
+
+    consoleInfoSpy = jest.spyOn(console, 'info').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleInfoSpy.mockRestore();
+
+    if (!originalLocalStorageDescriptor) {
+      delete win.localStorage;
+      delete global.localStorage;
+    } else {
+      Object.defineProperty(win, 'localStorage', originalLocalStorageDescriptor);
+      global.localStorage = originalLocalStorageInstance;
+    }
+
+    if (!originalSessionStorageDescriptor) {
+      delete win.sessionStorage;
+      delete global.sessionStorage;
+    } else {
+      Object.defineProperty(win, 'sessionStorage', originalSessionStorageDescriptor);
+      global.sessionStorage = originalSessionStorageInstance;
+    }
+
+    if (!hadWindow) {
+      delete global.window;
+    } else {
+      global.window = originalWindow;
+    }
+  });
+
+  test('mirrors backup for legacy cine prefix keys', () => {
+    const storageApi = require('../../src/scripts/storage.js');
+
+    controlledStorage.setItem(SCHEMA_KEY, '{"version":1}');
+    controlledStorage.removeItem(SCHEMA_BACKUP_KEY);
+
+    storageApi.ensureCriticalStorageBackups();
+
+    expect(controlledStorage.getItem(SCHEMA_BACKUP_KEY)).toBe('{"version":1}');
+  });
+});


### PR DESCRIPTION
## Summary
- expand the critical storage guard so it mirrors backups for both cameraPowerPlanner and cinePowerPlanner key variants
- keep the legacy storage bundle in sync with the new guard behaviour
- add a unit test that verifies cine-prefixed schema cache entries receive mirrored backups

## Testing
- npm run test:jest -- --runTestsByPath tests/unit/storage-critical-backup-variants.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e2f39527008320a2a1abf19b9aa165