### PR TITLE
Fix ESLint module parsing for modern support check scripts

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -86,9 +86,13 @@ module.exports = [
     },
   },
   {
-    files: ['src/scripts/modern-support-check.js'],
+    files: ['**/modern-support-check.{js,mjs}'],
     languageOptions: {
+      ecmaVersion: 2021,
       sourceType: 'module',
+      globals: {
+        ...baseGlobals,
+      },
     },
   },
   ...appScriptConfigs,


### PR DESCRIPTION
## Summary
- ensure eslint treats all modern support check variants as ES modules to avoid parsing errors

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e6209a8a808320bec62ea5f9cee742