### PR TITLE
Add plain-language power summary panel

### DIFF
--- a/index.html
+++ b/index.html
@@ -424,6 +424,21 @@
     <p id="pinWarning" class="status-message" role="status" aria-live="polite" aria-describedby="batteryLabel"></p>
     <p id="dtapWarning" class="status-message" role="status" aria-live="polite" aria-describedby="batteryLabel"></p>
     <p id="hotswapWarning" class="status-message" role="status" aria-live="polite" aria-describedby="batteryHotswapLabel"></p>
+    <section
+      id="resultsPlainSummary"
+      class="results-plain-summary"
+      aria-labelledby="resultsPlainSummaryTitle"
+    >
+      <h3 id="resultsPlainSummaryTitle">Quick summary</h3>
+      <p
+        id="resultsPlainSummaryText"
+        class="results-plain-summary-text"
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+      ></p>
+      <p id="resultsPlainSummaryNote" class="results-plain-summary-note"></p>
+    </section>
     <div id="temperatureNote"></div>
     <button id="runtimeFeedbackBtn" type="button">
       <span class="btn-icon icon-glyph" aria-hidden="true" data-icon-font="essential">&#xF13E;</span>Submit User Runtime Feedback
@@ -2946,7 +2961,15 @@
                   data-help-highlight="#setupDiagram"
                 ><em>Connection Diagram</em></a>
                 in order. Each section updates immediately so you can verify power draw, cable routing and runtime checks at a
-                glance.
+                glance. The
+                <a
+                  class="help-link"
+                  href="#resultsPlainSummary"
+                  data-help-target="#resultsPlainSummary"
+                  data-help-highlight="#resultsPlainSummary"
+                >Quick summary</a>
+                card inside <em>Power Summary</em> turns the totals into plain language and keeps working offline so every
+                change is easy to explain.
               </li>
               <li>
                 Before wrapping up, download an

