### PR TITLE
Fix automatic gear highlight for note variants

### DIFF
--- a/src/scripts/app-setups.js
+++ b/src/scripts/app-setups.js
@@ -2271,6 +2271,33 @@ function normalizeAutoGearName(name) {
     return stripAutoGearContext(name).toLowerCase();
 }
 
+function normalizeAutoGearNotesKey(value) {
+    const base = typeof normalizeAutoGearText === 'function'
+        ? normalizeAutoGearText(value, { collapseWhitespace: true })
+        : (value == null ? '' : String(value)).trim().replace(/\s+/g, ' ');
+    if (!base) {
+        return '';
+    }
+    return base.replace(/^[\s\-–—]+/u, '').trim().toLowerCase();
+}
+
+function getAutoGearSpanNotesKey(span) {
+    if (!span || !span.dataset) {
+        return '';
+    }
+    const datasetNotes = typeof span.dataset.autoGearNotes === 'string'
+        ? span.dataset.autoGearNotes
+        : '';
+    if (datasetNotes) {
+        return normalizeAutoGearNotesKey(datasetNotes);
+    }
+    const notesNode = span.querySelector('.auto-gear-notes');
+    if (!notesNode || typeof notesNode.textContent !== 'string') {
+        return '';
+    }
+    return normalizeAutoGearNotesKey(notesNode.textContent);
+}
+
 function matchesAutoGearItem(target, actual) {
     if (!target || !actual) return false;
     const normTarget = normalizeAutoGearName(target);
@@ -2867,6 +2894,13 @@ function configureAutoGearSpan(span, normalizedItem, quantity, rule) {
             span.appendChild(document.createTextNode(` - ${selectorLabel}`));
         }
     }
