### PR TITLE
Fix auto gear backup toggle persistence

### DIFF
--- a/legacy/scripts/app-core-new-2.js
+++ b/legacy/scripts/app-core-new-2.js
@@ -16721,6 +16721,7 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
       handleAutoGearSavePreset: handleAutoGearSavePreset,
       handleAutoGearDeletePreset: handleAutoGearDeletePreset,
       applyAutoGearBackupVisibility: applyAutoGearBackupVisibility,
+      setAutoGearBackupsVisible: setAutoGearBackupsVisible,
       setAutoGearAutoPresetId: setAutoGearAutoPresetId,
       syncAutoGearAutoPreset: syncAutoGearAutoPreset,
       updateAutoGearCatalogOptions: updateAutoGearCatalogOptions,

--- a/legacy/scripts/app-session.js
+++ b/legacy/scripts/app-session.js
@@ -3562,6 +3562,8 @@ if (settingsButton && settingsDialog) {
       renderAutoGearRulesList();
       renderAutoGearDraftLists();
       updateAutoGearCatalogOptions();
+      callSessionCoreFunction('renderAutoGearBackupControls', [], { defer: true });
+      callSessionCoreFunction('applyAutoGearBackupVisibility', [], { defer: true });
     }
     if (activeSettingsTabId) {
       activateSettingsTab(activeSettingsTabId);
@@ -3654,6 +3656,13 @@ if (settingsButton && settingsDialog) {
       }
       if (settingsShowAutoBackups) {
         applyShowAutoBackupsPreference(settingsShowAutoBackups.checked);
+      }
+      var autoGearShowBackupsToggle =
+        typeof document !== 'undefined' && typeof document.getElementById === 'function'
+          ? document.getElementById('autoGearShowBackups')
+          : null;
+      if (autoGearShowBackupsToggle) {
+        callSessionCoreFunction('setAutoGearBackupsVisible', [!!autoGearShowBackupsToggle.checked]);
       }
       if (accentColorInput) {
         var color = accentColorInput.value;

--- a/src/scripts/app-core-new-2.js
+++ b/src/scripts/app-core-new-2.js
@@ -16483,6 +16483,7 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
       handleAutoGearSavePreset,
       handleAutoGearDeletePreset,
       applyAutoGearBackupVisibility,
+      setAutoGearBackupsVisible,
       setAutoGearAutoPresetId,
       syncAutoGearAutoPreset,
       updateAutoGearCatalogOptions,

--- a/src/scripts/app-session.js
+++ b/src/scripts/app-session.js
@@ -4477,6 +4477,8 @@ const mountVoltageResetButtonRef = (() => {
       renderAutoGearRulesList();
       renderAutoGearDraftLists();
       updateAutoGearCatalogOptions();
+      callSessionCoreFunction('renderAutoGearBackupControls', [], { defer: true });
+      callSessionCoreFunction('applyAutoGearBackupVisibility', [], { defer: true });
     }
     if (activeSettingsTabId) {
       activateSettingsTab(activeSettingsTabId);
@@ -4584,6 +4586,16 @@ const mountVoltageResetButtonRef = (() => {
       }
       if (settingsShowAutoBackups) {
         applyShowAutoBackupsPreference(settingsShowAutoBackups.checked);
+      }
+      const autoGearShowBackupsToggle =
+        typeof document !== 'undefined' && typeof document.getElementById === 'function'
+          ? document.getElementById('autoGearShowBackups')
+          : null;
+      if (autoGearShowBackupsToggle) {
+        callSessionCoreFunction(
+          'setAutoGearBackupsVisible',
+          [Boolean(autoGearShowBackupsToggle.checked)],
+        );
       }
       if (accentColorInput) {
         const color = accentColorInput.value;

--- a/tests/unit/coreModules.test.js
+++ b/tests/unit/coreModules.test.js
@@ -44,6 +44,7 @@ describe('core module registrations', () => {
       'handleAutoGearSavePreset',
       'handleAutoGearDeletePreset',
       'applyAutoGearBackupVisibility',
+      'setAutoGearBackupsVisible',
       'renderAutoGearBackupControls',
       'renderAutoGearBackupRetentionControls',
       'renderAutoGearDraftImpact',

--- a/tools/appScriptGlobals.json
+++ b/tools/appScriptGlobals.json
@@ -597,6 +597,7 @@
     "handleAutoGearPresetSelection",
     "handleAutoGearSavePreset",
     "handleAutoGearShowBackupsToggle",
+    "setAutoGearBackupsVisible",
     "hasCustomAccentSelection",
     "helpButton",
     "helpDialog",


### PR DESCRIPTION
## Summary
- ensure the auto gear backups section refreshes when opening the settings dialog
- persist the auto gear backup visibility preference when saving settings by invoking the new core helper
- expose the visibility helper globally and update the globals manifest and tests

## Testing
- npm test -- --runTestsByPath tests/unit/coreModules.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e4c16cbe188320842676964fe2698d