### PR TITLE
Fix gear list cache invalidation for project form

### DIFF
--- a/src/scripts/app-setups.js
+++ b/src/scripts/app-setups.js
@@ -4016,6 +4016,9 @@ function buildCustomItemEntryElement(categoryKey, categoryLabel, data) {
 }
 
 function persistCustomItemsChange() {
+  if (typeof markProjectFormDataDirty === 'function') {
+    markProjectFormDataDirty();
+  }
   if (typeof saveCurrentGearList === 'function') {
     saveCurrentGearList();
   }
@@ -6630,6 +6633,7 @@ function ensureGearListActions() {
             }
 
             if (shouldSync) {
+                markProjectFormDataDirty();
                 saveCurrentGearList();
                 saveCurrentSession();
                 checkSetupChanged();
@@ -6647,6 +6651,7 @@ function ensureGearListActions() {
                 updateCustomItemPreview(target.closest('.gear-custom-item'));
             }
             if (target.matches('input, textarea')) {
+                markProjectFormDataDirty();
                 saveCurrentGearList();
                 saveCurrentSession();
                 checkSetupChanged();


### PR DESCRIPTION
## Summary
- mark project form data as dirty whenever gear list controls change or persist custom items

## Testing
- npm run test:unit -- tests/unit/coreModules.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e656d825f083209125a8a0bc3a86ea