### PR TITLE
Ensure settings appearance module loads in modern bundle

### DIFF
--- a/src/scripts/loader.js
+++ b/src/scripts/loader.js
@@ -1148,6 +1148,7 @@ CRITICAL_GLOBAL_DEFINITIONS.push({
     'src/scripts/modules/globals.js',
     'src/scripts/modules/offline.js',
     'src/scripts/modules/core-shared.js',
+    'src/scripts/modules/settings-and-appearance.js',
     'src/scripts/modules/features/auto-gear-rules.js',
     'src/scripts/modules/features/backup.js',
     'src/scripts/modules/features/print-workflow.js',


### PR DESCRIPTION
## Summary
- include the settings and appearance module in the modern loader bundle so the cineSettingsAppearance runtime registers before session setup

## Testing
- npm run lint *(fails: pre-existing eslint errors in untouched files)*

------
https://chatgpt.com/codex/tasks/task_e_68e3aa2011808320b75eb332fa629c35