### PR TITLE
Improve legacy import compatibility for projects and backups

### DIFF
--- a/tests/script/backupCompatibility.test.js
+++ b/tests/script/backupCompatibility.test.js
@@ -168,5 +168,33 @@ describe('backup compatibility utilities', () => {
     );
     expect(sections.sessionStorage).toBeNull();
   });
+
+  test('extractBackupSections converts Map-based backup payloads', () => {
+    const { extractBackupSections } = loadApp();
+
+    const dataMap = new Map();
+    dataMap.set('setups', new Map([
+      ['MapSetup', { name: 'MapSetup', items: [] }],
+    ]));
+
+    const rootMap = new Map();
+    rootMap.set('data', dataMap);
+    rootMap.set('fullBackups', new Map([
+      ['entry', { createdAt: '2024-03-01T00:00:00.000Z' }],
+    ]));
+    rootMap.set('settings', new Map([
+      ['cameraPowerPlanner_setups', { Primary: { name: 'Primary', items: [] } }],
+    ]));
+
+    const sections = extractBackupSections(rootMap);
+
+    expect(sections.data.setups).toEqual({ MapSetup: { name: 'MapSetup', items: [] } });
+    expect(sections.data.fullBackups).toEqual([
+      { createdAt: '2024-03-01T00:00:00.000Z' },
+    ]);
+    expect(sections.settings.cameraPowerPlanner_setups).toBe(
+      JSON.stringify({ Primary: { name: 'Primary', items: [] } }),
+    );
+  });
 });
 


### PR DESCRIPTION
## Summary
- add map-like detection and conversion utilities to legacy storage import paths
- extend project normalization to accept map, tuple-array, and mixed project containers
- update backup utilities to normalize map-based payloads and expand regression coverage

## Testing
- npm run test:jest -- --runTestsByPath tests/unit/storage.test.js tests/script/backupCompatibility.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e59227905c8320ab11c4c0268b39dd