### PR TITLE
Refactor module infrastructure around shared architecture kernel

### DIFF
--- a/src/scripts/modules/architecture-kernel.js
+++ b/src/scripts/modules/architecture-kernel.js
@@ -1,0 +1,510 @@
+(function () {
+  const DEFAULT_PENDING_QUEUE_KEY = '__cinePendingModuleRegistrations__';
+
+  function fallbackDetectGlobalScope() {
+    if (typeof globalThis !== 'undefined') {
+      return globalThis;
+    }
+    if (typeof window !== 'undefined') {
+      return window;
+    }
+    if (typeof self !== 'undefined') {
+      return self;
+    }
+    if (typeof global !== 'undefined') {
+      return global;
+    }
+    return {};
+  }
+
+  const LOCAL_SCOPE = fallbackDetectGlobalScope();
+
+  function fallbackTryRequire(modulePath) {
+    if (typeof require !== 'function') {
+      return null;
+    }
+
+    try {
+      return require(modulePath);
+    } catch (error) {
+      void error;
+      return null;
+    }
+  }
+
+  function resolveArchitecture(scope) {
+    const targetScope = scope || LOCAL_SCOPE;
+
+    const required = fallbackTryRequire('./architecture.js');
+    if (required && typeof required === 'object') {
+      return required;
+    }
+
+    if (targetScope && typeof targetScope.cineModuleArchitecture === 'object') {
+      return targetScope.cineModuleArchitecture;
+    }
+
+    return null;
+  }
+
+  function resolveArchitectureHelpers(scope) {
+    const targetScope = scope || LOCAL_SCOPE;
+
+    const required = fallbackTryRequire('./architecture-helpers.js');
+    if (required && typeof required === 'object') {
+      return required;
+    }
+
+    if (targetScope && typeof targetScope.cineModuleArchitectureHelpers === 'object') {
+      return targetScope.cineModuleArchitectureHelpers;
+    }
+
+    return null;
+  }
+
+  const ARCHITECTURE = resolveArchitecture(LOCAL_SCOPE);
+  const ARCHITECTURE_HELPERS = resolveArchitectureHelpers(LOCAL_SCOPE);
+
+  function fallbackCollectCandidateScopes(primary) {
+    const scopes = [];
+
+    function pushScope(scope) {
+      if (!scope || (typeof scope !== 'object' && typeof scope !== 'function')) {
+        return;
+      }
+      if (scopes.indexOf(scope) === -1) {
+        scopes.push(scope);
+      }
+    }
+
+    pushScope(primary);
+    if (typeof globalThis !== 'undefined') pushScope(globalThis);
+    if (typeof window !== 'undefined') pushScope(window);
+    if (typeof self !== 'undefined') pushScope(self);
+    if (typeof global !== 'undefined') pushScope(global);
+
+    return scopes;
+  }
+
+  function fallbackDefineHiddenProperty(target, name, value) {
+    if (!target || (typeof target !== 'object' && typeof target !== 'function')) {
+      return false;
+    }
+
+    try {
+      Object.defineProperty(target, name, {
+        configurable: true,
+        enumerable: false,
+        writable: true,
+        value,
+      });
+      return true;
+    } catch (error) {
+      void error;
+    }
+
+    try {
+      target[name] = value;
+      return true;
+    } catch (assignmentError) {
+      void assignmentError;
+    }
+
+    return false;
+  }
+
+  function fallbackEnsureQueue(scope, key) {
+    const targetScope = scope || LOCAL_SCOPE;
+    const queueKey = typeof key === 'string' && key ? key : DEFAULT_PENDING_QUEUE_KEY;
+
+    if (!targetScope || typeof targetScope !== 'object') {
+      return null;
+    }
+
+    let queue = targetScope[queueKey];
+    if (Array.isArray(queue)) {
+      return queue;
+    }
+
+    if (!fallbackDefineHiddenProperty(targetScope, queueKey, [])) {
+      return null;
+    }
+
+    queue = targetScope[queueKey];
+    if (!Array.isArray(queue)) {
+      return null;
+    }
+
+    return queue;
+  }
+
+  function shouldBypassDeepFreeze(value) {
+    if (!value || (typeof value !== 'object' && typeof value !== 'function')) {
+      return false;
+    }
+
+    try {
+      if (typeof value.pipe === 'function' && typeof value.unpipe === 'function') {
+        return true;
+      }
+
+      if (typeof value.on === 'function' && typeof value.emit === 'function') {
+        if (typeof value.write === 'function' || typeof value.read === 'function') {
+          return true;
+        }
+
+        const ctorName = value.constructor && value.constructor.name;
+        if (ctorName && /Stream|Emitter|Port/i.test(ctorName)) {
+          return true;
+        }
+      }
+
+      if (typeof Symbol !== 'undefined' && value[Symbol.toStringTag]) {
+        const tag = value[Symbol.toStringTag];
+        if (typeof tag === 'string' && /Stream|Port/i.test(tag)) {
+          return true;
+        }
+      }
+    } catch (inspectionError) {
+      void inspectionError;
+    }
+
+    return false;
+  }
+
+  function fallbackFreezeDeep(value, seen = new WeakSet()) {
+    if (!value || (typeof value !== 'object' && typeof value !== 'function')) {
+      return value;
+    }
+
+    if (shouldBypassDeepFreeze(value)) {
+      return value;
+    }
+
+    if (seen.has(value)) {
+      return value;
+    }
+
+    seen.add(value);
+
+    const keys = Object.getOwnPropertyNames(value);
+    for (let index = 0; index < keys.length; index += 1) {
+      const key = keys[index];
+      const descriptor = Object.getOwnPropertyDescriptor(value, key);
+      if (!descriptor || ('get' in descriptor) || ('set' in descriptor)) {
+        continue;
+      }
+
+      fallbackFreezeDeep(descriptor.value, seen);
+    }
+
+    return Object.freeze(value);
+  }
+
+  function fallbackSafeWarn(message, detail) {
+    if (typeof console === 'undefined' || typeof console.warn !== 'function') {
+      return;
+    }
+
+    try {
+      if (typeof detail === 'undefined') {
+        console.warn(message);
+      } else {
+        console.warn(message, detail);
+      }
+    } catch (error) {
+      void error;
+    }
+  }
+
+  function fallbackResolveModuleRegistry(scope) {
+    const targetScope = scope || LOCAL_SCOPE;
+
+    const required = fallbackTryRequire('./registry.js');
+    if (required && typeof required === 'object') {
+      return required;
+    }
+
+    const scopes = fallbackCollectCandidateScopes(targetScope);
+    for (let index = 0; index < scopes.length; index += 1) {
+      const candidate = scopes[index];
+      if (candidate && typeof candidate.cineModules === 'object') {
+        return candidate.cineModules;
+      }
+    }
+
+    return null;
+  }
+
+  function fallbackQueueModuleRegistration(scope, name, api, options) {
+    const targetScope = scope || LOCAL_SCOPE;
+    const queue = fallbackEnsureQueue(targetScope, DEFAULT_PENDING_QUEUE_KEY);
+    if (!queue) {
+      return false;
+    }
+
+    const payload = Object.freeze({
+      name,
+      api,
+      options: Object.freeze({ ...(options || {}) }),
+    });
+
+    try {
+      queue.push(payload);
+      return true;
+    } catch (error) {
+      void error;
+    }
+
+    try {
+      queue[queue.length] = payload;
+      return true;
+    } catch (assignmentError) {
+      void assignmentError;
+    }
+
+    return false;
+  }
+
+  function fallbackResolveFromScopes(propertyName, options) {
+    const settings = options || {};
+    const predicate = typeof settings.predicate === 'function' ? settings.predicate : null;
+    const scopes = Array.isArray(settings.scopes)
+      ? settings.scopes.slice()
+      : fallbackCollectCandidateScopes(settings.primaryScope || LOCAL_SCOPE);
+
+    for (let index = 0; index < scopes.length; index += 1) {
+      const scope = scopes[index];
+      if (!scope || (typeof scope !== 'object' && typeof scope !== 'function')) {
+        continue;
+      }
+
+      if (predicate) {
+        try {
+          if (predicate(scope, propertyName)) {
+            return scope;
+          }
+        } catch (error) {
+          void error;
+        }
+        continue;
+      }
+
+      const candidate = scope[propertyName];
+      if (typeof candidate !== 'undefined') {
+        return candidate;
+      }
+    }
+
+    return null;
+  }
+
+  function preferFunction(helperFn, architectureFn, fallbackFn) {
+    return function applyPreferred() {
+      const args = arguments;
+
+      if (typeof helperFn === 'function') {
+        try {
+          const helperResult = helperFn.apply(null, args);
+          if (typeof helperResult !== 'undefined' && helperResult !== null) {
+            return helperResult;
+          }
+        } catch (error) {
+          void error;
+        }
+      }
+
+      if (typeof architectureFn === 'function') {
+        try {
+          const architectureResult = architectureFn.apply(null, args);
+          if (typeof architectureResult !== 'undefined' && architectureResult !== null) {
+            return architectureResult;
+          }
+        } catch (error) {
+          void error;
+        }
+      }
+
+      return fallbackFn.apply(null, args);
+    };
+  }
+
+  const detectGlobalScope = preferFunction(
+    ARCHITECTURE_HELPERS && ARCHITECTURE_HELPERS.detectGlobalScope,
+    ARCHITECTURE && ARCHITECTURE.detectGlobalScope,
+    fallbackDetectGlobalScope,
+  );
+
+  const PRIMARY_SCOPE = detectGlobalScope();
+
+  function fallbackCollectWithPrimary(primary) {
+    return fallbackCollectCandidateScopes(primary || PRIMARY_SCOPE);
+  }
+
+  const baseCollectCandidateScopes = preferFunction(
+    ARCHITECTURE_HELPERS && ARCHITECTURE_HELPERS.collectCandidateScopes,
+    ARCHITECTURE && ARCHITECTURE.collectCandidateScopes,
+    fallbackCollectWithPrimary,
+  );
+
+  function collectCandidateScopes(primary) {
+    return baseCollectCandidateScopes(primary || PRIMARY_SCOPE);
+  }
+
+  const tryRequire = preferFunction(
+    ARCHITECTURE_HELPERS && ARCHITECTURE_HELPERS.tryRequire,
+    ARCHITECTURE && ARCHITECTURE.tryRequire,
+    fallbackTryRequire,
+  );
+
+  const defineHiddenProperty = preferFunction(
+    ARCHITECTURE_HELPERS && ARCHITECTURE_HELPERS.defineHiddenProperty,
+    ARCHITECTURE && ARCHITECTURE.defineHiddenProperty,
+    fallbackDefineHiddenProperty,
+  );
+
+  function ensureQueue(scope, key) {
+    const resolvedScope = scope || PRIMARY_SCOPE;
+    const resolvedKey = typeof key === 'string' && key ? key : getPendingQueueKey();
+
+    const helperFn = ARCHITECTURE_HELPERS && ARCHITECTURE_HELPERS.ensureQueue;
+    if (typeof helperFn === 'function') {
+      try {
+        const helperQueue = helperFn(resolvedScope, resolvedKey);
+        if (Array.isArray(helperQueue)) {
+          return helperQueue;
+        }
+      } catch (error) {
+        void error;
+      }
+    }
+
+    const architectureFn = ARCHITECTURE && ARCHITECTURE.ensureQueue;
+    if (typeof architectureFn === 'function') {
+      try {
+        const architectureQueue = architectureFn(resolvedScope, resolvedKey);
+        if (Array.isArray(architectureQueue)) {
+          return architectureQueue;
+        }
+      } catch (error) {
+        void error;
+      }
+    }
+
+    return fallbackEnsureQueue(resolvedScope, resolvedKey);
+  }
+
+  const freezeDeep = preferFunction(
+    ARCHITECTURE_HELPERS && ARCHITECTURE_HELPERS.freezeDeep,
+    ARCHITECTURE && ARCHITECTURE.freezeDeep,
+    fallbackFreezeDeep,
+  );
+
+  const safeWarn = preferFunction(
+    ARCHITECTURE_HELPERS && ARCHITECTURE_HELPERS.safeWarn,
+    ARCHITECTURE && ARCHITECTURE.safeWarn,
+    fallbackSafeWarn,
+  );
+
+  function resolveModuleRegistry(scope) {
+    const targetScope = scope || PRIMARY_SCOPE;
+
+    if (ARCHITECTURE_HELPERS && typeof ARCHITECTURE_HELPERS.resolveModuleRegistry === 'function') {
+      try {
+        const resolved = ARCHITECTURE_HELPERS.resolveModuleRegistry(targetScope);
+        if (resolved && typeof resolved === 'object') {
+          return resolved;
+        }
+      } catch (error) {
+        void error;
+      }
+    }
+
+    return preferFunction(null, ARCHITECTURE && ARCHITECTURE.resolveModuleRegistry, fallbackResolveModuleRegistry)(
+      targetScope,
+    );
+  }
+
+  const baseResolveFromScopes = preferFunction(
+    ARCHITECTURE_HELPERS && ARCHITECTURE_HELPERS.resolveFromScopes,
+    ARCHITECTURE && ARCHITECTURE.resolveFromScopes,
+    fallbackResolveFromScopes,
+  );
+
+  function resolveFromScopes(propertyName, options) {
+    const settings = options ? { ...options } : {};
+    if (!settings.primaryScope) {
+      settings.primaryScope = PRIMARY_SCOPE;
+    }
+    return baseResolveFromScopes(propertyName, settings);
+  }
+
+  function queueModuleRegistration(scope, name, api, options) {
+    const targetScope = scope || PRIMARY_SCOPE;
+
+    if (ARCHITECTURE_HELPERS && typeof ARCHITECTURE_HELPERS.queueModuleRegistration === 'function') {
+      try {
+        if (ARCHITECTURE_HELPERS.queueModuleRegistration(targetScope, name, api, options)) {
+          return true;
+        }
+      } catch (error) {
+        void error;
+      }
+    }
+
+    return fallbackQueueModuleRegistration(targetScope, name, api, options);
+  }
+
+  function getPendingQueueKey() {
+    if (ARCHITECTURE_HELPERS && typeof ARCHITECTURE_HELPERS.pendingQueueKey === 'string' && ARCHITECTURE_HELPERS.pendingQueueKey) {
+      return ARCHITECTURE_HELPERS.pendingQueueKey;
+    }
+    return DEFAULT_PENDING_QUEUE_KEY;
+  }
+
+  const kernel = Object.freeze({
+    architecture: ARCHITECTURE || null,
+    helpers: ARCHITECTURE_HELPERS || null,
+    detectGlobalScope,
+    getGlobalScope() {
+      return PRIMARY_SCOPE;
+    },
+    collectCandidateScopes,
+    tryRequire,
+    defineHiddenProperty,
+    ensureQueue,
+    freezeDeep,
+    safeWarn,
+    resolveModuleRegistry,
+    resolveFromScopes,
+    queueModuleRegistration,
+    getPendingQueueKey,
+  });
+
+  const registry = resolveModuleRegistry(PRIMARY_SCOPE);
+  const registrationOptions = {
+    category: 'infrastructure',
+    description: 'Unified kernel for module detection, registry resolution and queue management.',
+    replace: true,
+  };
+
+  if (registry && typeof registry.register === 'function') {
+    try {
+      registry.register('cineModuleArchitectureKernel', kernel, registrationOptions);
+    } catch (error) {
+      safeWarn('cineModuleArchitectureKernel: immediate registry registration failed.', error);
+      queueModuleRegistration(PRIMARY_SCOPE, 'cineModuleArchitectureKernel', kernel, registrationOptions);
+    }
+  } else {
+    queueModuleRegistration(PRIMARY_SCOPE, 'cineModuleArchitectureKernel', kernel, registrationOptions);
+  }
+
+  if (PRIMARY_SCOPE && typeof PRIMARY_SCOPE === 'object' && !PRIMARY_SCOPE.cineModuleArchitectureKernel) {
+    defineHiddenProperty(PRIMARY_SCOPE, 'cineModuleArchitectureKernel', kernel);
+  }
+
+  if (typeof module !== 'undefined' && module && module.exports) {
+    module.exports = kernel;
+  }
+})();
+

