### PR TITLE
Expose auto gear preset handlers in runtime exports

### DIFF
--- a/src/scripts/app-core-new-2.js
+++ b/src/scripts/app-core-new-2.js
@@ -17323,6 +17323,8 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
       saveAutoGearRuleFromEditor,
       handleAutoGearImportSelection,
       handleAutoGearPresetSelection,
+      handleAutoGearSavePreset,
+      handleAutoGearDeletePreset,
       applyAutoGearBackupVisibility,
       setAutoGearAutoPresetId,
       syncAutoGearAutoPreset,


### PR DESCRIPTION
## Summary
- export the auto gear preset save/delete handlers from the part 2 runtime so UI buttons can call them

## Testing
- npm run lint *(fails: existing lint errors in unrelated modules)*

------
https://chatgpt.com/codex/tasks/task_e_68e2fa55fb4c832082818eb15faad01e