### PR TITLE
Enhance logging retention diagnostics

### DIFF
--- a/docs/offline-readiness.md
+++ b/docs/offline-readiness.md
@@ -180,6 +180,10 @@ exported artifacts if it does not already exist) with:
 - **Share and restore results.** Record whether manual saves, autosaves, shareable bundles,
   imports and automatic rollbacks behaved as expected. Document anything that required a
   retry so auditors know what to watch during the next drill.
+- **Logger retention counters.** Capture the snapshot from `cineLogging.getStats()` so the
+  audit trail shows how many diagnostics entries were recorded, when retention trimmed the
+  history and how many events were preserved. Keeping this metadata with the exported
+  backups proves that no warnings disappeared silently while the limit rotated entries.
 - **Cache status.** Confirm the help dialog, legal pages and other locally stored Uicons or
   helper scripts rendered correctly while offline. A quick note here proves the service
   worker cache stayed intact.

--- a/tests/unit/loggingModule.test.js
+++ b/tests/unit/loggingModule.test.js
@@ -1,0 +1,88 @@
+jest.mock('../../src/scripts/storage.js', () => ({}));
+jest.mock('../../src/scripts/app-session.js', () => ({}));
+jest.mock('../../src/scripts/app-setups.js', () => ({}));
+
+const { setupModuleHarness } = require('../helpers/moduleHarness');
+
+describe('cineLogging module stats', () => {
+  let harness;
+  let logging;
+  let sessionStore;
+
+  beforeEach(() => {
+    harness = setupModuleHarness();
+
+    sessionStore = new Map();
+    global.sessionStorage = {
+      getItem: jest.fn((key) => (sessionStore.has(key) ? sessionStore.get(key) : null)),
+      setItem: jest.fn((key, value) => {
+        sessionStore.set(key, String(value));
+      }),
+      removeItem: jest.fn((key) => {
+        sessionStore.delete(key);
+      }),
+    };
+
+    logging = require('../../src/scripts/modules/logging.js');
+    logging.clearHistory({ persist: false });
+    harness.moduleGlobals.safeWarn.mockClear();
+  });
+
+  afterEach(() => {
+    delete global.sessionStorage;
+    if (harness) {
+      harness.teardown();
+      harness = null;
+    }
+  });
+
+  it('records history trims and exposes retention stats', () => {
+    const baselineStats = logging.getStats();
+    const baselineRuntime = baselineStats.runtimeEntries;
+    const baselineDropped = baselineStats.droppedEntries;
+
+    expect(baselineStats.retainedEntries).toBe(0);
+
+    logging.setConfig({ historyLimit: 2, persistSession: false }, { persist: false });
+
+    logging.info('alpha');
+    logging.info('beta');
+    logging.info('gamma');
+
+    const stats = logging.getStats();
+
+    expect(stats.runtimeEntries).toBe(baselineRuntime + 3);
+    expect(stats.retainedEntries).toBe(2);
+    expect(stats.droppedEntries).toBe(baselineDropped + 1);
+    expect(stats.historyLimit).toBe(2);
+    expect(stats.lastDrop).toEqual(
+      expect.objectContaining({
+        count: 1,
+        limit: 2,
+        source: 'append',
+      }),
+    );
+
+    if (stats.lastDrop.timestamp !== null) {
+      expect(typeof stats.lastDrop.timestamp).toBe('number');
+    }
+    if (stats.lastDrop.isoTimestamp !== null) {
+      expect(typeof stats.lastDrop.isoTimestamp).toBe('string');
+    }
+
+    const trimWarnings = harness.moduleGlobals.safeWarn.mock.calls.filter(
+      ([message]) => message === 'cineLogging: history trimmed to enforce retention limit',
+    );
+
+    expect(trimWarnings.length).toBeGreaterThanOrEqual(1);
+    const lastWarning = trimWarnings[trimWarnings.length - 1];
+    expect(lastWarning[1]).toEqual(
+      expect.objectContaining({
+        limit: 2,
+        removed: 1,
+        source: 'append',
+      }),
+    );
+  });
+});
+


### PR DESCRIPTION
## Summary
- extend cineLogging with retention metrics, including runtime entry counts, drop tracking and a new `getStats` API that also surfaces in the initialization log
- issue a guarded warning when history pruning occurs and expose last-drop metadata so diagnostics can prove whether entries were trimmed
- document the new stats snapshot in the offline readiness guide and cover the behaviour with a dedicated unit test

## Testing
- npm run test:unit *(fails: autoGearBackupRetention expectations for max retention — existing suite failure)*

------
https://chatgpt.com/codex/tasks/task_e_68e4ba60b87c832089f2c87c6bd28b0f