### PR TITLE
Improve deep clone performance with structured clone fallback

### DIFF
--- a/legacy/scripts/modules/features/auto-gear-rules.js
+++ b/legacy/scripts/modules/features/auto-gear-rules.js
@@ -27,17 +27,66 @@ function _typeof(o) { "@babel/helpers - typeof"; return _typeof = "function" == 
     return {};
   }
   var GLOBAL_SCOPE = detectGlobalScope();
-  var MODULE_DEEP_CLONE = GLOBAL_SCOPE && typeof GLOBAL_SCOPE.__cineDeepClone === 'function' ? GLOBAL_SCOPE.__cineDeepClone : function moduleFallbackDeepClone(value) {
+  function moduleJsonDeepClone(value) {
     if (value === null || _typeof(value) !== 'object') {
       return value;
     }
     try {
       return JSON.parse(JSON.stringify(value));
-    } catch (cloneError) {
-      void cloneError;
+    } catch (jsonCloneError) {
+      void jsonCloneError;
     }
     return value;
-  };
+  }
+  function moduleResolveStructuredClone(scope) {
+    if (typeof structuredClone === 'function') {
+      return structuredClone;
+    }
+    if (scope && typeof scope.structuredClone === 'function') {
+      try {
+        return scope.structuredClone.bind(scope);
+      } catch (bindError) {
+        void bindError;
+      }
+    }
+    if (typeof require === 'function') {
+      try {
+        var nodeUtil = require('node:util');
+        if (nodeUtil && typeof nodeUtil.structuredClone === 'function') {
+          return nodeUtil.structuredClone.bind(nodeUtil);
+        }
+      } catch (nodeUtilError) {
+        void nodeUtilError;
+      }
+      try {
+        var legacyUtil = require('util');
+        if (legacyUtil && typeof legacyUtil.structuredClone === 'function') {
+          return legacyUtil.structuredClone.bind(legacyUtil);
+        }
+      } catch (legacyUtilError) {
+        void legacyUtilError;
+      }
+    }
+    return null;
+  }
+  function moduleCreateResilientDeepClone(scope) {
+    var structuredCloneImpl = moduleResolveStructuredClone(scope);
+    if (!structuredCloneImpl) {
+      return moduleJsonDeepClone;
+    }
+    return function moduleResilientDeepClone(value) {
+      if (value === null || _typeof(value) !== 'object') {
+        return value;
+      }
+      try {
+        return structuredCloneImpl(value);
+      } catch (structuredCloneError) {
+        void structuredCloneError;
+      }
+      return moduleJsonDeepClone(value);
+    };
+  }
+  var MODULE_DEEP_CLONE = GLOBAL_SCOPE && typeof GLOBAL_SCOPE.__cineDeepClone === 'function' ? GLOBAL_SCOPE.__cineDeepClone : moduleCreateResilientDeepClone(GLOBAL_SCOPE);
   function resolveModuleBase(scope) {
     if ((typeof cineModuleBase === "undefined" ? "undefined" : _typeof(cineModuleBase)) === 'object' && cineModuleBase) {
       return cineModuleBase;
@@ -242,7 +291,7 @@ function _typeof(o) { "@babel/helpers - typeof"; return _typeof = "function" == 
       }
     }
     try {
-      return JSON.parse(JSON.stringify(value));
+      return moduleJsonDeepClone(value);
     } catch (error) {
       void error;
     }

--- a/src/scripts/app-session.js
+++ b/src/scripts/app-session.js
@@ -41,22 +41,106 @@ if (typeof globalThis !== 'undefined' && typeof globalThis.STRONG_SEARCH_MATCH_T
   globalThis.STRONG_SEARCH_MATCH_TYPES = FALLBACK_STRONG_SEARCH_MATCH_TYPES;
 }
 
+function getSessionCloneScope() {
+  if (typeof CORE_GLOBAL_SCOPE !== 'undefined' && CORE_GLOBAL_SCOPE) {
+    return CORE_GLOBAL_SCOPE;
+  }
+
+  if (typeof globalThis !== 'undefined') {
+    return globalThis;
+  }
+
+  if (typeof window !== 'undefined') {
+    return window;
+  }
+
+  if (typeof self !== 'undefined') {
+    return self;
+  }
+
+  if (typeof global !== 'undefined') {
+    return global;
+  }
+
+  return null;
+}
+
+function sessionJsonDeepClone(value) {
+  if (value === null || typeof value !== 'object') {
+    return value;
+  }
+
+  try {
+    return JSON.parse(JSON.stringify(value));
+  } catch (jsonCloneError) {
+    void jsonCloneError;
+  }
+
+  return value;
+}
+
+function sessionResolveStructuredClone(scope) {
+  if (typeof structuredClone === 'function') {
+    return structuredClone;
+  }
+
+  if (scope && typeof scope.structuredClone === 'function') {
+    try {
+      return scope.structuredClone.bind(scope);
+    } catch (bindError) {
+      void bindError;
+    }
+  }
+
+  if (typeof require === 'function') {
+    try {
+      const nodeUtil = require('node:util');
+      if (nodeUtil && typeof nodeUtil.structuredClone === 'function') {
+        return nodeUtil.structuredClone.bind(nodeUtil);
+      }
+    } catch (nodeUtilError) {
+      void nodeUtilError;
+    }
+
+    try {
+      const legacyUtil = require('util');
+      if (legacyUtil && typeof legacyUtil.structuredClone === 'function') {
+        return legacyUtil.structuredClone.bind(legacyUtil);
+      }
+    } catch (legacyUtilError) {
+      void legacyUtilError;
+    }
+  }
+
+  return null;
+}
+
+function sessionCreateResilientDeepClone(scope) {
+  const structuredCloneImpl = sessionResolveStructuredClone(scope);
+
+  if (!structuredCloneImpl) {
+    return sessionJsonDeepClone;
+  }
+
+  return function sessionResilientDeepClone(value) {
+    if (value === null || typeof value !== 'object') {
+      return value;
+    }
+
+    try {
+      return structuredCloneImpl(value);
+    } catch (structuredCloneError) {
+      void structuredCloneError;
+    }
+
+    return sessionJsonDeepClone(value);
+  };
+}
+
 const SESSION_DEEP_CLONE =
   CORE_GLOBAL_SCOPE && typeof CORE_GLOBAL_SCOPE.__cineDeepClone === 'function'
     ? CORE_GLOBAL_SCOPE.__cineDeepClone
-    : function sessionFallbackDeepClone(value) {
-        if (value === null || typeof value !== 'object') {
-          return value;
-        }
-
-        try {
-          return JSON.parse(JSON.stringify(value));
-        } catch (cloneError) {
-          void cloneError;
-        }
-
-        return value;
-      };
+    : sessionCreateResilientDeepClone(getSessionCloneScope());
 
 if (CORE_GLOBAL_SCOPE && typeof CORE_GLOBAL_SCOPE.__cineDeepClone !== 'function') {
   try {

--- a/src/scripts/app-setups.js
+++ b/src/scripts/app-setups.js
@@ -157,25 +157,85 @@ function getGlobalScope() {
     );
 }
 
+function resolveSetupsStructuredClone(scope) {
+    if (typeof structuredClone === 'function') {
+        return structuredClone;
+    }
+
+    if (scope && typeof scope.structuredClone === 'function') {
+        try {
+            return scope.structuredClone.bind(scope);
+        } catch (bindError) {
+            void bindError;
+        }
+    }
+
+    if (typeof require === 'function') {
+        try {
+            const nodeUtil = require('node:util');
+            if (nodeUtil && typeof nodeUtil.structuredClone === 'function') {
+                return nodeUtil.structuredClone.bind(nodeUtil);
+            }
+        } catch (nodeUtilError) {
+            void nodeUtilError;
+        }
+
+        try {
+            const legacyUtil = require('util');
+            if (legacyUtil && typeof legacyUtil.structuredClone === 'function') {
+                return legacyUtil.structuredClone.bind(legacyUtil);
+            }
+        } catch (legacyUtilError) {
+            void legacyUtilError;
+        }
+    }
+
+    return null;
+}
+
+function setupsJsonDeepClone(value) {
+    if (value === null || typeof value !== 'object') {
+        return value;
+    }
+
+    try {
+        return JSON.parse(JSON.stringify(value));
+    } catch (jsonCloneError) {
+        void jsonCloneError;
+    }
+
+    return value;
+}
+
+function createSetupsDeepClone(scope) {
+    const structuredCloneImpl = resolveSetupsStructuredClone(scope);
+
+    if (!structuredCloneImpl) {
+        return setupsJsonDeepClone;
+    }
+
+    return function setupsResilientDeepClone(value) {
+        if (value === null || typeof value !== 'object') {
+            return value;
+        }
+
+        try {
+            return structuredCloneImpl(value);
+        } catch (structuredCloneError) {
+            void structuredCloneError;
+        }
+
+        return setupsJsonDeepClone(value);
+    };
+}
+
 const SETUPS_DEEP_CLONE = (() => {
     const scope = getGlobalScope();
     if (scope && typeof scope.__cineDeepClone === 'function') {
         return scope.__cineDeepClone;
     }
 
-    return function setupsFallbackDeepClone(value) {
-        if (value === null || typeof value !== 'object') {
-            return value;
-        }
-
-        try {
-            return JSON.parse(JSON.stringify(value));
-        } catch (cloneError) {
-            void cloneError;
-        }
-
-        return value;
-    };
+    return createSetupsDeepClone(scope);
 })();
 
 function gearListGetSafeHtmlSectionsImpl(html) {

--- a/src/scripts/loader.js
+++ b/src/scripts/loader.js
@@ -696,15 +696,60 @@ function loaderManualDeepCloneValue(value, memo) {
   return value;
 }
 
+function loaderResolveStructuredClone(scope) {
+  if (typeof structuredClone === 'function') {
+    return structuredClone;
+  }
+
+  if (scope && typeof scope.structuredClone === 'function') {
+    try {
+      return scope.structuredClone.bind(scope);
+    } catch (bindError) {
+      void bindError;
+    }
+  }
+
+  if (typeof require === 'function') {
+    try {
+      var nodeUtil = require('node:util');
+      if (nodeUtil && typeof nodeUtil.structuredClone === 'function') {
+        return nodeUtil.structuredClone.bind(nodeUtil);
+      }
+    } catch (nodeUtilError) {
+      void nodeUtilError;
+    }
+
+    try {
+      var legacyUtil = require('util');
+      if (legacyUtil && typeof legacyUtil.structuredClone === 'function') {
+        return legacyUtil.structuredClone.bind(legacyUtil);
+      }
+    } catch (legacyUtilError) {
+      void legacyUtilError;
+    }
+  }
+
+  return null;
+}
+
 function loaderCreateDeepCloneUtility() {
+  var globalScope =
+    (typeof globalThis !== 'undefined' && globalThis)
+      || (typeof window !== 'undefined' && window)
+      || (typeof self !== 'undefined' && self)
+      || (typeof global !== 'undefined' && global)
+      || null;
+
+  var structuredCloneImpl = loaderResolveStructuredClone(globalScope);
+
   return function loaderDeepClone(value) {
     if (value === null || typeof value !== 'object') {
       return value;
     }
 
-    if (typeof structuredClone === 'function') {
+    if (structuredCloneImpl) {
       try {
-        return structuredClone(value);
+        return structuredCloneImpl(value);
       } catch (structuredCloneError) {
         void structuredCloneError;
       }

--- a/src/scripts/storage.js
+++ b/src/scripts/storage.js
@@ -63,22 +63,82 @@
     }
   }
 
+  function storageJsonDeepClone(value) {
+    if (value === null || typeof value !== 'object') {
+      return value;
+    }
+
+    try {
+      return JSON.parse(JSON.stringify(value));
+    } catch (jsonCloneError) {
+      void jsonCloneError;
+    }
+
+    return value;
+  }
+
+  function storageResolveStructuredClone(scope) {
+    if (typeof structuredClone === 'function') {
+      return structuredClone;
+    }
+
+    if (scope && typeof scope.structuredClone === 'function') {
+      try {
+        return scope.structuredClone.bind(scope);
+      } catch (bindError) {
+        void bindError;
+      }
+    }
+
+    if (typeof require === 'function') {
+      try {
+        const nodeUtil = require('node:util');
+        if (nodeUtil && typeof nodeUtil.structuredClone === 'function') {
+          return nodeUtil.structuredClone.bind(nodeUtil);
+        }
+      } catch (nodeUtilError) {
+        void nodeUtilError;
+      }
+
+      try {
+        const legacyUtil = require('util');
+        if (legacyUtil && typeof legacyUtil.structuredClone === 'function') {
+          return legacyUtil.structuredClone.bind(legacyUtil);
+        }
+      } catch (legacyUtilError) {
+        void legacyUtilError;
+      }
+    }
+
+    return null;
+  }
+
+  function storageCreateResilientDeepClone(scope) {
+    const structuredCloneImpl = storageResolveStructuredClone(scope);
+
+    if (!structuredCloneImpl) {
+      return storageJsonDeepClone;
+    }
+
+    return function storageResilientDeepClone(value) {
+      if (value === null || typeof value !== 'object') {
+        return value;
+      }
+
+      try {
+        return structuredCloneImpl(value);
+      } catch (structuredCloneError) {
+        void structuredCloneError;
+      }
+
+      return storageJsonDeepClone(value);
+    };
+  }
+
   const STORAGE_DEEP_CLONE =
     GLOBAL_SCOPE && typeof GLOBAL_SCOPE.__cineDeepClone === 'function'
       ? GLOBAL_SCOPE.__cineDeepClone
-      : function storageFallbackDeepClone(value) {
-          if (value === null || typeof value !== 'object') {
-            return value;
-          }
-
-          try {
-            return JSON.parse(JSON.stringify(value));
-          } catch (cloneError) {
-            void cloneError;
-          }
-
-          return value;
-        };
+      : storageCreateResilientDeepClone(GLOBAL_SCOPE);
 
   if (GLOBAL_SCOPE && typeof GLOBAL_SCOPE.__cineDeepClone !== 'function') {
     try {


### PR DESCRIPTION
## Summary
- prefer the native structured clone implementation for the shared `__cineDeepClone` helper and mirror the change in the legacy bundle
- update storage, session, feature, and loader modules to reuse the resilient deep-clone detection so persistence and backups stay efficient
- enhance the overview logging utilities to rely on the shared deep-clone helper before falling back to manual copies

## Testing
- npm run lint
- npx jest --runInBand tests/unit/project-delete-backup.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e66ec1ce28832094fe447423adf8d6