### PR TITLE
Fix dialog toggle detection for help modal

### DIFF
--- a/legacy/scripts/app-core-new-1.js
+++ b/legacy/scripts/app-core-new-1.js
@@ -4902,9 +4902,15 @@ if (CORE_PART1_RUNTIME_SCOPE && CORE_PART1_RUNTIME_SCOPE.__cineCorePart1Initiali
   function isDialogOpen(dialog) {
     if (!dialog) return false;
     if (typeof dialog.open === 'boolean') {
-      return dialog.open;
+      if (dialog.open) {
+        return true;
+      }
+      if (typeof dialog.hasAttribute === 'function' && dialog.hasAttribute('open')) {
+        return true;
+      }
+      return false;
     }
-    return dialog.hasAttribute('open');
+    return typeof dialog.hasAttribute === 'function' && dialog.hasAttribute('open');
   }
   function memoizeNormalization(fn) {
     var cache = new Map();

--- a/src/scripts/app-core-new-1.js
+++ b/src/scripts/app-core-new-1.js
@@ -5596,9 +5596,15 @@ function closeDialog(dialog) {
 function isDialogOpen(dialog) {
   if (!dialog) return false;
   if (typeof dialog.open === 'boolean') {
-    return dialog.open;
+    if (dialog.open) {
+      return true;
+    }
+    if (typeof dialog.hasAttribute === 'function' && dialog.hasAttribute('open')) {
+      return true;
+    }
+    return false;
   }
-  return dialog.hasAttribute('open');
+  return typeof dialog.hasAttribute === 'function' && dialog.hasAttribute('open');
 }
 
 /**


### PR DESCRIPTION
## Summary
- ensure the dialog toggle helper treats the `open` attribute as a fallback when the `open` property remains false
- apply the same fix to the legacy runtime so both modern and legacy bundles keep parity

## Testing
- npm test -- --runTestsByPath tests/dom/globalFeatureSearch.test.js *(fails: existing lint errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68e305b3dcdc8320b9dd33c18a5ae95f