### PR TITLE
Refactor appearance settings into dedicated module

### DIFF
--- a/src/scripts/app-session.js
+++ b/src/scripts/app-session.js
@@ -3500,87 +3500,182 @@ if (setupNameInput && saveSetupBtn) {
   });
 }
 
-// Dark mode handling
-function updateThemeColor(isDark) {
-  const meta = document.querySelector('meta[name="theme-color"]');
-  if (meta) {
-    meta.setAttribute('content', isDark ? '#1c1c1e' : '#ffffff');
-  }
-}
+const warnMountVoltageHelper = typeof warnMissingMountVoltageHelper === 'function'
+  ? warnMissingMountVoltageHelper
+  : () => {};
 
-function setToggleIcon(button, glyph) {
-  if (!button) return;
-  let iconSpan = button.querySelector('.icon-glyph');
-  if (!iconSpan) {
-    iconSpan = document.createElement('span');
-    iconSpan.className = 'icon-glyph';
-    iconSpan.setAttribute('aria-hidden', 'true');
-    button.textContent = '';
-    button.appendChild(iconSpan);
-  }
+let updateThemeColor = () => {};
+let setToggleIcon = () => {};
+let applyDarkMode = () => {};
+let applyHighContrast = () => {};
+let applyReduceMotion = () => {};
+let applyRelaxedSpacing = () => {};
+let applyPinkMode = () => {};
+let persistPinkModePreference = () => {};
+let rememberSettingsPinkModeBaseline = () => {};
+let revertSettingsPinkModeIfNeeded = () => {};
+let rememberSettingsTemperatureUnitBaseline = () => {};
+let revertSettingsTemperatureUnitIfNeeded = () => {};
+let applyShowAutoBackupsPreference = () => {};
+let rememberSettingsShowAutoBackupsBaseline = () => {};
+let revertSettingsShowAutoBackupsIfNeeded = () => {};
+let rememberSettingsMountVoltagesBaseline = () => {};
+let revertSettingsMountVoltagesIfNeeded = () => {};
+let handlePinkModeIconPress = () => {};
+let triggerPinkModeIconAnimation = () => {};
+let startPinkModeIconRotation = () => {};
+let stopPinkModeIconRotation = () => {};
+let startPinkModeAnimatedIconRotation = () => {};
+let stopPinkModeAnimatedIconRotation = () => {};
+let applyPinkModeIcon = () => {};
+let isPinkModeActive = () => !!(typeof document !== 'undefined' && document.body && document.body.classList.contains('pink-mode'));
 
-  const glyphConfig =
-    glyph && typeof glyph === 'object' && (glyph.markup || glyph.className)
-      ? glyph
-      : { value: glyph };
+const appearanceModuleFactory = ensureSessionRuntimePlaceholder(
+  'cineSettingsAppearance',
+  () => null,
+);
 
-  const classNames = ['icon-glyph'];
-  if (glyphConfig.className) {
-    classNames.push(glyphConfig.className);
-  }
-  iconSpan.className = classNames.join(' ');
-
-  if (glyphConfig.markup) {
-    iconSpan.innerHTML = ensureSvgHasAriaHidden(glyphConfig.markup);
-    iconSpan.removeAttribute('data-icon-font');
-  } else {
-    applyIconGlyph(iconSpan, glyphConfig.value);
-  }
-}
-
-function getIconGlyphSafe(name) {
-  if (!name) return null;
-  if (typeof ICON_GLYPHS !== 'object' || !ICON_GLYPHS) {
-    return null;
-  }
-  return ICON_GLYPHS[name] || null;
-}
-
-function applyDarkMode(enabled) {
-  if (enabled) {
-    document.body.classList.add("dark-mode");
-    document.documentElement.classList.add("dark-mode");
-    document.body.classList.remove("light-mode");
-    document.documentElement.classList.remove("light-mode");
-    if (darkModeToggle) {
-      const sunGlyph = getIconGlyphSafe('sun');
-      if (sunGlyph) {
-        setToggleIcon(darkModeToggle, sunGlyph);
+const appearanceContext = {
+  document: typeof document !== 'undefined' ? document : null,
+  window: typeof window !== 'undefined' ? window : null,
+  elements: {
+    darkModeToggle: typeof darkModeToggle !== 'undefined' ? darkModeToggle : null,
+    pinkModeToggle: typeof pinkModeToggle !== 'undefined' ? pinkModeToggle : null,
+    pinkModeHelpIcon: typeof pinkModeHelpIcon !== 'undefined' ? pinkModeHelpIcon : null,
+  },
+  settings: {
+    darkMode: typeof settingsDarkMode !== 'undefined' ? settingsDarkMode : null,
+    highContrast: typeof settingsHighContrast !== 'undefined' ? settingsHighContrast : null,
+    pinkMode: typeof settingsPinkMode !== 'undefined' ? settingsPinkMode : null,
+    reduceMotion: typeof settingsReduceMotion !== 'undefined' ? settingsReduceMotion : null,
+    relaxedSpacing: typeof settingsRelaxedSpacing !== 'undefined' ? settingsRelaxedSpacing : null,
+    showAutoBackups: typeof settingsShowAutoBackups !== 'undefined' ? settingsShowAutoBackups : null,
+    temperatureUnit: typeof settingsTemperatureUnit !== 'undefined' ? settingsTemperatureUnit : null,
+  },
+  accent: {
+    accentColorInput: typeof accentColorInput !== 'undefined' ? accentColorInput : null,
+    getAccentColor: () => accentColor,
+    setAccentColor: value => {
+      accentColor = value;
+    },
+    getPrevAccentColor: () => prevAccentColor,
+    setPrevAccentColor: value => {
+      prevAccentColor = value;
+    },
+    getHighContrastAccentColor: () => HIGH_CONTRAST_ACCENT_COLOR,
+    clearAccentColorOverrides: () => {
+      if (typeof clearAccentColorOverrides === 'function') {
+        clearAccentColorOverrides();
       }
-      darkModeToggle.setAttribute("aria-pressed", "true");
-    }
-  } else {
-    document.body.classList.remove("dark-mode");
-    document.documentElement.classList.remove("dark-mode");
-    document.body.classList.add("light-mode");
-    document.documentElement.classList.add("light-mode");
-    if (darkModeToggle) {
-      const moonGlyph = getIconGlyphSafe('moon');
-      if (moonGlyph) {
-        setToggleIcon(darkModeToggle, moonGlyph);
+    },
+    applyAccentColor: value => {
+      if (typeof applyAccentColor === 'function') {
+        applyAccentColor(value);
       }
-      darkModeToggle.setAttribute("aria-pressed", "false");
-    }
-  }
-  const highContrast = typeof isHighContrastActive === 'function' ? isHighContrastActive() : false;
-  const accentSource = highContrast ? HIGH_CONTRAST_ACCENT_COLOR : accentColor;
-  if (typeof refreshDarkModeAccentBoost === 'function') {
-    refreshDarkModeAccentBoost({ color: accentSource, highContrast });
-  }
-  updateThemeColor(enabled);
-  if (settingsDarkMode) {
-    settingsDarkMode.checked = enabled;
-  }
+    },
+    updateAccentColorResetButtonState: () => {
+      if (typeof updateAccentColorResetButtonState === 'function') {
+        updateAccentColorResetButtonState();
+      }
+    },
+    refreshDarkModeAccentBoost: payload => {
+      if (typeof refreshDarkModeAccentBoost === 'function') {
+        refreshDarkModeAccentBoost(payload);
+      }
+    },
+    isHighContrastActive: () => (typeof isHighContrastActive === 'function' ? isHighContrastActive() : false),
+  },
+  icons: {
+    registry: typeof ICON_GLYPHS === 'object' ? ICON_GLYPHS : null,
+    applyIconGlyph: typeof applyIconGlyph === 'function' ? (element, glyph) => applyIconGlyph(element, glyph) : null,
+    ensureSvgHasAriaHidden: typeof ensureSvgHasAriaHidden === 'function' ? ensureSvgHasAriaHidden : null,
+    pinkModeIcons: typeof pinkModeIcons === 'object' ? pinkModeIcons : null,
+    startPinkModeAnimatedIcons: typeof startPinkModeAnimatedIcons === 'function' ? startPinkModeAnimatedIcons : null,
+    stopPinkModeAnimatedIcons: typeof stopPinkModeAnimatedIcons === 'function' ? stopPinkModeAnimatedIcons : null,
+    triggerPinkModeIconRain: typeof triggerPinkModeIconRain === 'function' ? triggerPinkModeIconRain : null,
+  },
+  storage: {
+    getLocalStorage: () => {
+      try {
+        return typeof localStorage !== 'undefined' ? localStorage : null;
+      } catch (storageError) {
+        void storageError;
+        return null;
+      }
+    },
+  },
+  preferences: {
+    getTemperatureUnit: () => temperatureUnit,
+    setTemperatureUnit: value => {
+      temperatureUnit = value;
+    },
+    applyTemperatureUnitPreference: typeof applyTemperatureUnitPreference === 'function' ? applyTemperatureUnitPreference : null,
+    getShowAutoBackups: () => showAutoBackups,
+    setShowAutoBackups: value => {
+      showAutoBackups = Boolean(value);
+    },
+    ensureAutoBackupsFromProjects: typeof ensureAutoBackupsFromProjects === 'function' ? ensureAutoBackupsFromProjects : null,
+  },
+  autoBackups: {
+    populateSetupSelect: typeof populateSetupSelect === 'function' ? populateSetupSelect : null,
+    setupSelect: typeof setupSelect !== 'undefined' ? setupSelect : null,
+    setupNameInput: typeof setupNameInput !== 'undefined' ? setupNameInput : null,
+  },
+  mountVoltages: {
+    getPreferencesClone: () => getSessionMountVoltagePreferencesClone(),
+    applyPreferences: (preferences, options) => applySessionMountVoltagePreferences(preferences, options),
+    supportedTypes: typeof SUPPORTED_MOUNT_VOLTAGE_TYPES !== 'undefined' ? SUPPORTED_MOUNT_VOLTAGE_TYPES : [],
+    defaultVoltages: typeof DEFAULT_MOUNT_VOLTAGES !== 'undefined' ? DEFAULT_MOUNT_VOLTAGES : {},
+    updateInputsFromState: () => {
+      const updateFn = getSessionRuntimeFunction('updateMountVoltageInputsFromState');
+      if (updateFn) {
+        try {
+          updateFn();
+        } catch (updateError) {
+          warnMountVoltageHelper('updateMountVoltageInputsFromState', updateError);
+        }
+      } else {
+        warnMountVoltageHelper('updateMountVoltageInputsFromState');
+      }
+    },
+    warnMissingHelper: (name, error) => {
+      warnMountVoltageHelper(name, error);
+    },
+  },
+};
+
+const appearanceModule = appearanceModuleFactory && typeof appearanceModuleFactory.initialize === 'function'
+  ? appearanceModuleFactory.initialize(appearanceContext)
+  : null;
+
+if (appearanceModule) {
+  updateThemeColor = appearanceModule.updateThemeColor || updateThemeColor;
+  setToggleIcon = appearanceModule.setToggleIcon || setToggleIcon;
+  applyDarkMode = appearanceModule.applyDarkMode || applyDarkMode;
+  applyHighContrast = appearanceModule.applyHighContrast || applyHighContrast;
+  applyReduceMotion = appearanceModule.applyReduceMotion || applyReduceMotion;
+  applyRelaxedSpacing = appearanceModule.applyRelaxedSpacing || applyRelaxedSpacing;
+  applyPinkMode = appearanceModule.applyPinkMode || applyPinkMode;
+  persistPinkModePreference = appearanceModule.persistPinkModePreference || persistPinkModePreference;
+  rememberSettingsPinkModeBaseline = appearanceModule.rememberSettingsPinkModeBaseline || rememberSettingsPinkModeBaseline;
+  revertSettingsPinkModeIfNeeded = appearanceModule.revertSettingsPinkModeIfNeeded || revertSettingsPinkModeIfNeeded;
+  rememberSettingsTemperatureUnitBaseline = appearanceModule.rememberSettingsTemperatureUnitBaseline || rememberSettingsTemperatureUnitBaseline;
+  revertSettingsTemperatureUnitIfNeeded = appearanceModule.revertSettingsTemperatureUnitIfNeeded || revertSettingsTemperatureUnitIfNeeded;
+  applyShowAutoBackupsPreference = appearanceModule.applyShowAutoBackupsPreference || applyShowAutoBackupsPreference;
+  rememberSettingsShowAutoBackupsBaseline = appearanceModule.rememberSettingsShowAutoBackupsBaseline || rememberSettingsShowAutoBackupsBaseline;
+  revertSettingsShowAutoBackupsIfNeeded = appearanceModule.revertSettingsShowAutoBackupsIfNeeded || revertSettingsShowAutoBackupsIfNeeded;
+  rememberSettingsMountVoltagesBaseline = appearanceModule.rememberSettingsMountVoltagesBaseline || rememberSettingsMountVoltagesBaseline;
+  revertSettingsMountVoltagesIfNeeded = appearanceModule.revertSettingsMountVoltagesIfNeeded || revertSettingsMountVoltagesIfNeeded;
+  handlePinkModeIconPress = appearanceModule.handlePinkModeIconPress || handlePinkModeIconPress;
+  triggerPinkModeIconAnimation = appearanceModule.triggerPinkModeIconAnimation || triggerPinkModeIconAnimation;
+  startPinkModeIconRotation = appearanceModule.startPinkModeIconRotation || startPinkModeIconRotation;
+  stopPinkModeIconRotation = appearanceModule.stopPinkModeIconRotation || stopPinkModeIconRotation;
+  startPinkModeAnimatedIconRotation = appearanceModule.startPinkModeAnimatedIconRotation || startPinkModeAnimatedIconRotation;
+  stopPinkModeAnimatedIconRotation = appearanceModule.stopPinkModeAnimatedIconRotation || stopPinkModeAnimatedIconRotation;
+  applyPinkModeIcon = appearanceModule.applyPinkModeIcon || applyPinkModeIcon;
+  isPinkModeActive = appearanceModule.isPinkModeActive || isPinkModeActive;
+} else if (typeof console !== 'undefined' && console && typeof console.warn === 'function') {
+  console.warn('cineSettingsAppearance module is not available; settings appearance features are limited.');
 }
 
 let darkModeEnabled = false;
@@ -3608,57 +3703,6 @@ if (darkModeToggle) {
   });
 }
 
-function applyHighContrast(enabled) {
-  if (enabled) {
-    if (document.body) {
-      document.body.classList.add("high-contrast");
-    }
-    document.documentElement.classList.add("high-contrast");
-    applyAccentColor(accentColor);
-    if (document.body && document.body.classList.contains('pink-mode')) {
-      clearAccentColorOverrides();
-    }
-  } else {
-    if (document.body) {
-      document.body.classList.remove("high-contrast");
-    }
-    document.documentElement.classList.remove("high-contrast");
-    if (document.body && document.body.classList.contains('pink-mode')) {
-      clearAccentColorOverrides();
-    } else {
-      applyAccentColor(accentColor);
-    }
-  }
-}
-
-function applyReduceMotion(enabled) {
-  const root = typeof document !== 'undefined' ? document.documentElement : null;
-  const body = typeof document !== 'undefined' ? document.body : null;
-  if (root) {
-    root.classList.toggle('reduce-motion', Boolean(enabled));
-  }
-  if (body) {
-    body.classList.toggle('reduce-motion', Boolean(enabled));
-  }
-  if (typeof settingsReduceMotion !== 'undefined' && settingsReduceMotion) {
-    settingsReduceMotion.checked = Boolean(enabled);
-  }
-}
-
-function applyRelaxedSpacing(enabled) {
-  const root = typeof document !== 'undefined' ? document.documentElement : null;
-  const body = typeof document !== 'undefined' ? document.body : null;
-  if (root) {
-    root.classList.toggle('relaxed-spacing', Boolean(enabled));
-  }
-  if (body) {
-    body.classList.toggle('relaxed-spacing', Boolean(enabled));
-  }
-  if (typeof settingsRelaxedSpacing !== 'undefined' && settingsRelaxedSpacing) {
-    settingsRelaxedSpacing.checked = Boolean(enabled);
-  }
-}
-
 let highContrastEnabled = false;
 try {
   highContrastEnabled = localStorage.getItem("highContrast") === "true";
@@ -3667,278 +3711,13 @@ try {
 }
 applyHighContrast(highContrastEnabled);
 
-// Pink mode handling
-
-function stopPinkModeIconRotation() {
-  if (pinkModeIconRotationTimer) {
-    clearInterval(pinkModeIconRotationTimer);
-    pinkModeIconRotationTimer = null;
-  }
-}
-
-const PINK_MODE_ICON_RAIN_PRESS_TRIGGER_COUNT = 5;
-const PINK_MODE_ICON_RAIN_PRESS_WINDOW_MS = 6000;
-let pinkModeIconPressTimestamps = [];
-
-function prunePinkModeIconPressHistory(now) {
-  const cutoff = now - PINK_MODE_ICON_RAIN_PRESS_WINDOW_MS;
-  if (cutoff <= 0 || !pinkModeIconPressTimestamps.length) {
-    return;
-  }
-  pinkModeIconPressTimestamps = pinkModeIconPressTimestamps.filter(
-    timestamp => timestamp >= cutoff
-  );
-}
-
-function handlePinkModeIconPress() {
-  const now = Date.now();
-  prunePinkModeIconPressHistory(now);
-  pinkModeIconPressTimestamps.push(now);
-  if (
-    pinkModeIconPressTimestamps.length >= PINK_MODE_ICON_RAIN_PRESS_TRIGGER_COUNT &&
-    typeof triggerPinkModeIconRain === 'function'
-  ) {
-    pinkModeIconPressTimestamps = [];
-    triggerPinkModeIconRain();
-  }
-}
-
 if (typeof window !== 'undefined') {
-  window.handlePinkModeIconPress = handlePinkModeIconPress;
-}
-
-function triggerPinkModeIconAnimation() {
-  const targets = [];
-  if (pinkModeToggle) {
-    const toggleIcon = pinkModeToggle.querySelector('.pink-mode-icon');
-    if (toggleIcon) {
-      targets.push(toggleIcon);
-    }
-  }
-  if (pinkModeHelpIcon) {
-    targets.push(pinkModeHelpIcon);
-  }
-  if (!targets.length) {
-    return;
-  }
-  targets.forEach(target => {
-    target.classList.remove(PINK_MODE_ICON_ANIMATION_CLASS);
-    // Force a reflow so the animation restarts even when toggled quickly
-    target.getBoundingClientRect();
-    target.classList.add(PINK_MODE_ICON_ANIMATION_CLASS);
-    if (PINK_MODE_ICON_ANIMATION_RESET_DELAY > 0) {
-      setTimeout(() => {
-        target.classList.remove(PINK_MODE_ICON_ANIMATION_CLASS);
-      }, PINK_MODE_ICON_ANIMATION_RESET_DELAY);
-    }
-  });
-}
-
-function applyPinkModeIcon(iconConfig, { animate = false } = {}) {
-  if (!iconConfig) return;
-  if (pinkModeToggle) {
-    setToggleIcon(pinkModeToggle, iconConfig);
-  }
-  if (pinkModeHelpIcon) {
-    pinkModeHelpIcon.className = 'help-icon icon-glyph icon-svg pink-mode-icon';
-    pinkModeHelpIcon.innerHTML = iconConfig.markup || '';
-  }
-  if (animate) {
-    triggerPinkModeIconAnimation();
-  }
-}
-
-function startPinkModeIconRotation() {
-  const sequence = Array.isArray(pinkModeIcons.onSequence)
-    ? pinkModeIcons.onSequence
-    : [];
-  if (!sequence.length) {
-    applyPinkModeIcon(pinkModeIcons.off, { animate: false });
-    return;
-  }
-  stopPinkModeIconRotation();
-  if (!pinkModeToggle && !pinkModeHelpIcon) {
-    return;
-  }
-  pinkModeIconIndex = 0;
-  applyPinkModeIcon(sequence[pinkModeIconIndex], { animate: true });
-  pinkModeIconRotationTimer = setInterval(() => {
-    pinkModeIconIndex = (pinkModeIconIndex + 1) % sequence.length;
-    applyPinkModeIcon(sequence[pinkModeIconIndex], { animate: true });
-  }, PINK_MODE_ICON_INTERVAL_MS);
-  if (
-    pinkModeIconRotationTimer &&
-    typeof pinkModeIconRotationTimer.unref === 'function'
-  ) {
-    pinkModeIconRotationTimer.unref();
-  }
-}
-
-function applyPinkMode(enabled) {
-  if (enabled) {
-    document.body.classList.add("pink-mode");
-    document.documentElement.classList.add("pink-mode");
-    if (accentColorInput) {
-      accentColorInput.disabled = true;
-    }
-    clearAccentColorOverrides();
-    if (pinkModeToggle) {
-      pinkModeToggle.setAttribute("aria-pressed", "true");
-    }
-    startPinkModeIconRotation();
-    startPinkModeAnimatedIcons();
-  } else {
-    stopPinkModeAnimatedIcons();
-    document.body.classList.remove("pink-mode");
-    document.documentElement.classList.remove("pink-mode");
-    if (accentColorInput) {
-      accentColorInput.disabled = false;
-    }
-    applyAccentColor(accentColor);
-    stopPinkModeIconRotation();
-    applyPinkModeIcon(pinkModeIcons.off, { animate: false });
-    if (pinkModeToggle) {
-      pinkModeToggle.setAttribute("aria-pressed", "false");
-    }
-  }
-  if (settingsPinkMode) {
-    settingsPinkMode.checked = enabled;
-  }
-  if (typeof updateAccentColorResetButtonState === 'function') {
-    updateAccentColorResetButtonState();
-  }
-}
-
-function isPinkModeActive() {
-  return !!(document.body && document.body.classList.contains('pink-mode'));
+  window.handlePinkModeIconPress = () => {
+    handlePinkModeIconPress();
+  };
 }
 
 let pinkModeEnabled = false;
-
-let settingsInitialPinkMode = isPinkModeActive();
-let settingsInitialTemperatureUnit =
-  typeof temperatureUnit === 'string' ? temperatureUnit : 'celsius';
-let settingsInitialShowAutoBackups = Boolean(showAutoBackups);
-let settingsInitialMountVoltages = getSessionMountVoltagePreferencesClone();
-
-function persistPinkModePreference(enabled) {
-  pinkModeEnabled = !!enabled;
-  applyPinkMode(pinkModeEnabled);
-  try {
-    localStorage.setItem('pinkMode', pinkModeEnabled);
-  } catch (e) {
-    console.warn('Could not save pink mode preference', e);
-  }
-}
-
-function rememberSettingsPinkModeBaseline() {
-  settingsInitialPinkMode = isPinkModeActive();
-}
-
-function revertSettingsPinkModeIfNeeded() {
-  if (isPinkModeActive() !== settingsInitialPinkMode) {
-    persistPinkModePreference(settingsInitialPinkMode);
-  }
-}
-
-function rememberSettingsTemperatureUnitBaseline() {
-  if (typeof temperatureUnit === 'string') {
-    settingsInitialTemperatureUnit = temperatureUnit;
-  }
-}
-
-function revertSettingsTemperatureUnitIfNeeded() {
-  const baseline =
-    typeof settingsInitialTemperatureUnit === 'string'
-      ? settingsInitialTemperatureUnit
-      : 'celsius';
-
-  if (typeof applyTemperatureUnitPreference === 'function') {
-    if (temperatureUnit !== baseline) {
-      applyTemperatureUnitPreference(baseline, {
-        persist: false,
-        forceUpdate: true
-      });
-    } else if (settingsTemperatureUnit) {
-      settingsTemperatureUnit.value = baseline;
-    }
-  } else if (settingsTemperatureUnit) {
-    settingsTemperatureUnit.value = baseline;
-  }
-}
-
-function applyShowAutoBackupsPreference(enabled, options = {}) {
-  const config = typeof options === 'object' && options !== null ? options : {};
-  const persist = config.persist !== false;
-  const forceRepopulate = Boolean(config.forceRepopulate);
-  const normalized = Boolean(enabled);
-  const previousValue = Boolean(showAutoBackups);
-  const changed = normalized !== previousValue;
-
-  showAutoBackups = normalized;
-
-  if (normalized && typeof ensureAutoBackupsFromProjects === 'function') {
-    try {
-      ensureAutoBackupsFromProjects();
-    } catch (error) {
-      console.warn('Failed to sync auto backups from project storage', error);
-    }
-  }
-
-  if (persist && typeof localStorage !== 'undefined') {
-    try {
-      localStorage.setItem('showAutoBackups', normalized);
-    } catch (error) {
-      console.warn('Could not save auto backup visibility preference', error);
-    }
-  }
-
-  if (!changed && !forceRepopulate) {
-    if (settingsShowAutoBackups) {
-      settingsShowAutoBackups.checked = normalized;
-    }
-    return;
-  }
-
-  const prevValue = setupSelect ? setupSelect.value : '';
-  const prevName = setupNameInput ? setupNameInput.value : '';
-
-  try {
-    populateSetupSelect();
-  } catch (error) {
-    console.warn('Failed to refresh setup selector after changing auto backup visibility', error);
-  }
-
-  if (setupSelect) {
-    if (normalized || !prevValue || !prevValue.startsWith('auto-backup-')) {
-      setupSelect.value = prevValue;
-    } else {
-      setupSelect.value = '';
-    }
-  }
-
-  if (setupNameInput) {
-    setupNameInput.value = prevName;
-  }
-
-  if (settingsShowAutoBackups) {
-    settingsShowAutoBackups.checked = normalized;
-  }
-}
-
-function rememberSettingsShowAutoBackupsBaseline() {
-  settingsInitialShowAutoBackups = Boolean(showAutoBackups);
-}
-
-function revertSettingsShowAutoBackupsIfNeeded() {
-  const baseline = Boolean(settingsInitialShowAutoBackups);
-  if (Boolean(showAutoBackups) !== baseline) {
-    applyShowAutoBackupsPreference(baseline, { forceRepopulate: true });
-  } else if (settingsShowAutoBackups) {
-    settingsShowAutoBackups.checked = baseline;
-  }
-}
-
 try {
   pinkModeEnabled = localStorage.getItem('pinkMode') === 'true';
 } catch (e) {
@@ -3973,9 +3752,11 @@ if (settingsShowAutoBackups) {
 
 if (settingsTemperatureUnit) {
   settingsTemperatureUnit.addEventListener('change', () => {
-    applyTemperatureUnitPreference(settingsTemperatureUnit.value, {
-      persist: false
-    });
+    if (typeof applyTemperatureUnitPreference === 'function') {
+      applyTemperatureUnitPreference(settingsTemperatureUnit.value, {
+        persist: false
+      });
+    }
   });
 }
 
@@ -11397,37 +11178,6 @@ function applySessionMountVoltagePreferences(preferences, options = {}) {
       } catch (updateError) {
         void updateError;
       }
-    }
-  }
-}
-
-function rememberSettingsMountVoltagesBaseline() {
-  settingsInitialMountVoltages = getSessionMountVoltagePreferencesClone();
-}
-
-function revertSettingsMountVoltagesIfNeeded() {
-  const baseline = settingsInitialMountVoltages || getSessionMountVoltagePreferencesClone();
-  const current = getSessionMountVoltagePreferencesClone();
-  const changed = SUPPORTED_MOUNT_VOLTAGE_TYPES.some(type => {
-    const baselineEntry = baseline[type] || DEFAULT_MOUNT_VOLTAGES[type];
-    const currentEntry = current[type] || DEFAULT_MOUNT_VOLTAGES[type];
-    return (
-      Number(baselineEntry.high) !== Number(currentEntry.high)
-      || Number(baselineEntry.low) !== Number(currentEntry.low)
-    );
-  });
-  if (changed) {
-    applySessionMountVoltagePreferences(baseline, { persist: true, triggerUpdate: true });
-  } else {
-    const updateMountVoltageInputsFromStateFn = getSessionRuntimeFunction('updateMountVoltageInputsFromState');
-    if (updateMountVoltageInputsFromStateFn) {
-      try {
-        updateMountVoltageInputsFromStateFn();
-      } catch (updateError) {
-        warnMissingMountVoltageHelper('updateMountVoltageInputsFromState', updateError);
-      }
-    } else {
-      warnMissingMountVoltageHelper('updateMountVoltageInputsFromState');
     }
   }
 }

--- a/src/scripts/modules/settings-and-appearance.js
+++ b/src/scripts/modules/settings-and-appearance.js
@@ -1,0 +1,1124 @@
+/* global cineModuleBase */
+
+(function () {
+  function detectGlobalScope() {
+    if (typeof globalThis !== 'undefined') {
+      return globalThis;
+    }
+    if (typeof window !== 'undefined') {
+      return window;
+    }
+    if (typeof self !== 'undefined') {
+      return self;
+    }
+    if (typeof global !== 'undefined') {
+      return global;
+    }
+    return {};
+  }
+
+  const GLOBAL_SCOPE = detectGlobalScope();
+
+  function resolveModuleBase(scope) {
+    if (typeof cineModuleBase === 'object' && cineModuleBase) {
+      return cineModuleBase;
+    }
+
+    if (typeof require === 'function') {
+      try {
+        const required = require('./base.js');
+        if (required && typeof required === 'object') {
+          return required;
+        }
+      } catch (error) {
+        void error;
+      }
+    }
+
+    if (scope && typeof scope.cineModuleBase === 'object') {
+      return scope.cineModuleBase;
+    }
+
+    return null;
+  }
+
+  const MODULE_BASE = resolveModuleBase(GLOBAL_SCOPE);
+  if (!MODULE_BASE) {
+    return;
+  }
+
+  const freezeDeep = typeof MODULE_BASE.freezeDeep === 'function'
+    ? function freezeWithBase(value) {
+        try {
+          return MODULE_BASE.freezeDeep(value);
+        } catch (error) {
+          void error;
+        }
+        return value;
+      }
+    : function identity(value) {
+        return value;
+      };
+
+  const safeWarn = typeof MODULE_BASE.safeWarn === 'function'
+    ? function warnWithBase(message, detail) {
+        try {
+          MODULE_BASE.safeWarn(message, detail);
+        } catch (error) {
+          void error;
+        }
+      }
+    : function fallbackSafeWarn(message, detail) {
+        if (typeof console === 'undefined' || !console || typeof console.warn !== 'function') {
+          return;
+        }
+        try {
+          if (typeof detail === 'undefined') {
+            console.warn(message);
+          } else {
+            console.warn(message, detail);
+          }
+        } catch (error) {
+          void error;
+        }
+      };
+
+  const informModuleGlobals = typeof MODULE_BASE.informModuleGlobals === 'function'
+    ? function informWithBase(name, api) {
+        try {
+          MODULE_BASE.informModuleGlobals(name, api);
+        } catch (error) {
+          void error;
+        }
+      }
+    : function noopInform() {};
+
+  const registerOrQueueModule = typeof MODULE_BASE.registerOrQueueModule === 'function'
+    ? function registerWithBase(name, api, metadata, onError) {
+        try {
+          MODULE_BASE.registerOrQueueModule(name, api, metadata, onError);
+        } catch (error) {
+          if (typeof onError === 'function') {
+            try {
+              onError(error);
+            } catch (handlerError) {
+              void handlerError;
+            }
+          } else {
+            safeWarn('cineSettingsAppearance: Unable to register module.', error);
+          }
+        }
+      }
+    : function fallbackRegister() {};
+
+  const exposeGlobal = typeof MODULE_BASE.exposeGlobal === 'function'
+    ? function exposeWithBase(name, value, options) {
+        try {
+          return MODULE_BASE.exposeGlobal(name, value, GLOBAL_SCOPE, options);
+        } catch (error) {
+          void error;
+          return false;
+        }
+      }
+    : function fallbackExpose(name, value) {
+        if (!GLOBAL_SCOPE || typeof GLOBAL_SCOPE !== 'object') {
+          return false;
+        }
+        try {
+          GLOBAL_SCOPE[name] = value;
+          return true;
+        } catch (error) {
+          void error;
+        }
+        return false;
+      };
+
+  function cloneContext(context) {
+    if (!context || typeof context !== 'object') {
+      return {};
+    }
+
+    const copy = {};
+    const keys = Object.keys(context);
+    for (let index = 0; index < keys.length; index += 1) {
+      const key = keys[index];
+      copy[key] = context[key];
+    }
+    return copy;
+  }
+
+  function createFallbackContext() {
+    const getDocument = () => {
+      if (typeof document !== 'undefined') {
+        return document;
+      }
+      return null;
+    };
+
+    const getWindow = () => {
+      if (typeof window !== 'undefined') {
+        return window;
+      }
+      return null;
+    };
+
+    return {
+      getDocument,
+      getWindow,
+      settings: {},
+      elements: {},
+      accent: {},
+      icons: {},
+      storage: {},
+      preferences: {},
+      autoBackups: {},
+      mountVoltages: {},
+      helpers: {},
+    };
+  }
+
+  function resolveDocument(context) {
+    if (!context) {
+      return null;
+    }
+    if (typeof context.getDocument === 'function') {
+      try {
+        const doc = context.getDocument();
+        if (doc && typeof doc === 'object') {
+          return doc;
+        }
+      } catch (error) {
+        void error;
+      }
+    }
+    if (context.document && typeof context.document === 'object') {
+      return context.document;
+    }
+    if (typeof document !== 'undefined' && document) {
+      return document;
+    }
+    return null;
+  }
+
+  function resolveWindow(context) {
+    if (!context) {
+      return null;
+    }
+    if (typeof context.getWindow === 'function') {
+      try {
+        const win = context.getWindow();
+        if (win && typeof win === 'object') {
+          return win;
+        }
+      } catch (error) {
+        void error;
+      }
+    }
+    if (context.window && typeof context.window === 'object') {
+      return context.window;
+    }
+    if (typeof window !== 'undefined' && window) {
+      return window;
+    }
+    return null;
+  }
+
+  function getLocalStorage(context) {
+    const storage = context.storage || {};
+    if (storage && typeof storage.getLocalStorage === 'function') {
+      try {
+        const resolved = storage.getLocalStorage();
+        if (resolved) {
+          return resolved;
+        }
+      } catch (error) {
+        void error;
+      }
+    }
+    if (storage && storage.localStorage) {
+      return storage.localStorage;
+    }
+    if (typeof localStorage !== 'undefined') {
+      return localStorage;
+    }
+    return null;
+  }
+
+  function callOptional(fn, args, defaultValue) {
+    if (typeof fn !== 'function') {
+      return defaultValue;
+    }
+    try {
+      return fn.apply(null, Array.isArray(args) ? args : []);
+    } catch (error) {
+      safeWarn('cineSettingsAppearance: helper invocation failed.', error);
+      return defaultValue;
+    }
+  }
+
+  function createAppearanceManager(rawContext) {
+    const context = cloneContext(createFallbackContext());
+    const provided = cloneContext(rawContext);
+    const providedKeys = Object.keys(provided);
+    for (let index = 0; index < providedKeys.length; index += 1) {
+      const key = providedKeys[index];
+      const value = provided[key];
+      if (value && typeof value === 'object' && !Array.isArray(value)) {
+        context[key] = cloneContext(value);
+      } else {
+        context[key] = value;
+      }
+    }
+
+    const doc = resolveDocument(context);
+    const win = resolveWindow(context);
+
+    const elements = context.elements || {};
+    const settings = context.settings || {};
+    const accent = context.accent || {};
+    const icons = context.icons || {};
+    const preferences = context.preferences || {};
+    const autoBackups = context.autoBackups || {};
+    const mountVoltages = context.mountVoltages || {};
+    const helpers = context.helpers || {};
+
+    let pinkModeIconRotationTimer = null;
+    let pinkModeIconIndex = 0;
+    const PINK_MODE_ICON_RAIN_PRESS_TRIGGER_COUNT = 5;
+    const PINK_MODE_ICON_RAIN_PRESS_WINDOW_MS = 6000;
+    const PINK_MODE_ICON_ANIMATION_RESET_DELAY = context.pinkModeIconAnimationResetDelay || 400;
+    const PINK_MODE_ICON_ANIMATION_CLASS = context.pinkModeIconAnimationClass || 'pink-mode-icon-animate';
+    const PINK_MODE_ICON_INTERVAL_MS = context.pinkModeIconIntervalMs || 1500;
+    let pinkModeIconPressTimestamps = [];
+
+    let pinkModeEnabled = false;
+    let settingsInitialPinkMode = false;
+    let settingsInitialTemperatureUnit = 'celsius';
+    let settingsInitialShowAutoBackups = false;
+
+    function getRoot() {
+      return doc && doc.documentElement ? doc.documentElement : null;
+    }
+
+    function getBody() {
+      return doc && doc.body ? doc.body : null;
+    }
+
+    function getAccentColor() {
+      if (typeof accent.getAccentColor === 'function') {
+        return accent.getAccentColor();
+      }
+      return accent.accentColor || '#001589';
+    }
+
+    function setAccentColor(value) {
+      if (typeof accent.setAccentColor === 'function') {
+        accent.setAccentColor(value);
+      } else {
+        accent.accentColor = value;
+      }
+    }
+
+    function getPrevAccentColor() {
+      if (typeof accent.getPrevAccentColor === 'function') {
+        return accent.getPrevAccentColor();
+      }
+      return accent.prevAccentColor || getAccentColor();
+    }
+
+    function setPrevAccentColor(value) {
+      if (typeof accent.setPrevAccentColor === 'function') {
+        accent.setPrevAccentColor(value);
+      } else {
+        accent.prevAccentColor = value;
+      }
+    }
+
+    function getHighContrastAccentColor() {
+      if (typeof accent.getHighContrastAccentColor === 'function') {
+        return accent.getHighContrastAccentColor();
+      }
+      return accent.highContrastAccentColor || '#ffffff';
+    }
+
+    function isHighContrastActive() {
+      if (typeof accent.isHighContrastActive === 'function') {
+        try {
+          return !!accent.isHighContrastActive();
+        } catch (error) {
+          safeWarn('cineSettingsAppearance: isHighContrastActive failed.', error);
+        }
+      }
+      const body = getBody();
+      return !!(body && body.classList && body.classList.contains('high-contrast'));
+    }
+
+    function updateAccentColorResetButtonState() {
+      if (typeof accent.updateAccentColorResetButtonState === 'function') {
+        try {
+          accent.updateAccentColorResetButtonState();
+        } catch (error) {
+          safeWarn('cineSettingsAppearance: updateAccentColorResetButtonState failed.', error);
+        }
+      }
+    }
+
+    function clearAccentColorOverrides() {
+      if (typeof accent.clearAccentColorOverrides === 'function') {
+        try {
+          accent.clearAccentColorOverrides();
+        } catch (error) {
+          safeWarn('cineSettingsAppearance: clearAccentColorOverrides failed.', error);
+        }
+      }
+    }
+
+    function applyAccentColor(value) {
+      if (typeof accent.applyAccentColor === 'function') {
+        try {
+          accent.applyAccentColor(value);
+        } catch (error) {
+          safeWarn('cineSettingsAppearance: applyAccentColor failed.', error);
+        }
+      }
+    }
+
+    function refreshDarkModeAccentBoost(payload) {
+      if (typeof accent.refreshDarkModeAccentBoost === 'function') {
+        try {
+          accent.refreshDarkModeAccentBoost(payload);
+        } catch (error) {
+          safeWarn('cineSettingsAppearance: refreshDarkModeAccentBoost failed.', error);
+        }
+      }
+    }
+
+    function ensureSvgHasAriaHidden(markup) {
+      if (typeof icons.ensureSvgHasAriaHidden === 'function') {
+        return icons.ensureSvgHasAriaHidden(markup);
+      }
+      return markup;
+    }
+
+    function applyIconGlyph(target, glyph) {
+      if (typeof icons.applyIconGlyph === 'function') {
+        try {
+          icons.applyIconGlyph(target, glyph);
+        } catch (error) {
+          safeWarn('cineSettingsAppearance: applyIconGlyph failed.', error);
+        }
+      }
+    }
+
+    function getIconGlyph(name) {
+      if (!name) {
+        return null;
+      }
+      if (typeof icons.getIconGlyph === 'function') {
+        try {
+          return icons.getIconGlyph(name);
+        } catch (error) {
+          safeWarn('cineSettingsAppearance: getIconGlyph failed.', error);
+          return null;
+        }
+      }
+      const registry = icons.registry && typeof icons.registry === 'object' ? icons.registry : null;
+      if (registry && registry[name]) {
+        return registry[name];
+      }
+      if (typeof GLOBAL_SCOPE.ICON_GLYPHS === 'object' && GLOBAL_SCOPE.ICON_GLYPHS) {
+        return GLOBAL_SCOPE.ICON_GLYPHS[name] || null;
+      }
+      return null;
+    }
+
+    function updateThemeColor(isDark) {
+      const documentRef = doc;
+      if (!documentRef || typeof documentRef.querySelector !== 'function') {
+        return;
+      }
+      const meta = documentRef.querySelector('meta[name="theme-color"]');
+      if (!meta) {
+        return;
+      }
+      try {
+        meta.setAttribute('content', isDark ? '#1c1c1e' : '#ffffff');
+      } catch (error) {
+        safeWarn('cineSettingsAppearance: unable to update theme-color meta tag.', error);
+      }
+    }
+
+    function setToggleIcon(button, glyph) {
+      if (!button) {
+        return;
+      }
+      let iconSpan = button.querySelector && button.querySelector('.icon-glyph');
+      if (!iconSpan && doc && typeof doc.createElement === 'function') {
+        iconSpan = doc.createElement('span');
+        iconSpan.className = 'icon-glyph';
+        iconSpan.setAttribute('aria-hidden', 'true');
+        try {
+          button.textContent = '';
+          button.appendChild(iconSpan);
+        } catch (error) {
+          safeWarn('cineSettingsAppearance: unable to attach toggle icon.', error);
+          return;
+        }
+      }
+      if (!iconSpan) {
+        return;
+      }
+
+      const glyphConfig = glyph && typeof glyph === 'object' && (glyph.markup || glyph.className)
+        ? glyph
+        : { value: glyph };
+
+      const classNames = ['icon-glyph'];
+      if (glyphConfig.className) {
+        classNames.push(glyphConfig.className);
+      }
+      iconSpan.className = classNames.join(' ');
+
+      if (glyphConfig.markup) {
+        iconSpan.innerHTML = ensureSvgHasAriaHidden(glyphConfig.markup);
+        iconSpan.removeAttribute('data-icon-font');
+      } else {
+        applyIconGlyph(iconSpan, glyphConfig.value);
+      }
+    }
+
+    function applyDarkMode(enabled) {
+      const root = getRoot();
+      const body = getBody();
+      if (!root || !body) {
+        return;
+      }
+
+      if (enabled) {
+        body.classList.add('dark-mode');
+        root.classList.add('dark-mode');
+        body.classList.remove('light-mode');
+        root.classList.remove('light-mode');
+        if (elements.darkModeToggle) {
+          const sunGlyph = getIconGlyph('sun');
+          if (sunGlyph) {
+            setToggleIcon(elements.darkModeToggle, sunGlyph);
+          }
+          elements.darkModeToggle.setAttribute('aria-pressed', 'true');
+        }
+      } else {
+        body.classList.remove('dark-mode');
+        root.classList.remove('dark-mode');
+        body.classList.add('light-mode');
+        root.classList.add('light-mode');
+        if (elements.darkModeToggle) {
+          const moonGlyph = getIconGlyph('moon');
+          if (moonGlyph) {
+            setToggleIcon(elements.darkModeToggle, moonGlyph);
+          }
+          elements.darkModeToggle.setAttribute('aria-pressed', 'false');
+        }
+      }
+
+      const highContrast = isHighContrastActive();
+      const accentSource = highContrast ? getHighContrastAccentColor() : getAccentColor();
+      refreshDarkModeAccentBoost({ color: accentSource, highContrast });
+      updateThemeColor(enabled);
+      if (settings.darkMode) {
+        settings.darkMode.checked = !!enabled;
+      }
+    }
+
+    function applyHighContrast(enabled) {
+      const root = getRoot();
+      const body = getBody();
+      if (!root) {
+        return;
+      }
+
+      if (enabled) {
+        if (body) {
+          body.classList.add('high-contrast');
+        }
+        root.classList.add('high-contrast');
+        applyAccentColor(getAccentColor());
+        if (body && body.classList.contains('pink-mode')) {
+          clearAccentColorOverrides();
+        }
+      } else {
+        if (body) {
+          body.classList.remove('high-contrast');
+        }
+        root.classList.remove('high-contrast');
+        if (body && body.classList.contains('pink-mode')) {
+          clearAccentColorOverrides();
+        } else {
+          applyAccentColor(getAccentColor());
+        }
+      }
+
+      if (settings.highContrast) {
+        settings.highContrast.checked = !!enabled;
+      }
+    }
+
+    function applyReduceMotion(enabled) {
+      const root = getRoot();
+      const body = getBody();
+      if (root) {
+        root.classList.toggle('reduce-motion', Boolean(enabled));
+      }
+      if (body) {
+        body.classList.toggle('reduce-motion', Boolean(enabled));
+      }
+      if (settings.reduceMotion) {
+        settings.reduceMotion.checked = Boolean(enabled);
+      }
+    }
+
+    function applyRelaxedSpacing(enabled) {
+      const root = getRoot();
+      const body = getBody();
+      if (root) {
+        root.classList.toggle('relaxed-spacing', Boolean(enabled));
+      }
+      if (body) {
+        body.classList.toggle('relaxed-spacing', Boolean(enabled));
+      }
+      if (settings.relaxedSpacing) {
+        settings.relaxedSpacing.checked = Boolean(enabled);
+      }
+    }
+
+    function stopPinkModeIconRotation() {
+      if (pinkModeIconRotationTimer) {
+        try {
+          clearInterval(pinkModeIconRotationTimer);
+        } catch (error) {
+          safeWarn('cineSettingsAppearance: unable to stop pink mode rotation.', error);
+        }
+        pinkModeIconRotationTimer = null;
+      }
+    }
+
+    function startPinkModeAnimatedIcons() {
+      if (typeof icons.startPinkModeAnimatedIcons === 'function') {
+        try {
+          icons.startPinkModeAnimatedIcons();
+        } catch (error) {
+          safeWarn('cineSettingsAppearance: startPinkModeAnimatedIcons failed.', error);
+        }
+      }
+    }
+
+    function stopPinkModeAnimatedIcons() {
+      if (typeof icons.stopPinkModeAnimatedIcons === 'function') {
+        try {
+          icons.stopPinkModeAnimatedIcons();
+        } catch (error) {
+          safeWarn('cineSettingsAppearance: stopPinkModeAnimatedIcons failed.', error);
+        }
+      }
+    }
+
+    function applyPinkModeIcon(iconConfig, options) {
+      if (!iconConfig) {
+        return;
+      }
+      const shouldAnimate = options && options.animate === true;
+      const toggle = elements.pinkModeToggle || null;
+      const helpIcon = elements.pinkModeHelpIcon || null;
+
+      if (toggle) {
+        setToggleIcon(toggle, iconConfig);
+      }
+
+      if (helpIcon) {
+        helpIcon.className = 'help-icon icon-glyph icon-svg pink-mode-icon';
+        helpIcon.innerHTML = iconConfig.markup || '';
+      }
+
+      if (shouldAnimate) {
+        triggerPinkModeIconAnimation();
+      }
+    }
+
+    function triggerPinkModeIconAnimation() {
+      const targets = [];
+      const toggle = elements.pinkModeToggle || null;
+      if (toggle) {
+        const toggleIcon = toggle.querySelector && toggle.querySelector('.pink-mode-icon');
+        if (toggleIcon) {
+          targets.push(toggleIcon);
+        }
+      }
+      if (elements.pinkModeHelpIcon) {
+        targets.push(elements.pinkModeHelpIcon);
+      }
+      if (!targets.length) {
+        return;
+      }
+
+      for (let index = 0; index < targets.length; index += 1) {
+        const target = targets[index];
+        try {
+          target.classList.remove(PINK_MODE_ICON_ANIMATION_CLASS);
+          if (typeof target.getBoundingClientRect === 'function') {
+            target.getBoundingClientRect();
+          }
+          target.classList.add(PINK_MODE_ICON_ANIMATION_CLASS);
+        } catch (error) {
+          safeWarn('cineSettingsAppearance: unable to animate pink mode icon.', error);
+        }
+
+        if (PINK_MODE_ICON_ANIMATION_RESET_DELAY > 0) {
+          setTimeout(() => {
+            try {
+              target.classList.remove(PINK_MODE_ICON_ANIMATION_CLASS);
+            } catch (resetError) {
+              safeWarn('cineSettingsAppearance: failed to reset pink mode animation.', resetError);
+            }
+          }, PINK_MODE_ICON_ANIMATION_RESET_DELAY);
+        }
+      }
+    }
+
+    function startPinkModeIconRotation() {
+      const sequence = Array.isArray(icons.pinkModeIcons && icons.pinkModeIcons.onSequence)
+        ? icons.pinkModeIcons.onSequence
+        : [];
+      if (!sequence.length) {
+        applyPinkModeIcon(icons.pinkModeIcons ? icons.pinkModeIcons.off : null, { animate: false });
+        return;
+      }
+
+      stopPinkModeIconRotation();
+
+      const toggle = elements.pinkModeToggle || null;
+      const helpIcon = elements.pinkModeHelpIcon || null;
+      if (!toggle && !helpIcon) {
+        return;
+      }
+
+      pinkModeIconIndex = 0;
+      applyPinkModeIcon(sequence[pinkModeIconIndex], { animate: true });
+      try {
+        pinkModeIconRotationTimer = setInterval(() => {
+          pinkModeIconIndex = (pinkModeIconIndex + 1) % sequence.length;
+          applyPinkModeIcon(sequence[pinkModeIconIndex], { animate: true });
+        }, PINK_MODE_ICON_INTERVAL_MS);
+        if (pinkModeIconRotationTimer && typeof pinkModeIconRotationTimer.unref === 'function') {
+          pinkModeIconRotationTimer.unref();
+        }
+      } catch (error) {
+        pinkModeIconRotationTimer = null;
+        safeWarn('cineSettingsAppearance: unable to schedule pink mode rotation.', error);
+      }
+    }
+
+    function triggerPinkModeIconRain() {
+      if (typeof icons.triggerPinkModeIconRain === 'function') {
+        try {
+          icons.triggerPinkModeIconRain();
+        } catch (error) {
+          safeWarn('cineSettingsAppearance: triggerPinkModeIconRain failed.', error);
+        }
+      }
+    }
+
+    function prunePinkModeIconPressHistory(now) {
+      const cutoff = now - PINK_MODE_ICON_RAIN_PRESS_WINDOW_MS;
+      if (cutoff <= 0 || !pinkModeIconPressTimestamps.length) {
+        return;
+      }
+      pinkModeIconPressTimestamps = pinkModeIconPressTimestamps.filter(timestamp => timestamp >= cutoff);
+    }
+
+    function handlePinkModeIconPress() {
+      const now = Date.now();
+      prunePinkModeIconPressHistory(now);
+      pinkModeIconPressTimestamps.push(now);
+      if (
+        pinkModeIconPressTimestamps.length >= PINK_MODE_ICON_RAIN_PRESS_TRIGGER_COUNT
+        && typeof icons.triggerPinkModeIconRain === 'function'
+      ) {
+        pinkModeIconPressTimestamps = [];
+        triggerPinkModeIconRain();
+      }
+    }
+
+    function startPinkModeAnimatedIconRotation() {
+      startPinkModeIconRotation();
+      startPinkModeAnimatedIcons();
+    }
+
+    function stopPinkModeAnimatedIconRotation() {
+      stopPinkModeAnimatedIcons();
+      stopPinkModeIconRotation();
+    }
+
+    function applyPinkMode(enabled) {
+      const root = getRoot();
+      const body = getBody();
+      if (!root || !body) {
+        return;
+      }
+
+      if (enabled) {
+        body.classList.add('pink-mode');
+        root.classList.add('pink-mode');
+        if (accent.accentColorInput) {
+          accent.accentColorInput.disabled = true;
+        }
+        clearAccentColorOverrides();
+        if (elements.pinkModeToggle) {
+          elements.pinkModeToggle.setAttribute('aria-pressed', 'true');
+        }
+        startPinkModeAnimatedIconRotation();
+      } else {
+        stopPinkModeAnimatedIconRotation();
+        body.classList.remove('pink-mode');
+        root.classList.remove('pink-mode');
+        if (accent.accentColorInput) {
+          accent.accentColorInput.disabled = false;
+        }
+        applyAccentColor(getAccentColor());
+        if (icons.pinkModeIcons && icons.pinkModeIcons.off) {
+          applyPinkModeIcon(icons.pinkModeIcons.off, { animate: false });
+        }
+        if (elements.pinkModeToggle) {
+          elements.pinkModeToggle.setAttribute('aria-pressed', 'false');
+        }
+      }
+
+      if (settings.pinkMode) {
+        settings.pinkMode.checked = !!enabled;
+      }
+      updateAccentColorResetButtonState();
+    }
+
+    function isPinkModeActive() {
+      const body = getBody();
+      return !!(body && body.classList && body.classList.contains('pink-mode'));
+    }
+
+    function persistPinkModePreference(enabled) {
+      pinkModeEnabled = !!enabled;
+      applyPinkMode(pinkModeEnabled);
+      const storage = getLocalStorage(context);
+      if (!storage) {
+        return;
+      }
+      try {
+        storage.setItem('pinkMode', pinkModeEnabled);
+      } catch (error) {
+        safeWarn('cineSettingsAppearance: Could not save pink mode preference.', error);
+      }
+    }
+
+    function rememberSettingsPinkModeBaseline() {
+      settingsInitialPinkMode = isPinkModeActive();
+    }
+
+    function revertSettingsPinkModeIfNeeded() {
+      if (isPinkModeActive() !== settingsInitialPinkMode) {
+        persistPinkModePreference(settingsInitialPinkMode);
+      }
+    }
+
+    function getTemperatureUnit() {
+      if (typeof preferences.getTemperatureUnit === 'function') {
+        return preferences.getTemperatureUnit();
+      }
+      return preferences.temperatureUnit || 'celsius';
+    }
+
+    function setTemperatureUnit(value) {
+      if (typeof preferences.setTemperatureUnit === 'function') {
+        preferences.setTemperatureUnit(value);
+      } else {
+        preferences.temperatureUnit = value;
+      }
+    }
+
+    function rememberSettingsTemperatureUnitBaseline() {
+      const current = getTemperatureUnit();
+      settingsInitialTemperatureUnit = typeof current === 'string' ? current : 'celsius';
+    }
+
+    function revertSettingsTemperatureUnitIfNeeded() {
+      const baseline = typeof settingsInitialTemperatureUnit === 'string'
+        ? settingsInitialTemperatureUnit
+        : 'celsius';
+
+      const applyPreference = preferences.applyTemperatureUnitPreference;
+      if (typeof applyPreference === 'function') {
+        if (getTemperatureUnit() !== baseline) {
+          try {
+            applyPreference(baseline, { persist: false, forceUpdate: true });
+            setTemperatureUnit(baseline);
+          } catch (error) {
+            safeWarn('cineSettingsAppearance: Failed to revert temperature unit preference.', error);
+          }
+        } else if (settings.temperatureUnit) {
+          settings.temperatureUnit.value = baseline;
+        }
+      } else if (settings.temperatureUnit) {
+        settings.temperatureUnit.value = baseline;
+      }
+    }
+
+    function getShowAutoBackups() {
+      if (typeof preferences.getShowAutoBackups === 'function') {
+        return !!preferences.getShowAutoBackups();
+      }
+      if (typeof preferences.showAutoBackups === 'boolean') {
+        return preferences.showAutoBackups;
+      }
+      return false;
+    }
+
+    function setShowAutoBackups(value) {
+      if (typeof preferences.setShowAutoBackups === 'function') {
+        preferences.setShowAutoBackups(value);
+      } else {
+        preferences.showAutoBackups = !!value;
+      }
+    }
+
+    function applyShowAutoBackupsPreference(enabled, options) {
+      const config = options && typeof options === 'object' ? options : {};
+      const persist = config.persist !== false;
+      const forceRepopulate = Boolean(config.forceRepopulate);
+      const normalized = Boolean(enabled);
+      const previousValue = getShowAutoBackups();
+      const changed = normalized !== previousValue;
+
+      setShowAutoBackups(normalized);
+
+      if (normalized && typeof preferences.ensureAutoBackupsFromProjects === 'function') {
+        callOptional(preferences.ensureAutoBackupsFromProjects);
+      }
+
+      if (persist) {
+        const storage = getLocalStorage(context);
+        if (storage) {
+          try {
+            storage.setItem('showAutoBackups', normalized);
+          } catch (error) {
+            safeWarn('cineSettingsAppearance: Could not save auto backup visibility preference.', error);
+          }
+        }
+      }
+
+      if (!changed && !forceRepopulate) {
+        if (settings.showAutoBackups) {
+          settings.showAutoBackups.checked = normalized;
+        }
+        return;
+      }
+
+      const setupSelect = autoBackups.setupSelect || null;
+      const setupNameInput = autoBackups.setupNameInput || null;
+
+      const previousSelectValue = setupSelect ? setupSelect.value : '';
+      const previousNameValue = setupNameInput ? setupNameInput.value : '';
+
+      if (typeof autoBackups.populateSetupSelect === 'function') {
+        try {
+          autoBackups.populateSetupSelect();
+        } catch (error) {
+          safeWarn('cineSettingsAppearance: Failed to refresh setup selector.', error);
+        }
+      }
+
+      if (setupSelect) {
+        try {
+          if (normalized || !previousSelectValue || !previousSelectValue.startsWith('auto-backup-')) {
+            setupSelect.value = previousSelectValue;
+          } else {
+            setupSelect.value = '';
+          }
+        } catch (error) {
+          safeWarn('cineSettingsAppearance: Failed to update setup select after auto backup change.', error);
+        }
+      }
+
+      if (setupNameInput) {
+        try {
+          setupNameInput.value = previousNameValue;
+        } catch (error) {
+          safeWarn('cineSettingsAppearance: Unable to restore setup name after auto backup change.', error);
+        }
+      }
+
+      if (settings.showAutoBackups) {
+        settings.showAutoBackups.checked = normalized;
+      }
+    }
+
+    function rememberSettingsShowAutoBackupsBaseline() {
+      settingsInitialShowAutoBackups = Boolean(getShowAutoBackups());
+    }
+
+    function revertSettingsShowAutoBackupsIfNeeded() {
+      const baseline = Boolean(settingsInitialShowAutoBackups);
+      if (Boolean(getShowAutoBackups()) !== baseline) {
+        applyShowAutoBackupsPreference(baseline, { forceRepopulate: true });
+      } else if (settings.showAutoBackups) {
+        settings.showAutoBackups.checked = baseline;
+      }
+    }
+
+    function rememberSettingsMountVoltagesBaseline() {
+      if (typeof mountVoltages.rememberBaseline === 'function') {
+        try {
+          mountVoltages.rememberBaseline();
+        } catch (error) {
+          safeWarn('cineSettingsAppearance: rememberBaseline for mount voltages failed.', error);
+        }
+        return;
+      }
+      if (typeof mountVoltages.getPreferencesClone === 'function') {
+        try {
+          mountVoltages.settingsInitial = mountVoltages.getPreferencesClone();
+        } catch (error) {
+          safeWarn('cineSettingsAppearance: Failed to clone mount voltage preferences.', error);
+        }
+      }
+    }
+
+    function revertSettingsMountVoltagesIfNeeded() {
+      if (typeof mountVoltages.revertBaseline === 'function') {
+        try {
+          mountVoltages.revertBaseline();
+        } catch (error) {
+          safeWarn('cineSettingsAppearance: revertBaseline for mount voltages failed.', error);
+        }
+        return;
+      }
+
+      const cloneFn = mountVoltages.getPreferencesClone;
+      const applyFn = mountVoltages.applyPreferences;
+      const updateInputsFn = mountVoltages.updateInputsFromState;
+      const warnHelper = mountVoltages.warnMissingHelper || (() => {});
+      const supportedTypes = Array.isArray(mountVoltages.supportedTypes)
+        ? mountVoltages.supportedTypes
+        : [];
+      const defaults = mountVoltages.defaultVoltages && typeof mountVoltages.defaultVoltages === 'object'
+        ? mountVoltages.defaultVoltages
+        : {};
+
+      let baseline = mountVoltages.settingsInitial;
+      if (!baseline && typeof cloneFn === 'function') {
+        baseline = cloneFn();
+      }
+
+      let current = baseline;
+      if (typeof cloneFn === 'function') {
+        try {
+          current = cloneFn();
+        } catch (error) {
+          warnHelper('getMountVoltagePreferencesClone', error);
+        }
+      }
+
+      const changed = supportedTypes.some(type => {
+        const baselineEntry = baseline && baseline[type] ? baseline[type] : defaults[type];
+        const currentEntry = current && current[type] ? current[type] : defaults[type];
+        if (!baselineEntry || !currentEntry) {
+          return false;
+        }
+        return (
+          Number(baselineEntry.high) !== Number(currentEntry.high)
+          || Number(baselineEntry.low) !== Number(currentEntry.low)
+        );
+      });
+
+      if (changed) {
+        if (typeof applyFn === 'function') {
+          try {
+            applyFn(baseline, { persist: true, triggerUpdate: true });
+          } catch (error) {
+            warnHelper('applyMountVoltagePreferences', error);
+          }
+        }
+      } else if (typeof updateInputsFn === 'function') {
+        try {
+          updateInputsFn();
+        } catch (error) {
+          warnHelper('updateMountVoltageInputsFromState', error);
+        }
+      }
+    }
+
+    return freezeDeep({
+      updateThemeColor,
+      setToggleIcon,
+      applyDarkMode,
+      applyHighContrast,
+      applyReduceMotion,
+      applyRelaxedSpacing,
+      applyPinkMode,
+      persistPinkModePreference,
+      rememberSettingsPinkModeBaseline,
+      revertSettingsPinkModeIfNeeded,
+      rememberSettingsTemperatureUnitBaseline,
+      revertSettingsTemperatureUnitIfNeeded,
+      applyShowAutoBackupsPreference,
+      rememberSettingsShowAutoBackupsBaseline,
+      revertSettingsShowAutoBackupsIfNeeded,
+      rememberSettingsMountVoltagesBaseline,
+      revertSettingsMountVoltagesIfNeeded,
+      handlePinkModeIconPress,
+      triggerPinkModeIconAnimation,
+      startPinkModeIconRotation,
+      stopPinkModeIconRotation,
+      applyPinkModeIcon,
+      startPinkModeAnimatedIconRotation,
+      stopPinkModeAnimatedIconRotation,
+      isPinkModeActive,
+      setAccentColor,
+      setPrevAccentColor,
+      getAccentColor,
+      getPrevAccentColor,
+      setShowAutoBackups,
+      getShowAutoBackups,
+    });
+  }
+
+  function initialize(context) {
+    return createAppearanceManager(context || {});
+  }
+
+  const api = freezeDeep({
+    initialize,
+  });
+
+  informModuleGlobals('cineSettingsAppearance', api);
+
+  registerOrQueueModule(
+    'cineSettingsAppearance',
+    api,
+    {
+      category: 'ui',
+      description: 'Appearance and settings helpers for the application UI.',
+      replace: true,
+      connections: ['cineModuleGlobals', 'cineModuleEnvironment', 'cineUi'],
+    },
+    (error) => {
+      safeWarn('cineSettingsAppearance: Unable to register module.', error);
+    },
+  );
+
+  exposeGlobal('cineSettingsAppearance', api, {
+    configurable: true,
+    enumerable: false,
+    writable: false,
+  });
+
+  if (typeof module !== 'undefined' && module && module.exports) {
+    module.exports = api;
+  }
+})();
+


### PR DESCRIPTION
## Summary
- introduce a cineSettingsAppearance module that centralizes the dark mode, pink mode, accessibility, and backup preference helpers with environment-aware fallbacks
- wire app-session settings handling through the new module by registering DOM context, delegating persistence helpers, and removing inline duplication while keeping existing event listeners intact

## Testing
- `npm test` *(fails: repository currently has numerous pre-existing lint errors; see command output for details)*

------
https://chatgpt.com/codex/tasks/task_e_68e36004e6608320a9dea7ed3f1d56bb