### PR TITLE
Ensure hard reload button falls back when offline reload fails

### DIFF
--- a/src/scripts/app-events.js
+++ b/src/scripts/app-events.js
@@ -5,7 +5,8 @@
           normalizeSetupName, createProjectInfoSnapshotForStorage,
           applyDynamicFieldValues, applyBatteryPlateSelectionFromBattery,
           getPowerSelectionSnapshot, applyStoredPowerSelection,
-          callCoreFunctionIfAvailable */
+          callCoreFunctionIfAvailable, suspendProjectPersistence,
+          resumeProjectPersistence */
 
 const eventsLogger = (function resolveEventsLogger() {
   const scopes = [];

--- a/src/scripts/app-session.js
+++ b/src/scripts/app-session.js
@@ -30,6 +30,7 @@
           helpResultsSummary, helpResultsAssist */
 /* eslint-enable no-redeclare */
 /* global enqueueCoreBootTask */
+/* global suspendProjectPersistence, resumeProjectPersistence, isProjectPersistenceSuspended */
 const FALLBACK_STRONG_SEARCH_MATCH_TYPES = new Set(['exactKey', 'keyPrefix', 'keySubset']);
 if (typeof globalThis !== 'undefined' && typeof globalThis.STRONG_SEARCH_MATCH_TYPES === 'undefined') {
   globalThis.STRONG_SEARCH_MATCH_TYPES = FALLBACK_STRONG_SEARCH_MATCH_TYPES;
@@ -8404,12 +8405,21 @@ async function clearCachesAndReload() {
 
   if (offlineModule && typeof offlineModule.reloadApp === 'function') {
     try {
-      await offlineModule.reloadApp({
+      const result = await offlineModule.reloadApp({
         window,
         navigator: typeof navigator !== 'undefined' ? navigator : undefined,
         caches: typeof caches !== 'undefined' ? caches : undefined,
       });
-      return;
+
+      const reloadHandled =
+        result === true ||
+        (result &&
+          typeof result === 'object' &&
+          (result.reloadTriggered === true || result.navigationTriggered === true));
+
+      if (reloadHandled) {
+        return;
+      }
     } catch (offlineReloadError) {
       console.warn('Offline module reload failed, falling back to manual refresh', offlineReloadError);
     }


### PR DESCRIPTION
## Summary
- ensure the offline reload helper reports success before skipping the manual fallback
- declare persistence helper globals used in the event handlers so linting recognizes them

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e3de679d2883209ddaf264895fb335