### PR TITLE
Close overview dialog when clicking backdrop

### DIFF
--- a/src/scripts/overview.js
+++ b/src/scripts/overview.js
@@ -739,6 +739,19 @@ function generatePrintableOverview(config = {}) {
 
     const overviewDialog = document.getElementById('overviewDialog');
     overviewDialog.innerHTML = overviewHtml;
+
+    if (overviewDialog && !overviewDialog.hasAttribute('data-overview-outside-close')) {
+        overviewDialog.addEventListener('click', event => {
+            if (event.target === overviewDialog) {
+                closeDialog(overviewDialog);
+            }
+        });
+        overviewDialog.addEventListener('cancel', event => {
+            event.preventDefault();
+            closeDialog(overviewDialog);
+        });
+        overviewDialog.setAttribute('data-overview-outside-close', '');
+    }
     const content = overviewDialog.querySelector('#overviewDialogContent');
 
     const applyThemeClasses = (target) => {


### PR DESCRIPTION
## Summary
- close the overview dialog when users click the modal backdrop, matching help and settings behavior
- guard event registration so the outside-click handler is only bound once per dialog instance

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e585f3288c83209d5976c6be4f471d