### PR TITLE
Add additional card reader device entries

### DIFF
--- a/src/data/devices/gearList.js
+++ b/src/data/devices/gearList.js
@@ -2691,6 +2691,42 @@ const gear = {
         "slots": 2,
         "busPowered": true,
         "notes": "Magnetic metal enclosure with included USB-C to USB-C and USB-C to USB-A cables."
+      },
+      "Delkin Devices CFexpress Type B & SD UHS-II Reader": {
+        "brand": "Delkin Devices",
+        "model": "DDREADER-54",
+        "supportedMedia": ["CFexpress Type B", "SD UHS-II", "SD UHS-I"],
+        "interface": "USB 3.2 Gen 2 (USB-C, 10 Gb/s)",
+        "slots": 2,
+        "busPowered": true,
+        "notes": "Rugged metal housing with non-slip rubber foot; ships with reversible USB-C to USB-C and USB-C to USB-A cables."
+      },
+      "Atomos USB-C 3.1 Docking Station": {
+        "brand": "Atomos",
+        "model": "Docking Station USB-C 3.1",
+        "supportedMedia": ["AtomX SSDmini", "Master Caddy II"],
+        "interface": "USB 3.1 Gen 2 (USB-C, 10 Gb/s)",
+        "slots": 1,
+        "busPowered": true,
+        "notes": "Tool-free dock for AtomX SSDmini and Master Caddy media; includes 80 cm USB-C to USB-C cable."
+      },
+      "Blackjet UX-1 Cinema Dock": {
+        "brand": "Blackjet",
+        "model": "UX-1 Cinema Dock",
+        "supportedMedia": ["CFast 2.0", "XQD", "SxS", "Red MINI-MAG", "SD UHS-II", "microSD UHS-I"],
+        "interface": "Thunderbolt 3 (40 Gb/s)",
+        "slots": 6,
+        "busPowered": false,
+        "notes": "Modular desktop dock with swappable media modules; dual Thunderbolt 3 ports support daisy-chaining."
+      },
+      "OWC Atlas FXR CFexpress Type B Reader": {
+        "brand": "OWC",
+        "model": "Atlas FXR",
+        "supportedMedia": ["CFexpress Type B"],
+        "interface": "USB 3.2 Gen 2 (USB-C, 10 Gb/s)",
+        "slots": 1,
+        "busPowered": true,
+        "notes": "Pocket-sized aluminium reader with integrated heat sink; includes USB-C to USB-C and USB-C to USB-A cables."
       }
     },
     "lenses": {


### PR DESCRIPTION
## Summary
- expand the accessories card reader catalog with additional Thunderbolt and USB-C options from Delkin Devices, Atomos, Blackjet, and OWC
- capture supported media formats, slot counts, and connectivity details for the newly listed readers

## Testing
- not run (data-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e66bbf6ee083208351222c915087da