### PR TITLE
Implement delta-aware auto backups

### DIFF
--- a/src/scripts/app-core-new-1.js
+++ b/src/scripts/app-core-new-1.js
@@ -5459,6 +5459,34 @@ function cloneProjectEntryForSetup(projectEntry) {
     }
   }
 
+  const metadata = projectEntry && typeof projectEntry === 'object'
+    ? projectEntry.__cineAutoBackupMetadata
+    : null;
+  if (metadata && typeof metadata === 'object') {
+    try {
+      Object.defineProperty(snapshot, '__cineAutoBackupMetadata', {
+        configurable: true,
+        enumerable: false,
+        writable: true,
+        value: {
+          version: typeof metadata.version === 'number' ? metadata.version : 1,
+          snapshotType: metadata.snapshotType === 'delta' ? 'delta' : 'full',
+          base: typeof metadata.base === 'string' ? metadata.base : null,
+          sequence: typeof metadata.sequence === 'number' ? metadata.sequence : 0,
+          createdAt: typeof metadata.createdAt === 'string' ? metadata.createdAt : null,
+          changedKeys: Array.isArray(metadata.changedKeys) ? metadata.changedKeys.slice() : [],
+          removedKeys: Array.isArray(metadata.removedKeys) ? metadata.removedKeys.slice() : [],
+        },
+      });
+    } catch (error) {
+      try {
+        snapshot.__cineAutoBackupMetadata = metadata;
+      } catch (assignmentError) {
+        void assignmentError;
+      }
+    }
+  }
+
   return snapshot;
 }
 


### PR DESCRIPTION
## Summary
- add metadata-aware serialization helpers in storage to store auto backups as compact snapshot/delta records
- update auto-backup workflow to attach snapshot metadata and alternate between full snapshots and incremental deltas
- preserve snapshot metadata when cloning auto backups and refresh unit tests for the new storage format

## Testing
- npm run test:jest *(fails: shared project gear list dom suite requires runtime updates after new snapshot format)*

------
https://chatgpt.com/codex/tasks/task_e_68e3a91f8ee88320a836575fc8cf2da7