### PR TITLE
Add verification log template to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,9 +314,11 @@ access.
 6. **Archive with confidence.** Delete the rehearsal profile after confirming
    everything restored cleanly. Label and file the verified exports with your
    production’s archival checklist and add a short verification log (timestamp,
-   machine, operator and notes). The paper trail makes it easy to prove that
-   save, share, import, backup and restore workflows were validated end-to-end
-   before anyone relies on them in the field.
+   machine, operator and notes). Use the [verification log
+   template](docs/verification-log-template.md) to capture consistent evidence
+   across teams. The paper trail makes it easy to prove that save, share,
+   import, backup and restore workflows were validated end-to-end before anyone
+   relies on them in the field.
 7. **Log the runtime guard.** In the same profile, open the developer console
    and confirm `window.__cineRuntimeIntegrity.ok` is `true`. If you need a fresh
    report, run `window.cineRuntime.verifyCriticalFlows({ warnOnFailure: true })`

--- a/docs/documentation-maintenance.md
+++ b/docs/documentation-maintenance.md
@@ -58,12 +58,18 @@ copy offline.【F:src/scripts/script.js†L92-L183】
    synchronized with UI labels, keyboard shortcuts and verification logging guidance so crews
    rehearse the exact workflows the code exposes through `cinePersistence`, `cineUi` and the
    runtime guard.
-4. **Operations manuals.** Confirm `docs/offline-readiness.md`,
+4. **Verification log template.** Update `docs/verification-log-template.md` whenever
+   diagnostic commands change or new persistence safeguards ship. The template calls for
+   console outputs from `window.__cineRuntimeIntegrity`,
+   `window.cineRuntime.verifyCriticalFlows({ warnOnFailure: true })` and the
+   `cinePersistence` inspection helpers, so keep the references aligned with runtime and
+   persistence modules when they evolve.【F:src/scripts/script.js†L315-L357】【F:src/scripts/modules/runtime.js†L1663-L1782】【F:src/scripts/modules/persistence.js†L775-L880】
+5. **Operations manuals.** Confirm `docs/offline-readiness.md`,
    `docs/operations-checklist.md`, `docs/backup-rotation-guide.md` and `docs/testing-plan.md`
    include the new logic. These printable guides travel with field kits, so add or update
    drills that prove autosave, backup rotation and restore rehearsals still behave exactly
    as the latest build.
-5. **In-app legal and static pages.** If the change surfaces on legal disclosures or other
+6. **In-app legal and static pages.** If the change surfaces on legal disclosures or other
    static pages in `legal/`, mirror the update in every localized HTML file so offline
    references stay consistent.
 

--- a/docs/operations-checklist.md
+++ b/docs/operations-checklist.md
@@ -62,6 +62,8 @@ update the repository or hand off a project at the end of the day.
    and files inspected) to your archival log or create one beside the exports
    if it does not exist yet. Pair the note with checksum manifests so every
    crew member can prove when the save → share → import rehearsal succeeded.
+   Use the [verification log template](verification-log-template.md) so every
+   team records the same evidence and diagnostic outputs.
 
 ## 3. Offline confidence checks
 

