### PR TITLE
Fix missing device change helpers in global exports

### DIFF
--- a/legacy/scripts/app-core-new-2.js
+++ b/legacy/scripts/app-core-new-2.js
@@ -16505,6 +16505,10 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
       return adjustGearListSelectWidth;
     }], ['adjustGearListSelectWidths', function () {
       return adjustGearListSelectWidths;
+    }], ['getDeviceChanges', function () {
+      return getDeviceChanges;
+    }], ['applyDeviceChanges', function () {
+      return applyDeviceChanges;
     }], ['deviceMap', function () {
       return deviceMap;
     }], ['helpMap', function () {

--- a/src/scripts/app-core-new-2.js
+++ b/src/scripts/app-core-new-2.js
@@ -17334,6 +17334,8 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
       ['applyFilterSelectionsToGearList', () => applyFilterSelectionsToGearList],
       ['adjustGearListSelectWidth', () => adjustGearListSelectWidth],
       ['adjustGearListSelectWidths', () => adjustGearListSelectWidths],
+      ['getDeviceChanges', () => getDeviceChanges],
+      ['applyDeviceChanges', () => applyDeviceChanges],
       ['deviceMap', () => deviceMap],
       ['helpMap', () => helpMap],
       ['featureSearchEntries', () => featureSearchEntries],


### PR DESCRIPTION
## Summary
- expose the device change diff helpers through the global runtime so sharing can access them
- ensure both modern and legacy bundles export the helpers to avoid regressions

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e2f50866788320bc4b971e7a40672b