### PR TITLE
Improve force reload URL resolution for relative hrefs

### DIFF
--- a/legacy/scripts/modules/offline.js
+++ b/legacy/scripts/modules/offline.js
@@ -905,6 +905,79 @@ function _typeof(o) { "@babel/helpers - typeof"; return _typeof = "function" == 
       return '';
     }
   }
+  function readLocationPathnameSafe(locationLike) {
+    if (!locationLike || _typeof(locationLike) !== 'object') {
+      return '';
+    }
+    try {
+      var pathname = locationLike.pathname;
+      return typeof pathname === 'string' ? pathname : '';
+    } catch (error) {
+      void error;
+      return '';
+    }
+  }
+  function readLocationOriginSafe(locationLike) {
+    if (!locationLike || _typeof(locationLike) !== 'object') {
+      return '';
+    }
+    try {
+      var origin = locationLike.origin;
+      if (typeof origin === 'string' && origin) {
+        return origin;
+      }
+    } catch (error) {
+      void error;
+    }
+    var href = readLocationHrefSafe(locationLike);
+    if (!href) {
+      return '';
+    }
+    if (typeof URL === 'function') {
+      try {
+        return new URL(href).origin;
+      } catch (originError) {
+        void originError;
+      }
+    }
+    var originMatch = href.match(/^([a-zA-Z][a-zA-Z\d+.-]*:\/\/[^/]+)/);
+    return originMatch && originMatch[1] ? originMatch[1] : '';
+  }
+  function getForceReloadBaseCandidates(locationLike, originalHref) {
+    var candidates = [];
+    var addCandidate = function addCandidate(value) {
+      if (typeof value !== 'string') {
+        return;
+      }
+      var trimmed = value.trim();
+      if (!trimmed || candidates.indexOf(trimmed) !== -1) {
+        return;
+      }
+      candidates.push(trimmed);
+    };
+    var safeHref = readLocationHrefSafe(locationLike);
+    if (safeHref) {
+      addCandidate(safeHref);
+    }
+    if (typeof originalHref === 'string' && originalHref) {
+      addCandidate(originalHref);
+    }
+    var origin = readLocationOriginSafe(locationLike);
+    var pathname = readLocationPathnameSafe(locationLike);
+    if (origin) {
+      if (pathname) {
+        addCandidate("".concat(origin).concat(pathname));
+      }
+      addCandidate("".concat(origin, "/"));
+    }
+    if (typeof window !== 'undefined' && window && window.location) {
+      var windowHref = readLocationHrefSafe(window.location);
+      if (windowHref) {
+        addCandidate(windowHref);
+      }
+    }
+    return candidates;
+  }
   function normaliseHrefForComparison(value, baseHref) {
     if (typeof value !== 'string') {
       return '';
@@ -933,6 +1006,7 @@ function _typeof(o) { "@babel/helpers - typeof"; return _typeof = "function" == 
     var param = typeof paramName === 'string' && paramName ? paramName : 'forceReload';
     var timestamp = Date.now().toString(36);
     var originalHref = readLocationHrefSafe(locationLike);
+    var baseCandidates = getForceReloadBaseCandidates(locationLike, originalHref);
     if (!originalHref) {
       return {
         originalHref: originalHref,
@@ -942,28 +1016,20 @@ function _typeof(o) { "@babel/helpers - typeof"; return _typeof = "function" == 
       };
     }
     if (typeof URL === 'function') {
-      try {
-        var url = new URL(originalHref);
-        url.searchParams.set(param, timestamp);
-        return {
-          originalHref: originalHref,
-          nextHref: url.toString(),
-          param: param,
-          timestamp: timestamp
-        };
-      } catch (urlError) {
-        void urlError;
+      var urlCandidates = [originalHref].concat(baseCandidates);
+      for (var index = 0; index < urlCandidates.length; index += 1) {
+        var candidate = urlCandidates[index];
         try {
-          var derived = new URL(originalHref, originalHref);
-          derived.searchParams.set(param, timestamp);
+          var url = index === 0 ? new URL(candidate) : new URL(originalHref, candidate);
+          url.searchParams.set(param, timestamp);
           return {
             originalHref: originalHref,
-            nextHref: derived.toString(),
+            nextHref: url.toString(),
             param: param,
             timestamp: timestamp
           };
-        } catch (fallbackError) {
-          void fallbackError;
+        } catch (candidateError) {
+          void candidateError;
         }
       }
     }
@@ -982,6 +1048,22 @@ function _typeof(o) { "@babel/helpers - typeof"; return _typeof = "function" == 
       href += "&".concat(param, "=").concat(timestamp);
     } else if (href) {
       href += "?".concat(param, "=").concat(timestamp);
+    }
+    if (typeof URL === 'function') {
+      for (var absoluteIndex = 0; absoluteIndex < baseCandidates.length; absoluteIndex += 1) {
+        var baseCandidate = baseCandidates[absoluteIndex];
+        try {
+          var absolute = new URL(href + hash, baseCandidate).toString();
+          return {
+            originalHref: originalHref,
+            nextHref: absolute,
+            param: param,
+            timestamp: timestamp
+          };
+        } catch (absoluteError) {
+          void absoluteError;
+        }
+      }
     }
     return {
       originalHref: originalHref,

--- a/src/scripts/modules/offline.js
+++ b/src/scripts/modules/offline.js
@@ -961,6 +961,98 @@
     }
   }
 
+  function readLocationPathnameSafe(locationLike) {
+    if (!locationLike || typeof locationLike !== 'object') {
+      return '';
+    }
+
+    try {
+      const pathname = locationLike.pathname;
+      return typeof pathname === 'string' ? pathname : '';
+    } catch (error) {
+      void error;
+      return '';
+    }
+  }
+
+  function readLocationOriginSafe(locationLike) {
+    if (!locationLike || typeof locationLike !== 'object') {
+      return '';
+    }
+
+    try {
+      const origin = locationLike.origin;
+      if (typeof origin === 'string' && origin) {
+        return origin;
+      }
+    } catch (error) {
+      void error;
+    }
+
+    const href = readLocationHrefSafe(locationLike);
+    if (!href) {
+      return '';
+    }
+
+    if (typeof URL === 'function') {
+      try {
+        return new URL(href).origin;
+      } catch (originError) {
+        void originError;
+      }
+    }
+
+    const originMatch = href.match(/^([a-zA-Z][a-zA-Z\d+.-]*:\/\/[^/]+)/);
+    return originMatch && originMatch[1] ? originMatch[1] : '';
+  }
+
+  function getForceReloadBaseCandidates(locationLike, originalHref) {
+    const candidates = [];
+    const unique = new Set();
+
+    const addCandidate = (value) => {
+      if (typeof value !== 'string') {
+        return;
+      }
+
+      const trimmed = value.trim();
+      if (!trimmed || unique.has(trimmed)) {
+        return;
+      }
+
+      unique.add(trimmed);
+      candidates.push(trimmed);
+    };
+
+    const safeHref = readLocationHrefSafe(locationLike);
+    if (safeHref) {
+      addCandidate(safeHref);
+    }
+
+    if (typeof originalHref === 'string' && originalHref) {
+      addCandidate(originalHref);
+    }
+
+    const origin = readLocationOriginSafe(locationLike);
+    const pathname = readLocationPathnameSafe(locationLike);
+
+    if (origin) {
+      if (pathname) {
+        addCandidate(`${origin}${pathname}`);
+      }
+      addCandidate(`${origin}/`);
+    }
+
+    if (typeof window !== 'undefined' && window && window.location) {
+      const windowHref = readLocationHrefSafe(window.location);
+      if (windowHref) {
+        addCandidate(windowHref);
+      }
+    }
+
+    return candidates;
+  }
+
   function normaliseHrefForComparison(value, baseHref) {
     if (typeof value !== 'string') {
       return '';
@@ -994,6 +1086,7 @@
     const param = typeof paramName === 'string' && paramName ? paramName : 'forceReload';
     const timestamp = Date.now().toString(36);
     const originalHref = readLocationHrefSafe(locationLike);
+    const baseCandidates = getForceReloadBaseCandidates(locationLike, originalHref);
 
     if (!originalHref) {
       return {
@@ -1005,29 +1098,22 @@
     }
 
     if (typeof URL === 'function') {
-      try {
-        const url = new URL(originalHref);
-        url.searchParams.set(param, timestamp);
-        return {
-          originalHref,
-          nextHref: url.toString(),
-          param,
-          timestamp,
-        };
-      } catch (urlError) {
-        void urlError;
+      const urlCandidates = [originalHref, ...baseCandidates];
+
+      for (let index = 0; index < urlCandidates.length; index += 1) {
+        const candidate = urlCandidates[index];
 
         try {
-          const derived = new URL(originalHref, originalHref);
-          derived.searchParams.set(param, timestamp);
+          const url = index === 0 ? new URL(candidate) : new URL(originalHref, candidate);
+          url.searchParams.set(param, timestamp);
           return {
             originalHref,
-            nextHref: derived.toString(),
+            nextHref: url.toString(),
             param,
             timestamp,
           };
-        } catch (fallbackError) {
-          void fallbackError;
+        } catch (candidateError) {
+          void candidateError;
         }
       }
     }
@@ -1049,6 +1135,24 @@
       href += `&${param}=${timestamp}`;
     } else if (href) {
       href += `?${param}=${timestamp}`;
+    }
+
+    if (typeof URL === 'function') {
+      for (let index = 0; index < baseCandidates.length; index += 1) {
+        const candidate = baseCandidates[index];
+
+        try {
+          const absolute = new URL(href + hash, candidate).toString();
+          return {
+            originalHref,
+            nextHref: absolute,
+            param,
+            timestamp,
+          };
+        } catch (absoluteError) {
+          void absoluteError;
+        }
+      }
     }
 
     return {

--- a/tests/unit/offlineModule.test.js
+++ b/tests/unit/offlineModule.test.js
@@ -207,17 +207,49 @@ describe('cineOffline module', () => {
 
     const location = {
       href: 'https://example.test/app?foo=bar#section',
-        replace: jest.fn(),
-        reload: jest.fn(),
-      };
-      const result = internal.triggerReload({ location });
+      replace: jest.fn(),
+      assign: jest.fn(),
+      reload: jest.fn(),
+    };
+    const result = internal.triggerReload({ location });
 
-      expect(result).toBe(true);
-      expect(location.replace).toHaveBeenCalledTimes(1);
-      const replacedUrl = location.replace.mock.calls[0][0];
-      expect(replacedUrl).toMatch(/forceReload=.*#section$/);
-      expect(replacedUrl).toMatch(/^https:\/\/example\.test\/app\?foo=bar&forceReload=/);
-      expect(location.reload).not.toHaveBeenCalled();
+    expect(result).toBe(true);
+    expect(location.replace).toHaveBeenCalledTimes(1);
+    const replacedUrl = location.replace.mock.calls[0][0];
+    expect(replacedUrl).toMatch(/forceReload=.*#section$/);
+    expect(replacedUrl).toMatch(/^https:\/\/example\.test\/app\?foo=bar&forceReload=/);
+    expect(location.reload).not.toHaveBeenCalled();
+
+    nowSpy.mockRestore();
+  });
+
+  test('triggerReload resolves relative location hrefs using origin and pathname', () => {
+    const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(1234567890000);
+
+    let currentHref = 'index.html?foo=bar#section';
+    const location = {
+      origin: 'https://example.test',
+      pathname: '/app/index.html',
+      get href() {
+        return currentHref;
+      },
+      set href(value) {
+        currentHref = value;
+      },
+      replace: jest.fn((value) => {
+        currentHref = value;
+      }),
+      assign: jest.fn(),
+      reload: jest.fn(),
+    };
+
+    const result = internal.triggerReload({ location });
+
+    expect(result).toBe(true);
+    expect(location.replace).toHaveBeenCalledTimes(1);
+    const replacedUrl = location.replace.mock.calls[0][0];
+    expect(replacedUrl).toBe('https://example.test/app/index.html?foo=bar&forceReload=fr5hugk0#section');
+    expect(location.reload).not.toHaveBeenCalled();
 
     nowSpy.mockRestore();
   });


### PR DESCRIPTION
## Summary
- add safe origin and pathname helpers plus base candidate selection when building forced reload URLs in both the modern and legacy bundles
- ensure forced reload fallbacks promote relative hrefs to absolute URLs before attempting navigation
- extend the offline module tests to cover relative href reload scenarios

## Testing
- npm test -- --runTestsByPath tests/unit/offlineModule.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e643bad81c83208120d6e92a563793