--- a/legacy/scripts/app-core-new-1.js
+++ b/legacy/scripts/app-core-new-1.js
@@ -7230,6 +7230,22 @@ if (CORE_PART1_RUNTIME_SCOPE && CORE_PART1_RUNTIME_SCOPE.__cineCorePart1Initiali
       }
     }
     if (!resultsLocalizationApplied) {
+      var resultsPlainSummaryElem = document.getElementById("resultsPlainSummary");
+      if (resultsPlainSummaryElem) {
+        resultsPlainSummaryElem.setAttribute("data-help", texts[lang].resultsPlainSummaryHelp);
+      }
+      var resultsPlainSummaryTitleElem = document.getElementById("resultsPlainSummaryTitle");
+      if (resultsPlainSummaryTitleElem) {
+        resultsPlainSummaryTitleElem.textContent = texts[lang].resultsPlainSummaryTitle;
+      }
+      var resultsPlainSummaryTextElem = document.getElementById("resultsPlainSummaryText");
+      if (resultsPlainSummaryTextElem) {
+        resultsPlainSummaryTextElem.textContent = texts[lang].resultsPlainSummaryPrompt;
+      }
+      var resultsPlainSummaryNoteElem = document.getElementById("resultsPlainSummaryNote");
+      if (resultsPlainSummaryNoteElem) {
+        resultsPlainSummaryNoteElem.textContent = texts[lang].resultsPlainSummaryNote;
+      }
       var breakdownListTarget = typeof breakdownListElem !== "undefined" && breakdownListElem ? breakdownListElem : document.getElementById('breakdownList');
       if (breakdownListTarget) {
         breakdownListTarget.setAttribute("data-help", texts[lang].breakdownListHelp);

--- a/legacy/scripts/modules/results.js
+++ b/legacy/scripts/modules/results.js
@@ -570,6 +570,162 @@ function _typeof(o) { "@babel/helpers - typeof"; return _typeof = "function" == 
     if (breakdownList) {
       var breakdownHelp = resolveText('breakdownListHelp');
       setHelpAttribute(breakdownList, breakdownHelp);
+  }
+
+  function getNonEmptyString(value) {
+    if (typeof value !== 'string') {
+      return '';
+    }
+    var trimmed = value.trim();
+    return trimmed ? trimmed : '';
+  }
+
+  function replaceSummaryTokens(template, tokens) {
+    if (typeof template !== 'string' || !template) {
+      return '';
+    }
+    var result = template;
+    for (var key in tokens) {
+      if (!Object.prototype.hasOwnProperty.call(tokens, key)) {
+        continue;
+      }
+      var tokenValue = tokens[key];
+      var placeholder = '{' + key + '}';
+      if (result.indexOf(placeholder) === -1) {
+        continue;
+      }
+      var replacement = typeof tokenValue === 'undefined' ? '' : String(tokenValue);
+      result = result.split(placeholder).join(replacement);
+    }
+    return result;
+  }
+
+  function selectSummaryBatteryName(labelText, batteryName, unnamedLabel) {
+    var resolvedLabel = getNonEmptyString(labelText);
+    if (resolvedLabel) {
+      return resolvedLabel;
+    }
+    var resolvedBattery = getNonEmptyString(batteryName);
+    if (resolvedBattery) {
+      return resolvedBattery;
+    }
+    return getNonEmptyString(unnamedLabel);
+  }
+
+  function formatRuntimeHoursForSummary(runtimeHours) {
+    if (!Number.isFinite(runtimeHours)) {
+      return '';
+    }
+    return runtimeHours >= 10 ? runtimeHours.toFixed(1) : runtimeHours.toFixed(2);
+  }
+
+  function buildPlainSummaryText(summaryOptions) {
+    var opts = summaryOptions || {};
+    var summaryPrompt = getNonEmptyString(opts.summaryPrompt);
+    var needBatterySummary = getNonEmptyString(opts.needBatterySummary) || summaryPrompt;
+    var unnamedBatteryLabel = getNonEmptyString(opts.unnamedBatteryLabel);
+    var batteryNameSummary = selectSummaryBatteryName(opts.batteryLabelText, opts.battery, unnamedBatteryLabel);
+    var totalPowerDisplay = Number.isFinite(opts.totalWatt) ? opts.totalWatt.toFixed(1) : '0.0';
+
+    if (!opts.battery) {
+      var promptWhenMissingBattery = opts.totalWatt > 0 ? needBatterySummary : summaryPrompt;
+      return promptWhenMissingBattery || needBatterySummary || summaryPrompt || batteryNameSummary || '';
+    }
+
+    if (!Number.isFinite(opts.runtimeHoursValue)) {
+      if (
+        opts.unlimitedSummaryTemplate &&
+        Number.isFinite(opts.totalWatt) &&
+        opts.totalWatt === 0
+      ) {
+        var unlimitedSummary = replaceSummaryTokens(opts.unlimitedSummaryTemplate, {
+          batteryName: batteryNameSummary || unnamedBatteryLabel || '',
+          totalPower: totalPowerDisplay
+        });
+        if (unlimitedSummary) {
+          return unlimitedSummary;
+        }
+      }
+      return needBatterySummary || summaryPrompt || batteryNameSummary || '';
+    }
+
+    if (
+      opts.runtimeSummaryTemplate &&
+      opts.batteriesNeededValue !== null &&
+      Number.isFinite(opts.batteriesNeededValue) &&
+      opts.batteriesNeededValue > 0
+    ) {
+      var formattedHours = formatRuntimeHoursForSummary(opts.runtimeHoursValue);
+      var runtimeSummary = replaceSummaryTokens(opts.runtimeSummaryTemplate, {
+        batteryName: batteryNameSummary || unnamedBatteryLabel || '',
+        hours: formattedHours,
+        batteryCount: String(opts.batteriesNeededValue),
+        totalPower: totalPowerDisplay
+      });
+      if (runtimeSummary) {
+        return runtimeSummary;
+      }
+    }
+
+    return summaryPrompt || needBatterySummary || batteryNameSummary || '';
+  }
+
+    var resultsPlainSummary = resolveElementFromOptions(
+      opts,
+      'resultsPlainSummaryElem',
+      'resultsPlainSummary',
+      'resultsPlainSummaryElem'
+    );
+    if (resultsPlainSummary) {
+      setHelpAttribute(resultsPlainSummary, resolveText('resultsPlainSummaryHelp'));
+    }
+
+    var resultsPlainSummaryTitle = resolveElementFromOptions(
+      opts,
+      'resultsPlainSummaryTitleElem',
+      'resultsPlainSummaryTitle',
+      'resultsPlainSummaryTitleElem'
+    );
+    if (resultsPlainSummaryTitle) {
+      try {
+        resultsPlainSummaryTitle.textContent =
+          resolveText('resultsPlainSummaryTitle') || resultsPlainSummaryTitle.textContent || '';
+      } catch (error) {
+        void error;
+      }
+    }
+
+    var resultsPlainSummaryText = resolveElementFromOptions(
+      opts,
+      'resultsPlainSummaryTextElem',
+      'resultsPlainSummaryText',
+      'resultsPlainSummaryTextElem'
+    );
+    if (resultsPlainSummaryText) {
+      var summaryPrompt = resolveText('resultsPlainSummaryPrompt');
+      if (!summaryPrompt && typeof resultsPlainSummaryText.textContent === 'string') {
+        summaryPrompt = resultsPlainSummaryText.textContent;
+      }
+      try {
+        resultsPlainSummaryText.textContent = summaryPrompt;
+      } catch (error) {
+        void error;
+      }
+    }
+
+    var resultsPlainSummaryNote = resolveElementFromOptions(
+      opts,
+      'resultsPlainSummaryNoteElem',
+      'resultsPlainSummaryNote',
+      'resultsPlainSummaryNoteElem'
+    );
+    if (resultsPlainSummaryNote) {
+      try {
+        resultsPlainSummaryNote.textContent =
+          resolveText('resultsPlainSummaryNote') || resultsPlainSummaryNote.textContent || '';
+      } catch (error) {
+        void error;
+      }
     }
     function applyLabel(element, labelKey, helpKey) {
       if (!element) {
@@ -733,6 +889,8 @@ function _typeof(o) { "@babel/helpers - typeof"; return _typeof = "function" == 
     var tempNote = resolveElementFromOptions(opts, 'tempNote', 'temperatureNote');
     setHelpAttribute(tempNote, resolveText('temperatureNoteHelp'));
     runtimeFeedbackState.elements.breakdownListElem = breakdownList;
+    runtimeFeedbackState.elements.resultsPlainSummaryElem = resultsPlainSummary;
+    runtimeFeedbackState.elements.resultsPlainSummaryTextElem = resultsPlainSummaryText;
     runtimeFeedbackState.elements.totalPowerLabel = totalPowerLabel;
     runtimeFeedbackState.elements.batteryCountLabel = batteryCountLabel;
     runtimeFeedbackState.elements.batteryLifeLabel = batteryLifeLabel;
@@ -938,6 +1096,18 @@ function _typeof(o) { "@babel/helpers - typeof"; return _typeof = "function" == 
     var hotswapSelect = resolveElementFromOptions(opts, 'hotswapSelect', 'batteryHotswapSelect', 'hotswapSelect');
     var motorSelects = resolveSelectCollection(opts, 'motorSelects', ['motor1Select', 'motor2Select', 'motor3Select', 'motor4Select'], 'motorSelects');
     var controllerSelects = resolveSelectCollection(opts, 'controllerSelects', ['controller1Select', 'controller2Select', 'controller3Select', 'controller4Select'], 'controllerSelects');
+    var resultsPlainSummaryTarget = resolveElementFromOptions(
+      opts,
+      'resultsPlainSummaryElem',
+      'resultsPlainSummary',
+      'resultsPlainSummaryElem'
+    );
+    var resultsPlainSummaryTextTarget = resolveElementFromOptions(
+      opts,
+      'resultsPlainSummaryTextElem',
+      'resultsPlainSummaryText',
+      'resultsPlainSummaryTextElem'
+    );
     var totalPowerTarget = resolveElementFromOptions(opts, 'totalPowerElem', 'totalPower', 'totalPowerElem');
     var breakdownListTarget = resolveElementFromOptions(opts, 'breakdownListElem', 'breakdownList', 'breakdownListElem');
     var totalCurrent144Target = resolveElementFromOptions(opts, 'totalCurrent144Elem', 'totalCurrent144', 'totalCurrent144Elem');
@@ -960,6 +1130,8 @@ function _typeof(o) { "@babel/helpers - typeof"; return _typeof = "function" == 
     runtimeFeedbackState.elements.hotswapSelect = hotswapSelect;
     runtimeFeedbackState.elements.motorSelects = motorSelects;
     runtimeFeedbackState.elements.controllerSelects = controllerSelects;
+    runtimeFeedbackState.elements.resultsPlainSummaryElem = resultsPlainSummaryTarget;
+    runtimeFeedbackState.elements.resultsPlainSummaryTextElem = resultsPlainSummaryTextTarget;
     runtimeFeedbackState.elements.totalPowerElem = totalPowerTarget;
     runtimeFeedbackState.elements.breakdownListElem = breakdownListTarget;
     runtimeFeedbackState.elements.totalCurrent144Elem = totalCurrent144Target;
@@ -977,11 +1149,26 @@ function _typeof(o) { "@babel/helpers - typeof"; return _typeof = "function" == 
     function safeSelectValue(select) {
       return select && typeof select.value === 'string' ? select.value : '';
     }
+    function getSelectedOptionLabel(select) {
+      if (!select || typeof select.selectedIndex !== 'number') {
+        return '';
+      }
+      var options = select.options;
+      if (!options || select.selectedIndex < 0 || select.selectedIndex >= options.length) {
+        return '';
+      }
+      var option = options[select.selectedIndex];
+      if (!option || typeof option.textContent !== 'string') {
+        return '';
+      }
+      return option.textContent.trim();
+    }
     var camera = safeSelectValue(cameraSelect);
     var monitor = safeSelectValue(monitorSelect);
     var video = safeSelectValue(videoSelect);
     var distance = safeSelectValue(distanceSelect);
     var battery = safeSelectValue(batterySelect);
+    var batteryLabelText = getSelectedOptionLabel(batterySelect);
     var motors = motorSelects.map(function mapMotor(select) {
       return safeSelectValue(select);
     });
@@ -1276,6 +1463,9 @@ function _typeof(o) { "@babel/helpers - typeof"; return _typeof = "function" == 
       };
     }
     var hours = null;
+    var runtimeHoursValue = null;
+    var batteriesNeeded = null;
+    var batteriesNeededValue = null;
     if (!battery || !devices.batteries || !devices.batteries[battery]) {
       if (batteryLifeTarget && typeof batteryLifeTarget.textContent !== 'undefined') {
         try {
@@ -1307,6 +1497,9 @@ function _typeof(o) { "@babel/helpers - typeof"; return _typeof = "function" == 
         }
       }
       setLastRuntimeHoursFn(null);
+      runtimeHoursValue = null;
+      batteriesNeeded = null;
+      batteriesNeededValue = null;
       if (drawPowerDiagramFn) {
         try {
           drawPowerDiagramFn(0, segments, 0);
@@ -1377,10 +1570,12 @@ function _typeof(o) { "@babel/helpers - typeof"; return _typeof = "function" == 
         }
       }
       setLastRuntimeHoursFn(hours);
-      var batteriesNeeded = 1;
+      runtimeHoursValue = hours;
+      batteriesNeeded = 1;
       if (Number.isFinite(hours) && hours > 0) {
         batteriesNeeded = Math.max(1, Math.ceil(10 / hours));
       }
+      batteriesNeededValue = batteriesNeeded;
       if (batteryCountTarget && typeof batteryCountTarget.textContent !== 'undefined') {
         try {
           batteryCountTarget.textContent = String(batteriesNeeded);
@@ -1678,6 +1873,7 @@ function _typeof(o) { "@babel/helpers - typeof"; return _typeof = "function" == 
         }
       }
       setLastRuntimeHoursFn(combinedRuntime);
+      runtimeHoursValue = combinedRuntime;
       if (batteryLifeLabelTarget) {
         var label = resolveText('batteryLifeLabel');
         var runtimeUserCountNote = resolveText('runtimeUserCountNote');
@@ -1711,6 +1907,8 @@ function _typeof(o) { "@babel/helpers - typeof"; return _typeof = "function" == 
       if (Number.isFinite(combinedRuntime) && combinedRuntime > 0) {
         batteriesNeededFeedback = Math.max(1, Math.ceil(10 / combinedRuntime));
       }
+      batteriesNeeded = batteriesNeededFeedback;
+      batteriesNeededValue = batteriesNeededFeedback;
       if (batteryCountTarget && typeof batteryCountTarget.textContent !== 'undefined') {
         try {
           batteryCountTarget.textContent = String(batteriesNeededFeedback);
@@ -1735,6 +1933,30 @@ function _typeof(o) { "@babel/helpers - typeof"; return _typeof = "function" == 
         }
       }
     }
+    if (resultsPlainSummaryTextTarget) {
+      var summaryPrompt = resolveText('resultsPlainSummaryPrompt') || '';
+      var summaryTextValue = buildPlainSummaryText({
+        summaryPrompt: summaryPrompt,
+        needBatterySummary: resolveText('resultsPlainSummaryNeedBattery'),
+        runtimeSummaryTemplate: resolveText('resultsPlainSummaryRuntime'),
+        unlimitedSummaryTemplate: resolveText('resultsPlainSummaryUnlimited'),
+        unnamedBatteryLabel: resolveText('resultsPlainSummaryUnnamedBattery'),
+        batteryLabelText: batteryLabelText,
+        battery: battery,
+        totalWatt: totalWatt,
+        runtimeHoursValue: runtimeHoursValue,
+        batteriesNeededValue: batteriesNeededValue
+      });
+      if (!summaryTextValue) {
+        summaryTextValue = summaryPrompt;
+      }
+      try {
+        resultsPlainSummaryTextTarget.textContent = summaryTextValue;
+      } catch (error) {
+        void error;
+      }
+    }
+
     if (renderTemperatureNoteFn) {
       try {
         renderTemperatureNoteFn(getLastRuntimeHoursFn());

--- a/legacy/scripts/translations.js
+++ b/legacy/scripts/translations.js
@@ -57,6 +57,20 @@ var texts = {
     setupManageHeadingHelp: "Manage saved projects: save, load, or clear configurations.",
     deviceSelectionHeadingHelp: "Choose cameras, monitors, and accessories for your rig.",
     resultsHeadingHelp: "See power consumption, estimated runtime, and battery counts.",
+    resultsPlainSummaryTitle: "Quick summary",
+    resultsPlainSummaryHelp:
+      "Explains the power summary in plain language so you can confirm runtime and battery needs without reading every table.",
+    resultsPlainSummaryPrompt:
+      "Add devices and choose a battery to see a plain-language summary of runtime and consumption.",
+    resultsPlainSummaryNeedBattery:
+      "Choose a battery to see how long the rig will run and how many packs to pack.",
+    resultsPlainSummaryRuntime:
+      "With {batteryName}, expect about {hours} hours of runtime. Pack {batteryCount} batteries for a 10-hour day. Your rig currently draws {totalPower} W.",
+    resultsPlainSummaryUnlimited:
+      "With {batteryName}, your rig draws {totalPower} W, so runtime stays unlimited. Keep a charged pack connected before recording.",
+    resultsPlainSummaryNote:
+      "The planner saves these numbers offline automatically. Update your backups after big changes.",
+    resultsPlainSummaryUnnamedBattery: "your selected battery",
     deviceManagerHeadingHelp: "Add, edit or remove entries from the device database, including categories, subcategories and attributes.",
     batteryComparisonHeadingHelp: "Compare runtimes for all compatible batteries.",
     batteryTableBatteryHelp: "Battery name and mount that can power your current build.",
@@ -1356,6 +1370,20 @@ var texts = {
     setupManageHeadingHelp: "Gestisci le configurazioni salvate: salva, carica o cancella configurazioni.",
     deviceSelectionHeadingHelp: "Scegli fotocamere, monitor e accessori per la tua configurazione.",
     resultsHeadingHelp: "Vedi il consumo di energia, la durata stimata e il numero di batterie.",
+    resultsPlainSummaryTitle: "Riepilogo rapido",
+    resultsPlainSummaryHelp:
+      "Spiega il riepilogo di potenza con termini semplici e supporta la pianificazione dell'autonomia.",
+    resultsPlainSummaryPrompt:
+      "Aggiungi dispositivi e scegli una batteria per vedere un riepilogo in linguaggio semplice.",
+    resultsPlainSummaryNeedBattery:
+      "Scegli una batteria per scoprire quanta autonomia avrai e quanti pacchi portare.",
+    resultsPlainSummaryRuntime:
+      "Con {batteryName} puoi aspettarti circa {hours} ore di autonomia. Per una giornata da 10 ore porta {batteryCount} batterie. Il tuo setup assorbe attualmente {totalPower} W.",
+    resultsPlainSummaryUnlimited:
+      "Con {batteryName} il tuo setup assorbe {totalPower} W, quindi l'autonomia rimane virtualmente illimitata. Tieni comunque collegata una batteria carica prima di girare.",
+    resultsPlainSummaryNote:
+      "Il planner salva questi valori offline in automatico. Aggiorna i backup dopo modifiche importanti.",
+    resultsPlainSummaryUnnamedBattery: "la batteria selezionata",
     deviceManagerHeadingHelp: "Aggiungi, modifica o rimuovi elementi dal database dei dispositivi, inclusi categorie, sottocategorie e attributi.",
     batteryComparisonHeadingHelp: "Confronta le autonomie di tutte le batterie compatibili.",
     batteryTableBatteryHelp: "Nome della batteria e attacco che possono alimentare la tua configurazione.",
@@ -2654,6 +2682,20 @@ var texts = {
     setupManageHeadingHelp: "Administra los proyectos guardados: guárdalos, cárgalos o borra la configuración actual.",
     deviceSelectionHeadingHelp: "Elige cámaras, monitores y accesorios para tu equipo.",
     resultsHeadingHelp: "Consulta el consumo de energía, la autonomía estimada y la cantidad de baterías.",
+    resultsPlainSummaryTitle: "Resumen rápido",
+    resultsPlainSummaryHelp:
+      "Explica el resumen de potencia con un lenguaje sencillo y ayuda a planificar la autonomía.",
+    resultsPlainSummaryPrompt:
+      "Añade dispositivos y elige una batería para ver un resumen en lenguaje claro.",
+    resultsPlainSummaryNeedBattery:
+      "Elige una batería para saber cuánto durará tu equipo y cuántos packs llevar.",
+    resultsPlainSummaryRuntime:
+      "Con {batteryName} tendrás unas {hours} horas de autonomía. Para una jornada de 10 horas lleva {batteryCount} baterías. Tu equipo consume ahora {totalPower} W.",
+    resultsPlainSummaryUnlimited:
+      "Con {batteryName} tu equipo consume {totalPower} W, así que la autonomía es prácticamente ilimitada. Asegúrate de tener una batería cargada conectada antes de grabar.",
+    resultsPlainSummaryNote:
+      "El planificador guarda estos datos offline automáticamente. Actualiza tus copias de seguridad después de cambios importantes.",
+    resultsPlainSummaryUnnamedBattery: "la batería seleccionada",
     deviceManagerHeadingHelp: "Añade, edita o elimina entradas de la base de datos de dispositivos, incluidas categorías, subcategorías y atributos.",
     batteryComparisonHeadingHelp: "Compara los tiempos de funcionamiento de todas las baterías compatibles.",
     batteryTableBatteryHelp: "Nombre de la batería y montura capaces de alimentar tu configuración.",
@@ -3952,6 +3994,20 @@ var texts = {
     setupManageHeadingHelp: "Gérez les configurations enregistrées : sauvegarder, charger ou effacer.",
     deviceSelectionHeadingHelp: "Choisissez les caméras, moniteurs et accessoires de votre équipement.",
     resultsHeadingHelp: "Affiche la consommation, l’autonomie estimée et le nombre de batteries.",
+    resultsPlainSummaryTitle: "Résumé rapide",
+    resultsPlainSummaryHelp:
+      "Explique le résumé de puissance avec des mots simples et aide à planifier l’autonomie.",
+    resultsPlainSummaryPrompt:
+      "Ajoutez des appareils et choisissez une batterie pour obtenir un résumé en langage clair.",
+    resultsPlainSummaryNeedBattery:
+      "Choisissez une batterie pour connaître l'autonomie et le nombre de packs à prévoir.",
+    resultsPlainSummaryRuntime:
+      "Avec {batteryName}, comptez environ {hours} heures d'autonomie. Pour une journée de 10 heures, prévoyez {batteryCount} batteries. Votre configuration consomme actuellement {totalPower} W.",
+    resultsPlainSummaryUnlimited:
+      "Avec {batteryName}, votre configuration consomme {totalPower} W : l'autonomie reste donc illimitée. Gardez tout de même une batterie chargée branchée avant de tourner.",
+    resultsPlainSummaryNote:
+      "Le planificateur enregistre ces données hors ligne automatiquement. Mettez à jour vos sauvegardes après des modifications importantes.",
+    resultsPlainSummaryUnnamedBattery: "la batterie sélectionnée",
     deviceManagerHeadingHelp: "Ajoutez, modifiez ou supprimez des entrées de la base de données des appareils, y compris les catégories, sous-catégories et attributs.",
     batteryComparisonHeadingHelp: "Compare l’autonomie de toutes les batteries compatibles.",
     batteryTableBatteryHelp: "Nom de la batterie et type de montage capables d’alimenter votre configuration.",
@@ -5250,6 +5306,20 @@ var texts = {
     setupManageHeadingHelp: "Gespeicherte Projekte verwalten: Projekte speichern, laden oder löschen.",
     deviceSelectionHeadingHelp: "Wähle Kameras, Monitore und Zubehör für dein Setup.",
     resultsHeadingHelp: "Zeigt Stromverbrauch, geschätzte Laufzeit und benötigte Akkus.",
+    resultsPlainSummaryTitle: "Schnellüberblick",
+    resultsPlainSummaryHelp:
+      "Erläutert die Leistungsübersicht in Alltagssprache und unterstützt die Laufzeitplanung.",
+    resultsPlainSummaryPrompt:
+      "Füge Geräte hinzu und wähle einen Akku, um eine leicht verständliche Zusammenfassung zu erhalten.",
+    resultsPlainSummaryNeedBattery:
+      "Wähle einen Akku, um Laufzeit und benötigte Packs zu sehen.",
+    resultsPlainSummaryRuntime:
+      "Mit {batteryName} kannst du mit etwa {hours} Stunden Laufzeit rechnen. Für einen 10-Stunden-Tag solltest du {batteryCount} Akkus einplanen. Dein Aufbau zieht derzeit {totalPower} W.",
+    resultsPlainSummaryUnlimited:
+      "Mit {batteryName} zieht dein Aufbau {totalPower} W und die Laufzeit bleibt praktisch unbegrenzt. Halte vor dem Dreh trotzdem einen geladenen Akku bereit.",
+    resultsPlainSummaryNote:
+      "Die Angaben werden offline automatisch gespeichert. Aktualisiere nach größeren Änderungen deine Sicherungen.",
+    resultsPlainSummaryUnnamedBattery: "dein ausgewählter Akku",
     deviceManagerHeadingHelp: "Füge Einträge zur Gerätedatenbank hinzu, bearbeite oder entferne sie – inklusive Kategorien, Unterkategorien und Attributen.",
     batteryComparisonHeadingHelp: "Vergleicht Laufzeiten aller kompatiblen Batterien.",
     batteryTableBatteryHelp: "Akkuname und Mount, die dein aktuelles Setup versorgen können.",

--- a/src/scripts/app-core-new-1.js
+++ b/src/scripts/app-core-new-1.js
@@ -8153,6 +8153,25 @@ function setLanguage(lang) {
 
   if (!resultsLocalizationApplied) {
     // Results labels
+  const resultsPlainSummaryElem = document.getElementById("resultsPlainSummary");
+  if (resultsPlainSummaryElem) {
+    resultsPlainSummaryElem.setAttribute(
+      "data-help",
+      texts[lang].resultsPlainSummaryHelp
+    );
+  }
+  const resultsPlainSummaryTitleElem = document.getElementById("resultsPlainSummaryTitle");
+  if (resultsPlainSummaryTitleElem) {
+    resultsPlainSummaryTitleElem.textContent = texts[lang].resultsPlainSummaryTitle;
+  }
+  const resultsPlainSummaryTextElem = document.getElementById("resultsPlainSummaryText");
+  if (resultsPlainSummaryTextElem) {
+    resultsPlainSummaryTextElem.textContent = texts[lang].resultsPlainSummaryPrompt;
+  }
+  const resultsPlainSummaryNoteElem = document.getElementById("resultsPlainSummaryNote");
+  if (resultsPlainSummaryNoteElem) {
+    resultsPlainSummaryNoteElem.textContent = texts[lang].resultsPlainSummaryNote;
+  }
   const breakdownListTarget =
     typeof breakdownListElem !== "undefined" && breakdownListElem
       ? breakdownListElem

--- a/src/scripts/translations.js
+++ b/src/scripts/translations.js
@@ -75,6 +75,20 @@ const texts = {
       "Choose cameras, monitors, and accessories for your rig.",
     resultsHeadingHelp:
       "See power consumption, estimated runtime, and battery counts.",
+    resultsPlainSummaryTitle: "Quick summary",
+    resultsPlainSummaryHelp:
+      "Explains the power summary in plain language so you can confirm runtime and battery needs without reading every table.",
+    resultsPlainSummaryPrompt:
+      "Add devices and choose a battery to see a plain-language summary of runtime and consumption.",
+    resultsPlainSummaryNeedBattery:
+      "Choose a battery to see how long the rig will run and how many packs to pack.",
+    resultsPlainSummaryRuntime:
+      "With {batteryName}, expect about {hours} hours of runtime. Pack {batteryCount} batteries for a 10-hour day. Your rig currently draws {totalPower} W.",
+    resultsPlainSummaryUnlimited:
+      "With {batteryName}, your rig draws {totalPower} W, so runtime stays unlimited. Keep a charged pack connected before recording.",
+    resultsPlainSummaryNote:
+      "The planner saves these numbers offline automatically. Update your backups after big changes.",
+    resultsPlainSummaryUnnamedBattery: "your selected battery",
     deviceManagerHeadingHelp:
       "Add, edit or remove entries from the device database, including categories, subcategories and attributes.",
     batteryComparisonHeadingHelp:
@@ -1610,6 +1624,20 @@ const texts = {
       "Scegli fotocamere, monitor e accessori per la tua configurazione.",
     resultsHeadingHelp:
       "Vedi il consumo di energia, la durata stimata e il numero di batterie.",
+    resultsPlainSummaryTitle: "Riepilogo rapido",
+    resultsPlainSummaryHelp:
+      "Spiega il riepilogo di potenza con termini semplici e supporta la pianificazione dell'autonomia.",
+    resultsPlainSummaryPrompt:
+      "Aggiungi dispositivi e scegli una batteria per vedere un riepilogo in linguaggio semplice.",
+    resultsPlainSummaryNeedBattery:
+      "Scegli una batteria per scoprire quanta autonomia avrai e quanti pacchi portare.",
+    resultsPlainSummaryRuntime:
+      "Con {batteryName} puoi aspettarti circa {hours} ore di autonomia. Per una giornata da 10 ore porta {batteryCount} batterie. Il tuo setup assorbe attualmente {totalPower} W.",
+    resultsPlainSummaryUnlimited:
+      "Con {batteryName} il tuo setup assorbe {totalPower} W, quindi l'autonomia rimane virtualmente illimitata. Tieni comunque collegata una batteria carica prima di girare.",
+    resultsPlainSummaryNote:
+      "Il planner salva questi valori offline in automatico. Aggiorna i backup dopo modifiche importanti.",
+    resultsPlainSummaryUnnamedBattery: "la batteria selezionata",
     deviceManagerHeadingHelp:
       "Aggiungi, modifica o rimuovi elementi dal database dei dispositivi, inclusi categorie, sottocategorie e attributi.",
     batteryComparisonHeadingHelp:
@@ -3132,6 +3160,20 @@ const texts = {
       "Elige cámaras, monitores y accesorios para tu equipo.",
     resultsHeadingHelp:
       "Consulta el consumo de energía, la autonomía estimada y la cantidad de baterías.",
+    resultsPlainSummaryTitle: "Resumen rápido",
+    resultsPlainSummaryHelp:
+      "Explica el resumen de potencia con un lenguaje sencillo y ayuda a planificar la autonomía.",
+    resultsPlainSummaryPrompt:
+      "Añade dispositivos y elige una batería para ver un resumen en lenguaje claro.",
+    resultsPlainSummaryNeedBattery:
+      "Elige una batería para saber cuánto durará tu equipo y cuántos packs llevar.",
+    resultsPlainSummaryRuntime:
+      "Con {batteryName} tendrás unas {hours} horas de autonomía. Para una jornada de 10 horas lleva {batteryCount} baterías. Tu equipo consume ahora {totalPower} W.",
+    resultsPlainSummaryUnlimited:
+      "Con {batteryName} tu equipo consume {totalPower} W, así que la autonomía es prácticamente ilimitada. Asegúrate de tener una batería cargada conectada antes de grabar.",
+    resultsPlainSummaryNote:
+      "El planificador guarda estos datos offline automáticamente. Actualiza tus copias de seguridad después de cambios importantes.",
+    resultsPlainSummaryUnnamedBattery: "la batería seleccionada",
     deviceManagerHeadingHelp:
       "Añade, edita o elimina entradas de la base de datos de dispositivos, incluidas categorías, subcategorías y atributos.",
     batteryComparisonHeadingHelp:
@@ -4668,6 +4710,20 @@ const texts = {
       "Choisissez les caméras, moniteurs et accessoires de votre équipement.",
     resultsHeadingHelp:
       "Affiche la consommation, l’autonomie estimée et le nombre de batteries.",
+    resultsPlainSummaryTitle: "Résumé rapide",
+    resultsPlainSummaryHelp:
+      "Explique le résumé de puissance avec des mots simples et aide à planifier l’autonomie.",
+    resultsPlainSummaryPrompt:
+      "Ajoutez des appareils et choisissez une batterie pour obtenir un résumé en langage clair.",
+    resultsPlainSummaryNeedBattery:
+      "Choisissez une batterie pour connaître l'autonomie et le nombre de packs à prévoir.",
+    resultsPlainSummaryRuntime:
+      "Avec {batteryName}, comptez environ {hours} heures d'autonomie. Pour une journée de 10 heures, prévoyez {batteryCount} batteries. Votre configuration consomme actuellement {totalPower} W.",
+    resultsPlainSummaryUnlimited:
+      "Avec {batteryName}, votre configuration consomme {totalPower} W : l'autonomie reste donc illimitée. Gardez tout de même une batterie chargée branchée avant de tourner.",
+    resultsPlainSummaryNote:
+      "Le planificateur enregistre ces données hors ligne automatiquement. Mettez à jour vos sauvegardes après des modifications importantes.",
+    resultsPlainSummaryUnnamedBattery: "la batterie sélectionnée",
     deviceManagerHeadingHelp:
       "Ajoutez, modifiez ou supprimez des entrées de la base de données des appareils, y compris les catégories, sous-catégories et attributs.",
     batteryComparisonHeadingHelp:
@@ -6215,6 +6271,20 @@ const texts = {
       "Wähle Kameras, Monitore und Zubehör für dein Setup.",
     resultsHeadingHelp:
       "Zeigt Stromverbrauch, geschätzte Laufzeit und benötigte Akkus.",
+    resultsPlainSummaryTitle: "Schnellüberblick",
+    resultsPlainSummaryHelp:
+      "Erläutert die Leistungsübersicht in Alltagssprache und unterstützt die Laufzeitplanung.",
+    resultsPlainSummaryPrompt:
+      "Füge Geräte hinzu und wähle einen Akku, um eine leicht verständliche Zusammenfassung zu erhalten.",
+    resultsPlainSummaryNeedBattery:
+      "Wähle einen Akku, um Laufzeit und benötigte Packs zu sehen.",
+    resultsPlainSummaryRuntime:
+      "Mit {batteryName} kannst du mit etwa {hours} Stunden Laufzeit rechnen. Für einen 10-Stunden-Tag solltest du {batteryCount} Akkus einplanen. Dein Aufbau zieht derzeit {totalPower} W.",
+    resultsPlainSummaryUnlimited:
+      "Mit {batteryName} zieht dein Aufbau {totalPower} W und die Laufzeit bleibt praktisch unbegrenzt. Halte vor dem Dreh trotzdem einen geladenen Akku bereit.",
+    resultsPlainSummaryNote:
+      "Die Angaben werden offline automatisch gespeichert. Aktualisiere nach größeren Änderungen deine Sicherungen.",
+    resultsPlainSummaryUnnamedBattery: "dein ausgewählter Akku",
     deviceManagerHeadingHelp:
       "Füge Einträge zur Gerätedatenbank hinzu, bearbeite oder entferne sie – inklusive Kategorien, Unterkategorien und Attributen.",
     batteryComparisonHeadingHelp:

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -525,6 +525,53 @@ textarea {
   color: var(--status-error-text-color);
 }
 
+.results-plain-summary {
+  margin-block: 1.5rem;
+  padding: 1.25rem 1.5rem;
+  border-radius: calc(var(--border-radius) * 2);
+  background: var(--panel-bg);
+  border: 1px solid var(--panel-border);
+  box-shadow: var(--panel-shadow);
+  transition: box-shadow 120ms ease, border-color 120ms ease;
+}
+
+.results-plain-summary:hover,
+.results-plain-summary:focus-within {
+  box-shadow: var(--panel-shadow-hover);
+  border-color: color-mix(in srgb, var(--panel-border) 70%, var(--accent-color));
+}
+
+.results-plain-summary-title,
+#resultsPlainSummaryTitle {
+  margin-block: 0 0.5rem;
+  font-size: calc(var(--font-size-relative-base) * var(--font-scale-lg));
+}
+
+.results-plain-summary-text,
+#resultsPlainSummaryText {
+  margin-block: 0;
+  line-height: var(--line-height-relaxed);
+}
+
+.results-plain-summary-note,
+#resultsPlainSummaryNote {
+  margin-block: 0.75rem 0 0;
+  color: var(--muted-text-color);
+  font-size: calc(var(--font-size-relative-base) * var(--font-scale-sm));
+}
+
+body.dark-mode .results-plain-summary {
+  background: rgba(255, 255, 255, 0.04);
+  border-color: rgba(255, 255, 255, 0.15);
+  box-shadow: none;
+}
+
+body.dark-mode .results-plain-summary:hover,
+body.dark-mode .results-plain-summary:focus-within {
+  border-color: color-mix(in srgb, rgba(255, 255, 255, 0.3) 70%, var(--accent-color));
+  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.35);
+}
+
 /* Improve keyboard accessibility by clearly showing focus outlines for links, inputs, and textareas */
 button:focus,
 a:focus,

--- a/tests/unit/resultsModule.test.js
+++ b/tests/unit/resultsModule.test.js
@@ -79,6 +79,10 @@ describe('cineResults module', () => {
     const doc = { getElementById: jest.fn(() => null) };
 
     const elements = {
+      resultsPlainSummaryElem: createElement(''),
+      resultsPlainSummaryTitleElem: createElement('Existing summary title'),
+      resultsPlainSummaryTextElem: createElement('Existing summary text'),
+      resultsPlainSummaryNoteElem: createElement('Existing summary note'),
       breakdownListElem: createElement('Existing help'),
       totalPowerLabel: createElement('Total Power (existing)'),
       batteryCountLabel: createElement('Battery count'),
@@ -109,6 +113,14 @@ describe('cineResults module', () => {
       lang: 'en',
       langTexts: {
         breakdownListHelp: 'Power distribution details',
+        resultsPlainSummaryTitle: 'Quick recap',
+        resultsPlainSummaryHelp: 'Plain summary help',
+        resultsPlainSummaryPrompt: 'Add gear for summary.',
+        resultsPlainSummaryNeedBattery: 'Pick a battery to get runtime.',
+        resultsPlainSummaryRuntime: '{batteryName} {hours}h {batteryCount} packs {totalPower}W',
+        resultsPlainSummaryUnlimited: 'Unlimited with {batteryName} at {totalPower}W',
+        resultsPlainSummaryNote: 'Numbers save offline.',
+        resultsPlainSummaryUnnamedBattery: 'your selected battery',
         totalPowerLabel: 'Total Power',
         totalPowerHelp: 'Shows the maximum draw.',
         batteryCountLabel: 'Batteries needed',
@@ -145,6 +157,10 @@ describe('cineResults module', () => {
     });
 
     expect(success).toBe(true);
+    expect(elements.resultsPlainSummaryElem.attributes['data-help']).toBe('Plain summary help');
+    expect(elements.resultsPlainSummaryTitleElem.textContent).toBe('Quick recap');
+    expect(elements.resultsPlainSummaryTextElem.textContent).toBe('Add gear for summary.');
+    expect(elements.resultsPlainSummaryNoteElem.textContent).toBe('Numbers save offline.');
     expect(elements.breakdownListElem.attributes['data-help']).toBe('Power distribution details');
     expect(elements.totalPowerLabel.textContent).toBe('Total Power');
     expect(elements.totalPowerLabel.attributes['data-help']).toBe('Shows the maximum draw.');
@@ -230,6 +246,8 @@ describe('cineResults module', () => {
     const batteryComparisonSection = { style: { display: 'none' } };
     const batteryTableElem = createElement('');
     batteryTableElem.innerHTML = '';
+    const resultsPlainSummaryElem = createElement('');
+    const resultsPlainSummaryTextElem = createElement('');
 
     const breakdownListElem = {
       _html: '',
@@ -298,6 +316,16 @@ describe('cineResults module', () => {
         runtimeUserCountNote: 'Used by {count}',
         batteryLifeHelp: 'Life help',
         runtimeAverageNote: 'Average note',
+        resultsPlainSummaryTitle: 'Quick summary',
+        resultsPlainSummaryHelp: 'Plain summary help',
+        resultsPlainSummaryPrompt: 'Add devices and choose a battery to see a plain-language summary of runtime and consumption.',
+        resultsPlainSummaryNeedBattery: 'Choose a battery to see how long the rig will run and how many packs to pack.',
+        resultsPlainSummaryRuntime:
+          'With {batteryName}, expect about {hours} hours of runtime. Pack {batteryCount} batteries for a 10-hour day. Your rig currently draws {totalPower} W.',
+        resultsPlainSummaryUnlimited:
+          'With {batteryName}, your rig draws {totalPower} W, so runtime stays unlimited. Keep a charged pack connected before recording.',
+        resultsPlainSummaryNote: 'The planner saves these numbers offline automatically. Update your backups after big changes.',
+        resultsPlainSummaryUnnamedBattery: 'your selected battery',
       },
     };
 
@@ -358,6 +386,8 @@ describe('cineResults module', () => {
         batteryComparisonSection,
         batteryTableElem,
         setupDiagramContainer,
+        resultsPlainSummaryElem,
+        resultsPlainSummaryTextElem,
       },
       motorSelects,
       controllerSelects,
@@ -398,6 +428,9 @@ describe('cineResults module', () => {
     expect(batteryLifeLabelElem.textContent).toContain('Used by 5');
     expect(batteryLifeLabelElem.attributes['data-help']).toBe('Life help');
     expect(runtimeAverageNoteElem.textContent).toBe('Average note');
+    expect(resultsPlainSummaryTextElem.textContent).toBe(
+      'With BatteryA, expect about 3.20 hours of runtime. Pack 4 batteries for a 10-hour day. Your rig currently draws 41.0 W.'
+    );
     expect(pinWarnElem.textContent).toContain('Pin OK');
     expect(setStatusMessage).toHaveBeenCalledWith(
       hotswapWarnElem,


### PR DESCRIPTION
## Summary
- add a quick plain-language summary panel inside the Power Summary section, complete with styling and help updates
- wire runtime calculations and translations across the modern and legacy bundles so the summary stays in sync offline
- extend the translations and unit coverage to protect the new behaviour

## Testing
- npm test -- --runTestsByPath tests/unit/resultsModule.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e63fb0e8a483208008d609758cea5a