### PR TITLE
Avoid marking cine module base when not extensible

### DIFF
--- a/legacy/scripts/app-core-new-2.js
+++ b/legacy/scripts/app-core-new-2.js
@@ -17070,40 +17070,43 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
         coreSafeFreezeRegistryAdd(moduleBase);
 
         var marked = false;
+        var markerKey = '__cineSafeFreezeWrapped';
+        var hasExistingMarker = Object.prototype.hasOwnProperty.call(moduleBase, markerKey);
+        var canAttachMarker = true;
 
-        try {
-          moduleBase.__cineSafeFreezeWrapped = true;
-          if (moduleBase.__cineSafeFreezeWrapped) {
-            marked = true;
+        if (!hasExistingMarker && typeof Object.isExtensible === 'function') {
+          try {
+            canAttachMarker = Object.isExtensible(moduleBase);
+          } catch (isExtensibleError) {
+            void isExtensibleError;
+            canAttachMarker = true;
           }
-        } catch (assignError) {
-          void assignError;
         }
 
-        if (!marked && typeof Object.defineProperty === 'function') {
-          var canDefine = true;
+        var shouldAttemptDirectMark = hasExistingMarker || canAttachMarker;
 
-          if (typeof Object.isExtensible === 'function') {
-            try {
-              canDefine = Object.isExtensible(moduleBase);
-            } catch (isExtensibleError) {
-              void isExtensibleError;
-              canDefine = true;
-            }
-          }
-
-          if (canDefine || Object.prototype.hasOwnProperty.call(moduleBase, '__cineSafeFreezeWrapped')) {
-            try {
-              Object.defineProperty(moduleBase, '__cineSafeFreezeWrapped', {
-                configurable: false,
-                enumerable: false,
-                writable: false,
-                value: true
-              });
+        if (shouldAttemptDirectMark) {
+          try {
+            moduleBase[markerKey] = true;
+            if (moduleBase[markerKey]) {
               marked = true;
-            } catch (defineError) {
-              void defineError;
             }
+          } catch (assignError) {
+            void assignError;
+          }
+        }
+
+        if (!marked && shouldAttemptDirectMark && typeof Object.defineProperty === 'function') {
+          try {
+            Object.defineProperty(moduleBase, markerKey, {
+              configurable: false,
+              enumerable: false,
+              writable: false,
+              value: true
+            });
+            marked = true;
+          } catch (defineError) {
+            void defineError;
           }
         }
 


### PR DESCRIPTION
## Summary
- guard the cine module base marker so it is only applied when the base object can accept it
- mirror the defensive marker logic in the legacy bundle to keep runtime behaviour aligned

## Testing
- npm test -- --watch=false *(fails: existing lint errors for project persistence helpers)*

------
https://chatgpt.com/codex/tasks/task_e_68e3d320a13483209601079e66521d0e