### PR TITLE
Ensure auto gear coverage summary is available globally

### DIFF
--- a/legacy/scripts/app-core-new-2.js
+++ b/legacy/scripts/app-core-new-2.js
@@ -16567,6 +16567,8 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
       return applyAutoGearRulesToTableHtml;
     }], ['importAutoGearRulesFromData', function () {
       return importAutoGearRulesFromData;
+    }], ['getAutoGearRuleCoverageSummary', function () {
+      return getAutoGearRuleCoverageSummary;
     }], ['createAutoGearBackup', function () {
       return createAutoGearBackup;
     }], ['restoreAutoGearBackup', function () {

--- a/src/scripts/app-core-new-2.js
+++ b/src/scripts/app-core-new-2.js
@@ -17467,6 +17467,7 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
       ['buildDefaultVideoDistributionAutoGearRules', () => buildDefaultVideoDistributionAutoGearRules],
       ['applyAutoGearRulesToTableHtml', () => applyAutoGearRulesToTableHtml],
       ['importAutoGearRulesFromData', () => importAutoGearRulesFromData],
+      ['getAutoGearRuleCoverageSummary', () => getAutoGearRuleCoverageSummary],
       ['createAutoGearBackup', () => createAutoGearBackup],
       ['restoreAutoGearBackup', () => restoreAutoGearBackup],
       ['getAutoGearRules', () => getAutoGearRules],


### PR DESCRIPTION
## Summary
- export getAutoGearRuleCoverageSummary from the core runtime so sharing can access it

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2f9ff7c408320b6366d0a1b534c23