### PR TITLE
Integrate battery comparison localization into results module

### DIFF
--- a/legacy/scripts/app-core-new-1.js
+++ b/legacy/scripts/app-core-new-1.js
@@ -6686,25 +6686,8 @@ if (CORE_PART1_RUNTIME_SCOPE && CORE_PART1_RUNTIME_SCOPE.__cineCorePart1Initiali
     deviceManagerHeadingElem.textContent = texts[lang].deviceManagerHeading;
     deviceManagerHeadingElem.setAttribute("data-help", texts[lang].deviceManagerHeadingHelp);
     var batteryComparisonHeadingElem = document.getElementById("batteryComparisonHeading");
-    batteryComparisonHeadingElem.textContent = texts[lang].batteryComparisonHeading;
-    batteryComparisonHeadingElem.setAttribute("data-help", texts[lang].batteryComparisonHeadingHelp);
     var batteryComparisonDescriptionElem = document.getElementById("batteryComparisonDescription");
-    if (batteryComparisonDescriptionElem) {
-      batteryComparisonDescriptionElem.textContent = texts[lang].batteryComparisonDescription;
-      if (texts[lang].batteryComparisonDescriptionHelp) {
-        batteryComparisonDescriptionElem.setAttribute("data-help", texts[lang].batteryComparisonDescriptionHelp);
-      } else {
-        batteryComparisonDescriptionElem.removeAttribute("data-help");
-      }
-    }
     var batteryTableElem = document.getElementById("batteryTable");
-    if (batteryTableElem) {
-      if (texts[lang].batteryComparisonTableHelp) {
-        batteryTableElem.setAttribute("data-help", texts[lang].batteryComparisonTableHelp);
-      } else {
-        batteryTableElem.removeAttribute("data-help");
-      }
-    }
     var setupDiagramHeadingElem = document.getElementById("setupDiagramHeading");
     setupDiagramHeadingElem.textContent = texts[lang].setupDiagramHeading;
     setupDiagramHeadingElem.setAttribute("data-help", texts[lang].setupDiagramHeadingHelp);
@@ -6961,6 +6944,44 @@ if (CORE_PART1_RUNTIME_SCOPE && CORE_PART1_RUNTIME_SCOPE.__cineCorePart1Initiali
       } catch (cineResultsError) {
         console.warn('cineResults.localizeResultsSection failed', cineResultsError);
         resultsLocalizationApplied = false;
+      }
+    }
+    var batteryComparisonLocalized = false;
+    if (cineResultsModule && typeof cineResultsModule.localizeBatteryComparisonSection === 'function') {
+      try {
+        batteryComparisonLocalized = cineResultsModule.localizeBatteryComparisonSection({
+          lang: lang,
+          langTexts: texts[lang] || {},
+          fallbackTexts: texts.en || {},
+          document: document,
+          batteryComparisonHeading: batteryComparisonHeadingElem,
+          batteryComparisonDescription: batteryComparisonDescriptionElem,
+          batteryComparisonTable: batteryTableElem
+        });
+      } catch (cineResultsError) {
+        console.warn('cineResults.localizeBatteryComparisonSection failed', cineResultsError);
+        batteryComparisonLocalized = false;
+      }
+    }
+    if (!batteryComparisonLocalized) {
+      if (batteryComparisonHeadingElem) {
+        batteryComparisonHeadingElem.textContent = texts[lang].batteryComparisonHeading;
+        batteryComparisonHeadingElem.setAttribute("data-help", texts[lang].batteryComparisonHeadingHelp);
+      }
+      if (batteryComparisonDescriptionElem) {
+        batteryComparisonDescriptionElem.textContent = texts[lang].batteryComparisonDescription;
+        if (texts[lang].batteryComparisonDescriptionHelp) {
+          batteryComparisonDescriptionElem.setAttribute("data-help", texts[lang].batteryComparisonDescriptionHelp);
+        } else {
+          batteryComparisonDescriptionElem.removeAttribute("data-help");
+        }
+      }
+      if (batteryTableElem) {
+        if (texts[lang].batteryComparisonTableHelp) {
+          batteryTableElem.setAttribute("data-help", texts[lang].batteryComparisonTableHelp);
+        } else {
+          batteryTableElem.removeAttribute("data-help");
+        }
       }
     }
     if (!resultsLocalizationApplied) {

--- a/legacy/scripts/modules/results.js
+++ b/legacy/scripts/modules/results.js
@@ -376,6 +376,30 @@ function _typeof(o) { "@babel/helpers - typeof"; return _typeof = "function" == 
       }
     }
   }
