### PR TITLE
Improve scope collection caching

### DIFF
--- a/src/scripts/modules/architecture-kernel.js
+++ b/src/scripts/modules/architecture-kernel.js
@@ -105,7 +105,91 @@
         })
       : null;
 
+  function resolveScopeCollector() {
+    if (typeof require === 'function') {
+      try {
+        const required = require('./helpers/scope-collector.js');
+        if (required && typeof required.createCollector === 'function') {
+          return required;
+        }
+      } catch (error) {
+        void error;
+      }
+    }
+
+    const candidates = [];
+
+    function pushCandidate(scope) {
+      if (!scope || (typeof scope !== 'object' && typeof scope !== 'function')) {
+        return;
+      }
+      if (candidates.indexOf(scope) === -1) {
+        candidates.push(scope);
+      }
+    }
+
+    pushCandidate(LOCAL_SCOPE);
+    if (typeof globalThis !== 'undefined') pushCandidate(globalThis);
+    if (typeof window !== 'undefined') pushCandidate(window);
+    if (typeof self !== 'undefined') pushCandidate(self);
+    if (typeof global !== 'undefined') pushCandidate(global);
+
+    for (let index = 0; index < candidates.length; index += 1) {
+      const scope = candidates[index];
+      try {
+        const collector = scope && scope.__cineScopeCollector;
+        if (collector && typeof collector.createCollector === 'function') {
+          return collector;
+        }
+      } catch (error) {
+        void error;
+      }
+    }
+
+    return null;
+  }
+
+  const SCOPE_COLLECTOR = resolveScopeCollector();
+  const createScopeCollector =
+    SCOPE_COLLECTOR && typeof SCOPE_COLLECTOR.createCollector === 'function'
+      ? SCOPE_COLLECTOR.createCollector
+      : null;
+  const DEFAULT_EXTRAS_KEY = { key: 'defaultExtras' };
+  const HELPER_COLLECTOR_CACHE = [];
+
+  function resolveHelperCollector(detectFn, extras) {
+    if (!createScopeCollector) {
+      return null;
+    }
+
+    const extrasKey = Array.isArray(extras) ? extras : DEFAULT_EXTRAS_KEY;
+
+    for (let index = 0; index < HELPER_COLLECTOR_CACHE.length; index += 1) {
+      const entry = HELPER_COLLECTOR_CACHE[index];
+      if (entry.detect === detectFn && entry.extras === extrasKey) {
+        return entry.collector;
+      }
+    }
+
+    const collector = createScopeCollector({
+      detectGlobalScope: detectFn,
+      additionalScopes: Array.isArray(extras) ? extras : undefined,
+    });
+
+    if (collector) {
+      HELPER_COLLECTOR_CACHE.push({ detect: detectFn, extras: extrasKey, collector });
+      return collector;
+    }
+
+    return null;
+  }
+
   function fallbackCollectCandidateScopes(primary) {
+    const collector = resolveHelperCollector(fallbackDetectGlobalScope, null);
+    if (collector) {
+      return collector(primary);
+    }
+
     const scopes = [];
 
     function pushScope(scope) {

--- a/src/scripts/modules/helpers/scope-collector.js
+++ b/src/scripts/modules/helpers/scope-collector.js
@@ -1,0 +1,243 @@
+(function () {
+  function detectGlobalScope() {
+    if (typeof globalThis !== 'undefined') {
+      return globalThis;
+    }
+    if (typeof window !== 'undefined') {
+      return window;
+    }
+    if (typeof self !== 'undefined') {
+      return self;
+    }
+    if (typeof global !== 'undefined') {
+      return global;
+    }
+    return {};
+  }
+
+  function isObjectLike(value) {
+    return !!value && (typeof value === 'object' || typeof value === 'function');
+  }
+
+  function freezeArray(array) {
+    if (typeof Object.freeze === 'function') {
+      try {
+        return Object.freeze(array);
+      } catch (error) {
+        void error;
+      }
+    }
+    return array;
+  }
+
+  function cloneArray(array) {
+    if (!array) {
+      return [];
+    }
+    try {
+      return Array.prototype.slice.call(array);
+    } catch (error) {
+      void error;
+    }
+    const clone = [];
+    for (let index = 0; index < array.length; index += 1) {
+      clone[index] = array[index];
+    }
+    return clone;
+  }
+
+  function createPrimaryCache() {
+    return {
+      objects: typeof WeakMap === 'function' ? new WeakMap() : null,
+      primitives: Object.create(null),
+      empty: null,
+    };
+  }
+
+  function getPrimaryCacheEntry(cache, primary) {
+    if (!cache) {
+      return null;
+    }
+
+    if (isObjectLike(primary)) {
+      if (!cache.objects) {
+        return null;
+      }
+      let entry = cache.objects.get(primary);
+      if (!entry) {
+        entry = { cached: false, value: null };
+        cache.objects.set(primary, entry);
+      }
+      return entry;
+    }
+
+    const key = typeof primary + ':' + String(primary);
+    let entry = cache.primitives[key];
+    if (!entry) {
+      entry = { cached: false, value: null };
+      cache.primitives[key] = entry;
+    }
+    return entry;
+  }
+
+  function pushUnique(target, value) {
+    if (!isObjectLike(value)) {
+      return;
+    }
+    if (target.indexOf(value) === -1) {
+      target.push(value);
+    }
+  }
+
+  const BASE_SCOPES = (function buildBaseScopes() {
+    const scopes = [];
+    pushUnique(scopes, typeof globalThis !== 'undefined' ? globalThis : null);
+    pushUnique(scopes, typeof window !== 'undefined' ? window : null);
+    pushUnique(scopes, typeof self !== 'undefined' ? self : null);
+    pushUnique(scopes, typeof global !== 'undefined' ? global : null);
+    return freezeArray(scopes);
+  })();
+
+  const EMPTY_EXTRAS = freezeArray([]);
+  const SUPPORTS_WEAKMAP = typeof WeakMap === 'function';
+  const DETECT_CACHE = SUPPORTS_WEAKMAP ? new WeakMap() : null;
+
+  function sanitizeExtras(extras) {
+    if (!Array.isArray(extras) || extras.length === 0) {
+      return EMPTY_EXTRAS;
+    }
+
+    const sanitized = [];
+    for (let index = 0; index < extras.length; index += 1) {
+      pushUnique(sanitized, extras[index]);
+    }
+
+    if (sanitized.length === 0) {
+      return EMPTY_EXTRAS;
+    }
+
+    return freezeArray(sanitized);
+  }
+
+  function computeCandidateScopes(primary, detectFn, extrasList) {
+    const scopes = [];
+    pushUnique(scopes, primary);
+
+    let detected = null;
+    if (typeof detectFn === 'function') {
+      try {
+        detected = detectFn();
+      } catch (error) {
+        void error;
+        detected = null;
+      }
+    }
+    pushUnique(scopes, detected);
+
+    for (let index = 0; index < BASE_SCOPES.length; index += 1) {
+      pushUnique(scopes, BASE_SCOPES[index]);
+    }
+
+    if (Array.isArray(extrasList)) {
+      for (let index = 0; index < extrasList.length; index += 1) {
+        pushUnique(scopes, extrasList[index]);
+      }
+    }
+
+    return freezeArray(scopes);
+  }
+
+  function getExtrasCache(detectEntry, extrasList) {
+    if (!detectEntry) {
+      return null;
+    }
+
+    if (extrasList === EMPTY_EXTRAS) {
+      if (!detectEntry.empty) {
+        detectEntry.empty = createPrimaryCache();
+      }
+      return detectEntry.empty;
+    }
+
+    if (!detectEntry.extras) {
+      if (!SUPPORTS_WEAKMAP) {
+        return null;
+      }
+      detectEntry.extras = new WeakMap();
+    }
+
+    let extrasEntry = detectEntry.extras.get(extrasList);
+    if (!extrasEntry) {
+      extrasEntry = createPrimaryCache();
+      detectEntry.extras.set(extrasList, extrasEntry);
+    }
+    return extrasEntry;
+  }
+
+  function getDetectEntry(detectFn) {
+    if (!DETECT_CACHE) {
+      return null;
+    }
+
+    let entry = DETECT_CACHE.get(detectFn);
+    if (!entry) {
+      entry = { empty: null, extras: null };
+      DETECT_CACHE.set(detectFn, entry);
+    }
+    return entry;
+  }
+
+  function collectInternal(primary, detectFn, extrasList, cacheEntry) {
+    if (cacheEntry) {
+      const primaryEntry = getPrimaryCacheEntry(cacheEntry, primary);
+      if (primaryEntry) {
+        if (primaryEntry.cached) {
+          return cloneArray(primaryEntry.value);
+        }
+        const computed = computeCandidateScopes(primary, detectFn, extrasList);
+        primaryEntry.value = computed;
+        primaryEntry.cached = true;
+        return cloneArray(computed);
+      }
+    }
+
+    const computedFallback = computeCandidateScopes(primary, detectFn, extrasList);
+    return cloneArray(computedFallback);
+  }
+
+  function createCollector(options) {
+    const detectFn = options && typeof options.detectGlobalScope === 'function'
+      ? options.detectGlobalScope
+      : detectGlobalScope;
+    const extrasList = sanitizeExtras(options && options.additionalScopes);
+    const detectEntry = getDetectEntry(detectFn);
+    const cacheEntry = getExtrasCache(detectEntry, extrasList);
+
+    return function collectWithPreset(primary) {
+      return collectInternal(primary, detectFn, extrasList, cacheEntry);
+    };
+  }
+
+  function collectCandidateScopes(primary, options) {
+    const collector = createCollector(options || {});
+    return collector(primary);
+  }
+
+  const exportsObject = {
+    collectCandidateScopes,
+    createCollector,
+    getBaseScopes() {
+      return cloneArray(BASE_SCOPES);
+    },
+  };
+
+  const GLOBAL_SCOPE = detectGlobalScope();
+
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = exportsObject;
+  }
+
+  if (GLOBAL_SCOPE && !GLOBAL_SCOPE.__cineScopeCollector) {
+    GLOBAL_SCOPE.__cineScopeCollector = exportsObject;
+  }
+})();


### PR DESCRIPTION
## Summary
- add a shared scope collector helper that caches global scope discovery work
- integrate the helper into the architecture modules so runtime and fallback scope collection reuse cached results
- reuse cached base-scope extras to avoid redundant array creation in the base module

## Testing
- npm run lint *(fails: pre-existing unused variable warning in src/scripts/storage.js)*

------
https://chatgpt.com/codex/tasks/task_e_68e636ec025083209aab268ce6fee683