### PR TITLE
Restore schema.json entries and add missing attributes

### DIFF
--- a/src/data/schema.json
+++ b/src/data/schema.json
@@ -50,7 +50,8 @@
         "attributes": [
           "from",
           "lengthM",
-          "to"
+          "to",
+          "connectors"
         ]
       },
       "video": {
@@ -343,7 +344,8 @@
       "screenSizeInches",
       "videoInputs",
       "videoOutputs",
-      "wirelessTx"
+      "wirelessTx",
+      "notes"
     ],
     "power": {
       "input": {


### PR DESCRIPTION
## Summary
- restore the full schema structure in `src/data/schema.json` so no existing attribute groups are removed
- append the newly observed `connectors` and `notes` attributes to the relevant schema sections to cover the latest dataset fields

## Testing
- npm test -- --runTestsByPath tests/data/findMissingAttributes.test.js *(fails: eslint reports pre-existing undefined helper references)*

------
https://chatgpt.com/codex/tasks/task_e_68e5a9165d008320aa53a63690f9e48c