### PR TITLE
Document lens overview specs

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -320,7 +320,7 @@ Print-freundliche Versionen findest du in `docs/operations-checklist.md`; der Tr
 - Einträge gruppieren nach Kategorie, Duplikate werden zusammengeführt. Szenarien ergänzen passende Rigs, Wetter- oder Spezialzubehör.
 - Automatische Regeln laufen nach dem Generator und fügen szenariospezifische Anpassungen hinzu.
 - Abdeckungsnotizen aus dem Regel-Dashboard erscheinen in Druckansichten, Exporten und Bundles, damit Offline-Reviews identisch zum In-App-Status bleiben.
-- Objektivreihen enthalten Frontdurchmesser, Gewicht, Naheinstellgrenze, Rod-Anforderungen und Mattebox-Komponenten. Akkureihen berücksichtigen Rechnercounts und Hot-Swap-Hardware.
+- Objektivreihen enthalten Frontdurchmesser, Gewicht, Naheinstellgrenze, Rod-Anforderungen und Mattebox-Komponenten. Die druckbare Overview spiegelt diese Auswahl mit Marke, Mount, Durchmesser, Fokus, Gewicht, Rod-Support und Notizen, sodass Ausleihpakete offline dieselben Specs tragen. Akkureihen berücksichtigen Rechnercounts und Hot-Swap-Hardware.
 - Crewdetails, Monitoring, Verteilung und Notizen erscheinen in Exporten.
 - Listen werden mit dem Projekt gespeichert, erscheinen in Overviews, Bundles und lassen sich mit **Geräteliste löschen** zurücksetzen.
 

--- a/README.en.md
+++ b/README.en.md
@@ -765,8 +765,10 @@ data.
 - Coverage annotations from the automatic gear dashboard appear in print views,
   exports and shareable bundles so offline reviews match the in-app summary.
 - Lens rows include front diameter, weight, minimum focus, rod requirements and
-  matte box components. Battery rows account for calculator counts and required
-  hot-swap hardware.
+  matte box components. The printable overview mirrors these selections with
+  brand, mount, diameter, focus, weight, rod support and notes so checkout
+  packets carry the same lens specs offline. Battery rows account for
+  calculator counts and required hot-swap hardware.
 - Crew details, monitoring configurations, video distribution preferences and
   custom notes appear in exports so departments stay aligned.
 - Gear lists save with the project, appear in printable overviews, live inside

--- a/README.es.md
+++ b/README.es.md
@@ -319,7 +319,7 @@ Rutinas repetibles para mantener proyectos, respaldos y recursos offline sincron
 - Los elementos se agrupan por categoría y fusionan duplicados. Los escenarios añaden rigging, protección climática y accesorios especializados para reflejar la realidad del rodaje.
 - Las reglas automáticas se ejecutan tras el generador para añadir o quitar elementos específicos sin editar JSON a mano.
 - Las anotaciones de cobertura del panel de reglas aparecen en vistas impresas, exportaciones y paquetes compartidos para que las revisiones offline reflejen el mismo resumen.
-- Las filas de lentes incluyen diámetro frontal, peso, mínimo enfoque, necesidad de varillas y componentes de matte box. Las filas de baterías consideran cantidades y hardware para hot-swap.
+- Las filas de lentes incluyen diámetro frontal, peso, mínimo enfoque, necesidad de varillas y componentes de matte box. La vista general imprimible refleja estas selecciones con marca, montura, diámetro, enfoque, peso, soporte de varillas y notas para que los paquetes de entrega mantengan las mismas especificaciones sin conexión. Las filas de baterías consideran cantidades y hardware para hot-swap.
 - Detalles del equipo, configuraciones de monitoreo, preferencias de distribución de vídeo y notas personalizadas aparecen en las exportaciones.
 - Las listas se guardan con el proyecto, aparecen en las vistas imprimibles y en los paquetes; puedes reiniciarlas con **Eliminar lista de equipo**.
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -322,7 +322,7 @@ Ces routines garantissent que projets, backups et ressources hors ligne restent 
 - Les entrées sont regroupées par catégorie et les doublons fusionnés. Les scénarios ajoutent rigging, protections météo et accessoires spécifiques pour refléter la réalité terrain.
 - Les règles automatiques s’exécutent après le générateur pour ajouter ou retirer des éléments sans modifier le JSON à la main.
 - Les annotations de couverture du tableau des règles apparaissent dans les vues imprimables, les exports et les bundles partagés afin que les revues hors ligne reflètent le même résumé.
-- Les lignes d’objectifs incluent diamètre frontal, poids, mise au point minimale, besoin de rods et composants matte box. Les lignes batteries tiennent compte du nombre et du matériel de bascule à chaud.
+- Les lignes d’objectifs incluent diamètre frontal, poids, mise au point minimale, besoin de rods et composants matte box. Le résumé imprimable reflète ces sélections avec marque, monture, diamètre, focus, poids, support de rods et notes pour que les dossiers restent complets hors-ligne. Les lignes batteries tiennent compte du nombre et du matériel de bascule à chaud.
 - Détails de l’équipe, configurations de monitoring, distribution vidéo et notes personnalisées apparaissent dans les exports.
 - Les listes sont sauvegardées avec le projet, visibles dans les aperçus imprimables et incluses dans les bundles ; utilisez **Supprimer la liste** pour repartir de zéro.
 

