### PR TITLE
Declare persistence guard globals

### DIFF
--- a/src/scripts/app-session.js
+++ b/src/scripts/app-session.js
@@ -26,6 +26,8 @@
           normalizeBatteryPlateValue, applyBatteryPlateSelectionFromBattery,
           getPowerSelectionSnapshot, applyStoredPowerSelection,
           settingsReduceMotion, settingsRelaxedSpacing, callCoreFunctionIfAvailable,
+          suspendProjectPersistence, resumeProjectPersistence,
+          isProjectPersistenceSuspended,
           recordFeatureSearchUsage, extractFeatureSearchFilter,
           helpResultsSummary, helpResultsAssist */
 /* eslint-enable no-redeclare */


### PR DESCRIPTION
## Summary
- expose the persistence guard helpers in the app-session global declarations so eslint recognises the existing guard functions

## Testing
- npm run lint
- npm test *(fails: storage auto-backup expectations in existing suite)*

------
https://chatgpt.com/codex/tasks/task_e_68e42f1214c08320b5cd0fbe9e387323