### PR TITLE
Ensure manual auto gear presets replace temporary autosave entries

### DIFF
--- a/legacy/scripts/app-core-new-2.js
+++ b/legacy/scripts/app-core-new-2.js
@@ -2064,7 +2064,8 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
         }
         return;
       }
-      if (autoGearAutoPresetIdState) {
+      var previousAutoPresetId = autoGearAutoPresetIdState || '';
+      if (previousAutoPresetId) {
         setAutoGearAutoPresetId('', {
           persist: true,
           skipRender: true
@@ -2077,6 +2078,11 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
         autoGearPresets[existingIndex] = normalizedPreset;
       } else {
         autoGearPresets.push(normalizedPreset);
+      }
+      if (previousAutoPresetId && previousAutoPresetId !== normalizedPreset.id) {
+        autoGearPresets = autoGearPresets.filter(function (preset) {
+          return preset.id !== previousAutoPresetId;
+        });
       }
       autoGearPresets = sortAutoGearPresets(autoGearPresets.slice());
       persistAutoGearPresets(autoGearPresets);

--- a/src/scripts/app-core-new-2.js
+++ b/src/scripts/app-core-new-2.js
@@ -2458,14 +2458,18 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
         }
         return;
       }
-        if (autoGearAutoPresetIdState) {
-          setAutoGearAutoPresetId('', { persist: true, skipRender: true });
-        }
+      const previousAutoPresetId = autoGearAutoPresetIdState || '';
+      if (previousAutoPresetId) {
+        setAutoGearAutoPresetId('', { persist: true, skipRender: true });
+      }
       const existingIndex = autoGearPresets.findIndex(preset => preset.id === normalizedPreset.id);
       if (existingIndex >= 0) {
         autoGearPresets[existingIndex] = normalizedPreset;
       } else {
         autoGearPresets.push(normalizedPreset);
+      }
+      if (previousAutoPresetId && previousAutoPresetId !== normalizedPreset.id) {
+        autoGearPresets = autoGearPresets.filter(preset => preset.id !== previousAutoPresetId);
       }
       autoGearPresets = sortAutoGearPresets(autoGearPresets.slice());
       persistAutoGearPresets(autoGearPresets);


### PR DESCRIPTION
## Summary
- clear the stored auto-saved preset id before saving manual automatic gear presets
- remove any leftover temporary auto-saved preset entry once a named preset is stored
- keep the legacy runtime in sync with the new preset clean-up behaviour

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e2feade7288320b80254f3a23a769e