### PR TITLE
Fix flag forwarding when running targeted unit tests

### DIFF
--- a/tools/runUnitTests.js
+++ b/tools/runUnitTests.js
@@ -39,7 +39,7 @@ for (let index = 0; index < cliArgs.length; index += 1) {
     forwardedArgs.push(arg);
 
     const next = cliArgs[index + 1];
-    if (next && !next.startsWith('-') && !resolveTestPath(next)) {
+    if (next && !next.startsWith('-')) {
       forwardedArgs.push(next);
       index += 1;
     }


### PR DESCRIPTION
## Summary
- ensure flag values following forwarded CLI options are preserved even when they point into the tests directory

## Testing
- npm run test:unit -- --findRelatedTests tests/unit/storage.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e62a3b338c8320b5bf89b3a1579b10