### PR TITLE
Remove cage rod compatibility warning

### DIFF
--- a/legacy/scripts/app-setups.js
+++ b/legacy/scripts/app-setups.js
@@ -3874,7 +3874,6 @@ function generateGearListHtml() {
     });
   };
   var lensSupportItems = [];
-  var requiredRodTypes = new Set();
   var addedRodPairs = new Set();
   selectedLensNames.forEach(function (name) {
     var lens = devices.lenses && devices.lenses[name];
@@ -3888,20 +3887,8 @@ function generateGearListHtml() {
       lensSupportItems.push("".concat(baseRodType, " rods ").concat(rodLength, "cm"));
       addedRodPairs.add(rodKey);
     }
-    var typesForRequirement = normalizedRodTypes.length ? normalizedRodTypes : [baseRodType];
-    typesForRequirement.forEach(function (rt) {
-      return requiredRodTypes.add(rt);
-    });
     if (lens.needsLensSupport) {
       lensSupportItems.push("".concat(baseRodType, " lens support"));
-    }
-  });
-  var cageRod = (_devices$accessories3 = devices.accessories) === null || _devices$accessories3 === void 0 || (_devices$accessories3 = _devices$accessories3.cages) === null || _devices$accessories3 === void 0 || (_devices$accessories3 = _devices$accessories3[selectedNames.cage]) === null || _devices$accessories3 === void 0 ? void 0 : _devices$accessories3.rodStandard;
-  var cageRodTypes = parseRodTypes(cageRod);
-  var hasCageRodInfo = Array.isArray(cageRod) ? cageRod.length > 0 : Boolean(cageRod);
-  requiredRodTypes.forEach(function (rt) {
-    if (hasCageRodInfo && !cageRodTypes.includes(rt)) {
-      lensSupportItems.push("".concat(glyphText(ICON_GLYPHS.warning), "\xA0cage incompatible with ").concat(rt, " rods"));
     }
   });
   addRow('Lens Support', formatItems(lensSupportItems));

--- a/src/scripts/app-setups.js
+++ b/src/scripts/app-setups.js
@@ -4154,7 +4154,6 @@ function gearListGenerateHtmlImpl(info = {}) {
         return order.filter(type => rodSet.has(type));
     };
     const lensSupportItems = [];
-    const requiredRodTypes = new Set();
     const addedRodPairs = new Set();
     selectedLensNames.forEach(name => {
         const lens = devices.lenses && devices.lenses[name];
@@ -4168,18 +4167,8 @@ function gearListGenerateHtmlImpl(info = {}) {
             lensSupportItems.push(`${baseRodType} rods ${rodLength}cm`);
             addedRodPairs.add(rodKey);
         }
-        const typesForRequirement = normalizedRodTypes.length ? normalizedRodTypes : [baseRodType];
-        typesForRequirement.forEach(rt => requiredRodTypes.add(rt));
         if (lens.needsLensSupport) {
             lensSupportItems.push(`${baseRodType} lens support`);
-        }
-    });
-    const cageRod = devices.accessories?.cages?.[selectedNames.cage]?.rodStandard;
-    const cageRodTypes = parseRodTypes(cageRod);
-    const hasCageRodInfo = Array.isArray(cageRod) ? cageRod.length > 0 : Boolean(cageRod);
-    requiredRodTypes.forEach(rt => {
-        if (hasCageRodInfo && !cageRodTypes.includes(rt)) {
-            lensSupportItems.push(`${glyphText(ICON_GLYPHS.warning)}\u00A0cage incompatible with ${rt} rods`);
         }
     });
     addRow('Lens Support', formatItems(lensSupportItems));


### PR DESCRIPTION
## Summary
- remove the lens support warning that flagged cage and rod incompatibility

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e5931ea69c8320bf2a87808c12b002