### PR TITLE
Fix service worker hard reload detection

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -113,12 +113,12 @@ function shouldBypassCache(request, requestUrl) {
   }
 
   const { cache } = request;
-  if (cache === 'reload' || cache === 'no-store') {
+  if (cache === 'reload' || cache === 'no-store' || cache === 'no-cache') {
     return true;
   }
 
   const cacheControl = request.headers && request.headers.get && request.headers.get('Cache-Control');
-  if (cacheControl && /no-cache|max-age=0/i.test(cacheControl)) {
+  if (cacheControl && /no-cache|no-store|max-age=0/i.test(cacheControl)) {
     return true;
   }
 


### PR DESCRIPTION
## Summary
- ensure service worker treats no-cache/no-store reload hints as cache bypass requests
- allow hard reloads to fetch fresh resources while still updating the offline cache

## Testing
- npm run lint *(fails: pre-existing lint errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68e308e7f11c83208753fac0ea356886