### PR TITLE
Fix auto gear module registration syntax for older browsers

### DIFF
--- a/legacy/scripts/modules/features/auto-gear-rules.js
+++ b/legacy/scripts/modules/features/auto-gear-rules.js
@@ -1370,7 +1370,7 @@ function resetAutoGearRulesToFactoryAdditions() {
       if (typeof console !== 'undefined' && typeof console.warn === 'function') {
         console.warn('Unable to register cineFeatureAutoGearRules module.', error);
       }
-    },
+    }
   );
 
   const globalExports = [

--- a/src/scripts/modules/features/auto-gear-rules.js
+++ b/src/scripts/modules/features/auto-gear-rules.js
@@ -1370,7 +1370,7 @@ function resetAutoGearRulesToFactoryAdditions() {
       if (typeof console !== 'undefined' && typeof console.warn === 'function') {
         console.warn('Unable to register cineFeatureAutoGearRules module.', error);
       }
-    },
+    }
   );
 
   const globalExports = [


### PR DESCRIPTION
## Summary
- remove the trailing comma from the auto gear module registration callback so the bundle parses on older browsers
- mirror the compatibility fix in the legacy bundle to keep both builds aligned

## Testing
- npm test -- --runTestsByPath tests/dummy.test.js *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e308aa585883208d62feddf0c31743