### PR TITLE
Avoid freezing Ethereum providers in environment bridge

### DIFF
--- a/legacy/scripts/modules/environment-bridge.js
+++ b/legacy/scripts/modules/environment-bridge.js
@@ -62,6 +62,11 @@ function _typeof(o) { "@babel/helpers - typeof"; return _typeof = "function" == 
     if (!value || _typeof(value) !== 'object' && typeof value !== 'function') {
       return false;
     }
+
+    if (isEthereumProviderCandidate(value)) {
+      return true;
+    }
+
     try {
       if (typeof value.pipe === 'function' && typeof value.unpipe === 'function') {
         return true;
@@ -86,6 +91,52 @@ function _typeof(o) { "@babel/helpers - typeof"; return _typeof = "function" == 
     }
     return false;
   }
+
+  function isEthereumProviderCandidate(value) {
+    if (!value || _typeof(value) !== 'object' && typeof value !== 'function') {
+      return false;
+    }
+
+    if (PRIMARY_SCOPE && _typeof(PRIMARY_SCOPE) === 'object') {
+      try {
+        if (value === PRIMARY_SCOPE.ethereum) {
+          return true;
+        }
+      } catch (error) {
+        void error;
+        return true;
+      }
+    }
+
+    try {
+      if (value.isMetaMask === true) {
+        return true;
+      }
+    } catch (inspectionError) {
+      if (inspectionError && typeof inspectionError.message === 'string' && /metamask/i.test(inspectionError.message)) {
+        return true;
+      }
+    }
+
+    try {
+      if (typeof value.request === 'function' && typeof value.on === 'function') {
+        if (typeof value.removeListener === 'function' || typeof value.removeEventListener === 'function') {
+          return true;
+        }
+
+        var ctorName = value.constructor && value.constructor.name;
+        if (ctorName && /Ethereum|MetaMask|Provider/i.test(ctorName)) {
+          return true;
+        }
+      }
+    } catch (accessError) {
+      void accessError;
+      return true;
+    }
+
+    return false;
+  }
+
   function fallbackFreezeDeep(value, seen) {
     var localSeen = seen;
     if (!localSeen) {
@@ -109,6 +160,11 @@ function _typeof(o) { "@babel/helpers - typeof"; return _typeof = "function" == 
     if (shouldBypassDeepFreeze(value)) {
       return value;
     }
+
+    if (isEthereumProviderCandidate(value)) {
+      return value;
+    }
+
     if (typeof localSeen.has === 'function' && localSeen.has(value)) {
       return value;
     }

--- a/src/scripts/modules/environment-bridge.js
+++ b/src/scripts/modules/environment-bridge.js
@@ -73,6 +73,10 @@
       return false;
     }
 
+    if (isEthereumProviderCandidate(value)) {
+      return true;
+    }
+
     try {
       if (typeof value.pipe === 'function' && typeof value.unpipe === 'function') {
         return true;
@@ -102,6 +106,51 @@
     return false;
   }
 
+  function isEthereumProviderCandidate(value) {
+    if (!value || (typeof value !== 'object' && typeof value !== 'function')) {
+      return false;
+    }
+
+    if (PRIMARY_SCOPE && typeof PRIMARY_SCOPE === 'object') {
+      try {
+        if (value === PRIMARY_SCOPE.ethereum) {
+          return true;
+        }
+      } catch (error) {
+        void error;
+        return true;
+      }
+    }
+
+    try {
+      if (value.isMetaMask === true) {
+        return true;
+      }
+    } catch (inspectionError) {
+      if (inspectionError && typeof inspectionError.message === 'string' && /metamask/i.test(inspectionError.message)) {
+        return true;
+      }
+    }
+
+    try {
+      if (typeof value.request === 'function' && typeof value.on === 'function') {
+        if (typeof value.removeListener === 'function' || typeof value.removeEventListener === 'function') {
+          return true;
+        }
+
+        var ctorName = value.constructor && value.constructor.name;
+        if (ctorName && /Ethereum|MetaMask|Provider/i.test(ctorName)) {
+          return true;
+        }
+      }
+    } catch (accessError) {
+      void accessError;
+      return true;
+    }
+
+    return false;
+  }
+
   function fallbackFreezeDeep(value, seen) {
     var localSeen = seen;
     if (!localSeen) {
@@ -125,6 +174,10 @@
     }
 
     if (shouldBypassDeepFreeze(value)) {
+      return value;
+    }
+
+    if (isEthereumProviderCandidate(value)) {
       return value;
     }
 

--- a/tests/unit/environmentBridge.test.js
+++ b/tests/unit/environmentBridge.test.js
@@ -1,0 +1,39 @@
+const path = require('path');
+
+describe('environment-bridge', () => {
+  afterEach(() => {
+    delete global.cineEnvironmentBridge;
+    delete require.cache[path.resolve(__dirname, '../../src/scripts/modules/environment-bridge.js')];
+  });
+
+  test('freezeDeep bypasses ethereum provider candidates', () => {
+    const bridge = require('../../src/scripts/modules/environment-bridge.js');
+    const provider = {
+      isMetaMask: true,
+      request: jest.fn(),
+      on: jest.fn(),
+      removeListener: jest.fn(),
+      _metamask: {
+        isUnlocked: jest.fn(),
+      },
+    };
+
+    const previousEthereum = global.ethereum;
+    global.ethereum = provider;
+
+    try {
+      const container = { provider };
+      const frozen = bridge.freezeDeep(container);
+
+      expect(frozen).toBe(container);
+      expect(Object.isFrozen(container)).toBe(true);
+      expect(Object.isFrozen(provider)).toBe(false);
+    } finally {
+      if (typeof previousEthereum === 'undefined') {
+        delete global.ethereum;
+      } else {
+        global.ethereum = previousEthereum;
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- skip deep-freeze processing for MetaMask-style Ethereum providers to prevent console warnings
- mirror the provider guard in legacy bundles and cover the behavior with a new unit test

## Testing
- npm run test:unit

------
https://chatgpt.com/codex/tasks/task_e_68e309f177848320a08c34ef8b266b16