### PR TITLE
Refactor module architecture instantiation

### DIFF
--- a/docs/architecture/module-registry.md
+++ b/docs/architecture/module-registry.md
@@ -68,6 +68,10 @@ worker used during offline rehearsals) without mutating the main global scope.
   `globalThis.cineModuleArchitectureFactory` and piggybacks on the offline
   asset list. No network access is required, and the existing service worker
   continues to ship the script alongside local Uicons, fonts and help content.
+- **Unified instantiation.** Both the modern and legacy bundles now share the
+  same `createArchitectureInstance()` scaffolding so the fallback queue,
+  immutability and warning semantics stay in lockstep whenever a feature spins
+  up a scoped architecture.
 
 ## Blueprint helper
 


### PR DESCRIPTION
## Summary
- share a reusable architecture instantiation helper so scope detection, queue fallbacks, deep freeze and warnings stay aligned
- apply the same core instantiation flow to the legacy architecture bundle to maintain parity
- document the unified instantiation approach in the module registry guide

## Testing
- `npm test -- --runTestsByPath tests/unit/moduleRegistry.test.js` *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e3eb652ce88320b4e3669614a28056