### PR TITLE
Add dynamic clamp-on mattebox backings to auto gear

### DIFF
--- a/src/scripts/app-setups.js
+++ b/src/scripts/app-setups.js
@@ -3049,6 +3049,111 @@ function computeAutoGearScenarioOutcome(rule, scenarioSet) {
     return { active: allPresent, multiplier: allPresent ? 1 : 0 };
 }
 
+function normalizeClampOnDiameterKey(value) {
+    if (!Number.isFinite(value)) return '';
+    return Number(value).toFixed(3);
+}
+
+function formatClampOnDiameterLabel(value) {
+    if (!Number.isFinite(value)) return '';
+    const rounded = Number(Number(value).toFixed(2));
+    if (!Number.isFinite(rounded)) return '';
+    return String(rounded);
+}
+
+function shouldAugmentClampOnRule(rule) {
+    if (!rule || typeof rule !== 'object') return false;
+    const matteboxList = Array.isArray(rule.mattebox) ? rule.mattebox.filter(Boolean) : [];
+    if (!matteboxList.length) return false;
+    const normalized = matteboxList
+        .map(value => normalizeAutoGearTriggerValue(value).replace(/-/g, ' '))
+        .filter(Boolean);
+    if (!normalized.length) return false;
+    return normalized.includes('clamp on');
+}
+
+function buildClampOnBackingAdditionsFromInfo(info) {
+    const lensValue = info ? info.lenses : '';
+    let lensNames = [];
+    if (Array.isArray(lensValue)) {
+        lensNames = lensValue.filter(name => typeof name === 'string' && name.trim());
+    } else if (typeof lensValue === 'string') {
+        lensNames = lensValue
+            .split(',')
+            .map(name => name.trim())
+            .filter(Boolean);
+    }
+    if (!lensNames.length) return [];
+    const lensDb = devices && devices.lenses ? devices.lenses : null;
+    if (!lensDb || typeof lensDb !== 'object') return [];
+    const normalizedLookup = new Map();
+    Object.keys(lensDb).forEach(name => {
+        if (typeof name !== 'string' || !name) return;
+        const normalized = name.trim().toLowerCase();
+        if (normalized && !normalizedLookup.has(normalized)) {
+            normalizedLookup.set(normalized, lensDb[name]);
+        }
+    });
+    const diameterMap = new Map();
+    lensNames.forEach(selectionName => {
+        if (typeof selectionName !== 'string') return;
+        const trimmed = selectionName.trim();
+        if (!trimmed) return;
+        const normalized = trimmed.toLowerCase();
+        let lens = Object.prototype.hasOwnProperty.call(lensDb, trimmed) ? lensDb[trimmed] : null;
+        if (!lens && normalizedLookup.has(normalized)) {
+            lens = normalizedLookup.get(normalized);
+        }
+        if (!lens || typeof lens !== 'object') return;
+        const diameter = Number(lens.frontDiameterMm);
+        if (!Number.isFinite(diameter) || diameter <= 0) return;
+        const key = normalizeClampOnDiameterKey(diameter);
+        if (!key) return;
+        if (!diameterMap.has(key)) {
+            diameterMap.set(key, { diameter, lenses: [] });
+        }
+        const entry = diameterMap.get(key);
+        if (entry.lenses.indexOf(trimmed) === -1) {
+            entry.lenses.push(trimmed);
+        }
+    });
+    if (!diameterMap.size) return [];
+    const sorted = Array.from(diameterMap.values()).sort((a, b) => {
+        if (a.diameter === b.diameter) return 0;
+        return a.diameter < b.diameter ? -1 : 1;
+    });
+    return sorted.map(({ diameter, lenses }) => {
+        const sizeLabel = formatClampOnDiameterLabel(diameter) || String(Number(diameter));
+        const item = {
+            name: `Mattebox Clamp-On Backing ${sizeLabel}mm`,
+            category: 'Matte box + filter',
+            quantity: 1,
+        };
+        if (Array.isArray(lenses) && lenses.length) {
+            item.contextNotes = [`Lenses: ${lenses.join(', ')}`];
+        }
+        return item;
+    });
+}
+
+function mergeAutoGearAdditions(baseAdditions, extraAdditions) {
+    const result = [];
+    const seen = new Set();
+    const pushUnique = (item) => {
+        if (!item || typeof item !== 'object') return;
+        const name = typeof item.name === 'string' ? item.name.trim() : '';
+        if (!name) return;
+        const category = typeof item.category === 'string' ? item.category.trim() : '';
+        const key = `${name.toLowerCase()}|${category.toLowerCase()}`;
+        if (seen.has(key)) return;
+        seen.add(key);
+        result.push(item);
+    };
+    baseAdditions.forEach(pushUnique);
+    extraAdditions.forEach(pushUnique);
+    return result;
+}
+
 function applyAutoGearRulesToTableHtml(tableHtml, info) {
     if (!tableHtml || !autoGearRules.length || typeof document === 'undefined') return tableHtml;
   const scenarios = info && info.requiredScenarios
@@ -3480,7 +3585,15 @@ function applyAutoGearRulesToTableHtml(tableHtml, info) {
                 }
             }
         });