--- a/docs/verification-log-template.md
+++ b/docs/verification-log-template.md
@@ -1,0 +1,75 @@
+# Verification Log Template
+
+Maintaining a consistent verification log proves that every save, share, import,
+backup and restore rehearsal behaved exactly as documented—even when crews work
+entirely offline. Pair this template with the [Save, Share & Import
+Drill](../README.md#save-share--import-drill), [Offline Readiness
+Runbook](offline-readiness.md) and [Operational
+Checklist](operations-checklist.md) so every rehearsal captures the same
+evidence, commands and media artifacts.
+
+## How to use this template
+
+1. Create a new entry each time you finish a rehearsal, incident response or
+   pre-travel sweep. Store the log beside exported backups and bundles on your
+   redundant media.
+2. Attach console output for `window.__cineRuntimeIntegrity` plus the result of
+   `window.cineRuntime.verifyCriticalFlows({ warnOnFailure: true })` so auditors
+   can confirm runtime, persistence and offline safeguards were intact when the
+   rehearsal completed.【F:src/scripts/script.js†L315-L357】【F:src/scripts/modules/runtime.js†L1663-L1782】
+3. Capture `Quick safeguards → Download full backup` and `Quick safeguards → Open
+   Backup & Restore` actions from **Settings → Data & Storage** so the log proves
+   the in-app backups succeeded and the activity feed recorded the action.
+   Note the `Latest activity` timestamps and grab a snapshot of the Diagnostics
+   log filter state while you are there.【F:index.html†L2530-L2649】
+4. Record a copy of `window.cinePersistence.__internal.inspectAllBindings()`
+   and `window.cinePersistence.storage.exportAllData()` whenever you introduce
+   new storage bindings or migrate persistence logic. These snapshots prove
+   every binding resolved correctly and document the scope of the archived
+   payload before media rotation.【F:src/scripts/modules/persistence.js†L775-L880】
+5. Include hashes or checksum manifests for every exported file. If a browser
+   blocks direct downloads, reference the fallback window transcript so the log
+   still shows how the payload left the app.
+6. File the completed entry in both digital (JSON, Markdown or text) and printed
+   form. The physical copy belongs in the travel kit so crews can review it even
+   when no workstation is available.
+
+## Recommended fields
+
+| Field | Details to capture |
+| --- | --- |
+| Timestamp & operator | Local time, operator initials and reason for the rehearsal. |
+| Workstation context | Machine name, browser version, OS build and whether the session was online or offline. |
+| Projects & backups checked | Project names, manual saves, `auto-backup-…` snapshots and planner backups reviewed. |
+| Commands & console output | Paste outputs for `window.__cineRuntimeIntegrity`, `window.cineRuntime.verifyCriticalFlows()`, `window.cinePersistence.__internal.inspectAllBindings()` and any other diagnostic calls you ran. |
+| Exports generated | Filenames, sizes and checksum values for planner backups, project bundles, automatic gear rule exports and diff logs. |
+| Quick safeguards evidence | Screenshot or log entry ID showing the **Quick safeguards** backup action plus the `Latest activity` timestamps you verified. |
+| Diagnostics log filters | Which filters were active, whether the “no entries” banner appeared and any noteworthy warnings captured. |
+| Diff review notes | Summary of the **Compare versions** results, including any unexpected additions or removals and a link to the exported JSON diff. |
+| Follow-up actions | Tickets filed, translation updates required, documentation touch points and the storage locations for redundant media. |
+
+## Sample entry
+
+```text
+Timestamp & operator: 2025-03-12 18:42 PST – M. Rivera (pre-travel sweep)
+Workstation context: CPP-Field-02, Firefox ESR 115.9, macOS 13.6.1, offline
+Projects & backups checked: "Prelight Master" manual save 2025-03-12 18:20, auto-backup-2025-03-12-18-30, planner-backup.json (15.2 MB)
+Commands & console output: __cineRuntimeIntegrity.ok === true; verifyCriticalFlows() returned ok with no missing safeguards; inspectAllBindings() showed 0 unresolved bindings
+Exports generated: planner-backup-2025-03-12.json (SHA256: …), prelight-master.cpproject (SHA256: …), auto-gear-rules-2025-03-12.json (SHA256: …), compare-prelight-2025-03-12.json (SHA256: …)
+Quick safeguards evidence: Download full backup recorded as Activity ID 482; Latest project save 18:20, Latest auto backup 18:30, Latest full app backup 18:42
+Diagnostics log filters: All levels, namespace filter cleared, persist session enabled; no hidden entries banner present
+Diff review notes: Manual vs auto-backup difference limited to slate notes paragraph spacing; JSON diff attached
+Follow-up actions: Update Spanish README gear-rule appendix, copy exports to Vault A & Vault B, sync printed log with travel binder
+```
+
+## Storage and retention tips
+
+- Keep the log under version control if your organization mirrors documentation
+  repositories, but always redact project-sensitive payloads before committing
+  them. Store the full exports on encrypted offline media instead.
+- When an incident occurs, append the log entry with cross-references to
+  diagnostics or browser console transcripts so future crews can replay the
+  timeline without relying on memory.
+- Treat missing console output or absent checksum entries as a failed rehearsal.
+  Repeat the drill until every field is complete so downstream teams inherit a
+  provably safe environment.


### PR DESCRIPTION
## Summary
- add a reusable verification log template that captures runtime guard checks, quick safeguard evidence, and persistence inspection outputs
- reference the template from the primary README and the operations checklist so rehearsal logs stay consistent across crews
- expand the documentation maintenance guide with instructions to keep the template aligned with runtime and persistence diagnostics

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68e584014fc88320b50b2900e118afa3