### PR TITLE
Fix auto gear monitor default selector normalization

### DIFF
--- a/legacy/scripts/app-core-new-1.js
+++ b/legacy/scripts/app-core-new-1.js
@@ -2428,7 +2428,11 @@ if (CORE_PART1_RUNTIME_SCOPE && CORE_PART1_RUNTIME_SCOPE.__cineCorePart1Initiali
   var AUTO_GEAR_CUSTOM_CATEGORY = '';
   var GEAR_LIST_CATEGORIES = ['Camera', 'Camera Support', 'Media', 'Lens', 'Lens Support', 'Matte box + filter', 'LDS (FIZ)', 'Camera Batteries', 'Monitoring Batteries', 'Chargers', 'Monitoring', 'Monitoring support', 'Rigging', 'Power', 'Grip', 'Carts and Transportation', 'Miscellaneous', 'Consumables'];
   var AUTO_GEAR_SELECTOR_TYPES = ['none', 'monitor', 'directorMonitor', 'tripodHeadBrand', 'tripodBowl', 'tripodTypes', 'tripodSpreader'];
-  var AUTO_GEAR_SELECTOR_TYPE_SET = new Set(AUTO_GEAR_SELECTOR_TYPES);
+  var AUTO_GEAR_SELECTOR_TYPE_MAP = AUTO_GEAR_SELECTOR_TYPES.reduce(function(map, type) {
+    map[type.toLowerCase()] = type;
+    return map;
+  }, Object.create(null));
+  var AUTO_GEAR_SELECTOR_TYPE_SET = new Set(Object.keys(AUTO_GEAR_SELECTOR_TYPE_MAP));
   var AUTO_GEAR_MONITOR_FALLBACKS = ['SmallHD Ultra 7', 'SmallHD Focus', 'SmallHD Cine 7'];
   var AUTO_GEAR_TRIPOD_SELECTOR_TYPES = new Set(['tripodHeadBrand', 'tripodBowl', 'tripodTypes', 'tripodSpreader']);
   var AUTO_GEAR_TRIPOD_FIELD_IDS = {
@@ -2492,7 +2496,8 @@ if (CORE_PART1_RUNTIME_SCOPE && CORE_PART1_RUNTIME_SCOPE.__cineCorePart1Initiali
   function normalizeAutoGearSelectorType(value) {
     var candidate = typeof value === 'string' ? value.trim().toLowerCase() : '';
     if (!candidate) return 'none';
-    return AUTO_GEAR_SELECTOR_TYPE_SET.has(candidate) ? candidate : 'none';
+    if (!AUTO_GEAR_SELECTOR_TYPE_SET.has(candidate)) return 'none';
+    return AUTO_GEAR_SELECTOR_TYPE_MAP[candidate] || 'none';
   }
   function normalizeAutoGearSelectorDefault(type, value) {
     var text = normalizeAutoGearText(value);

--- a/src/scripts/app-core-new-1.js
+++ b/src/scripts/app-core-new-1.js
@@ -2969,7 +2969,11 @@ const AUTO_GEAR_SELECTOR_TYPES = [
   'tripodTypes',
   'tripodSpreader',
 ];
-const AUTO_GEAR_SELECTOR_TYPE_SET = new Set(AUTO_GEAR_SELECTOR_TYPES);
+const AUTO_GEAR_SELECTOR_TYPE_MAP = AUTO_GEAR_SELECTOR_TYPES.reduce((map, type) => {
+  map[type.toLowerCase()] = type;
+  return map;
+}, Object.create(null));
+const AUTO_GEAR_SELECTOR_TYPE_SET = new Set(Object.keys(AUTO_GEAR_SELECTOR_TYPE_MAP));
 const AUTO_GEAR_MONITOR_FALLBACKS = ['SmallHD Ultra 7', 'SmallHD Focus', 'SmallHD Cine 7'];
 const AUTO_GEAR_TRIPOD_SELECTOR_TYPES = new Set([
   'tripodHeadBrand',
@@ -3083,7 +3087,8 @@ function normalizeAutoGearText(value, { collapseWhitespace = true } = {}) {
 function normalizeAutoGearSelectorType(value) {
   const candidate = typeof value === 'string' ? value.trim().toLowerCase() : '';
   if (!candidate) return 'none';
-  return AUTO_GEAR_SELECTOR_TYPE_SET.has(candidate) ? candidate : 'none';
+  if (!AUTO_GEAR_SELECTOR_TYPE_SET.has(candidate)) return 'none';
+  return AUTO_GEAR_SELECTOR_TYPE_MAP[candidate] || 'none';
 }
 
 /**


### PR DESCRIPTION
## Summary
- ensure auto gear selector normalization handles mixed-case types so director monitor defaults stay enabled
- mirror the normalization fix in the legacy bundle to keep builds aligned

## Testing
- npm test *(fails: existing lint errors about unrelated globals)*

------
https://chatgpt.com/codex/tasks/task_e_68e2fa2d68ac8320bed249f13113f49e