+    if (span.dataset) {
+        if (normalizedItem.notes) {
+            span.dataset.autoGearNotes = normalizedItem.notes;
+        } else if (Object.prototype.hasOwnProperty.call(span.dataset, 'autoGearNotes')) {
+            delete span.dataset.autoGearNotes;
+        }
+    }
     if (normalizedItem.notes) {
         const delimiter = normalizedItem.notes.trim().toLowerCase().startsWith('incl') ? ' ' : ' – ';
         const notesSpan = document.createElement('span');
@@ -2887,9 +2921,22 @@ function addAutoGearItem(cell, item, rule) {
     const name = normalizedItem.name ? normalizedItem.name.trim() : '';
     if (!name) return;
     const spans = Array.from(cell.querySelectorAll('.gear-item'));
+    const targetNotesKey = normalizeAutoGearNotesKey(normalizedItem.notes);
     for (const span of spans) {
         const spanName = span.getAttribute('data-gear-name') || (span.textContent || '').replace(/^(\d+)x\s+/, '').trim();
         if (matchesAutoGearItem(name, spanName)) {
+            const spanNotesKey = getAutoGearSpanNotesKey(span);
+            if (targetNotesKey) {
+                if (span.classList.contains('auto-gear-item')) {
+                    if (!spanNotesKey || spanNotesKey !== targetNotesKey) {
+                        continue;
+                    }
+                } else if (spanNotesKey && spanNotesKey !== targetNotesKey) {
+                    continue;
+                }
+            } else if (span.classList.contains('auto-gear-item') && spanNotesKey) {
+                continue;
+            }
             if (span.classList.contains('auto-gear-item')) {
                 const newCount = getSpanCount(span) + quantity;
                 updateSpanCountInPlace(span, newCount);
@@ -2897,6 +2944,13 @@ function addAutoGearItem(cell, item, rule) {
                     mergeAutoGearSpanContextNotes(span, normalizedItem.contextNotes, quantity);
                 } else {
                     renderAutoGearSpanContextNotes(span);
+                }
+                if (span.dataset) {
+                    if (normalizedItem.notes) {
+                        span.dataset.autoGearNotes = normalizedItem.notes;
+                    } else if (Object.prototype.hasOwnProperty.call(span.dataset, 'autoGearNotes')) {
+                        delete span.dataset.autoGearNotes;
+                    }
                 }
                 if (rule && typeof rule === 'object') {
                     appendAutoGearRuleSource(span, rule);

--- a/tests/dom/autoGearHighlightNotes.test.js
+++ b/tests/dom/autoGearHighlightNotes.test.js
@@ -1,0 +1,105 @@
+const { setupScriptEnvironment } = require('../helpers/scriptEnvironment');
+
+describe('automatic gear highlight note handling', () => {
+  let env;
+
+  afterEach(() => {
+    env?.cleanup();
+    env = null;
+  });
+
+  test('keeps separate auto-gear spans for note variants', () => {
+    env = setupScriptEnvironment({
+      disableFreeze: true,
+      globals: {
+        buildDefaultVideoDistributionAutoGearRules: () => [],
+        buildDefaultMatteboxAutoGearRules: () => [],
+        buildVideoDistributionAutoRules: () => [],
+      },
+    });
+    const { utils } = env;
+
+    expect(typeof global.setAutoGearRules).toBe('function');
+
+    const fiveDayRule = {
+      id: 'rule-every-5-days',
+      label: 'Every 5 shooting days',
+      scenarios: [],
+      mattebox: [],
+      cameraHandle: [],
+      viewfinderExtension: [],
+      deliveryResolution: [],
+      videoDistribution: [],
+      camera: [],
+      monitor: [],
+      crewPresent: [],
+      crewAbsent: [],
+      wireless: [],
+      motors: [],
+      controllers: [],
+      distance: [],
+      shootingDays: { mode: 'every', value: 5 },
+      add: [
+        {
+          id: 'item-eye-leather',
+          name: 'Bluestar eye leather made of microfiber oval, large',
+          category: 'Consumables',
+          quantity: 4,
+        },
+        {
+          id: 'item-gaff-primary',
+          name: 'Pro Gaff Tape',
+          category: 'Consumables',
+          quantity: 2,
+          notes: 'Primary color roll',
+        },
+        {
+          id: 'item-gaff-secondary',
+          name: 'Pro Gaff Tape',
+          category: 'Consumables',
+          quantity: 2,
+          notes: 'Secondary color roll',
+        },
+        {
+          id: 'item-clapper',
+          name: 'Clapper Stick',
+          category: 'Rigging',
+          quantity: 4,
+        },
+        {
+          id: 'item-kimtech',
+          name: 'Kimtech Wipes',
+          category: 'Consumables',
+          quantity: 2,
+        },
+        {
+          id: 'item-sprigs',
+          name: 'Sprigs Red 1/4"',
+          category: 'Consumables',
+          quantity: 1,
+        },
+      ],
+      remove: [],
+    };
+
+    global.setAutoGearRules([fiveDayRule]);
+
+    const html = utils.generateGearListHtml({
+      projectName: 'Highlight QA',
+      shootingDays: ['2024-01-01 to 2024-01-31'],
+    });
+
+    utils.displayGearAndRequirements(html);
+
+    const gearListOutput = document.getElementById('gearListOutput');
+    expect(gearListOutput).not.toBeNull();
+
+    const proGaffNodes = Array.from(
+      gearListOutput.querySelectorAll('.auto-gear-item')
+    ).filter((node) => node.getAttribute('data-gear-name') === 'Pro Gaff Tape');
+
+    expect(proGaffNodes).toHaveLength(2);
+    const noteLabels = proGaffNodes.map((node) => node.dataset.autoGearNotes);
+    expect(noteLabels.sort()).toEqual(['Primary color roll', 'Secondary color roll']);
+  });
+});


### PR DESCRIPTION
## Summary
- ensure automatic gear matching skips spans with mismatched note labels so each rule addition remains distinct
- persist note metadata on auto gear spans so highlight and tooltips stay accurate after merges
- add a DOM regression test that exercises the every-five-day consumables rule with primary/secondary gaff tape entries

## Testing
- npx jest tests/dom/autoGearHighlightNotes.test.js --runInBand *(fails: cineRuntime integrity verification requires full production module bindings in the test harness)*

------
https://chatgpt.com/codex/tasks/task_e_68e5905691288320a9d27713a2329342