### PR TITLE
Fix connection diagram module loading

### DIFF
--- a/src/scripts/loader.js
+++ b/src/scripts/loader.js
@@ -1150,6 +1150,7 @@ CRITICAL_GLOBAL_DEFINITIONS.push({
     'src/scripts/modules/core-shared.js',
     'src/scripts/modules/settings-and-appearance.js',
     'src/scripts/modules/features/auto-gear-rules.js',
+    'src/scripts/modules/features/connection-diagram.js',
     'src/scripts/modules/features/backup.js',
     'src/scripts/modules/features/print-workflow.js',
     'src/scripts/modules/ui.js',

--- a/src/scripts/script.js
+++ b/src/scripts/script.js
@@ -24,6 +24,7 @@ if (typeof require === 'function' && typeof module !== 'undefined' && module && 
     'modules/features/help.js',
     'modules/features/feature-search.js',
     'modules/features/auto-gear-rules.js',
+    'modules/features/connection-diagram.js',
     'modules/features/backup.js',
     'modules/help.js',
     'modules/ui.js',


### PR DESCRIPTION
## Summary
- ensure the modern bundle loader pulls in the connection diagram feature module
- include the connection diagram module in the Node aggregation so tests and tooling use the same runtime pieces

## Testing
- npx eslint src/scripts/loader.js src/scripts/script.js

------
https://chatgpt.com/codex/tasks/task_e_68e3ab86e8588320936ef2295e55c03b