--- a/src/scripts/modules/base.js
+++ b/src/scripts/modules/base.js
@@ -1,4 +1,6 @@
 (function () {
+  const DEFAULT_PENDING_QUEUE_KEY = '__cinePendingModuleRegistrations__';
+
   function fallbackDetectGlobalScope() {
     if (typeof globalThis !== 'undefined') {
       return globalThis;
@@ -15,85 +17,7 @@
     return {};
   }
 
-  const LOCAL_SCOPE = fallbackDetectGlobalScope();
-
-  function resolveArchitecture(scope) {
-    const targetScope = scope || LOCAL_SCOPE;
-
-    if (typeof require === 'function') {
-      try {
-        const required = require('./architecture.js');
-        if (required && typeof required === 'object') {
-          return required;
-        }
-      } catch (error) {
-        void error;
-      }
-    }
-
-    if (targetScope && typeof targetScope.cineModuleArchitecture === 'object') {
-      return targetScope.cineModuleArchitecture;
-    }
-
-    return null;
-  }
-
-  function resolveArchitectureHelpers(scope) {
-    const targetScope = scope || LOCAL_SCOPE;
-
-    if (typeof require === 'function') {
-      try {
-        const required = require('./architecture-helpers.js');
-        if (required && typeof required === 'object') {
-          return required;
-        }
-      } catch (error) {
-        void error;
-      }
-    }
-
-    if (targetScope && typeof targetScope.cineModuleArchitectureHelpers === 'object') {
-      return targetScope.cineModuleArchitectureHelpers;
-    }
-
-    return null;
-  }
-
-  const ARCHITECTURE = resolveArchitecture(LOCAL_SCOPE);
-  const ARCHITECTURE_HELPERS = resolveArchitectureHelpers(LOCAL_SCOPE);
-
-  function detectWithArchitecture() {
-    if (ARCHITECTURE && typeof ARCHITECTURE.detectGlobalScope === 'function') {
-      try {
-        const detected = ARCHITECTURE.detectGlobalScope();
-        if (detected) {
-          return detected;
-        }
-      } catch (error) {
-        void error;
-      }
-    }
-    return fallbackDetectGlobalScope();
-  }
-
-  const detectGlobalScope =
-    ARCHITECTURE_HELPERS && typeof ARCHITECTURE_HELPERS.detectGlobalScope === 'function'
-      ? function detectWithHelpers() {
-          try {
-            const detected = ARCHITECTURE_HELPERS.detectGlobalScope();
-            if (detected) {
-              return detected;
-            }
-          } catch (error) {
-            void error;
-          }
-          return detectWithArchitecture();
-        }
-      : detectWithArchitecture;
-
-  const PRIMARY_SCOPE = detectGlobalScope();
-
-  function fallbackCollectCandidateScopes(primary) {
+  function fallbackCollectCandidateScopes(primary, baseScope) {
     const scopes = [];
 
     function pushScope(scope) {
@@ -105,7 +29,7 @@
       }
     }
 
-    pushScope(primary);
+    pushScope(primary || baseScope);
     if (typeof globalThis !== 'undefined') pushScope(globalThis);
     if (typeof window !== 'undefined') pushScope(window);
     if (typeof self !== 'undefined') pushScope(self);
@@ -113,39 +37,6 @@
 
     return scopes;
   }
-
-  function collectWithArchitecture(primary) {
-    const target = primary || PRIMARY_SCOPE;
-
-    if (ARCHITECTURE && typeof ARCHITECTURE.collectCandidateScopes === 'function') {
-      try {
-        const collected = ARCHITECTURE.collectCandidateScopes(target);
-        if (Array.isArray(collected) && collected.length > 0) {
-          return collected;
-        }
-      } catch (error) {
-        void error;
-      }
-    }
-
-    return fallbackCollectCandidateScopes(target);
-  }
-
-  const collectCandidateScopes =
-    ARCHITECTURE_HELPERS && typeof ARCHITECTURE_HELPERS.collectCandidateScopes === 'function'
-      ? function (primary) {
-          const target = primary || PRIMARY_SCOPE;
-          try {
-            const collected = ARCHITECTURE_HELPERS.collectCandidateScopes(target);
-            if (Array.isArray(collected) && collected.length > 0) {
-              return collected;
-            }
-          } catch (error) {
-            void error;
-          }
-          return collectWithArchitecture(target);
-        }
-      : collectWithArchitecture;
 
   function fallbackTryRequire(modulePath) {
     if (typeof require !== 'function') {
@@ -160,81 +51,11 @@
     }
   }
 
-  function tryRequireWithArchitecture(modulePath) {
-    if (ARCHITECTURE && typeof ARCHITECTURE.tryRequire === 'function') {
-      try {
-        const result = ARCHITECTURE.tryRequire(modulePath);
-        if (typeof result !== 'undefined') {
-          return result;
-        }
-      } catch (error) {
-        void error;
-      }
-    }
-
-    return fallbackTryRequire(modulePath);
-  }
-
-  const baseTryRequire =
-    ARCHITECTURE_HELPERS && typeof ARCHITECTURE_HELPERS.tryRequire === 'function'
-      ? function (modulePath) {
-          const result = ARCHITECTURE_HELPERS.tryRequire(modulePath);
-          return typeof result === 'undefined' ? tryRequireWithArchitecture(modulePath) : result;
-        }
-      : tryRequireWithArchitecture;
-
-  function baseResolveModuleRegistry(scope) {
-    const targetScope = scope || PRIMARY_SCOPE;
-
-    if (ARCHITECTURE_HELPERS && typeof ARCHITECTURE_HELPERS.resolveModuleRegistry === 'function') {
-      try {
-        const helpersResolved = ARCHITECTURE_HELPERS.resolveModuleRegistry(targetScope);
-        if (helpersResolved && typeof helpersResolved === 'object') {
-          return helpersResolved;
-        }
-      } catch (error) {
-        void error;
-      }
-    }
-
-    const required = baseTryRequire('./registry.js');
-    if (required && typeof required === 'object') {
-      return required;
-    }
-
-    const scopes = collectCandidateScopes(targetScope);
-    for (let index = 0; index < scopes.length; index += 1) {
-      const candidate = scopes[index];
-      if (candidate && typeof candidate.cineModules === 'object') {
-        return candidate.cineModules;
-      }
-    }
-
-    return null;
-  }
-
-  let cachedModuleRegistry = null;
-  let hasResolvedRegistry = false;
-
-  function getModuleRegistry(scope) {
-    if (!hasResolvedRegistry || (scope && scope !== PRIMARY_SCOPE)) {
-      const resolved = baseResolveModuleRegistry(scope);
-      if (scope && scope !== PRIMARY_SCOPE) {
-        return resolved;
-      }
-      cachedModuleRegistry = resolved;
-      hasResolvedRegistry = true;
-    }
-
-    return cachedModuleRegistry;
-  }
-
-  const PENDING_QUEUE_KEY =
-    ARCHITECTURE_HELPERS && typeof ARCHITECTURE_HELPERS.pendingQueueKey === 'string'
-      ? ARCHITECTURE_HELPERS.pendingQueueKey
-      : '__cinePendingModuleRegistrations__';
-
   function fallbackDefineHiddenProperty(target, name, value) {
+    if (!target || (typeof target !== 'object' && typeof target !== 'function')) {
+      return false;
+    }
+
     try {
       Object.defineProperty(target, name, {
         configurable: true,
@@ -257,133 +78,29 @@
     return false;
   }
 
-  function defineHiddenPropertyWithArchitecture(target, name, value) {
-    if (ARCHITECTURE && typeof ARCHITECTURE.defineHiddenProperty === 'function') {
-      try {
-        if (ARCHITECTURE.defineHiddenProperty(target, name, value)) {
-          return true;
-        }
-      } catch (error) {
-        void error;
-      }
-    }
-
-    return fallbackDefineHiddenProperty(target, name, value);
-  }
-
-  const defineHiddenProperty =
-    ARCHITECTURE_HELPERS && typeof ARCHITECTURE_HELPERS.defineHiddenProperty === 'function'
-      ? function (target, name, value) {
-          try {
-            if (ARCHITECTURE_HELPERS.defineHiddenProperty(target, name, value)) {
-              return true;
-            }
-          } catch (error) {
-            void error;
-          }
-          return defineHiddenPropertyWithArchitecture(target, name, value);
-        }
-      : defineHiddenPropertyWithArchitecture;
-
-  function ensureQueueWithArchitecture(scope) {
-    const targetScope = scope || PRIMARY_SCOPE;
-    if (ARCHITECTURE && typeof ARCHITECTURE.ensureQueue === 'function') {
-      try {
-        const queue = ARCHITECTURE.ensureQueue(targetScope, PENDING_QUEUE_KEY);
-        if (Array.isArray(queue)) {
-          return queue;
-        }
-      } catch (error) {
-        void error;
-      }
-    }
+  function fallbackEnsureQueue(scope, key, baseScope) {
+    const targetScope = scope || baseScope;
+    const queueKey = typeof key === 'string' && key ? key : DEFAULT_PENDING_QUEUE_KEY;
 
     if (!targetScope || typeof targetScope !== 'object') {
       return null;
     }
 
-    let queue = targetScope[PENDING_QUEUE_KEY];
+    let queue = targetScope[queueKey];
     if (Array.isArray(queue)) {
       return queue;
     }
 
-    if (!defineHiddenProperty(targetScope, PENDING_QUEUE_KEY, [])) {
+    if (!fallbackDefineHiddenProperty(targetScope, queueKey, [])) {
       return null;
     }
 
-    queue = targetScope[PENDING_QUEUE_KEY];
+    queue = targetScope[queueKey];
     if (!Array.isArray(queue)) {
       return null;
     }
 
     return queue;
-  }
-
-  const ensureQueue =
-    ARCHITECTURE_HELPERS && typeof ARCHITECTURE_HELPERS.ensureQueue === 'function'
-      ? function (scope) {
-          try {
-            const queue = ARCHITECTURE_HELPERS.ensureQueue(scope || PRIMARY_SCOPE, PENDING_QUEUE_KEY);
-            if (Array.isArray(queue)) {
-              return queue;
-            }
-          } catch (error) {
-            void error;
-          }
-          return ensureQueueWithArchitecture(scope);
-        }
-      : ensureQueueWithArchitecture;
-
-  function queueModuleRegistration(scope, name, api, options) {
-    const targetScope = scope || PRIMARY_SCOPE;
-
-    if (ARCHITECTURE_HELPERS && typeof ARCHITECTURE_HELPERS.queueModuleRegistration === 'function') {
-      try {
-        if (ARCHITECTURE_HELPERS.queueModuleRegistration(targetScope, name, api, options)) {
-          return true;
-        }
-      } catch (error) {
-        void error;
-      }
-    }
-
-    const queue = ensureQueue(targetScope);
-    if (!queue) {
-      return false;
-    }
-
-    const payload = Object.freeze({
-      name,
-      api,
-      options: Object.freeze({ ...(options || {}) }),
-    });
-
-    try {
-      queue.push(payload);
-    } catch (error) {
-      void error;
-      queue[queue.length] = payload;
-    }
-
-    return true;
-  }
-
-  function baseRegisterOrQueueModule(scope, registry, name, api, options, onError) {
-    if (registry && typeof registry.register === 'function') {
-      try {
-        registry.register(name, api, options);
-        return true;
-      } catch (error) {
-        if (typeof onError === 'function') {
-          onError(error);
-        } else {
-          void error;
-        }
-      }
-    }
-
-    queueModuleRegistration(scope, name, api, options);
-    return false;
   }
 
   function shouldBypassDeepFreeze(value) {
@@ -448,30 +165,6 @@
     return Object.freeze(value);
   }
 
-  function freezeWithArchitecture(value) {
-    if (ARCHITECTURE && typeof ARCHITECTURE.freezeDeep === 'function') {
-      try {
-        return ARCHITECTURE.freezeDeep(value);
-      } catch (error) {
-        void error;
-      }
-    }
-
-    return fallbackFreezeDeep(value);
-  }
-
-  const baseFreezeDeep =
-    ARCHITECTURE_HELPERS && typeof ARCHITECTURE_HELPERS.freezeDeep === 'function'
-      ? function (value) {
-          try {
-            return ARCHITECTURE_HELPERS.freezeDeep(value);
-          } catch (error) {
-            void error;
-          }
-          return freezeWithArchitecture(value);
-        }
-      : freezeWithArchitecture;
-
   function fallbackSafeWarn(message, detail) {
     if (typeof console === 'undefined' || typeof console.warn !== 'function') {
       return;
@@ -488,10 +181,305 @@
     }
   }
 
-  function safeWarnWithArchitecture(message, detail) {
-    if (ARCHITECTURE && typeof ARCHITECTURE.safeWarn === 'function') {
+  function fallbackResolveModuleRegistry(scope, baseScope) {
+    const targetScope = scope || baseScope;
+
+    const required = fallbackTryRequire('./registry.js');
+    if (required && typeof required === 'object') {
+      return required;
+    }
+
+    const scopes = fallbackCollectCandidateScopes(targetScope, baseScope);
+    for (let index = 0; index < scopes.length; index += 1) {
+      const candidate = scopes[index];
+      if (candidate && typeof candidate.cineModules === 'object') {
+        return candidate.cineModules;
+      }
+    }
+
+    return null;
+  }
+
+  function fallbackQueueModuleRegistration(scope, name, api, options, baseScope) {
+    const targetScope = scope || baseScope;
+    const queue = fallbackEnsureQueue(targetScope, DEFAULT_PENDING_QUEUE_KEY, baseScope);
+    if (!queue) {
+      return false;
+    }
+
+    const payload = Object.freeze({
+      name,
+      api,
+      options: Object.freeze({ ...(options || {}) }),
+    });
+
+    try {
+      queue.push(payload);
+      return true;
+    } catch (error) {
+      void error;
+    }
+
+    try {
+      queue[queue.length] = payload;
+      return true;
+    } catch (assignmentError) {
+      void assignmentError;
+    }
+
+    return false;
+  }
+
+  function createFallbackKernel(primaryScope) {
+    const baseScope = primaryScope || fallbackDetectGlobalScope();
+
+    return {
+      detectGlobalScope: fallbackDetectGlobalScope,
+      getGlobalScope() {
+        return baseScope;
+      },
+      collectCandidateScopes(primary) {
+        return fallbackCollectCandidateScopes(primary || baseScope, baseScope);
+      },
+      tryRequire: fallbackTryRequire,
+      defineHiddenProperty: fallbackDefineHiddenProperty,
+      ensureQueue(scope, key) {
+        return fallbackEnsureQueue(scope || baseScope, key, baseScope);
+      },
+      freezeDeep: fallbackFreezeDeep,
+      safeWarn: fallbackSafeWarn,
+      resolveModuleRegistry(scope) {
+        return fallbackResolveModuleRegistry(scope || baseScope, baseScope);
+      },
+      queueModuleRegistration(scope, name, api, options) {
+        return fallbackQueueModuleRegistration(scope || baseScope, name, api, options, baseScope);
+      },
+      getPendingQueueKey() {
+        return DEFAULT_PENDING_QUEUE_KEY;
+      },
+    };
+  }
+
+  function resolveArchitectureKernel(scope) {
+    const targetScope = scope || fallbackDetectGlobalScope();
+
+    if (typeof require === 'function') {
       try {
-        ARCHITECTURE.safeWarn(message, detail);
+        const required = require('./architecture-kernel.js');
+        if (required && typeof required === 'object') {
+          return required;
+        }
+      } catch (error) {
+        void error;
+      }
+    }
+
+    if (targetScope && typeof targetScope.cineModuleArchitectureKernel === 'object') {
+      return targetScope.cineModuleArchitectureKernel;
+    }
+
+    return null;
+  }
+
+  const LOCAL_SCOPE = fallbackDetectGlobalScope();
+  const RESOLVED_KERNEL = resolveArchitectureKernel(LOCAL_SCOPE);
+  const ACTIVE_KERNEL = RESOLVED_KERNEL || createFallbackKernel(LOCAL_SCOPE);
+
+  function detectGlobalScope() {
+    if (ACTIVE_KERNEL && typeof ACTIVE_KERNEL.detectGlobalScope === 'function') {
+      try {
+        const detected = ACTIVE_KERNEL.detectGlobalScope();
+        if (detected) {
+          return detected;
+        }
+      } catch (error) {
+        void error;
+      }
+    }
+    return fallbackDetectGlobalScope();
+  }
+
+  const PRIMARY_SCOPE =
+    ACTIVE_KERNEL && typeof ACTIVE_KERNEL.getGlobalScope === 'function'
+      ? (function resolvePrimaryScope() {
+          try {
+            const scoped = ACTIVE_KERNEL.getGlobalScope();
+            if (scoped) {
+              return scoped;
+            }
+          } catch (error) {
+            void error;
+          }
+          return detectGlobalScope();
+        })()
+      : detectGlobalScope();
+
+  const PENDING_QUEUE_KEY =
+    ACTIVE_KERNEL && typeof ACTIVE_KERNEL.getPendingQueueKey === 'function'
+      ? ACTIVE_KERNEL.getPendingQueueKey()
+      : DEFAULT_PENDING_QUEUE_KEY;
+
+  function collectCandidateScopes(primary) {
+    if (ACTIVE_KERNEL && typeof ACTIVE_KERNEL.collectCandidateScopes === 'function') {
+      try {
+        const collected = ACTIVE_KERNEL.collectCandidateScopes(primary || PRIMARY_SCOPE);
+        if (Array.isArray(collected) && collected.length > 0) {
+          return collected;
+        }
+      } catch (error) {
+        void error;
+      }
+    }
+
+    return fallbackCollectCandidateScopes(primary || PRIMARY_SCOPE, PRIMARY_SCOPE);
+  }
+
+  function baseTryRequire(modulePath) {
+    if (ACTIVE_KERNEL && typeof ACTIVE_KERNEL.tryRequire === 'function') {
+      try {
+        const result = ACTIVE_KERNEL.tryRequire(modulePath);
+        if (typeof result !== 'undefined') {
+          return result;
+        }
+      } catch (error) {
+        void error;
+      }
+    }
+
+    return fallbackTryRequire(modulePath);
+  }
+
+  function baseResolveModuleRegistry(scope) {
+    const targetScope = scope || PRIMARY_SCOPE;
+
+    if (ACTIVE_KERNEL && typeof ACTIVE_KERNEL.resolveModuleRegistry === 'function') {
+      try {
+        const resolved = ACTIVE_KERNEL.resolveModuleRegistry(targetScope);
+        if (resolved && typeof resolved === 'object') {
+          return resolved;
+        }
+      } catch (error) {
+        void error;
+      }
+    }
+
+    const required = baseTryRequire('./registry.js');
+    if (required && typeof required === 'object') {
+      return required;
+    }
+
+    const scopes = collectCandidateScopes(targetScope);
+    for (let index = 0; index < scopes.length; index += 1) {
+      const candidate = scopes[index];
+      if (candidate && typeof candidate.cineModules === 'object') {
+        return candidate.cineModules;
+      }
+    }
+
+    return null;
+  }
+
+  let cachedModuleRegistry = null;
+  let hasResolvedRegistry = false;
+
+  function getModuleRegistry(scope) {
+    if (!hasResolvedRegistry || (scope && scope !== PRIMARY_SCOPE)) {
+      const resolved = baseResolveModuleRegistry(scope);
+      if (scope && scope !== PRIMARY_SCOPE) {
+        return resolved;
+      }
+      cachedModuleRegistry = resolved;
+      hasResolvedRegistry = true;
+    }
+
+    return cachedModuleRegistry;
+  }
+
+  function ensureQueue(scope) {
+    const targetScope = scope || PRIMARY_SCOPE;
+
+    if (ACTIVE_KERNEL && typeof ACTIVE_KERNEL.ensureQueue === 'function') {
+      try {
+        const queue = ACTIVE_KERNEL.ensureQueue(targetScope, PENDING_QUEUE_KEY);
+        if (Array.isArray(queue)) {
+          return queue;
+        }
+      } catch (error) {
+        void error;
+      }
+    }
+
+    return fallbackEnsureQueue(targetScope, PENDING_QUEUE_KEY, PRIMARY_SCOPE);
+  }
+
+  function queueModuleRegistration(scope, name, api, options) {
+    const targetScope = scope || PRIMARY_SCOPE;
+
+    if (ACTIVE_KERNEL && typeof ACTIVE_KERNEL.queueModuleRegistration === 'function') {
+      try {
+        if (ACTIVE_KERNEL.queueModuleRegistration(targetScope, name, api, options)) {
+          return true;
+        }
+      } catch (error) {
+        void error;
+      }
+    }
+
+    const queue = ensureQueue(targetScope);
+    if (!queue) {
+      return false;
+    }
+
+    const payload = Object.freeze({
+      name,
+      api,
+      options: Object.freeze({ ...(options || {}) }),
+    });
+
+    try {
+      queue.push(payload);
+    } catch (error) {
+      void error;
+      queue[queue.length] = payload;
+    }
+
+    return true;
+  }
+
+  function baseRegisterOrQueueModule(scope, registry, name, api, options, onError) {
+    if (registry && typeof registry.register === 'function') {
+      try {
+        registry.register(name, api, options);
+        return true;
+      } catch (error) {
+        if (typeof onError === 'function') {
+          onError(error);
+        } else {
+          void error;
+        }
+      }
+    }
+
+    queueModuleRegistration(scope, name, api, options);
+    return false;
+  }
+
+  function baseFreezeDeep(value) {
+    if (ACTIVE_KERNEL && typeof ACTIVE_KERNEL.freezeDeep === 'function') {
+      try {
+        return ACTIVE_KERNEL.freezeDeep(value);
+      } catch (error) {
+        void error;
+      }
+    }
+
+    return fallbackFreezeDeep(value);
+  }
+
+  function baseSafeWarn(message, detail) {
+    if (ACTIVE_KERNEL && typeof ACTIVE_KERNEL.safeWarn === 'function') {
+      try {
+        ACTIVE_KERNEL.safeWarn(message, detail);
         return;
       } catch (error) {
         void error;
@@ -500,19 +488,6 @@
 
     fallbackSafeWarn(message, detail);
   }
-
-  const baseSafeWarn =
-    ARCHITECTURE_HELPERS && typeof ARCHITECTURE_HELPERS.safeWarn === 'function'
-      ? function (message, detail) {
-          try {
-            ARCHITECTURE_HELPERS.safeWarn(message, detail);
-            return;
-          } catch (error) {
-            void error;
-          }
-          safeWarnWithArchitecture(message, detail);
-        }
-      : safeWarnWithArchitecture;
 
   function exposeGlobal(name, value, scope, options = {}) {
     const targetScope = scope || PRIMARY_SCOPE;
@@ -586,3 +561,4 @@
     module.exports = baseApi;
   }
 })();
+


### PR DESCRIPTION
## Summary
- add a shared architecture kernel module that unifies scope detection, queue management, and immutability fallbacks
- refactor cineModuleBase to consume the kernel utilities for registry resolution, queuing, and safe warnings
- rewrite cineModuleSystem to use the shared kernel while preserving base integration and module exposure helpers

## Testing
- npm run lint *(fails: pre-existing lint errors unrelated to the new kernel work)*

------
https://chatgpt.com/codex/tasks/task_e_68e2fde725a48320aca84daf804f10e0