### PR TITLE
Improve storage fallback handling

### DIFF
--- a/src/scripts/app-session.js
+++ b/src/scripts/app-session.js
@@ -26,12 +26,8 @@
           normalizeBatteryPlateValue, applyBatteryPlateSelectionFromBattery,
           getPowerSelectionSnapshot, applyStoredPowerSelection,
           settingsReduceMotion, settingsRelaxedSpacing, callCoreFunctionIfAvailable,
-          suspendProjectPersistence, resumeProjectPersistence,
-          isProjectPersistenceSuspended,
           recordFeatureSearchUsage, extractFeatureSearchFilter,
-          helpResultsSummary, helpResultsAssist,
-          suspendProjectPersistence, resumeProjectPersistence,
-          isProjectPersistenceSuspended */
+          helpResultsSummary, helpResultsAssist */
 /* eslint-enable no-redeclare */
 /* global enqueueCoreBootTask */
 /* global suspendProjectPersistence, resumeProjectPersistence, isProjectPersistenceSuspended */

--- a/src/scripts/storage.js
+++ b/src/scripts/storage.js
@@ -2034,6 +2034,7 @@ function normalizeLegacyMigrationBackupCreatedAt(value, fallbackIso) {
       try {
         return { value: new Date(numeric).toISOString(), changed: true };
       } catch (error) {
+        void error;
         return { value: fallback || new Date().toISOString(), changed: true };
       }
     }
@@ -2043,6 +2044,7 @@ function normalizeLegacyMigrationBackupCreatedAt(value, fallbackIso) {
         const iso = new Date(timestamp).toISOString();
         return { value: iso, changed: iso !== trimmed };
       } catch (error) {
+        void error;
         return { value: fallback || new Date().toISOString(), changed: true };
       }
     }
@@ -2053,6 +2055,7 @@ function normalizeLegacyMigrationBackupCreatedAt(value, fallbackIso) {
     try {
       return { value: new Date(value).toISOString(), changed: true };
     } catch (error) {
+      void error;
       return { value: fallback || new Date().toISOString(), changed: true };
     }
   }
@@ -2063,6 +2066,7 @@ function normalizeLegacyMigrationBackupCreatedAt(value, fallbackIso) {
       try {
         return { value: value.toISOString(), changed: true };
       } catch (error) {
+        void error;
         return { value: fallback || new Date().toISOString(), changed: true };
       }
     }
@@ -2089,6 +2093,7 @@ function normalizeLegacyMigrationBackupValue(rawValue, fallbackIso) {
   try {
     parsed = JSON.parse(rawValue);
   } catch (parseError) {
+    void parseError;
     return trySerializeMigrationBackupValue({ createdAt: fallback, data: rawValue });
   }
 


### PR DESCRIPTION
## Summary
- remove duplicate global annotations that caused eslint no-redeclare failures around the session bootstrap helpers
- clarify intentional error swallowing in legacy backup normalization by explicitly handling caught errors so linting passes while keeping robust fallbacks

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e3eb70eebc83208f23a59ed322b4d0