### PR TITLE
Fix duplicate compression summary condition

### DIFF
--- a/src/scripts/storage.js
+++ b/src/scripts/storage.js
@@ -269,8 +269,6 @@ function logCompressionSavingsEvent(kind, identifier, message, savings, percent)
     now - entry.lastSummaryAt >= COMPRESSION_LOG_SUMMARY_WINDOW_MS
   ) {
     shouldSummarize = true;
-  } else if (now === null && entry.suppressedSinceSummary >= COMPRESSION_WARNING_BATCH_SIZE) {
-    shouldSummarize = true;
   }
 
   if (shouldSummarize && typeof console.info === 'function') {


### PR DESCRIPTION
## Summary
- remove the duplicate compression summary branch in storage.js to satisfy eslint's no-dupe-else-if rule while keeping logging logic intact

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e62a73864c8320b583d0e160a44faf