--- a/README.it.md
+++ b/README.it.md
@@ -321,7 +321,7 @@ Queste routine mantengono progetti, backup e risorse offline sincronizzati su og
 - Le voci sono raggruppate per categoria e i duplicati fusi. Gli scenari aggiungono rigging, protezioni meteo e accessori specialistici per rispecchiare il lavoro reale.
 - Le regole automatiche si eseguono dopo il generatore per aggiungere o rimuovere elementi specifici senza toccare il JSON.
 - Le annotazioni di copertura del pannello regole compaiono nelle stampe, negli export e nei bundle condivisi così le revisioni offline vedono lo stesso riepilogo.
-- Le righe obiettivi includono diametro frontale, peso, minima di fuoco, necessità di aste e componenti della matte box. Le righe batterie considerano quantità e hardware per l’hot swap.
+- Le righe obiettivi includono diametro frontale, peso, minima di fuoco, necessità di aste e componenti della matte box. La panoramica stampabile replica queste scelte con marca, attacco, diametro, fuoco, peso, supporto aste e note così i dossier restano completi anche offline. Le righe batterie considerano quantità e hardware per l’hot swap.
 - Dettagli troupe, configurazioni di monitoraggio, distribuzione video e note personalizzate appaiono negli export.
 - Le liste vengono salvate con il progetto, compaiono nelle overview stampabili e nei bundle; puoi azzerarle con **Elimina lista attrezzatura**.
 

--- a/README.md
+++ b/README.md
@@ -790,8 +790,10 @@ data.
 - Coverage annotations from the automatic gear dashboard appear in print views,
   exports and shareable bundles so offline reviews match the in-app summary.
 - Lens rows include front diameter, weight, minimum focus, rod requirements and
-  matte box components. Battery rows account for calculator counts and required
-  hot-swap hardware.
+  matte box components. The printable overview mirrors these selections with
+  brand, mount, diameter, focus, weight, rod support and notes so checkout
+  packets carry the same lens specs offline. Battery rows account for
+  calculator counts and required hot-swap hardware.
 - Crew details, monitoring configurations, video distribution preferences and
   custom notes appear in exports so departments stay aligned.
 - Gear lists save with the project, appear in printable overviews, live inside

