### PR TITLE
Fix auto gear editor fallback for factory rules

### DIFF
--- a/legacy/scripts/app-core-new-2.js
+++ b/legacy/scripts/app-core-new-2.js
@@ -3564,10 +3564,16 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
         return;
       }
       visibleRules.forEach(function (rule) {
+        var index = ruleIndexByObject.get(rule);
         var _texts$currentLang44, _texts$en119, _texts$currentLang45, _texts$en120, _texts$currentLang46, _texts$en121;
         var wrapper = document.createElement('div');
         wrapper.className = 'auto-gear-rule';
         wrapper.dataset.ruleId = rule.id;
+        if (typeof index === 'number' && index >= 0) {
+          wrapper.dataset.ruleIndex = String(index);
+        } else {
+          delete wrapper.dataset.ruleIndex;
+        }
         var info = document.createElement('div');
         info.className = 'auto-gear-rule-info';
         var title = document.createElement('p');
@@ -3789,6 +3795,11 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
         editBtn.type = 'button';
         editBtn.className = 'auto-gear-edit';
         editBtn.dataset.ruleId = rule.id;
+        if (typeof index === 'number' && index >= 0) {
+          editBtn.dataset.ruleIndex = String(index);
+        } else {
+          delete editBtn.dataset.ruleIndex;
+        }
         var editLabel = ((_texts$currentLang44 = texts[currentLang]) === null || _texts$currentLang44 === void 0 ? void 0 : _texts$currentLang44.editBtn) || ((_texts$en119 = texts.en) === null || _texts$en119 === void 0 ? void 0 : _texts$en119.editBtn) || 'Edit';
         editBtn.textContent = editLabel;
         editBtn.setAttribute('data-help', editLabel);
@@ -3797,6 +3808,11 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
         duplicateBtn.type = 'button';
         duplicateBtn.className = 'auto-gear-duplicate';
         duplicateBtn.dataset.ruleId = rule.id;
+        if (typeof index === 'number' && index >= 0) {
+          duplicateBtn.dataset.ruleIndex = String(index);
+        } else {
+          delete duplicateBtn.dataset.ruleIndex;
+        }
         var duplicateLabel = ((_texts$currentLang45 = texts[currentLang]) === null || _texts$currentLang45 === void 0 ? void 0 : _texts$currentLang45.autoGearDuplicateRule) || ((_texts$en120 = texts.en) === null || _texts$en120 === void 0 ? void 0 : _texts$en120.autoGearDuplicateRule) || 'Duplicate';
         duplicateBtn.textContent = duplicateLabel;
         duplicateBtn.setAttribute('data-help', duplicateLabel);
@@ -3805,6 +3821,11 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
         deleteBtn.type = 'button';
         deleteBtn.className = 'auto-gear-delete';
         deleteBtn.dataset.ruleId = rule.id;
+        if (typeof index === 'number' && index >= 0) {
+          deleteBtn.dataset.ruleIndex = String(index);
+        } else {
+          delete deleteBtn.dataset.ruleIndex;
+        }
         var deleteLabel = ((_texts$currentLang46 = texts[currentLang]) === null || _texts$currentLang46 === void 0 ? void 0 : _texts$currentLang46.autoGearDeleteRule) || ((_texts$en121 = texts.en) === null || _texts$en121 === void 0 ? void 0 : _texts$en121.autoGearDeleteRule) || 'Delete';
         deleteBtn.textContent = deleteLabel;
         deleteBtn.setAttribute('data-help', deleteLabel);
@@ -4380,11 +4401,23 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
       if (!autoGearEditor) return;
       var initialDraft = options.initialDraft,
         _options$highlightLab = options.highlightLabel,
-        highlightLabel = _options$highlightLab === void 0 ? false : _options$highlightLab;
+        highlightLabel = _options$highlightLab === void 0 ? false : _options$highlightLab,
+        ruleIndex = options.ruleIndex;
       var rules = getAutoGearRules();
-      var source = initialDraft ? initialDraft : ruleId ? rules.find(function (rule) {
-        return rule.id === ruleId;
-      }) : null;
+      var source = null;
+      if (initialDraft) {
+        source = initialDraft;
+      } else if (ruleId) {
+        source = rules.find(function (rule) {
+          return rule && rule.id === ruleId;
+        }) || null;
+      }
+      if (!source && ruleIndex !== null && ruleIndex !== undefined) {
+        var parsedIndex = typeof ruleIndex === 'number' ? ruleIndex : Number.parseInt(ruleIndex, 10);
+        if (Number.isInteger(parsedIndex) && parsedIndex >= 0 && parsedIndex < rules.length) {
+          source = rules[parsedIndex] || null;
+        }
+      }
       autoGearEditorDraft = createAutoGearDraft(source);
       autoGearEditorActiveItem = null;
       autoGearEditor.hidden = false;
@@ -4768,13 +4801,21 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
       showNotification('success', successMessage);
       closeAutoGearEditor();
     }
-    function duplicateAutoGearRule(ruleId) {
+    function duplicateAutoGearRule(ruleId, ruleIndex) {
       var _texts$en142;
-      if (!ruleId) return;
       var rules = getAutoGearRules();
-      var original = rules.find(function (rule) {
-        return rule && rule.id === ruleId;
-      });
+      var original = null;
+      if (ruleId) {
+        original = rules.find(function (rule) {
+          return rule && rule.id === ruleId;
+        }) || null;
+      }
+      if (!original && ruleIndex !== null && ruleIndex !== undefined) {
+        var parsedIndex = typeof ruleIndex === 'number' ? ruleIndex : Number.parseInt(ruleIndex, 10);
+        if (Number.isInteger(parsedIndex) && parsedIndex >= 0 && parsedIndex < rules.length) {
+          original = rules[parsedIndex] || null;
+        }
+      }
       if (!original) return;
       var langTexts = texts[currentLang] || texts.en || {};
       var suffixBase = typeof langTexts.autoGearDuplicateSuffix === 'string' ? langTexts.autoGearDuplicateSuffix.trim() : '';
@@ -4831,12 +4872,21 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
         highlightLabel: true
       });
     }
