### PR TITLE
Improve resilience of forced reload navigation detection

### DIFF
--- a/legacy/scripts/app-session.js
+++ b/legacy/scripts/app-session.js
@@ -8365,6 +8365,75 @@ function waitForReloadNavigation(beforeHref) {
     }, timeout);
   });
 }
+function scheduleForceReloadNavigationWarning(locationLike, baseHref, description, before, expected, initialAfter) {
+  var schedule = null;
+  try {
+    if (typeof window !== 'undefined' && window && typeof window.setTimeout === 'function') {
+      schedule = window.setTimeout.bind(window);
+    }
+  } catch (error) {
+    void error;
+  }
+  if (!schedule) {
+    if (typeof setTimeout === 'function') {
+      schedule = setTimeout;
+    } else {
+      console.warn('Forced reload navigation attempt did not update location', {
+        description: description,
+        before: before,
+        after: initialAfter,
+        expected: expected
+      });
+      return;
+    }
+  }
+  var resolved = false;
+  var evaluate = function evaluate() {
+    var currentRaw = readLocationHrefSafe(locationLike);
+    var current = normaliseForceReloadHref(currentRaw, baseHref);
+    if (expected && (current === expected || current === "".concat(expected, "#")) || before !== current && current && (!expected || current === expected)) {
+      resolved = true;
+      return {
+        matched: true,
+        value: current
+      };
+    }
+    return {
+      matched: false,
+      value: current
+    };
+  };
+  var verifyDelays = [120, 360];
+  verifyDelays.forEach(function (delay, index) {
+    var isFinalCheck = index === verifyDelays.length - 1;
+    var runCheck = function runCheck() {
+      if (resolved) {
+        return;
+      }
+      var result = evaluate();
+      if (result.matched) {
+        return;
+      }
+      if (isFinalCheck) {
+        resolved = true;
+        console.warn('Forced reload navigation attempt did not update location', {
+          description: description,
+          before: before,
+          after: result.value,
+          expected: expected
+        });
+      }
+    };
+    try {
+      schedule(runCheck, delay);
+    } catch (scheduleError) {
+      void scheduleError;
+      if (isFinalCheck) {
+        runCheck();
+      }
+    }
+  });
+}
 function attemptForceReloadNavigation(locationLike, nextHref, baseHref, applyFn, description) {
   if (!locationLike || typeof applyFn !== 'function' || typeof nextHref !== 'string' || !nextHref) {
     return false;
@@ -8386,12 +8455,7 @@ function attemptForceReloadNavigation(locationLike, nextHref, baseHref, applyFn,
   if (expected && (after === expected || after === "".concat(expected, "#")) || before !== after && after && (!expected || after === expected)) {
     return true;
   }
-  console.warn('Forced reload navigation attempt did not update location', {
-    description: description,
-    before: before,
-    after: after,
-    expected: expected
-  });
+  scheduleForceReloadNavigationWarning(locationLike, baseHref, description, before, expected, after);
   return false;
 }
 

--- a/src/scripts/modules/offline.js
+++ b/src/scripts/modules/offline.js
@@ -1059,6 +1059,93 @@
     };
   }
 
+  function scheduleForceReloadNavigationWarning(
+    locationLike,
+    baseHref,
+    description,
+    before,
+    expected,
+    initialAfter,
+  ) {
+    let schedule = null;
+
+    try {
+      if (typeof window !== 'undefined' && window && typeof window.setTimeout === 'function') {
+        schedule = window.setTimeout.bind(window);
+      }
+    } catch (error) {
+      void error;
+    }
+
+    if (!schedule) {
+      if (typeof setTimeout === 'function') {
+        schedule = setTimeout;
+      } else {
+        safeWarn('Forced reload navigation attempt did not update location', {
+          description,
+          before,
+          after: initialAfter,
+          expected,
+        });
+        return;
+      }
+    }
+
+    let resolved = false;
+
+    const evaluate = () => {
+      const currentRaw = readLocationHrefSafe(locationLike);
+      const current = normaliseHrefForComparison(currentRaw, baseHref);
+
+      if (
+        (expected && (current === expected || current === `${expected}#`))
+        || (before !== current && current && (!expected || current === expected))
+      ) {
+        resolved = true;
+        return { matched: true, value: current };
+      }
+
+      return { matched: false, value: current };
+    };
+
+    const verifyDelays = [120, 360];
+
+    verifyDelays.forEach((delay, index) => {
+      const isFinalCheck = index === verifyDelays.length - 1;
+
+      const runCheck = () => {
+        if (resolved) {
+          return;
+        }
+
+        const result = evaluate();
+
+        if (result.matched) {
+          return;
+        }
+
+        if (isFinalCheck) {
+          resolved = true;
+          safeWarn('Forced reload navigation attempt did not update location', {
+            description,
+            before,
+            after: result.value,
+            expected,
+          });
+        }
+      };
+
+      try {
+        schedule(runCheck, delay);
+      } catch (scheduleError) {
+        void scheduleError;
+        if (isFinalCheck) {
+          runCheck();
+        }
+      }
+    });
+  }
+
   function attemptForceReloadNavigation(locationLike, nextHref, baseHref, applyFn, description) {
     if (!locationLike || typeof applyFn !== 'function' || typeof nextHref !== 'string' || !nextHref) {
       return false;
@@ -1085,12 +1172,7 @@
       return true;
     }
 
-    safeWarn('Forced reload navigation attempt did not update location', {
-      description,
-      before,
-      after,
-      expected,
-    });
+    scheduleForceReloadNavigationWarning(locationLike, baseHref, description, before, expected, after);
 
     return false;
   }

--- a/src/scripts/storage.js
+++ b/src/scripts/storage.js
@@ -2378,6 +2378,7 @@ function ensureProjectEntryCompressed(value, contextName) {
     try {
       JSON.parse(value);
     } catch (nonJsonStringError) {
+      void nonJsonStringError;
       return value;
     }
 


### PR DESCRIPTION
## Summary
- add a scheduled verification helper for forced reload navigation so we only warn after delayed checks in both modern and legacy bundles
- reuse the helper from the offline module to avoid repeated false positives when navigation succeeds asynchronously
- ensure catch blocks remain lint-clean when parsing storage values without altering saved project data

## Testing
- npm run lint
- npm run check-consistency

------
https://chatgpt.com/codex/tasks/task_e_68e635e8ff688320ac98687938dad18b