### PR TITLE
Prevent MetaMask web3 getter warnings

### DIFF
--- a/src/scripts/modules/environment-bridge.js
+++ b/src/scripts/modules/environment-bridge.js
@@ -199,6 +199,12 @@
 
     for (var index = 0; index < keys.length; index += 1) {
       var key = keys[index];
+
+      if (key === 'web3' && value === PRIMARY_SCOPE) {
+        // Accessing the deprecated MetaMask web3 shim logs noisy warnings. Skip it entirely
+        // to avoid touching the getter while still freezing the remaining globals.
+        continue;
+      }
       var descriptor;
       try {
         descriptor = Object.getOwnPropertyDescriptor(value, key);

--- a/src/scripts/modules/runtime.js
+++ b/src/scripts/modules/runtime.js
@@ -773,6 +773,11 @@
     const keys = Object.getOwnPropertyNames(value);
     for (let index = 0; index < keys.length; index += 1) {
       const key = keys[index];
+      if (key === 'web3' && value === GLOBAL_SCOPE) {
+        // Touching the deprecated MetaMask web3 shim triggers warning logs; skip it while
+        // preserving the freeze behavior for the remaining global properties.
+        continue;
+      }
       const descriptor = Object.getOwnPropertyDescriptor(value, key);
       if (!descriptor || ('get' in descriptor) || ('set' in descriptor)) {
         continue;


### PR DESCRIPTION
## Summary
- skip the deprecated MetaMask web3 shim when deeply freezing the global scope in the environment bridge
- mirror the same safeguard in the runtime fallback freezer to avoid triggering noisy console warnings

## Testing
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68e35a43893083208a410f98f00cd1e0