### PR TITLE
Remove hover help status panel overlay

### DIFF
--- a/legacy/scripts/app-session.js
+++ b/legacy/scripts/app-session.js
@@ -7401,13 +7401,6 @@ if (helpButton && helpDialog) {
   var hoverHelpHighlightedTarget = null;
   var hoverHelpPointerClientX = null;
   var hoverHelpPointerClientY = null;
-  var hoverHelpStatus = null;
-  var hoverHelpStatusHeading = null;
-  var hoverHelpStatusBody = null;
-  var hoverHelpStatusShortcuts = null;
-  var hoverHelpStatusShortcutsHeading = null;
-  var hoverHelpStatusShortcutsList = null;
-  var hoverHelpStatusHint = null;
   var parseHoverHelpSelectorList = function parseHoverHelpSelectorList(value) {
     if (typeof value !== 'string') return [];
     return value.split(',').map(function (selector) {
@@ -8007,143 +8000,11 @@ if (helpButton && helpDialog) {
     }
     return fragment;
   };
-  var removeHoverHelpStatus = function removeHoverHelpStatus() {
-    if (hoverHelpStatus) {
-      hoverHelpStatus.remove();
-    }
-    hoverHelpStatus = null;
-    hoverHelpStatusHeading = null;
-    hoverHelpStatusBody = null;
-    hoverHelpStatusShortcuts = null;
-    hoverHelpStatusShortcutsHeading = null;
-    hoverHelpStatusShortcutsList = null;
-    hoverHelpStatusHint = null;
-  };
-  var setElementHidden = function setElementHidden(element, hidden) {
-    if (!element) return;
-    if (hidden) {
-      element.setAttribute('hidden', '');
-    } else {
-      element.removeAttribute('hidden');
-    }
-  };
-  var ensureHoverHelpStatus = function ensureHoverHelpStatus() {
-    var _document2;
-    if (hoverHelpStatus && hoverHelpStatus.isConnected) {
-      return hoverHelpStatus;
-    }
-    var body = (_document2 = document) === null || _document2 === void 0 ? void 0 : _document2.body;
-    if (!body) {
-      return null;
-    }
-    removeHoverHelpStatus();
-    hoverHelpStatus = document.createElement('div');
-    hoverHelpStatus.id = 'hoverHelpStatus';
-    hoverHelpStatus.setAttribute('role', 'status');
-    hoverHelpStatus.setAttribute('aria-live', 'polite');
-    hoverHelpStatus.setAttribute('aria-atomic', 'true');
-    hoverHelpStatusHeading = document.createElement('div');
-    hoverHelpStatusHeading.className = 'hover-help-status-heading';
-    hoverHelpStatus.appendChild(hoverHelpStatusHeading);
-    hoverHelpStatusBody = document.createElement('div');
-    hoverHelpStatusBody.className = 'hover-help-status-body';
-    hoverHelpStatus.appendChild(hoverHelpStatusBody);
-    hoverHelpStatusShortcuts = document.createElement('div');
-    hoverHelpStatusShortcuts.className = 'hover-help-status-shortcuts';
-    hoverHelpStatusShortcutsHeading = document.createElement('div');
-    hoverHelpStatusShortcutsHeading.className = 'hover-help-status-shortcuts-heading';
-    hoverHelpStatusShortcuts.appendChild(hoverHelpStatusShortcutsHeading);
-    hoverHelpStatusShortcutsList = document.createElement('ul');
-    hoverHelpStatusShortcutsList.className = 'hover-help-status-shortcuts-list';
-    hoverHelpStatusShortcuts.appendChild(hoverHelpStatusShortcutsList);
-    hoverHelpStatus.appendChild(hoverHelpStatusShortcuts);
-    setElementHidden(hoverHelpStatusShortcuts, true);
-    hoverHelpStatusHint = document.createElement('div');
-    hoverHelpStatusHint.className = 'hover-help-status-hint';
-    hoverHelpStatus.appendChild(hoverHelpStatusHint);
-    body.appendChild(hoverHelpStatus);
-    return hoverHelpStatus;
-  };
-  var updateHoverHelpStatus = function updateHoverHelpStatus() {
-    var _ref20 = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {},
-      _ref20$heading = _ref20.heading,
-      heading = _ref20$heading === void 0 ? '' : _ref20$heading,
-      _ref20$details = _ref20.details,
-      details = _ref20$details === void 0 ? [] : _ref20$details,
-      _ref20$shortcuts = _ref20.shortcuts,
-      shortcuts = _ref20$shortcuts === void 0 ? [] : _ref20$shortcuts,
-      hint = _ref20.hint;
-    var statusEl = ensureHoverHelpStatus();
-    if (!statusEl) {
-      return;
-    }
-    if (hoverHelpStatusHeading) {
-      hoverHelpStatusHeading.textContent = heading || '';
-      setElementHidden(hoverHelpStatusHeading, !heading);
-    }
-    if (hoverHelpStatusBody) {
-      hoverHelpStatusBody.textContent = '';
-      var detailList = Array.isArray(details) ? details.filter(Boolean) : [];
-      if (detailList.length) {
-        hoverHelpStatusBody.appendChild(createHoverHelpDetailsFragment(detailList));
-        setElementHidden(hoverHelpStatusBody, false);
-      } else {
-        setElementHidden(hoverHelpStatusBody, true);
-      }
-    }
-    if (hoverHelpStatusShortcuts && hoverHelpStatusShortcutsList) {
-      hoverHelpStatusShortcutsList.textContent = '';
-      var shortcutItems = Array.isArray(shortcuts) ? shortcuts.filter(Boolean) : [];
-      if (shortcutItems.length) {
-        var headingText = getHoverHelpLocaleValue('hoverHelpShortcutsHeading');
-        if (hoverHelpStatusShortcutsHeading) {
-          hoverHelpStatusShortcutsHeading.textContent = headingText || '';
-          setElementHidden(hoverHelpStatusShortcutsHeading, !headingText);
-        }
-        shortcutItems.forEach(function (text) {
-          var item = document.createElement('li');
-          item.textContent = text;
-          hoverHelpStatusShortcutsList.appendChild(item);
-        });
-        setElementHidden(hoverHelpStatusShortcuts, false);
-      } else {
-        setElementHidden(hoverHelpStatusShortcuts, true);
-      }
-    }
-    if (hoverHelpStatusHint) {
-      var resolvedHint = typeof hint === 'string' && hint.trim() ? hint : getHoverHelpLocaleValue('hoverHelpExitHint');
-      hoverHelpStatusHint.textContent = resolvedHint || '';
-      setElementHidden(hoverHelpStatusHint, !resolvedHint);
-    }
-  };
-  var renderHoverHelpStatusIntro = function renderHoverHelpStatusIntro() {
-    var heading = getHoverHelpLocaleValue('hoverHelpButtonLabel');
-    var description = getHoverHelpLocaleValue('hoverHelpButtonHelp');
-    var details = description ? [description] : [];
-    updateHoverHelpStatus({
-      heading: heading,
-      details: details
-    });
-  };
-  var renderHoverHelpStatusForTarget = function renderHoverHelpStatusForTarget(label, detailText, shortcutList) {
-    var heading = label && label.trim() ? label.trim() : getHoverHelpLocaleValue('hoverHelpButtonLabel');
-    var details = Array.isArray(detailText) ? detailText.filter(Boolean) : [];
-    var resolvedDetails = details.length ? details : [getHoverHelpLocaleValue('hoverHelpFallbackGeneric')];
-    var shortcuts = Array.isArray(shortcutList) ? shortcutList.filter(Boolean) : [];
-    updateHoverHelpStatus({
-      heading: heading,
-      details: resolvedDetails,
-      shortcuts: shortcuts
-    });
-  };
   var updateHoverHelpTooltip = function updateHoverHelpTooltip(target) {
     hoverHelpCurrentTarget = target || null;
     setHoverHelpHighlight(target || null);
     if (!hoverHelpActive || !hoverHelpTooltip || !target) {
       hideHoverHelpTooltip();
-      if (hoverHelpActive) {
-        renderHoverHelpStatusIntro();
-      }
       return;
     }
     var _collectHoverHelpCont = collectHoverHelpContent(target),
@@ -8155,7 +8016,6 @@ if (helpButton && helpDialog) {
     var shortcutList = Array.isArray(shortcuts) ? shortcuts.filter(Boolean) : [];
     if (!hasLabel && detailText.length === 0 && shortcutList.length === 0) {
       hideHoverHelpTooltip();
-      renderHoverHelpStatusIntro();
       return;
     }
     hoverHelpTooltip.textContent = '';
@@ -8195,6 +8055,13 @@ if (helpButton && helpDialog) {
         hoverHelpTooltip.appendChild(shortcutsWrapper);
       }
     }
+    var exitHint = getHoverHelpLocaleValue('hoverHelpExitHint');
+    if (exitHint) {
+      var hintEl = document.createElement('div');
+      hintEl.className = 'hover-help-hint';
+      hintEl.textContent = exitHint;
+      hoverHelpTooltip.appendChild(hintEl);
+    }
     var wasHidden = hoverHelpTooltip.hasAttribute('hidden');
     if (wasHidden) {
       hoverHelpTooltip.style.visibility = 'hidden';
@@ -8205,7 +8072,6 @@ if (helpButton && helpDialog) {
       hoverHelpTooltip.style.removeProperty('visibility');
     }
     hoverHelpTooltip.removeAttribute('hidden');
-    renderHoverHelpStatusForTarget(hasLabel ? label : '', detailText, shortcutList);
   };
   var canInteractDuringHoverHelp = function canInteractDuringHoverHelp(target) {
     if (!hoverHelpActive || !target) return false;
@@ -8221,7 +8087,6 @@ if (helpButton && helpDialog) {
     clearHoverHelpHighlight();
     document.body.style.cursor = '';
     document.body.classList.remove('hover-help-active');
-    removeHoverHelpStatus();
   };
   var startHoverHelp = function startHoverHelp() {
     hoverHelpActive = true;
@@ -8234,7 +8099,6 @@ if (helpButton && helpDialog) {
     hoverHelpTooltip.setAttribute('role', 'tooltip');
     hoverHelpTooltip.setAttribute('hidden', '');
     document.body.appendChild(hoverHelpTooltip);
-    renderHoverHelpStatusIntro();
   };
   var refreshTooltipPosition = function refreshTooltipPosition() {
     if (hoverHelpActive && hoverHelpTooltip && hoverHelpCurrentTarget) {

--- a/src/scripts/app-session.js
+++ b/src/scripts/app-session.js
@@ -8351,13 +8351,6 @@ if (helpButton && helpDialog) {
   let hoverHelpHighlightedTarget = null;
   let hoverHelpPointerClientX = null;
   let hoverHelpPointerClientY = null;
-  let hoverHelpStatus = null;
-  let hoverHelpStatusHeading = null;
-  let hoverHelpStatusBody = null;
-  let hoverHelpStatusShortcuts = null;
-  let hoverHelpStatusShortcutsHeading = null;
-  let hoverHelpStatusShortcutsList = null;
-  let hoverHelpStatusHint = null;
 
   const parseHoverHelpSelectorList = value => {
     if (typeof value !== 'string') return [];
@@ -9028,143 +9021,11 @@ if (helpButton && helpDialog) {
     return fragment;
   };
 
-  const removeHoverHelpStatus = () => {
-    if (hoverHelpStatus) {
-      hoverHelpStatus.remove();
-    }
-    hoverHelpStatus = null;
-    hoverHelpStatusHeading = null;
-    hoverHelpStatusBody = null;
-    hoverHelpStatusShortcuts = null;
-    hoverHelpStatusShortcutsHeading = null;
-    hoverHelpStatusShortcutsList = null;
-    hoverHelpStatusHint = null;
-  };
-
-  const setElementHidden = (element, hidden) => {
-    if (!element) return;
-    if (hidden) {
-      element.setAttribute('hidden', '');
-    } else {
-      element.removeAttribute('hidden');
-    }
-  };
-
-  const ensureHoverHelpStatus = () => {
-    if (hoverHelpStatus && hoverHelpStatus.isConnected) {
-      return hoverHelpStatus;
-    }
-    const body = document?.body;
-    if (!body) {
-      return null;
-    }
-    removeHoverHelpStatus();
-    hoverHelpStatus = document.createElement('div');
-    hoverHelpStatus.id = 'hoverHelpStatus';
-    hoverHelpStatus.setAttribute('role', 'status');
-    hoverHelpStatus.setAttribute('aria-live', 'polite');
-    hoverHelpStatus.setAttribute('aria-atomic', 'true');
-
-    hoverHelpStatusHeading = document.createElement('div');
-    hoverHelpStatusHeading.className = 'hover-help-status-heading';
-    hoverHelpStatus.appendChild(hoverHelpStatusHeading);
-
-    hoverHelpStatusBody = document.createElement('div');
-    hoverHelpStatusBody.className = 'hover-help-status-body';
-    hoverHelpStatus.appendChild(hoverHelpStatusBody);
-
-    hoverHelpStatusShortcuts = document.createElement('div');
-    hoverHelpStatusShortcuts.className = 'hover-help-status-shortcuts';
-    hoverHelpStatusShortcutsHeading = document.createElement('div');
-    hoverHelpStatusShortcutsHeading.className = 'hover-help-status-shortcuts-heading';
-    hoverHelpStatusShortcuts.appendChild(hoverHelpStatusShortcutsHeading);
-    hoverHelpStatusShortcutsList = document.createElement('ul');
-    hoverHelpStatusShortcutsList.className = 'hover-help-status-shortcuts-list';
-    hoverHelpStatusShortcuts.appendChild(hoverHelpStatusShortcutsList);
-    hoverHelpStatus.appendChild(hoverHelpStatusShortcuts);
-    setElementHidden(hoverHelpStatusShortcuts, true);
-
-    hoverHelpStatusHint = document.createElement('div');
-    hoverHelpStatusHint.className = 'hover-help-status-hint';
-    hoverHelpStatus.appendChild(hoverHelpStatusHint);
-
-    body.appendChild(hoverHelpStatus);
-    return hoverHelpStatus;
-  };
-
-  const updateHoverHelpStatus = ({ heading = '', details = [], shortcuts = [], hint } = {}) => {
-    const statusEl = ensureHoverHelpStatus();
-    if (!statusEl) {
-      return;
-    }
-    if (hoverHelpStatusHeading) {
-      hoverHelpStatusHeading.textContent = heading || '';
-      setElementHidden(hoverHelpStatusHeading, !heading);
-    }
-    if (hoverHelpStatusBody) {
-      hoverHelpStatusBody.textContent = '';
-      const detailList = Array.isArray(details) ? details.filter(Boolean) : [];
-      if (detailList.length) {
-        hoverHelpStatusBody.appendChild(createHoverHelpDetailsFragment(detailList));
-        setElementHidden(hoverHelpStatusBody, false);
-      } else {
-        setElementHidden(hoverHelpStatusBody, true);
-      }
-    }
-    if (hoverHelpStatusShortcuts && hoverHelpStatusShortcutsList) {
-      hoverHelpStatusShortcutsList.textContent = '';
-      const shortcutItems = Array.isArray(shortcuts) ? shortcuts.filter(Boolean) : [];
-      if (shortcutItems.length) {
-        const headingText = getHoverHelpLocaleValue('hoverHelpShortcutsHeading');
-        if (hoverHelpStatusShortcutsHeading) {
-          hoverHelpStatusShortcutsHeading.textContent = headingText || '';
-          setElementHidden(hoverHelpStatusShortcutsHeading, !headingText);
-        }
-        shortcutItems.forEach(text => {
-          const item = document.createElement('li');
-          item.textContent = text;
-          hoverHelpStatusShortcutsList.appendChild(item);
-        });
-        setElementHidden(hoverHelpStatusShortcuts, false);
-      } else {
-        setElementHidden(hoverHelpStatusShortcuts, true);
-      }
-    }
-    if (hoverHelpStatusHint) {
-      const resolvedHint =
-        typeof hint === 'string' && hint.trim()
-          ? hint
-          : getHoverHelpLocaleValue('hoverHelpExitHint');
-      hoverHelpStatusHint.textContent = resolvedHint || '';
-      setElementHidden(hoverHelpStatusHint, !resolvedHint);
-    }
-  };
-
-  const renderHoverHelpStatusIntro = () => {
-    const heading = getHoverHelpLocaleValue('hoverHelpButtonLabel');
-    const description = getHoverHelpLocaleValue('hoverHelpButtonHelp');
-    const details = description ? [description] : [];
-    updateHoverHelpStatus({ heading, details });
-  };
-
-  const renderHoverHelpStatusForTarget = (label, detailText, shortcutList) => {
-    const heading = label && label.trim()
-      ? label.trim()
-      : getHoverHelpLocaleValue('hoverHelpButtonLabel');
-    const details = Array.isArray(detailText) ? detailText.filter(Boolean) : [];
-    const resolvedDetails = details.length ? details : [getHoverHelpLocaleValue('hoverHelpFallbackGeneric')];
-    const shortcuts = Array.isArray(shortcutList) ? shortcutList.filter(Boolean) : [];
-    updateHoverHelpStatus({ heading, details: resolvedDetails, shortcuts });
-  };
-
   const updateHoverHelpTooltip = target => {
     hoverHelpCurrentTarget = target || null;
     setHoverHelpHighlight(target || null);
     if (!hoverHelpActive || !hoverHelpTooltip || !target) {
       hideHoverHelpTooltip();
-      if (hoverHelpActive) {
-        renderHoverHelpStatusIntro();
-      }
       return;
     }
     const { label, details, shortcuts } = collectHoverHelpContent(target);
@@ -9175,7 +9036,6 @@ if (helpButton && helpDialog) {
       : [];
     if (!hasLabel && detailText.length === 0 && shortcutList.length === 0) {
       hideHoverHelpTooltip();
-      renderHoverHelpStatusIntro();
       return;
     }
     hoverHelpTooltip.textContent = '';
@@ -9215,6 +9075,13 @@ if (helpButton && helpDialog) {
         hoverHelpTooltip.appendChild(shortcutsWrapper);
       }
     }
+    const exitHint = getHoverHelpLocaleValue('hoverHelpExitHint');
+    if (exitHint) {
+      const hintEl = document.createElement('div');
+      hintEl.className = 'hover-help-hint';
+      hintEl.textContent = exitHint;
+      hoverHelpTooltip.appendChild(hintEl);
+    }
     const wasHidden = hoverHelpTooltip.hasAttribute('hidden');
     if (wasHidden) {
       hoverHelpTooltip.style.visibility = 'hidden';
@@ -9225,7 +9092,6 @@ if (helpButton && helpDialog) {
       hoverHelpTooltip.style.removeProperty('visibility');
     }
     hoverHelpTooltip.removeAttribute('hidden');
-    renderHoverHelpStatusForTarget(hasLabel ? label : '', detailText, shortcutList);
   };
 
   const canInteractDuringHoverHelp = target => {
@@ -9244,7 +9110,6 @@ if (helpButton && helpDialog) {
     clearHoverHelpHighlight();
     document.body.style.cursor = '';
     document.body.classList.remove('hover-help-active');
-    removeHoverHelpStatus();
   };
 
   // Start hover-help mode: close the dialog, create the tooltip element and
@@ -9260,7 +9125,6 @@ if (helpButton && helpDialog) {
     hoverHelpTooltip.setAttribute('role', 'tooltip');
     hoverHelpTooltip.setAttribute('hidden', '');
     document.body.appendChild(hoverHelpTooltip);
-    renderHoverHelpStatusIntro();
   };
 
   const refreshTooltipPosition = () => {

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -4358,6 +4358,14 @@ body.pink-mode .favorite-toggle.favorited:active {
   gap: 4px;
 }
 
+#hoverHelpTooltip .hover-help-hint {
+  border-top: 1px solid color-mix(in srgb, var(--accent-color) 35%, transparent);
+  padding-top: 4px;
+  margin-top: 2px;
+  font-size: calc(var(--font-size-base) * 0.82);
+  color: color-mix(in srgb, var(--text-color) 70%, transparent);
+}
+
 #hoverHelpTooltip .hover-help-shortcuts-heading {
   font-weight: 600;
   font-size: calc(var(--font-size-base) * var(--font-scale-compact));
@@ -4389,108 +4397,14 @@ body.dark-mode #hoverHelpTooltip .hover-help-shortcut {
   border-color: color-mix(in srgb, var(--accent-color) 60%, transparent);
 }
 
+
 body.high-contrast #hoverHelpTooltip .hover-help-shortcut {
   background: color-mix(in srgb, var(--surface-color) 70%, transparent);
   border-color: currentColor;
 }
 
-#hoverHelpStatus {
-  position: fixed;
-  right: calc(16px + env(safe-area-inset-right, 0px));
-  bottom: calc(16px + env(safe-area-inset-bottom, 0px));
-  z-index: 999;
-  max-width: min(360px, 90vw);
-  background: var(--surface-color);
-  color: var(--text-color);
-  border: 1px solid color-mix(in srgb, var(--accent-color) 60%, transparent);
-  box-shadow: var(--panel-shadow);
-  border-radius: 8px;
-  padding: 12px 14px;
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-  font-size: calc(var(--font-size-base) * var(--font-scale-compact));
-}
-
-#hoverHelpStatus[hidden] {
-  display: none;
-}
-
-#hoverHelpStatus .hover-help-status-heading {
-  font-weight: 600;
-  letter-spacing: 0.01em;
-}
-
-#hoverHelpStatus .hover-help-status-body {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-  line-height: 1.4;
-}
-
-#hoverHelpStatus .hover-help-status-body p {
-  margin: 0;
-}
-
-#hoverHelpStatus .hover-help-status-body ul {
-  margin: 0;
-  padding-inline-start: 18px;
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-}
-
-#hoverHelpStatus .hover-help-status-shortcuts {
-  border-top: 1px solid color-mix(in srgb, var(--accent-color) 40%, transparent);
-  padding-top: 6px;
-  margin-top: 2px;
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-}
-
-#hoverHelpStatus .hover-help-status-shortcuts-heading {
-  font-weight: 600;
-  font-size: calc(var(--font-size-base) * var(--font-scale-compact));
-  letter-spacing: 0.01em;
-}
-
-#hoverHelpStatus .hover-help-status-shortcuts-list {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 6px;
-}
-
-#hoverHelpStatus .hover-help-status-shortcuts-list li {
-  background: color-mix(in srgb, var(--accent-color) 18%, transparent);
-  border: 1px solid color-mix(in srgb, var(--accent-color) 45%, transparent);
-  border-radius: 4px;
-  padding: 2px 6px;
-  font-family: var(--font-family-mono, var(--font-family));
-  font-size: calc(var(--font-size-base) * 0.78);
-  line-height: 1.2;
-  white-space: nowrap;
-}
-
-#hoverHelpStatus .hover-help-status-hint {
-  font-size: calc(var(--font-size-base) * 0.82);
-  color: color-mix(in srgb, var(--text-color) 70%, transparent);
-}
-
-body.dark-mode #hoverHelpStatus .hover-help-status-shortcuts-list li {
-  background: color-mix(in srgb, var(--accent-color) 35%, rgba(0, 0, 0, 0.45));
-  border-color: color-mix(in srgb, var(--accent-color) 60%, transparent);
-}
-
-body.high-contrast #hoverHelpStatus {
-  border-color: currentColor;
-}
-
-body.high-contrast #hoverHelpStatus .hover-help-status-shortcuts-list li {
-  background: color-mix(in srgb, var(--surface-color) 70%, transparent);
+body.high-contrast #hoverHelpTooltip .hover-help-hint {
+  color: currentColor;
   border-color: currentColor;
 }
 


### PR DESCRIPTION
## Summary
- remove the hover help status overlay so only the contextual tooltip is shown
- add an exit hint directly to the tooltip and style it for light, dark, and high-contrast modes
- mirror the hover help updates in the legacy build script

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e2f73ab62c832082b771b9b5c02760