### PR TITLE
Guard connection diagram autosave initialization

### DIFF
--- a/src/scripts/app-core-new-2.js
+++ b/src/scripts/app-core-new-2.js
@@ -12661,7 +12661,10 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
     if (connectionDiagramModule && typeof connectionDiagramModule.createConnectionDiagram === 'function') {
       try {
         const scheduleProjectAutoSaveFn =
-          typeof scheduleProjectAutoSave === 'function' ? scheduleProjectAutoSave : null;
+          typeof globalThis !== 'undefined' &&
+          typeof globalThis.scheduleProjectAutoSave === 'function'
+            ? globalThis.scheduleProjectAutoSave
+            : null;
 
         const connectionDiagram = connectionDiagramModule.createConnectionDiagram({
           document,


### PR DESCRIPTION
## Summary
- guard the connection diagram runtime against missing global autosave hooks during initialization so the module can load without runtime errors

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e3af4592b0832087bf3c93067dd02b