### PR TITLE
Update Spanish quick start checklist wording

### DIFF
--- a/legacy/scripts/translations.js
+++ b/legacy/scripts/translations.js
@@ -3827,7 +3827,7 @@ var texts = {
     helpNoResultsSuggestionSynonyms: "Busca apodos del equipo, números de parte de baterías o palabras clave más cortas.",
     helpNoResultsSuggestionQuickStart: "Ve a la %s para repasar cómo guardar, compartir y hacer copias de seguridad.",
     helpNoResultsSuggestionBackup: "Abre %1$s y comienza un %2$s para confirmar tus exportaciones sin conexión antes de cambiar algo.",
-    helpQuickStartChecklistTitle: "Lista de inicio rápido",
+    helpQuickStartChecklistTitle: "Lista de comprobación de inicio rápido",
     helpDataSafetyTitle: "Protege tu trabajo",
     helpRestoreDrillTitle: "Ensayo de restauración",
     helpDataAuditTitle: "Revisión mensual de salud de datos",

--- a/src/scripts/translations.js
+++ b/src/scripts/translations.js
@@ -4490,7 +4490,7 @@ const texts = {
       "Ve a la %s para repasar cómo guardar, compartir y hacer copias de seguridad.",
     helpNoResultsSuggestionBackup:
       "Abre %1$s y comienza un %2$s para confirmar tus exportaciones sin conexión antes de cambiar algo.",
-    helpQuickStartChecklistTitle: "Lista de inicio rápido",
+    helpQuickStartChecklistTitle: "Lista de comprobación de inicio rápido",
     helpDataSafetyTitle: "Protege tu trabajo",
    helpRestoreDrillTitle: "Ensayo de restauración",
     helpDataAuditTitle: "Revisión mensual de salud de datos",


### PR DESCRIPTION
## Summary
- update the Spanish quick start checklist label to use the clearer "Lista de comprobación de inicio rápido"
- mirror the translation update in the legacy bundle to keep both UIs aligned

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e62712f8ac83209e6aff5546e860af