### PR TITLE
Fix Auto Gear editor runtime exports

### DIFF
--- a/legacy/scripts/app-core-new-2.js
+++ b/legacy/scripts/app-core-new-2.js
@@ -16321,6 +16321,7 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
       renderAutoGearMonitorDefaultsControls: renderAutoGearMonitorDefaultsControls,
       renderAutoGearPresetsControls: renderAutoGearPresetsControls,
       renderAutoGearRulesList: renderAutoGearRulesList,
+      openAutoGearEditor: openAutoGearEditor,
       overviewSectionIcons: overviewSectionIcons,
       saveAutoGearRuleFromEditor: saveAutoGearRuleFromEditor,
       handleAutoGearImportSelection: handleAutoGearImportSelection,

--- a/src/scripts/app-core-new-2.js
+++ b/src/scripts/app-core-new-2.js
@@ -17319,6 +17319,7 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
       renderAutoGearMonitorDefaultsControls,
       renderAutoGearPresetsControls,
       renderAutoGearRulesList,
+      openAutoGearEditor,
       overviewSectionIcons,
       saveAutoGearRuleFromEditor,
       handleAutoGearImportSelection,


### PR DESCRIPTION
## Summary
- expose the Auto Gear editor runtime function in the modern bundle so session helpers can open the editor
- keep the legacy runtime exports in sync with the modern build

## Testing
- npm test -- --runTestsByPath tests/smoke.test.js *(fails: existing lint errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68e2fab11c0083209a101c600f1c483c