-    function deleteAutoGearRule(ruleId) {
+    function deleteAutoGearRule(ruleId, ruleIndex) {
       var _texts$currentLang57, _texts$en143;
       var rules = getAutoGearRules();
-      var index = rules.findIndex(function (rule) {
-        return rule.id === ruleId;
-      });
+      var index = -1;
+      if (ruleId) {
+        index = rules.findIndex(function (rule) {
+          return rule && rule.id === ruleId;
+        });
+      }
+      if (index < 0 && ruleIndex !== null && ruleIndex !== undefined) {
+        var parsedIndex = typeof ruleIndex === 'number' ? ruleIndex : Number.parseInt(ruleIndex, 10);
+        if (Number.isInteger(parsedIndex) && parsedIndex >= 0 && parsedIndex < rules.length) {
+          index = parsedIndex;
+        }
+      }
       if (index < 0) return;
       var confirmation = ((_texts$currentLang57 = texts[currentLang]) === null || _texts$currentLang57 === void 0 ? void 0 : _texts$currentLang57.autoGearDeleteConfirm) || ((_texts$en143 = texts.en) === null || _texts$en143 === void 0 ? void 0 : _texts$en143.autoGearDeleteConfirm) || 'Delete this rule?';
       if (!window.confirm(confirmation)) return;

--- a/legacy/scripts/app-session.js
+++ b/legacy/scripts/app-session.js
@@ -4548,11 +4548,23 @@ if (settingsButton && settingsDialog) {
       var button = targetElement && typeof targetElement.closest === 'function' ? targetElement.closest('button') : null;
       if (!button) return;
       if (button.classList.contains('auto-gear-edit')) {
-        invokeSessionOpenAutoGearEditor(button.dataset.ruleId || '');
+        var ruleId = button.dataset.ruleId || '';
+        var ruleIndex = button.dataset.ruleIndex;
+        var options = {};
+        if (ruleIndex !== undefined) {
+          options.ruleIndex = ruleIndex;
+        }
+        invokeSessionOpenAutoGearEditor(ruleId, options);
       } else if (button.classList.contains('auto-gear-duplicate')) {
-        duplicateAutoGearRule(button.dataset.ruleId || '');
+        duplicateAutoGearRule(button.dataset.ruleId || '', button.dataset.ruleIndex);
       } else if (button.classList.contains('auto-gear-delete')) {
-        deleteAutoGearRule(button.dataset.ruleId || '');
+        var deleteRuleId = button.dataset.ruleId || '';
+        var deleteRuleIndex = button.dataset.ruleIndex;
+        if (deleteRuleIndex !== undefined) {
+          deleteAutoGearRule(deleteRuleId, deleteRuleIndex);
+        } else {
+          deleteAutoGearRule(deleteRuleId);
+        }
       }
     });
   }

