### PR TITLE
Document release verification packet workflow

### DIFF
--- a/docs/documentation-maintenance.md
+++ b/docs/documentation-maintenance.md
@@ -110,6 +110,30 @@ copy offline.【F:src/scripts/script.js†L92-L183】
 - Screenshot or export updates (as required) – regenerate any documentation images or
   printable PDFs referenced in manuals so crews see the latest UI states while offline.
 
+## 5. Assemble the documentation verification packet
+
+Follow the [Documentation Verification Packet guide](documentation-verification-packet.md) to
+bundle everything reviewers need when they audit the release offline. The packet keeps the
+written guidance, supporting exports and verification artefacts together so crews can trust the
+instructions even years later when internet access is unavailable.
+
+1. **Collect updated manuals.** Export or print the primary README, localized READMEs,
+   printable runbooks and legal pages that changed. Confirm each PDF references the same
+   version string surfaced through `cinePersistence` and `cineOffline` so operators know which
+   build the instructions cover.【F:src/scripts/modules/persistence.js†L1-L125】【F:src/scripts/modules/offline.js†L1-L188】
+2. **Attach verification evidence.** Include the latest planner backup, project bundle and
+   automatic gear rules export used during rehearsal. These files prove that save, share,
+   import, backup and restore remained stable when the documentation was signed off. Pair them
+   with the console capture from `window.__cineRuntimeIntegrity` to document the runtime guard
+   status at release time.【F:src/scripts/script.js†L92-L183】
+3. **Record the checklist outcome.** Add the completed [Documentation Update
+   Checklist](documentation-update-checklist.md) with boxes ticked and initials or signatures.
+   Attach the verification log entry that lists the workstation, browser build and timestamp so
+   auditors can trace the rehearsal lineage.
+4. **Store redundantly.** Zip the packet and copy it to at least two offline drives that travel
+   separately with the release media. Note the storage locations in `docs/verification-log`
+   entries or your change log so teams know where to find the canonical documentation bundle.
+
 Maintaining this cadence guarantees the planner’s guidance, translations and offline-first
 workflows stay in sync, keeping user data safe even in the most isolated production
 environments.

--- a/docs/documentation-update-checklist.md
+++ b/docs/documentation-update-checklist.md
@@ -33,5 +33,6 @@ This checklist condenses the workflow from the [Documentation, Help & Translatio
 - [ ] Update the verification log (using `docs/verification-log-template.md`) with the version, browser, workstation and command outputs collected during testing.
 - [ ] Store the verified planner backup, project bundle, automatic gear rules export and a ZIP of the repository alongside the updated documentation so crews can prove parity later.
 - [ ] Attach rendered PDFs or screenshots of modified help pages if the change affected visual layout or iconography.
+- [ ] Assemble the release documentation packet following `docs/documentation-verification-packet.md` and record where redundant offline copies live.
 
 Running this checklist alongside the full maintenance guide keeps documentation, translations and offline workflows in sync with the product while protecting user data across every save, share, import, backup and restore path.

--- a/docs/documentation-verification-packet.md
+++ b/docs/documentation-verification-packet.md
@@ -1,0 +1,52 @@
+# Documentation Verification Packet
+
+This guide explains how to assemble a release-ready documentation packet that mirrors the
+application state crews rely on in the field. The packet travels with the Cine Power Planner
+build, ensuring offline operators can validate instructions and restore data even years after the
+release. Every component reinforces the core principle that saving, sharing, importing, backing
+up and restoring must never risk user data.
+
+## 1. Capture the written record
+
+1. **Snapshot the READMEs.** Export the primary README and each localized variant to PDF or
+   plain-text archives so translations stay aligned with the code at release.
+2. **Include runbooks and manuals.** Add updated copies of the offline readiness runbook,
+   operations checklist, backup rotation guide, documentation maintenance guide and testing
+   plan. These walkthroughs teach crews how to rehearse saves, shares, imports, backups and
+   restores without network access.
+3. **Mirror in-app help.** If contextual help or legal pages changed, export the relevant HTML
+   so offline reviewers can confirm the UI still matches the documentation.
+
+## 2. Bundle verification artefacts
+
+1. **Planner backup.** Include the `planner-backup.json` generated during the final rehearsal.
+   This file proves every project, autosave, automatic gear rule, favorite and runtime note
+   survived export.
+2. **Project bundle.** Attach the `project-name.json` bundle used to validate targeted restores.
+   Pair it with any supplemental automatic gear rule exports that affect the workflow.
+3. **Runtime guard capture.** Save the console output from `window.__cineRuntimeIntegrity` or
+   `window.cineRuntime.verifyCriticalFlows({ warnOnFailure: true })` to show the persistence
+   guard confirmed all gateways before sign-off.【F:src/scripts/script.js†L92-L183】
+4. **Checklist evidence.** Add the completed Documentation Update Checklist and the verification
+   log entry that records the workstation, browser build, timestamps and storage locations.
+
+## 3. Package for offline storage
+
+1. **Organize by release.** Place the documentation exports and artefacts in a folder named with
+   the semantic version and build hash recorded in the app header and verification logs.
+2. **Compress and checksum.** Zip the folder, compute SHA-256 and SHA-512 hashes and store the
+   manifest alongside the archive so crews can detect tampering even when offline.
+3. **Distribute redundantly.** Copy the archive and checksum manifest to at least two encrypted
+   drives that travel separately. Record the storage locations in the verification log.
+
+## 4. Verify restoration paths periodically
+
+1. **Quarterly audits.** Once per quarter, restore the archived planner backup and project bundle
+   into a fresh offline browser profile. Confirm the documentation packet still matches the UI and
+   that the runtime guard reports `{ ok: true }` with no missing safeguards.
+2. **Update when workflows change.** If a new save, share, import, backup or restore feature ships,
+   rebuild the packet immediately so offline crews never operate with stale instructions.
+
+Maintaining a rigorous documentation verification packet keeps the written guidance, translations
+and recovery artefacts synchronized with the product, protecting user data under every offline
+scenario the planner supports.


### PR DESCRIPTION
## Summary
- extend the documentation maintenance guide with a release-ready verification packet procedure that reinforces offline audits
- add a checklist step that requires compiling the packet for every change
- introduce a dedicated documentation verification packet guide that explains how to capture manuals, exports and guard evidence

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e5ac7d9da88320aa526a3693025935