### PR TITLE
Highlight near-limit current warnings as yellow notes

### DIFF
--- a/legacy/scripts/app-core-new-1.js
+++ b/legacy/scripts/app-core-new-1.js
@@ -6951,6 +6951,7 @@ if (CORE_PART1_RUNTIME_SCOPE && CORE_PART1_RUNTIME_SCOPE.__cineCorePart1Initiali
   var STATUS_CLASS_BY_LEVEL = {
     info: 'status-message--info',
     success: 'status-message--success',
+    note: 'status-message--note',
     warning: 'status-message--warning',
     danger: 'status-message--danger'
   };

--- a/legacy/scripts/app-core-new-2.js
+++ b/legacy/scripts/app-core-new-2.js
@@ -14243,7 +14243,7 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
           pinSeverity = 'danger';
         } else if (totalCurrentLow > maxPinA * 0.8) {
           setStatusMessage(pinWarnTarget, texts[currentLang].warnPinNear.replace("{current}", totalCurrentLow.toFixed(2)).replace("{max}", maxPinA));
-          pinSeverity = 'warning';
+          pinSeverity = 'note';
         }
         if (!bMountCam) {
           if (totalCurrentLow > maxDtapA) {
@@ -14251,7 +14251,7 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
             dtapSeverity = 'danger';
           } else if (totalCurrentLow > maxDtapA * 0.8) {
             setStatusMessage(dtapWarnTarget, texts[currentLang].warnDTapNear.replace("{current}", totalCurrentLow.toFixed(2)).replace("{max}", maxDtapA));
-            dtapSeverity = 'warning';
+            dtapSeverity = 'note';
           }
         }
         var hasPinLimit = typeof maxPinA === 'number' && maxPinA > 0;

--- a/legacy/scripts/overview.js
+++ b/legacy/scripts/overview.js
@@ -158,6 +158,7 @@ function generatePrintableOverview() {
   var severityClassMap = {
     danger: 'status-message--danger',
     warning: 'status-message--warning',
+    note: 'status-message--note',
     success: 'status-message--success',
     info: 'status-message--info'
   };

--- a/src/scripts/app-core-new-1.js
+++ b/src/scripts/app-core-new-1.js
@@ -7655,6 +7655,7 @@ function detectBrand(name) {
 const STATUS_CLASS_BY_LEVEL = {
   info: 'status-message--info',
   success: 'status-message--success',
+  note: 'status-message--note',
   warning: 'status-message--warning',
   danger: 'status-message--danger'
 };

--- a/src/scripts/app-core-new-2.js
+++ b/src/scripts/app-core-new-2.js
@@ -15214,7 +15214,7 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
               .replace("{current}", totalCurrentLow.toFixed(2))
               .replace("{max}", maxPinA)
           );
-          pinSeverity = 'warning';
+          pinSeverity = 'note';
         }
         if (!bMountCam) {
           if (totalCurrentLow > maxDtapA) {
@@ -15232,7 +15232,7 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
                 .replace("{current}", totalCurrentLow.toFixed(2))
                 .replace("{max}", maxDtapA)
             );
-            dtapSeverity = 'warning';
+            dtapSeverity = 'note';
           }
         }
         const hasPinLimit = typeof maxPinA === 'number' && maxPinA > 0;

--- a/src/scripts/overview.js
+++ b/src/scripts/overview.js
@@ -177,6 +177,7 @@ function generatePrintableOverview(config = {}) {
     const severityClassMap = {
         danger: 'status-message--danger',
         warning: 'status-message--warning',
+        note: 'status-message--note',
         success: 'status-message--success',
         info: 'status-message--info'
     };

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -129,10 +129,12 @@
   --line-height-relaxed: 1.65;
   --status-error-bg: #ff8a80;
   --status-warning-bg: #ff6b6b;
+  --status-note-bg: #fff4b8;
   --status-success-bg: #dfd;
   --status-border-color: #ccc;
   --status-error-text-color: #000;
   --status-warning-text-color: #ffffff;
+  --status-note-text-color: #000;
   --status-success-text-color: #000;
   --camera-color: #4caf50;
   --monitor-color: #2196f3;
@@ -489,6 +491,7 @@ textarea {
 
 .status-message--info,
 .status-message--success,
+.status-message--note,
 .status-message--warning,
 .status-message--danger {
   padding: 0.5em 0.75em;
@@ -505,6 +508,11 @@ textarea {
 .status-message--success {
   background-color: var(--status-success-bg);
   color: var(--status-success-text-color);
+}
+
+.status-message--note {
+  background-color: var(--status-note-bg);
+  color: var(--status-note-text-color);
 }
 
 .status-message--warning {
@@ -6131,10 +6139,12 @@ html.dark-mode,
   --neutral-color: #bbbbbb;
   --status-error-bg: rgba(255, 120, 120, 0.45);
   --status-warning-bg: rgba(255, 107, 107, 0.65);
+  --status-note-bg: rgba(255, 214, 102, 0.25);
   --status-success-bg: rgba(102, 187, 106, 0.2);
   --status-border-color: #444;
   --status-error-text-color: #ffffff;
   --status-warning-text-color: #ffffff;
+  --status-note-text-color: #ffe082;
   --status-success-text-color: #f0f0f0;
   --diagram-node-fill: #444;
   --power-color: #ff6666;
@@ -6180,10 +6190,12 @@ body.high-contrast {
   --neutral-color: #fff;
   --status-error-bg: #f00;
   --status-warning-bg: #ff0;
+  --status-note-bg: #ff0;
   --status-success-bg: #0f0;
   --status-border-color: #fff;
   --status-error-text-color: #000;
   --status-warning-text-color: #000;
+  --status-note-text-color: #000;
   --status-success-text-color: #000;
   --diagram-node-fill: #fff;
   --power-color: #f00;
@@ -7872,6 +7884,7 @@ body.pink-mode,
     --status-success-text-color: #000 !important;
     --status-warning-text-color: #000 !important;
     --status-error-text-color: #000 !important;
+    --status-note-text-color: #000 !important;
   }
 
   .status-message--warning {
@@ -7879,6 +7892,10 @@ body.pink-mode,
   }
 
   .status-message--success {
+    color: #000 !important;
+  }
+
+  .status-message--note {
     color: #000 !important;
   }
 


### PR DESCRIPTION
## Summary
- treat near-limit pin and D-Tap warnings as note severity instead of warning
- add styling and theme variables so note severity displays with a yellow background across modes and print views
- update overview generation and legacy code paths to recognize the new note severity class

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e2f5a3ff34832095ebf43f44e5445b