### PR TITLE
Add fallback dialog for auto gear preset naming

### DIFF
--- a/docs/auto-gear-rule-options.md
+++ b/docs/auto-gear-rule-options.md
@@ -33,6 +33,14 @@ planner predictable, offline-ready and data-safe.
 * When exporting or backing up, store these rules using the existing automatic gear backup and
   preset infrastructure so user data remains safe and offline-capable.
 
+## Preset naming reliability
+
+* Browsers that disable native `prompt()` dialogs (for example installed PWAs running without a
+  URL bar) now trigger an inline naming modal within the Automatic gear preset panel. A quick timing
+  check detects blocked prompts or thrown errors so the inline fallback opens automatically instead
+  of treating the save as cancelled. The dialog keeps the experience accessible offline and
+  guarantees presets can still be saved without losing user data.【F:src/scripts/app-core-new-2.js†L2497-L2524】【F:src/styles/style.css†L2583-L2624】
+
 ## Draft impact preview cues
 
 * The draft impact preview surfaces stacked changes whenever multiple rules touch the same gear

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -2575,6 +2575,7 @@ body.high-contrast .settings-tab[aria-selected="true"] {
 }
 
 .auto-gear-preset-panel {
+  position: relative;
   margin-top: 16px;
   margin-bottom: 16px;
   padding: 16px;
@@ -2618,6 +2619,48 @@ body.high-contrast .settings-tab[aria-selected="true"] {
   flex-wrap: wrap;
   align-items: center;
   gap: 12px;
+}
+
+.auto-gear-preset-name-dialog {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 16px;
+  background: color-mix(in srgb, var(--surface-color) 55%, transparent);
+  z-index: 5;
+}
+
+.auto-gear-preset-name-dialog[hidden] {
+  display: none;
+}
+
+.auto-gear-preset-name-card {
+  width: min(100%, 360px);
+  padding: 16px;
+  border: 1px solid var(--panel-border);
+  border-radius: var(--border-radius);
+  background: var(--panel-bg);
+  box-shadow: var(--panel-shadow);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.auto-gear-preset-name-label {
+  font-weight: var(--font-weight-semibold);
+}
+
+.auto-gear-preset-name-input {
+  width: 100%;
+}
+
+.auto-gear-preset-name-error {
+  margin: 0;
+  min-height: 1.25rem;
+  color: var(--danger-color, #b00020);
+  font-size: calc(var(--font-size-relative-base) * var(--font-scale-xs));
 }
 
 .auto-gear-preset-row label {


### PR DESCRIPTION
## Summary
- add an inline fallback dialog so auto gear presets can be named when native prompts are unavailable
- style the preset panel to host the dialog overlay and align the new form controls
- update the auto gear documentation with details about the new preset naming safeguard

## Testing
- npm run lint *(fails: existing globals such as `formatNumberForComparison` are undefined in lint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68e30338696c832094de8b30dfaedc69