### PR TITLE
Improve forced reload fallback handling

### DIFF
--- a/legacy/scripts/app-session.js
+++ b/legacy/scripts/app-session.js
@@ -8903,62 +8903,59 @@ function scheduleForceReloadFallbacks(win, locationLike) {
   var hashBase = fallbackHref ? fallbackHref.split('#')[0] : baseHref || originalHref || '';
   var hashFallback = hashBase ? "".concat(hashBase, "#forceReload-").concat(Date.now().toString(36)) : '';
   var steps = [];
-  if (hasReload) {
+  var nextDelay = 350;
+  var queueStep = function queueStep(run) {
     steps.push({
-      delay: 350,
+      delay: nextDelay,
+      run: run
+    });
+    nextDelay += 300;
+  };
+  if (fallbackHref) {
+    if (typeof locationLike.assign === 'function') {
+      queueStep(function () {
+        try {
+          locationLike.assign(fallbackHref);
+        } catch (error) {
+          console.warn('Forced reload fallback via location.assign failed', error);
+        }
+      });
+    }
+    if (typeof locationLike.replace === 'function') {
+      queueStep(function () {
+        try {
+          locationLike.replace(fallbackHref);
+        } catch (error) {
+          console.warn('Forced reload fallback via location.replace failed', error);
+        }
+      });
+    }
+    queueStep(function () {
+      try {
+        locationLike.href = fallbackHref;
+      } catch (error) {
+        console.warn('Forced reload fallback via href assignment failed', error);
+      }
+    });
+  }
+  if (hashFallback && hashFallback !== fallbackHref) {
+    queueStep(function () {
+      try {
+        locationLike.href = hashFallback;
+      } catch (error) {
+        console.warn('Forced reload fallback via hash injection failed', error);
+      }
+    });
+  }
+  if (hasReload) {
+    var reloadDelay = steps.length ? nextDelay : 350;
+    steps.push({
+      delay: reloadDelay,
       run: function run() {
         try {
           locationLike.reload();
         } catch (error) {
           console.warn('Timed force reload fallback failed', error);
-        }
-      }
-    });
-  }
-  if (fallbackHref) {
-    if (typeof locationLike.assign === 'function') {
-      steps.push({
-        delay: hasReload ? 850 : 350,
-        run: function run() {
-          try {
-            locationLike.assign(fallbackHref);
-          } catch (error) {
-            console.warn('Forced reload fallback via location.assign failed', error);
-          }
-        }
-      });
-    }
-    if (typeof locationLike.replace === 'function') {
-      steps.push({
-        delay: hasReload ? 1150 : 650,
-        run: function run() {
-          try {
-            locationLike.replace(fallbackHref);
-          } catch (error) {
-            console.warn('Forced reload fallback via location.replace failed', error);
-          }
-        }
-      });
-    }
-    steps.push({
-      delay: hasReload ? 1450 : 950,
-      run: function run() {
-        try {
-          locationLike.href = fallbackHref;
-        } catch (error) {
-          console.warn('Forced reload fallback via href assignment failed', error);
-        }
-      }
-    });
-  }
-  if (hashFallback && hashFallback !== fallbackHref) {
-    steps.push({
-      delay: hasReload ? 1750 : 1250,
-      run: function run() {
-        try {
-          locationLike.href = hashFallback;
-        } catch (error) {
-          console.warn('Forced reload fallback via hash injection failed', error);
         }
       }
     });
@@ -9025,7 +9022,8 @@ function executeForceReloadContext(context) {
       location.href = url;
     }, 'location.href assignment');
   }
-  if (!navigationTriggered && hasReload) {
+  var canOnlyReload = !nextHref || nextHref === originalHref;
+  if (!navigationTriggered && canOnlyReload && hasReload) {
     try {
       location.reload();
       navigationTriggered = true;

--- a/src/scripts/modules/offline.js
+++ b/src/scripts/modules/offline.js
@@ -1314,66 +1314,65 @@
 
     const steps = [];
 
-    if (hasReload) {
+    let nextDelay = 350;
+
+    const queueStep = (run) => {
       steps.push({
-        delay: 350,
+        delay: nextDelay,
+        run,
+      });
+      nextDelay += 300;
+    };
+
+    if (fallbackHref) {
+      if (typeof locationLike.assign === 'function') {
+        queueStep(() => {
+          try {
+            locationLike.assign(fallbackHref);
+          } catch (error) {
+            safeWarn('Forced reload fallback via location.assign failed', error);
+          }
+        });
+      }
+
+      if (typeof locationLike.replace === 'function') {
+        queueStep(() => {
+          try {
+            locationLike.replace(fallbackHref);
+          } catch (error) {
+            safeWarn('Forced reload fallback via location.replace failed', error);
+          }
+        });
+      }
+
+      queueStep(() => {
+        try {
+          locationLike.href = fallbackHref;
+        } catch (error) {
+          safeWarn('Forced reload fallback via href assignment failed', error);
+        }
+      });
+    }
+
+    if (hashFallback && hashFallback !== fallbackHref) {
+      queueStep(() => {
+        try {
+          locationLike.href = hashFallback;
+        } catch (error) {
+          safeWarn('Forced reload fallback via hash injection failed', error);
+        }
+      });
+    }
+
+    if (hasReload) {
+      const reloadDelay = steps.length ? nextDelay : 350;
+      steps.push({
+        delay: reloadDelay,
         run() {
           try {
             locationLike.reload();
           } catch (error) {
             safeWarn('Timed force reload fallback failed', error);
-          }
-        },
-      });
-    }
-
-    if (fallbackHref) {
-      if (typeof locationLike.assign === 'function') {
-        steps.push({
-          delay: hasReload ? 850 : 350,
-          run() {
-            try {
-              locationLike.assign(fallbackHref);
-            } catch (error) {
-              safeWarn('Forced reload fallback via location.assign failed', error);
-            }
-          },
-        });
-      }
-
-      if (typeof locationLike.replace === 'function') {
-        steps.push({
-          delay: hasReload ? 1150 : 650,
-          run() {
-            try {
-              locationLike.replace(fallbackHref);
-            } catch (error) {
-              safeWarn('Forced reload fallback via location.replace failed', error);
-            }
-          },
-        });
-      }
-
-      steps.push({
-        delay: hasReload ? 1450 : 950,
-        run() {
-          try {
-            locationLike.href = fallbackHref;
-          } catch (error) {
-            safeWarn('Forced reload fallback via href assignment failed', error);
-          }
-        },
-      });
-    }
-
-    if (hashFallback && hashFallback !== fallbackHref) {
-      steps.push({
-        delay: hasReload ? 1750 : 1250,
-        run() {
-          try {
-            locationLike.href = hashFallback;
-          } catch (error) {
-            safeWarn('Forced reload fallback via hash injection failed', error);
           }
         },
       });
@@ -1445,7 +1444,9 @@
       );
     }
 
-    if (!navigationTriggered && hasReload) {
+    const canOnlyReload = !nextHref || nextHref === originalHref;
+
+    if (!navigationTriggered && canOnlyReload && hasReload) {
       try {
         location.reload();
         navigationTriggered = true;

--- a/tests/unit/offlineModule.test.js
+++ b/tests/unit/offlineModule.test.js
@@ -274,7 +274,11 @@ describe('cineOffline module', () => {
     });
     location.reload = reload;
 
-    const setTimeoutSpy = jest.fn();
+    const scheduledCallbacks = [];
+    const setTimeoutSpy = jest.fn(callback => {
+      scheduledCallbacks.push(callback);
+      return scheduledCallbacks.length;
+    });
 
     const windowMock = {
       location,
@@ -284,8 +288,19 @@ describe('cineOffline module', () => {
     const result = internal.triggerReload(windowMock);
 
     expect(result).toBe(false);
-    expect(reload).toHaveBeenCalledTimes(1);
+    expect(reload).not.toHaveBeenCalled();
     expect(setTimeoutSpy).toHaveBeenCalled();
+
+    scheduledCallbacks.forEach(callback => {
+      try {
+        callback();
+      } catch (error) {
+        // The fallback helpers already report their own errors.
+        void error;
+      }
+    });
+
+    expect(reload).toHaveBeenCalledTimes(1);
   });
 
     test('registerServiceWorker registers immediately when the document is already loaded', async () => {


### PR DESCRIPTION
## Summary
- reorder the force-reload fallbacks so navigation attempts update the URL before any timed reload occurs
- only fall back to an immediate reload when no alternate URL is available and keep the legacy bundle in sync
- exercise the delayed fallback flow in the offline module unit test

## Testing
- npx jest tests/unit/offlineModule.test.js --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68e669ff93c4832089e7b4fa90511dac