### PR TITLE
Optimize offline reload cleanup concurrency

### DIFF
--- a/src/scripts/modules/offline.js
+++ b/src/scripts/modules/offline.js
@@ -1053,19 +1053,24 @@
       }
     }
 
-    let serviceWorkersUnregistered = false;
-    try {
-      serviceWorkersUnregistered = await unregisterServiceWorkers(options.navigator);
-    } catch (error) {
-      safeWarn('Service worker cleanup failed', error);
-    }
-
-    let cachesCleared = false;
-    try {
-      cachesCleared = await clearCacheStorage(options.caches);
-    } catch (error) {
-      safeWarn('Cache clear failed', error);
-    }
+    const [serviceWorkersUnregistered, cachesCleared] = await Promise.all([
+      (async () => {
+        try {
+          return await unregisterServiceWorkers(options.navigator);
+        } catch (error) {
+          safeWarn('Service worker cleanup failed', error);
+          return false;
+        }
+      })(),
+      (async () => {
+        try {
+          return await clearCacheStorage(options.caches);
+        } catch (error) {
+          safeWarn('Cache clear failed', error);
+          return false;
+        }
+      })(),
+    ]);
 
     let reloadTriggered = false;
     const reloadFn = typeof options.reloadWindow === 'function' ? options.reloadWindow : triggerReload;


### PR DESCRIPTION
## Summary
- run the reload flow's service worker unregister and cache deletion phases in parallel so the forced reload completes sooner

## Testing
- npm run test:unit -- offlineModule *(fails: baseline storage expectations include gearListAndProjectRequirementsGenerated flag)*

------
https://chatgpt.com/codex/tasks/task_e_68e55e19eed483208e0b558752da2502