### PR TITLE
Prevent power warning when battery selection is empty

### DIFF
--- a/legacy/scripts/modules/results.js
+++ b/legacy/scripts/modules/results.js
@@ -1607,17 +1607,19 @@ function _typeof(o) { "@babel/helpers - typeof"; return _typeof = "function" == 
           dtapSeverity = 'note';
         }
       }
-      var hasPinLimit = typeof maxPinA === 'number' && maxPinA > 0;
-      var pinsInsufficient = !hasPinLimit || totalCurrentLow > maxPinA;
-      var hasDtapRating = typeof maxDtapA === 'number' && maxDtapA > 0;
-      var dtapAllowed = !bMountCam && hasDtapRating;
-      var dtapInsufficient = !dtapAllowed || hasDtapRating && totalCurrentLow > maxDtapA;
-      if (totalCurrentLow > 0 && pinsInsufficient && dtapInsufficient) {
-        var option = batterySelect && batterySelect.options ? batterySelect.options[batterySelect.selectedIndex] : null;
-        var labelText = option && typeof option.textContent === 'string' ? option.textContent.trim() : battery || '';
-        if (showPowerWarningDialogFn) {
-          try {
-            showPowerWarningDialogFn({
+        var hasPinLimit = typeof maxPinA === 'number' && maxPinA > 0;
+        var pinsInsufficient = !hasPinLimit || totalCurrentLow > maxPinA;
+        var hasDtapRating = typeof maxDtapA === 'number' && maxDtapA > 0;
+        var dtapAllowed = !bMountCam && hasDtapRating;
+        var dtapInsufficient = !dtapAllowed || hasDtapRating && totalCurrentLow > maxDtapA;
+        var batteryValue = typeof battery === 'string' ? battery.trim() : '';
+        var hasBatterySelection = batteryValue !== '' && batteryValue.toLowerCase() !== 'none';
+        if (totalCurrentLow > 0 && pinsInsufficient && dtapInsufficient && hasBatterySelection) {
+          var option = batterySelect && batterySelect.options ? batterySelect.options[batterySelect.selectedIndex] : null;
+          var labelText = option && typeof option.textContent === 'string' ? option.textContent.trim() : battery || '';
+          if (showPowerWarningDialogFn) {
+            try {
+              showPowerWarningDialogFn({
               batteryName: labelText,
               current: totalCurrentLow,
               hasPinLimit: hasPinLimit,

--- a/src/scripts/modules/results.js
+++ b/src/scripts/modules/results.js
@@ -1714,7 +1714,10 @@
       var hasDtapRating = typeof maxDtapA === 'number' && maxDtapA > 0;
       var dtapAllowed = !bMountCam && hasDtapRating;
       var dtapInsufficient = !dtapAllowed || (hasDtapRating && totalCurrentLow > maxDtapA);
-      if (totalCurrentLow > 0 && pinsInsufficient && dtapInsufficient) {
+      var batteryValue = typeof battery === 'string' ? battery.trim() : '';
+      var hasBatterySelection =
+        batteryValue !== '' && batteryValue.toLowerCase() !== 'none';
+      if (totalCurrentLow > 0 && pinsInsufficient && dtapInsufficient && hasBatterySelection) {
         var option = batterySelect && batterySelect.options ? batterySelect.options[batterySelect.selectedIndex] : null;
         var labelText = option && typeof option.textContent === 'string' ? option.textContent.trim() : (battery || '');
         if (showPowerWarningDialogFn) {


### PR DESCRIPTION
## Summary
- require a real battery selection before triggering the power warning in results calculations
- apply the same guard to the legacy results module to keep behaviour aligned

## Testing
- npm test -- --runTestsByPath tests/unit/resultsModule.test.js *(fails: eslint reports `CORE_SHARED` is not defined in src/scripts/app-session.js)*

------
https://chatgpt.com/codex/tasks/task_e_68e64d94d700832093cd440ad5824612