### PR TITLE
feat: add opt-in diagnostics console capture toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -2593,7 +2593,8 @@
         >
           <h4 id="loggingHeading">Diagnostics log</h4>
           <p id="loggingIntro" class="storage-summary-note">
-            Monitor runtime diagnostics captured on this device. Updates live while Settings stay open.
+            Monitor runtime diagnostics captured on this device. Enable console capture below when you need deeper debugging.
+            Updates live while Settings stay open.
           </p>
           <div class="logging-controls">
             <div class="logging-filter">
@@ -2629,6 +2630,13 @@
               <label for="loggingConsoleOutput" id="loggingConsoleOutputLabel">Mirror to console</label>
               <input type="checkbox" id="loggingConsoleOutput" />
               <p id="loggingConsoleOutputHelp" class="settings-hint">Keep the browser console in sync with this log.</p>
+            </div>
+            <div class="settings-field settings-field-toggle">
+              <label for="loggingCaptureConsole" id="loggingCaptureConsoleLabel">Capture console output</label>
+              <input type="checkbox" id="loggingCaptureConsole" />
+              <p id="loggingCaptureConsoleHelp" class="settings-hint">
+                Record console messages for diagnostics. Turning this on may affect performance.
+              </p>
             </div>
             <div class="settings-field settings-field-toggle">
               <label for="loggingCaptureErrors" id="loggingCaptureErrorsLabel">Capture global errors</label>

--- a/src/scripts/app-core-new-1.js
+++ b/src/scripts/app-core-new-1.js
@@ -9716,6 +9716,18 @@ function setLanguage(lang) {
       || loggingConsoleOutputHelp.textContent;
     loggingConsoleOutputHelp.textContent = consoleHelp;
   }
+  if (loggingCaptureConsoleLabel) {
+    const consoleCaptureLabel = texts[lang].loggingCaptureConsoleLabel
+      || texts.en?.loggingCaptureConsoleLabel
+      || loggingCaptureConsoleLabel.textContent;
+    loggingCaptureConsoleLabel.textContent = consoleCaptureLabel;
+  }
+  if (loggingCaptureConsoleHelp) {
+    const consoleCaptureHelp = texts[lang].loggingCaptureConsoleHelp
+      || texts.en?.loggingCaptureConsoleHelp
+      || loggingCaptureConsoleHelp.textContent;
+    loggingCaptureConsoleHelp.textContent = consoleCaptureHelp;
+  }
   if (loggingCaptureErrorsLabel) {
     const captureLabel = texts[lang].loggingCaptureErrorsLabel
       || texts.en?.loggingCaptureErrorsLabel
@@ -16560,6 +16572,8 @@ const loggingHistoryLimit = document.getElementById('loggingHistoryLimit');
 const loggingHistoryLimitHelp = document.getElementById('loggingHistoryLimitHelp');
 const loggingConsoleOutputLabel = document.getElementById('loggingConsoleOutputLabel');
 const loggingConsoleOutputHelp = document.getElementById('loggingConsoleOutputHelp');
+const loggingCaptureConsoleLabel = document.getElementById('loggingCaptureConsoleLabel');
+const loggingCaptureConsoleHelp = document.getElementById('loggingCaptureConsoleHelp');
 const loggingCaptureErrorsLabel = document.getElementById('loggingCaptureErrorsLabel');
 const loggingCaptureErrorsHelp = document.getElementById('loggingCaptureErrorsHelp');
 const loggingPersistSessionLabel = document.getElementById('loggingPersistSessionLabel');

--- a/src/scripts/app-session.js
+++ b/src/scripts/app-session.js
@@ -7092,6 +7092,9 @@ const loggingHistoryLimitHelpEl = typeof document !== 'undefined'
 const loggingConsoleOutputInput = typeof document !== 'undefined'
   ? document.getElementById('loggingConsoleOutput')
   : null;
+const loggingCaptureConsoleInput = typeof document !== 'undefined'
+  ? document.getElementById('loggingCaptureConsole')
+  : null;
 const loggingCaptureErrorsInput = typeof document !== 'undefined'
   ? document.getElementById('loggingCaptureErrors')
   : null;
@@ -7301,6 +7304,7 @@ function setLoggingControlsDisabled(disabled) {
     loggingNamespaceFilterEl,
     loggingHistoryLimitInput,
     loggingConsoleOutputInput,
+    loggingCaptureConsoleInput,
     loggingCaptureErrorsInput,
     loggingPersistSessionInput,
   ];
@@ -7593,6 +7597,7 @@ function applyLoggingConfig(config) {
     input.setAttribute('aria-checked', checked ? 'true' : 'false');
   };
   setToggleState(loggingConsoleOutputInput, config.consoleOutput !== false);
+  setToggleState(loggingCaptureConsoleInput, config.captureConsole === true);
   setToggleState(loggingCaptureErrorsInput, config.captureGlobalErrors !== false);
   setToggleState(loggingPersistSessionInput, config.persistSession !== false);
 }
