### PR TITLE
Mark gear list generation when project info exists

### DIFF
--- a/tests/dom/saveCurrentGearList.test.js
+++ b/tests/dom/saveCurrentGearList.test.js
@@ -42,7 +42,7 @@ describe('saveCurrentGearList project info handling', () => {
       gearListAndProjectRequirementsGenerated,
     } = lastCall[1];
     expect(lastCall[1].gearList).toBeUndefined();
-    expect(gearListAndProjectRequirementsGenerated).toBe(false);
+    expect(gearListAndProjectRequirementsGenerated).toBe(true);
     expect(projectInfo).toEqual(utils.getCurrentProjectInfo());
     expect(projectInfo).toMatchObject({
       projectName: 'Empty Project',
@@ -109,7 +109,7 @@ describe('saveCurrentGearList project info handling', () => {
       projectName: 'Snapshot Project',
     });
     expect(savedSetup.gearList).toBeUndefined();
-    expect(savedSetup.gearListAndProjectRequirementsGenerated).toBe(false);
+    expect(savedSetup.gearListAndProjectRequirementsGenerated).toBe(true);
 
     savedSetup.projectInfo.projectName = 'Mutated via setups';
     const infoAfterMutation = utils.getCurrentProjectInfo();

--- a/tests/script/shareExport.test.js
+++ b/tests/script/shareExport.test.js
@@ -315,7 +315,7 @@ describe('project sharing helpers', () => {
       projectName: 'Exported Project',
       notes: 'Stored notes',
     }));
-    expect(parsed.gearListAndProjectRequirementsGenerated).toBe(false);
+    expect(parsed.gearListAndProjectRequirementsGenerated).toBe(true);
     expect(loadProjectMock).toHaveBeenCalled();
     delete global.currentProjectInfo;
   });
@@ -374,7 +374,7 @@ describe('project sharing helpers', () => {
       contacts: 'Producer',
       schedule: 'Night shoot',
     }));
-    expect(parsed.gearListAndProjectRequirementsGenerated).toBe(false);
+    expect(parsed.gearListAndProjectRequirementsGenerated).toBe(true);
     expect(loadProjectMock).toHaveBeenCalled();
     delete global.currentProjectInfo;
   });


### PR DESCRIPTION
## Summary
- ensure the gear list generation flag treats stored project info as a trigger across export, auto backup, and session restore flows
- add recursive helpers that safely detect meaningful project info values without breaking proxy-based state objects
- adjust project gear list tests to expect the updated flag behavior when requirements data is available

## Testing
- npm run test:jest -- tests/dom/saveCurrentGearList.test.js *(fails: TypeError from deep-freeze instrumentation in test environment)*
- RUN_HEAVY_TESTS=true npm run test:jest -- tests/script/shareExport.test.js *(fails: heavy runtime modules are unavailable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e55b97c8248320bcc185c1d2508139