### PR TITLE
Fix auto-backup deduplication guard

### DIFF
--- a/src/scripts/app-session.js
+++ b/src/scripts/app-session.js
@@ -27,7 +27,9 @@
           getPowerSelectionSnapshot, applyStoredPowerSelection,
           settingsReduceMotion, settingsRelaxedSpacing, callCoreFunctionIfAvailable,
           recordFeatureSearchUsage, extractFeatureSearchFilter,
-          helpResultsSummary, helpResultsAssist */
+          helpResultsSummary, helpResultsAssist,
+          isProjectPersistenceSuspended, suspendProjectPersistence,
+          resumeProjectPersistence */
 /* eslint-enable no-redeclare */
 /* global enqueueCoreBootTask */
 const FALLBACK_STRONG_SEARCH_MATCH_TYPES = new Set(['exactKey', 'keyPrefix', 'keySubset']);

--- a/src/scripts/storage.js
+++ b/src/scripts/storage.js
@@ -3458,14 +3458,14 @@ function enforceAutoBackupLimits(container) {
   const removed = [];
 
   const autoBackups = collectAutoBackupEntries(container, STORAGE_AUTO_BACKUP_NAME_PREFIX);
+  removed.push(...removeDuplicateAutoBackupEntries(container, autoBackups));
   if (autoBackups.length > MAX_AUTO_BACKUPS) {
-    removed.push(...removeDuplicateAutoBackupEntries(container, autoBackups));
     pruneAutoBackupEntries(container, autoBackups, MAX_AUTO_BACKUPS, removed);
   }
 
   const deletionBackups = collectAutoBackupEntries(container, STORAGE_AUTO_BACKUP_DELETION_PREFIX);
+  removed.push(...removeDuplicateAutoBackupEntries(container, deletionBackups));
   if (deletionBackups.length > MAX_DELETION_BACKUPS) {
-    removed.push(...removeDuplicateAutoBackupEntries(container, deletionBackups));
     pruneAutoBackupEntries(container, deletionBackups, MAX_DELETION_BACKUPS, removed);
   }
 


### PR DESCRIPTION
## Summary
- declare project persistence helpers in the session script so linting recognizes the global implementations
- ensure automatic backup deduplication runs even when the retention limit has not been exceeded, preserving only the newest copies while respecting user data

## Testing
- npm test -- --watch=false *(fails: existing module freezing issues in the test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e42ed13b448320beee66076ad72f5c