### PR TITLE
chore: reinforce documentation verification workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -989,6 +989,11 @@ coverage and recovery instructions. Each update should:
 - Cross-check the [Documentation Coverage Matrix](docs/documentation-coverage-matrix.md) so every
   workflow change includes updated README copy, help topics, printable runbooks, translations and
   rehearsal evidence before sign-off.
+- Capture the artefacts listed in the [Documentation Verification Packet](docs/documentation-verification-packet.md)
+  so every release stores synchronized manuals, rehearsal exports and verification logs in redundant
+  offline locations. Attach the packet location to your verification notes so future crews know where
+  to retrieve the canonical documentation bundle when rehearsing saves, shares, imports, backups and
+  restores.
 
 ## Development
 

--- a/docs/documentation-maintenance.md
+++ b/docs/documentation-maintenance.md
@@ -78,6 +78,11 @@ copy offline.【F:src/scripts/script.js†L92-L183】
 6. **In-app legal and static pages.** If the change surfaces on legal disclosures or other
    static pages in `legal/`, mirror the update in every localized HTML file so offline
    references stay consistent.
+7. **Data schema references.** When datasets or schema attributes change, refresh
+   `docs/schema-inventory.md`, any related help topics and translation keys so operators see
+   accurate field names when auditing backups or reconciling planner exports. Note the schema
+   revision in your verification log so crews can trace which data structures the
+   documentation describes during save, share, import, backup and restore rehearsals.
 
 ## 2. Update translations in lockstep
 

--- a/docs/documentation-update-checklist.md
+++ b/docs/documentation-update-checklist.md
@@ -14,6 +14,7 @@ This checklist condenses the workflow from the [Documentation, Help & Translatio
 - [ ] Revise contextual help topics, hover help strings and FAQ answers in `src/scripts/help/` and `index.html` so offline crews see accurate instructions.
 - [ ] Synchronize printable manuals and runbooks in `docs/` (save/share reference, offline readiness, operations checklist, backup rotation guide, testing plan) with the change.
 - [ ] Update legal pages in `legal/` if any disclosures or policy links reference the updated feature.
+- [ ] Mark the affected rows in `docs/documentation-coverage-matrix.md` and update the entries so reviewers can trace which surfaces now document the revised save, share, import, backup and restore behavior.
 
 ## 3. Refresh translations
 
@@ -34,5 +35,6 @@ This checklist condenses the workflow from the [Documentation, Help & Translatio
 - [ ] Store the verified planner backup, project bundle, automatic gear rules export and a ZIP of the repository alongside the updated documentation so crews can prove parity later.
 - [ ] Attach rendered PDFs or screenshots of modified help pages if the change affected visual layout or iconography.
 - [ ] Assemble the release documentation packet following `docs/documentation-verification-packet.md` and record where redundant offline copies live.
+- [ ] Note the storage locations for the packet inside the verification log so future crews can retrieve the canonical manuals and rehearsal artefacts without reconnecting to the network.
 
 Running this checklist alongside the full maintenance guide keeps documentation, translations and offline workflows in sync with the product while protecting user data across every save, share, import, backup and restore path.


### PR DESCRIPTION
## Summary
- highlight the documentation verification packet in the main README so release notes always include offline artefacts
- extend the maintenance guide with schema update expectations to keep backups, help text and translations aligned
- expand the documentation checklist to cover the coverage matrix and storing packet locations in verification logs

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68e672d03c8c8320933e552e25f69185