@@ -7730,6 +7735,7 @@ function initializeLoggingPanel() {
   };
 
   registerToggleHandler(loggingConsoleOutputInput, 'consoleOutput');
+  registerToggleHandler(loggingCaptureConsoleInput, 'captureConsole');
   registerToggleHandler(loggingCaptureErrorsInput, 'captureGlobalErrors');
   registerToggleHandler(loggingPersistSessionInput, 'persistSession');
 

--- a/src/scripts/modules/logging.js
+++ b/src/scripts/modules/logging.js
@@ -735,7 +735,7 @@
     consoleOutput: true,
     persistSession: true,
     captureGlobalErrors: true,
-    captureConsole: true,
+    captureConsole: false,
   };
 
   const DEFAULT_CONFIG = freezeDeep(DEFAULT_CONFIG_VALUES);

--- a/src/scripts/translations.js
+++ b/src/scripts/translations.js
@@ -754,7 +754,7 @@ const texts = {
     loggingHeading: "Diagnostics log",
     loggingHeadingHelp: "Review runtime diagnostics without leaving Settings.",
     loggingIntro:
-      "The log updates live while Settings stay open. Nothing leaves this device.",
+      "The log updates live while Settings stay open. Enable console capture below when you need deeper debugging. Nothing leaves this device.",
     loggingLevelFilterLabel: "Show entries from",
     loggingLevelFilterHelp: "Choose the minimum level to display.",
     loggingLevelFilterAll: "All levels",
@@ -772,6 +772,9 @@ const texts = {
     loggingConsoleOutputLabel: "Mirror to console",
     loggingConsoleOutputHelp:
       "Keep the browser console in sync with these entries.",
+    loggingCaptureConsoleLabel: "Capture console output",
+    loggingCaptureConsoleHelp:
+      "Record console messages for diagnostics. Turning this on may affect performance.",
     loggingCaptureErrorsLabel: "Capture global errors",
     loggingCaptureErrorsHelp:
       "Record uncaught errors and unhandled promise rejections.",
@@ -2749,7 +2752,7 @@ const texts = {
     loggingHeading: "Registro diagnostico",
     loggingHeadingHelp: "Controlla le diagnostiche in tempo reale senza lasciare Impostazioni.",
     loggingIntro:
-      "Il registro si aggiorna in tempo reale finché Impostazioni resta aperto. I dati non lasciano questo dispositivo.",
+      "Il registro si aggiorna in tempo reale finché Impostazioni resta aperto. Attiva la cattura della console qui sotto quando ti serve un debug più approfondito. I dati non lasciano questo dispositivo.",
     loggingLevelFilterLabel: "Mostra le voci da",
     loggingLevelFilterHelp: "Scegli il livello minimo da visualizzare.",
     loggingLevelFilterAll: "Tutti i livelli",
@@ -2767,6 +2770,9 @@ const texts = {
     loggingConsoleOutputLabel: "Specchia nella console",
     loggingConsoleOutputHelp:
       "Mantiene sincronizzata la console del browser con questo registro.",
+    loggingCaptureConsoleLabel: "Acquisisci output della console",
+    loggingCaptureConsoleHelp:
+      "Registra i messaggi della console per la diagnostica. L’attivazione può influire sulle prestazioni.",
     loggingCaptureErrorsLabel: "Acquisisci errori globali",
     loggingCaptureErrorsHelp:
       "Registra errori non gestiti e promesse respinte.",
@@ -4255,7 +4261,7 @@ const texts = {
     loggingHeading: "Registro de diagnósticos",
     loggingHeadingHelp: "Revise los diagnósticos en tiempo real sin salir de Ajustes.",
     loggingIntro:
-      "El registro se actualiza en vivo mientras Ajustes permanece abierto. Nada sale de este dispositivo.",
+      "El registro se actualiza en vivo mientras Ajustes permanece abierto. Activa la captura de la consola abajo cuando necesites una depuración más detallada. Nada sale de este dispositivo.",
     loggingLevelFilterLabel: "Mostrar entradas desde",
     loggingLevelFilterHelp: "Elija el nivel mínimo que desea ver.",
     loggingLevelFilterAll: "Todos los niveles",
@@ -4272,6 +4278,9 @@ const texts = {
     loggingHistoryLimitAria: "Definir cuántas entradas del registro quedan disponibles sin conexión",
     loggingConsoleOutputLabel: "Reflejar en la consola",
     loggingConsoleOutputHelp: "Mantiene sincronizada la consola del navegador.",
+    loggingCaptureConsoleLabel: "Capturar salida de la consola",
+    loggingCaptureConsoleHelp:
+      "Registra los mensajes de la consola para diagnósticos. Activarlo puede afectar al rendimiento.",
     loggingCaptureErrorsLabel: "Capturar errores globales",
     loggingCaptureErrorsHelp:
       "Registra errores no capturados y rechazos de promesas.",
@@ -5771,7 +5780,7 @@ const texts = {
     loggingHeading: "Journal de diagnostics",
     loggingHeadingHelp: "Consultez les diagnostics en direct sans quitter les paramètres.",
     loggingIntro:
-      "Le journal se met à jour en direct tant que la fenêtre Paramètres reste ouverte. Rien ne quitte cet appareil.",
+      "Le journal se met à jour en direct tant que la fenêtre Paramètres reste ouverte. Activez la capture de la console ci-dessous lorsque vous avez besoin d’un débogage plus poussé. Rien ne quitte cet appareil.",
     loggingLevelFilterLabel: "Afficher les entrées à partir de",
     loggingLevelFilterHelp: "Choisissez le niveau minimal à afficher.",
     loggingLevelFilterAll: "Tous les niveaux",
@@ -5789,6 +5798,9 @@ const texts = {
     loggingConsoleOutputLabel: "Dupliquer dans la console",
     loggingConsoleOutputHelp:
       "Maintient la console du navigateur synchronisée avec ce journal.",
+    loggingCaptureConsoleLabel: "Capturer la sortie de la console",
+    loggingCaptureConsoleHelp:
+      "Enregistre les messages de console pour le diagnostic. L’activation peut affecter les performances.",
     loggingCaptureErrorsLabel: "Capturer les erreurs globales",
     loggingCaptureErrorsHelp:
       "Enregistre les erreurs non interceptées et les promesses rejetées.",
@@ -7292,7 +7304,7 @@ const texts = {
     loggingHeading: "Diagnoseprotokoll",
     loggingHeadingHelp: "Prüfen Sie Laufzeitdiagnosen direkt in den Einstellungen.",
     loggingIntro:
-      "Das Protokoll aktualisiert sich live, solange die Einstellungen geöffnet bleiben. Es verlässt nie dieses Gerät.",
+      "Das Protokoll aktualisiert sich live, solange die Einstellungen geöffnet bleiben. Aktivieren Sie unten die Konsolenerfassung, wenn Sie eine detailliertere Fehlersuche benötigen. Es verlässt nie dieses Gerät.",
     loggingLevelFilterLabel: "Einträge anzeigen ab",
     loggingLevelFilterHelp: "Wählen Sie die minimale Stufe.",
     loggingLevelFilterAll: "Alle Stufen",
@@ -7310,6 +7322,9 @@ const texts = {
     loggingConsoleOutputLabel: "Auch in Konsole spiegeln",
     loggingConsoleOutputHelp:
       "Hält die Browserkonsole mit diesen Einträgen synchron.",
+    loggingCaptureConsoleLabel: "Konsolenausgabe erfassen",
+    loggingCaptureConsoleHelp:
+      "Protokolliert Konsolennachrichten für die Diagnose. Das Aktivieren kann die Leistung beeinflussen.",
     loggingCaptureErrorsLabel: "Globale Fehler erfassen",
     loggingCaptureErrorsHelp:
       "Erfasst unbehandelte Fehler und Promise-Ablehnungen.",


### PR DESCRIPTION
## Summary
- disable console capture by default and add a settings toggle so users can opt into console capture permanently
- wire the new control into the logging panel logic and update localized help text

## Testing
- npm test *(fails: existing eslint no-undef errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e5a7667fd08320bc6dc9a1e7a9b744