### PR TITLE
Refine auto-backup triggers to avoid noise

### DIFF
--- a/src/scripts/app-setups.js
+++ b/src/scripts/app-setups.js
@@ -6015,6 +6015,7 @@ function saveCurrentGearList() {
         setups[selectedStorageKey] = setup;
         storeSetups(setups);
     }
+    return changed;
 }
 
 function deleteCurrentGearList() {


### PR DESCRIPTION
## Summary
- defer auto-backup change counting until an autosave actually commits and clear pending state on reset
- introduce a shared notifier so autosave and gear-list persistence only raise commit events when data mutates
- return mutation flags from setup and gear-list saves to prevent redundant auto-backup captures during selector churn

## Testing
- npm test -- --runInBand *(fails: command interrupted after running for several minutes without finishing)*

------
https://chatgpt.com/codex/tasks/task_e_68e653dd98148320839658093d0a4b64