### PR TITLE
Optimize migration backup compression variants

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -261,7 +261,7 @@ Dieser kurze Ablauf sollte bei neuen Teammitgliedern, frisch eingerichteten Work
 - **Gespeicherte Projektsnapshots** – Projektliste speichert alle Saves und erzeugt alle zehn Minuten `auto-backup-…`.
 - **Vollbackups** – **Einstellungen → Backup & Wiederherstellung → Backup** erstellt `planner-backup.json` inkl. aller Projekte, Geräte, Regeln und UI-States; vor jeder Wiederherstellung wird ein Sicherheitsbackup angelegt.
 - **Backup-Verlauf** – Jede Vollsicherung schreibt einen Eintrag, der sich in **Einstellungen → Daten & Speicher** prüfen oder zusammen mit dem Archiv exportieren lässt. Zeitstempel und Dateinamen bleiben so auch offline nachvollziehbar.
-- **Verborgene Migrations-Backups** – Vor Überschreibungen wird der vorige JSON-Snapshot im geschützten `__legacyMigrationBackup` abgelegt und bei Fehlern automatisch wiederhergestellt.
+- **Verborgene Migrations-Backups** – Vor Überschreibungen wird der vorige JSON-Snapshot im geschützten `__legacyMigrationBackup` abgelegt und bei Fehlern automatisch wiederhergestellt. Die Komprimierung wählt jetzt automatisch die kleinste sichere Kodierung, damit Sicherungen weiterhin in das Browser-Kontingent passen.
 - **Automatische Regel-Snapshots** – Änderungen in **Automatische Gear-Regeln** erzeugen alle zehn Minuten Sicherheitskopien.
 - **Factory Reset** – löscht Daten erst nach automatischem Backup.
 - **Stündliche Erinnerungen** – Hintergrundroutine fordert stündlich zu Backups auf.

--- a/README.en.md
+++ b/README.en.md
@@ -585,7 +585,9 @@ Use Cine Power Planner end-to-end with the following routine:
   preferences, the app now preserves the previous JSON snapshot in a protected
   `__legacyMigrationBackup` slot. If a write ever fails or produces corrupt
   data, the recovery tools automatically fall back to that safety copy so no
-  user data disappears.
+  user data disappears. Compression now auto-selects the tightest safe encoding
+  so migration backups keep fitting within the browser quota even as datasets
+  grow.
 - **Automatic gear snapshots** – rule changes trigger timestamped safety copies
   every 10 minutes in **Settings → Automatic Gear Rules**, and you can restore or
   export them if a customization misfires.

--- a/README.es.md
+++ b/README.es.md
@@ -261,7 +261,7 @@ Repite esta rutina cuando se incorpore personal, se prepare una estación nueva 
 - **Instantáneas guardadas** – El selector conserva cada plan manual y crea `auto-backup-…` cada diez minutos mientras la app está abierta.
 - **Copias completas** – **Configuración → Copia de seguridad y restauración → Copia de seguridad** descarga `planner-backup.json` con proyectos, dispositivos, comentarios, reglas y estado de UI. Antes de restaurar se crea un respaldo de seguridad y se muestran avisos si el archivo proviene de otra versión.
 - **Libro de historial** – Cada copia completa añade una entrada que puedes auditar en **Configuración → Datos y almacenamiento** o exportar junto al archivo. Mantiene sellos horarios y nombres alineados con tu bitácora aunque trabajes sin conexión.
-- **Resguardos ocultos de migración** – Antes de sobrescribir planners, configuraciones o preferencias, la app guarda el JSON anterior en `__legacyMigrationBackup`. Si algo falla, la recuperación vuelve automáticamente a esa copia.
+- **Resguardos ocultos de migración** – Antes de sobrescribir planners, configuraciones o preferencias, la app guarda el JSON anterior en `__legacyMigrationBackup`. Si algo falla, la recuperación vuelve automáticamente a esa copia. La compresión ahora selecciona automáticamente la codificación segura más compacta para que las copias sigan dentro de la cuota del navegador.
 - **Historial automático de reglas** – Los cambios en **Reglas automáticas** generan copias con sello horario cada diez minutos.
 - **Restablecimiento de fábrica** – Borra datos sólo después de descargar un backup.
 - **Recordatorios por hora** – Una rutina en segundo plano sugiere realizar una copia adicional cada hora.

