### PR TITLE
Track generated gear status in projects and exports

### DIFF
--- a/legacy/scripts/app-setups.js
+++ b/legacy/scripts/app-setups.js
@@ -632,6 +632,7 @@ function downloadSharedProject(shareFileName, includeAutoGear) {
     currentSetup.gearSelectors = gearSelectors;
   }
   var combinedHtml = getCurrentGearListHtml();
+  currentSetup.gearListAndProjectRequirementsGenerated = Boolean(combinedHtml);
   if (combinedHtml) {
     var _getSafeGearListHtmlS = getSafeGearListHtmlSections(combinedHtml),
       projectHtml = _getSafeGearListHtmlS.projectHtml,
@@ -4734,6 +4735,7 @@ function collectProjectInfoFromRequirementsGrid() {
 function saveCurrentGearList() {
   if (factoryResetInProgress) return;
   var html = getCurrentGearListHtml();
+  var gearListGenerated = Boolean(html);
   var info = projectForm ? collectProjectFormData() : {};
   info.sliderBowl = getSetupsCoreValue('getSliderBowlValue');
   info.easyrig = getSetupsCoreValue('getEasyrigValue');
@@ -4814,7 +4816,8 @@ function saveCurrentGearList() {
   if (typeof saveProject === 'function' && typeof effectiveStorageKey === 'string') {
     var payload = {
       projectInfo: projectInfoSnapshot,
-      gearList: html
+      gearList: html,
+      gearListAndProjectRequirementsGenerated: gearListGenerated
     };
     if (powerSelectionSnapshot) {
       payload.powerSelection = powerSelectionSnapshot;
@@ -4845,6 +4848,11 @@ function saveCurrentGearList() {
     }
   } else if (setup.gearList !== '') {
     setup.gearList = '';
+    changed = true;
+  }
+
+  if (setup.gearListAndProjectRequirementsGenerated !== gearListGenerated) {
+    setup.gearListAndProjectRequirementsGenerated = gearListGenerated;
     changed = true;
   }
   if (projectInfoSignature) {

--- a/legacy/scripts/storage.js
+++ b/legacy/scripts/storage.js
@@ -4359,11 +4359,27 @@ function _typeof(o) { "@babel/helpers - typeof"; return _typeof = "function" == 
         if (typeof data.projectHtml === 'string') {
           htmlSources.push(data.projectHtml);
         }
-        if (isPlainObject(data.project) && typeof data.project.projectHtml === 'string') {
-          htmlSources.push(data.project.projectHtml);
+        if (typeof data.gearHtml === 'string') {
+          htmlSources.push(data.gearHtml);
         }
-        if (isPlainObject(normalizedGearList) && typeof normalizedGearList.projectHtml === 'string') {
-          htmlSources.push(normalizedGearList.projectHtml);
+        if (isPlainObject(data.project)) {
+          if (typeof data.project.projectHtml === 'string') {
+            htmlSources.push(data.project.projectHtml);
+          }
+          if (typeof data.project.gearHtml === 'string') {
+            htmlSources.push(data.project.gearHtml);
+          }
+        }
+        if (isPlainObject(data.gearList) && typeof data.gearList.gearHtml === 'string') {
+          htmlSources.push(data.gearList.gearHtml);
+        }
+        if (isPlainObject(normalizedGearList)) {
+          if (typeof normalizedGearList.projectHtml === 'string') {
+            htmlSources.push(normalizedGearList.projectHtml);
+          }
+          if (typeof normalizedGearList.gearHtml === 'string') {
+            htmlSources.push(normalizedGearList.gearHtml);
+          }
         } else if (typeof normalizedGearList === 'string') {
           htmlSources.push(normalizedGearList);
         }
@@ -4395,6 +4411,9 @@ function _typeof(o) { "@babel/helpers - typeof"; return _typeof = "function" == 
             }
           }
         }
+        _normalized2.gearListAndProjectRequirementsGenerated = typeof data.gearListAndProjectRequirementsGenerated === 'boolean' ? data.gearListAndProjectRequirementsGenerated : htmlSources.some(function (value) {
+          return typeof value === 'string' && value.trim();
+        });
         if (normalizedAutoGearRules && normalizedAutoGearRules.length) {
           _normalized2.autoGearRules = cloneAutoGearRules(normalizedAutoGearRules);
         }
@@ -4432,8 +4451,8 @@ function _typeof(o) { "@babel/helpers - typeof"; return _typeof = "function" == 
     }
     return null;
   }
-  var LEGACY_PROJECT_ROOT_KEYS = new Set(["gearList", "projectInfo", "projectHtml", "gearHtml", "autoGearRules", "powerSelection"]);
-  var NORMALIZED_PROJECT_KEYS = new Set(["gearList", "projectInfo", "autoGearRules", "diagramPositions", "gearSelectors", "powerSelection"]);
+  var LEGACY_PROJECT_ROOT_KEYS = new Set(["gearList", "projectInfo", "projectHtml", "gearHtml", "autoGearRules", "powerSelection", "gearListAndProjectRequirementsGenerated"]);
+  var NORMALIZED_PROJECT_KEYS = new Set(["gearList", "projectInfo", "autoGearRules", "diagramPositions", "gearSelectors", "powerSelection", "gearListAndProjectRequirementsGenerated"]);
   function isNormalizedProjectEntry(entry) {
     if (!isPlainObject(entry)) {
       return false;
@@ -4470,6 +4489,9 @@ function _typeof(o) { "@babel/helpers - typeof"; return _typeof = "function" == 
       if (!isPlainObject(powerSelection)) {
         return false;
       }
+    }
+    if (Object.prototype.hasOwnProperty.call(entry, "gearListAndProjectRequirementsGenerated") && typeof entry.gearListAndProjectRequirementsGenerated !== "boolean") {
+      return false;
     }
     return true;
   }

--- a/src/scripts/app-setups.js
+++ b/src/scripts/app-setups.js
@@ -945,6 +945,7 @@ function downloadSharedProject(shareFileName, includeAutoGear) {
     currentSetup.gearSelectors = gearSelectors;
   }
   const combinedHtml = gearListGetCurrentHtmlImpl();
+  currentSetup.gearListAndProjectRequirementsGenerated = Boolean(combinedHtml);
   if (combinedHtml) {
     const { projectHtml, gearHtml } = gearListGetSafeHtmlSectionsImpl(combinedHtml);
     if (projectHtml) currentSetup.projectHtml = projectHtml;
@@ -5011,6 +5012,7 @@ function saveCurrentGearList() {
     if (factoryResetInProgress) return;
     if (isProjectPersistenceSuspended()) return;
     const html = gearListGetCurrentHtmlImpl();
+    const gearListGenerated = Boolean(html);
     const info = projectForm ? collectProjectFormData() : {};
     info.sliderBowl = getSetupsCoreValue('getSliderBowlValue');
     info.easyrig = getSetupsCoreValue('getEasyrigValue');
@@ -5128,7 +5130,8 @@ function saveCurrentGearList() {
     if (typeof saveProject === 'function' && typeof effectiveStorageKey === 'string') {
         const payload = {
             projectInfo: projectInfoSnapshot,
-            gearList: html
+            gearList: html,
+            gearListAndProjectRequirementsGenerated: gearListGenerated
         };
         if (powerSelectionSnapshot) {
             payload.powerSelection = powerSelectionSnapshot;
@@ -5169,6 +5172,11 @@ function saveCurrentGearList() {
         }
     } else if (setup.gearList !== '') {
         setup.gearList = '';
+        changed = true;
+    }
+
+    if (setup.gearListAndProjectRequirementsGenerated !== gearListGenerated) {
+        setup.gearListAndProjectRequirementsGenerated = gearListGenerated;
         changed = true;
     }
 

--- a/src/scripts/storage.js
+++ b/src/scripts/storage.js
@@ -5988,11 +5988,27 @@ function normalizeProject(data) {
       if (typeof data.projectHtml === 'string') {
         htmlSources.push(data.projectHtml);
       }
-      if (isPlainObject(data.project) && typeof data.project.projectHtml === 'string') {
-        htmlSources.push(data.project.projectHtml);
+      if (typeof data.gearHtml === 'string') {
+        htmlSources.push(data.gearHtml);
       }
-      if (isPlainObject(normalizedGearList) && typeof normalizedGearList.projectHtml === 'string') {
-        htmlSources.push(normalizedGearList.projectHtml);
+      if (isPlainObject(data.project)) {
+        if (typeof data.project.projectHtml === 'string') {
+          htmlSources.push(data.project.projectHtml);
+        }
+        if (typeof data.project.gearHtml === 'string') {
+          htmlSources.push(data.project.gearHtml);
+        }
+      }
+      if (isPlainObject(data.gearList) && typeof data.gearList.gearHtml === 'string') {
+        htmlSources.push(data.gearList.gearHtml);
+      }
+      if (isPlainObject(normalizedGearList)) {
+        if (typeof normalizedGearList.projectHtml === 'string') {
+          htmlSources.push(normalizedGearList.projectHtml);
+        }
+        if (typeof normalizedGearList.gearHtml === 'string') {
+          htmlSources.push(normalizedGearList.gearHtml);
+        }
       } else if (typeof normalizedGearList === 'string') {
         htmlSources.push(normalizedGearList);
       }
@@ -6024,6 +6040,10 @@ function normalizeProject(data) {
           }
         }
       }
+      const derivedGenerationFlag = typeof data.gearListAndProjectRequirementsGenerated === 'boolean'
+        ? data.gearListAndProjectRequirementsGenerated
+        : htmlSources.some((value) => typeof value === 'string' && value.trim());
+      normalized.gearListAndProjectRequirementsGenerated = derivedGenerationFlag;
       if (normalizedAutoGearRules && normalizedAutoGearRules.length) {
         normalized.autoGearRules = cloneAutoGearRules(normalizedAutoGearRules);
       }
@@ -6099,6 +6119,7 @@ var LEGACY_PROJECT_ROOT_KEYS = new Set([
   "gearHtml",
   "autoGearRules",
   "powerSelection",
+  "gearListAndProjectRequirementsGenerated",
 ]);
 
 var NORMALIZED_PROJECT_KEYS = new Set([
@@ -6108,6 +6129,7 @@ var NORMALIZED_PROJECT_KEYS = new Set([
   "diagramPositions",
   "gearSelectors",
   "powerSelection",
+  "gearListAndProjectRequirementsGenerated",
 ]);
 
 function isNormalizedProjectEntry(entry) {
@@ -6153,6 +6175,12 @@ function isNormalizedProjectEntry(entry) {
     if (!isPlainObject(powerSelection)) {
       return false;
     }
+  }
+  if (
+    Object.prototype.hasOwnProperty.call(entry, "gearListAndProjectRequirementsGenerated")
+    && typeof entry.gearListAndProjectRequirementsGenerated !== "boolean"
+  ) {
+    return false;
   }
   return true;
 }

--- a/tests/dom/deleteGearList.test.js
+++ b/tests/dom/deleteGearList.test.js
@@ -115,8 +115,10 @@ describe('delete gear list action', () => {
     const finalArg = saveSetupsMock.mock.calls[saveSetupsMock.mock.calls.length - 1][0];
     expect(finalArg['Project One'].gearList).toBeUndefined();
     expect(finalArg['Project One'].projectInfo).toBeUndefined();
+    expect(finalArg['Project One'].gearListAndProjectRequirementsGenerated).toBeUndefined();
     expect(storedSetups['Project One'].gearList).toBeUndefined();
     expect(storedSetups['Project One'].projectInfo).toBeUndefined();
+    expect(storedSetups['Project One'].gearListAndProjectRequirementsGenerated).toBeUndefined();
 
     const gearListOutput = document.getElementById('gearListOutput');
     expect(gearListOutput.innerHTML).toBe('');

--- a/tests/dom/saveCurrentGearList.test.js
+++ b/tests/dom/saveCurrentGearList.test.js
@@ -35,8 +35,15 @@ describe('saveCurrentGearList project info handling', () => {
     const lastCall = globals.saveProject.mock.calls[globals.saveProject.mock.calls.length - 1];
     expect(lastCall[0]).toBe('Empty Project');
 
-    const { projectInfo, gearList, diagramPositions, autoGearRules } = lastCall[1];
+    const {
+      projectInfo,
+      gearList,
+      diagramPositions,
+      autoGearRules,
+      gearListAndProjectRequirementsGenerated,
+    } = lastCall[1];
     expect(gearList).toBe('');
+    expect(gearListAndProjectRequirementsGenerated).toBe(false);
     expect(projectInfo).toEqual(utils.getCurrentProjectInfo());
     expect(projectInfo).toMatchObject({
       projectName: 'Empty Project',
@@ -102,6 +109,7 @@ describe('saveCurrentGearList project info handling', () => {
     expect(savedSetup.projectInfo).toMatchObject({
       projectName: 'Snapshot Project',
     });
+    expect(savedSetup.gearListAndProjectRequirementsGenerated).toBe(false);
 
     savedSetup.projectInfo.projectName = 'Mutated via setups';
     const infoAfterMutation = utils.getCurrentProjectInfo();

--- a/tests/script/restoreSessionState.test.js
+++ b/tests/script/restoreSessionState.test.js
@@ -127,6 +127,44 @@ describe('restoreSessionState', () => {
     env.cleanup();
   });
 
+  test('does not regenerate gear list when imported project explicitly omits it', () => {
+    const previousProjectInfo = { projectName: 'Old Project', codec: 'ProRes' };
+    const storedPayload = {
+      gearList: '',
+      projectInfo: null,
+      powerSelection: null
+    };
+
+    const loadProjectMock = jest.fn(() => storedPayload);
+    const saveProjectMock = jest.fn();
+
+    const env = setupScriptEnvironment({
+      readyState: 'complete',
+      globals: {
+        currentProjectInfo: previousProjectInfo,
+        loadSessionState: jest.fn(() => null),
+        loadProject: loadProjectMock,
+        saveProject: saveProjectMock,
+        deleteProject: jest.fn()
+      }
+    });
+
+    const gearListOutput = document.getElementById('gearListOutput');
+    const generateSpy = typeof window.generateGearListHtml === 'function'
+      ? jest.spyOn(window, 'generateGearListHtml')
+      : null;
+
+    expect(loadProjectMock).toHaveBeenCalled();
+    expect(gearListOutput.classList.contains('hidden')).toBe(true);
+    expect(gearListOutput.innerHTML.trim()).toBe('');
+    expect(window.currentProjectInfo).toBeNull();
+    if (generateSpy) {
+      expect(generateSpy).not.toHaveBeenCalled();
+      generateSpy.mockRestore();
+    }
+    env.cleanup();
+  });
+
   test('restores automatic gear highlight preference from session state', () => {
     const highlightGearHtml = `
       <h2>Highlight Project</h2>

--- a/tests/script/shareExport.test.js
+++ b/tests/script/shareExport.test.js
@@ -315,6 +315,7 @@ describe('project sharing helpers', () => {
       projectName: 'Exported Project',
       notes: 'Stored notes',
     }));
+    expect(parsed.gearListAndProjectRequirementsGenerated).toBe(false);
     expect(loadProjectMock).toHaveBeenCalled();
     delete global.currentProjectInfo;
   });
@@ -373,6 +374,7 @@ describe('project sharing helpers', () => {
       contacts: 'Producer',
       schedule: 'Night shoot',
     }));
+    expect(parsed.gearListAndProjectRequirementsGenerated).toBe(false);
     expect(loadProjectMock).toHaveBeenCalled();
     delete global.currentProjectInfo;
   });
@@ -492,6 +494,7 @@ describe('project sharing helpers', () => {
     expect(capturedPayloads[0].payload.batteryPlate).toBe('');
     expect(capturedPayloads[0].payload.batteryHotswap).toBe('');
     expect(capturedPayloads[0].payload).not.toHaveProperty('powerSelection');
+    expect(capturedPayloads[0].payload.gearListAndProjectRequirementsGenerated).toBe(false);
 
     clickSpy.mockRestore();
     createSpy.mockRestore();

--- a/tests/unit/storage.test.js
+++ b/tests/unit/storage.test.js
@@ -105,6 +105,11 @@ const parseLocalStorageJSON = (key) => {
 
 const getDecodedLocalStorageItem = (key) => decodeStoredValue(localStorage.getItem(key));
 
+const withGenerationFlag = (value, generated = true) => ({
+  ...value,
+  gearListAndProjectRequirementsGenerated: generated,
+});
+
 const expectAutoBackupSnapshot = (entry, expectedPayload, options = {}) => {
   expect(entry).toBeDefined();
   expect(typeof entry).toBe('object');
@@ -855,8 +860,8 @@ describe('project storage', () => {
   test('saveProject stores data per project name', () => {
     saveProject('A', { gearList: '<ul>A</ul>' });
     saveProject('B', { gearList: '<ul>B</ul>' });
-    expect(loadProject('A')).toEqual({ gearList: '<ul>A</ul>', projectInfo: null });
-    expect(loadProject('B')).toEqual({ gearList: '<ul>B</ul>', projectInfo: null });
+    expect(loadProject('A')).toEqual(withGenerationFlag({ gearList: '<ul>A</ul>', projectInfo: null }));
+    expect(loadProject('B')).toEqual(withGenerationFlag({ gearList: '<ul>B</ul>', projectInfo: null }));
   });
 
   test('loadProject resolves entries saved with surrounding whitespace', () => {
@@ -864,8 +869,8 @@ describe('project storage', () => {
       ' Spaced ': { gearList: '<ul>Saved</ul>', projectInfo: null },
     }));
 
-    expect(loadProject(' Spaced ')).toEqual({ gearList: '<ul>Saved</ul>', projectInfo: null });
-    expect(loadProject('Spaced')).toEqual({ gearList: '<ul>Saved</ul>', projectInfo: null });
+    expect(loadProject(' Spaced ')).toEqual(withGenerationFlag({ gearList: '<ul>Saved</ul>', projectInfo: null }));
+    expect(loadProject('Spaced')).toEqual(withGenerationFlag({ gearList: '<ul>Saved</ul>', projectInfo: null }));
   });
 
   test('saveProject normalizes project keys with surrounding whitespace when unused', () => {
@@ -877,15 +882,15 @@ describe('project storage', () => {
 
     const stored = parseLocalStorageJSON(PROJECT_KEY);
     expect(stored['Old Name ']).toBeUndefined();
-    expect(stored['Old Name']).toEqual({ gearList: '<ul>Updated</ul>', projectInfo: null });
-    expect(loadProject('Old Name ')).toEqual({ gearList: '<ul>Updated</ul>', projectInfo: null });
+    expect(stored['Old Name']).toEqual(withGenerationFlag({ gearList: '<ul>Updated</ul>', projectInfo: null }));
+    expect(loadProject('Old Name ')).toEqual(withGenerationFlag({ gearList: '<ul>Updated</ul>', projectInfo: null }));
   });
 
   test('deleteProject removes entries even when addressed with trimmed names', () => {
     saveProject('Keep ', { gearList: '<ul>Keep</ul>', projectInfo: null });
     saveProject('Drop', { gearList: '<ul>Drop</ul>', projectInfo: null });
 
-    expect(loadProject('Keep')).toEqual({ gearList: '<ul>Keep</ul>', projectInfo: null });
+    expect(loadProject('Keep')).toEqual(withGenerationFlag({ gearList: '<ul>Keep</ul>', projectInfo: null }));
 
     deleteProject(' Drop ');
 
@@ -896,12 +901,12 @@ describe('project storage', () => {
 
   test('saveProject normalizes null gearList to empty string', () => {
     saveProject('NullProj', { gearList: null });
-    expect(loadProject('NullProj')).toEqual({ gearList: '', projectInfo: null });
+    expect(loadProject('NullProj')).toEqual(withGenerationFlag({ gearList: '', projectInfo: null }, false));
   });
 
   test('saveProject strips non-object projectInfo values', () => {
     saveProject('InfoProj', { gearList: '<ul>Info</ul>', projectInfo: 'bad' });
-    expect(loadProject('InfoProj')).toEqual({ gearList: '<ul>Info</ul>', projectInfo: null });
+    expect(loadProject('InfoProj')).toEqual(withGenerationFlag({ gearList: '<ul>Info</ul>', projectInfo: null }));
   });
 
   test('saveProject removes older duplicate auto backups before trimming unique entries', () => {
@@ -970,7 +975,7 @@ describe('project storage', () => {
       stored[backupKeys[0]],
       { gearList: '<ul>Initial</ul>', projectInfo: { notes: 'original' } },
     );
-    expect(stored['Overwrite Demo']).toEqual({ gearList: '<ul>Updated</ul>', projectInfo: { notes: 'updated' } });
+    expect(stored['Overwrite Demo']).toEqual(withGenerationFlag({ gearList: '<ul>Updated</ul>', projectInfo: { notes: 'updated' } }));
 
     jest.useRealTimers();
   });
@@ -986,7 +991,7 @@ describe('project storage', () => {
 
     const stored = parseLocalStorageJSON(PROJECT_KEY);
     expect(Object.keys(stored).filter(key => key.startsWith('auto-backup-'))).toHaveLength(0);
-    expect(stored['No Change']).toEqual({ gearList: '<ul>Same</ul>', projectInfo: null });
+    expect(stored['No Change']).toEqual(withGenerationFlag({ gearList: '<ul>Same</ul>', projectInfo: null }));
 
     jest.useRealTimers();
   });
@@ -1131,7 +1136,7 @@ describe('project storage', () => {
 
     const projects = loadProject();
     expect(projects).toEqual({
-      'Project-updated': { gearList: '<p>Legacy project</p>', projectInfo: null },
+      'Project-updated': withGenerationFlag({ gearList: '<p>Legacy project</p>', projectInfo: null }),
     });
 
     const storedBackup = getDecodedLocalStorageItem(migrationBackupKeyFor(PROJECT_KEY));
@@ -1144,11 +1149,11 @@ describe('project storage', () => {
 
     deleteProject('Drop');
     expect(loadProject('Drop')).toBeNull();
-    expect(loadProject('Keep')).toEqual({ gearList: '<ul>Keep</ul>', projectInfo: null });
+    expect(loadProject('Keep')).toEqual(withGenerationFlag({ gearList: '<ul>Keep</ul>', projectInfo: null }));
     const afterFirstDeletion = loadProject();
     const dropBackupKey = Object.keys(afterFirstDeletion).find((name) => name.includes('Drop'));
     expect(dropBackupKey).toBeDefined();
-    expect(afterFirstDeletion[dropBackupKey]).toEqual({ gearList: '<ul>Drop</ul>', projectInfo: null });
+    expect(afterFirstDeletion[dropBackupKey]).toEqual(withGenerationFlag({ gearList: '<ul>Drop</ul>', projectInfo: null }));
 
     deleteProject('Keep');
     expect(loadProject('Keep')).toBeNull();
@@ -1944,7 +1949,7 @@ describe('export/import all data', () => {
       expect(loadSetups()).toEqual({ A: { foo: 1 } });
       expect(loadSessionState()).toEqual({ camera: 'CamA' });
     expect(loadFeedback()).toEqual({ note: 'hi' });
-    expect(loadProject('Proj')).toEqual({ gearList: '<ol></ol>', projectInfo: null });
+    expect(loadProject('Proj')).toEqual(withGenerationFlag({ gearList: '<ol></ol>', projectInfo: null }));
     expect(loadFavorites()).toEqual({ cat: ['B'] });
     expect(loadAutoGearRules()).toEqual(data.autoGearRules);
     expect(loadAutoGearBackups()).toEqual(data.autoGearBackups);
@@ -2034,7 +2039,7 @@ describe('export/import all data', () => {
 
     expect(loadFeedback()).toEqual({ message: 'snapshot' });
     expect(loadFavorites()).toEqual({ camera: ['Mini'] });
-    expect(loadProject('Snapshot')).toEqual({ gearList: '<p>Snapshot</p>', projectInfo: null });
+    expect(loadProject('Snapshot')).toEqual(withGenerationFlag({ gearList: '<p>Snapshot</p>', projectInfo: null }));
 
     expect(loadAutoGearRules()).toEqual([
       { id: 'snap-rule', label: 'Snap', scenarios: [], add: [], remove: [] },
@@ -2125,7 +2130,7 @@ describe('export/import all data', () => {
       ]
     };
     importAllData(data);
-    expect(loadProject('OldProj')).toEqual({ gearList: '<ul></ul>', projectInfo: null });
+    expect(loadProject('OldProj')).toEqual(withGenerationFlag({ gearList: '<ul></ul>', projectInfo: null }, false));
   });
 
   test('importAllData merges project map without overwriting existing entries', () => {
@@ -2139,14 +2144,14 @@ describe('export/import all data', () => {
     };
     importAllData(data);
     const projects = loadProject();
-    expect(projects.Duplicate).toEqual({ gearList: '<ul>Original</ul>', projectInfo: null });
+    expect(projects.Duplicate).toEqual(withGenerationFlag({ gearList: '<ul>Original</ul>', projectInfo: null }));
     const duplicateKeys = Object.keys(projects).filter((name) => name.toLowerCase().startsWith('duplicate'));
     expect(duplicateKeys.length).toBe(2);
     const importedDuplicate = duplicateKeys.find((name) => name !== 'Duplicate');
     expect(importedDuplicate).toBeTruthy();
-    expect(projects[importedDuplicate]).toEqual({ gearList: '<ul>Replacement</ul>', projectInfo: { projectName: 'Dup' } });
-    expect(projects.Fresh).toEqual({ gearList: '<ul>Fresh</ul>', projectInfo: { projectName: 'Fresh' } });
-    expect(projects.Existing).toEqual({ gearList: '<ul>Existing</ul>', projectInfo: null });
+    expect(projects[importedDuplicate]).toEqual(withGenerationFlag({ gearList: '<ul>Replacement</ul>', projectInfo: { projectName: 'Dup' } }));
+    expect(projects.Fresh).toEqual(withGenerationFlag({ gearList: '<ul>Fresh</ul>', projectInfo: { projectName: 'Fresh' } }));
+    expect(projects.Existing).toEqual(withGenerationFlag({ gearList: '<ul>Existing</ul>', projectInfo: null }));
   });
 
   test('importAllData merges legacy project arrays without replacing existing ones', () => {
@@ -2159,29 +2164,29 @@ describe('export/import all data', () => {
     };
     importAllData(data);
     const projects = loadProject();
-    expect(projects.Legacy).toEqual({ gearList: '<ul>Old</ul>', projectInfo: null });
+    expect(projects.Legacy).toEqual(withGenerationFlag({ gearList: '<ul>Old</ul>', projectInfo: null }));
     const legacyKeys = Object.keys(projects).filter((name) => name.toLowerCase().startsWith('legacy'));
     expect(legacyKeys.length).toBe(2);
     const importedLegacy = legacyKeys.find((name) => name !== 'Legacy');
     expect(importedLegacy).toBeTruthy();
-    expect(projects[importedLegacy]).toEqual({ gearList: '<ul>New</ul>', projectInfo: null });
+    expect(projects[importedLegacy]).toEqual(withGenerationFlag({ gearList: '<ul>New</ul>', projectInfo: null }));
     const unnamedEntry = Object.entries(projects).find(([name, proj]) => {
       return name !== 'Legacy' && proj.gearList === '<ul>Unnamed</ul>';
     });
     expect(unnamedEntry).toBeDefined();
-    expect(unnamedEntry[1]).toEqual({ gearList: '<ul>Unnamed</ul>', projectInfo: null });
+    expect(unnamedEntry[1]).toEqual(withGenerationFlag({ gearList: '<ul>Unnamed</ul>', projectInfo: null }));
   });
 
   test('importAllData handles legacy project string payload', () => {
     const data = { project: '<section>Legacy</section>' };
     importAllData(data);
-    expect(loadProject('')).toEqual({ gearList: '<section>Legacy</section>', projectInfo: null });
+    expect(loadProject('')).toEqual(withGenerationFlag({ gearList: '<section>Legacy</section>', projectInfo: null }));
   });
 
   test('importAllData handles legacy project map entries stored as strings', () => {
     const data = { project: { Legacy: '<div>Legacy</div>' } };
     importAllData(data);
-    expect(loadProject('Legacy')).toEqual({ gearList: '<div>Legacy</div>', projectInfo: null });
+    expect(loadProject('Legacy')).toEqual(withGenerationFlag({ gearList: '<div>Legacy</div>', projectInfo: null }));
   });
 
   test('importAllData handles project map entries stored as JSON strings', () => {
@@ -2211,7 +2216,7 @@ describe('export/import all data', () => {
   test('importAllData handles legacy single gearList', () => {
     const data = { gearList: '<p></p>' };
     importAllData(data);
-    expect(loadProject('')).toEqual({ gearList: '<p></p>', projectInfo: null });
+    expect(loadProject('')).toEqual(withGenerationFlag({ gearList: '<p></p>', projectInfo: null }, false));
   });
 
   test('loadProject normalizes stored JSON string payloads', () => {
@@ -2348,11 +2353,11 @@ describe('export/import all data', () => {
     });
 
     const projects = loadProject();
-    expect(projects.Legacy).toEqual({ gearList: '<div>Legacy</div>', projectInfo: null });
-    expect(projects.WithInfo).toEqual({
+    expect(projects.Legacy).toEqual(withGenerationFlag({ gearList: '<div>Legacy</div>', projectInfo: null }));
+    expect(projects.WithInfo).toEqual(withGenerationFlag({
       gearList: '<div>Info</div>',
       projectInfo: { projectName: 'WithInfo' },
-    });
+    }));
   });
 
   test('importAllData parses project JSON arrays stored as strings', () => {
@@ -2364,13 +2369,13 @@ describe('export/import all data', () => {
     });
 
     const projects = loadProject();
-    expect(projects.JsonProject).toEqual({
+    expect(projects.JsonProject).toEqual(withGenerationFlag({
       gearList: '<section>JSON</section>',
       projectInfo: null,
-    });
+    }));
     const inlineEntry = Object.entries(projects).find(([, value]) => value.gearList === '<article>Inline</article>');
     expect(inlineEntry).toBeDefined();
-    expect(inlineEntry[1]).toEqual({ gearList: '<article>Inline</article>', projectInfo: null });
+    expect(inlineEntry[1]).toEqual(withGenerationFlag({ gearList: '<article>Inline</article>', projectInfo: null }));
   });
 
   test('importAllData normalizes nested legacy project payloads', () => {


### PR DESCRIPTION
## Summary
- add a gearListAndProjectRequirementsGenerated flag when saving projects, setups, and shared exports so the current generation state is persisted across modern and legacy runtimes
- propagate the new flag through project normalization in storage to preserve explicit true/false values in saved data and adjust helpers accordingly
- update unit and integration tests to expect the new flag and cover download payloads for the share workflow

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e4c353324c8320ba789d21537fe131