--- a/src/scripts/translations.js
+++ b/src/scripts/translations.js
@@ -1446,7 +1446,7 @@ const texts = {
     saveSetupHelp:
       "Store the devices and battery you have selected so the project can be recalled later. Press Enter or Ctrl+S (Cmd+S on Mac) to save quickly; the Save button stays disabled until a name is entered.",
     generateOverviewHelp:
-      "Rebuilds the print-ready summary for the selected saved project and opens the overview dialog so you can review power and connection details before printing when ready.",
+      "Rebuilds the print-ready summary for the selected saved project and opens the overview dialog so you can review power and connection details before printing when ready. Lens selections render with brand, mount, diameter, focus, weight, rod support and notes so exports cover spec-sensitive checkouts.",
     generateGearListHelp:
       "Build a categorized table that combines selected gear with project requirements. The list refreshes on every change, merges duplicate items with counts and auto-adds required cables, rigging, lens supports, matte box parts, battery counts with hotswap hardware, default monitors for each role and scenario-specific accessories. Entries are sorted alphabetically and include hover descriptions.",
     shareSetupHelp:
@@ -2917,7 +2917,7 @@ const texts = {
     deleteSetupHelp: "Elimina la configurazione salvata selezionata.",
     saveSetupHelp: "Salva la configurazione corrente. Premi Invio o Ctrl+S (Cmd+S su Mac) per salvare rapidamente; il pulsante Salva rimane disabilitato finché non viene inserito un nome.",
     generateOverviewHelp:
-      "Ricostruisce il riepilogo pronto per la stampa del progetto salvato selezionato e apre la finestra panoramica così puoi rivedere i dettagli di alimentazione e connessione prima di stampare quando preferisci.",
+      "Ricostruisce il riepilogo pronto per la stampa del progetto salvato selezionato e apre la finestra panoramica così puoi rivedere i dettagli di alimentazione e connessione prima di stampare quando preferisci. La sezione obiettivi mostra marca, attacco, diametro, fuoco, peso, supporto aste e note così gli export coprono le verifiche sensibili alle specifiche.",
     generateGearListHelp:
       "Genera una tabella categorizzata che combina l'attrezzatura selezionata con i requisiti del progetto. L'elenco si aggiorna a ogni modifica, unisce i duplicati con un conteggio e aggiunge automaticamente cavi, rigging, supporti lente, componenti matte box, conteggi batteria con hotswap, monitor predefiniti per ogni ruolo e accessori specifici per gli scenari. Gli elementi sono ordinati alfabeticamente e includono descrizioni al passaggio del mouse.",
     shareSetupHelp:
@@ -4398,7 +4398,7 @@ const texts = {
     deleteSetupHelp: "Elimina la configuración guardada seleccionada.",
     saveSetupHelp: "Guarda la configuración actual. Pulsa Intro o Ctrl+S (Cmd+S en Mac) para guardar rápidamente; el botón Guardar permanece desactivado hasta que se introduce un nombre.",
     generateOverviewHelp:
-      "Reconstruye el resumen listo para imprimir del proyecto guardado seleccionado y abre la ventana de overview para que revises los detalles de alimentación y conexión antes de imprimir cuando quieras.",
+      "Reconstruye el resumen listo para imprimir del proyecto guardado seleccionado y abre la ventana de overview para que revises los detalles de alimentación y conexión antes de imprimir cuando quieras. Las ópticas seleccionadas se muestran con marca, montura, diámetro, enfoque, peso, soporte de varillas y notas para que los exports cubran chequeos sensibles a especificaciones.",
     generateGearListHelp:
       "Genera una tabla categorizada que combina el equipo seleccionado con los requisitos del proyecto. La lista se actualiza con cada cambio, fusiona duplicados con sus cantidades y añade automáticamente cables, rigging, soportes de lente, piezas de matte box, recuentos de baterías con hotswap, monitores predeterminados para cada rol y accesorios específicos de los escenarios. Los elementos se ordenan alfabéticamente e incluyen descripciones al pasar el cursor.",
     shareSetupHelp:
@@ -5891,7 +5891,7 @@ const texts = {
     deleteSetupHelp: "Supprime la configuration enregistrée sélectionnée.",
     saveSetupHelp: "Enregistre la configuration actuelle. Appuyez sur Entrée ou Ctrl+S (Cmd+S sur Mac) pour enregistrer rapidement ; le bouton Enregistrer reste désactivé tant qu'aucun nom n'est saisi.",
     generateOverviewHelp:
-      "Reconstruit le résumé prêt à l'impression du projet enregistré sélectionné et ouvre la fenêtre d'aperçu pour examiner les détails d'alimentation et de connexion avant d'imprimer quand vous êtes prêt.",
+      "Reconstruit le résumé prêt à l'impression du projet enregistré sélectionné et ouvre la fenêtre d'aperçu pour examiner les détails d'alimentation et de connexion avant d'imprimer quand vous êtes prêt. La section optiques affiche marque, monture, diamètre, focus, poids, support de rods et notes afin que les exports couvrent les contrôles sensibles aux spécifications.",
     generateGearListHelp:
       "Génère un tableau catégorisé combinant le matériel sélectionné et les exigences du projet. La liste se met à jour à chaque changement, fusionne les doublons avec leur quantité et ajoute automatiquement câbles, rigging, supports d'objectif, éléments de matte box, nombre de batteries avec matériel de hotswap, moniteurs par rôle et accessoires spécifiques aux scénarios. Chaque entrée est triée alphabétiquement et offre une description au survol.",
     shareSetupHelp:
@@ -7388,7 +7388,7 @@ const texts = {
     deleteSetupHelp: "Löscht das ausgewählte gespeicherte Projekt.",
     saveSetupHelp: "Speichert das aktuelle Projekt. Drücke Eingabe oder Strg+S (Cmd+S auf dem Mac), um schnell zu speichern; der Speichern-Button bleibt deaktiviert, bis ein Name eingegeben ist.",
     generateOverviewHelp:
-      "Erstellt die druckfertige Übersicht für das ausgewählte gespeicherte Projekt neu und öffnet das Übersichtsfenster, damit du Strom- und Verbindungsdetails prüfen kannst, bevor du bei Bedarf druckst.",
+      "Erstellt die druckfertige Übersicht für das ausgewählte gespeicherte Projekt neu und öffnet das Übersichtsfenster, damit du Strom- und Verbindungsdetails prüfen kannst, bevor du bei Bedarf druckst. Die Objektivsektion zeigt Marke, Mount, Durchmesser, Fokus, Gewicht, Rod-Support und Notizen, damit Exporte spezifikationskritische Checks abdecken.",
     generateGearListHelp:
       "Erstellt eine kategorisierte Tabelle aus ausgewähltem Equipment und Projektanforderungen. Die Liste aktualisiert sich bei jeder Änderung, fasst doppelte Einträge mit Anzahl zusammen und ergänzt automatisch benötigte Kabel, Rigging, Linsensupports, Matte-Box-Bauteile, Batteriezahlen mit Hotswap-Hardware, Standardmonitore pro Rolle sowie szenariospezifisches Zubehör. Alle Posten sind alphabetisch sortiert und zeigen beim Überfahren eine Beschreibung.",
     shareSetupHelp:


### PR DESCRIPTION
## Summary
- note that printable overviews now surface lens brand, mount, diameter, focus, weight, rod support and notes across the English and localized READMEs
- expand the overview help tooltip in every supported language to mention the detailed lens specs included in the summary dialog

## Testing
- Not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e596fb19408320a30c3d1b289cd3ed