### PR TITLE
Follow-up: Prevent duplicate auto backups during rapid imports

### DIFF
--- a/src/scripts/app-events.js
+++ b/src/scripts/app-events.js
@@ -72,7 +72,7 @@ const AUTO_BACKUP_ALLOWED_REASONS = [
   'change-threshold',
   'safeguard',
 ];
-const AUTO_BACKUP_RATE_LIMITED_REASONS = new Set(['import']);
+const AUTO_BACKUP_RATE_LIMITED_REASONS = new Set();
 
 const AUTO_BACKUP_REASON_DEDUP_INTERVAL_MS = 2 * 60 * 1000;
 const lastAutoBackupReasonState = new Map();


### PR DESCRIPTION
## Summary
- retain the duplicate import protections while allowing each successive import to capture its own auto backup
- remove the import trigger from the rate-limited reasons so imports are not throttled for 10 minutes

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e63482fed4832095bf012c59c19769