### PR TITLE
Handle missing auto gear delete runtime

### DIFF
--- a/src/scripts/app-session.js
+++ b/src/scripts/app-session.js
@@ -5196,7 +5196,8 @@ if (autoGearAddItemButton) {
       } else if (button.classList.contains('auto-gear-duplicate')) {
         duplicateAutoGearRule(button.dataset.ruleId || '');
       } else if (button.classList.contains('auto-gear-delete')) {
-        deleteAutoGearRule(button.dataset.ruleId || '');
+        const ruleId = button.dataset.ruleId || '';
+        callSessionCoreFunction('deleteAutoGearRule', [ruleId]);
       }
     });
   }


### PR DESCRIPTION
## Summary
- ensure the auto gear delete button delegates through the session core helper so it works even before the core runtime is loaded

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e624cc017c8320819859dc32ec3637