### PR TITLE
Disable compression for active auto gear rules

### DIFF
--- a/legacy/scripts/storage.js
+++ b/legacy/scripts/storage.js
@@ -7116,7 +7116,9 @@ function _typeof(o) { "@babel/helpers - typeof"; return _typeof = "function" == 
     var normalizedRules = skipNormalization ? safeRules : Array.isArray(safeRules) ? normalizeLegacyLongGopStructure(safeRules) : [];
     var safeStorage = getSafeLocalStorage();
     ensurePreWriteMigrationBackup(safeStorage, AUTO_GEAR_RULES_STORAGE_KEY);
-    saveJSONToStorage(safeStorage, AUTO_GEAR_RULES_STORAGE_KEY, normalizedRules, "Error saving automatic gear rules to localStorage:");
+    saveJSONToStorage(safeStorage, AUTO_GEAR_RULES_STORAGE_KEY, normalizedRules, "Error saving automatic gear rules to localStorage:", {
+      disableCompression: true
+    });
     return normalizedRules;
   }
   function loadAutoGearBackups() {

--- a/src/scripts/storage.js
+++ b/src/scripts/storage.js
@@ -8194,6 +8194,9 @@ function saveAutoGearRules(rules, options = {}) {
     AUTO_GEAR_RULES_STORAGE_KEY,
     normalizedRules,
     "Error saving automatic gear rules to localStorage:",
+    {
+      disableCompression: true,
+    },
   );
   return normalizedRules;
 }


### PR DESCRIPTION
## Summary
- stop compressing the primary auto gear rules payload when saving to storage
- keep automatic backups eligible for compression while mirroring the change in legacy runtime code

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e623025a408320aef1b4f569ffe840