### PR TITLE
Improve environment deep freeze safety

### DIFF
--- a/legacy/scripts/modules/environment-bridge.js
+++ b/legacy/scripts/modules/environment-bridge.js
@@ -65,6 +65,19 @@ function _typeof(o) { "@babel/helpers - typeof"; return _typeof = "function" == 
     if (isEthereumProviderCandidate(value)) {
       return true;
     }
+    if (value === PRIMARY_SCOPE) {
+      return true;
+    }
+    if (typeof console !== 'undefined') {
+      try {
+        if (value === console) {
+          return true;
+        }
+      } catch (consoleError) {
+        void consoleError;
+        return true;
+      }
+    }
     try {
       if (typeof value.pipe === 'function' && typeof value.unpipe === 'function') {
         return true;
@@ -169,6 +182,11 @@ function _typeof(o) { "@babel/helpers - typeof"; return _typeof = "function" == 
     }
     for (var index = 0; index < keys.length; index += 1) {
       var key = keys[index];
+
+      if (key === 'web3' && value === PRIMARY_SCOPE) {
+        continue;
+      }
+
       var descriptor;
       try {
         descriptor = Object.getOwnPropertyDescriptor(value, key);
@@ -179,7 +197,17 @@ function _typeof(o) { "@babel/helpers - typeof"; return _typeof = "function" == 
       if (!descriptor || descriptor.get || descriptor.set) {
         continue;
       }
-      fallbackFreezeDeep(descriptor.value, localSeen);
+
+      var child = descriptor.value;
+
+      if (!child || _typeof(child) !== 'object' && typeof child !== 'function') {
+        continue;
+      }
+
+      fallbackFreezeDeep(child, localSeen);
+    }
+    if (value === PRIMARY_SCOPE) {
+      return value;
     }
     try {
       return Object.freeze(value);

--- a/legacy/scripts/modules/environment.js
+++ b/legacy/scripts/modules/environment.js
@@ -280,9 +280,64 @@ function _typeof(o) { "@babel/helpers - typeof"; return _typeof = "function" == 
     queueModuleRegistrationForScope(targetScope, name, api, options);
     return false;
   }
+  function isEthereumProviderCandidate(value) {
+    if (!value || _typeof(value) !== 'object' && typeof value !== 'function') {
+      return false;
+    }
+    if (PRIMARY_SCOPE && _typeof(PRIMARY_SCOPE) === 'object') {
+      try {
+        if (value === PRIMARY_SCOPE.ethereum) {
+          return true;
+        }
+      } catch (error) {
+        void error;
+        return true;
+      }
+    }
+    try {
+      if (value.isMetaMask === true) {
+        return true;
+      }
+    } catch (inspectionError) {
+      if (inspectionError && typeof inspectionError.message === 'string' && /metamask/i.test(inspectionError.message)) {
+        return true;
+      }
+    }
+    try {
+      if (typeof value.request === 'function' && typeof value.on === 'function') {
+        if (typeof value.removeListener === 'function' || typeof value.removeEventListener === 'function') {
+          return true;
+        }
+        var ctorName = value.constructor && value.constructor.name;
+        if (ctorName && /Ethereum|MetaMask|Provider/i.test(ctorName)) {
+          return true;
+        }
+      }
+    } catch (accessError) {
+      void accessError;
+      return true;
+    }
+    return false;
+  }
   function shouldBypassDeepFreeze(value) {
     if (!value || _typeof(value) !== 'object' && typeof value !== 'function') {
       return false;
+    }
+    if (isEthereumProviderCandidate(value)) {
+      return true;
+    }
+    if (value === PRIMARY_SCOPE) {
+      return true;
+    }
+    if (typeof console !== 'undefined') {
+      try {
+        if (value === console) {
+          return true;
+        }
+      } catch (consoleError) {
+        void consoleError;
+        return true;
+      }
     }
     try {
       if (typeof value.pipe === 'function' && typeof value.unpipe === 'function') {
@@ -308,28 +363,75 @@ function _typeof(o) { "@babel/helpers - typeof"; return _typeof = "function" == 
     }
     return false;
   }
-  function fallbackFreezeDeep(value) {
-    var seen = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : new WeakSet();
+  function fallbackFreezeDeep(value, seen) {
+    var localSeen = seen;
+    if (!localSeen) {
+      if (typeof WeakSet === 'function') {
+        localSeen = new WeakSet();
+      } else {
+        var seenValues = [];
+        localSeen = {
+          add: function add(item) {
+            seenValues.push(item);
+          },
+          has: function has(item) {
+            return seenValues.indexOf(item) !== -1;
+          }
+        };
+      }
+    }
     if (!value || _typeof(value) !== 'object' && typeof value !== 'function') {
       return value;
     }
     if (shouldBypassDeepFreeze(value)) {
       return value;
     }
-    if (seen.has(value)) {
+    if (isEthereumProviderCandidate(value)) {
       return value;
     }
-    seen.add(value);
-    var keys = Object.getOwnPropertyNames(value);
+    if (typeof localSeen.has === 'function' && localSeen.has(value)) {
+      return value;
+    }
+    if (typeof localSeen.add === 'function') {
+      localSeen.add(value);
+    }
+    var keys;
+    try {
+      keys = Object.getOwnPropertyNames(value);
+    } catch (error) {
+      void error;
+      keys = [];
+    }
     for (var index = 0; index < keys.length; index += 1) {
       var key = keys[index];
-      var descriptor = Object.getOwnPropertyDescriptor(value, key);
+      if (key === 'web3' && value === PRIMARY_SCOPE) {
+        continue;
+      }
+      var descriptor;
+      try {
+        descriptor = Object.getOwnPropertyDescriptor(value, key);
+      } catch (descriptorError) {
+        void descriptorError;
+        descriptor = null;
+      }
       if (!descriptor || 'get' in descriptor || 'set' in descriptor) {
         continue;
       }
-      fallbackFreezeDeep(descriptor.value, seen);
+      var child = descriptor.value;
+      if (!child || _typeof(child) !== 'object' && typeof child !== 'function') {
+        continue;
+      }
+      fallbackFreezeDeep(child, localSeen);
     }
-    return Object.freeze(value);
+    if (value === PRIMARY_SCOPE) {
+      return value;
+    }
+    try {
+      return Object.freeze(value);
+    } catch (freezeError) {
+      void freezeError;
+      return value;
+    }
   }
   function freezeDeep(value, seen) {
     var base = getModuleBase();

--- a/legacy/scripts/modules/helpers/immutability-builtins.js
+++ b/legacy/scripts/modules/helpers/immutability-builtins.js
@@ -86,6 +86,19 @@ function _typeof(o) { "@babel/helpers - typeof"; return _typeof = "function" == 
       if (isImmutableBuiltin(value)) {
         return value;
       }
+      if (value) {
+        var globalCandidates = [];
+        if (typeof globalThis !== 'undefined') globalCandidates.push(globalThis);
+        if (typeof global !== 'undefined') globalCandidates.push(global);
+        if (typeof self !== 'undefined') globalCandidates.push(self);
+        if (typeof window !== 'undefined') globalCandidates.push(window);
+        if (globalCandidates.indexOf(value) !== -1) {
+          return value;
+        }
+        if (typeof console !== 'undefined' && value === console) {
+          return value;
+        }
+      }
       for (var _len = arguments.length, rest = new Array(_len > 1 ? _len - 1 : 0), _key = 1; _key < _len; _key++) {
         rest[_key - 1] = arguments[_key];
       }

--- a/src/scripts/modules/base.js
+++ b/src/scripts/modules/base.js
@@ -137,12 +137,76 @@
     return null;
   })();
 
+  function isEthereumProviderCandidate(value) {
+    if (!value || (typeof value !== 'object' && typeof value !== 'function')) {
+      return false;
+    }
+
+    if (typeof PRIMARY_SCOPE !== 'undefined' && PRIMARY_SCOPE && typeof PRIMARY_SCOPE === 'object') {
+      try {
+        if (value === PRIMARY_SCOPE.ethereum) {
+          return true;
+        }
+      } catch (error) {
+        void error;
+        return true;
+      }
+    }
+
+    try {
+      if (value.isMetaMask === true) {
+        return true;
+      }
+    } catch (inspectionError) {
+      if (inspectionError && typeof inspectionError.message === 'string' && /metamask/i.test(inspectionError.message)) {
+        return true;
+      }
+    }
+
+    try {
+      if (typeof value.request === 'function' && typeof value.on === 'function') {
+        if (typeof value.removeListener === 'function' || typeof value.removeEventListener === 'function') {
+          return true;
+        }
+
+        const ctorName = value.constructor && value.constructor.name;
+        if (ctorName && /Ethereum|MetaMask|Provider/i.test(ctorName)) {
+          return true;
+        }
+      }
+    } catch (accessError) {
+      void accessError;
+      return true;
+    }
+
+    return false;
+  }
+
   function shouldBypassDeepFreeze(value) {
     if (!value || (typeof value !== 'object' && typeof value !== 'function')) {
       return false;
     }
 
     try {
+      if (isEthereumProviderCandidate(value)) {
+        return true;
+      }
+
+      if (typeof console !== 'undefined') {
+        try {
+          if (value === console) {
+            return true;
+          }
+        } catch (consoleError) {
+          void consoleError;
+          return true;
+        }
+      }
+
+      if (typeof PRIMARY_SCOPE !== 'undefined' && value === PRIMARY_SCOPE) {
+        return true;
+      }
+
       if (
         BUILTIN_IMMUTABILITY &&
         typeof BUILTIN_IMMUTABILITY.isImmutableBuiltin === 'function' &&
@@ -179,7 +243,24 @@
     return false;
   }
 
-  function fallbackFreezeDeep(value, seen = new WeakSet()) {
+  function fallbackFreezeDeep(value, seen) {
+    let localSeen = seen;
+    if (!localSeen) {
+      if (typeof WeakSet === 'function') {
+        localSeen = new WeakSet();
+      } else {
+        const seenValues = [];
+        localSeen = {
+          add(item) {
+            seenValues.push(item);
+          },
+          has(item) {
+            return seenValues.indexOf(item) !== -1;
+          },
+        };
+      }
+    }
+
     if (!value || (typeof value !== 'object' && typeof value !== 'function')) {
       return value;
     }
@@ -188,32 +269,56 @@
       return value;
     }
 
-    if (seen.has(value)) {
+    if (isEthereumProviderCandidate(value)) {
       return value;
     }
 
-    seen.add(value);
+    if (typeof localSeen.has === 'function' && localSeen.has(value)) {
+      return value;
+    }
+
+    if (typeof localSeen.add === 'function') {
+      localSeen.add(value);
+    }
 
     let keys;
     try {
       keys = Object.getOwnPropertyNames(value);
     } catch (error) {
       void error;
-      return value;
+      keys = [];
     }
+
     for (let index = 0; index < keys.length; index += 1) {
       const key = keys[index];
-      let child;
-      try {
-        child = value[key];
-      } catch (accessError) {
-        void accessError;
-        child = undefined;
+
+      if (typeof PRIMARY_SCOPE !== 'undefined' && key === 'web3' && value === PRIMARY_SCOPE) {
+        continue;
       }
+
+      let descriptor;
+      try {
+        descriptor = Object.getOwnPropertyDescriptor(value, key);
+      } catch (descriptorError) {
+        void descriptorError;
+        descriptor = null;
+      }
+
+      if (!descriptor || descriptor.get || descriptor.set) {
+        continue;
+      }
+
+      const child = descriptor.value;
+
       if (!child || (typeof child !== 'object' && typeof child !== 'function')) {
         continue;
       }
-      fallbackFreezeDeep(child, seen);
+
+      fallbackFreezeDeep(child, localSeen);
+    }
+
+    if (typeof PRIMARY_SCOPE !== 'undefined' && value === PRIMARY_SCOPE) {
+      return value;
     }
 
     try {

--- a/src/scripts/modules/environment-bridge.js
+++ b/src/scripts/modules/environment-bridge.js
@@ -77,6 +77,21 @@
       return true;
     }
 
+    if (value === PRIMARY_SCOPE) {
+      return true;
+    }
+
+    if (typeof console !== 'undefined') {
+      try {
+        if (value === console) {
+          return true;
+        }
+      } catch (consoleError) {
+        void consoleError;
+        return true;
+      }
+    }
+
     try {
       if (typeof value.pipe === 'function' && typeof value.unpipe === 'function') {
         return true;
@@ -206,19 +221,33 @@
         continue;
       }
 
-      var child;
+      var descriptor;
       try {
-        child = value[key];
-      } catch (accessError) {
-        void accessError;
-        child = undefined;
+        descriptor = Object.getOwnPropertyDescriptor(value, key);
+      } catch (descriptorError) {
+        void descriptorError;
+        descriptor = null;
       }
+
+      if (!descriptor) {
+        continue;
+      }
+
+      if (descriptor.get || descriptor.set) {
+        continue;
+      }
+
+      var child = descriptor.value;
 
       if (!child || (typeof child !== 'object' && typeof child !== 'function')) {
         continue;
       }
 
       fallbackFreezeDeep(child, localSeen);
+    }
+
+    if (value === PRIMARY_SCOPE) {
+      return value;
     }
 
     try {

--- a/src/scripts/modules/helpers/immutability-builtins.js
+++ b/src/scripts/modules/helpers/immutability-builtins.js
@@ -151,6 +151,23 @@
       if (isImmutableBuiltin(value)) {
         return value;
       }
+
+      if (value) {
+        const globalCandidates = [];
+        if (typeof globalThis !== 'undefined') globalCandidates.push(globalThis);
+        if (typeof global !== 'undefined') globalCandidates.push(global);
+        if (typeof self !== 'undefined') globalCandidates.push(self);
+        if (typeof window !== 'undefined') globalCandidates.push(window);
+
+        if (globalCandidates.indexOf(value) !== -1) {
+          return value;
+        }
+
+        if (typeof console !== 'undefined' && value === console) {
+          return value;
+        }
+      }
+
       return originalFreeze.call(Object, value, ...rest);
     }
 

--- a/tests/unit/environmentBridge.test.js
+++ b/tests/unit/environmentBridge.test.js
@@ -36,4 +36,22 @@ describe('environment-bridge', () => {
       }
     }
   });
+
+  test('freezeDeep skips accessor properties without invoking getters', () => {
+    const bridge = require('../../src/scripts/modules/environment-bridge.js');
+    const target = {};
+    const getter = jest.fn(() => ({ nested: {} }));
+
+    Object.defineProperty(target, 'expensive', {
+      configurable: true,
+      enumerable: false,
+      get: getter,
+    });
+
+    const frozen = bridge.freezeDeep(target);
+
+    expect(frozen).toBe(target);
+    expect(Object.isFrozen(target)).toBe(true);
+    expect(getter).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary
- skip freezing sensitive platform globals such as the window console and ethereum providers in the environment bridge
- avoid touching accessor properties when performing deep freeze across the environment, base, and architecture layers
- mirror the protections in the legacy modules and extend unit coverage for the freezeDeep behaviour

## Testing
- npm run test:unit

------
https://chatgpt.com/codex/tasks/task_e_68e5b185d8248320bc76ff66e4d92c02