### PR TITLE
chore: bump version to 1.0.20

### DIFF
--- a/index.html
+++ b/index.html
@@ -2668,7 +2668,7 @@
             hidden
           >
         <h3 id="aboutHeading">About &amp; Support</h3>
-        <p id="aboutVersion">Version 1.0.19</p>
+        <p id="aboutVersion">Version 1.0.20</p>
         <p><a href="https://github.com" id="supportLink" target="_blank">Support</a></p>
       </section>
           <div class="button-row action-buttons">

--- a/legacy/scripts/app-core-new-1.js
+++ b/legacy/scripts/app-core-new-1.js
@@ -1098,7 +1098,7 @@ if (CORE_PART1_RUNTIME_SCOPE && CORE_PART1_RUNTIME_SCOPE.__cineCorePart1Initiali
     var _require = require('./overview.js');
     generatePrintableOverview = _require.generatePrintableOverview;
   } catch (_unused) {}
-  var APP_VERSION = typeof CORE_SHARED.APP_VERSION === 'string' ? CORE_SHARED.APP_VERSION : '1.0.19';
+  var APP_VERSION = typeof CORE_SHARED.APP_VERSION === 'string' ? CORE_SHARED.APP_VERSION : '1.0.20';
   if (typeof window !== 'undefined') {
     var lottie = window.lottie;
     if (lottie && typeof lottie.useWebWorker === 'function') {

--- a/legacy/scripts/modules/core-shared.js
+++ b/legacy/scripts/modules/core-shared.js
@@ -848,7 +848,7 @@ function _typeof(o) { "@babel/helpers - typeof"; return _typeof = "function" == 
     return resolved;
   }
   var LZString = resolveLzString();
-  var APP_VERSION = '1.0.19';
+  var APP_VERSION = '1.0.20';
   var shared = freezeDeep({
     APP_VERSION: APP_VERSION,
     stableStringify: stableStringify,

--- a/legacy/scripts/script.js
+++ b/legacy/scripts/script.js
@@ -39,7 +39,7 @@ if (typeof require === 'function' && typeof module !== 'undefined' && module && 
   attemptRegistryBackfill(globalScope);
   var aggregatedExports = module.exports;
   var combinedAppVersion = aggregatedExports && aggregatedExports.APP_VERSION;
-  var APP_VERSION = "1.0.19";
+  var APP_VERSION = "1.0.20";
   if (combinedAppVersion && combinedAppVersion !== APP_VERSION) {
     throw new Error("Combined app version (".concat(combinedAppVersion, ") does not match script marker (").concat(APP_VERSION, ")."));
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cine-power-planner",
-  "version": "1.0.19",
+  "version": "1.0.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cine-power-planner",
-      "version": "1.0.19",
+    "version": "1.0.20",
       "license": "ISC",
       "dependencies": {
         "lottie-web": "^5.13.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cine-power-planner",
-  "version": "1.0.19",
+  "version": "1.0.20",
   "description": "Browser-based tool for planning professional camera setups powered by V-Mount or B-Mount batteries. It calculates total power consumption, current draw at 14.4 V and 12 V, and estimated battery runtime while checking that the battery can safely deliver the required power.",
   "main": "src/data/index.js",
   "scripts": {

--- a/service-worker.js
+++ b/service-worker.js
@@ -201,7 +201,7 @@ let CACHE_VERSION = null;
   }
 
 if (!CACHE_VERSION) {
-CACHE_VERSION = '1.0.19';
+CACHE_VERSION = '1.0.20';
 }
 
 const CACHE_NAME = `cine-power-planner-v${CACHE_VERSION}`;

--- a/src/scripts/app-core-new-1.js
+++ b/src/scripts/app-core-new-1.js
@@ -1441,7 +1441,7 @@ try {
   // overview generation not needed in test environments without module support
 }
 
-var APP_VERSION = typeof CORE_SHARED.APP_VERSION === 'string' ? CORE_SHARED.APP_VERSION : '1.0.19';
+var APP_VERSION = typeof CORE_SHARED.APP_VERSION === 'string' ? CORE_SHARED.APP_VERSION : '1.0.20';
 
 if (typeof window !== 'undefined') {
   const lottie = window.lottie;

--- a/src/scripts/modules/core-shared.js
+++ b/src/scripts/modules/core-shared.js
@@ -1053,7 +1053,7 @@
 
   const LZString = resolveLzString();
 
-  const APP_VERSION = '1.0.19';
+  const APP_VERSION = '1.0.20';
 
   const shared = freezeDeep({
     APP_VERSION,

--- a/src/scripts/script.js
+++ b/src/scripts/script.js
@@ -104,7 +104,7 @@ if (typeof require === 'function' && typeof module !== 'undefined' && module && 
 
   const aggregatedExports = module.exports;
   const combinedAppVersion = aggregatedExports && aggregatedExports.APP_VERSION;
-  const APP_VERSION = "1.0.19"; // Version marker for consistency checks
+  const APP_VERSION = "1.0.20"; // Version marker for consistency checks
 
   if (combinedAppVersion && combinedAppVersion !== APP_VERSION) {
     throw new Error(


### PR DESCRIPTION
## Summary
- bump the application version to 1.0.20 across build metadata, scripts, and the UI so all components report the same release number

## Testing
- npm run lint *(fails: src/scripts/storage.js:2380 nonJsonStringError defined but never used; pre-existing issue)*

------
https://chatgpt.com/codex/tasks/task_e_68e6355c956c832095fa685c501156d8