### PR TITLE
Guard cineModuleBase freeze marker on sealed objects

### DIFF
--- a/legacy/scripts/app-core-new-2.js
+++ b/legacy/scripts/app-core-new-2.js
@@ -17080,6 +17080,21 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
           void assignError;
         }
 
+        var existingDescriptor = null;
+
+        if (typeof Object.getOwnPropertyDescriptor === 'function') {
+          try {
+            existingDescriptor = Object.getOwnPropertyDescriptor(moduleBase, '__cineSafeFreezeWrapped');
+          } catch (descriptorError) {
+            void descriptorError;
+            existingDescriptor = null;
+          }
+        }
+
+        if (existingDescriptor && existingDescriptor.value === true) {
+          marked = true;
+        }
+
         if (!marked && typeof Object.defineProperty === 'function') {
           var canDefine = true;
 
@@ -17092,7 +17107,9 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
             }
           }
 
-          if (canDefine || Object.prototype.hasOwnProperty.call(moduleBase, '__cineSafeFreezeWrapped')) {
+          var canRedefineExisting = existingDescriptor && (existingDescriptor.configurable || existingDescriptor.writable);
+
+          if (canDefine && !existingDescriptor || canRedefineExisting) {
             try {
               Object.defineProperty(moduleBase, '__cineSafeFreezeWrapped', {
                 configurable: false,

--- a/src/scripts/app-core-new-2.js
+++ b/src/scripts/app-core-new-2.js
@@ -16585,6 +16585,24 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
           void assignError;
         }
 
+        let existingDescriptor = null;
+
+        if (typeof Object.getOwnPropertyDescriptor === 'function') {
+          try {
+            existingDescriptor = Object.getOwnPropertyDescriptor(
+              moduleBase,
+              '__cineSafeFreezeWrapped'
+            );
+          } catch (descriptorError) {
+            void descriptorError;
+            existingDescriptor = null;
+          }
+        }
+
+        if (existingDescriptor && existingDescriptor.value === true) {
+          marked = true;
+        }
+
         if (!marked && typeof Object.defineProperty === 'function') {
           let canDefine = true;
 
@@ -16597,7 +16615,10 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
             }
           }
 
-          if (canDefine || Object.prototype.hasOwnProperty.call(moduleBase, '__cineSafeFreezeWrapped')) {
+          const canRedefineExisting =
+            existingDescriptor && (existingDescriptor.configurable || existingDescriptor.writable);
+
+          if ((canDefine && !existingDescriptor) || canRedefineExisting) {
             try {
               Object.defineProperty(moduleBase, '__cineSafeFreezeWrapped', {
                 configurable: false,


### PR DESCRIPTION
## Summary
- avoid redefining the cineModuleBase freeze marker when the target object is sealed
- detect existing __cineSafeFreezeWrapped descriptors so the installer gracefully skips immutable markers

## Testing
- npm test -- --runTestsByPath tests/unit/coreModules.test.js *(fails: lint complains about missing project persistence globals)*

------
https://chatgpt.com/codex/tasks/task_e_68e3d332648083208f80722078b62220