### PR TITLE
Add fallback help copy for monthly data audit

### DIFF
--- a/docs/documentation-update-checklist.md
+++ b/docs/documentation-update-checklist.md
@@ -12,6 +12,7 @@ This checklist condenses the workflow from the [Documentation, Help & Translatio
 
 - [ ] Edit `README.md` and every localized README to reflect the new workflows, especially the **Key Workflow Reference**, **Save, Share & Import Drill**, **Backup & Recovery** and **Emergency Recovery Playbook** sections.
 - [ ] Revise contextual help topics, hover help strings and FAQ answers in `src/scripts/help/` and `index.html` so offline crews see accurate instructions.
+- [ ] Keep the fallback HTML inside `index.html` help callouts aligned with the rendered topics so crews retain guidance even if scripts fail to load offline.
 - [ ] Synchronize printable manuals and runbooks in `docs/` (save/share reference, offline readiness, operations checklist, backup rotation guide, testing plan) with the change.
 - [ ] Update legal pages in `legal/` if any disclosures or policy links reference the updated feature.
 

--- a/index.html
+++ b/index.html
@@ -3012,10 +3012,22 @@
             </p>
             <h5 id="helpDataAuditHeading">Monthly data health check</h5>
             <ol id="helpDataAuditList">
-              <li id="helpDataAuditStep1"></li>
-              <li id="helpDataAuditStep2"></li>
-              <li id="helpDataAuditStep3"></li>
-              <li id="helpDataAuditStep4"></li>
+              <li id="helpDataAuditStep1">
+                Open Settings, switch to <em>Backup &amp; Restore</em> and run <strong>Backup</strong>
+                to capture a fresh snapshot before auditing downloads.
+              </li>
+              <li id="helpDataAuditStep2">
+                Export each active project with <strong>Export project</strong> and store the files in two
+                separate locations before making changes.
+              </li>
+              <li id="helpDataAuditStep3">
+                While offline, trigger <em>Force reload</em> and confirm the Offline indicator stays visible
+                as projects and help articles load from local storage.
+              </li>
+              <li id="helpDataAuditStep4">
+                Run <strong>Restore rehearsal</strong> with your latest backup and verify every project, device
+                and rule before closing the rehearsal without publishing changes.
+              </li>
             </ol>
             <p id="helpDataAuditNote" class="help-callout-note">
               Log the results in your backup rotation checklist so you always know which copies were verified offline.


### PR DESCRIPTION
## Summary
- add fallback Monthly data health check copy inside the help dialog so instructions remain visible even if scripting fails offline
- remind documentation maintainers to keep the help dialog fallback HTML in sync when updating copy

## Testing
- npm run lint *(fails: `performance` is already defined as a built-in global variable in tests/dom/fullUserExperienceSpeed.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68e62707970883208915d80bcc0f2954