### PR TITLE
Guard auto gear seeding until module is available

### DIFF
--- a/legacy/scripts/app-core-new-1.js
+++ b/legacy/scripts/app-core-new-1.js
@@ -8229,7 +8229,13 @@ function normalizeAutoGearConditionLogic(value) {
     if (autoGearVideoDistributionSelect) {
       refreshAutoGearVideoDistributionOptions(autoGearEditorDraft === null || autoGearEditorDraft === void 0 ? void 0 : autoGearEditorDraft.videoDistribution);
     }
-    seedAutoGearRulesFromCurrentProject();
+    callCoreFunctionIfAvailable(
+      'seedAutoGearRulesFromCurrentProject',
+      [],
+      {
+        defer: true
+      }
+    );
     callCoreFunctionIfAvailable('renderAutoGearRulesList', [], {
       defer: true
     });

--- a/src/scripts/app-core-new-1.js
+++ b/src/scripts/app-core-new-1.js
@@ -9372,7 +9372,11 @@ function setLanguage(lang) {
   if (autoGearVideoDistributionSelect) {
     refreshAutoGearVideoDistributionOptions(autoGearEditorDraft?.videoDistribution);
   }
-  seedAutoGearRulesFromCurrentProject();
+  callCoreFunctionIfAvailable(
+    'seedAutoGearRulesFromCurrentProject',
+    [],
+    { defer: true }
+  );
   callCoreFunctionIfAvailable('renderAutoGearRulesList', [], { defer: true });
   callCoreFunctionIfAvailable('renderAutoGearDraftLists', [], { defer: true });
   callCoreFunctionIfAvailable('updateAutoGearCatalogOptions', [], { defer: true });


### PR DESCRIPTION
## Summary
- defer auto gear rule seeding until the module is registered when applying translations
- mirror the guarded invocation in the legacy bundle to keep both builds aligned

## Testing
- npm run lint *(fails: reports missing persistence guard helpers already flagged in main branch)*

------
https://chatgpt.com/codex/tasks/task_e_68e3d67602f083208f7f6921771693e1