-        rule.add.forEach(item => {
+        const baseAdditions = Array.isArray(rule.add) ? rule.add.slice() : [];
+        let additions = baseAdditions;
+        if (shouldAugmentClampOnRule(rule)) {
+            const clampBackings = buildClampOnBackingAdditionsFromInfo(info);
+            if (clampBackings.length) {
+                additions = mergeAutoGearAdditions(baseAdditions, clampBackings);
+            }
+        }
+        additions.forEach(item => {
             const quantity = normalizeAutoGearQuantity(item.quantity) * effectiveMultiplier;
             const scaledItem = quantity === normalizeAutoGearQuantity(item.quantity)
                 ? item

--- a/src/scripts/translations.js
+++ b/src/scripts/translations.js
@@ -320,7 +320,7 @@ const texts = {
     autoGearShootingDaysValueLabel: "Shooting days value",
     autoGearMatteboxLabel: "Mattebox options",
     autoGearMatteboxHelp:
-      "Apply this rule when these mattebox choices are selected.",
+      "Apply this rule when these mattebox choices are selected. Clamp-on rules automatically add the matching backing sizes for the selected lens fronts.",
     autoGearMatteboxPlaceholder: "Select mattebox options",
     autoGearCameraHandleLabel: "Camera handles",
     autoGearCameraHandleHelp:
@@ -2267,7 +2267,7 @@ const texts = {
     autoGearShootingDaysValueLabel: "Valore giorni di ripresa",
     autoGearMatteboxLabel: "Opzioni matte box",
     autoGearMatteboxHelp:
-      "Applica la regola quando sono selezionate queste opzioni di matte box.",
+      "Applica la regola quando sono selezionate queste opzioni di matte box. Le regole clamp-on aggiungono automaticamente i back clamp della misura corretta per i diametri frontali delle ottiche selezionate.",
     autoGearMatteboxPlaceholder: "Seleziona opzioni matte box",
     autoGearCameraHandleLabel: "Maniglie camera",
     autoGearCameraHandleHelp:
@@ -3749,7 +3749,7 @@ const texts = {
     autoGearShootingDaysValueLabel: "Valor de días de rodaje",
     autoGearMatteboxLabel: "Opciones de matte box",
     autoGearMatteboxHelp:
-      "Aplica la regla cuando se eligen estas opciones de matte box.",
+      "Aplica la regla cuando se eligen estas opciones de matte box. Las reglas clamp-on añaden automáticamente los respaldos del tamaño correcto para los frentes de óptica seleccionados.",
     autoGearMatteboxPlaceholder: "Selecciona opciones de matte box",
     autoGearCameraHandleLabel: "Empuñaduras de cámara",
     autoGearCameraHandleHelp:
@@ -5233,7 +5233,7 @@ const texts = {
     autoGearShootingDaysValueLabel: "Valeur de jours de tournage",
     autoGearMatteboxLabel: "Options de matte box",
     autoGearMatteboxHelp:
-      "Appliquer la règle lorsque ces options de matte box sont sélectionnées.",
+      "Appliquer la règle lorsque ces options de matte box sont sélectionnées. Les règles clamp-on ajoutent automatiquement les adaptateurs arrière correspondants aux diamètres frontaux des optiques sélectionnées.",
     autoGearMatteboxPlaceholder: "Sélectionnez des options de matte box",
     autoGearCameraHandleLabel: "Poignées caméra",
     autoGearCameraHandleHelp:
@@ -6728,7 +6728,7 @@ const texts = {
     autoGearShootingDaysValueLabel: "Drehtage-Wert",
     autoGearMatteboxLabel: "Mattebox-Optionen",
     autoGearMatteboxHelp:
-      "Regel anwenden, wenn diese Mattebox-Optionen gewählt sind.",
+      "Regel anwenden, wenn diese Mattebox-Optionen gewählt sind. Clamp-On-Regeln fügen automatisch die passenden Backings für die Frontdurchmesser der ausgewählten Objektive hinzu.",
     autoGearMatteboxPlaceholder: "Mattebox-Optionen auswählen",
     autoGearCameraHandleLabel: "Kamera-Handgriffe",
     autoGearCameraHandleHelp:


### PR DESCRIPTION
## Summary
- add dynamic clamp-on backing gear items for matte box auto rules based on the selected lens front diameters
- document the new clamp-on backing behaviour in the matte box auto-gear help text across supported languages

## Testing
- npm test -- --runInBand *(fails: TypeError in sharedProjectGearList tests)*

------
https://chatgpt.com/codex/tasks/task_e_68e5944051c88320a5e575ec7b7328c6