--- a/src/scripts/app-core-new-2.js
+++ b/src/scripts/app-core-new-2.js
@@ -4046,9 +4046,15 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
       }
     
       visibleRules.forEach(rule => {
+        const index = ruleIndexByObject.get(rule);
         const wrapper = document.createElement('div');
         wrapper.className = 'auto-gear-rule';
         wrapper.dataset.ruleId = rule.id;
+        if (typeof index === 'number' && index >= 0) {
+          wrapper.dataset.ruleIndex = String(index);
+        } else {
+          delete wrapper.dataset.ruleIndex;
+        }
         const info = document.createElement('div');
         info.className = 'auto-gear-rule-info';
         const title = document.createElement('p');
@@ -4308,6 +4314,11 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
         editBtn.type = 'button';
         editBtn.className = 'auto-gear-edit';
         editBtn.dataset.ruleId = rule.id;
+        if (typeof index === 'number' && index >= 0) {
+          editBtn.dataset.ruleIndex = String(index);
+        } else {
+          delete editBtn.dataset.ruleIndex;
+        }
         const editLabel = texts[currentLang]?.editBtn || texts.en?.editBtn || 'Edit';
         editBtn.textContent = editLabel;
         editBtn.setAttribute('data-help', editLabel);
@@ -4316,6 +4327,11 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
         duplicateBtn.type = 'button';
         duplicateBtn.className = 'auto-gear-duplicate';
         duplicateBtn.dataset.ruleId = rule.id;
+        if (typeof index === 'number' && index >= 0) {
+          duplicateBtn.dataset.ruleIndex = String(index);
+        } else {
+          delete duplicateBtn.dataset.ruleIndex;
+        }
         const duplicateLabel = texts[currentLang]?.autoGearDuplicateRule
           || texts.en?.autoGearDuplicateRule
           || 'Duplicate';
@@ -4326,6 +4342,11 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
         deleteBtn.type = 'button';
         deleteBtn.className = 'auto-gear-delete';
         deleteBtn.dataset.ruleId = rule.id;
+        if (typeof index === 'number' && index >= 0) {
+          deleteBtn.dataset.ruleIndex = String(index);
+        } else {
+          delete deleteBtn.dataset.ruleIndex;
+        }
         const deleteLabel = texts[currentLang]?.autoGearDeleteRule
           || texts.en?.autoGearDeleteRule
           || 'Delete';
@@ -4928,11 +4949,25 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
     
     function openAutoGearEditor(ruleId, options = {}) {
       if (!autoGearEditor) return;
-      const { initialDraft, highlightLabel = false } = options;
+      const { initialDraft, highlightLabel = false, ruleIndex = null } = options;
       const rules = getAutoGearRules();
-      const source = initialDraft
-        ? initialDraft
-        : (ruleId ? rules.find(rule => rule.id === ruleId) : null);
+      let source = null;
+      if (initialDraft) {
+        source = initialDraft;
+      } else if (ruleId) {
+        source = rules.find(rule => rule && rule.id === ruleId) || null;
+      }
+      if (!source && ruleIndex !== null && ruleIndex !== undefined) {
+        const parsedIndex = typeof ruleIndex === 'number'
+          ? ruleIndex
+          : Number.parseInt(ruleIndex, 10);
+        if (Number.isInteger(parsedIndex) && parsedIndex >= 0 && parsedIndex < rules.length) {
+          source = rules[parsedIndex] || null;
+        }
+      }
+      if (!source && !initialDraft) {
+        source = null;
+      }
       autoGearEditorDraft = createAutoGearDraft(source);
       autoGearEditorActiveItem = null;
       autoGearEditor.hidden = false;
@@ -5373,10 +5408,20 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
       closeAutoGearEditor();
     }
     
-    function duplicateAutoGearRule(ruleId) {
-      if (!ruleId) return;
+    function duplicateAutoGearRule(ruleId, ruleIndex) {
       const rules = getAutoGearRules();
-      const original = rules.find(rule => rule && rule.id === ruleId);
+      let original = null;
+      if (ruleId) {
+        original = rules.find(rule => rule && rule.id === ruleId) || null;
+      }
+      if (!original && ruleIndex !== null && ruleIndex !== undefined) {
+        const parsedIndex = typeof ruleIndex === 'number'
+          ? ruleIndex
+          : Number.parseInt(ruleIndex, 10);
+        if (Number.isInteger(parsedIndex) && parsedIndex >= 0 && parsedIndex < rules.length) {
+          original = rules[parsedIndex] || null;
+        }
+      }
       if (!original) return;
     
       const langTexts = texts[currentLang] || texts.en || {};
@@ -5444,9 +5489,20 @@ if (CORE_PART2_RUNTIME_SCOPE && CORE_PART2_RUNTIME_SCOPE.__cineCorePart2Initiali
       openAutoGearEditor(null, { initialDraft: duplicateRule, highlightLabel: true });
     }
     
-    function deleteAutoGearRule(ruleId) {
+    function deleteAutoGearRule(ruleId, ruleIndex) {
       const rules = getAutoGearRules();
-      const index = rules.findIndex(rule => rule.id === ruleId);
+      let index = -1;
+      if (ruleId) {
+        index = rules.findIndex(rule => rule && rule.id === ruleId);
+      }
+      if (index < 0 && ruleIndex !== null && ruleIndex !== undefined) {
+        const parsedIndex = typeof ruleIndex === 'number'
+          ? ruleIndex
+          : Number.parseInt(ruleIndex, 10);
+        if (Number.isInteger(parsedIndex) && parsedIndex >= 0 && parsedIndex < rules.length) {
+          index = parsedIndex;
+        }
+      }
       if (index < 0) return;
       const confirmation = texts[currentLang]?.autoGearDeleteConfirm
         || texts.en?.autoGearDeleteConfirm

--- a/src/scripts/app-session.js
+++ b/src/scripts/app-session.js
@@ -5192,12 +5192,21 @@ if (autoGearAddItemButton) {
         : null;
       if (!button) return;
       if (button.classList.contains('auto-gear-edit')) {
-        invokeSessionOpenAutoGearEditor(button.dataset.ruleId || '');
+        const ruleId = button.dataset.ruleId || '';
+        const ruleIndex = button.dataset.ruleIndex;
+        const options = {};
+        if (ruleIndex !== undefined) {
+          options.ruleIndex = ruleIndex;
+        }
+        invokeSessionOpenAutoGearEditor(ruleId, options);
       } else if (button.classList.contains('auto-gear-duplicate')) {
-        duplicateAutoGearRule(button.dataset.ruleId || '');
+        const ruleId = button.dataset.ruleId || '';
+        duplicateAutoGearRule(ruleId, button.dataset.ruleIndex);
       } else if (button.classList.contains('auto-gear-delete')) {
         const ruleId = button.dataset.ruleId || '';
-        callSessionCoreFunction('deleteAutoGearRule', [ruleId]);
+        const ruleIndex = button.dataset.ruleIndex;
+        const args = ruleIndex !== undefined ? [ruleId, ruleIndex] : [ruleId];
+        callSessionCoreFunction('deleteAutoGearRule', args);
       }
     });
   }


### PR DESCRIPTION
## Summary
- ensure auto gear rule buttons carry a stable list index alongside their ids
- fall back to the rule index when opening, duplicating, or deleting rules if an id is missing in both modern and legacy runtimes
- update session event handlers to pass the new rule index metadata through to the runtime helpers

## Testing
- `npm run test:unit` *(fails: known console stubbing limitation in Jest along with an out-of-sync service worker asset manifest)*

------
https://chatgpt.com/codex/tasks/task_e_68e626ea8dc88320ab2900e837a0d212