### PR TITLE
Fix recording media form placeholder handling

### DIFF
--- a/legacy/scripts/app-core-new-2.js
+++ b/legacy/scripts/app-core-new-2.js
@@ -12711,19 +12711,49 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
       return Array.from(media).sort(localeSort);
     }
     var recordingMediaOptions = getAllRecordingMedia();
+
+    function resolveRecordingMediaPlaceholder() {
+      var _texts$en, _texts$currentLang;
+      var fallbackProjectForm = ((_texts$en = texts === null || texts === void 0 ? void 0 : texts.en) === null || _texts$en === void 0 ? void 0 : _texts$en.projectForm) || {};
+      var projectFormTexts = ((_texts$currentLang = texts === null || texts === void 0 ? void 0 : texts[currentLang]) === null || _texts$currentLang === void 0 ? void 0 : _texts$currentLang.projectForm) || fallbackProjectForm;
+      var placeholder = projectFormTexts.storageTypePlaceholder || fallbackProjectForm.storageTypePlaceholder || 'Select media type';
+      var text = typeof placeholder === 'string' ? placeholder.trim() : '';
+      return text || 'Select media type';
+    }
+
+    function appendRecordingMediaPlaceholder(select) {
+      if (!select) return;
+      var option = document.createElement('option');
+      option.value = '';
+      option.textContent = resolveRecordingMediaPlaceholder();
+      option.dataset.placeholder = 'true';
+      select.appendChild(option);
+    }
+
     function updateRecordingMediaOptions() {
       recordingMediaOptions = getAllRecordingMedia();
       document.querySelectorAll('.recording-media-select').forEach(function (sel) {
         var cur = sel.value;
         sel.innerHTML = '';
-        addEmptyOption(sel);
+        appendRecordingMediaPlaceholder(sel);
         recordingMediaOptions.forEach(function (optVal) {
           var opt = document.createElement('option');
           opt.value = optVal;
           opt.textContent = optVal;
           sel.appendChild(opt);
         });
-        if (recordingMediaOptions.includes(cur)) sel.value = cur;
+        if (recordingMediaOptions.includes(cur)) {
+          sel.value = cur;
+        } else if (cur && cur !== 'None') {
+          var opt = document.createElement('option');
+          opt.value = cur;
+          opt.textContent = cur;
+          opt.dataset.extraOption = 'true';
+          sel.appendChild(opt);
+          sel.value = cur;
+        } else {
+          sel.value = '';
+        }
       });
     }
     function createRecordingMediaRow() {
@@ -12734,7 +12764,7 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
       var select = document.createElement('select');
       select.className = 'recording-media-select';
       select.name = 'recordingMediaType';
-      addEmptyOption(select);
+      appendRecordingMediaPlaceholder(select);
       recordingMediaOptions.forEach(function (optVal) {
         var opt = document.createElement('option');
         opt.value = optVal;
@@ -12749,6 +12779,8 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
           select.appendChild(opt);
         }
         select.value = type;
+      } else {
+        select.value = '';
       }
       row.appendChild(createFieldWithLabel(select, 'Type'));
       var notesInput = document.createElement('input');

--- a/src/scripts/app-core-new-2.js
+++ b/src/scripts/app-core-new-2.js
@@ -13941,23 +13941,53 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
     }
     
     let recordingMediaOptions = getAllRecordingMedia();
-    
+
+    function resolveRecordingMediaPlaceholder() {
+      const fallbackProjectForm = (texts?.en && texts.en.projectForm) || {};
+      const projectFormTexts = (texts?.[currentLang] && texts[currentLang].projectForm) || fallbackProjectForm;
+      const placeholder = projectFormTexts.storageTypePlaceholder
+        || fallbackProjectForm.storageTypePlaceholder
+        || 'Select media type';
+      const text = typeof placeholder === 'string' ? placeholder.trim() : '';
+      return text || 'Select media type';
+    }
+
+    function appendRecordingMediaPlaceholder(select) {
+      if (!select) return;
+      const option = document.createElement('option');
+      option.value = '';
+      option.textContent = resolveRecordingMediaPlaceholder();
+      option.dataset.placeholder = 'true';
+      select.appendChild(option);
+    }
+
     function updateRecordingMediaOptions() {
       recordingMediaOptions = getAllRecordingMedia();
       document.querySelectorAll('.recording-media-select').forEach(sel => {
         const cur = sel.value;
         sel.innerHTML = '';
-        addEmptyOption(sel);
+        appendRecordingMediaPlaceholder(sel);
         recordingMediaOptions.forEach(optVal => {
           const opt = document.createElement('option');
           opt.value = optVal;
           opt.textContent = optVal;
           sel.appendChild(opt);
         });
-        if (recordingMediaOptions.includes(cur)) sel.value = cur;
+        if (recordingMediaOptions.includes(cur)) {
+          sel.value = cur;
+        } else if (cur && cur !== 'None') {
+          const opt = document.createElement('option');
+          opt.value = cur;
+          opt.textContent = cur;
+          opt.dataset.extraOption = 'true';
+          sel.appendChild(opt);
+          sel.value = cur;
+        } else {
+          sel.value = '';
+        }
       });
     }
-    
+
     // Build a row allowing the user to specify recording media details.
     function createRecordingMediaRow(type = '', notes = '') {
       const row = document.createElement('div');
@@ -13966,7 +13996,7 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
       const select = document.createElement('select');
       select.className = 'recording-media-select';
       select.name = 'recordingMediaType';
-      addEmptyOption(select);
+      appendRecordingMediaPlaceholder(select);
       recordingMediaOptions.forEach(optVal => {
         const opt = document.createElement('option');
         opt.value = optVal;
@@ -13981,6 +14011,8 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
           select.appendChild(opt);
         }
         select.value = type;
+      } else {
+        select.value = '';
       }
       row.appendChild(createFieldWithLabel(select, 'Type'));
     


### PR DESCRIPTION
## Summary
- add localized placeholder options to recording media selects so they start empty
- preserve user-entered media types when the selectable options refresh
- mirror the same behaviour in the legacy bundle to keep offline builds aligned

## Testing
- npm run test:dom

------
https://chatgpt.com/codex/tasks/task_e_68e5af6f9bb083209b8fba94e30bba61