### PR TITLE
Optimize storage deduplication

### DIFF
--- a/src/scripts/storage.js
+++ b/src/scripts/storage.js
@@ -3709,16 +3709,23 @@ function getWindowStorage(name) {
 }
 
 function collectUniqueStorages(storages) {
+  if (!Array.isArray(storages) || storages.length === 0) {
+    return [];
+  }
+
   const unique = [];
+  const seen = new Set();
+
   for (let i = 0; i < storages.length; i += 1) {
     const storage = storages[i];
-    if (!storage || typeof storage.getItem !== 'function') {
+    if (!storage || typeof storage.getItem !== 'function' || seen.has(storage)) {
       continue;
     }
-    if (!unique.includes(storage)) {
-      unique.push(storage);
-    }
+
+    seen.add(storage);
+    unique.push(storage);
   }
+
   return unique;
 }
 


### PR DESCRIPTION
## Summary
- use a Set in `collectUniqueStorages` to avoid repeatedly scanning previously seen storage handles

## Testing
- npm run test:unit *(fails: auto gear backup retention expectations rely on a 120 entry limit while the runtime returns 150+)*

------
https://chatgpt.com/codex/tasks/task_e_68e435d408e0832091f389748b5a965e