### PR TITLE
Guard cine freeze wrapping on sealed module bases

### DIFF
--- a/legacy/scripts/app-core-new-2.js
+++ b/legacy/scripts/app-core-new-2.js
@@ -24,6 +24,51 @@ function AsyncFromSyncIterator(r) { function AsyncFromSyncIteratorContinuation(r
 var CORE_TEMPERATURE_QUEUE_KEY = '__cinePendingTemperatureNote';
 var CORE_TEMPERATURE_RENDER_NAME = 'renderTemperatureNote';
 var CORE_RUNTIME_CANDIDATE_SCOPES = [typeof CORE_GLOBAL_SCOPE !== 'undefined' && CORE_GLOBAL_SCOPE && (typeof CORE_GLOBAL_SCOPE === "undefined" ? "undefined" : _typeof(CORE_GLOBAL_SCOPE)) === 'object' ? CORE_GLOBAL_SCOPE : null, typeof globalThis !== 'undefined' && (typeof globalThis === "undefined" ? "undefined" : _typeof(globalThis)) === 'object' ? globalThis : null, typeof window !== 'undefined' && (typeof window === "undefined" ? "undefined" : _typeof(window)) === 'object' ? window : null, typeof self !== 'undefined' && (typeof self === "undefined" ? "undefined" : _typeof(self)) === 'object' ? self : null, typeof global !== 'undefined' && (typeof global === "undefined" ? "undefined" : _typeof(global)) === 'object' ? global : null].filter(Boolean);
+var CORE_SAFE_FREEZE_REGISTRY = typeof WeakSet === 'function' ? new WeakSet() : [];
+function coreSafeFreezeRegistryHas(value) {
+  if (!value || !CORE_SAFE_FREEZE_REGISTRY) {
+    return false;
+  }
+
+  if (typeof CORE_SAFE_FREEZE_REGISTRY.has === 'function') {
+    try {
+      return CORE_SAFE_FREEZE_REGISTRY.has(value);
+    } catch (registryHasError) {
+      void registryHasError;
+      return false;
+    }
+  }
+
+  for (var index = 0; index < CORE_SAFE_FREEZE_REGISTRY.length; index += 1) {
+    if (CORE_SAFE_FREEZE_REGISTRY[index] === value) {
+      return true;
+    }
+  }
+
+  return false;
+}
+function coreSafeFreezeRegistryAdd(value) {
+  if (!value || !CORE_SAFE_FREEZE_REGISTRY) {
+    return;
+  }
+
+  if (typeof CORE_SAFE_FREEZE_REGISTRY.add === 'function') {
+    try {
+      CORE_SAFE_FREEZE_REGISTRY.add(value);
+    } catch (registryAddError) {
+      void registryAddError;
+    }
+    return;
+  }
+
+  for (var index = 0; index < CORE_SAFE_FREEZE_REGISTRY.length; index += 1) {
+    if (CORE_SAFE_FREEZE_REGISTRY[index] === value) {
+      return;
+    }
+  }
+
+  CORE_SAFE_FREEZE_REGISTRY.push(value);
+}
 function createLocalRuntimeState(candidateScopes) {
   var scopes = [];
   var seenScopes = typeof Set === 'function' ? new Set() : null;
@@ -17002,9 +17047,12 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
         return;
       }
 
-      if (scope.cineModuleBase && typeof scope.cineModuleBase.freezeDeep === 'function' && !scope.cineModuleBase.__cineSafeFreezeWrapped) {
-        var originalFreezeDeep = scope.cineModuleBase.freezeDeep;
-        scope.cineModuleBase.freezeDeep = function safeFreezeDeep(value, seen) {
+      var moduleBase = scope.cineModuleBase;
+      var alreadyWrapped = !!(moduleBase && moduleBase.__cineSafeFreezeWrapped) || coreSafeFreezeRegistryHas(moduleBase);
+
+      if (moduleBase && typeof moduleBase.freezeDeep === 'function' && !alreadyWrapped) {
+        var originalFreezeDeep = moduleBase.freezeDeep;
+        moduleBase.freezeDeep = function safeFreezeDeep(value, seen) {
           try {
             return originalFreezeDeep(value, seen);
           } catch (freezeError) {
@@ -17018,12 +17066,50 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
             return value;
           }
         };
-        Object.defineProperty(scope.cineModuleBase, '__cineSafeFreezeWrapped', {
-          configurable: false,
-          enumerable: false,
-          writable: false,
-          value: true
-        });
+
+        coreSafeFreezeRegistryAdd(moduleBase);
+
+        var marked = false;
+
+        try {
+          moduleBase.__cineSafeFreezeWrapped = true;
+          if (moduleBase.__cineSafeFreezeWrapped) {
+            marked = true;
+          }
+        } catch (assignError) {
+          void assignError;
+        }
+
+        if (!marked && typeof Object.defineProperty === 'function') {
+          var canDefine = true;
+
+          if (typeof Object.isExtensible === 'function') {
+            try {
+              canDefine = Object.isExtensible(moduleBase);
+            } catch (isExtensibleError) {
+              void isExtensibleError;
+              canDefine = true;
+            }
+          }
+
+          if (canDefine || Object.prototype.hasOwnProperty.call(moduleBase, '__cineSafeFreezeWrapped')) {
+            try {
+              Object.defineProperty(moduleBase, '__cineSafeFreezeWrapped', {
+                configurable: false,
+                enumerable: false,
+                writable: false,
+                value: true
+              });
+              marked = true;
+            } catch (defineError) {
+              void defineError;
+            }
+          }
+        }
+
+        if (!marked && !coreSafeFreezeRegistryHas(moduleBase)) {
+          coreSafeFreezeRegistryAdd(moduleBase);
+        }
       }
 
       var MODULE_EXPORTS = {


### PR DESCRIPTION
## Summary
- add a registry that tracks cineModuleBase instances which already have the safe freeze wrapper installed
- skip defining the __cineSafeFreezeWrapped flag on sealed module bases while still wrapping freezeDeep safely in both modern and legacy bundles

## Testing
- npm run test:unit

------
https://chatgpt.com/codex/tasks/task_e_68e3cec337e883209fda9951926f3a21