### PR TITLE
Fix auto gear DOM interactions with standard gear wrapper

### DIFF
--- a/src/scripts/app-setups.js
+++ b/src/scripts/app-setups.js
@@ -2443,7 +2443,12 @@ function cleanupAutoGearCell(cell) {
         container.removeChild(container.lastChild);
     }
     const textContent = container.textContent ? container.textContent.trim() : '';
-    if (!textContent && !container.querySelector('.gear-item')) {
+    const hasStandardItems = Boolean(textContent) || Boolean(container.querySelector('.gear-item'));
+    const customItems = cell && typeof cell.querySelector === 'function'
+        ? cell.querySelector('.gear-custom-section .gear-custom-item')
+        : null;
+    const hasCustomItems = Boolean(customItems);
+    if (!hasStandardItems && !hasCustomItems) {
         const row = cell.closest('tr');
         const section = row ? row.closest('tbody') : null;
         if (section && section.classList.contains('auto-gear-category')) {


### PR DESCRIPTION
## Summary
- add a helper so auto gear DOM updates target the standard gear container when present
- update add/remove/cleanup logic to work with wrapped markup without touching the custom items section
- ensure auto gear cleanup preserves categories that still have custom items

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e5a469d9648320a85f336119672fa2