### PR TITLE
Prevent infinite reload loop when forcing legacy bundle

### DIFF
--- a/src/scripts/loader.js
+++ b/src/scripts/loader.js
@@ -443,6 +443,7 @@ CRITICAL_GLOBAL_DEFINITIONS.push({
   }
 
   var LEGACY_BUNDLE_STORAGE_KEY = 'cameraPowerPlanner_forceLegacyBundle';
+  var LEGACY_BUNDLE_RETRY_SESSION_KEY = 'cameraPowerPlanner_forceLegacyBundleRetry';
   var LEGACY_BUNDLE_MAX_AGE = 1000 * 60 * 60 * 24 * 7;
 
   function nowMilliseconds() {
@@ -454,6 +455,10 @@ CRITICAL_GLOBAL_DEFINITIONS.push({
 
   function getLegacyFlagStorages() {
     return collectStorages(['localStorage']);
+  }
+
+  function getLegacyRetryStorages() {
+    return collectStorages(['sessionStorage']);
   }
 
   function rememberLegacyBundlePreference() {
@@ -483,6 +488,33 @@ CRITICAL_GLOBAL_DEFINITIONS.push({
     return stored;
   }
 
+  function markLegacyBundleRetryAttempt() {
+    var storages = getLegacyRetryStorages();
+    if (!storages.length) {
+      return false;
+    }
+
+    var timestamp = nowMilliseconds();
+    var value = typeof timestamp === 'number' ? String(timestamp) : '1';
+    var marked = false;
+
+    for (var index = 0; index < storages.length; index += 1) {
+      var storage = storages[index];
+      if (!storage) {
+        continue;
+      }
+
+      try {
+        storage.setItem(LEGACY_BUNDLE_RETRY_SESSION_KEY, value);
+        marked = true;
+      } catch (setError) {
+        void setError;
+      }
+    }
+
+    return marked;
+  }
+
   function clearLegacyBundlePreference() {
     var storages = getLegacyFlagStorages();
     var cleared = false;
@@ -504,6 +536,31 @@ CRITICAL_GLOBAL_DEFINITIONS.push({
     }
 
     return cleared;
+  }
+
+  function hasLegacyBundleRetryAttempt() {
+    var storages = getLegacyRetryStorages();
+    if (!storages.length) {
+      return false;
+    }
+
+    for (var index = 0; index < storages.length; index += 1) {
+      var storage = storages[index];
+      if (!storage) {
+        continue;
+      }
+
+      try {
+        var rawValue = storage.getItem(LEGACY_BUNDLE_RETRY_SESSION_KEY);
+        if (typeof rawValue === 'string' && rawValue) {
+          return true;
+        }
+      } catch (readError) {
+        void readError;
+      }
+    }
+
+    return false;
   }
 
   function shouldForceLegacyBundle() {
@@ -556,8 +613,16 @@ CRITICAL_GLOBAL_DEFINITIONS.push({
     return forceLegacy;
   }
 
-  function triggerLegacyBundleReload() {
-    rememberLegacyBundlePreference();
+  function triggerLegacyBundleReload(options) {
+    var settings = options || {};
+
+    if (settings.rememberPreference !== false) {
+      rememberLegacyBundlePreference();
+    }
+
+    if (settings.markRetry === true) {
+      markLegacyBundleRetryAttempt();
+    }
 
     if (typeof window === 'undefined') {
       return false;
@@ -1147,11 +1212,16 @@ CRITICAL_GLOBAL_DEFINITIONS.push({
     if (shouldForceLegacyBundle()) {
       window.__CINE_POWER_LEGACY_BUNDLE__ = true;
 
+      if (hasLegacyBundleRetryAttempt()) {
+        loadScriptsSequentially(legacyScripts);
+        return;
+      }
+
       supportsModernFeatures(function (supportsModern) {
         if (supportsModern) {
           var cleared = clearLegacyBundlePreference();
           if (cleared) {
-            if (triggerLegacyBundleReload()) {
+            if (triggerLegacyBundleReload({ rememberPreference: false, markRetry: true })) {
               return;
             }
           }


### PR DESCRIPTION
## Summary
- track legacy bundle retry attempts in session storage to guard against repeated reloads
- allow triggerLegacyBundleReload to skip persisting the legacy preference when re-attempting the modern bundle
- stop retrying the modern bundle once a reload has already been attempted in the current session for both modern and legacy loaders

## Testing
- npm test *(fails: pre-existing lint errors in multiple files)*

------
https://chatgpt.com/codex/tasks/task_e_68e309d8eb2483209ae1de1804be0fca