### PR TITLE
Handle unreadable auto backup payloads gracefully

### DIFF
--- a/src/scripts/storage.js
+++ b/src/scripts/storage.js
@@ -971,7 +971,7 @@ function expandAutoBackupEntries(container, options) {
         payloadInfo = restoreAutoBackupSnapshotPayload(snapshot, name);
       } catch (payloadError) {
         console.warn('Failed to restore automatic backup payload while expanding snapshot', name, payloadError);
-        throw payloadError;
+        payloadInfo = { payload: {}, compressed: false, error: payloadError };
       }
       const payload = isPlainObject(payloadInfo.payload) ? payloadInfo.payload : {};
       const changedKeys = Array.isArray(snapshot.changedKeys) && snapshot.changedKeys.length


### PR DESCRIPTION
## Summary
- fall back to an empty payload when automatic backup restoration fails so expansion can continue

## Testing
- npm run test:unit -- storage

------
https://chatgpt.com/codex/tasks/task_e_68e5a0939c0883209780f59cd78670b3