### PR TITLE
Add additional tripod head options

### DIFF
--- a/docs/operations-checklist.md
+++ b/docs/operations-checklist.md
@@ -23,7 +23,10 @@ update the repository or hand off a project at the end of the day.
 
 1. **Load recent projects.** Open the primary project and at least one
    `auto-backup-…` entry. Verify gear lists, runtime feedback, favorites and
-   custom devices appear in both.
+   custom devices appear in both. Confirm the tripod catalog shows the newly
+   documented heads (Cartoni Maxima 40, Miller CX18 Fluid, Libec RH45D and
+   Vinten Vision 10AS) so offline crews can rely on the expanded options when
+   planning support kits.
 2. **Exercise manual save.** Make a harmless edit, press `Enter` or
    `Ctrl+S`/`⌘S`, then confirm the timestamp updates in the project selector.
 3. **Export safety snapshots.** Download both a `planner-backup.json` file and a

--- a/legacy/data/devices/gearList.js
+++ b/legacy/data/devices/gearList.js
@@ -5178,6 +5178,26 @@ function _arrayWithHoles(r) { if (Array.isArray(r)) return r; }
           "brand": "Manfrotto",
           "bowlSizeMm": 75,
           "material": "Aluminum"
+        },
+        "Cartoni Maxima 40 Head": {
+          "brand": "Cartoni",
+          "bowlSizeMm": 150,
+          "material": "Magnesium"
+        },
+        "Miller CX18 Fluid Head": {
+          "brand": "Miller",
+          "bowlSizeMm": 75,
+          "material": "Magnesium"
+        },
+        "Libec RH45D Head": {
+          "brand": "Libec",
+          "bowlSizeMm": 100,
+          "material": "Aluminum"
+        },
+        "Vinten Vision 10AS Head": {
+          "brand": "Vinten",
+          "bowlSizeMm": 100,
+          "material": "Aluminum"
         }
       },
       "tripods": {

--- a/src/data/devices/gearList.js
+++ b/src/data/devices/gearList.js
@@ -6296,6 +6296,26 @@ const gear = {
         "brand": "Manfrotto",
         "bowlSizeMm": 75,
         "material": "Aluminum"
+      },
+      "Cartoni Maxima 40 Head": {
+        "brand": "Cartoni",
+        "bowlSizeMm": 150,
+        "material": "Magnesium"
+      },
+      "Miller CX18 Fluid Head": {
+        "brand": "Miller",
+        "bowlSizeMm": 75,
+        "material": "Magnesium"
+      },
+      "Libec RH45D Head": {
+        "brand": "Libec",
+        "bowlSizeMm": 100,
+        "material": "Aluminum"
+      },
+      "Vinten Vision 10AS Head": {
+        "brand": "Vinten",
+        "bowlSizeMm": 100,
+        "material": "Aluminum"
       }
     },
     "tripods": {


### PR DESCRIPTION
## Summary
- add Cartoni Maxima 40, Miller CX18 Fluid, Libec RH45D and Vinten Vision 10AS entries to the tripod head catalog in both modern and legacy datasets
- remind crews via the operations checklist to confirm the expanded tripod head coverage during data integrity rehearsals

## Testing
- RUN_HEAVY_TESTS=true npm run test:jest -- --runTestsByPath tests/script/deviceDatabaseImport.test.js *(fails: Node assertion inside fallbackFreezeDeep when running heavy script tests in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e66bd6ee8083209183f1bc3842c6d2