### PR TITLE
Handle missing document body when positioning pink mode animations

### DIFF
--- a/legacy/scripts/app-core-new-1.js
+++ b/legacy/scripts/app-core-new-1.js
@@ -9452,7 +9452,37 @@ if (CORE_PART1_RUNTIME_SCOPE && CORE_PART1_RUNTIME_SCOPE.__cineCorePart1Initiali
     }
     return layer;
   }
-  function computePinkModeAnimationAvoidRegions(layer) {
+function resolvePinkModeHostExtent(host, hostRect, fallbackHeight) {
+  if (host && _typeof(host) === 'object') {
+    try {
+      var scrollHeight = host.scrollHeight;
+      if (typeof scrollHeight === 'number' && scrollHeight > 0) {
+        return scrollHeight;
+      }
+    } catch (error) {
+      void error;
+    }
+  }
+
+  if (hostRect && typeof hostRect.height === 'number' && hostRect.height > 0) {
+    return hostRect.height;
+  }
+
+  if (
+    hostRect &&
+    typeof hostRect.top === 'number' &&
+    typeof hostRect.bottom === 'number'
+  ) {
+    var derivedHeight = hostRect.bottom - hostRect.top;
+    if (Number.isFinite(derivedHeight) && derivedHeight > 0) {
+      return derivedHeight;
+    }
+  }
+
+  return fallbackHeight;
+}
+
+function computePinkModeAnimationAvoidRegions(layer) {
     if (typeof document === 'undefined' || typeof document.querySelectorAll !== 'function') {
       return Object.freeze([]);
     }
@@ -10140,7 +10170,7 @@ if (CORE_PART1_RUNTIME_SCOPE && CORE_PART1_RUNTIME_SCOPE.__cineCorePart1Initiali
     var viewportBottom = viewportTop + viewportHeight;
     var hostRect = host ? host.getBoundingClientRect() : null;
     var hostTop = hostRect ? hostRect.top + viewportTop : 0;
-    var hostHeight = host && typeof host.scrollHeight === 'number' && host.scrollHeight > 0 ? host.scrollHeight : hostRect && hostRect.height ? hostRect.height : viewportHeight;
+    var hostHeight = resolvePinkModeHostExtent(host, hostRect, viewportHeight);
     var hostBottom = hostTop + hostHeight;
     var visibleTop = Math.max(hostTop, viewportTop);
     var visibleBottom = Math.min(hostBottom, viewportBottom);

--- a/src/scripts/app-core-new-1.js
+++ b/src/scripts/app-core-new-1.js
@@ -10794,6 +10794,36 @@ function ensurePinkModeAnimationLayer(options) {
   return layer;
 }
 
+function resolvePinkModeHostExtent(host, hostRect, fallbackHeight) {
+  if (host && typeof host === 'object') {
+    try {
+      const scrollHeight = host.scrollHeight;
+      if (typeof scrollHeight === 'number' && scrollHeight > 0) {
+        return scrollHeight;
+      }
+    } catch (error) {
+      void error;
+    }
+  }
+
+  if (hostRect && typeof hostRect.height === 'number' && hostRect.height > 0) {
+    return hostRect.height;
+  }
+
+  if (
+    hostRect &&
+    typeof hostRect.top === 'number' &&
+    typeof hostRect.bottom === 'number'
+  ) {
+    const derivedHeight = hostRect.bottom - hostRect.top;
+    if (Number.isFinite(derivedHeight) && derivedHeight > 0) {
+      return derivedHeight;
+    }
+  }
+
+  return fallbackHeight;
+}
+
 function computePinkModeAnimationAvoidRegions(layer) {
   if (
     typeof document === 'undefined' ||
@@ -11599,12 +11629,7 @@ function spawnPinkModeAnimatedIconInstance(templates) {
   const viewportBottom = viewportTop + viewportHeight;
   const hostRect = host ? host.getBoundingClientRect() : null;
   const hostTop = hostRect ? hostRect.top + viewportTop : 0;
-  const hostHeight =
-    host && typeof host.scrollHeight === 'number' && host.scrollHeight > 0
-      ? host.scrollHeight
-      : hostRect && hostRect.height
-        ? hostRect.height
-        : viewportHeight;
+  const hostHeight = resolvePinkModeHostExtent(host, hostRect, viewportHeight);
   const hostBottom = hostTop + hostHeight;
   let visibleTop = Math.max(hostTop, viewportTop);
   let visibleBottom = Math.min(hostBottom, viewportBottom);


### PR DESCRIPTION
## Summary
- add a guard that resolves the pink mode animation host height without touching `document.body` when it is unavailable
- mirror the guard in the legacy runtime to prevent the same pre-body access crash during script bootstrap

## Testing
- npm test -- --runTestsByPath tests/dom/fullUserJourney.test.js *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e35e2b071083208d6dbb25fb780ddd