### PR TITLE
Update storage unit tests to require generation flag

### DIFF
--- a/tests/unit/storage.test.js
+++ b/tests/unit/storage.test.js
@@ -1847,11 +1847,7 @@ describe('export/import all data', () => {
       session: { camera: 'CamA' },
       feedback: { note: 'hi' },
       project: {
-        Proj: {
-          gearList: '<ul></ul>',
-          projectInfo: null,
-          gearListAndProjectRequirementsGenerated: true,
-        },
+        Proj: withGenerationFlag({ gearList: '<ul></ul>', projectInfo: null }),
       },
       favorites: { cat: ['A'] },
       autoGearRules: rules,
@@ -1991,11 +1987,12 @@ describe('export/import all data', () => {
         ],
       };
       importAllData(data);
-      expect(loadDeviceData()).toEqual(validDeviceData);
-      expect(loadSetups()).toEqual({ A: { foo: 1 } });
-      expect(loadSessionState()).toEqual({ camera: 'CamA' });
+    expect(loadDeviceData()).toEqual(validDeviceData);
+    expect(loadSetups()).toEqual({ A: { foo: 1 } });
+    expect(loadSessionState()).toEqual({ camera: 'CamA' });
     expect(loadFeedback()).toEqual({ note: 'hi' });
     expect(loadProject('Proj')).toEqual(withGenerationFlag({ gearList: '<ol></ol>', projectInfo: null }));
+    expect(exportAllData().project.Proj.gearListAndProjectRequirementsGenerated).toBe(true);
     expect(loadFavorites()).toEqual({ cat: ['B'] });
     expect(loadAutoGearRules()).toEqual(data.autoGearRules);
     expect(loadAutoGearBackups()).toEqual(data.autoGearBackups);


### PR DESCRIPTION
## Summary
- update the storage export test to use the generation flag helper when validating project data
- ensure the import/export round-trip asserts the gear-list generation flag remains true

## Testing
- npm run test:unit -- storage.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e58f7932e48320b1b1e080142a0627