### PR TITLE
Guard gear delete handler registration when document is frozen

### DIFF
--- a/legacy/scripts/app-setups.js
+++ b/legacy/scripts/app-setups.js
@@ -5616,7 +5616,11 @@ function ensureGearListActions() {
 }
 if (typeof document !== 'undefined' && typeof document.addEventListener === 'function') {
   var handlerKey = '__cameraPowerPlannerGearDeleteHandler';
-  if (!document[handlerKey]) {
+  var handlerStore = document;
+  if (typeof Object.isExtensible === 'function' && !Object.isExtensible(document)) {
+    handlerStore = typeof globalThis !== 'undefined' ? globalThis : typeof window !== 'undefined' ? window : document;
+  }
+  if (handlerStore && !handlerStore[handlerKey]) {
     var handleGearDeleteRequest = function handleGearDeleteRequest() {
       try {
         deleteCurrentGearList();
@@ -5625,12 +5629,16 @@ if (typeof document !== 'undefined' && typeof document.addEventListener === 'fun
       }
     };
     document.addEventListener('gearlist:delete-requested', handleGearDeleteRequest);
-    Object.defineProperty(document, handlerKey, {
-      value: handleGearDeleteRequest,
-      configurable: true,
-      writable: false,
-      enumerable: false
-    });
+    try {
+      Object.defineProperty(handlerStore, handlerKey, {
+        value: handleGearDeleteRequest,
+        configurable: true,
+        writable: false,
+        enumerable: false
+      });
+    } catch (error) {
+      handlerStore[handlerKey] = handleGearDeleteRequest;
+    }
   }
 }
 function bindGearListCageListener() {


### PR DESCRIPTION
## Summary
- avoid storing the gear delete handler on document when it is non-extensible by using a safe fallback container
- wrap handler registration bookkeeping in a try/catch to prevent runtime crashes while keeping a single listener registration

## Testing
- npm run lint *(fails: existing parsing error in src/scripts/modern-support-check.js)*

------
https://chatgpt.com/codex/tasks/task_e_68e5b0ce170c8320b553c3e53adb8bbe