### PR TITLE
Prevent duplicate auto backups for unchanged snapshots

### DIFF
--- a/src/scripts/app-events.js
+++ b/src/scripts/app-events.js
@@ -1653,6 +1653,51 @@ function autoBackup(options = {}) {
       currentSetup.gearSelectors = gearSelectors;
     }
     const currentSignature = computeAutoBackupStateSignature(currentSetup, gearSelectors, gearListGenerated);
+    const { name: latestStoredName, entry: latestStoredEntry } = resolveLatestAutoBackupEntry(setupsSnapshot);
+    if (
+      !force
+      && latestStoredName
+      && latestStoredEntry
+    ) {
+      try {
+        const latestStoredSignature = computeStoredAutoBackupSignature(
+          latestStoredName,
+          latestStoredEntry,
+        );
+        if (latestStoredSignature === currentSignature) {
+          const latestMetadata = readAutoBackupMetadata(latestStoredEntry);
+          const latestCreatedAt = latestMetadata && typeof latestMetadata.createdAt === 'string'
+            ? latestMetadata.createdAt
+            : null;
+          lastAutoBackupSignature = currentSignature;
+          lastAutoBackupName = latestStoredName;
+          lastAutoBackupCreatedAtIso = latestCreatedAt;
+          recordAutoBackupRun({
+            status: 'skipped',
+            reason: 'unchanged',
+            name: latestStoredName,
+            createdAt: latestCreatedAt,
+            context: reason,
+          });
+          lastAutoBackupReasonState.set(reason, {
+            timestamp: now.valueOf(),
+            signature: currentSignature,
+          });
+          return {
+            status: 'skipped',
+            reason: 'unchanged',
+            name: latestStoredName,
+            createdAt: latestCreatedAt,
+            context: reason,
+          };
+        }
+      } catch (signatureCompareError) {
+        console.warn(
+          'Failed to compare current auto backup against latest snapshot before saving',
+          signatureCompareError,
+        );
+      }
+    }
     if (!force) {
       const lastReasonState = lastAutoBackupReasonState.get(reason);
       if (lastReasonState) {


### PR DESCRIPTION
## Summary
- skip creating a new auto-backup when the latest stored snapshot already matches the current setup signature
- reuse existing metadata when skipping and preserve rate-limit bookkeeping to avoid repeated triggers
- warn when signature comparison fails so diagnostics stay visible without breaking backups

## Testing
- npm run lint
- npm run test:jest -- --runInBand tests/unit/backupFeatureModule.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e634c9b1b08320bf517071def44bf9