### PR TITLE
Handle reload fallback when offline module fails

### DIFF
--- a/src/scripts/app-session.js
+++ b/src/scripts/app-session.js
@@ -7957,12 +7957,16 @@ async function clearCachesAndReload() {
     || null;
 
   if (offlineModule && typeof offlineModule.reloadApp === 'function') {
-    await offlineModule.reloadApp({
-      window,
-      navigator: typeof navigator !== 'undefined' ? navigator : undefined,
-      caches: typeof caches !== 'undefined' ? caches : undefined,
-    });
-    return;
+    try {
+      await offlineModule.reloadApp({
+        window,
+        navigator: typeof navigator !== 'undefined' ? navigator : undefined,
+        caches: typeof caches !== 'undefined' ? caches : undefined,
+      });
+      return;
+    } catch (offlineReloadError) {
+      console.warn('Offline module reload failed, falling back to manual refresh', offlineReloadError);
+    }
   }
 
   let uiCacheCleared = false;


### PR DESCRIPTION
## Summary
- ensure the hard refresh button falls back to the manual cache clearing path when the offline module reload throws

## Testing
- npm test -- --runInBand *(fails: repository currently has pre-existing lint errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68e3ac268afc83209f5bbf39a99cef94