+  function createTextResolver(langTexts, fallbackTexts) {
+    var primary = langTexts && _typeof(langTexts) === 'object' ? langTexts : {};
+    var secondary = fallbackTexts && _typeof(fallbackTexts) === 'object' ? fallbackTexts : {};
+    return function resolveText(key) {
+      if (!key) {
+        return '';
+      }
+      var value = primary[key];
+      if (typeof value === 'string') {
+        var trimmed = value.trim();
+        if (trimmed) {
+          return trimmed;
+        }
+      }
+      value = secondary[key];
+      if (typeof value === 'string') {
+        var fallbackTrimmed = value.trim();
+        if (fallbackTrimmed) {
+          return fallbackTrimmed;
+        }
+      }
+      return '';
+    };
+  }
   function localizeResultsSection(options) {
     var opts = options || {};
     var deps = updateRuntimeDependencies(opts);
@@ -386,26 +410,7 @@ function _typeof(o) { "@babel/helpers - typeof"; return _typeof = "function" == 
     var lang = typeof opts.lang === 'string' ? opts.lang : '';
     var langTexts = opts.langTexts && _typeof(opts.langTexts) === 'object' ? opts.langTexts : {};
     var fallbackTexts = opts.fallbackTexts && _typeof(opts.fallbackTexts) === 'object' ? opts.fallbackTexts : {};
-    function resolveText(key) {
-      if (!key) {
-        return '';
-      }
-      var value = langTexts[key];
-      if (typeof value === 'string') {
-        var trimmed = value.trim();
-        if (trimmed) {
-          return trimmed;
-        }
-      }
-      value = fallbackTexts[key];
-      if (typeof value === 'string') {
-        var fallbackTrimmed = value.trim();
-        if (fallbackTrimmed) {
-          return fallbackTrimmed;
-        }
-      }
-      return '';
-    }
+    var resolveText = createTextResolver(langTexts, fallbackTexts);
     var breakdownList = resolveElementFromOptions(opts, 'breakdownListElem', 'breakdownList', 'breakdownListElem');
     if (breakdownList) {
       var breakdownHelp = resolveText('breakdownListHelp');
@@ -579,6 +584,58 @@ function _typeof(o) { "@babel/helpers - typeof"; return _typeof = "function" == 
     runtimeFeedbackState.elements.runtimeAverageNote = runtimeAverageNote;
     runtimeFeedbackState.elements.tempNote = tempNote;
     return true;
+  }
+  function localizeBatteryComparisonSection(options) {
+    var opts = options || {};
+    var doc = resolveDocument(opts);
+    if (!doc) {
+      return false;
+    }
+    var langTexts = opts.langTexts && _typeof(opts.langTexts) === 'object' ? opts.langTexts : {};
+    var fallbackTexts = opts.fallbackTexts && _typeof(opts.fallbackTexts) === 'object' ? opts.fallbackTexts : {};
+    var resolveText = createTextResolver(langTexts, fallbackTexts);
+    var heading = resolveElementFromOptions(opts, 'batteryComparisonHeading', 'batteryComparisonHeading', 'batteryComparisonHeading');
+    var description = resolveElementFromOptions(opts, 'batteryComparisonDescription', 'batteryComparisonDescription');
+    var table = resolveElementFromOptions(opts, 'batteryComparisonTable', 'batteryTable', 'batteryTable');
+    var localized = false;
+    if (heading) {
+      var headingText = resolveText('batteryComparisonHeading');
+      if (!headingText && typeof heading.textContent === 'string') {
+        headingText = heading.textContent;
+      }
+      try {
+        if (typeof heading.textContent === 'string') {
+          heading.textContent = headingText;
+        }
+      } catch (error) {
+        void error;
+      }
+      setHelpAttribute(heading, resolveText('batteryComparisonHeadingHelp'));
+      localized = true;
+    }
+    if (description) {
+      var descriptionText = resolveText('batteryComparisonDescription');
+      if (!descriptionText && typeof description.textContent === 'string') {
+        descriptionText = description.textContent;
+      }
+      try {
+        if (typeof description.textContent === 'string') {
+          description.textContent = descriptionText;
+        }
+      } catch (error) {
+        void error;
+      }
+      setHelpAttribute(description, resolveText('batteryComparisonDescriptionHelp'));
+      localized = true;
+    }
+    if (table) {
+      setHelpAttribute(table, resolveText('batteryComparisonTableHelp'));
+      localized = true;
+    }
+    runtimeFeedbackState.elements.batteryComparisonHeading = heading;
+    runtimeFeedbackState.elements.batteryComparisonDescription = description;
+    runtimeFeedbackState.elements.batteryComparisonTable = table;
+    return localized;
   }
   function attachHandlerOnce(target, eventName, handlerKey, factory) {
     if (!target || !eventName || !handlerKey || typeof factory !== 'function') {
@@ -811,6 +868,7 @@ function _typeof(o) { "@babel/helpers - typeof"; return _typeof = "function" == 
   }
   var resultsAPI = {
     localizeResultsSection: localizeResultsSection,
+    localizeBatteryComparisonSection: localizeBatteryComparisonSection,
     setupRuntimeFeedback: setupRuntimeFeedback
   };
   freezeDeep(resultsAPI);

--- a/src/scripts/app-core-new-1.js
+++ b/src/scripts/app-core-new-1.js
@@ -7450,39 +7450,10 @@ function setLanguage(lang) {
   );
 
   const batteryComparisonHeadingElem = document.getElementById("batteryComparisonHeading");
-  batteryComparisonHeadingElem.textContent = texts[lang].batteryComparisonHeading;
-  batteryComparisonHeadingElem.setAttribute(
-    "data-help",
-    texts[lang].batteryComparisonHeadingHelp
-  );
-
   const batteryComparisonDescriptionElem = document.getElementById(
     "batteryComparisonDescription"
   );
-  if (batteryComparisonDescriptionElem) {
-    batteryComparisonDescriptionElem.textContent =
-      texts[lang].batteryComparisonDescription;
-    if (texts[lang].batteryComparisonDescriptionHelp) {
-      batteryComparisonDescriptionElem.setAttribute(
-        "data-help",
-        texts[lang].batteryComparisonDescriptionHelp
-      );
-    } else {
-      batteryComparisonDescriptionElem.removeAttribute("data-help");
-    }
-  }
-
   const batteryTableElem = document.getElementById("batteryTable");
-  if (batteryTableElem) {
-    if (texts[lang].batteryComparisonTableHelp) {
-      batteryTableElem.setAttribute(
-        "data-help",
-        texts[lang].batteryComparisonTableHelp
-      );
-    } else {
-      batteryTableElem.removeAttribute("data-help");
-    }
-  }
 
   const setupDiagramHeadingElem = document.getElementById("setupDiagramHeading");
   setupDiagramHeadingElem.textContent = texts[lang].setupDiagramHeading;
@@ -7843,6 +7814,59 @@ function setLanguage(lang) {
     } catch (cineResultsError) {
       console.warn('cineResults.localizeResultsSection failed', cineResultsError);
       resultsLocalizationApplied = false;
+    }
+  }
+
+  var batteryComparisonLocalized = false;
+  if (
+    cineResultsModule &&
+    typeof cineResultsModule.localizeBatteryComparisonSection === "function"
+  ) {
+    try {
+      batteryComparisonLocalized = cineResultsModule.localizeBatteryComparisonSection({
+        lang: lang,
+        langTexts: texts[lang] || {},
+        fallbackTexts: texts.en || {},
+        document: document,
+        batteryComparisonHeading: batteryComparisonHeadingElem,
+        batteryComparisonDescription: batteryComparisonDescriptionElem,
+        batteryComparisonTable: batteryTableElem,
+      });
+    } catch (cineResultsError) {
+      console.warn("cineResults.localizeBatteryComparisonSection failed", cineResultsError);
+      batteryComparisonLocalized = false;
+    }
+  }
+
+  if (!batteryComparisonLocalized) {
+    if (batteryComparisonHeadingElem) {
+      batteryComparisonHeadingElem.textContent = texts[lang].batteryComparisonHeading;
+      batteryComparisonHeadingElem.setAttribute(
+        "data-help",
+        texts[lang].batteryComparisonHeadingHelp
+      );
+    }
+    if (batteryComparisonDescriptionElem) {
+      batteryComparisonDescriptionElem.textContent =
+        texts[lang].batteryComparisonDescription;
+      if (texts[lang].batteryComparisonDescriptionHelp) {
+        batteryComparisonDescriptionElem.setAttribute(
+          "data-help",
+          texts[lang].batteryComparisonDescriptionHelp
+        );
+      } else {
+        batteryComparisonDescriptionElem.removeAttribute("data-help");
+      }
+    }
+    if (batteryTableElem) {
+      if (texts[lang].batteryComparisonTableHelp) {
+        batteryTableElem.setAttribute(
+          "data-help",
+          texts[lang].batteryComparisonTableHelp
+        );
+      } else {
+        batteryTableElem.removeAttribute("data-help");
+      }
     }
   }
 

--- a/src/scripts/modules/results.js
+++ b/src/scripts/modules/results.js
@@ -362,6 +362,31 @@
     }
   }
 
+  function createTextResolver(langTexts, fallbackTexts) {
+    var primary = langTexts && typeof langTexts === 'object' ? langTexts : {};
+    var secondary = fallbackTexts && typeof fallbackTexts === 'object' ? fallbackTexts : {};
+    return function resolveText(key) {
+      if (!key) {
+        return '';
+      }
+      var value = primary[key];
+      if (typeof value === 'string') {
+        var trimmed = value.trim();
+        if (trimmed) {
+          return trimmed;
+        }
+      }
+      value = secondary[key];
+      if (typeof value === 'string') {
+        var fallbackTrimmed = value.trim();
+        if (fallbackTrimmed) {
+          return fallbackTrimmed;
+        }
+      }
+      return '';
+    };
+  }
+
   function localizeResultsSection(options) {
     var opts = options || {};
     var deps = updateRuntimeDependencies(opts);
@@ -374,26 +399,7 @@
     var langTexts = opts.langTexts && typeof opts.langTexts === 'object' ? opts.langTexts : {};
     var fallbackTexts = opts.fallbackTexts && typeof opts.fallbackTexts === 'object' ? opts.fallbackTexts : {};
 
-    function resolveText(key) {
-      if (!key) {
-        return '';
-      }
-      var value = langTexts[key];
-      if (typeof value === 'string') {
-        var trimmed = value.trim();
-        if (trimmed) {
-          return trimmed;
-        }
-      }
-      value = fallbackTexts[key];
-      if (typeof value === 'string') {
-        var fallbackTrimmed = value.trim();
-        if (fallbackTrimmed) {
-          return fallbackTrimmed;
-        }
-      }
-      return '';
-    }
+    var resolveText = createTextResolver(langTexts, fallbackTexts);
 
     var breakdownList = resolveElementFromOptions(opts, 'breakdownListElem', 'breakdownList', 'breakdownListElem');
     if (breakdownList) {
@@ -591,6 +597,81 @@
     runtimeFeedbackState.elements.tempNote = tempNote;
 
     return true;
+  }
+
+  function localizeBatteryComparisonSection(options) {
+    var opts = options || {};
+    var doc = resolveDocument(opts);
+    if (!doc) {
+      return false;
+    }
+
+    var langTexts = opts.langTexts && typeof opts.langTexts === 'object' ? opts.langTexts : {};
+    var fallbackTexts = opts.fallbackTexts && typeof opts.fallbackTexts === 'object' ? opts.fallbackTexts : {};
+    var resolveText = createTextResolver(langTexts, fallbackTexts);
+
+    var heading = resolveElementFromOptions(
+      opts,
+      'batteryComparisonHeading',
+      'batteryComparisonHeading',
+      'batteryComparisonHeading'
+    );
+    var description = resolveElementFromOptions(
+      opts,
+      'batteryComparisonDescription',
+      'batteryComparisonDescription'
+    );
+    var table = resolveElementFromOptions(
+      opts,
+      'batteryComparisonTable',
+      'batteryTable',
+      'batteryTable'
+    );
+
+    var localized = false;
+
+    if (heading) {
+      var headingText = resolveText('batteryComparisonHeading');
+      if (!headingText && typeof heading.textContent === 'string') {
+        headingText = heading.textContent;
+      }
+      try {
+        if (typeof heading.textContent === 'string') {
+          heading.textContent = headingText;
+        }
+      } catch (error) {
+        void error;
+      }
+      setHelpAttribute(heading, resolveText('batteryComparisonHeadingHelp'));
+      localized = true;
+    }
+
+    if (description) {
+      var descriptionText = resolveText('batteryComparisonDescription');
+      if (!descriptionText && typeof description.textContent === 'string') {
+        descriptionText = description.textContent;
+      }
+      try {
+        if (typeof description.textContent === 'string') {
+          description.textContent = descriptionText;
+        }
+      } catch (error) {
+        void error;
+      }
+      setHelpAttribute(description, resolveText('batteryComparisonDescriptionHelp'));
+      localized = true;
+    }
+
+    if (table) {
+      setHelpAttribute(table, resolveText('batteryComparisonTableHelp'));
+      localized = true;
+    }
+
+    runtimeFeedbackState.elements.batteryComparisonHeading = heading;
+    runtimeFeedbackState.elements.batteryComparisonDescription = description;
+    runtimeFeedbackState.elements.batteryComparisonTable = table;
+
+    return localized;
   }
 
   function attachHandlerOnce(target, eventName, handlerKey, factory) {
@@ -846,6 +927,7 @@
 
   var resultsAPI = {
     localizeResultsSection: localizeResultsSection,
+    localizeBatteryComparisonSection: localizeBatteryComparisonSection,
     setupRuntimeFeedback: setupRuntimeFeedback
   };
 


### PR DESCRIPTION
## Summary
- add a shared text resolver and new battery comparison localization routine to the cineResults module
- expose the new API from both modern and legacy builds so app-core can delegate heading, description, and table help updates
- keep a manual fallback in app-core when the module is unavailable to preserve existing behaviour

## Testing
- npm run lint *(fails: existing repository lint errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68e35eb0a4848320bfc7a7f43298bfd7