### PR TITLE
Set project summary flag when any project info exists

### DIFF
--- a/legacy/scripts/app-session.js
+++ b/legacy/scripts/app-session.js
@@ -969,6 +969,9 @@ function summarizeProjectCollection(collection) {
       info = entry.project.projectInfo;
     }
     if (!info) return;
+    if (!result.hasProjectInfo) {
+      result.hasProjectInfo = true;
+    }
     var stats = summarizeProjectInfoStats(info);
     if (stats.hasDetails) {
       result.hasProjectInfo = true;

--- a/src/scripts/app-session.js
+++ b/src/scripts/app-session.js
@@ -1832,6 +1832,9 @@ function summarizeProjectCollection(collection) {
       info = entry.project.projectInfo;
     }
     if (!info) return;
+    if (!result.hasProjectInfo) {
+      result.hasProjectInfo = true;
+    }
     const stats = summarizeProjectInfoStats(info);
     if (stats.hasDetails) {
       result.hasProjectInfo = true;


### PR DESCRIPTION
## Summary
- ensure the project summary logic flags project info presence as soon as any snapshot is encountered
- mirror the same behavior in the legacy session module to keep both builds consistent

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e5601672e083208a05b4d4f9c1d662