### PR TITLE
Ensure autosave persists unnamed projects

### DIFF
--- a/docs/save-share-restore-reference.md
+++ b/docs/save-share-restore-reference.md
@@ -6,6 +6,8 @@ The application exposes these routines through the frozen `cinePersistence` gate
 
 A compatibility watchdog upgrades any legacy project payloads on sight. When the reader encounters a single-project export, an array of unnamed saves, or a legacy project object, the importer now renames the recovered entry with an `-updated` suffix before persisting it in the normalized structure. Existing normalized saves keep their names, while upgraded copies automatically receive unique suffixed titles so they never overwrite recent work. This ensures every restored project inherits the modern field layout, autosave routines and backup hooks without dropping historical data.【F:src/scripts/storage.js†L2834-L2881】【F:src/scripts/storage.js†L4336-L4457】
 
+A silent guard now also captures unnamed in-progress sessions: autosave writes the gear list, requirements, diagram positions and auto-gear rules to the shared project store even when no setup name has been entered, and the restore flow looks up the anonymous slot while rebuilding the form after a reload.【F:src/scripts/app-setups.js†L4976-L5037】【F:src/scripts/app-session.js†L3143-L3163】
+
 A dedicated storage guardian runs on every launch to mirror each critical key into its backup slot before the UI touches data, ensuring that even legacy entries have a redundant copy ready before rehearsals or imports begin.【F:src/scripts/storage.js†L247-L376】【F:src/scripts/app-session.js†L10017-L10024】 The latest guard report is exposed globally so you can confirm the mirroring state from diagnostics panels.【F:src/scripts/storage.js†L347-L358】【F:src/scripts/app-core-new-2.js†L6266-L6349】
 
 ## Workflow matrix

--- a/src/scripts/app-session.js
+++ b/src/scripts/app-session.js
@@ -3155,7 +3155,7 @@ function applySharedSetup(shared, options = {}) {
         ? setupNameInput.value.trim()
         : '';
       const storageKey = selectedName || typedName;
-      if (storageKey) {
+      if (typeof storageKey === 'string') {
         saveProject(storageKey, payload);
       }
     }

--- a/src/scripts/app-setups.js
+++ b/src/scripts/app-setups.js
@@ -4978,11 +4978,14 @@ function saveCurrentGearList() {
         if (previousProjectInfo && Object.keys(previousProjectInfo).length) {
             pendingProjectInfo = previousProjectInfo;
         } else if (typeof loadProject === 'function') {
-            const fallbackKey =
-                (typeof effectiveStorageKey === 'string' && effectiveStorageKey)
-                    ? effectiveStorageKey
-                    : (projectStorageKey || selectedStorageKey || '');
-            if (fallbackKey) {
+            const fallbackKey = (typeof effectiveStorageKey === 'string')
+                ? effectiveStorageKey
+                : (typeof projectStorageKey === 'string' && projectStorageKey)
+                    ? projectStorageKey
+                    : (typeof selectedStorageKey === 'string'
+                        ? selectedStorageKey
+                        : '');
+            if (typeof fallbackKey === 'string') {
                 const existingProject = loadProject(fallbackKey);
                 if (existingProject && existingProject.projectInfo && Object.keys(existingProject.projectInfo).length) {
                     pendingProjectInfo = cloneProjectInfoForStorage(existingProject.projectInfo);
@@ -5021,7 +5024,7 @@ function saveCurrentGearList() {
             diagramPositionsSnapshotForSetups = cloneProjectInfoForStorage(diagramPositionsSnapshot);
         }
     }
-    if (typeof saveProject === 'function' && typeof effectiveStorageKey === 'string' && effectiveStorageKey) {
+    if (typeof saveProject === 'function' && typeof effectiveStorageKey === 'string') {
         const payload = {
             projectInfo: projectInfoSnapshot,
             gearList: html


### PR DESCRIPTION
## Summary
- allow autosave to persist projects even when no setup name has been entered by saving to the shared project store and reusing the unnamed entry during restores
- update the shared setup import path to store recovered data even when the destination name is still blank
- document that anonymous, in-progress sessions are now captured and restored automatically

## Testing
- npm test -- projectAutosave *(fails: existing lint errors and legacy global definitions)*

------
https://chatgpt.com/codex/tasks/task_e_68e2f3adbf1c83208cd3b189543d183e