### PR TITLE
Add documentation update checklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -955,6 +955,7 @@ behavior on every workstation.
 
 Keeping the help center, printable manuals and localized READMEs current is part of every
 feature change. Follow the [Documentation, Help & Translation Maintenance Guide](docs/documentation-maintenance.md)
+and the quick [Documentation Update Checklist](docs/documentation-update-checklist.md)
 whenever you ship a new workflow so offline crews inherit accurate drills, translation
 coverage and recovery instructions. Each update should:
 
@@ -965,6 +966,9 @@ coverage and recovery instructions. Each update should:
 - Keep the [Save, Share, Import, Backup & Restore Reference](docs/save-share-restore-reference.md)
   aligned with UI labels, keyboard shortcuts and verification drills so crews rehearse the
   exact workflows enforced in code when they validate documentation changes.
+- Use the checklist to log which UI surfaces changed, which modules they depend on and which
+  translations need attention so verification logs always prove that the documentation and
+  offline behavior match.
 - Keep the **Key Workflow Reference** table and **Repository Layout & Offline Assets** notes synchronized across each
   localized README so every crew references the same offline-first procedures and directory expectations.
 - Update translation keys and selectors so language options stay synchronized with the UI

--- a/docs/documentation-maintenance.md
+++ b/docs/documentation-maintenance.md
@@ -3,7 +3,9 @@
 Cine Power Planner treats documentation as a core feature of the product. Help content,
 offline manuals and translations must reflect the current behavior of the app so crews can
 trust every save, share, import, backup and restore workflow even when they are far from an
-internet connection. Use this guide whenever you add, remove or adjust functionality.
+internet connection. Use this guide whenever you add, remove or adjust functionality. For a
+condensed run-through before code review, follow the [Documentation Update Checklist](documentation-update-checklist.md)
+alongside this guide so no surface or translation is missed.
 
 All persistence-facing documentation should now reference the consolidated
 `cinePersistence` module so that future refactors maintain a single, lossless contract for

--- a/docs/documentation-update-checklist.md
+++ b/docs/documentation-update-checklist.md
@@ -1,0 +1,37 @@
+# Documentation Update Checklist
+
+This checklist condenses the workflow from the [Documentation, Help & Translation Maintenance Guide](documentation-maintenance.md) into a rapid review you can run before landing any feature or copy change. Every step protects the offline-first contract—saving, sharing, importing, backing up and restoring must continue to work flawlessly and must never risk user data. Complete each section in order and record the outcome in your verification log so teams travelling without connectivity inherit reliable instructions.
+
+## 1. Scope the change
+
+- [ ] List every UI surface the change touches (dialogs, tooltips, hover help, settings panes, legal pages and offline manuals).
+- [ ] Map the affected `cineModules` contracts (`cinePersistence`, `cineUi`, `cineOffline`, `cineRuntime` and friends) so references in docs stay aligned with the frozen APIs.
+- [ ] Note any new keyboard shortcuts, save/share/import/backup/restore affordances or runtime guard outputs that must appear in copy.
+
+## 2. Update primary documentation
+
+- [ ] Edit `README.md` and every localized README to reflect the new workflows, especially the **Key Workflow Reference**, **Save, Share & Import Drill**, **Backup & Recovery** and **Emergency Recovery Playbook** sections.
+- [ ] Revise contextual help topics, hover help strings and FAQ answers in `src/scripts/help/` and `index.html` so offline crews see accurate instructions.
+- [ ] Synchronize printable manuals and runbooks in `docs/` (save/share reference, offline readiness, operations checklist, backup rotation guide, testing plan) with the change.
+- [ ] Update legal pages in `legal/` if any disclosures or policy links reference the updated feature.
+
+## 3. Refresh translations
+
+- [ ] Add or update entries in `src/scripts/translations.js`, duplicating the English copy to other locales when a translation is not yet available.
+- [ ] Ensure every language selector in `index.html` and the settings dialog exposes the new or updated strings.
+- [ ] Flag untranslated copy in the pull request description so localization contributors can follow up quickly.
+
+## 4. Verify offline behavior matches the docs
+
+- [ ] Follow the [Save, Share & Import Drill](../README.md#save-share--import-drill) to confirm documented steps reflect reality.
+- [ ] Capture manual saves, auto backups, planner backups and project bundles before and after the change; confirm restores succeed in an isolated offline profile.
+- [ ] Inspect `window.__cineRuntimeIntegrity` and run `window.cineRuntime.verifyCriticalFlows({ warnOnFailure: true })` to prove every persistence safeguard documented in the guides remains available.
+- [ ] Re-open the help dialog, legal pages and device catalogs offline to ensure service-worker caches include the updated copy and locally stored Uicons.
+
+## 5. Archive evidence
+
+- [ ] Update the verification log (using `docs/verification-log-template.md`) with the version, browser, workstation and command outputs collected during testing.
+- [ ] Store the verified planner backup, project bundle, automatic gear rules export and a ZIP of the repository alongside the updated documentation so crews can prove parity later.
+- [ ] Attach rendered PDFs or screenshots of modified help pages if the change affected visual layout or iconography.
+
+Running this checklist alongside the full maintenance guide keeps documentation, translations and offline workflows in sync with the product while protecting user data across every save, share, import, backup and restore path.


### PR DESCRIPTION
## Summary
- add a concise documentation update checklist that reinforces offline-first save/share/backup routines
- reference the new checklist from the README and maintenance guide so every doc change logs affected surfaces and translations

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5a8df530083209279e63f398e6750