### PR TITLE
Fix flag forwarding when running targeted unit tests

### DIFF
--- a/tools/runUnitTests.js
+++ b/tools/runUnitTests.js
@@ -7,22 +7,49 @@ const baseArgs = ['--runInBand', '--selectProjects', 'unit'];
 const cliArgs = process.argv.slice(2);
 const testPaths = [];
 const forwardedArgs = [];
+const projectRoot = process.cwd();
+const testsRoot = path.resolve(projectRoot, 'tests');
 
-for (const arg of cliArgs) {
+const isWithinTestsDirectory = (filePath) => {
+  const relative = path.relative(testsRoot, filePath);
+  return relative && !relative.startsWith('..') && !path.isAbsolute(relative);
+};
+
+const resolveTestPath = (candidate) => {
+  const directPath = path.isAbsolute(candidate)
+    ? candidate
+    : path.resolve(projectRoot, candidate);
+
+  if (fs.existsSync(directPath) && isWithinTestsDirectory(directPath)) {
+    return directPath;
+  }
+
+  const unitPath = path.resolve(projectRoot, 'tests', 'unit', candidate);
+  if (fs.existsSync(unitPath)) {
+    return unitPath;
+  }
+
+  return null;
+};
+
+for (let index = 0; index < cliArgs.length; index += 1) {
+  const arg = cliArgs[index];
+
   if (arg.startsWith('-')) {
     forwardedArgs.push(arg);
+
+    const next = cliArgs[index + 1];
+    if (next && !next.startsWith('-') && !resolveTestPath(next)) {
+      forwardedArgs.push(next);
+      index += 1;
+    }
+
     continue;
   }
 
-  const maybeAbsolute = path.isAbsolute(arg) ? arg : path.resolve(process.cwd(), arg);
-  if (fs.existsSync(maybeAbsolute)) {
-    testPaths.push(maybeAbsolute);
-    continue;
-  }
-
-  const unitPath = path.resolve(process.cwd(), 'tests', 'unit', arg);
-  if (fs.existsSync(unitPath)) {
-    testPaths.push(unitPath);
+  const resolved = resolveTestPath(arg);
+  if (resolved) {
+    testPaths.push(resolved);
     continue;
   }
 


### PR DESCRIPTION
## Summary
- ensure the custom unit test runner only treats arguments inside the tests directory as test paths
- forward CLI flags together with their associated values so Jest receives complete options

## Testing
- npm run test:unit -- storage.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e625249e80832096a3214f57a283b2