--- a/README.fr.md
+++ b/README.fr.md
@@ -263,7 +263,7 @@ Cette routine prouve que sauvegarde, partage, import, backup et restauration fon
 - **Instantanés enregistrés** – Le sélecteur conserve chaque sauvegarde manuelle et crée un `auto-backup-…` toutes les dix minutes.
 - **Backups complets** – **Paramètres → Backup & Restauration → Backup** télécharge `planner-backup.json` avec projets, équipements personnalisés, retours, favoris, règles automatiques et état UI. Les restaurations créent une copie de sécurité et avertissent si le fichier provient d’une autre version.
 - **Journal d’historique** – Chaque backup complet ajoute une entrée consultable via **Paramètres → Données & stockage** ou exportable avec l’archive. Horodatages et noms restent alignés avec votre documentation même hors ligne.
-- **Backups de migration cachés** – Avant d’écraser planners, configurations ou préférences, l’application enregistre le JSON précédent dans `__legacyMigrationBackup`. En cas d’échec, les outils de récupération reviennent automatiquement à cette copie.
+- **Backups de migration cachés** – Avant d’écraser planners, configurations ou préférences, l’application enregistre le JSON précédent dans `__legacyMigrationBackup`. En cas d’échec, les outils de récupération reviennent automatiquement à cette copie. La compression choisit désormais automatiquement l’encodage sûr le plus compact afin que les sauvegardes restent dans le quota du navigateur.
 - **Snapshots automatiques des règles** – Les modifications dans **Règles automatiques** génèrent des copies horodatées toutes les dix minutes.
 - **Réinitialisation usine** – Efface les données uniquement après téléchargement d’un backup.
 - **Rappels horaires** – Une tâche de fond invite à créer un backup toutes les heures pour disposer d’une capture récente.

--- a/README.it.md
+++ b/README.it.md
@@ -263,7 +263,7 @@ Ripeti questa routine quando arriva un nuovo membro, allestisci una postazione o
 - **Snapshot salvati** – Il selettore conserva ogni salvataggio manuale e crea `auto-backup-…` ogni dieci minuti mentre l’app è aperta.
 - **Backup completi** – **Impostazioni → Backup e ripristino → Backup** scarica `planner-backup.json` con progetti, dispositivi, feedback, preferiti, regole automatiche e stato UI. I ripristini creano un backup di sicurezza e avvisano se il file proviene da un’altra versione.
 - **Registro storico** – Ogni backup completo aggiunge una voce consultabile in **Impostazioni → Dati e archiviazione** o esportabile insieme al file. Mantiene timestamp e nomi allineati alla documentazione anche offline.
-- **Backup di migrazione nascosti** – Prima di sovrascrivere planner, setup o preferenze, l’app salva il precedente JSON in `__legacyMigrationBackup`. In caso di errore, gli strumenti di recupero tornano automaticamente a quella copia.
+- **Backup di migrazione nascosti** – Prima di sovrascrivere planner, setup o preferenze, l’app salva il precedente JSON in `__legacyMigrationBackup`. In caso di errore, gli strumenti di recupero tornano automaticamente a quella copia. La compressione ora seleziona automaticamente la codifica sicura più compatta così i backup restano entro la quota del browser.
 - **Snapshot automatici delle regole** – Le modifiche in **Regole automatiche** generano copie con timestamp ogni dieci minuti.
 - **Ripristino impostazioni di fabbrica** – Cancella i dati solo dopo aver scaricato un backup.
 - **Promemoria orari** – Una routine in background suggerisce un backup aggiuntivo ogni ora per avere sempre una copia recente.

--- a/README.md
+++ b/README.md
@@ -590,7 +590,9 @@ Use Cine Power Planner end-to-end with the following routine:
   preferences, the app now preserves the previous JSON snapshot in a protected
   `__legacyMigrationBackup` slot. If a write ever fails or produces corrupt
   data, the recovery tools automatically fall back to that safety copy so no
-  user data disappears.
+  user data disappears. Compression now auto-selects the tightest safe encoding
+  so migration backups keep fitting within the browser quota even as datasets
+  grow.
 - **Automatic gear snapshots** – rule changes trigger timestamped safety copies
   every 10 minutes in **Settings → Automatic Gear Rules**, and you can restore or
   export them if a customization misfires.


### PR DESCRIPTION
## Summary
- add LZ-String strategy selection so migration backups and compressed storage pick the most compact safe variant
- enhance decoding paths to respect stored variants, improve logging, and keep migration snapshot import resilient
- document the smarter compression behaviour across localized READMEs and extend unit coverage for the new selection logic

## Testing
- npm run test:jest -- --runTestsByPath tests/unit/migrationBackupCompression.test.js tests/unit/storage.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e3007d8690832080dcb92a5b27116c